### PR TITLE
Parsing fixes for 2014 General Election results.

### DIFF
--- a/2014/20141104__ca__general__house.csv
+++ b/2014/20141104__ca__general__house.csv
@@ -117,11 +117,11 @@ Alameda,U.S. House,15,DEM,Eric Swalwell,89778
 Alameda,U.S. House,15,REP,Hugh Bussell,36934
 Contra Costa,U.S. House,15,DEM,Eric Swalwell,9978
 Contra Costa,U.S. House,15,REP,Hugh Bussell,6216
-Fresno,U.S. House,16,DEM,Jim  Costa,23616
+Fresno,U.S. House,16,DEM,Jim Costa,23616
 Fresno,U.S. House,16,REP,Johnny Tacherra,13360
-Madera,U.S. House,16,DEM,Jim  Costa,5701
+Madera,U.S. House,16,DEM,Jim Costa,5701
 Madera,U.S. House,16,REP,Johnny Tacherra,10865
-Merced,U.S. House,16,DEM,Jim  Costa,16960
+Merced,U.S. House,16,DEM,Jim Costa,16960
 Merced,U.S. House,16,REP,Johnny Tacherra,20718
 Alameda,U.S. House,17,DEM,Mike Honda,16160
 Alameda,U.S. House,17,DEM,Ro Khanna,15791
@@ -182,7 +182,7 @@ San Bernardino,U.S. House,27,REP,Jack Orswell,6603
 Los Angeles,U.S. House,28,DEM,Adam B. Schiff,91996
 Los Angeles,U.S. House,28,NPP,Steve Stokes,28268
 Los Angeles,U.S. House,29,DEM,Tony Cardenas,50096
-Los Angeles,U.S. House,29,REP,William  O'Callaghan Leader,17045
+Los Angeles,U.S. House,29,REP,William O'Callaghan Leader,17045
 Los Angeles,U.S. House,30,DEM,Brad Sherman,86301
 Los Angeles,U.S. House,30,REP,Mark S. Reed,44977
 Ventura,U.S. House,30,DEM,Brad Sherman,267
@@ -220,7 +220,7 @@ Riverside,U.S. House,41,REP,Steve Adams,35936
 Riverside,U.S. House,42,DEM,Tim Sheridan,38850
 Riverside,U.S. House,42,REP,Ken Calvert,74540
 Los Angeles,U.S. House,43,DEM,Maxine Waters,69681
-Los Angeles,U.S. House,43,REP,"John  Wood, Jr.",28521
+Los Angeles,U.S. House,43,REP,"John Wood, Jr.",28521
 Los Angeles,U.S. House,44,DEM,Janice Hahn,59670
 Los Angeles,U.S. House,44,PF,Adam Shbeita,9192
 Orange,U.S. House,45,DEM,Drew E. Leavens,56819

--- a/2014/20141104__ca__general__state_assembly.csv
+++ b/2014/20141104__ca__general__state_assembly.csv
@@ -82,4 +82,215 @@ Yolo,State Assembly,7,DEM,Kevin McCarty,4825
 Sacramento,State Assembly,8,DEM,Ken Cooley,62892
 Sacramento,State Assembly,8,REP,Douglas Haaland,48057
 Sacramento,State Assembly,9,DEM,Jim Cooper,41506
