### PR TITLE
Fix failing test in 2016 Primary.

### DIFF
--- a/2016/20160607__ca__primary.csv
+++ b/2016/20160607__ca__primary.csv
@@ -3164,7 +3164,7 @@ Alameda,U.S. Senate,,NPP,Clive Grey,1373
 Alameda,U.S. Senate,,NPP,Gar Myers,494
 Alameda,U.S. Senate,,LIB,Mark Matthew Herd,2338
 Alameda,U.S. Senate,,NPP,Scott A. Vineberg,289
-Alameda,U.S. Senate,,REP,Ron  Unz,1870
+Alameda,U.S. Senate,,REP,Ron Unz,1870
 Alameda,U.S. Senate,,NPP,Ric M. Llewellyn,1
 Alameda,U.S. Senate,,REP,Billy Falling,1
 Alameda,U.S. Senate,,REP,Alexis Stuart,0
@@ -3228,7 +3228,7 @@ Alpine,U.S. Senate,,NPP,Clive Grey,3
 Alpine,U.S. Senate,,NPP,Gar Myers,0
 Alpine,U.S. Senate,,LIB,Mark Matthew Herd,3
 Alpine,U.S. Senate,,NPP,Scott A. Vineberg,0
-Alpine,U.S. Senate,,REP,Ron  Unz,2
+Alpine,U.S. Senate,,REP,Ron Unz,2
 Alpine,U.S. Senate,,NPP,Ric M. Llewellyn,0
 Alpine,U.S. Senate,,REP,Billy Falling,0
 Alpine,U.S. Senate,,REP,Alexis Stuart,0
@@ -3275,7 +3275,7 @@ Amador,U.S. Senate,,NPP,Clive Grey,70
 Amador,U.S. Senate,,NPP,Gar Myers,5
 Amador,U.S. Senate,,LIB,Mark Matthew Herd,61
 Amador,U.S. Senate,,NPP,Scott A. Vineberg,18
-Amador,U.S. Senate,,REP,Ron  Unz,340
+Amador,U.S. Senate,,REP,Ron Unz,340
 Amador,U.S. Senate,,NPP,Ric M. Llewellyn,0
 Amador,U.S. Senate,,REP,Billy Falling,0
 Amador,U.S. Senate,,REP,Alexis Stuart,0
@@ -3319,7 +3319,7 @@ Butte,U.S. Senate,,NPP,Clive Grey,358
 Butte,U.S. Senate,,NPP,Gar Myers,31
 Butte,U.S. Senate,,LIB,Mark Matthew Herd,315
 Butte,U.S. Senate,,NPP,Scott A. Vineberg,125
-Butte,U.S. Senate,,REP,Ron  Unz,916
+Butte,U.S. Senate,,REP,Ron Unz,916
 Butte,U.S. Senate,,NPP,Ric M. Llewellyn,0
 Butte,U.S. Senate,,REP,Billy Falling,0
 Butte,U.S. Senate,,REP,Alexis Stuart,0
@@ -3368,7 +3368,7 @@ Calaveras,U.S. Senate,,NPP,Clive Grey,70
 Calaveras,U.S. Senate,,NPP,Gar Myers,12
 Calaveras,U.S. Senate,,LIB,Mark Matthew Herd,98
 Calaveras,U.S. Senate,,NPP,Scott A. Vineberg,30
-Calaveras,U.S. Senate,,REP,Ron  Unz,374
+Calaveras,U.S. Senate,,REP,Ron Unz,374
 Calaveras,U.S. Senate,,NPP,Ric M. Llewellyn,0
 Calaveras,U.S. Senate,,REP,Billy Falling,0
 Calaveras,U.S. Senate,,REP,Alexis Stuart,0
@@ -3412,7 +3412,7 @@ Colusa,U.S. Senate,,NPP,Clive Grey,16
 Colusa,U.S. Senate,,NPP,Gar Myers,10
 Colusa,U.S. Senate,,LIB,Mark Matthew Herd,22
 Colusa,U.S. Senate,,NPP,Scott A. Vineberg,5
-Colusa,U.S. Senate,,REP,Ron  Unz,108
+Colusa,U.S. Senate,,REP,Ron Unz,108
 Colusa,U.S. Senate,,NPP,Ric M. Llewellyn,0
 Colusa,U.S. Senate,,REP,Billy Falling,0
 Colusa,U.S. Senate,,REP,Alexis Stuart,0
@@ -3460,7 +3460,7 @@ Contra Costa,U.S. Senate,,NPP,Clive Grey,764
 Contra Costa,U.S. Senate,,NPP,Gar Myers,258
 Contra Costa,U.S. Senate,,LIB,Mark Matthew Herd,1868
 Contra Costa,U.S. Senate,,NPP,Scott A. Vineberg,184
-Contra Costa,U.S. Senate,,REP,Ron  Unz,3410
+Contra Costa,U.S. Senate,,REP,Ron Unz,3410
 Contra Costa,U.S. Senate,,NPP,Ric M. Llewellyn,0
 Contra Costa,U.S. Senate,,REP,Billy Falling,0
 Contra Costa,U.S. Senate,,REP,Alexis Stuart,0
@@ -3530,7 +3530,7 @@ Del Norte,U.S. Senate,,NPP,Clive Grey,39
 Del Norte,U.S. Senate,,NPP,Gar Myers,6
 Del Norte,U.S. Senate,,LIB,Mark Matthew Herd,23
 Del Norte,U.S. Senate,,NPP,Scott A. Vineberg,8
-Del Norte,U.S. Senate,,REP,Ron  Unz,58
+Del Norte,U.S. Senate,,REP,Ron Unz,58
 Del Norte,U.S. Senate,,NPP,Ric M. Llewellyn,0
 Del Norte,U.S. Senate,,REP,Billy Falling,0
 Del Norte,U.S. Senate,,REP,Alexis Stuart,0
@@ -3574,7 +3574,7 @@ El Dorado,U.S. Senate,,NPP,Clive Grey,309
 El Dorado,U.S. Senate,,NPP,Gar Myers,23
 El Dorado,U.S. Senate,,LIB,Mark Matthew Herd,375
 El Dorado,U.S. Senate,,NPP,Scott A. Vineberg,104
-El Dorado,U.S. Senate,,REP,Ron  Unz,1547
+El Dorado,U.S. Senate,,REP,Ron Unz,1547
 El Dorado,U.S. Senate,,NPP,Ric M. Llewellyn,0
 El Dorado,U.S. Senate,,REP,Billy Falling,0
 El Dorado,U.S. Senate,,REP,Alexis Stuart,0
@@ -3632,7 +3632,7 @@ Fresno,U.S. Senate,,NPP,Clive Grey,1065
 Fresno,U.S. Senate,,NPP,Gar Myers,164
 Fresno,U.S. Senate,,LIB,Mark Matthew Herd,607
 Fresno,U.S. Senate,,NPP,Scott A. Vineberg,192
-Fresno,U.S. Senate,,REP,Ron  Unz,1268
+Fresno,U.S. Senate,,REP,Ron Unz,1268
 Fresno,U.S. Senate,,NPP,Ric M. Llewellyn,1
 Fresno,U.S. Senate,,REP,Billy Falling,0
 Fresno,U.S. Senate,,REP,Alexis Stuart,0
@@ -3687,7 +3687,7 @@ Glenn,U.S. Senate,,NPP,Clive Grey,29
 Glenn,U.S. Senate,,NPP,Gar Myers,5
 Glenn,U.S. Senate,,LIB,Mark Matthew Herd,26
 Glenn,U.S. Senate,,NPP,Scott A. Vineberg,12
-Glenn,U.S. Senate,,REP,Ron  Unz,149
+Glenn,U.S. Senate,,REP,Ron Unz,149
 Glenn,U.S. Senate,,NPP,Ric M. Llewellyn,0
 Glenn,U.S. Senate,,REP,Billy Falling,0
 Glenn,U.S. Senate,,REP,Alexis Stuart,0
@@ -3737,7 +3737,7 @@ Humboldt,U.S. Senate,,NPP,Clive Grey,203
 Humboldt,U.S. Senate,,NPP,Gar Myers,45
 Humboldt,U.S. Senate,,LIB,Mark Matthew Herd,199
 Humboldt,U.S. Senate,,NPP,Scott A. Vineberg,62
-Humboldt,U.S. Senate,,REP,Ron  Unz,238
+Humboldt,U.S. Senate,,REP,Ron Unz,238
 Humboldt,U.S. Senate,,NPP,Ric M. Llewellyn,0
 Humboldt,U.S. Senate,,REP,Billy Falling,0
 Humboldt,U.S. Senate,,REP,Alexis Stuart,0
@@ -3781,7 +3781,7 @@ Imperial,U.S. Senate,,NPP,Clive Grey,87
 Imperial,U.S. Senate,,NPP,Gar Myers,160
 Imperial,U.S. Senate,,LIB,Mark Matthew Herd,85
 Imperial,U.S. Senate,,NPP,Scott A. Vineberg,57
-Imperial,U.S. Senate,,REP,Ron  Unz,169
+Imperial,U.S. Senate,,REP,Ron Unz,169
 Imperial,U.S. Senate,,NPP,Ric M. Llewellyn,0
 Imperial,U.S. Senate,,REP,Billy Falling,0
 Imperial,U.S. Senate,,REP,Alexis Stuart,0
@@ -3823,7 +3823,7 @@ Inyo,U.S. Senate,,NPP,Clive Grey,48
 Inyo,U.S. Senate,,NPP,Gar Myers,4
 Inyo,U.S. Senate,,LIB,Mark Matthew Herd,22
 Inyo,U.S. Senate,,NPP,Scott A. Vineberg,7
-Inyo,U.S. Senate,,REP,Ron  Unz,22
+Inyo,U.S. Senate,,REP,Ron Unz,22
 Inyo,U.S. Senate,,NPP,Ric M. Llewellyn,0
 Inyo,U.S. Senate,,REP,Billy Falling,0
 Inyo,U.S. Senate,,REP,Alexis Stuart,0
@@ -3868,7 +3868,7 @@ Kern,U.S. Senate,,NPP,Clive Grey,433
 Kern,U.S. Senate,,NPP,Gar Myers,126
 Kern,U.S. Senate,,LIB,Mark Matthew Herd,778
 Kern,U.S. Senate,,NPP,Scott A. Vineberg,205
-Kern,U.S. Senate,,REP,Ron  Unz,804
+Kern,U.S. Senate,,REP,Ron Unz,804
 Kern,U.S. Senate,,NPP,Ric M. Llewellyn,20
 Kern,U.S. Senate,,REP,Billy Falling,1
 Kern,U.S. Senate,,REP,Alexis Stuart,0