-Sacr
+Sacramento,State Assembly,9,DEM,Darrell R. Fong,34996
+San Joaquin,State Assembly,9,DEM,Jim Cooper,8682
+San Joaquin,State Assembly,9,DEM,Darrell R. Fong,5224
+Marin,State Assembly,10,DEM,Marc Levine,63444
+Marin,State Assembly,10,REP,Gregory Allen,20058
+Sonoma,State Assembly,10,DEM,Marc Levine,42192
+Sonoma,State Assembly,10,REP,Gregory Allen,15941
+Contra Costa,State Assembly,11,DEM,Jim Frazier,25118
+Contra Costa,State Assembly,11,REP,Alex Henthorn,15672
+Sacramento,State Assembly,11,DEM,Jim Frazier,448
+Sacramento,State Assembly,11,REP,Alex Henthorn,548
+Solano,State Assembly,11,DEM,Jim Frazier,28478
+Solano,State Assembly,11,REP,Alex Henthorn,20255
+San Joaquin,State Assembly,12,DEM,Harinder Grewal,10026
+San Joaquin,State Assembly,12,REP,Kristin Olsen,22073
+Stanislaus,State Assembly,12,DEM,Harinder Grewal,20726
+Stanislaus,State Assembly,12,REP,Kristin Olsen,40930
+San Joaquin,State Assembly,13,DEM,Susan Talamantes Eggman,40635
+San Joaquin,State Assembly,13,REP,Sol Jobrack,26254
+Contra Costa,State Assembly,14,DEM,Susan A. Bonilla,47372
+Contra Costa,State Assembly,14,REP,Joy D. Delepine,23299
+Solano,State Assembly,14,DEM,Susan A. Bonilla,21953
+Solano,State Assembly,14,REP,Joy D. Delepine,7999
+Alameda,State Assembly,15,DEM,Elizabeth Echols,38299
+Alameda,State Assembly,15,DEM,Tony Thurmond,39031
+Contra Costa,State Assembly,15,DEM,Elizabeth Echols,17772
+Contra Costa,State Assembly,15,DEM,Tony Thurmond,27630
+Alameda,State Assembly,16,DEM,Tim Sbranti,27619
+Alameda,State Assembly,16,REP,Catharine Baker,25593
+Contra Costa,State Assembly,16,DEM,Tim Sbranti,39533
+Contra Costa,State Assembly,16,REP,Catharine Baker,45859
+San Francisco,State Assembly,17,DEM,David Campos,60416
+San Francisco,State Assembly,17,DEM,David Chiu,63041
+Alameda,State Assembly,18,DEM,Rob Bonta,88243
+Alameda,State Assembly,18,REP,David Erlich,13537
+San Francisco,State Assembly,19,DEM,Phil Ting,68510
+San Francisco,State Assembly,19,REP,Rene Pineda,19295
+San Mateo,State Assembly,19,DEM,Phil Ting,12593
+San Mateo,State Assembly,19,REP,Rene Pineda,4875
+Alameda,State Assembly,20,DEM,Bill Quirk,56144
+Alameda,State Assembly,20,REP,Jaime Patino,22007
+Merced,State Assembly,21,DEM,Adam Gray,19163
+Merced,State Assembly,21,REP,Jack Mobley,18386
+Stanislaus,State Assembly,21,DEM,Adam Gray,15768
+Stanislaus,State Assembly,21,REP,Jack Mobley,12113
+San Mateo,State Assembly,22,DEM,Kevin Mullin,73940
+San Mateo,State Assembly,22,REP,Mark Gilham,30781
+Fresno,State Assembly,23,REP,Jim Patterson,80935
+Tulare,State Assembly,23,REP,Jim Patterson,1482
+San Mateo,State Assembly,24,DEM,Richard S. Gordon,21170
+San Mateo,State Assembly,24,REP,Diane Gabl,9136
+Santa Clara,State Assembly,24,DEM,Richard S. Gordon,56816
+Santa Clara,State Assembly,24,REP,Diane Gabl,24283
+Alameda,State Assembly,25,DEM,Kansen Chu,17860
+Alameda,State Assembly,25,REP,Bob Brunton,8079
+Santa Clara,State Assembly,25,DEM,Kansen Chu,39858
+Santa Clara,State Assembly,25,REP,Bob Brunton,17362
+Inyo,State Assembly,26,REP,Devon Mathis,2592
+Inyo,State Assembly,26,REP,Rudy Mendoza,1832
+Kern,State Assembly,26,REP,Devon Mathis,2711
+Kern,State Assembly,26,REP,Rudy Mendoza,1251
+Tulare,State Assembly,26,REP,Devon Mathis,29380
+Tulare,State Assembly,26,REP,Rudy Mendoza,26908
+Santa Clara,State Assembly,27,DEM,Nora Campos,49416
+Santa Clara,State Assembly,27,REP,G. Burt Lancaster,21779
+Santa Clara,State Assembly,28,DEM,Evan Low,71239
+Santa Clara,State Assembly,28,REP,Chuck Page,48645
+Monterey,State Assembly,29,DEM,Mark Stone,27775
+Monterey,State Assembly,29,REP,Palmer Kain,15147
+Santa Clara,State Assembly,29,DEM,Mark Stone,13793
+Santa Clara,State Assembly,29,REP,Palmer Kain,8381
+Santa Cruz,State Assembly,29,DEM,Mark Stone,46697
+Santa Cruz,State Assembly,29,REP,Palmer Kain,15375
+Monterey,State Assembly,30,DEM,Luis Alejo,18689
+Monterey,State Assembly,30,REP,Mark Starritt,10002
+San Benito,State Assembly,30,DEM,Luis Alejo,7385
+San Benito,State Assembly,30,REP,Mark Starritt,5903
+Santa Clara,State Assembly,30,DEM,Luis Alejo,11774
+Santa Clara,State Assembly,30,REP,Mark Starritt,10537
+Santa Cruz,State Assembly,30,DEM,Luis Alejo,5583
+Santa Cruz,State Assembly,30,REP,Mark Starritt,2745
+Fresno,State Assembly,31,DEM,Henry T. Perea,36165
+Fresno,State Assembly,31,NPP,Walter O. Villarreal,18017
+Kern,State Assembly,32,DEM,Rudy Salas,17234
+Kern,State Assembly,32,REP,Pedro A. Rios,9437
+Kings,State Assembly,32,DEM,Rudy Salas,9487
+Kings,State Assembly,32,REP,Pedro A. Rios,12594
+San Bernardino,State Assembly,33,DEM,John Coffey,23828
+San Bernardino,State Assembly,33,REP,Jay Obernolte,46144
+Kern,State Assembly,34,DEM,"Virginia ""Mari"" Goodman",24132
+Kern,State Assembly,34,REP,Shannon Grove,70403
+San Luis Obispo,State Assembly,35,DEM,Heidi Harmon,32178
+San Luis Obispo,State Assembly,35,REP,Katcho Achadjian,52710
+Santa Barbara,State Assembly,35,DEM,Heidi Harmon,13948
+Santa Barbara,State Assembly,35,REP,Katcho Achadjian,24742
+Kern,State Assembly,36,DEM,Steve Fox,2195
+Kern,State Assembly,36,REP,Tom Lackey,4827
+Los Angeles,State Assembly,36,DEM,Steve Fox,24481
+Los Angeles,State Assembly,36,REP,Tom Lackey,34391
+San Bernardino,State Assembly,36,DEM,Steve Fox,1190
+San Bernardino,State Assembly,36,REP,Tom Lackey,2889
+San Luis Obispo,State Assembly,37,DEM,Das Williams,0
+San Luis Obispo,State Assembly,37,REP,Ron DeBlauw,0
+Santa Barbara,State Assembly,37,DEM,Das Williams,41971
+Santa Barbara,State Assembly,37,REP,Ron DeBlauw,27553
+Ventura,State Assembly,37,DEM,Das Williams,33481
+Ventura,State Assembly,37,REP,Ron DeBlauw,25861
+Los Angeles,State Assembly,38,DEM,Jorge Salomon Fuentes,22940
+Los Angeles,State Assembly,38,REP,Scott Wilk,43028
+Ventura,State Assembly,38,DEM,Jorge Salomon Fuentes,9155
+Ventura,State Assembly,38,REP,Scott Wilk,20221
+Los Angeles,State Assembly,39,DEM,Raul Bocanegra,22284
+Los Angeles,State Assembly,39,DEM,Patty Lopez,22750
+San Bernardino,State Assembly,40,DEM,Kathleen Henry,31309
+San Bernardino,State Assembly,40,REP,Marc Steinorth,39303
+Los Angeles,State Assembly,41,DEM,Chris Holden,53407
+Los Angeles,State Assembly,41,REP,Nathaniel Tsai,30726
+San Bernardino,State Assembly,41,DEM,Chris Holden,9403
+San Bernardino,State Assembly,41,REP,Nathaniel Tsai,12400
+Riverside,State Assembly,42,DEM,Karalee Hargrove,34064
+Riverside,State Assembly,42,REP,Chad Mayes,41212
+San Bernardino,State Assembly,42,DEM,Karalee Hargrove,8018
+San Bernardino,State Assembly,42,REP,Chad Mayes,15305
+Los Angeles,State Assembly,43,DEM,Mike Gatto,51971
+Los Angeles,State Assembly,43,REP,Todd Royal,26192
+Los Angeles,State Assembly,44,DEM,Jacqui Irwin,1305
+Los Angeles,State Assembly,44,REP,Rob McCoy,1501
+Ventura,State Assembly,44,DEM,Jacqui Irwin,55793
+Ventura,State Assembly,44,REP,Rob McCoy,50584
+Los Angeles,State Assembly,45,DEM,Matt Dababneh,45087
+Los Angeles,State Assembly,45,REP,Susan Shelley,33696
+Ventura,State Assembly,45,DEM,Matt Dababneh,234
+Ventura,State Assembly,45,REP,Susan Shelley,359
+Los Angeles,State Assembly,46,DEM,Adrin Nazarian,45839
+Los Angeles,State Assembly,46,REP,Zachary Taylor,18164
+San Bernardino,State Assembly,47,DEM,Cheryl R. Brown,23632
+San Bernardino,State Assembly,47,DEM,Gil Navarro,17875
+Los Angeles,State Assembly,48,DEM,Roger Hernandez,30131
+Los Angeles,State Assembly,48,REP,Joe M. Gardner,25284
+Los Angeles,State Assembly,49,DEM,Ed Chau,33030
+Los Angeles,State Assembly,49,REP,Esthela Torres Siegrist,20678
+Los Angeles,State Assembly,50,DEM,Richard Bloom,78093
+Los Angeles,State Assembly,50,REP,Bradly S. Torgan,31113
+Los Angeles,State Assembly,51,DEM,Jimmy Gomez,42261
+Los Angeles,State Assembly,51,REP,Stephen C. Smith,8277
+Los Angeles,State Assembly,52,DEM,Freddie Rodriguez,9578
+Los Angeles,State Assembly,52,REP,Dorothy F. Pineda,4414
+San Bernardino,State Assembly,52,DEM,Freddie Rodriguez,18299
+San Bernardino,State Assembly,52,REP,Dorothy F. Pineda,15056
+Los Angeles,State Assembly,53,DEM,Sandra Mendoza,11753
+Los Angeles,State Assembly,53,DEM,Miguel Santiago,20472
+Los Angeles,State Assembly,54,DEM,Sebastian Mark Ridley Thomas,66082
+Los Angeles,State Assembly,54,REP,Glen Ratcliff,17506
+Los Angeles,State Assembly,55,DEM,Gregg D. Fritchle,10186
+Los Angeles,State Assembly,55,REP,Ling-Ling Chang,12628
+Orange,State Assembly,55,DEM,Gregg D. Fritchle,15477
+Orange,State Assembly,55,REP,Ling-Ling Chang,33078
+San Bernardino,State Assembly,55,DEM,Gregg D. Fritchle,5232
+San Bernardino,State Assembly,55,REP,Ling-Ling Chang,8607
+Imperial,State Assembly,56,DEM,Eduardo Garcia,12611
+Imperial,State Assembly,56,REP,Charles Bennett Jr.,8132
+Riverside,State Assembly,56,DEM,Eduardo Garcia,23060
+Riverside,State Assembly,56,REP,Charles Bennett Jr.,17215
+Los Angeles,State Assembly,57,DEM,Ian C. Calderon,32284
+Los Angeles,State Assembly,57,REP,Rita Topalian,30397
+Los Angeles,State Assembly,58,DEM,Cristina Garcia,43182
+Los Angeles,State Assembly,59,DEM,Reggie Jones-Sawyer,28493
+Riverside,State Assembly,60,DEM,Ken Park,21508
+Riverside,State Assembly,60,REP,Eric Linder,34348
+Riverside,State Assembly,61,DEM,Jose Medina,34160
+Riverside,State Assembly,61,REP,Rudy Aranda,23973
+Los Angeles,State Assembly,62,DEM,Autumn Burke,54304
+Los Angeles,State Assembly,62,REP,Ted J. Grose,17261
+Los Angeles,State Assembly,63,DEM,Anthony Rendon,28544
+Los Angeles,State Assembly,63,REP,Adam J. Miller,12781
+Los Angeles,State Assembly,64,DEM,Mike Gipson,30041
+Los Angeles,State Assembly,64,DEM,Prophet La'Omar Walker,17217
+Orange,State Assembly,65,DEM,Sharon Quirk-Silva,35204
+Orange,State Assembly,65,REP,Young Kim,42376
+Los Angeles,State Assembly,66,DEM,Al Muratsuchi,53695
+Los Angeles,State Assembly,66,REP,David Hadley,54401
+Riverside,State Assembly,67,DEM,Conrad Melton,24386
+Riverside,State Assembly,67,REP,Melissa Melendez,54018
+Orange,State Assembly,68,DEM,Anne Cameron,30749
+Orange,State Assembly,68,REP,Donald P. (Don) Wagner,66445
+Orange,State Assembly,69,DEM,Tom Daly,32332
+Orange,State Assembly,69,REP,Sherry Walker,15665
+Los Angeles,State Assembly,70,DEM,Patrick O'Donnell,48978
+Los Angeles,State Assembly,70,REP,John C. Goya,27755
+Riverside,State Assembly,71,REP,Brian W. Jones,4353
+Riverside,State Assembly,71,REP,Tony Teora,3757
+San Diego,State Assembly,71,REP,Brian W. Jones,60260
+San Diego,State Assembly,71,REP,Tony Teora,23178
+Orange,State Assembly,72,DEM,Joel Block,34793
+Orange,State Assembly,72,REP,Travis Allen,66150
+Orange,State Assembly,73,DEM,Wendy Gabriella,36292
+Orange,State Assembly,73,REP,William (Bill) Brough,76783
+Orange,State Assembly,74,REP,Keith D. Curry,40896
+Orange,State Assembly,74,REP,Matthew Harper,60070
+Riverside,State Assembly,75,DEM,Nicholas Shestople,6036
+Riverside,State Assembly,75,REP,Marie Waldron,14889
+San Diego,State Assembly,75,DEM,Nicholas Shestople,23725
+San Diego,State Assembly,75,REP,Marie Waldron,51263
+San Diego,State Assembly,76,REP,Rocky J. Chávez,58824
+San Diego,State Assembly,76,REP,Thomas Krouse,29065
+San Diego,State Assembly,77,DEM,"Ruben ""RJ"" Hernandez",43038
+San Diego,State Assembly,77,REP,Brian Maienschein,82987
+San Diego,State Assembly,78,DEM,Toni Atkins,72224
+San Diego,State Assembly,78,REP,Barbara Decker,45088
+San Diego,State Assembly,79,DEM,Shirley N. Weber,49264
+San Diego,State Assembly,79,AI,George R. Williams,30266
+San Diego,State Assembly,80,DEM,Lorena Gonzalez,43362