@@ -3925,7 +3925,7 @@ Kings,U.S. Senate,,NPP,Clive Grey,37
 Kings,U.S. Senate,,NPP,Gar Myers,10
 Kings,U.S. Senate,,LIB,Mark Matthew Herd,39
 Kings,U.S. Senate,,NPP,Scott A. Vineberg,25
-Kings,U.S. Senate,,REP,Ron  Unz,95
+Kings,U.S. Senate,,REP,Ron Unz,95
 Kings,U.S. Senate,,NPP,Ric M. Llewellyn,0
 Kings,U.S. Senate,,REP,Billy Falling,0
 Kings,U.S. Senate,,REP,Alexis Stuart,0
@@ -3967,7 +3967,7 @@ Lake,U.S. Senate,,NPP,Clive Grey,136
 Lake,U.S. Senate,,NPP,Gar Myers,10
 Lake,U.S. Senate,,LIB,Mark Matthew Herd,83
 Lake,U.S. Senate,,NPP,Scott A. Vineberg,27
-Lake,U.S. Senate,,REP,Ron  Unz,223
+Lake,U.S. Senate,,REP,Ron Unz,223
 Lake,U.S. Senate,,NPP,Ric M. Llewellyn,0
 Lake,U.S. Senate,,REP,Billy Falling,0
 Lake,U.S. Senate,,REP,Alexis Stuart,0
@@ -4016,7 +4016,7 @@ Lassen,U.S. Senate,,NPP,Clive Grey,57
 Lassen,U.S. Senate,,NPP,Gar Myers,5
 Lassen,U.S. Senate,,LIB,Mark Matthew Herd,41
 Lassen,U.S. Senate,,NPP,Scott A. Vineberg,3
-Lassen,U.S. Senate,,REP,Ron  Unz,74
+Lassen,U.S. Senate,,REP,Ron Unz,74
 Lassen,U.S. Senate,,NPP,Ric M. Llewellyn,0
 Lassen,U.S. Senate,,REP,Billy Falling,0
 Lassen,U.S. Senate,,REP,Alexis Stuart,0
@@ -4065,7 +4065,7 @@ Los Angeles,U.S. Senate,,NPP,Clive Grey,5127
 Los Angeles,U.S. Senate,,NPP,Gar Myers,2227
 Los Angeles,U.S. Senate,,LIB,Mark Matthew Herd,7925
 Los Angeles,U.S. Senate,,NPP,Scott A. Vineberg,2882
-Los Angeles,U.S. Senate,,REP,Ron  Unz,14174
+Los Angeles,U.S. Senate,,REP,Ron Unz,14174
 Los Angeles,U.S. Senate,,NPP,Ric M. Llewellyn,1
 Los Angeles,U.S. Senate,,REP,Billy Falling,5
 Los Angeles,U.S. Senate,,REP,Alexis Stuart,3
@@ -4273,7 +4273,7 @@ Madera,U.S. Senate,,NPP,Clive Grey,91
 Madera,U.S. Senate,,NPP,Gar Myers,32
 Madera,U.S. Senate,,LIB,Mark Matthew Herd,155
 Madera,U.S. Senate,,NPP,Scott A. Vineberg,76
-Madera,U.S. Senate,,REP,Ron  Unz,356
+Madera,U.S. Senate,,REP,Ron Unz,356
 Madera,U.S. Senate,,NPP,Ric M. Llewellyn,0
 Madera,U.S. Senate,,REP,Billy Falling,0
 Madera,U.S. Senate,,REP,Alexis Stuart,0
@@ -4321,7 +4321,7 @@ Marin,U.S. Senate,,NPP,Clive Grey,252
 Marin,U.S. Senate,,NPP,Gar Myers,37
 Marin,U.S. Senate,,LIB,Mark Matthew Herd,405
 Marin,U.S. Senate,,NPP,Scott A. Vineberg,29
-Marin,U.S. Senate,,REP,Ron  Unz,951
+Marin,U.S. Senate,,REP,Ron Unz,951
 Marin,U.S. Senate,,NPP,Ric M. Llewellyn,0
 Marin,U.S. Senate,,REP,Billy Falling,0
 Marin,U.S. Senate,,REP,Alexis Stuart,0
@@ -4366,7 +4366,7 @@ Mariposa,U.S. Senate,,NPP,Clive Grey,42
 Mariposa,U.S. Senate,,NPP,Gar Myers,6
 Mariposa,U.S. Senate,,LIB,Mark Matthew Herd,42
 Mariposa,U.S. Senate,,NPP,Scott A. Vineberg,14
-Mariposa,U.S. Senate,,REP,Ron  Unz,108
+Mariposa,U.S. Senate,,REP,Ron Unz,108
 Mariposa,U.S. Senate,,NPP,Ric M. Llewellyn,0
 Mariposa,U.S. Senate,,REP,Billy Falling,0
 Mariposa,U.S. Senate,,REP,Alexis Stuart,0
@@ -4410,7 +4410,7 @@ Mendocino,U.S. Senate,,NPP,Clive Grey,148
 Mendocino,U.S. Senate,,NPP,Gar Myers,16
 Mendocino,U.S. Senate,,LIB,Mark Matthew Herd,120
 Mendocino,U.S. Senate,,NPP,Scott A. Vineberg,20
-Mendocino,U.S. Senate,,REP,Ron  Unz,290
+Mendocino,U.S. Senate,,REP,Ron Unz,290
 Mendocino,U.S. Senate,,NPP,Ric M. Llewellyn,1
 Mendocino,U.S. Senate,,REP,Billy Falling,0
 Mendocino,U.S. Senate,,REP,Alexis Stuart,0
@@ -4454,7 +4454,7 @@ Merced,U.S. Senate,,NPP,Clive Grey,283
 Merced,U.S. Senate,,NPP,Gar Myers,104
 Merced,U.S. Senate,,LIB,Mark Matthew Herd,129
 Merced,U.S. Senate,,NPP,Scott A. Vineberg,27
-Merced,U.S. Senate,,REP,Ron  Unz,303
+Merced,U.S. Senate,,REP,Ron Unz,303
 Merced,U.S. Senate,,NPP,Ric M. Llewellyn,0
 Merced,U.S. Senate,,REP,Billy Falling,0
 Merced,U.S. Senate,,REP,Alexis Stuart,0
@@ -4498,7 +4498,7 @@ Modoc,U.S. Senate,,NPP,Clive Grey,27
 Modoc,U.S. Senate,,NPP,Gar Myers,2
 Modoc,U.S. Senate,,LIB,Mark Matthew Herd,7
 Modoc,U.S. Senate,,NPP,Scott A. Vineberg,3
-Modoc,U.S. Senate,,REP,Ron  Unz,18
+Modoc,U.S. Senate,,REP,Ron Unz,18
 Modoc,U.S. Senate,,NPP,Ric M. Llewellyn,0
 Modoc,U.S. Senate,,REP,Billy Falling,0
 Modoc,U.S. Senate,,REP,Alexis Stuart,0
@@ -4547,7 +4547,7 @@ Mono,U.S. Senate,,NPP,Clive Grey,26
 Mono,U.S. Senate,,NPP,Gar Myers,2
 Mono,U.S. Senate,,LIB,Mark Matthew Herd,21
 Mono,U.S. Senate,,NPP,Scott A. Vineberg,4
-Mono,U.S. Senate,,REP,Ron  Unz,40
+Mono,U.S. Senate,,REP,Ron Unz,40
 Mono,U.S. Senate,,NPP,Ric M. Llewellyn,0
 Mono,U.S. Senate,,REP,Billy Falling,0
 Mono,U.S. Senate,,REP,Alexis Stuart,0
@@ -4593,7 +4593,7 @@ Monterey,U.S. Senate,,NPP,Clive Grey,188
 Monterey,U.S. Senate,,NPP,Gar Myers,86
 Monterey,U.S. Senate,,LIB,Mark Matthew Herd,281
 Monterey,U.S. Senate,,NPP,Scott A. Vineberg,83
-Monterey,U.S. Senate,,REP,Ron  Unz,699
+Monterey,U.S. Senate,,REP,Ron Unz,699
 Monterey,U.S. Senate,,NPP,Ric M. Llewellyn,0
 Monterey,U.S. Senate,,REP,Billy Falling,0
 Monterey,U.S. Senate,,REP,Alexis Stuart,0
@@ -4643,7 +4643,7 @@ Napa,U.S. Senate,,NPP,Clive Grey,165
 Napa,U.S. Senate,,NPP,Gar Myers,53
 Napa,U.S. Senate,,LIB,Mark Matthew Herd,195
 Napa,U.S. Senate,,NPP,Scott A. Vineberg,49
-Napa,U.S. Senate,,REP,Ron  Unz,481
+Napa,U.S. Senate,,REP,Ron Unz,481
 Napa,U.S. Senate,,NPP,Ric M. Llewellyn,0
 Napa,U.S. Senate,,REP,Billy Falling,0
 Napa,U.S. Senate,,REP,Alexis Stuart,0
@@ -4693,7 +4693,7 @@ Nevada,U.S. Senate,,NPP,Clive Grey,170
 Nevada,U.S. Senate,,NPP,Gar Myers,21
 Nevada,U.S. Senate,,LIB,Mark Matthew Herd,234
 Nevada,U.S. Senate,,NPP,Scott A. Vineberg,53
-Nevada,U.S. Senate,,REP,Ron  Unz,702
+Nevada,U.S. Senate,,REP,Ron Unz,702
 Nevada,U.S. Senate,,NPP,Ric M. Llewellyn,1
 Nevada,U.S. Senate,,REP,Billy Falling,0
 Nevada,U.S. Senate,,REP,Alexis Stuart,0
@@ -4745,7 +4745,7 @@ Orange,U.S. Senate,,NPP,Clive Grey,1508
 Orange,U.S. Senate,,NPP,Gar Myers,522
 Orange,U.S. Senate,,LIB,Mark Matthew Herd,2889
 Orange,U.S. Senate,,NPP,Scott A. Vineberg,1998
-Orange,U.S. Senate,,REP,Ron  Unz,9122
+Orange,U.S. Senate,,REP,Ron Unz,9122
 Orange,U.S. Senate,,NPP,Ric M. Llewellyn,1
 Orange,U.S. Senate,,REP,Billy Falling,3
 Orange,U.S. Senate,,REP,Alexis Stuart,0