--- a/2014/20141104__ca__general__state_senate.csv
+++ b/2014/20141104__ca__general__state_senate.csv
@@ -110,9 +110,9 @@ Los Angeles,State Senate,34,REP,Janet Nguyen,10447
 Orange,State Senate,34,DEM,Jose Solorio,60941
 Orange,State Senate,34,REP,Janet Nguyen,85345
 Orange,State Senate,36,DEM,Gary Kephart,32873
-Orange,State Senate,36,REP,"Patricia C. ""Pat""  Bates",81387
+Orange,State Senate,36,REP,"Patricia C. ""Pat"" Bates",81387
 San Diego,State Senate,36,DEM,Gary Kephart,40666
-San Diego,State Senate,36,REP,"Patricia C. ""Pat""  Bates",59223
+San Diego,State Senate,36,REP,"Patricia C. ""Pat"" Bates",59223
 San Diego,State Senate,38,DEM,"Fotios ""Frank"" Tsimboukakis",66066
 San Diego,State Senate,38,REP,Joel Anderson,146510
 Imperial,State Senate,40,DEM,Rafael Estrada,7959

--- a/2014/20141104__ca__general__treasurer.csv
+++ b/2014/20141104__ca__general__treasurer.csv
@@ -1,0 +1,117 @@
+county,office,district,party,candidate,votes
+Alameda,Treasurer,,DEM,John Chiang,272615
+Alameda,Treasurer,,REP,Greg Conlon,71802
+Alpine,Treasurer,,DEM,John Chiang,279
+Alpine,Treasurer,,REP,Greg Conlon,178
+Amador,Treasurer,,DEM,John Chiang,5795
+Amador,Treasurer,,REP,Greg Conlon,6767
+Butte,Treasurer,,DEM,John Chiang,27915
+Butte,Treasurer,,REP,Greg Conlon,31410
+Calaveras,Treasurer,,DEM,John Chiang,6861
+Calaveras,Treasurer,,REP,Greg Conlon,8442
+Colusa,Treasurer,,DEM,John Chiang,1687
+Colusa,Treasurer,,REP,Greg Conlon,2380
+Contra Costa,Treasurer,,DEM,John Chiang,157989
+Contra Costa,Treasurer,,REP,Greg Conlon,86895
+Del Norte,Treasurer,,DEM,John Chiang,3520
+Del Norte,Treasurer,,REP,Greg Conlon,3304
+El Dorado,Treasurer,,DEM,John Chiang,27028
+El Dorado,Treasurer,,REP,Greg Conlon,32745
+Fresno,Treasurer,,DEM,John Chiang,79667
+Fresno,Treasurer,,REP,Greg Conlon,77599
+Glenn,Treasurer,,DEM,John Chiang,1965
+Glenn,Treasurer,,REP,Greg Conlon,3886
+Humboldt,Treasurer,,DEM,John Chiang,22635
+Humboldt,Treasurer,,REP,Greg Conlon,13298
+Imperial,Treasurer,,DEM,John Chiang,13064
+Imperial,Treasurer,,REP,Greg Conlon,7671
+Inyo,Treasurer,,DEM,John Chiang,2343
+Inyo,Treasurer,,REP,Greg Conlon,2981
+Kern,Treasurer,,DEM,John Chiang,53462
+Kern,Treasurer,,REP,Greg Conlon,78792
+Kings,Treasurer,,DEM,John Chiang,9742
+Kings,Treasurer,,REP,Greg Conlon,12297
+Lake,Treasurer,,DEM,John Chiang,9853
+Lake,Treasurer,,REP,Greg Conlon,7136
+Lassen,Treasurer,,DEM,John Chiang,2517
+Lassen,Treasurer,,REP,Greg Conlon,4220
+Los Angeles,Treasurer,,DEM,John Chiang,949745
+Los Angeles,Treasurer,,REP,Greg Conlon,469300
+Madera,Treasurer,,DEM,John Chiang,11028
+Madera,Treasurer,,REP,Greg Conlon,15462
+Marin,Treasurer,,DEM,John Chiang,61410
+Marin,Treasurer,,REP,Greg Conlon,21616
+Mariposa,Treasurer,,DEM,John Chiang,2686
+Mariposa,Treasurer,,REP,Greg Conlon,3763
+Mendocino,Treasurer,,DEM,John Chiang,15967
+Mendocino,Treasurer,,REP,Greg Conlon,7412
+Merced,Treasurer,,DEM,John Chiang,18668
+Merced,Treasurer,,REP,Greg Conlon,17821
+Modoc,Treasurer,,DEM,John Chiang,876
+Modoc,Treasurer,,REP,Greg Conlon,1930
+Mono,Treasurer,,DEM,John Chiang,1535
+Mono,Treasurer,,REP,Greg Conlon,1474
+Monterey,Treasurer,,DEM,John Chiang,47112
+Monterey,Treasurer,,REP,Greg Conlon,25018
+Napa,Treasurer,,DEM,John Chiang,22680
+Napa,Treasurer,,REP,Greg Conlon,13829
+Nevada,Treasurer,,DEM,John Chiang,19761
+Nevada,Treasurer,,REP,Greg Conlon,17561
+Orange,Treasurer,,DEM,John Chiang,262238
+Orange,Treasurer,,REP,Greg Conlon,344787
+Placer,Treasurer,,DEM,John Chiang,48984
+Placer,Treasurer,,REP,Greg Conlon,61651
+Plumas,Treasurer,,DEM,John Chiang,3033
+Plumas,Treasurer,,REP,Greg Conlon,3858
+Riverside,Treasurer,,DEM,John Chiang,161317
+Riverside,Treasurer,,REP,Greg Conlon,182133
+Sacramento,Treasurer,,DEM,John Chiang,199898
+Sacramento,Treasurer,,REP,Greg Conlon,117245
+San Benito,Treasurer,,DEM,John Chiang,7719
+San Benito,Treasurer,,REP,Greg Conlon,5499
+San Bernardino,Treasurer,,DEM,John Chiang,136785
+San Bernardino,Treasurer,,REP,Greg Conlon,145535
+San Diego,Treasurer,,DEM,John Chiang,341430
+San Diego,Treasurer,,REP,Greg Conlon,312406
+San Francisco,Treasurer,,DEM,John Chiang,175961
+San Francisco,Treasurer,,REP,Greg Conlon,33665
+San Joaquin,Treasurer,,DEM,John Chiang,62218
+San Joaquin,Treasurer,,REP,Greg Conlon,52032
+San Luis Obispo,Treasurer,,DEM,John Chiang,43434
+San Luis Obispo,Treasurer,,REP,Greg Conlon,40024
+San Mateo,Treasurer,,DEM,John Chiang,107241
+San Mateo,Treasurer,,REP,Greg Conlon,47126
+Santa Barbara,Treasurer,,DEM,John Chiang,59031
+Santa Barbara,Treasurer,,REP,Greg Conlon,47738
+Santa Clara,Treasurer,,DEM,John Chiang,258453
+Santa Clara,Treasurer,,REP,Greg Conlon,120893
+Santa Cruz,Treasurer,,DEM,John Chiang,52399
+Santa Cruz,Treasurer,,REP,Greg Conlon,17516
+Shasta,Treasurer,,DEM,John Chiang,20485
+Shasta,Treasurer,,REP,Greg Conlon,34862
+Sierra,Treasurer,,DEM,John Chiang,662
+Sierra,Treasurer,,REP,Greg Conlon,823
+Siskiyou,Treasurer,,DEM,John Chiang,5969
+Siskiyou,Treasurer,,REP,Greg Conlon,7501
+Solano,Treasurer,,DEM,John Chiang,54685
+Solano,Treasurer,,REP,Greg Conlon,32790
+Sonoma,Treasurer,,DEM,John Chiang,96953
+Sonoma,Treasurer,,REP,Greg Conlon,41448
+Stanislaus,Treasurer,,DEM,John Chiang,43655
+Stanislaus,Treasurer,,REP,Greg Conlon,45061
+Sutter,Treasurer,,DEM,John Chiang,8296
+Sutter,Treasurer,,REP,Greg Conlon,11680
+Tehama,Treasurer,,DEM,John Chiang,5296
+Tehama,Treasurer,,REP,Greg Conlon,9927
+Trinity,Treasurer,,DEM,John Chiang,1831
+Trinity,Treasurer,,REP,Greg Conlon,1978
+Tulare,Treasurer,,DEM,John Chiang,24572
+Tulare,Treasurer,,REP,Greg Conlon,36790
+Tuolumne,Treasurer,,DEM,John Chiang,7572
+Tuolumne,Treasurer,,REP,Greg Conlon,9095
+Ventura,Treasurer,,DEM,John Chiang,100708
+Ventura,Treasurer,,REP,Greg Conlon,93903
+Yolo,Treasurer,,DEM,John Chiang,30443
+Yolo,Treasurer,,REP,Greg Conlon,13776
+Yuba,Treasurer,,DEM,John Chiang,5120
+Yuba,Treasurer,,REP,Greg Conlon,7164


### PR DESCRIPTION
- State assembly was truncated
- Normalize candidate names for U.S. House and State Senate
- Treasurer was missing.