@@ -4838,7 +4838,7 @@ Placer,U.S. Senate,,NPP,Clive Grey,435
 Placer,U.S. Senate,,NPP,Gar Myers,43
 Placer,U.S. Senate,,LIB,Mark Matthew Herd,578
 Placer,U.S. Senate,,NPP,Scott A. Vineberg,291
-Placer,U.S. Senate,,REP,Ron  Unz,2764
+Placer,U.S. Senate,,REP,Ron Unz,2764
 Placer,U.S. Senate,,NPP,Ric M. Llewellyn,0
 Placer,U.S. Senate,,REP,Billy Falling,0
 Placer,U.S. Senate,,REP,Alexis Stuart,0
@@ -4905,7 +4905,7 @@ Plumas,U.S. Senate,,NPP,Clive Grey,42
 Plumas,U.S. Senate,,NPP,Gar Myers,5
 Plumas,U.S. Senate,,LIB,Mark Matthew Herd,19
 Plumas,U.S. Senate,,NPP,Scott A. Vineberg,3
-Plumas,U.S. Senate,,REP,Ron  Unz,78
+Plumas,U.S. Senate,,REP,Ron Unz,78
 Plumas,U.S. Senate,,NPP,Ric M. Llewellyn,0
 Plumas,U.S. Senate,,REP,Billy Falling,0
 Plumas,U.S. Senate,,REP,Alexis Stuart,0
@@ -4954,7 +4954,7 @@ Riverside,U.S. Senate,,NPP,Clive Grey,1828
 Riverside,U.S. Senate,,NPP,Gar Myers,760
 Riverside,U.S. Senate,,LIB,Mark Matthew Herd,1658
 Riverside,U.S. Senate,,NPP,Scott A. Vineberg,466
-Riverside,U.S. Senate,,REP,Ron  Unz,4649
+Riverside,U.S. Senate,,REP,Ron Unz,4649
 Riverside,U.S. Senate,,NPP,Ric M. Llewellyn,1
 Riverside,U.S. Senate,,REP,Billy Falling,2
 Riverside,U.S. Senate,,REP,Alexis Stuart,0
@@ -5027,7 +5027,7 @@ Sacramento,U.S. Senate,,NPP,Clive Grey,704
 Sacramento,U.S. Senate,,NPP,Gar Myers,268
 Sacramento,U.S. Senate,,LIB,Mark Matthew Herd,2005
 Sacramento,U.S. Senate,,NPP,Scott A. Vineberg,500
-Sacramento,U.S. Senate,,REP,Ron  Unz,6686
+Sacramento,U.S. Senate,,REP,Ron Unz,6686
 Sacramento,U.S. Senate,,NPP,Ric M. Llewellyn,0
 Sacramento,U.S. Senate,,REP,Billy Falling,4
 Sacramento,U.S. Senate,,REP,Alexis Stuart,1
@@ -5110,7 +5110,7 @@ San Benito,U.S. Senate,,NPP,Clive Grey,32
 San Benito,U.S. Senate,,NPP,Gar Myers,4
 San Benito,U.S. Senate,,LIB,Mark Matthew Herd,32
 San Benito,U.S. Senate,,NPP,Scott A. Vineberg,16
-San Benito,U.S. Senate,,REP,Ron  Unz,169
+San Benito,U.S. Senate,,REP,Ron Unz,169
 San Benito,U.S. Senate,,NPP,Ric M. Llewellyn,0
 San Benito,U.S. Senate,,REP,Billy Falling,0
 San Benito,U.S. Senate,,REP,Alexis Stuart,0
@@ -5156,7 +5156,7 @@ San Bernardino,U.S. Senate,,NPP,Clive Grey,882
 San Bernardino,U.S. Senate,,NPP,Gar Myers,387
 San Bernardino,U.S. Senate,,LIB,Mark Matthew Herd,2370
 San Bernardino,U.S. Senate,,NPP,Scott A. Vineberg,571
-San Bernardino,U.S. Senate,,REP,Ron  Unz,3867
+San Bernardino,U.S. Senate,,REP,Ron Unz,3867
 San Bernardino,U.S. Senate,,NPP,Ric M. Llewellyn,0
 San Bernardino,U.S. Senate,,REP,Billy Falling,0
 San Bernardino,U.S. Senate,,REP,Alexis Stuart,0
@@ -5252,7 +5252,7 @@ San Diego,U.S. Senate,,NPP,Clive Grey,2680
 San Diego,U.S. Senate,,NPP,Gar Myers,660
 San Diego,U.S. Senate,,LIB,Mark Matthew Herd,4832
 San Diego,U.S. Senate,,NPP,Scott A. Vineberg,779
-San Diego,U.S. Senate,,REP,Ron  Unz,10509
+San Diego,U.S. Senate,,REP,Ron Unz,10509
 San Diego,U.S. Senate,,NPP,Ric M. Llewellyn,0
 San Diego,U.S. Senate,,REP,Billy Falling,66
 San Diego,U.S. Senate,,REP,Alexis Stuart,0
@@ -5331,7 +5331,7 @@ San Francisco,U.S. Senate,,NPP,Clive Grey,665
 San Francisco,U.S. Senate,,NPP,Gar Myers,272
 San Francisco,U.S. Senate,,LIB,Mark Matthew Herd,1506
 San Francisco,U.S. Senate,,NPP,Scott A. Vineberg,587
-San Francisco,U.S. Senate,,REP,Ron  Unz,994
+San Francisco,U.S. Senate,,REP,Ron Unz,994
 San Francisco,U.S. Senate,,NPP,Ric M. Llewellyn,0
 San Francisco,U.S. Senate,,REP,Billy Falling,0
 San Francisco,U.S. Senate,,REP,Alexis Stuart,0
@@ -5385,7 +5385,7 @@ San Joaquin,U.S. Senate,,NPP,Clive Grey,696
 San Joaquin,U.S. Senate,,NPP,Gar Myers,123
 San Joaquin,U.S. Senate,,LIB,Mark Matthew Herd,783
 San Joaquin,U.S. Senate,,NPP,Scott A. Vineberg,102
-San Joaquin,U.S. Senate,,REP,Ron  Unz,3019
+San Joaquin,U.S. Senate,,REP,Ron Unz,3019
 San Joaquin,U.S. Senate,,NPP,Ric M. Llewellyn,0
 San Joaquin,U.S. Senate,,REP,Billy Falling,0
 San Joaquin,U.S. Senate,,REP,Alexis Stuart,0
@@ -5444,7 +5444,7 @@ San Luis Obispo,U.S. Senate,,NPP,Clive Grey,791
 San Luis Obispo,U.S. Senate,,NPP,Gar Myers,45
 San Luis Obispo,U.S. Senate,,LIB,Mark Matthew Herd,354
 San Luis Obispo,U.S. Senate,,NPP,Scott A. Vineberg,79
-San Luis Obispo,U.S. Senate,,REP,Ron  Unz,771
+San Luis Obispo,U.S. Senate,,REP,Ron Unz,771
 San Luis Obispo,U.S. Senate,,NPP,Ric M. Llewellyn,0
 San Luis Obispo,U.S. Senate,,REP,Billy Falling,0
 San Luis Obispo,U.S. Senate,,REP,Alexis Stuart,4
@@ -5498,7 +5498,7 @@ San Mateo,U.S. Senate,,NPP,Clive Grey,973
 San Mateo,U.S. Senate,,NPP,Gar Myers,477
 San Mateo,U.S. Senate,,LIB,Mark Matthew Herd,593
 San Mateo,U.S. Senate,,NPP,Scott A. Vineberg,192
-San Mateo,U.S. Senate,,REP,Ron  Unz,1223
+San Mateo,U.S. Senate,,REP,Ron Unz,1223
 San Mateo,U.S. Senate,,NPP,Ric M. Llewellyn,1
 San Mateo,U.S. Senate,,REP,Billy Falling,1
 San Mateo,U.S. Senate,,REP,Alexis Stuart,0
@@ -5561,7 +5561,7 @@ Santa Barbara,U.S. Senate,,NPP,Clive Grey,441
 Santa Barbara,U.S. Senate,,NPP,Gar Myers,52
 Santa Barbara,U.S. Senate,,LIB,Mark Matthew Herd,428
 Santa Barbara,U.S. Senate,,NPP,Scott A. Vineberg,152
-Santa Barbara,U.S. Senate,,REP,Ron  Unz,1562
+Santa Barbara,U.S. Senate,,REP,Ron Unz,1562
 Santa Barbara,U.S. Senate,,NPP,Ric M. Llewellyn,0
 Santa Barbara,U.S. Senate,,REP,Billy Falling,0
 Santa Barbara,U.S. Senate,,REP,Alexis Stuart,0
@@ -5615,7 +5615,7 @@ Santa Clara,U.S. Senate,,NPP,Clive Grey,2053
 Santa Clara,U.S. Senate,,NPP,Gar Myers,413
 Santa Clara,U.S. Senate,,LIB,Mark Matthew Herd,1689
 Santa Clara,U.S. Senate,,NPP,Scott A. Vineberg,520
-Santa Clara,U.S. Senate,,REP,Ron  Unz,3517
+Santa Clara,U.S. Senate,,REP,Ron Unz,3517
 Santa Clara,U.S. Senate,,NPP,Ric M. Llewellyn,0
 Santa Clara,U.S. Senate,,REP,Billy Falling,0
 Santa Clara,U.S. Senate,,REP,Alexis Stuart,0
@@ -5702,7 +5702,7 @@ Santa Cruz,U.S. Senate,,NPP,Clive Grey,326
 Santa Cruz,U.S. Senate,,NPP,Gar Myers,46
 Santa Cruz,U.S. Senate,,LIB,Mark Matthew Herd,349
 Santa Cruz,U.S. Senate,,NPP,Scott A. Vineberg,96
-Santa Cruz,U.S. Senate,,REP,Ron  Unz,525
+Santa Cruz,U.S. Senate,,REP,Ron Unz,525
 Santa Cruz,U.S. Senate,,NPP,Ric M. Llewellyn,0
 Santa Cruz,U.S. Senate,,REP,Billy Falling,1
 Santa Cruz,U.S. Senate,,REP,Alexis Stuart,0
@@ -5755,7 +5755,7 @@ Shasta,U.S. Senate,,NPP,Clive Grey,277
 Shasta,U.S. Senate,,NPP,Gar Myers,43
 Shasta,U.S. Senate,,LIB,Mark Matthew Herd,233
 Shasta,U.S. Senate,,NPP,Scott A. Vineberg,69
-Shasta,U.S. Senate,,REP,Ron  Unz,674
+Shasta,U.S. Senate,,REP,Ron Unz,674
 Shasta,U.S. Senate,,NPP,Ric M. Llewellyn,1
 Shasta,U.S. Senate,,REP,Billy Falling,0
 Shasta,U.S. Senate,,REP,Alexis Stuart,0
@@ -5804,7 +5804,7 @@ Sierra,U.S. Senate,,NPP,Clive Grey,17
 Sierra,U.S. Senate,,NPP,Gar Myers,0
 Sierra,U.S. Senate,,LIB,Mark Matthew Herd,4
 Sierra,U.S. Senate,,NPP,Scott A. Vineberg,5
-Sierra,U.S. Senate,,REP,Ron  Unz,16
+Sierra,U.S. Senate,,REP,Ron Unz,16
 Sierra,U.S. Senate,,NPP,Ric M. Llewellyn,0
 Sierra,U.S. Senate,,REP,Billy Falling,0
 Sierra,U.S. Senate,,REP,Alexis Stuart,0
@@ -5853,7 +5853,7 @@ Siskiyou,U.S. Senate,,NPP,Clive Grey,111
 Siskiyou,U.S. Senate,,NPP,Gar Myers,19
 Siskiyou,U.S. Senate,,LIB,Mark Matthew Herd,94
 Siskiyou,U.S. Senate,,NPP,Scott A. Vineberg,32
-Siskiyou,U.S. Senate,,REP,Ron  Unz,130
+Siskiyou,U.S. Senate,,REP,Ron Unz,130
 Siskiyou,U.S. Senate,,NPP,Ric M. Llewellyn,0
 Siskiyou,U.S. Senate,,REP,Billy Falling,0
 Siskiyou,U.S. Senate,,REP,Alexis Stuart,0
@@ -5902,7 +5902,7 @@ Solano,U.S. Senate,,NPP,Clive Grey,445
 Solano,U.S. Senate,,NPP,Gar Myers,98
 Solano,U.S. Senate,,LIB,Mark Matthew Herd,594
 Solano,U.S. Senate,,NPP,Scott A. Vineberg,69
-Solano,U.S. Senate,,REP,Ron  Unz,1953
+Solano,U.S. Senate,,REP,Ron Unz,1953
 Solano,U.S. Senate,,NPP,Ric M. Llewellyn,0
 Solano,U.S. Senate,,REP,Billy Falling,0
 Solano,U.S. Senate,,REP,Alexis Stuart,0
@@ -5961,7 +5961,7 @@ Sonoma,U.S. Senate,,NPP,Clive Grey,677
 Sonoma,U.S. Senate,,NPP,Gar Myers,76
 Sonoma,U.S. Senate,,LIB,Mark Matthew Herd,1045
 Sonoma,U.S. Senate,,NPP,Scott A. Vineberg,161
-Sonoma,U.S. Senate,,REP,Ron  Unz,1514
+Sonoma,U.S. Senate,,REP,Ron Unz,1514
 Sonoma,U.S. Senate,,NPP,Ric M. Llewellyn,3
 Sonoma,U.S. Senate,,REP,Billy Falling,0
 Sonoma,U.S. Senate,,REP,Alexis Stuart,1
@@ -6021,7 +6021,7 @@ Stanislaus,U.S. Senate,,NPP,Clive Grey,469
 Stanislaus,U.S. Senate,,NPP,Gar Myers,191
 Stanislaus,U.S. Senate,,LIB,Mark Matthew Herd,670
 Stanislaus,U.S. Senate,,NPP,Scott A. Vineberg,86
-Stanislaus,U.S. Senate,,REP,Ron  Unz,2048
+Stanislaus,U.S. Senate,,REP,Ron Unz,2048
 Stanislaus,U.S. Senate,,NPP,Ric M. Llewellyn,0
 Stanislaus,U.S. Senate,,REP,Billy Falling,0
 Stanislaus,U.S. Senate,,REP,Alexis Stuart,0
@@ -6073,7 +6073,7 @@ Sutter,U.S. Senate,,NPP,Clive Grey,56
 Sutter,U.S. Senate,,NPP,Gar Myers,7
 Sutter,U.S. Senate,,LIB,Mark Matthew Herd,81
 Sutter,U.S. Senate,,NPP,Scott A. Vineberg,40
-Sutter,U.S. Senate,,REP,Ron  Unz,450
+Sutter,U.S. Senate,,REP,Ron Unz,450
 Sutter,U.S. Senate,,NPP,Ric M. Llewellyn,0
 Sutter,U.S. Senate,,REP,Billy Falling,0
 Sutter,U.S. Senate,,REP,Alexis Stuart,0
@@ -6116,7 +6116,7 @@ Tehama,U.S. Senate,,NPP,Clive Grey,133
 Tehama,U.S. Senate,,NPP,Gar Myers,17
 Tehama,U.S. Senate,,LIB,Mark Matthew Herd,77
 Tehama,U.S. Senate,,NPP,Scott A. Vineberg,26
-Tehama,U.S. Senate,,REP,Ron  Unz,226
+Tehama,U.S. Senate,,REP,Ron Unz,226
 Tehama,U.S. Senate,,NPP,Ric M. Llewellyn,0
 Tehama,U.S. Senate,,REP,Billy Falling,1
 Tehama,U.S. Senate,,REP,Alexis Stuart,0
@@ -6163,7 +6163,7 @@ Trinity,U.S. Senate,,NPP,Clive Grey,45
 Trinity,U.S. Senate,,NPP,Gar Myers,2
 Trinity,U.S. Senate,,LIB,Mark Matthew Herd,35
 Trinity,U.S. Senate,,NPP,Scott A. Vineberg,3
-Trinity,U.S. Senate,,REP,Ron  Unz,60
+Trinity,U.S. Senate,,REP,Ron Unz,60
 Trinity,U.S. Senate,,NPP,Ric M. Llewellyn,0
 Trinity,U.S. Senate,,REP,Billy Falling,0
 Trinity,U.S. Senate,,REP,Alexis Stuart,0
@@ -6207,7 +6207,7 @@ Tulare,U.S. Senate,,NPP,Clive Grey,583
 Tulare,U.S. Senate,,NPP,Gar Myers,33
 Tulare,U.S. Senate,,LIB,Mark Matthew Herd,153
 Tulare,U.S. Senate,,NPP,Scott A. Vineberg,72
-Tulare,U.S. Senate,,REP,Ron  Unz,492
+Tulare,U.S. Senate,,REP,Ron Unz,492
 Tulare,U.S. Senate,,NPP,Ric M. Llewellyn,0
 Tulare,U.S. Senate,,REP,Billy Falling,1
 Tulare,U.S. Senate,,REP,Alexis Stuart,1
@@ -6259,7 +6259,7 @@ Tuolumne,U.S. Senate,,NPP,Clive Grey,111
 Tuolumne,U.S. Senate,,NPP,Gar Myers,11
 Tuolumne,U.S. Senate,,LIB,Mark Matthew Herd,83
 Tuolumne,U.S. Senate,,NPP,Scott A. Vineberg,25
-Tuolumne,U.S. Senate,,REP,Ron  Unz,386
+Tuolumne,U.S. Senate,,REP,Ron Unz,386
 Tuolumne,U.S. Senate,,NPP,Ric M. Llewellyn,0
 Tuolumne,U.S. Senate,,REP,Billy Falling,0
 Tuolumne,U.S. Senate,,REP,Alexis Stuart,0
@@ -6303,7 +6303,7 @@ Ventura,U.S. Senate,,NPP,Clive Grey,641
 Ventura,U.S. Senate,,NPP,Gar Myers,157
 Ventura,U.S. Senate,,LIB,Mark Matthew Herd,1248
 Ventura,U.S. Senate,,NPP,Scott A. Vineberg,222
-Ventura,U.S. Senate,,REP,Ron  Unz,3846
+Ventura,U.S. Senate,,REP,Ron Unz,3846
 Ventura,U.S. Senate,,NPP,Ric M. Llewellyn,0
 Ventura,U.S. Senate,,REP,Billy Falling,1
 Ventura,U.S. Senate,,REP,Alexis Stuart,0
@@ -6382,7 +6382,7 @@ Yolo,U.S. Senate,,NPP,Clive Grey,133
 Yolo,U.S. Senate,,NPP,Gar Myers,23
 Yolo,U.S. Senate,,LIB,Mark Matthew Herd,318
 Yolo,U.S. Senate,,NPP,Scott A. Vineberg,39
-Yolo,U.S. Senate,,REP,Ron  Unz,914
+Yolo,U.S. Senate,,REP,Ron Unz,914
 Yolo,U.S. Senate,,NPP,Ric M. Llewellyn,0
 Yolo,U.S. Senate,,REP,Billy Falling,0
 Yolo,U.S. Senate,,REP,Alexis Stuart,0
@@ -6440,7 +6440,7 @@ Yuba,U.S. Senate,,NPP,Clive Grey,48
 Yuba,U.S. Senate,,NPP,Gar Myers,18
 Yuba,U.S. Senate,,LIB,Mark Matthew Herd,127
 Yuba,U.S. Senate,,NPP,Scott A. Vineberg,49
-Yuba,U.S. Senate,,REP,Ron  Unz,372
+Yuba,U.S. Senate,,REP,Ron Unz,372
 Yuba,U.S. Senate,,NPP,Ric M. Llewellyn,0
 Yuba,U.S. Senate,,REP,Billy Falling,0
 Yuba,U.S. Senate,,REP,Alexis Stuart,0

--- a/src/parse_primary_2016.py
+++ b/src/parse_primary_2016.py
@@ -24,6 +24,8 @@ party_dict = {'Democratic': 'DEM',
 office_dict = {'United States Representative': 'U.S. House',
                'State Assembly Member': 'State Assembly'}
 
+# Clean up candidate names
+candidate_dict = {'Ron  Unz': 'Ron Unz'}
 
 # Columns to select
 columns = ['COUNTY_NAME', 'office', 'district',
@@ -48,7 +50,8 @@ voter_nominated = pandas.concat([voter_nominated, contest_split], axis=1)
 voter_nominated = voter_nominated.replace({'office': office_dict})[columns]
 
 result = pandas.concat([presidential, voter_nominated]
-                       ).replace({'PARTY_NAME': party_dict})
+                       ).replace({'PARTY_NAME': party_dict,
+                                  'CANDIDATE_NAME': candidate_dict})
 
 output_columns = ['county', 'office',
                   'district', 'party', 'candidate', 'votes']


### PR DESCRIPTION
CA SoS files have the U.S. Senate candidate Ron Unz coded as Ron  Unz (note two spaces).  Update the parsing code to clean this name up, and rerun to regenerate the clean data.  The test now passes.

Fixes #32 