### PR TITLE
Normalize candidate names.

### DIFF
--- a/2016/20161108__ca__general__alameda__precinct.csv
+++ b/2016/20161108__ca__general__alameda__precinct.csv
@@ -46239,2315 +46239,2315 @@ Alameda,9880400,Proposition 67,,N/A,Yes,0
 Alameda,9880400,Proposition 67,,N/A,No,0
 Alameda,9880500,Proposition 67,,N/A,Yes,0
 Alameda,9880500,Proposition 67,,N/A,No,0
-Alameda,200100,U.S. Senate,,DEM,Kamala Harris,535
-Alameda,200100,U.S. Senate,,DEM,Loretta Sanchez,79
-Alameda,200200,U.S. Senate,,DEM,Kamala Harris,501
-Alameda,200200,U.S. Senate,,DEM,Loretta Sanchez,84
-Alameda,200300,U.S. Senate,,DEM,Kamala Harris,388
-Alameda,200300,U.S. Senate,,DEM,Loretta Sanchez,75
-Alameda,200600,U.S. Senate,,DEM,Kamala Harris,467
-Alameda,200600,U.S. Senate,,DEM,Loretta Sanchez,69
-Alameda,200700,U.S. Senate,,DEM,Kamala Harris,469
-Alameda,200700,U.S. Senate,,DEM,Loretta Sanchez,71
-Alameda,200800,U.S. Senate,,DEM,Kamala Harris,444
-Alameda,200800,U.S. Senate,,DEM,Loretta Sanchez,67
-Alameda,201000,U.S. Senate,,DEM,Kamala Harris,443
-Alameda,201000,U.S. Senate,,DEM,Loretta Sanchez,69
-Alameda,201100,U.S. Senate,,DEM,Kamala Harris,480
-Alameda,201100,U.S. Senate,,DEM,Loretta Sanchez,57
-Alameda,201300,U.S. Senate,,DEM,Kamala Harris,454
-Alameda,201300,U.S. Senate,,DEM,Loretta Sanchez,68
-Alameda,201400,U.S. Senate,,DEM,Kamala Harris,484
-Alameda,201400,U.S. Senate,,DEM,Loretta Sanchez,67
-Alameda,201410,U.S. Senate,,DEM,Kamala Harris,403
-Alameda,201410,U.S. Senate,,DEM,Loretta Sanchez,61
-Alameda,201500,U.S. Senate,,DEM,Kamala Harris,436
-Alameda,201500,U.S. Senate,,DEM,Loretta Sanchez,61
-Alameda,201700,U.S. Senate,,DEM,Kamala Harris,377
-Alameda,201700,U.S. Senate,,DEM,Loretta Sanchez,82
-Alameda,201710,U.S. Senate,,DEM,Kamala Harris,485
-Alameda,201710,U.S. Senate,,DEM,Loretta Sanchez,136
-Alameda,201800,U.S. Senate,,DEM,Kamala Harris,522
-Alameda,201800,U.S. Senate,,DEM,Loretta Sanchez,84
-Alameda,201900,U.S. Senate,,DEM,Kamala Harris,226
-Alameda,201900,U.S. Senate,,DEM,Loretta Sanchez,65
-Alameda,202010,U.S. Senate,,DEM,Kamala Harris,138
-Alameda,202010,U.S. Senate,,DEM,Loretta Sanchez,33
-Alameda,202110,U.S. Senate,,DEM,Kamala Harris,621
-Alameda,202110,U.S. Senate,,DEM,Loretta Sanchez,150
-Alameda,202310,U.S. Senate,,DEM,Kamala Harris,422
-Alameda,202310,U.S. Senate,,DEM,Loretta Sanchez,76
-Alameda,202500,U.S. Senate,,DEM,Kamala Harris,264
-Alameda,202500,U.S. Senate,,DEM,Loretta Sanchez,85
-Alameda,202520,U.S. Senate,,DEM,Kamala Harris,290
-Alameda,202520,U.S. Senate,,DEM,Loretta Sanchez,84
-Alameda,202540,U.S. Senate,,DEM,Kamala Harris,353
-Alameda,202540,U.S. Senate,,DEM,Loretta Sanchez,118
-Alameda,202600,U.S. Senate,,DEM,Kamala Harris,316
-Alameda,202600,U.S. Senate,,DEM,Loretta Sanchez,141
-Alameda,202620,U.S. Senate,,DEM,Kamala Harris,316
-Alameda,202620,U.S. Senate,,DEM,Loretta Sanchez,129
-Alameda,202710,U.S. Senate,,DEM,Kamala Harris,394
-Alameda,202710,U.S. Senate,,DEM,Loretta Sanchez,90
-Alameda,202900,U.S. Senate,,DEM,Kamala Harris,434
-Alameda,202900,U.S. Senate,,DEM,Loretta Sanchez,59
-Alameda,203100,U.S. Senate,,DEM,Kamala Harris,517
-Alameda,203100,U.S. Senate,,DEM,Loretta Sanchez,69
-Alameda,203200,U.S. Senate,,DEM,Kamala Harris,408
-Alameda,203200,U.S. Senate,,DEM,Loretta Sanchez,45
-Alameda,203300,U.S. Senate,,DEM,Kamala Harris,525
-Alameda,203300,U.S. Senate,,DEM,Loretta Sanchez,73
-Alameda,203400,U.S. Senate,,DEM,Kamala Harris,468
-Alameda,203400,U.S. Senate,,DEM,Loretta Sanchez,70
-Alameda,203500,U.S. Senate,,DEM,Kamala Harris,744
-Alameda,203500,U.S. Senate,,DEM,Loretta Sanchez,143
-Alameda,203800,U.S. Senate,,DEM,Kamala Harris,626
-Alameda,203800,U.S. Senate,,DEM,Loretta Sanchez,109
-Alameda,204000,U.S. Senate,,DEM,Kamala Harris,184
-Alameda,204000,U.S. Senate,,DEM,Loretta Sanchez,28
-Alameda,204100,U.S. Senate,,DEM,Kamala Harris,330
-Alameda,204100,U.S. Senate,,DEM,Loretta Sanchez,54
-Alameda,204210,U.S. Senate,,DEM,Kamala Harris,437
-Alameda,204210,U.S. Senate,,DEM,Loretta Sanchez,135
-Alameda,204220,U.S. Senate,,DEM,Kamala Harris,297
-Alameda,204220,U.S. Senate,,DEM,Loretta Sanchez,97
-Alameda,204230,U.S. Senate,,DEM,Kamala Harris,427
-Alameda,204230,U.S. Senate,,DEM,Loretta Sanchez,64
-Alameda,204240,U.S. Senate,,DEM,Kamala Harris,267
-Alameda,204240,U.S. Senate,,DEM,Loretta Sanchez,88
-Alameda,204300,U.S. Senate,,DEM,Kamala Harris,477
-Alameda,204300,U.S. Senate,,DEM,Loretta Sanchez,76
-Alameda,204310,U.S. Senate,,DEM,Kamala Harris,529
-Alameda,204310,U.S. Senate,,DEM,Loretta Sanchez,91
-Alameda,204510,U.S. Senate,,DEM,Kamala Harris,443
-Alameda,204510,U.S. Senate,,DEM,Loretta Sanchez,121
-Alameda,204600,U.S. Senate,,DEM,Kamala Harris,376
-Alameda,204600,U.S. Senate,,DEM,Loretta Sanchez,112
-Alameda,204900,U.S. Senate,,DEM,Kamala Harris,271
-Alameda,204900,U.S. Senate,,DEM,Loretta Sanchez,126
-Alameda,204910,U.S. Senate,,DEM,Kamala Harris,361
-Alameda,204910,U.S. Senate,,DEM,Loretta Sanchez,132
-Alameda,205000,U.S. Senate,,DEM,Kamala Harris,489
-Alameda,205000,U.S. Senate,,DEM,Loretta Sanchez,53
-Alameda,205100,U.S. Senate,,DEM,Kamala Harris,559
-Alameda,205100,U.S. Senate,,DEM,Loretta Sanchez,76
-Alameda,205200,U.S. Senate,,DEM,Kamala Harris,620
-Alameda,205200,U.S. Senate,,DEM,Loretta Sanchez,82
-Alameda,205500,U.S. Senate,,DEM,Kamala Harris,569
-Alameda,205500,U.S. Senate,,DEM,Loretta Sanchez,72
-Alameda,205600,U.S. Senate,,DEM,Kamala Harris,841
-Alameda,205600,U.S. Senate,,DEM,Loretta Sanchez,127
-Alameda,205700,U.S. Senate,,DEM,Kamala Harris,618
-Alameda,205700,U.S. Senate,,DEM,Loretta Sanchez,69
-Alameda,205800,U.S. Senate,,DEM,Kamala Harris,513
-Alameda,205800,U.S. Senate,,DEM,Loretta Sanchez,61
-Alameda,205900,U.S. Senate,,DEM,Kamala Harris,570
-Alameda,205900,U.S. Senate,,DEM,Loretta Sanchez,55
-Alameda,206000,U.S. Senate,,DEM,Kamala Harris,450
-Alameda,206000,U.S. Senate,,DEM,Loretta Sanchez,50
-Alameda,206100,U.S. Senate,,DEM,Kamala Harris,550
-Alameda,206100,U.S. Senate,,DEM,Loretta Sanchez,79
-Alameda,206200,U.S. Senate,,DEM,Kamala Harris,455
-Alameda,206200,U.S. Senate,,DEM,Loretta Sanchez,68
-Alameda,206300,U.S. Senate,,DEM,Kamala Harris,489
-Alameda,206300,U.S. Senate,,DEM,Loretta Sanchez,81
-Alameda,206400,U.S. Senate,,DEM,Kamala Harris,487
-Alameda,206400,U.S. Senate,,DEM,Loretta Sanchez,66
-Alameda,206600,U.S. Senate,,DEM,Kamala Harris,474
-Alameda,206600,U.S. Senate,,DEM,Loretta Sanchez,116
-Alameda,206900,U.S. Senate,,DEM,Kamala Harris,267
-Alameda,206900,U.S. Senate,,DEM,Loretta Sanchez,57
-Alameda,207000,U.S. Senate,,DEM,Kamala Harris,591
-Alameda,207000,U.S. Senate,,DEM,Loretta Sanchez,95
-Alameda,207010,U.S. Senate,,DEM,Kamala Harris,558
-Alameda,207010,U.S. Senate,,DEM,Loretta Sanchez,81
-Alameda,207100,U.S. Senate,,DEM,Kamala Harris,253
-Alameda,207100,U.S. Senate,,DEM,Loretta Sanchez,28
-Alameda,207200,U.S. Senate,,DEM,Kamala Harris,467
-Alameda,207200,U.S. Senate,,DEM,Loretta Sanchez,51
-Alameda,207300,U.S. Senate,,DEM,Kamala Harris,428
-Alameda,207300,U.S. Senate,,DEM,Loretta Sanchez,57
-Alameda,207500,U.S. Senate,,DEM,Kamala Harris,592
-Alameda,207500,U.S. Senate,,DEM,Loretta Sanchez,103
-Alameda,207600,U.S. Senate,,DEM,Kamala Harris,400
-Alameda,207600,U.S. Senate,,DEM,Loretta Sanchez,117
-Alameda,207700,U.S. Senate,,DEM,Kamala Harris,703
-Alameda,207700,U.S. Senate,,DEM,Loretta Sanchez,207
-Alameda,208000,U.S. Senate,,DEM,Kamala Harris,417
-Alameda,208000,U.S. Senate,,DEM,Loretta Sanchez,61
-Alameda,208010,U.S. Senate,,DEM,Kamala Harris,729
-Alameda,208010,U.S. Senate,,DEM,Loretta Sanchez,132
-Alameda,208100,U.S. Senate,,DEM,Kamala Harris,445
-Alameda,208100,U.S. Senate,,DEM,Loretta Sanchez,75
-Alameda,208110,U.S. Senate,,DEM,Kamala Harris,402
-Alameda,208110,U.S. Senate,,DEM,Loretta Sanchez,73
-Alameda,208200,U.S. Senate,,DEM,Kamala Harris,440
-Alameda,208200,U.S. Senate,,DEM,Loretta Sanchez,77
-Alameda,208210,U.S. Senate,,DEM,Kamala Harris,518
-Alameda,208210,U.S. Senate,,DEM,Loretta Sanchez,71
-Alameda,208300,U.S. Senate,,DEM,Kamala Harris,620
-Alameda,208300,U.S. Senate,,DEM,Loretta Sanchez,86
-Alameda,208310,U.S. Senate,,DEM,Kamala Harris,472
-Alameda,208310,U.S. Senate,,DEM,Loretta Sanchez,97
-Alameda,208400,U.S. Senate,,DEM,Kamala Harris,569
-Alameda,208400,U.S. Senate,,DEM,Loretta Sanchez,117
-Alameda,208500,U.S. Senate,,DEM,Kamala Harris,531
-Alameda,208500,U.S. Senate,,DEM,Loretta Sanchez,83
-Alameda,208510,U.S. Senate,,DEM,Kamala Harris,636
-Alameda,208510,U.S. Senate,,DEM,Loretta Sanchez,69
-Alameda,208600,U.S. Senate,,DEM,Kamala Harris,531
-Alameda,208600,U.S. Senate,,DEM,Loretta Sanchez,81
-Alameda,208610,U.S. Senate,,DEM,Kamala Harris,592
-Alameda,208610,U.S. Senate,,DEM,Loretta Sanchez,81
-Alameda,208650,U.S. Senate,,DEM,Kamala Harris,272
-Alameda,208650,U.S. Senate,,DEM,Loretta Sanchez,46
-Alameda,208700,U.S. Senate,,DEM,Kamala Harris,615
-Alameda,208700,U.S. Senate,,DEM,Loretta Sanchez,126
-Alameda,208800,U.S. Senate,,DEM,Kamala Harris,608
-Alameda,208800,U.S. Senate,,DEM,Loretta Sanchez,110
-Alameda,208810,U.S. Senate,,DEM,Kamala Harris,657
-Alameda,208810,U.S. Senate,,DEM,Loretta Sanchez,101
-Alameda,208900,U.S. Senate,,DEM,Kamala Harris,575
-Alameda,208900,U.S. Senate,,DEM,Loretta Sanchez,117
-Alameda,208910,U.S. Senate,,DEM,Kamala Harris,485
-Alameda,208910,U.S. Senate,,DEM,Loretta Sanchez,96
-Alameda,208920,U.S. Senate,,DEM,Kamala Harris,320
-Alameda,208920,U.S. Senate,,DEM,Loretta Sanchez,50
-Alameda,209000,U.S. Senate,,DEM,Kamala Harris,562
-Alameda,209000,U.S. Senate,,DEM,Loretta Sanchez,72
-Alameda,209010,U.S. Senate,,DEM,Kamala Harris,577
-Alameda,209010,U.S. Senate,,DEM,Loretta Sanchez,101
-Alameda,209100,U.S. Senate,,DEM,Kamala Harris,545
-Alameda,209100,U.S. Senate,,DEM,Loretta Sanchez,66
-Alameda,209110,U.S. Senate,,DEM,Kamala Harris,501
-Alameda,209110,U.S. Senate,,DEM,Loretta Sanchez,67
-Alameda,209200,U.S. Senate,,DEM,Kamala Harris,714
-Alameda,209200,U.S. Senate,,DEM,Loretta Sanchez,133
-Alameda,209300,U.S. Senate,,DEM,Kamala Harris,819
-Alameda,209300,U.S. Senate,,DEM,Loretta Sanchez,140
-Alameda,209310,U.S. Senate,,DEM,Kamala Harris,841
-Alameda,209310,U.S. Senate,,DEM,Loretta Sanchez,124
-Alameda,209400,U.S. Senate,,DEM,Kamala Harris,703
-Alameda,209400,U.S. Senate,,DEM,Loretta Sanchez,86
-Alameda,209410,U.S. Senate,,DEM,Kamala Harris,389
-Alameda,209410,U.S. Senate,,DEM,Loretta Sanchez,55
-Alameda,209510,U.S. Senate,,DEM,Kamala Harris,789
-Alameda,209510,U.S. Senate,,DEM,Loretta Sanchez,94
-Alameda,209600,U.S. Senate,,DEM,Kamala Harris,562
-Alameda,209600,U.S. Senate,,DEM,Loretta Sanchez,99
-Alameda,209610,U.S. Senate,,DEM,Kamala Harris,378
-Alameda,209610,U.S. Senate,,DEM,Loretta Sanchez,77
-Alameda,209700,U.S. Senate,,DEM,Kamala Harris,566
-Alameda,209700,U.S. Senate,,DEM,Loretta Sanchez,138
-Alameda,209710,U.S. Senate,,DEM,Kamala Harris,555
-Alameda,209710,U.S. Senate,,DEM,Loretta Sanchez,117
-Alameda,209800,U.S. Senate,,DEM,Kamala Harris,483
-Alameda,209800,U.S. Senate,,DEM,Loretta Sanchez,108
-Alameda,209900,U.S. Senate,,DEM,Kamala Harris,617
-Alameda,209900,U.S. Senate,,DEM,Loretta Sanchez,117
-Alameda,213100,U.S. Senate,,DEM,Kamala Harris,696
-Alameda,213100,U.S. Senate,,DEM,Loretta Sanchez,160
-Alameda,213300,U.S. Senate,,DEM,Kamala Harris,811
-Alameda,213300,U.S. Senate,,DEM,Loretta Sanchez,228
-Alameda,213400,U.S. Senate,,DEM,Kamala Harris,405
-Alameda,213400,U.S. Senate,,DEM,Loretta Sanchez,104
-Alameda,213500,U.S. Senate,,DEM,Kamala Harris,886
-Alameda,213500,U.S. Senate,,DEM,Loretta Sanchez,175
-Alameda,213600,U.S. Senate,,DEM,Kamala Harris,586
-Alameda,213600,U.S. Senate,,DEM,Loretta Sanchez,118
-Alameda,213700,U.S. Senate,,DEM,Kamala Harris,503
-Alameda,213700,U.S. Senate,,DEM,Loretta Sanchez,92
-Alameda,213800,U.S. Senate,,DEM,Kamala Harris,726
-Alameda,213800,U.S. Senate,,DEM,Loretta Sanchez,157
-Alameda,213900,U.S. Senate,,DEM,Kamala Harris,403
-Alameda,213900,U.S. Senate,,DEM,Loretta Sanchez,80
-Alameda,214100,U.S. Senate,,DEM,Kamala Harris,543
-Alameda,214100,U.S. Senate,,DEM,Loretta Sanchez,117
-Alameda,214200,U.S. Senate,,DEM,Kamala Harris,760
-Alameda,214200,U.S. Senate,,DEM,Loretta Sanchez,159
-Alameda,214300,U.S. Senate,,DEM,Kamala Harris,447
-Alameda,214300,U.S. Senate,,DEM,Loretta Sanchez,96
-Alameda,214400,U.S. Senate,,DEM,Kamala Harris,502
-Alameda,214400,U.S. Senate,,DEM,Loretta Sanchez,99
-Alameda,214500,U.S. Senate,,DEM,Kamala Harris,474
-Alameda,214500,U.S. Senate,,DEM,Loretta Sanchez,79
-Alameda,214600,U.S. Senate,,DEM,Kamala Harris,727
-Alameda,214600,U.S. Senate,,DEM,Loretta Sanchez,114
-Alameda,214800,U.S. Senate,,DEM,Kamala Harris,814
-Alameda,214800,U.S. Senate,,DEM,Loretta Sanchez,122
-Alameda,215100,U.S. Senate,,DEM,Kamala Harris,797
-Alameda,215100,U.S. Senate,,DEM,Loretta Sanchez,101
-Alameda,215120,U.S. Senate,,DEM,Kamala Harris,835
-Alameda,215120,U.S. Senate,,DEM,Loretta Sanchez,132
-Alameda,215200,U.S. Senate,,DEM,Kamala Harris,516
-Alameda,215200,U.S. Senate,,DEM,Loretta Sanchez,74
-Alameda,215300,U.S. Senate,,DEM,Kamala Harris,786
-Alameda,215300,U.S. Senate,,DEM,Loretta Sanchez,106
-Alameda,215500,U.S. Senate,,DEM,Kamala Harris,543
-Alameda,215500,U.S. Senate,,DEM,Loretta Sanchez,91
-Alameda,215610,U.S. Senate,,DEM,Kamala Harris,877
-Alameda,215610,U.S. Senate,,DEM,Loretta Sanchez,146
-Alameda,215700,U.S. Senate,,DEM,Kamala Harris,631
-Alameda,215700,U.S. Senate,,DEM,Loretta Sanchez,116
-Alameda,215800,U.S. Senate,,DEM,Kamala Harris,541
-Alameda,215800,U.S. Senate,,DEM,Loretta Sanchez,103
-Alameda,215900,U.S. Senate,,DEM,Kamala Harris,369
-Alameda,215900,U.S. Senate,,DEM,Loretta Sanchez,75
-Alameda,223000,U.S. Senate,,DEM,Kamala Harris,475
-Alameda,223000,U.S. Senate,,DEM,Loretta Sanchez,94
-Alameda,223010,U.S. Senate,,DEM,Kamala Harris,673
-Alameda,223010,U.S. Senate,,DEM,Loretta Sanchez,103
-Alameda,223200,U.S. Senate,,DEM,Kamala Harris,991
-Alameda,223200,U.S. Senate,,DEM,Loretta Sanchez,176
-Alameda,223300,U.S. Senate,,DEM,Kamala Harris,670
-Alameda,223300,U.S. Senate,,DEM,Loretta Sanchez,94
-Alameda,223400,U.S. Senate,,DEM,Kamala Harris,533
-Alameda,223400,U.S. Senate,,DEM,Loretta Sanchez,69
-Alameda,224000,U.S. Senate,,DEM,Kamala Harris,759
-Alameda,224000,U.S. Senate,,DEM,Loretta Sanchez,124
-Alameda,224200,U.S. Senate,,DEM,Kamala Harris,985
-Alameda,224200,U.S. Senate,,DEM,Loretta Sanchez,152
-Alameda,224400,U.S. Senate,,DEM,Kamala Harris,327
-Alameda,224400,U.S. Senate,,DEM,Loretta Sanchez,81
-Alameda,224500,U.S. Senate,,DEM,Kamala Harris,965
-Alameda,224500,U.S. Senate,,DEM,Loretta Sanchez,170
-Alameda,224600,U.S. Senate,,DEM,Kamala Harris,692
-Alameda,224600,U.S. Senate,,DEM,Loretta Sanchez,87
-Alameda,224700,U.S. Senate,,DEM,Kamala Harris,725
-Alameda,224700,U.S. Senate,,DEM,Loretta Sanchez,128
-Alameda,224800,U.S. Senate,,DEM,Kamala Harris,374
-Alameda,224800,U.S. Senate,,DEM,Loretta Sanchez,50
-Alameda,225000,U.S. Senate,,DEM,Kamala Harris,406
-Alameda,225000,U.S. Senate,,DEM,Loretta Sanchez,37
-Alameda,225100,U.S. Senate,,DEM,Kamala Harris,613
-Alameda,225100,U.S. Senate,,DEM,Loretta Sanchez,70
-Alameda,225200,U.S. Senate,,DEM,Kamala Harris,435
-Alameda,225200,U.S. Senate,,DEM,Loretta Sanchez,62
-Alameda,225400,U.S. Senate,,DEM,Kamala Harris,930
-Alameda,225400,U.S. Senate,,DEM,Loretta Sanchez,199
-Alameda,225600,U.S. Senate,,DEM,Kamala Harris,538
-Alameda,225600,U.S. Senate,,DEM,Loretta Sanchez,96
-Alameda,225700,U.S. Senate,,DEM,Kamala Harris,708
-Alameda,225700,U.S. Senate,,DEM,Loretta Sanchez,133
-Alameda,225710,U.S. Senate,,DEM,Kamala Harris,743
-Alameda,225710,U.S. Senate,,DEM,Loretta Sanchez,109
-Alameda,225810,U.S. Senate,,DEM,Kamala Harris,501
-Alameda,225810,U.S. Senate,,DEM,Loretta Sanchez,77
-Alameda,225900,U.S. Senate,,DEM,Kamala Harris,623
-Alameda,225900,U.S. Senate,,DEM,Loretta Sanchez,88
-Alameda,225910,U.S. Senate,,DEM,Kamala Harris,958
-Alameda,225910,U.S. Senate,,DEM,Loretta Sanchez,136
-Alameda,226100,U.S. Senate,,DEM,Kamala Harris,530
-Alameda,226100,U.S. Senate,,DEM,Loretta Sanchez,83
-Alameda,226200,U.S. Senate,,DEM,Kamala Harris,756
-Alameda,226200,U.S. Senate,,DEM,Loretta Sanchez,79
-Alameda,226300,U.S. Senate,,DEM,Kamala Harris,551
-Alameda,226300,U.S. Senate,,DEM,Loretta Sanchez,97
-Alameda,226400,U.S. Senate,,DEM,Kamala Harris,503
-Alameda,226400,U.S. Senate,,DEM,Loretta Sanchez,75
-Alameda,244000,U.S. Senate,,DEM,Kamala Harris,571
-Alameda,244000,U.S. Senate,,DEM,Loretta Sanchez,104
-Alameda,244100,U.S. Senate,,DEM,Kamala Harris,843
-Alameda,244100,U.S. Senate,,DEM,Loretta Sanchez,157
-Alameda,244200,U.S. Senate,,DEM,Kamala Harris,550
-Alameda,244200,U.S. Senate,,DEM,Loretta Sanchez,95
-Alameda,244300,U.S. Senate,,DEM,Kamala Harris,848
-Alameda,244300,U.S. Senate,,DEM,Loretta Sanchez,160
-Alameda,244400,U.S. Senate,,DEM,Kamala Harris,648
-Alameda,244400,U.S. Senate,,DEM,Loretta Sanchez,119
-Alameda,244500,U.S. Senate,,DEM,Kamala Harris,540
-Alameda,244500,U.S. Senate,,DEM,Loretta Sanchez,113
-Alameda,244600,U.S. Senate,,DEM,Kamala Harris,442
-Alameda,244600,U.S. Senate,,DEM,Loretta Sanchez,95
-Alameda,244700,U.S. Senate,,DEM,Kamala Harris,587
-Alameda,244700,U.S. Senate,,DEM,Loretta Sanchez,145
-Alameda,244800,U.S. Senate,,DEM,Kamala Harris,542
-Alameda,244800,U.S. Senate,,DEM,Loretta Sanchez,128
-Alameda,244900,U.S. Senate,,DEM,Kamala Harris,406
-Alameda,244900,U.S. Senate,,DEM,Loretta Sanchez,90
-Alameda,245000,U.S. Senate,,DEM,Kamala Harris,584
-Alameda,245000,U.S. Senate,,DEM,Loretta Sanchez,81
-Alameda,245100,U.S. Senate,,DEM,Kamala Harris,597
-Alameda,245100,U.S. Senate,,DEM,Loretta Sanchez,82
-Alameda,245200,U.S. Senate,,DEM,Kamala Harris,905
-Alameda,245200,U.S. Senate,,DEM,Loretta Sanchez,171
-Alameda,260100,U.S. Senate,,DEM,Kamala Harris,438
-Alameda,260100,U.S. Senate,,DEM,Loretta Sanchez,171
-Alameda,260300,U.S. Senate,,DEM,Kamala Harris,739
-Alameda,260300,U.S. Senate,,DEM,Loretta Sanchez,184
-Alameda,260400,U.S. Senate,,DEM,Kamala Harris,451
-Alameda,260400,U.S. Senate,,DEM,Loretta Sanchez,102
-Alameda,260610,U.S. Senate,,DEM,Kamala Harris,441
-Alameda,260610,U.S. Senate,,DEM,Loretta Sanchez,103
-Alameda,260800,U.S. Senate,,DEM,Kamala Harris,471
-Alameda,260800,U.S. Senate,,DEM,Loretta Sanchez,122
-Alameda,260900,U.S. Senate,,DEM,Kamala Harris,599
-Alameda,260900,U.S. Senate,,DEM,Loretta Sanchez,98
-Alameda,261000,U.S. Senate,,DEM,Kamala Harris,630
-Alameda,261000,U.S. Senate,,DEM,Loretta Sanchez,122
-Alameda,261300,U.S. Senate,,DEM,Kamala Harris,592
-Alameda,261300,U.S. Senate,,DEM,Loretta Sanchez,131
-Alameda,261400,U.S. Senate,,DEM,Kamala Harris,453
-Alameda,261400,U.S. Senate,,DEM,Loretta Sanchez,100
-Alameda,261600,U.S. Senate,,DEM,Kamala Harris,581
-Alameda,261600,U.S. Senate,,DEM,Loretta Sanchez,118
-Alameda,261700,U.S. Senate,,DEM,Kamala Harris,482
-Alameda,261700,U.S. Senate,,DEM,Loretta Sanchez,99
-Alameda,262000,U.S. Senate,,DEM,Kamala Harris,672
-Alameda,262000,U.S. Senate,,DEM,Loretta Sanchez,92
-Alameda,262100,U.S. Senate,,DEM,Kamala Harris,528
-Alameda,262100,U.S. Senate,,DEM,Loretta Sanchez,106
-Alameda,280100,U.S. Senate,,DEM,Kamala Harris,1069
-Alameda,280100,U.S. Senate,,DEM,Loretta Sanchez,202
-Alameda,280500,U.S. Senate,,DEM,Kamala Harris,900
-Alameda,280500,U.S. Senate,,DEM,Loretta Sanchez,279
-Alameda,280700,U.S. Senate,,DEM,Kamala Harris,1059
-Alameda,280700,U.S. Senate,,DEM,Loretta Sanchez,238
-Alameda,281000,U.S. Senate,,DEM,Kamala Harris,842
-Alameda,281000,U.S. Senate,,DEM,Loretta Sanchez,231
-Alameda,281300,U.S. Senate,,DEM,Kamala Harris,764
-Alameda,281300,U.S. Senate,,DEM,Loretta Sanchez,170
-Alameda,281600,U.S. Senate,,DEM,Kamala Harris,747
-Alameda,281600,U.S. Senate,,DEM,Loretta Sanchez,175
-Alameda,300000,U.S. Senate,,DEM,Kamala Harris,713
-Alameda,300000,U.S. Senate,,DEM,Loretta Sanchez,205
-Alameda,300100,U.S. Senate,,DEM,Kamala Harris,763
-Alameda,300100,U.S. Senate,,DEM,Loretta Sanchez,198
-Alameda,300110,U.S. Senate,,DEM,Kamala Harris,505
-Alameda,300110,U.S. Senate,,DEM,Loretta Sanchez,127
-Alameda,300120,U.S. Senate,,DEM,Kamala Harris,809
-Alameda,300120,U.S. Senate,,DEM,Loretta Sanchez,244
-Alameda,300140,U.S. Senate,,DEM,Kamala Harris,687
-Alameda,300140,U.S. Senate,,DEM,Loretta Sanchez,195
-Alameda,300150,U.S. Senate,,DEM,Kamala Harris,583
-Alameda,300150,U.S. Senate,,DEM,Loretta Sanchez,157
-Alameda,300170,U.S. Senate,,DEM,Kamala Harris,347
-Alameda,300170,U.S. Senate,,DEM,Loretta Sanchez,111
-Alameda,300180,U.S. Senate,,DEM,Kamala Harris,432
-Alameda,300180,U.S. Senate,,DEM,Loretta Sanchez,134
-Alameda,300210,U.S. Senate,,DEM,Kamala Harris,461
-Alameda,300210,U.S. Senate,,DEM,Loretta Sanchez,149
-Alameda,300300,U.S. Senate,,DEM,Kamala Harris,471
-Alameda,300300,U.S. Senate,,DEM,Loretta Sanchez,121
-Alameda,300400,U.S. Senate,,DEM,Kamala Harris,885
-Alameda,300400,U.S. Senate,,DEM,Loretta Sanchez,271
-Alameda,301100,U.S. Senate,,DEM,Kamala Harris,472
-Alameda,301100,U.S. Senate,,DEM,Loretta Sanchez,137
-Alameda,301200,U.S. Senate,,DEM,Kamala Harris,495
-Alameda,301200,U.S. Senate,,DEM,Loretta Sanchez,110
-Alameda,301400,U.S. Senate,,DEM,Kamala Harris,911
-Alameda,301400,U.S. Senate,,DEM,Loretta Sanchez,262
-Alameda,301520,U.S. Senate,,DEM,Kamala Harris,897
-Alameda,301520,U.S. Senate,,DEM,Loretta Sanchez,249
-Alameda,301800,U.S. Senate,,DEM,Kamala Harris,553
-Alameda,301800,U.S. Senate,,DEM,Loretta Sanchez,184
-Alameda,301900,U.S. Senate,,DEM,Kamala Harris,555
-Alameda,301900,U.S. Senate,,DEM,Loretta Sanchez,140
-Alameda,302000,U.S. Senate,,DEM,Kamala Harris,590
-Alameda,302000,U.S. Senate,,DEM,Loretta Sanchez,156
-Alameda,302100,U.S. Senate,,DEM,Kamala Harris,391
-Alameda,302100,U.S. Senate,,DEM,Loretta Sanchez,107
-Alameda,302200,U.S. Senate,,DEM,Kamala Harris,902
-Alameda,302200,U.S. Senate,,DEM,Loretta Sanchez,225
-Alameda,302400,U.S. Senate,,DEM,Kamala Harris,401
-Alameda,302400,U.S. Senate,,DEM,Loretta Sanchez,154
-Alameda,302500,U.S. Senate,,DEM,Kamala Harris,786
-Alameda,302500,U.S. Senate,,DEM,Loretta Sanchez,229
-Alameda,302510,U.S. Senate,,DEM,Kamala Harris,475
-Alameda,302510,U.S. Senate,,DEM,Loretta Sanchez,146
-Alameda,302700,U.S. Senate,,DEM,Kamala Harris,515
-Alameda,302700,U.S. Senate,,DEM,Loretta Sanchez,143
-Alameda,303000,U.S. Senate,,DEM,Kamala Harris,478
-Alameda,303000,U.S. Senate,,DEM,Loretta Sanchez,156
-Alameda,303300,U.S. Senate,,DEM,Kamala Harris,654
-Alameda,303300,U.S. Senate,,DEM,Loretta Sanchez,177
-Alameda,303400,U.S. Senate,,DEM,Kamala Harris,438
-Alameda,303400,U.S. Senate,,DEM,Loretta Sanchez,140
-Alameda,303500,U.S. Senate,,DEM,Kamala Harris,489
-Alameda,303500,U.S. Senate,,DEM,Loretta Sanchez,133
-Alameda,303600,U.S. Senate,,DEM,Kamala Harris,853
-Alameda,303600,U.S. Senate,,DEM,Loretta Sanchez,248
-Alameda,303800,U.S. Senate,,DEM,Kamala Harris,562
-Alameda,303800,U.S. Senate,,DEM,Loretta Sanchez,150
-Alameda,304000,U.S. Senate,,DEM,Kamala Harris,523
-Alameda,304000,U.S. Senate,,DEM,Loretta Sanchez,168
-Alameda,304120,U.S. Senate,,DEM,Kamala Harris,820
-Alameda,304120,U.S. Senate,,DEM,Loretta Sanchez,243
-Alameda,304200,U.S. Senate,,DEM,Kamala Harris,443
-Alameda,304200,U.S. Senate,,DEM,Loretta Sanchez,121
-Alameda,304500,U.S. Senate,,DEM,Kamala Harris,478
-Alameda,304500,U.S. Senate,,DEM,Loretta Sanchez,150
-Alameda,304600,U.S. Senate,,DEM,Kamala Harris,605
-Alameda,304600,U.S. Senate,,DEM,Loretta Sanchez,197
-Alameda,304700,U.S. Senate,,DEM,Kamala Harris,451
-Alameda,304700,U.S. Senate,,DEM,Loretta Sanchez,141
-Alameda,304800,U.S. Senate,,DEM,Kamala Harris,518
-Alameda,304800,U.S. Senate,,DEM,Loretta Sanchez,171
-Alameda,304900,U.S. Senate,,DEM,Kamala Harris,487
-Alameda,304900,U.S. Senate,,DEM,Loretta Sanchez,129
-Alameda,305000,U.S. Senate,,DEM,Kamala Harris,407
-Alameda,305000,U.S. Senate,,DEM,Loretta Sanchez,116
-Alameda,305010,U.S. Senate,,DEM,Kamala Harris,708
-Alameda,305010,U.S. Senate,,DEM,Loretta Sanchez,131
-Alameda,305100,U.S. Senate,,DEM,Kamala Harris,654
-Alameda,305100,U.S. Senate,,DEM,Loretta Sanchez,186
-Alameda,305400,U.S. Senate,,DEM,Kamala Harris,519
-Alameda,305400,U.S. Senate,,DEM,Loretta Sanchez,119
-Alameda,305410,U.S. Senate,,DEM,Kamala Harris,423
-Alameda,305410,U.S. Senate,,DEM,Loretta Sanchez,152
-Alameda,305500,U.S. Senate,,DEM,Kamala Harris,559
-Alameda,305500,U.S. Senate,,DEM,Loretta Sanchez,213
-Alameda,305600,U.S. Senate,,DEM,Kamala Harris,581
-Alameda,305600,U.S. Senate,,DEM,Loretta Sanchez,175
-Alameda,305700,U.S. Senate,,DEM,Kamala Harris,585
-Alameda,305700,U.S. Senate,,DEM,Loretta Sanchez,146
-Alameda,310000,U.S. Senate,,DEM,Kamala Harris,667
-Alameda,310000,U.S. Senate,,DEM,Loretta Sanchez,111
-Alameda,310100,U.S. Senate,,DEM,Kamala Harris,595
-Alameda,310100,U.S. Senate,,DEM,Loretta Sanchez,122
-Alameda,310200,U.S. Senate,,DEM,Kamala Harris,559
-Alameda,310200,U.S. Senate,,DEM,Loretta Sanchez,107
-Alameda,310300,U.S. Senate,,DEM,Kamala Harris,538
-Alameda,310300,U.S. Senate,,DEM,Loretta Sanchez,111
-Alameda,310400,U.S. Senate,,DEM,Kamala Harris,573
-Alameda,310400,U.S. Senate,,DEM,Loretta Sanchez,120
-Alameda,310500,U.S. Senate,,DEM,Kamala Harris,516
-Alameda,310500,U.S. Senate,,DEM,Loretta Sanchez,68
-Alameda,310600,U.S. Senate,,DEM,Kamala Harris,586
-Alameda,310600,U.S. Senate,,DEM,Loretta Sanchez,75
-Alameda,310700,U.S. Senate,,DEM,Kamala Harris,909
-Alameda,310700,U.S. Senate,,DEM,Loretta Sanchez,164
-Alameda,310900,U.S. Senate,,DEM,Kamala Harris,951
-Alameda,310900,U.S. Senate,,DEM,Loretta Sanchez,149
-Alameda,311100,U.S. Senate,,DEM,Kamala Harris,948
-Alameda,311100,U.S. Senate,,DEM,Loretta Sanchez,119
-Alameda,311200,U.S. Senate,,DEM,Kamala Harris,844
-Alameda,311200,U.S. Senate,,DEM,Loretta Sanchez,111
-Alameda,311400,U.S. Senate,,DEM,Kamala Harris,591
-Alameda,311400,U.S. Senate,,DEM,Loretta Sanchez,81
-Alameda,311500,U.S. Senate,,DEM,Kamala Harris,1050
-Alameda,311500,U.S. Senate,,DEM,Loretta Sanchez,161
-Alameda,311700,U.S. Senate,,DEM,Kamala Harris,890
-Alameda,311700,U.S. Senate,,DEM,Loretta Sanchez,196
-Alameda,323000,U.S. Senate,,DEM,Kamala Harris,603
-Alameda,323000,U.S. Senate,,DEM,Loretta Sanchez,92
-Alameda,323200,U.S. Senate,,DEM,Kamala Harris,672
-Alameda,323200,U.S. Senate,,DEM,Loretta Sanchez,114
-Alameda,325100,U.S. Senate,,DEM,Kamala Harris,734
-Alameda,325100,U.S. Senate,,DEM,Loretta Sanchez,131
-Alameda,325110,U.S. Senate,,DEM,Kamala Harris,540
-Alameda,325110,U.S. Senate,,DEM,Loretta Sanchez,93
-Alameda,325200,U.S. Senate,,DEM,Kamala Harris,695
-Alameda,325200,U.S. Senate,,DEM,Loretta Sanchez,113
-Alameda,325300,U.S. Senate,,DEM,Kamala Harris,835
-Alameda,325300,U.S. Senate,,DEM,Loretta Sanchez,165
-Alameda,325400,U.S. Senate,,DEM,Kamala Harris,526
-Alameda,325400,U.S. Senate,,DEM,Loretta Sanchez,87
-Alameda,325500,U.S. Senate,,DEM,Kamala Harris,617
-Alameda,325500,U.S. Senate,,DEM,Loretta Sanchez,91
-Alameda,325510,U.S. Senate,,DEM,Kamala Harris,1063
-Alameda,325510,U.S. Senate,,DEM,Loretta Sanchez,155
-Alameda,325600,U.S. Senate,,DEM,Kamala Harris,561
-Alameda,325600,U.S. Senate,,DEM,Loretta Sanchez,63
-Alameda,325700,U.S. Senate,,DEM,Kamala Harris,999
-Alameda,325700,U.S. Senate,,DEM,Loretta Sanchez,134
-Alameda,325800,U.S. Senate,,DEM,Kamala Harris,992
-Alameda,325800,U.S. Senate,,DEM,Loretta Sanchez,146
-Alameda,333100,U.S. Senate,,DEM,Kamala Harris,646
-Alameda,333100,U.S. Senate,,DEM,Loretta Sanchez,134
-Alameda,333200,U.S. Senate,,DEM,Kamala Harris,749
-Alameda,333200,U.S. Senate,,DEM,Loretta Sanchez,155
-Alameda,333210,U.S. Senate,,DEM,Kamala Harris,387
-Alameda,333210,U.S. Senate,,DEM,Loretta Sanchez,64
-Alameda,333400,U.S. Senate,,DEM,Kamala Harris,325
-Alameda,333400,U.S. Senate,,DEM,Loretta Sanchez,104
-Alameda,333410,U.S. Senate,,DEM,Kamala Harris,951
-Alameda,333410,U.S. Senate,,DEM,Loretta Sanchez,201
-Alameda,333500,U.S. Senate,,DEM,Kamala Harris,875
-Alameda,333500,U.S. Senate,,DEM,Loretta Sanchez,138
-Alameda,333510,U.S. Senate,,DEM,Kamala Harris,897
-Alameda,333510,U.S. Senate,,DEM,Loretta Sanchez,130
-Alameda,333600,U.S. Senate,,DEM,Kamala Harris,271
-Alameda,333600,U.S. Senate,,DEM,Loretta Sanchez,37
-Alameda,333800,U.S. Senate,,DEM,Kamala Harris,645
-Alameda,333800,U.S. Senate,,DEM,Loretta Sanchez,167
-Alameda,333900,U.S. Senate,,DEM,Kamala Harris,498
-Alameda,333900,U.S. Senate,,DEM,Loretta Sanchez,127
-Alameda,334000,U.S. Senate,,DEM,Kamala Harris,497
-Alameda,334000,U.S. Senate,,DEM,Loretta Sanchez,177
-Alameda,334100,U.S. Senate,,DEM,Kamala Harris,757
-Alameda,334100,U.S. Senate,,DEM,Loretta Sanchez,164
-Alameda,334600,U.S. Senate,,DEM,Kamala Harris,859
-Alameda,334600,U.S. Senate,,DEM,Loretta Sanchez,321
-Alameda,334700,U.S. Senate,,DEM,Kamala Harris,255
-Alameda,334700,U.S. Senate,,DEM,Loretta Sanchez,159
-Alameda,335000,U.S. Senate,,DEM,Kamala Harris,857
-Alameda,335000,U.S. Senate,,DEM,Loretta Sanchez,187
-Alameda,335100,U.S. Senate,,DEM,Kamala Harris,657
-Alameda,335100,U.S. Senate,,DEM,Loretta Sanchez,167
-Alameda,335200,U.S. Senate,,DEM,Kamala Harris,346
-Alameda,335200,U.S. Senate,,DEM,Loretta Sanchez,87
-Alameda,335300,U.S. Senate,,DEM,Kamala Harris,665
-Alameda,335300,U.S. Senate,,DEM,Loretta Sanchez,141
-Alameda,335400,U.S. Senate,,DEM,Kamala Harris,833
-Alameda,335400,U.S. Senate,,DEM,Loretta Sanchez,182
-Alameda,335500,U.S. Senate,,DEM,Kamala Harris,342
-Alameda,335500,U.S. Senate,,DEM,Loretta Sanchez,89
-Alameda,335700,U.S. Senate,,DEM,Kamala Harris,730
-Alameda,335700,U.S. Senate,,DEM,Loretta Sanchez,127
-Alameda,335710,U.S. Senate,,DEM,Kamala Harris,575
-Alameda,335710,U.S. Senate,,DEM,Loretta Sanchez,112
-Alameda,335810,U.S. Senate,,DEM,Kamala Harris,421
-Alameda,335810,U.S. Senate,,DEM,Loretta Sanchez,94
-Alameda,335900,U.S. Senate,,DEM,Kamala Harris,449
-Alameda,335900,U.S. Senate,,DEM,Loretta Sanchez,89
-Alameda,336100,U.S. Senate,,DEM,Kamala Harris,516
-Alameda,336100,U.S. Senate,,DEM,Loretta Sanchez,118
-Alameda,336110,U.S. Senate,,DEM,Kamala Harris,426
-Alameda,336110,U.S. Senate,,DEM,Loretta Sanchez,117
-Alameda,336200,U.S. Senate,,DEM,Kamala Harris,588
-Alameda,336200,U.S. Senate,,DEM,Loretta Sanchez,155
-Alameda,336400,U.S. Senate,,DEM,Kamala Harris,424
-Alameda,336400,U.S. Senate,,DEM,Loretta Sanchez,122
-Alameda,336500,U.S. Senate,,DEM,Kamala Harris,460
-Alameda,336500,U.S. Senate,,DEM,Loretta Sanchez,80
-Alameda,336600,U.S. Senate,,DEM,Kamala Harris,701
-Alameda,336600,U.S. Senate,,DEM,Loretta Sanchez,136
-Alameda,336610,U.S. Senate,,DEM,Kamala Harris,404
-Alameda,336610,U.S. Senate,,DEM,Loretta Sanchez,73
-Alameda,336710,U.S. Senate,,DEM,Kamala Harris,879
-Alameda,336710,U.S. Senate,,DEM,Loretta Sanchez,152
-Alameda,336900,U.S. Senate,,DEM,Kamala Harris,526
-Alameda,336900,U.S. Senate,,DEM,Loretta Sanchez,114
-Alameda,336910,U.S. Senate,,DEM,Kamala Harris,407
-Alameda,336910,U.S. Senate,,DEM,Loretta Sanchez,62
-Alameda,337000,U.S. Senate,,DEM,Kamala Harris,378
-Alameda,337000,U.S. Senate,,DEM,Loretta Sanchez,98
-Alameda,337100,U.S. Senate,,DEM,Kamala Harris,201
-Alameda,337100,U.S. Senate,,DEM,Loretta Sanchez,45
-Alameda,337110,U.S. Senate,,DEM,Kamala Harris,175
-Alameda,337110,U.S. Senate,,DEM,Loretta Sanchez,53
-Alameda,337200,U.S. Senate,,DEM,Kamala Harris,274
-Alameda,337200,U.S. Senate,,DEM,Loretta Sanchez,75
-Alameda,344000,U.S. Senate,,DEM,Kamala Harris,499
-Alameda,344000,U.S. Senate,,DEM,Loretta Sanchez,133
-Alameda,344010,U.S. Senate,,DEM,Kamala Harris,354
-Alameda,344010,U.S. Senate,,DEM,Loretta Sanchez,124
-Alameda,344100,U.S. Senate,,DEM,Kamala Harris,335
-Alameda,344100,U.S. Senate,,DEM,Loretta Sanchez,99
-Alameda,344200,U.S. Senate,,DEM,Kamala Harris,699
-Alameda,344200,U.S. Senate,,DEM,Loretta Sanchez,136
-Alameda,344400,U.S. Senate,,DEM,Kamala Harris,649
-Alameda,344400,U.S. Senate,,DEM,Loretta Sanchez,126
-Alameda,344500,U.S. Senate,,DEM,Kamala Harris,927
-Alameda,344500,U.S. Senate,,DEM,Loretta Sanchez,161
-Alameda,344600,U.S. Senate,,DEM,Kamala Harris,573
-Alameda,344600,U.S. Senate,,DEM,Loretta Sanchez,82
-Alameda,344700,U.S. Senate,,DEM,Kamala Harris,448
-Alameda,344700,U.S. Senate,,DEM,Loretta Sanchez,60
-Alameda,344800,U.S. Senate,,DEM,Kamala Harris,443
-Alameda,344800,U.S. Senate,,DEM,Loretta Sanchez,80
-Alameda,344900,U.S. Senate,,DEM,Kamala Harris,605
-Alameda,344900,U.S. Senate,,DEM,Loretta Sanchez,76
-Alameda,345000,U.S. Senate,,DEM,Kamala Harris,511
-Alameda,345000,U.S. Senate,,DEM,Loretta Sanchez,123
-Alameda,345100,U.S. Senate,,DEM,Kamala Harris,638
-Alameda,345100,U.S. Senate,,DEM,Loretta Sanchez,117
-Alameda,345200,U.S. Senate,,DEM,Kamala Harris,840
-Alameda,345200,U.S. Senate,,DEM,Loretta Sanchez,121
-Alameda,345310,U.S. Senate,,DEM,Kamala Harris,658
-Alameda,345310,U.S. Senate,,DEM,Loretta Sanchez,93
-Alameda,345400,U.S. Senate,,DEM,Kamala Harris,651
-Alameda,345400,U.S. Senate,,DEM,Loretta Sanchez,131
-Alameda,345500,U.S. Senate,,DEM,Kamala Harris,477
-Alameda,345500,U.S. Senate,,DEM,Loretta Sanchez,81
-Alameda,345600,U.S. Senate,,DEM,Kamala Harris,522
-Alameda,345600,U.S. Senate,,DEM,Loretta Sanchez,99
-Alameda,345700,U.S. Senate,,DEM,Kamala Harris,588
-Alameda,345700,U.S. Senate,,DEM,Loretta Sanchez,81
-Alameda,345800,U.S. Senate,,DEM,Kamala Harris,313
-Alameda,345800,U.S. Senate,,DEM,Loretta Sanchez,47
-Alameda,345900,U.S. Senate,,DEM,Kamala Harris,471
-Alameda,345900,U.S. Senate,,DEM,Loretta Sanchez,79
-Alameda,346000,U.S. Senate,,DEM,Kamala Harris,221
-Alameda,346000,U.S. Senate,,DEM,Loretta Sanchez,64
-Alameda,346100,U.S. Senate,,DEM,Kamala Harris,472
-Alameda,346100,U.S. Senate,,DEM,Loretta Sanchez,157
-Alameda,346200,U.S. Senate,,DEM,Kamala Harris,610
-Alameda,346200,U.S. Senate,,DEM,Loretta Sanchez,213
-Alameda,347110,U.S. Senate,,DEM,Kamala Harris,229
-Alameda,347110,U.S. Senate,,DEM,Loretta Sanchez,63
-Alameda,347200,U.S. Senate,,DEM,Kamala Harris,641
-Alameda,347200,U.S. Senate,,DEM,Loretta Sanchez,184
-Alameda,347300,U.S. Senate,,DEM,Kamala Harris,614
-Alameda,347300,U.S. Senate,,DEM,Loretta Sanchez,91
-Alameda,353300,U.S. Senate,,DEM,Kamala Harris,350
-Alameda,353300,U.S. Senate,,DEM,Loretta Sanchez,75
-Alameda,353310,U.S. Senate,,DEM,Kamala Harris,653
-Alameda,353310,U.S. Senate,,DEM,Loretta Sanchez,178
-Alameda,353400,U.S. Senate,,DEM,Kamala Harris,605
-Alameda,353400,U.S. Senate,,DEM,Loretta Sanchez,102
-Alameda,353500,U.S. Senate,,DEM,Kamala Harris,710
-Alameda,353500,U.S. Senate,,DEM,Loretta Sanchez,118
-Alameda,353600,U.S. Senate,,DEM,Kamala Harris,533
-Alameda,353600,U.S. Senate,,DEM,Loretta Sanchez,100
-Alameda,353800,U.S. Senate,,DEM,Kamala Harris,338
-Alameda,353800,U.S. Senate,,DEM,Loretta Sanchez,77
-Alameda,353900,U.S. Senate,,DEM,Kamala Harris,572
-Alameda,353900,U.S. Senate,,DEM,Loretta Sanchez,179
-Alameda,354000,U.S. Senate,,DEM,Kamala Harris,595
-Alameda,354000,U.S. Senate,,DEM,Loretta Sanchez,230
-Alameda,354100,U.S. Senate,,DEM,Kamala Harris,840
-Alameda,354100,U.S. Senate,,DEM,Loretta Sanchez,206
-Alameda,354110,U.S. Senate,,DEM,Kamala Harris,389
-Alameda,354110,U.S. Senate,,DEM,Loretta Sanchez,93
-Alameda,354300,U.S. Senate,,DEM,Kamala Harris,517
-Alameda,354300,U.S. Senate,,DEM,Loretta Sanchez,255
-Alameda,354400,U.S. Senate,,DEM,Kamala Harris,432
-Alameda,354400,U.S. Senate,,DEM,Loretta Sanchez,154
-Alameda,354500,U.S. Senate,,DEM,Kamala Harris,630
-Alameda,354500,U.S. Senate,,DEM,Loretta Sanchez,282
-Alameda,354700,U.S. Senate,,DEM,Kamala Harris,409
-Alameda,354700,U.S. Senate,,DEM,Loretta Sanchez,220
-Alameda,354900,U.S. Senate,,DEM,Kamala Harris,334
-Alameda,354900,U.S. Senate,,DEM,Loretta Sanchez,112
-Alameda,354910,U.S. Senate,,DEM,Kamala Harris,389
-Alameda,354910,U.S. Senate,,DEM,Loretta Sanchez,158
-Alameda,355000,U.S. Senate,,DEM,Kamala Harris,382
-Alameda,355000,U.S. Senate,,DEM,Loretta Sanchez,110
-Alameda,355100,U.S. Senate,,DEM,Kamala Harris,526
-Alameda,355100,U.S. Senate,,DEM,Loretta Sanchez,237
-Alameda,356000,U.S. Senate,,DEM,Kamala Harris,526
-Alameda,356000,U.S. Senate,,DEM,Loretta Sanchez,150
-Alameda,356200,U.S. Senate,,DEM,Kamala Harris,405
-Alameda,356200,U.S. Senate,,DEM,Loretta Sanchez,234
-Alameda,356210,U.S. Senate,,DEM,Kamala Harris,511
-Alameda,356210,U.S. Senate,,DEM,Loretta Sanchez,223
-Alameda,356400,U.S. Senate,,DEM,Kamala Harris,188
-Alameda,356400,U.S. Senate,,DEM,Loretta Sanchez,150
-Alameda,356500,U.S. Senate,,DEM,Kamala Harris,502
-Alameda,356500,U.S. Senate,,DEM,Loretta Sanchez,352
-Alameda,361000,U.S. Senate,,DEM,Kamala Harris,420
-Alameda,361000,U.S. Senate,,DEM,Loretta Sanchez,205
-Alameda,361130,U.S. Senate,,DEM,Kamala Harris,266
-Alameda,361130,U.S. Senate,,DEM,Loretta Sanchez,86
-Alameda,361200,U.S. Senate,,DEM,Kamala Harris,529
-Alameda,361200,U.S. Senate,,DEM,Loretta Sanchez,150
-Alameda,361300,U.S. Senate,,DEM,Kamala Harris,207
-Alameda,361300,U.S. Senate,,DEM,Loretta Sanchez,119
-Alameda,361500,U.S. Senate,,DEM,Kamala Harris,459
-Alameda,361500,U.S. Senate,,DEM,Loretta Sanchez,210
-Alameda,362100,U.S. Senate,,DEM,Kamala Harris,316
-Alameda,362100,U.S. Senate,,DEM,Loretta Sanchez,109
-Alameda,362110,U.S. Senate,,DEM,Kamala Harris,569
-Alameda,362110,U.S. Senate,,DEM,Loretta Sanchez,198
-Alameda,362300,U.S. Senate,,DEM,Kamala Harris,420
-Alameda,362300,U.S. Senate,,DEM,Loretta Sanchez,137
-Alameda,362500,U.S. Senate,,DEM,Kamala Harris,179
-Alameda,362500,U.S. Senate,,DEM,Loretta Sanchez,73
-Alameda,362510,U.S. Senate,,DEM,Kamala Harris,514
-Alameda,362510,U.S. Senate,,DEM,Loretta Sanchez,113
-Alameda,362600,U.S. Senate,,DEM,Kamala Harris,580
-Alameda,362600,U.S. Senate,,DEM,Loretta Sanchez,122
-Alameda,362700,U.S. Senate,,DEM,Kamala Harris,714
-Alameda,362700,U.S. Senate,,DEM,Loretta Sanchez,81
-Alameda,362800,U.S. Senate,,DEM,Kamala Harris,617
-Alameda,362800,U.S. Senate,,DEM,Loretta Sanchez,80
-Alameda,362900,U.S. Senate,,DEM,Kamala Harris,468
-Alameda,362900,U.S. Senate,,DEM,Loretta Sanchez,81
-Alameda,363000,U.S. Senate,,DEM,Kamala Harris,631
-Alameda,363000,U.S. Senate,,DEM,Loretta Sanchez,162
-Alameda,363100,U.S. Senate,,DEM,Kamala Harris,651
-Alameda,363100,U.S. Senate,,DEM,Loretta Sanchez,179
-Alameda,363200,U.S. Senate,,DEM,Kamala Harris,315
-Alameda,363200,U.S. Senate,,DEM,Loretta Sanchez,124
-Alameda,363310,U.S. Senate,,DEM,Kamala Harris,761
-Alameda,363310,U.S. Senate,,DEM,Loretta Sanchez,186
-Alameda,363600,U.S. Senate,,DEM,Kamala Harris,651
-Alameda,363600,U.S. Senate,,DEM,Loretta Sanchez,181
-Alameda,364200,U.S. Senate,,DEM,Kamala Harris,802
-Alameda,364200,U.S. Senate,,DEM,Loretta Sanchez,182
-Alameda,364300,U.S. Senate,,DEM,Kamala Harris,421
-Alameda,364300,U.S. Senate,,DEM,Loretta Sanchez,69
-Alameda,364310,U.S. Senate,,DEM,Kamala Harris,449
-Alameda,364310,U.S. Senate,,DEM,Loretta Sanchez,98
-Alameda,364400,U.S. Senate,,DEM,Kamala Harris,865
-Alameda,364400,U.S. Senate,,DEM,Loretta Sanchez,155
-Alameda,364510,U.S. Senate,,DEM,Kamala Harris,611
-Alameda,364510,U.S. Senate,,DEM,Loretta Sanchez,80
-Alameda,364600,U.S. Senate,,DEM,Kamala Harris,699
-Alameda,364600,U.S. Senate,,DEM,Loretta Sanchez,167
-Alameda,364700,U.S. Senate,,DEM,Kamala Harris,596
-Alameda,364700,U.S. Senate,,DEM,Loretta Sanchez,111
-Alameda,364800,U.S. Senate,,DEM,Kamala Harris,425
-Alameda,364800,U.S. Senate,,DEM,Loretta Sanchez,91
-Alameda,364900,U.S. Senate,,DEM,Kamala Harris,930
-Alameda,364900,U.S. Senate,,DEM,Loretta Sanchez,143
-Alameda,365000,U.S. Senate,,DEM,Kamala Harris,372
-Alameda,365000,U.S. Senate,,DEM,Loretta Sanchez,68
-Alameda,365200,U.S. Senate,,DEM,Kamala Harris,624
-Alameda,365200,U.S. Senate,,DEM,Loretta Sanchez,120
-Alameda,373100,U.S. Senate,,DEM,Kamala Harris,349
-Alameda,373100,U.S. Senate,,DEM,Loretta Sanchez,119
-Alameda,373400,U.S. Senate,,DEM,Kamala Harris,648
-Alameda,373400,U.S. Senate,,DEM,Loretta Sanchez,276
-Alameda,373500,U.S. Senate,,DEM,Kamala Harris,366
-Alameda,373500,U.S. Senate,,DEM,Loretta Sanchez,183
-Alameda,373900,U.S. Senate,,DEM,Kamala Harris,534
-Alameda,373900,U.S. Senate,,DEM,Loretta Sanchez,124
-Alameda,380200,U.S. Senate,,DEM,Kamala Harris,825
-Alameda,380200,U.S. Senate,,DEM,Loretta Sanchez,217
-Alameda,380300,U.S. Senate,,DEM,Kamala Harris,925
-Alameda,380300,U.S. Senate,,DEM,Loretta Sanchez,243
-Alameda,380400,U.S. Senate,,DEM,Kamala Harris,850
-Alameda,380400,U.S. Senate,,DEM,Loretta Sanchez,196
-Alameda,380600,U.S. Senate,,DEM,Kamala Harris,632
-Alameda,380600,U.S. Senate,,DEM,Loretta Sanchez,171
-Alameda,380700,U.S. Senate,,DEM,Kamala Harris,666
-Alameda,380700,U.S. Senate,,DEM,Loretta Sanchez,212
-Alameda,400100,U.S. Senate,,DEM,Kamala Harris,457
-Alameda,400100,U.S. Senate,,DEM,Loretta Sanchez,104
-Alameda,400200,U.S. Senate,,DEM,Kamala Harris,603
-Alameda,400200,U.S. Senate,,DEM,Loretta Sanchez,66
-Alameda,400300,U.S. Senate,,DEM,Kamala Harris,617
-Alameda,400300,U.S. Senate,,DEM,Loretta Sanchez,62
-Alameda,400400,U.S. Senate,,DEM,Kamala Harris,394
-Alameda,400400,U.S. Senate,,DEM,Loretta Sanchez,68
-Alameda,400500,U.S. Senate,,DEM,Kamala Harris,396
-Alameda,400500,U.S. Senate,,DEM,Loretta Sanchez,45
-Alameda,400600,U.S. Senate,,DEM,Kamala Harris,513
-Alameda,400600,U.S. Senate,,DEM,Loretta Sanchez,71
-Alameda,400700,U.S. Senate,,DEM,Kamala Harris,539
-Alameda,400700,U.S. Senate,,DEM,Loretta Sanchez,55
-Alameda,400800,U.S. Senate,,DEM,Kamala Harris,471
-Alameda,400800,U.S. Senate,,DEM,Loretta Sanchez,69
-Alameda,400900,U.S. Senate,,DEM,Kamala Harris,921
-Alameda,400900,U.S. Senate,,DEM,Loretta Sanchez,106
-Alameda,401100,U.S. Senate,,DEM,Kamala Harris,804
-Alameda,401100,U.S. Senate,,DEM,Loretta Sanchez,123
-Alameda,410100,U.S. Senate,,DEM,Kamala Harris,685
-Alameda,410100,U.S. Senate,,DEM,Loretta Sanchez,256
-Alameda,410300,U.S. Senate,,DEM,Kamala Harris,521
-Alameda,410300,U.S. Senate,,DEM,Loretta Sanchez,235
-Alameda,410400,U.S. Senate,,DEM,Kamala Harris,851
-Alameda,410400,U.S. Senate,,DEM,Loretta Sanchez,202
-Alameda,410500,U.S. Senate,,DEM,Kamala Harris,370
-Alameda,410500,U.S. Senate,,DEM,Loretta Sanchez,150
-Alameda,410600,U.S. Senate,,DEM,Kamala Harris,571
-Alameda,410600,U.S. Senate,,DEM,Loretta Sanchez,121
-Alameda,415000,U.S. Senate,,DEM,Kamala Harris,351
-Alameda,415000,U.S. Senate,,DEM,Loretta Sanchez,223
-Alameda,415200,U.S. Senate,,DEM,Kamala Harris,312
-Alameda,415200,U.S. Senate,,DEM,Loretta Sanchez,117
-Alameda,415300,U.S. Senate,,DEM,Kamala Harris,482
-Alameda,415300,U.S. Senate,,DEM,Loretta Sanchez,217
-Alameda,415500,U.S. Senate,,DEM,Kamala Harris,382
-Alameda,415500,U.S. Senate,,DEM,Loretta Sanchez,145
-Alameda,415600,U.S. Senate,,DEM,Kamala Harris,422
-Alameda,415600,U.S. Senate,,DEM,Loretta Sanchez,171
-Alameda,415800,U.S. Senate,,DEM,Kamala Harris,337
-Alameda,415800,U.S. Senate,,DEM,Loretta Sanchez,163
-Alameda,415900,U.S. Senate,,DEM,Kamala Harris,264
-Alameda,415900,U.S. Senate,,DEM,Loretta Sanchez,84
-Alameda,420500,U.S. Senate,,DEM,Kamala Harris,438
-Alameda,420500,U.S. Senate,,DEM,Loretta Sanchez,208
-Alameda,420600,U.S. Senate,,DEM,Kamala Harris,637
-Alameda,420600,U.S. Senate,,DEM,Loretta Sanchez,251
-Alameda,420700,U.S. Senate,,DEM,Kamala Harris,378
-Alameda,420700,U.S. Senate,,DEM,Loretta Sanchez,248
-Alameda,420900,U.S. Senate,,DEM,Kamala Harris,284
-Alameda,420900,U.S. Senate,,DEM,Loretta Sanchez,171
-Alameda,421000,U.S. Senate,,DEM,Kamala Harris,207
-Alameda,421000,U.S. Senate,,DEM,Loretta Sanchez,129
-Alameda,421100,U.S. Senate,,DEM,Kamala Harris,435
-Alameda,421100,U.S. Senate,,DEM,Loretta Sanchez,185
-Alameda,421200,U.S. Senate,,DEM,Kamala Harris,298
-Alameda,421200,U.S. Senate,,DEM,Loretta Sanchez,187
-Alameda,421300,U.S. Senate,,DEM,Kamala Harris,323
-Alameda,421300,U.S. Senate,,DEM,Loretta Sanchez,222
-Alameda,421400,U.S. Senate,,DEM,Kamala Harris,470
-Alameda,421400,U.S. Senate,,DEM,Loretta Sanchez,368
-Alameda,421510,U.S. Senate,,DEM,Kamala Harris,376
-Alameda,421510,U.S. Senate,,DEM,Loretta Sanchez,278
-Alameda,421700,U.S. Senate,,DEM,Kamala Harris,622
-Alameda,421700,U.S. Senate,,DEM,Loretta Sanchez,365
-Alameda,421900,U.S. Senate,,DEM,Kamala Harris,478
-Alameda,421900,U.S. Senate,,DEM,Loretta Sanchez,320
-Alameda,422000,U.S. Senate,,DEM,Kamala Harris,525
-Alameda,422000,U.S. Senate,,DEM,Loretta Sanchez,264
-Alameda,422100,U.S. Senate,,DEM,Kamala Harris,621
-Alameda,422100,U.S. Senate,,DEM,Loretta Sanchez,282
-Alameda,422300,U.S. Senate,,DEM,Kamala Harris,637
-Alameda,422300,U.S. Senate,,DEM,Loretta Sanchez,330
-Alameda,422600,U.S. Senate,,DEM,Kamala Harris,670
-Alameda,422600,U.S. Senate,,DEM,Loretta Sanchez,371
-Alameda,422700,U.S. Senate,,DEM,Kamala Harris,505
-Alameda,422700,U.S. Senate,,DEM,Loretta Sanchez,267
-Alameda,422810,U.S. Senate,,DEM,Kamala Harris,417
-Alameda,422810,U.S. Senate,,DEM,Loretta Sanchez,212
-Alameda,422900,U.S. Senate,,DEM,Kamala Harris,449
-Alameda,422900,U.S. Senate,,DEM,Loretta Sanchez,345
-Alameda,422910,U.S. Senate,,DEM,Kamala Harris,635
-Alameda,422910,U.S. Senate,,DEM,Loretta Sanchez,322
-Alameda,422920,U.S. Senate,,DEM,Kamala Harris,525
-Alameda,422920,U.S. Senate,,DEM,Loretta Sanchez,190
-Alameda,423000,U.S. Senate,,DEM,Kamala Harris,350
-Alameda,423000,U.S. Senate,,DEM,Loretta Sanchez,244
-Alameda,423100,U.S. Senate,,DEM,Kamala Harris,405
-Alameda,423100,U.S. Senate,,DEM,Loretta Sanchez,216
-Alameda,423400,U.S. Senate,,DEM,Kamala Harris,361
-Alameda,423400,U.S. Senate,,DEM,Loretta Sanchez,143
-Alameda,423500,U.S. Senate,,DEM,Kamala Harris,283
-Alameda,423500,U.S. Senate,,DEM,Loretta Sanchez,137
-Alameda,423600,U.S. Senate,,DEM,Kamala Harris,325
-Alameda,423600,U.S. Senate,,DEM,Loretta Sanchez,126
-Alameda,423610,U.S. Senate,,DEM,Kamala Harris,670
-Alameda,423610,U.S. Senate,,DEM,Loretta Sanchez,356
-Alameda,423710,U.S. Senate,,DEM,Kamala Harris,475
-Alameda,423710,U.S. Senate,,DEM,Loretta Sanchez,221
-Alameda,424000,U.S. Senate,,DEM,Kamala Harris,666
-Alameda,424000,U.S. Senate,,DEM,Loretta Sanchez,303
-Alameda,424100,U.S. Senate,,DEM,Kamala Harris,292
-Alameda,424100,U.S. Senate,,DEM,Loretta Sanchez,165
-Alameda,424300,U.S. Senate,,DEM,Kamala Harris,561
-Alameda,424300,U.S. Senate,,DEM,Loretta Sanchez,450
-Alameda,424400,U.S. Senate,,DEM,Kamala Harris,548
-Alameda,424400,U.S. Senate,,DEM,Loretta Sanchez,276
-Alameda,430170,U.S. Senate,,DEM,Kamala Harris,583
-Alameda,430170,U.S. Senate,,DEM,Loretta Sanchez,290
-Alameda,430400,U.S. Senate,,DEM,Kamala Harris,173
-Alameda,430400,U.S. Senate,,DEM,Loretta Sanchez,112
-Alameda,430600,U.S. Senate,,DEM,Kamala Harris,597
-Alameda,430600,U.S. Senate,,DEM,Loretta Sanchez,218
-Alameda,430700,U.S. Senate,,DEM,Kamala Harris,381
-Alameda,430700,U.S. Senate,,DEM,Loretta Sanchez,135
-Alameda,430900,U.S. Senate,,DEM,Kamala Harris,372
-Alameda,430900,U.S. Senate,,DEM,Loretta Sanchez,143
-Alameda,431100,U.S. Senate,,DEM,Kamala Harris,537
-Alameda,431100,U.S. Senate,,DEM,Loretta Sanchez,208
-Alameda,431800,U.S. Senate,,DEM,Kamala Harris,564
-Alameda,431800,U.S. Senate,,DEM,Loretta Sanchez,246
-Alameda,432010,U.S. Senate,,DEM,Kamala Harris,689
-Alameda,432010,U.S. Senate,,DEM,Loretta Sanchez,344
-Alameda,432110,U.S. Senate,,DEM,Kamala Harris,522
-Alameda,432110,U.S. Senate,,DEM,Loretta Sanchez,365
-Alameda,432200,U.S. Senate,,DEM,Kamala Harris,429
-Alameda,432200,U.S. Senate,,DEM,Loretta Sanchez,239
-Alameda,432300,U.S. Senate,,DEM,Kamala Harris,563
-Alameda,432300,U.S. Senate,,DEM,Loretta Sanchez,356
-Alameda,432400,U.S. Senate,,DEM,Kamala Harris,508
-Alameda,432400,U.S. Senate,,DEM,Loretta Sanchez,283
-Alameda,432600,U.S. Senate,,DEM,Kamala Harris,310
-Alameda,432600,U.S. Senate,,DEM,Loretta Sanchez,231
-Alameda,432700,U.S. Senate,,DEM,Kamala Harris,667
-Alameda,432700,U.S. Senate,,DEM,Loretta Sanchez,302
-Alameda,432810,U.S. Senate,,DEM,Kamala Harris,349
-Alameda,432810,U.S. Senate,,DEM,Loretta Sanchez,162
-Alameda,432900,U.S. Senate,,DEM,Kamala Harris,506
-Alameda,432900,U.S. Senate,,DEM,Loretta Sanchez,204
-Alameda,433100,U.S. Senate,,DEM,Kamala Harris,453
-Alameda,433100,U.S. Senate,,DEM,Loretta Sanchez,317
-Alameda,433200,U.S. Senate,,DEM,Kamala Harris,358
-Alameda,433200,U.S. Senate,,DEM,Loretta Sanchez,169
-Alameda,433400,U.S. Senate,,DEM,Kamala Harris,673
-Alameda,433400,U.S. Senate,,DEM,Loretta Sanchez,200
-Alameda,433500,U.S. Senate,,DEM,Kamala Harris,420
-Alameda,433500,U.S. Senate,,DEM,Loretta Sanchez,259
-Alameda,433610,U.S. Senate,,DEM,Kamala Harris,729
-Alameda,433610,U.S. Senate,,DEM,Loretta Sanchez,238
-Alameda,433700,U.S. Senate,,DEM,Kamala Harris,687
-Alameda,433700,U.S. Senate,,DEM,Loretta Sanchez,239
-Alameda,433900,U.S. Senate,,DEM,Kamala Harris,262
-Alameda,433900,U.S. Senate,,DEM,Loretta Sanchez,73
-Alameda,440100,U.S. Senate,,DEM,Kamala Harris,486
-Alameda,440100,U.S. Senate,,DEM,Loretta Sanchez,311
-Alameda,440300,U.S. Senate,,DEM,Kamala Harris,644
-Alameda,440300,U.S. Senate,,DEM,Loretta Sanchez,365
-Alameda,440400,U.S. Senate,,DEM,Kamala Harris,711
-Alameda,440400,U.S. Senate,,DEM,Loretta Sanchez,421
-Alameda,440610,U.S. Senate,,DEM,Kamala Harris,627
-Alameda,440610,U.S. Senate,,DEM,Loretta Sanchez,317
-Alameda,440800,U.S. Senate,,DEM,Kamala Harris,291
-Alameda,440800,U.S. Senate,,DEM,Loretta Sanchez,154
-Alameda,440900,U.S. Senate,,DEM,Kamala Harris,462
-Alameda,440900,U.S. Senate,,DEM,Loretta Sanchez,261
-Alameda,441100,U.S. Senate,,DEM,Kamala Harris,727
-Alameda,441100,U.S. Senate,,DEM,Loretta Sanchez,382
-Alameda,441300,U.S. Senate,,DEM,Kamala Harris,330
-Alameda,441300,U.S. Senate,,DEM,Loretta Sanchez,184
-Alameda,441400,U.S. Senate,,DEM,Kamala Harris,400
-Alameda,441400,U.S. Senate,,DEM,Loretta Sanchez,226
-Alameda,442100,U.S. Senate,,DEM,Kamala Harris,712
-Alameda,442100,U.S. Senate,,DEM,Loretta Sanchez,425
-Alameda,442600,U.S. Senate,,DEM,Kamala Harris,289
-Alameda,442600,U.S. Senate,,DEM,Loretta Sanchez,109
-Alameda,442700,U.S. Senate,,DEM,Kamala Harris,400
-Alameda,442700,U.S. Senate,,DEM,Loretta Sanchez,222
-Alameda,443000,U.S. Senate,,DEM,Kamala Harris,424
-Alameda,443000,U.S. Senate,,DEM,Loretta Sanchez,219
-Alameda,443100,U.S. Senate,,DEM,Kamala Harris,422
-Alameda,443100,U.S. Senate,,DEM,Loretta Sanchez,202
-Alameda,443200,U.S. Senate,,DEM,Kamala Harris,292
-Alameda,443200,U.S. Senate,,DEM,Loretta Sanchez,165
-Alameda,443300,U.S. Senate,,DEM,Kamala Harris,399
-Alameda,443300,U.S. Senate,,DEM,Loretta Sanchez,176
-Alameda,443400,U.S. Senate,,DEM,Kamala Harris,576
-Alameda,443400,U.S. Senate,,DEM,Loretta Sanchez,226
-Alameda,443500,U.S. Senate,,DEM,Kamala Harris,360
-Alameda,443500,U.S. Senate,,DEM,Loretta Sanchez,200
-Alameda,447200,U.S. Senate,,DEM,Kamala Harris,824
-Alameda,447200,U.S. Senate,,DEM,Loretta Sanchez,265
-Alameda,447600,U.S. Senate,,DEM,Kamala Harris,424
-Alameda,447600,U.S. Senate,,DEM,Loretta Sanchez,167
-Alameda,450300,U.S. Senate,,DEM,Kamala Harris,411
-Alameda,450300,U.S. Senate,,DEM,Loretta Sanchez,210
-Alameda,450400,U.S. Senate,,DEM,Kamala Harris,700
-Alameda,450400,U.S. Senate,,DEM,Loretta Sanchez,305
-Alameda,450610,U.S. Senate,,DEM,Kamala Harris,416
-Alameda,450610,U.S. Senate,,DEM,Loretta Sanchez,155
-Alameda,450800,U.S. Senate,,DEM,Kamala Harris,457
-Alameda,450800,U.S. Senate,,DEM,Loretta Sanchez,187
-Alameda,451000,U.S. Senate,,DEM,Kamala Harris,596
-Alameda,451000,U.S. Senate,,DEM,Loretta Sanchez,306
-Alameda,451510,U.S. Senate,,DEM,Kamala Harris,489
-Alameda,451510,U.S. Senate,,DEM,Loretta Sanchez,251
-Alameda,451600,U.S. Senate,,DEM,Kamala Harris,500
-Alameda,451600,U.S. Senate,,DEM,Loretta Sanchez,250
-Alameda,451700,U.S. Senate,,DEM,Kamala Harris,396
-Alameda,451700,U.S. Senate,,DEM,Loretta Sanchez,235
-Alameda,452100,U.S. Senate,,DEM,Kamala Harris,457
-Alameda,452100,U.S. Senate,,DEM,Loretta Sanchez,233
-Alameda,452200,U.S. Senate,,DEM,Kamala Harris,771
-Alameda,452200,U.S. Senate,,DEM,Loretta Sanchez,316
-Alameda,452400,U.S. Senate,,DEM,Kamala Harris,429
-Alameda,452400,U.S. Senate,,DEM,Loretta Sanchez,272
-Alameda,452500,U.S. Senate,,DEM,Kamala Harris,356
-Alameda,452500,U.S. Senate,,DEM,Loretta Sanchez,163
-Alameda,453100,U.S. Senate,,DEM,Kamala Harris,545
-Alameda,453100,U.S. Senate,,DEM,Loretta Sanchez,175
-Alameda,453300,U.S. Senate,,DEM,Kamala Harris,288
-Alameda,453300,U.S. Senate,,DEM,Loretta Sanchez,169
-Alameda,453400,U.S. Senate,,DEM,Kamala Harris,471
-Alameda,453400,U.S. Senate,,DEM,Loretta Sanchez,185
-Alameda,453500,U.S. Senate,,DEM,Kamala Harris,526
-Alameda,453500,U.S. Senate,,DEM,Loretta Sanchez,281
-Alameda,453900,U.S. Senate,,DEM,Kamala Harris,528
-Alameda,453900,U.S. Senate,,DEM,Loretta Sanchez,268
-Alameda,453920,U.S. Senate,,DEM,Kamala Harris,411
-Alameda,453920,U.S. Senate,,DEM,Loretta Sanchez,155
-Alameda,454100,U.S. Senate,,DEM,Kamala Harris,478
-Alameda,454100,U.S. Senate,,DEM,Loretta Sanchez,216
-Alameda,454500,U.S. Senate,,DEM,Kamala Harris,404
-Alameda,454500,U.S. Senate,,DEM,Loretta Sanchez,170
-Alameda,455000,U.S. Senate,,DEM,Kamala Harris,288
-Alameda,455000,U.S. Senate,,DEM,Loretta Sanchez,93
-Alameda,455100,U.S. Senate,,DEM,Kamala Harris,403
-Alameda,455100,U.S. Senate,,DEM,Loretta Sanchez,147
-Alameda,455300,U.S. Senate,,DEM,Kamala Harris,401
-Alameda,455300,U.S. Senate,,DEM,Loretta Sanchez,214
-Alameda,455400,U.S. Senate,,DEM,Kamala Harris,464
-Alameda,455400,U.S. Senate,,DEM,Loretta Sanchez,186
-Alameda,455500,U.S. Senate,,DEM,Kamala Harris,261
-Alameda,455500,U.S. Senate,,DEM,Loretta Sanchez,149
-Alameda,455700,U.S. Senate,,DEM,Kamala Harris,299
-Alameda,455700,U.S. Senate,,DEM,Loretta Sanchez,92
-Alameda,455900,U.S. Senate,,DEM,Kamala Harris,771
-Alameda,455900,U.S. Senate,,DEM,Loretta Sanchez,344
-Alameda,456200,U.S. Senate,,DEM,Kamala Harris,525
-Alameda,456200,U.S. Senate,,DEM,Loretta Sanchez,199
-Alameda,456500,U.S. Senate,,DEM,Kamala Harris,429
-Alameda,456500,U.S. Senate,,DEM,Loretta Sanchez,144
-Alameda,456600,U.S. Senate,,DEM,Kamala Harris,560
-Alameda,456600,U.S. Senate,,DEM,Loretta Sanchez,171
-Alameda,456900,U.S. Senate,,DEM,Kamala Harris,385
-Alameda,456900,U.S. Senate,,DEM,Loretta Sanchez,117
-Alameda,457100,U.S. Senate,,DEM,Kamala Harris,488
-Alameda,457100,U.S. Senate,,DEM,Loretta Sanchez,136
-Alameda,457300,U.S. Senate,,DEM,Kamala Harris,551
-Alameda,457300,U.S. Senate,,DEM,Loretta Sanchez,171
-Alameda,457400,U.S. Senate,,DEM,Kamala Harris,490
-Alameda,457400,U.S. Senate,,DEM,Loretta Sanchez,131
-Alameda,457500,U.S. Senate,,DEM,Kamala Harris,702
-Alameda,457500,U.S. Senate,,DEM,Loretta Sanchez,256
-Alameda,457700,U.S. Senate,,DEM,Kamala Harris,519
-Alameda,457700,U.S. Senate,,DEM,Loretta Sanchez,154
-Alameda,457900,U.S. Senate,,DEM,Kamala Harris,420
-Alameda,457900,U.S. Senate,,DEM,Loretta Sanchez,129
-Alameda,458200,U.S. Senate,,DEM,Kamala Harris,553
-Alameda,458200,U.S. Senate,,DEM,Loretta Sanchez,238
-Alameda,458300,U.S. Senate,,DEM,Kamala Harris,610
-Alameda,458300,U.S. Senate,,DEM,Loretta Sanchez,251
-Alameda,458500,U.S. Senate,,DEM,Kamala Harris,394
-Alameda,458500,U.S. Senate,,DEM,Loretta Sanchez,95
-Alameda,458800,U.S. Senate,,DEM,Kamala Harris,358
-Alameda,458800,U.S. Senate,,DEM,Loretta Sanchez,272
-Alameda,458900,U.S. Senate,,DEM,Kamala Harris,253
-Alameda,458900,U.S. Senate,,DEM,Loretta Sanchez,177
-Alameda,470400,U.S. Senate,,DEM,Kamala Harris,515
-Alameda,470400,U.S. Senate,,DEM,Loretta Sanchez,272
-Alameda,470600,U.S. Senate,,DEM,Kamala Harris,451
-Alameda,470600,U.S. Senate,,DEM,Loretta Sanchez,171
-Alameda,470900,U.S. Senate,,DEM,Kamala Harris,579
-Alameda,470900,U.S. Senate,,DEM,Loretta Sanchez,234
-Alameda,471300,U.S. Senate,,DEM,Kamala Harris,411
-Alameda,471300,U.S. Senate,,DEM,Loretta Sanchez,192
-Alameda,471800,U.S. Senate,,DEM,Kamala Harris,426
-Alameda,471800,U.S. Senate,,DEM,Loretta Sanchez,195
-Alameda,471900,U.S. Senate,,DEM,Kamala Harris,462
-Alameda,471900,U.S. Senate,,DEM,Loretta Sanchez,174
-Alameda,472000,U.S. Senate,,DEM,Kamala Harris,557
-Alameda,472000,U.S. Senate,,DEM,Loretta Sanchez,211
-Alameda,472200,U.S. Senate,,DEM,Kamala Harris,561
-Alameda,472200,U.S. Senate,,DEM,Loretta Sanchez,258
-Alameda,472300,U.S. Senate,,DEM,Kamala Harris,427
-Alameda,472300,U.S. Senate,,DEM,Loretta Sanchez,184
-Alameda,472400,U.S. Senate,,DEM,Kamala Harris,473
-Alameda,472400,U.S. Senate,,DEM,Loretta Sanchez,216
-Alameda,472500,U.S. Senate,,DEM,Kamala Harris,598
-Alameda,472500,U.S. Senate,,DEM,Loretta Sanchez,266
-Alameda,473300,U.S. Senate,,DEM,Kamala Harris,644
-Alameda,473300,U.S. Senate,,DEM,Loretta Sanchez,265
-Alameda,473400,U.S. Senate,,DEM,Kamala Harris,481
-Alameda,473400,U.S. Senate,,DEM,Loretta Sanchez,200
-Alameda,473500,U.S. Senate,,DEM,Kamala Harris,626
-Alameda,473500,U.S. Senate,,DEM,Loretta Sanchez,275
-Alameda,473600,U.S. Senate,,DEM,Kamala Harris,228
-Alameda,473600,U.S. Senate,,DEM,Loretta Sanchez,110
-Alameda,473800,U.S. Senate,,DEM,Kamala Harris,551
-Alameda,473800,U.S. Senate,,DEM,Loretta Sanchez,254
-Alameda,473900,U.S. Senate,,DEM,Kamala Harris,630
-Alameda,473900,U.S. Senate,,DEM,Loretta Sanchez,243
-Alameda,474010,U.S. Senate,,DEM,Kamala Harris,450
-Alameda,474010,U.S. Senate,,DEM,Loretta Sanchez,180
-Alameda,474020,U.S. Senate,,DEM,Kamala Harris,607
-Alameda,474020,U.S. Senate,,DEM,Loretta Sanchez,246
-Alameda,474300,U.S. Senate,,DEM,Kamala Harris,446
-Alameda,474300,U.S. Senate,,DEM,Loretta Sanchez,159
-Alameda,474500,U.S. Senate,,DEM,Kamala Harris,625
-Alameda,474500,U.S. Senate,,DEM,Loretta Sanchez,238
-Alameda,474600,U.S. Senate,,DEM,Kamala Harris,371
-Alameda,474600,U.S. Senate,,DEM,Loretta Sanchez,163
-Alameda,474700,U.S. Senate,,DEM,Kamala Harris,296
-Alameda,474700,U.S. Senate,,DEM,Loretta Sanchez,142
-Alameda,474900,U.S. Senate,,DEM,Kamala Harris,614
-Alameda,474900,U.S. Senate,,DEM,Loretta Sanchez,272
-Alameda,475000,U.S. Senate,,DEM,Kamala Harris,403
-Alameda,475000,U.S. Senate,,DEM,Loretta Sanchez,148
-Alameda,475100,U.S. Senate,,DEM,Kamala Harris,382
-Alameda,475100,U.S. Senate,,DEM,Loretta Sanchez,154
-Alameda,475200,U.S. Senate,,DEM,Kamala Harris,465
-Alameda,475200,U.S. Senate,,DEM,Loretta Sanchez,235
-Alameda,475500,U.S. Senate,,DEM,Kamala Harris,504
-Alameda,475500,U.S. Senate,,DEM,Loretta Sanchez,172
-Alameda,475520,U.S. Senate,,DEM,Kamala Harris,472
-Alameda,475520,U.S. Senate,,DEM,Loretta Sanchez,180
-Alameda,475540,U.S. Senate,,DEM,Kamala Harris,485
-Alameda,475540,U.S. Senate,,DEM,Loretta Sanchez,191
-Alameda,476100,U.S. Senate,,DEM,Kamala Harris,642
-Alameda,476100,U.S. Senate,,DEM,Loretta Sanchez,210
-Alameda,476110,U.S. Senate,,DEM,Kamala Harris,488
-Alameda,476110,U.S. Senate,,DEM,Loretta Sanchez,144
-Alameda,481200,U.S. Senate,,DEM,Kamala Harris,593
-Alameda,481200,U.S. Senate,,DEM,Loretta Sanchez,459
-Alameda,481410,U.S. Senate,,DEM,Kamala Harris,198
-Alameda,481410,U.S. Senate,,DEM,Loretta Sanchez,135
-Alameda,481500,U.S. Senate,,DEM,Kamala Harris,386
-Alameda,481500,U.S. Senate,,DEM,Loretta Sanchez,242
-Alameda,481800,U.S. Senate,,DEM,Kamala Harris,521
-Alameda,481800,U.S. Senate,,DEM,Loretta Sanchez,298
-Alameda,483000,U.S. Senate,,DEM,Kamala Harris,279
-Alameda,483000,U.S. Senate,,DEM,Loretta Sanchez,189
-Alameda,491000,U.S. Senate,,DEM,Kamala Harris,439
-Alameda,491000,U.S. Senate,,DEM,Loretta Sanchez,181
-Alameda,491100,U.S. Senate,,DEM,Kamala Harris,818
-Alameda,491100,U.S. Senate,,DEM,Loretta Sanchez,255
-Alameda,491200,U.S. Senate,,DEM,Kamala Harris,709
-Alameda,491200,U.S. Senate,,DEM,Loretta Sanchez,317
-Alameda,491300,U.S. Senate,,DEM,Kamala Harris,722
-Alameda,491300,U.S. Senate,,DEM,Loretta Sanchez,244
-Alameda,491500,U.S. Senate,,DEM,Kamala Harris,441
-Alameda,491500,U.S. Senate,,DEM,Loretta Sanchez,169
-Alameda,500100,U.S. Senate,,DEM,Kamala Harris,552
-Alameda,500100,U.S. Senate,,DEM,Loretta Sanchez,290
-Alameda,500110,U.S. Senate,,DEM,Kamala Harris,476
-Alameda,500110,U.S. Senate,,DEM,Loretta Sanchez,284
-Alameda,500120,U.S. Senate,,DEM,Kamala Harris,249
-Alameda,500120,U.S. Senate,,DEM,Loretta Sanchez,177
-Alameda,500130,U.S. Senate,,DEM,Kamala Harris,564
-Alameda,500130,U.S. Senate,,DEM,Loretta Sanchez,240
-Alameda,500140,U.S. Senate,,DEM,Kamala Harris,573
-Alameda,500140,U.S. Senate,,DEM,Loretta Sanchez,273
-Alameda,500200,U.S. Senate,,DEM,Kamala Harris,395
-Alameda,500200,U.S. Senate,,DEM,Loretta Sanchez,212
-Alameda,500210,U.S. Senate,,DEM,Kamala Harris,335
-Alameda,500210,U.S. Senate,,DEM,Loretta Sanchez,189
-Alameda,500230,U.S. Senate,,DEM,Kamala Harris,296
-Alameda,500230,U.S. Senate,,DEM,Loretta Sanchez,179
-Alameda,500300,U.S. Senate,,DEM,Kamala Harris,354
-Alameda,500300,U.S. Senate,,DEM,Loretta Sanchez,182
-Alameda,500310,U.S. Senate,,DEM,Kamala Harris,564
-Alameda,500310,U.S. Senate,,DEM,Loretta Sanchez,290
-Alameda,500320,U.S. Senate,,DEM,Kamala Harris,363
-Alameda,500320,U.S. Senate,,DEM,Loretta Sanchez,167
-Alameda,500340,U.S. Senate,,DEM,Kamala Harris,338
-Alameda,500340,U.S. Senate,,DEM,Loretta Sanchez,153
-Alameda,500400,U.S. Senate,,DEM,Kamala Harris,717
-Alameda,500400,U.S. Senate,,DEM,Loretta Sanchez,367
-Alameda,500410,U.S. Senate,,DEM,Kamala Harris,667
-Alameda,500410,U.S. Senate,,DEM,Loretta Sanchez,281
-Alameda,500500,U.S. Senate,,DEM,Kamala Harris,447
-Alameda,500500,U.S. Senate,,DEM,Loretta Sanchez,233
-Alameda,500600,U.S. Senate,,DEM,Kamala Harris,355
-Alameda,500600,U.S. Senate,,DEM,Loretta Sanchez,203
-Alameda,500700,U.S. Senate,,DEM,Kamala Harris,503
-Alameda,500700,U.S. Senate,,DEM,Loretta Sanchez,268
-Alameda,500910,U.S. Senate,,DEM,Kamala Harris,287
-Alameda,500910,U.S. Senate,,DEM,Loretta Sanchez,152
-Alameda,501000,U.S. Senate,,DEM,Kamala Harris,455
-Alameda,501000,U.S. Senate,,DEM,Loretta Sanchez,226
-Alameda,501200,U.S. Senate,,DEM,Kamala Harris,326
-Alameda,501200,U.S. Senate,,DEM,Loretta Sanchez,128
-Alameda,501300,U.S. Senate,,DEM,Kamala Harris,449
-Alameda,501300,U.S. Senate,,DEM,Loretta Sanchez,203
-Alameda,501400,U.S. Senate,,DEM,Kamala Harris,620
-Alameda,501400,U.S. Senate,,DEM,Loretta Sanchez,244
-Alameda,501410,U.S. Senate,,DEM,Kamala Harris,354
-Alameda,501410,U.S. Senate,,DEM,Loretta Sanchez,168
-Alameda,501600,U.S. Senate,,DEM,Kamala Harris,579
-Alameda,501600,U.S. Senate,,DEM,Loretta Sanchez,307
-Alameda,501610,U.S. Senate,,DEM,Kamala Harris,637
-Alameda,501610,U.S. Senate,,DEM,Loretta Sanchez,274
-Alameda,501620,U.S. Senate,,DEM,Kamala Harris,411
-Alameda,501620,U.S. Senate,,DEM,Loretta Sanchez,195
-Alameda,501630,U.S. Senate,,DEM,Kamala Harris,501
-Alameda,501630,U.S. Senate,,DEM,Loretta Sanchez,220
-Alameda,501640,U.S. Senate,,DEM,Kamala Harris,472
-Alameda,501640,U.S. Senate,,DEM,Loretta Sanchez,243
-Alameda,501800,U.S. Senate,,DEM,Kamala Harris,427
-Alameda,501800,U.S. Senate,,DEM,Loretta Sanchez,206
-Alameda,501830,U.S. Senate,,DEM,Kamala Harris,493
-Alameda,501830,U.S. Senate,,DEM,Loretta Sanchez,249
-Alameda,501840,U.S. Senate,,DEM,Kamala Harris,388
-Alameda,501840,U.S. Senate,,DEM,Loretta Sanchez,207
-Alameda,501910,U.S. Senate,,DEM,Kamala Harris,443
-Alameda,501910,U.S. Senate,,DEM,Loretta Sanchez,172
-Alameda,502000,U.S. Senate,,DEM,Kamala Harris,358
-Alameda,502000,U.S. Senate,,DEM,Loretta Sanchez,148
-Alameda,502010,U.S. Senate,,DEM,Kamala Harris,319
-Alameda,502010,U.S. Senate,,DEM,Loretta Sanchez,134
-Alameda,502020,U.S. Senate,,DEM,Kamala Harris,689
-Alameda,502020,U.S. Senate,,DEM,Loretta Sanchez,307
-Alameda,502030,U.S. Senate,,DEM,Kamala Harris,276
-Alameda,502030,U.S. Senate,,DEM,Loretta Sanchez,156
-Alameda,502100,U.S. Senate,,DEM,Kamala Harris,359
-Alameda,502100,U.S. Senate,,DEM,Loretta Sanchez,180
-Alameda,502200,U.S. Senate,,DEM,Kamala Harris,397
-Alameda,502200,U.S. Senate,,DEM,Loretta Sanchez,134
-Alameda,502210,U.S. Senate,,DEM,Kamala Harris,339
-Alameda,502210,U.S. Senate,,DEM,Loretta Sanchez,202
-Alameda,502220,U.S. Senate,,DEM,Kamala Harris,555
-Alameda,502220,U.S. Senate,,DEM,Loretta Sanchez,257
-Alameda,502400,U.S. Senate,,DEM,Kamala Harris,381
-Alameda,502400,U.S. Senate,,DEM,Loretta Sanchez,192
-Alameda,502410,U.S. Senate,,DEM,Kamala Harris,286
-Alameda,502410,U.S. Senate,,DEM,Loretta Sanchez,145
-Alameda,502500,U.S. Senate,,DEM,Kamala Harris,288
-Alameda,502500,U.S. Senate,,DEM,Loretta Sanchez,221
-Alameda,502600,U.S. Senate,,DEM,Kamala Harris,438
-Alameda,502600,U.S. Senate,,DEM,Loretta Sanchez,252
-Alameda,502710,U.S. Senate,,DEM,Kamala Harris,335
-Alameda,502710,U.S. Senate,,DEM,Loretta Sanchez,175
-Alameda,502720,U.S. Senate,,DEM,Kamala Harris,403
-Alameda,502720,U.S. Senate,,DEM,Loretta Sanchez,221
-Alameda,502740,U.S. Senate,,DEM,Kamala Harris,414
-Alameda,502740,U.S. Senate,,DEM,Loretta Sanchez,209
-Alameda,502800,U.S. Senate,,DEM,Kamala Harris,355
-Alameda,502800,U.S. Senate,,DEM,Loretta Sanchez,184
-Alameda,502900,U.S. Senate,,DEM,Kamala Harris,407
-Alameda,502900,U.S. Senate,,DEM,Loretta Sanchez,203
-Alameda,502920,U.S. Senate,,DEM,Kamala Harris,480
-Alameda,502920,U.S. Senate,,DEM,Loretta Sanchez,192
-Alameda,520110,U.S. Senate,,DEM,Kamala Harris,417
-Alameda,520110,U.S. Senate,,DEM,Loretta Sanchez,150
-Alameda,520210,U.S. Senate,,DEM,Kamala Harris,465
-Alameda,520210,U.S. Senate,,DEM,Loretta Sanchez,206
-Alameda,520220,U.S. Senate,,DEM,Kamala Harris,495
-Alameda,520220,U.S. Senate,,DEM,Loretta Sanchez,238
-Alameda,520230,U.S. Senate,,DEM,Kamala Harris,489
-Alameda,520230,U.S. Senate,,DEM,Loretta Sanchez,174
-Alameda,520240,U.S. Senate,,DEM,Kamala Harris,635
-Alameda,520240,U.S. Senate,,DEM,Loretta Sanchez,246
-Alameda,520300,U.S. Senate,,DEM,Kamala Harris,506
-Alameda,520300,U.S. Senate,,DEM,Loretta Sanchez,253
-Alameda,520310,U.S. Senate,,DEM,Kamala Harris,344
-Alameda,520310,U.S. Senate,,DEM,Loretta Sanchez,122
-Alameda,520320,U.S. Senate,,DEM,Kamala Harris,446
-Alameda,520320,U.S. Senate,,DEM,Loretta Sanchez,208
-Alameda,520400,U.S. Senate,,DEM,Kamala Harris,563
-Alameda,520400,U.S. Senate,,DEM,Loretta Sanchez,246
-Alameda,520420,U.S. Senate,,DEM,Kamala Harris,558
-Alameda,520420,U.S. Senate,,DEM,Loretta Sanchez,228
-Alameda,520500,U.S. Senate,,DEM,Kamala Harris,364
-Alameda,520500,U.S. Senate,,DEM,Loretta Sanchez,121
-Alameda,520600,U.S. Senate,,DEM,Kamala Harris,741
-Alameda,520600,U.S. Senate,,DEM,Loretta Sanchez,233
-Alameda,520610,U.S. Senate,,DEM,Kamala Harris,439
-Alameda,520610,U.S. Senate,,DEM,Loretta Sanchez,173
-Alameda,520630,U.S. Senate,,DEM,Kamala Harris,309
-Alameda,520630,U.S. Senate,,DEM,Loretta Sanchez,121
-Alameda,520700,U.S. Senate,,DEM,Kamala Harris,683
-Alameda,520700,U.S. Senate,,DEM,Loretta Sanchez,282
-Alameda,520710,U.S. Senate,,DEM,Kamala Harris,387
-Alameda,520710,U.S. Senate,,DEM,Loretta Sanchez,155
-Alameda,520810,U.S. Senate,,DEM,Kamala Harris,354
-Alameda,520810,U.S. Senate,,DEM,Loretta Sanchez,128
-Alameda,520820,U.S. Senate,,DEM,Kamala Harris,607
-Alameda,520820,U.S. Senate,,DEM,Loretta Sanchez,227
-Alameda,520840,U.S. Senate,,DEM,Kamala Harris,598
-Alameda,520840,U.S. Senate,,DEM,Loretta Sanchez,231
-Alameda,520860,U.S. Senate,,DEM,Kamala Harris,535
-Alameda,520860,U.S. Senate,,DEM,Loretta Sanchez,179
-Alameda,520870,U.S. Senate,,DEM,Kamala Harris,469
-Alameda,520870,U.S. Senate,,DEM,Loretta Sanchez,176
-Alameda,521100,U.S. Senate,,DEM,Kamala Harris,685
-Alameda,521100,U.S. Senate,,DEM,Loretta Sanchez,304
-Alameda,521110,U.S. Senate,,DEM,Kamala Harris,511
-Alameda,521110,U.S. Senate,,DEM,Loretta Sanchez,185
-Alameda,521300,U.S. Senate,,DEM,Kamala Harris,572
-Alameda,521300,U.S. Senate,,DEM,Loretta Sanchez,205
-Alameda,521500,U.S. Senate,,DEM,Kamala Harris,485
-Alameda,521500,U.S. Senate,,DEM,Loretta Sanchez,180
-Alameda,522000,U.S. Senate,,DEM,Kamala Harris,402
-Alameda,522000,U.S. Senate,,DEM,Loretta Sanchez,136
-Alameda,522020,U.S. Senate,,DEM,Kamala Harris,443
-Alameda,522020,U.S. Senate,,DEM,Loretta Sanchez,155
-Alameda,522110,U.S. Senate,,DEM,Kamala Harris,828
-Alameda,522110,U.S. Senate,,DEM,Loretta Sanchez,287
-Alameda,522120,U.S. Senate,,DEM,Kamala Harris,591
-Alameda,522120,U.S. Senate,,DEM,Loretta Sanchez,236
-Alameda,522130,U.S. Senate,,DEM,Kamala Harris,420
-Alameda,522130,U.S. Senate,,DEM,Loretta Sanchez,130
-Alameda,522140,U.S. Senate,,DEM,Kamala Harris,352
-Alameda,522140,U.S. Senate,,DEM,Loretta Sanchez,115
-Alameda,522150,U.S. Senate,,DEM,Kamala Harris,742
-Alameda,522150,U.S. Senate,,DEM,Loretta Sanchez,287
-Alameda,522200,U.S. Senate,,DEM,Kamala Harris,329
-Alameda,522200,U.S. Senate,,DEM,Loretta Sanchez,117
-Alameda,522400,U.S. Senate,,DEM,Kamala Harris,331
-Alameda,522400,U.S. Senate,,DEM,Loretta Sanchez,127
-Alameda,523100,U.S. Senate,,DEM,Kamala Harris,276
-Alameda,523100,U.S. Senate,,DEM,Loretta Sanchez,84
-Alameda,523110,U.S. Senate,,DEM,Kamala Harris,779
-Alameda,523110,U.S. Senate,,DEM,Loretta Sanchez,341
-Alameda,523120,U.S. Senate,,DEM,Kamala Harris,335
-Alameda,523120,U.S. Senate,,DEM,Loretta Sanchez,117
-Alameda,523300,U.S. Senate,,DEM,Kamala Harris,791
-Alameda,523300,U.S. Senate,,DEM,Loretta Sanchez,300
-Alameda,523700,U.S. Senate,,DEM,Kamala Harris,397
-Alameda,523700,U.S. Senate,,DEM,Loretta Sanchez,168
-Alameda,523710,U.S. Senate,,DEM,Kamala Harris,377
-Alameda,523710,U.S. Senate,,DEM,Loretta Sanchez,131
-Alameda,523720,U.S. Senate,,DEM,Kamala Harris,413
-Alameda,523720,U.S. Senate,,DEM,Loretta Sanchez,175
-Alameda,523800,U.S. Senate,,DEM,Kamala Harris,434
-Alameda,523800,U.S. Senate,,DEM,Loretta Sanchez,141
-Alameda,540300,U.S. Senate,,DEM,Kamala Harris,731
-Alameda,540300,U.S. Senate,,DEM,Loretta Sanchez,343
-Alameda,540400,U.S. Senate,,DEM,Kamala Harris,343
-Alameda,540400,U.S. Senate,,DEM,Loretta Sanchez,89
-Alameda,540500,U.S. Senate,,DEM,Kamala Harris,447
-Alameda,540500,U.S. Senate,,DEM,Loretta Sanchez,201
-Alameda,540600,U.S. Senate,,DEM,Kamala Harris,670
-Alameda,540600,U.S. Senate,,DEM,Loretta Sanchez,334
-Alameda,540700,U.S. Senate,,DEM,Kamala Harris,448
-Alameda,540700,U.S. Senate,,DEM,Loretta Sanchez,208
-Alameda,540800,U.S. Senate,,DEM,Kamala Harris,676
-Alameda,540800,U.S. Senate,,DEM,Loretta Sanchez,343
-Alameda,541100,U.S. Senate,,DEM,Kamala Harris,490
-Alameda,541100,U.S. Senate,,DEM,Loretta Sanchez,320
-Alameda,542000,U.S. Senate,,DEM,Kamala Harris,703
-Alameda,542000,U.S. Senate,,DEM,Loretta Sanchez,300
-Alameda,542200,U.S. Senate,,DEM,Kamala Harris,454
-Alameda,542200,U.S. Senate,,DEM,Loretta Sanchez,240
-Alameda,543300,U.S. Senate,,DEM,Kamala Harris,640
-Alameda,543300,U.S. Senate,,DEM,Loretta Sanchez,261
-Alameda,544400,U.S. Senate,,DEM,Kamala Harris,531
-Alameda,544400,U.S. Senate,,DEM,Loretta Sanchez,222
-Alameda,545000,U.S. Senate,,DEM,Kamala Harris,702
-Alameda,545000,U.S. Senate,,DEM,Loretta Sanchez,250
-Alameda,546000,U.S. Senate,,DEM,Kamala Harris,475
-Alameda,546000,U.S. Senate,,DEM,Loretta Sanchez,180
-Alameda,546100,U.S. Senate,,DEM,Kamala Harris,667
-Alameda,546100,U.S. Senate,,DEM,Loretta Sanchez,227
-Alameda,546600,U.S. Senate,,DEM,Kamala Harris,611
-Alameda,546600,U.S. Senate,,DEM,Loretta Sanchez,228
-Alameda,547700,U.S. Senate,,DEM,Kamala Harris,675
-Alameda,547700,U.S. Senate,,DEM,Loretta Sanchez,167
-Alameda,547710,U.S. Senate,,DEM,Kamala Harris,1069
-Alameda,547710,U.S. Senate,,DEM,Loretta Sanchez,253
-Alameda,547740,U.S. Senate,,DEM,Kamala Harris,509
-Alameda,547740,U.S. Senate,,DEM,Loretta Sanchez,158
-Alameda,547750,U.S. Senate,,DEM,Kamala Harris,595
-Alameda,547750,U.S. Senate,,DEM,Loretta Sanchez,156
-Alameda,547760,U.S. Senate,,DEM,Kamala Harris,560
-Alameda,547760,U.S. Senate,,DEM,Loretta Sanchez,166
-Alameda,547780,U.S. Senate,,DEM,Kamala Harris,549
-Alameda,547780,U.S. Senate,,DEM,Loretta Sanchez,198
-Alameda,547790,U.S. Senate,,DEM,Kamala Harris,440
-Alameda,547790,U.S. Senate,,DEM,Loretta Sanchez,151
-Alameda,821100,U.S. Senate,,DEM,Kamala Harris,639
-Alameda,821100,U.S. Senate,,DEM,Loretta Sanchez,211
-Alameda,821110,U.S. Senate,,DEM,Kamala Harris,450
-Alameda,821110,U.S. Senate,,DEM,Loretta Sanchez,206
-Alameda,821140,U.S. Senate,,DEM,Kamala Harris,465
-Alameda,821140,U.S. Senate,,DEM,Loretta Sanchez,143
-Alameda,821200,U.S. Senate,,DEM,Kamala Harris,654
-Alameda,821200,U.S. Senate,,DEM,Loretta Sanchez,249
-Alameda,821210,U.S. Senate,,DEM,Kamala Harris,639
-Alameda,821210,U.S. Senate,,DEM,Loretta Sanchez,320
-Alameda,821400,U.S. Senate,,DEM,Kamala Harris,412
-Alameda,821400,U.S. Senate,,DEM,Loretta Sanchez,179
-Alameda,821500,U.S. Senate,,DEM,Kamala Harris,483
-Alameda,821500,U.S. Senate,,DEM,Loretta Sanchez,167
-Alameda,821600,U.S. Senate,,DEM,Kamala Harris,378
-Alameda,821600,U.S. Senate,,DEM,Loretta Sanchez,271
-Alameda,821710,U.S. Senate,,DEM,Kamala Harris,338
-Alameda,821710,U.S. Senate,,DEM,Loretta Sanchez,165
-Alameda,821730,U.S. Senate,,DEM,Kamala Harris,703
-Alameda,821730,U.S. Senate,,DEM,Loretta Sanchez,309
-Alameda,821800,U.S. Senate,,DEM,Kamala Harris,464
-Alameda,821800,U.S. Senate,,DEM,Loretta Sanchez,174
-Alameda,821810,U.S. Senate,,DEM,Kamala Harris,316
-Alameda,821810,U.S. Senate,,DEM,Loretta Sanchez,133
-Alameda,821900,U.S. Senate,,DEM,Kamala Harris,472
-Alameda,821900,U.S. Senate,,DEM,Loretta Sanchez,196
-Alameda,821910,U.S. Senate,,DEM,Kamala Harris,354
-Alameda,821910,U.S. Senate,,DEM,Loretta Sanchez,109
-Alameda,822000,U.S. Senate,,DEM,Kamala Harris,625
-Alameda,822000,U.S. Senate,,DEM,Loretta Sanchez,183
-Alameda,822010,U.S. Senate,,DEM,Kamala Harris,643
-Alameda,822010,U.S. Senate,,DEM,Loretta Sanchez,190
-Alameda,822200,U.S. Senate,,DEM,Kamala Harris,483
-Alameda,822200,U.S. Senate,,DEM,Loretta Sanchez,152
-Alameda,823000,U.S. Senate,,DEM,Kamala Harris,427
-Alameda,823000,U.S. Senate,,DEM,Loretta Sanchez,249
-Alameda,823100,U.S. Senate,,DEM,Kamala Harris,346
-Alameda,823100,U.S. Senate,,DEM,Loretta Sanchez,340
-Alameda,823200,U.S. Senate,,DEM,Kamala Harris,584
-Alameda,823200,U.S. Senate,,DEM,Loretta Sanchez,493
-Alameda,823400,U.S. Senate,,DEM,Kamala Harris,490
-Alameda,823400,U.S. Senate,,DEM,Loretta Sanchez,168
-Alameda,823500,U.S. Senate,,DEM,Kamala Harris,356
-Alameda,823500,U.S. Senate,,DEM,Loretta Sanchez,171
-Alameda,823510,U.S. Senate,,DEM,Kamala Harris,406
-Alameda,823510,U.S. Senate,,DEM,Loretta Sanchez,262
-Alameda,823600,U.S. Senate,,DEM,Kamala Harris,666
-Alameda,823600,U.S. Senate,,DEM,Loretta Sanchez,234
-Alameda,823610,U.S. Senate,,DEM,Kamala Harris,344
-Alameda,823610,U.S. Senate,,DEM,Loretta Sanchez,164
-Alameda,823700,U.S. Senate,,DEM,Kamala Harris,713
-Alameda,823700,U.S. Senate,,DEM,Loretta Sanchez,213
-Alameda,823710,U.S. Senate,,DEM,Kamala Harris,338
-Alameda,823710,U.S. Senate,,DEM,Loretta Sanchez,117
-Alameda,823720,U.S. Senate,,DEM,Kamala Harris,453
-Alameda,823720,U.S. Senate,,DEM,Loretta Sanchez,138
-Alameda,823730,U.S. Senate,,DEM,Kamala Harris,647
-Alameda,823730,U.S. Senate,,DEM,Loretta Sanchez,276
-Alameda,823800,U.S. Senate,,DEM,Kamala Harris,585
-Alameda,823800,U.S. Senate,,DEM,Loretta Sanchez,208
-Alameda,823810,U.S. Senate,,DEM,Kamala Harris,458
-Alameda,823810,U.S. Senate,,DEM,Loretta Sanchez,179
-Alameda,823900,U.S. Senate,,DEM,Kamala Harris,425
-Alameda,823900,U.S. Senate,,DEM,Loretta Sanchez,148
-Alameda,830100,U.S. Senate,,DEM,Kamala Harris,348
-Alameda,830100,U.S. Senate,,DEM,Loretta Sanchez,87
-Alameda,830200,U.S. Senate,,DEM,Kamala Harris,697
-Alameda,830200,U.S. Senate,,DEM,Loretta Sanchez,225
-Alameda,830210,U.S. Senate,,DEM,Kamala Harris,769
-Alameda,830210,U.S. Senate,,DEM,Loretta Sanchez,176
-Alameda,830300,U.S. Senate,,DEM,Kamala Harris,800
-Alameda,830300,U.S. Senate,,DEM,Loretta Sanchez,200
-Alameda,830500,U.S. Senate,,DEM,Kamala Harris,795
-Alameda,830500,U.S. Senate,,DEM,Loretta Sanchez,187
-Alameda,830700,U.S. Senate,,DEM,Kamala Harris,678
-Alameda,830700,U.S. Senate,,DEM,Loretta Sanchez,170
-Alameda,831000,U.S. Senate,,DEM,Kamala Harris,397
-Alameda,831000,U.S. Senate,,DEM,Loretta Sanchez,175
-Alameda,831100,U.S. Senate,,DEM,Kamala Harris,343
-Alameda,831100,U.S. Senate,,DEM,Loretta Sanchez,139
-Alameda,831200,U.S. Senate,,DEM,Kamala Harris,573
-Alameda,831200,U.S. Senate,,DEM,Loretta Sanchez,195
-Alameda,831210,U.S. Senate,,DEM,Kamala Harris,320
-Alameda,831210,U.S. Senate,,DEM,Loretta Sanchez,140
-Alameda,831230,U.S. Senate,,DEM,Kamala Harris,476
-Alameda,831230,U.S. Senate,,DEM,Loretta Sanchez,158
-Alameda,831300,U.S. Senate,,DEM,Kamala Harris,691
-Alameda,831300,U.S. Senate,,DEM,Loretta Sanchez,241
-Alameda,831400,U.S. Senate,,DEM,Kamala Harris,377
-Alameda,831400,U.S. Senate,,DEM,Loretta Sanchez,144
-Alameda,831410,U.S. Senate,,DEM,Kamala Harris,434
-Alameda,831410,U.S. Senate,,DEM,Loretta Sanchez,186
-Alameda,831500,U.S. Senate,,DEM,Kamala Harris,668
-Alameda,831500,U.S. Senate,,DEM,Loretta Sanchez,252
-Alameda,831510,U.S. Senate,,DEM,Kamala Harris,378
-Alameda,831510,U.S. Senate,,DEM,Loretta Sanchez,147
-Alameda,831610,U.S. Senate,,DEM,Kamala Harris,583
-Alameda,831610,U.S. Senate,,DEM,Loretta Sanchez,236
-Alameda,831700,U.S. Senate,,DEM,Kamala Harris,478
-Alameda,831700,U.S. Senate,,DEM,Loretta Sanchez,145
-Alameda,831710,U.S. Senate,,DEM,Kamala Harris,615
-Alameda,831710,U.S. Senate,,DEM,Loretta Sanchez,225
-Alameda,831810,U.S. Senate,,DEM,Kamala Harris,663
-Alameda,831810,U.S. Senate,,DEM,Loretta Sanchez,275
-Alameda,831830,U.S. Senate,,DEM,Kamala Harris,422
-Alameda,831830,U.S. Senate,,DEM,Loretta Sanchez,223
-Alameda,831900,U.S. Senate,,DEM,Kamala Harris,633
-Alameda,831900,U.S. Senate,,DEM,Loretta Sanchez,278
-Alameda,831920,U.S. Senate,,DEM,Kamala Harris,649
-Alameda,831920,U.S. Senate,,DEM,Loretta Sanchez,292
-Alameda,832000,U.S. Senate,,DEM,Kamala Harris,592
-Alameda,832000,U.S. Senate,,DEM,Loretta Sanchez,213
-Alameda,832010,U.S. Senate,,DEM,Kamala Harris,419
-Alameda,832010,U.S. Senate,,DEM,Loretta Sanchez,207
-Alameda,832200,U.S. Senate,,DEM,Kamala Harris,600
-Alameda,832200,U.S. Senate,,DEM,Loretta Sanchez,242
-Alameda,832210,U.S. Senate,,DEM,Kamala Harris,639
-Alameda,832210,U.S. Senate,,DEM,Loretta Sanchez,232
-Alameda,832300,U.S. Senate,,DEM,Kamala Harris,640
-Alameda,832300,U.S. Senate,,DEM,Loretta Sanchez,288
-Alameda,832500,U.S. Senate,,DEM,Kamala Harris,589
-Alameda,832500,U.S. Senate,,DEM,Loretta Sanchez,261
-Alameda,832510,U.S. Senate,,DEM,Kamala Harris,567
-Alameda,832510,U.S. Senate,,DEM,Loretta Sanchez,255
-Alameda,832600,U.S. Senate,,DEM,Kamala Harris,407
-Alameda,832600,U.S. Senate,,DEM,Loretta Sanchez,165
-Alameda,832620,U.S. Senate,,DEM,Kamala Harris,438
-Alameda,832620,U.S. Senate,,DEM,Loretta Sanchez,231
-Alameda,832800,U.S. Senate,,DEM,Kamala Harris,537
-Alameda,832800,U.S. Senate,,DEM,Loretta Sanchez,278
-Alameda,832810,U.S. Senate,,DEM,Kamala Harris,306
-Alameda,832810,U.S. Senate,,DEM,Loretta Sanchez,168
-Alameda,832900,U.S. Senate,,DEM,Kamala Harris,650
-Alameda,832900,U.S. Senate,,DEM,Loretta Sanchez,310
-Alameda,833000,U.S. Senate,,DEM,Kamala Harris,628
-Alameda,833000,U.S. Senate,,DEM,Loretta Sanchez,436
-Alameda,833100,U.S. Senate,,DEM,Kamala Harris,602
-Alameda,833100,U.S. Senate,,DEM,Loretta Sanchez,348
-Alameda,833200,U.S. Senate,,DEM,Kamala Harris,581
-Alameda,833200,U.S. Senate,,DEM,Loretta Sanchez,227
-Alameda,833210,U.S. Senate,,DEM,Kamala Harris,361
-Alameda,833210,U.S. Senate,,DEM,Loretta Sanchez,184
-Alameda,833300,U.S. Senate,,DEM,Kamala Harris,327
-Alameda,833300,U.S. Senate,,DEM,Loretta Sanchez,194
-Alameda,833310,U.S. Senate,,DEM,Kamala Harris,304
-Alameda,833310,U.S. Senate,,DEM,Loretta Sanchez,154
-Alameda,833400,U.S. Senate,,DEM,Kamala Harris,387
-Alameda,833400,U.S. Senate,,DEM,Loretta Sanchez,158
-Alameda,833410,U.S. Senate,,DEM,Kamala Harris,440
-Alameda,833410,U.S. Senate,,DEM,Loretta Sanchez,202
-Alameda,833500,U.S. Senate,,DEM,Kamala Harris,701
-Alameda,833500,U.S. Senate,,DEM,Loretta Sanchez,360
-Alameda,833610,U.S. Senate,,DEM,Kamala Harris,444
-Alameda,833610,U.S. Senate,,DEM,Loretta Sanchez,318
-Alameda,833700,U.S. Senate,,DEM,Kamala Harris,311
-Alameda,833700,U.S. Senate,,DEM,Loretta Sanchez,153
-Alameda,833710,U.S. Senate,,DEM,Kamala Harris,544
-Alameda,833710,U.S. Senate,,DEM,Loretta Sanchez,338
-Alameda,834000,U.S. Senate,,DEM,Kamala Harris,709
-Alameda,834000,U.S. Senate,,DEM,Loretta Sanchez,290
-Alameda,834200,U.S. Senate,,DEM,Kamala Harris,739
-Alameda,834200,U.S. Senate,,DEM,Loretta Sanchez,318
-Alameda,834400,U.S. Senate,,DEM,Kamala Harris,513
-Alameda,834400,U.S. Senate,,DEM,Loretta Sanchez,209
-Alameda,834600,U.S. Senate,,DEM,Kamala Harris,550
-Alameda,834600,U.S. Senate,,DEM,Loretta Sanchez,215
-Alameda,834700,U.S. Senate,,DEM,Kamala Harris,795
-Alameda,834700,U.S. Senate,,DEM,Loretta Sanchez,248
-Alameda,835000,U.S. Senate,,DEM,Kamala Harris,565
-Alameda,835000,U.S. Senate,,DEM,Loretta Sanchez,189
-Alameda,835100,U.S. Senate,,DEM,Kamala Harris,544
-Alameda,835100,U.S. Senate,,DEM,Loretta Sanchez,201
-Alameda,835300,U.S. Senate,,DEM,Kamala Harris,496
-Alameda,835300,U.S. Senate,,DEM,Loretta Sanchez,162
-Alameda,835310,U.S. Senate,,DEM,Kamala Harris,611
-Alameda,835310,U.S. Senate,,DEM,Loretta Sanchez,283
-Alameda,835500,U.S. Senate,,DEM,Kamala Harris,394
-Alameda,835500,U.S. Senate,,DEM,Loretta Sanchez,116
-Alameda,835600,U.S. Senate,,DEM,Kamala Harris,438
-Alameda,835600,U.S. Senate,,DEM,Loretta Sanchez,164
-Alameda,835610,U.S. Senate,,DEM,Kamala Harris,337
-Alameda,835610,U.S. Senate,,DEM,Loretta Sanchez,106
-Alameda,835730,U.S. Senate,,DEM,Kamala Harris,495
-Alameda,835730,U.S. Senate,,DEM,Loretta Sanchez,148
-Alameda,835800,U.S. Senate,,DEM,Kamala Harris,589
-Alameda,835800,U.S. Senate,,DEM,Loretta Sanchez,364
-Alameda,835820,U.S. Senate,,DEM,Kamala Harris,677
-Alameda,835820,U.S. Senate,,DEM,Loretta Sanchez,230
-Alameda,835900,U.S. Senate,,DEM,Kamala Harris,584
-Alameda,835900,U.S. Senate,,DEM,Loretta Sanchez,292
-Alameda,836000,U.S. Senate,,DEM,Kamala Harris,630
-Alameda,836000,U.S. Senate,,DEM,Loretta Sanchez,181
-Alameda,836110,U.S. Senate,,DEM,Kamala Harris,747
-Alameda,836110,U.S. Senate,,DEM,Loretta Sanchez,191
-Alameda,836200,U.S. Senate,,DEM,Kamala Harris,773
-Alameda,836200,U.S. Senate,,DEM,Loretta Sanchez,208
-Alameda,836210,U.S. Senate,,DEM,Kamala Harris,489
-Alameda,836210,U.S. Senate,,DEM,Loretta Sanchez,135
-Alameda,836400,U.S. Senate,,DEM,Kamala Harris,420
-Alameda,836400,U.S. Senate,,DEM,Loretta Sanchez,120
-Alameda,836500,U.S. Senate,,DEM,Kamala Harris,694
-Alameda,836500,U.S. Senate,,DEM,Loretta Sanchez,202
-Alameda,836600,U.S. Senate,,DEM,Kamala Harris,698
-Alameda,836600,U.S. Senate,,DEM,Loretta Sanchez,220
-Alameda,837000,U.S. Senate,,DEM,Kamala Harris,493
-Alameda,837000,U.S. Senate,,DEM,Loretta Sanchez,161
-Alameda,837100,U.S. Senate,,DEM,Kamala Harris,572
-Alameda,837100,U.S. Senate,,DEM,Loretta Sanchez,163
-Alameda,837200,U.S. Senate,,DEM,Kamala Harris,318
-Alameda,837200,U.S. Senate,,DEM,Loretta Sanchez,102
-Alameda,837300,U.S. Senate,,DEM,Kamala Harris,651
-Alameda,837300,U.S. Senate,,DEM,Loretta Sanchez,174
-Alameda,837400,U.S. Senate,,DEM,Kamala Harris,580
-Alameda,837400,U.S. Senate,,DEM,Loretta Sanchez,134
-Alameda,837500,U.S. Senate,,DEM,Kamala Harris,414
-Alameda,837500,U.S. Senate,,DEM,Loretta Sanchez,134
-Alameda,837600,U.S. Senate,,DEM,Kamala Harris,538
-Alameda,837600,U.S. Senate,,DEM,Loretta Sanchez,190
-Alameda,837700,U.S. Senate,,DEM,Kamala Harris,595
-Alameda,837700,U.S. Senate,,DEM,Loretta Sanchez,140
-Alameda,837710,U.S. Senate,,DEM,Kamala Harris,346
-Alameda,837710,U.S. Senate,,DEM,Loretta Sanchez,79
-Alameda,837800,U.S. Senate,,DEM,Kamala Harris,380
-Alameda,837800,U.S. Senate,,DEM,Loretta Sanchez,104
-Alameda,837900,U.S. Senate,,DEM,Kamala Harris,297
-Alameda,837900,U.S. Senate,,DEM,Loretta Sanchez,100
-Alameda,838000,U.S. Senate,,DEM,Kamala Harris,714
-Alameda,838000,U.S. Senate,,DEM,Loretta Sanchez,228
-Alameda,838110,U.S. Senate,,DEM,Kamala Harris,848
-Alameda,838110,U.S. Senate,,DEM,Loretta Sanchez,177
-Alameda,838300,U.S. Senate,,DEM,Kamala Harris,588
-Alameda,838300,U.S. Senate,,DEM,Loretta Sanchez,236
-Alameda,838500,U.S. Senate,,DEM,Kamala Harris,763
-Alameda,838500,U.S. Senate,,DEM,Loretta Sanchez,310
-Alameda,838600,U.S. Senate,,DEM,Kamala Harris,551
-Alameda,838600,U.S. Senate,,DEM,Loretta Sanchez,176
-Alameda,838700,U.S. Senate,,DEM,Kamala Harris,557
-Alameda,838700,U.S. Senate,,DEM,Loretta Sanchez,229
-Alameda,839530,U.S. Senate,,DEM,Kamala Harris,434
-Alameda,839530,U.S. Senate,,DEM,Loretta Sanchez,176
-Alameda,850300,U.S. Senate,,DEM,Kamala Harris,654
-Alameda,850300,U.S. Senate,,DEM,Loretta Sanchez,383
-Alameda,850320,U.S. Senate,,DEM,Kamala Harris,234
-Alameda,850320,U.S. Senate,,DEM,Loretta Sanchez,130
-Alameda,850330,U.S. Senate,,DEM,Kamala Harris,449
-Alameda,850330,U.S. Senate,,DEM,Loretta Sanchez,162
-Alameda,850400,U.S. Senate,,DEM,Kamala Harris,276
-Alameda,850400,U.S. Senate,,DEM,Loretta Sanchez,172
-Alameda,850410,U.S. Senate,,DEM,Kamala Harris,349
-Alameda,850410,U.S. Senate,,DEM,Loretta Sanchez,237
-Alameda,850500,U.S. Senate,,DEM,Kamala Harris,506
-Alameda,850500,U.S. Senate,,DEM,Loretta Sanchez,309
-Alameda,850600,U.S. Senate,,DEM,Kamala Harris,493
-Alameda,850600,U.S. Senate,,DEM,Loretta Sanchez,389
-Alameda,850800,U.S. Senate,,DEM,Kamala Harris,276
-Alameda,850800,U.S. Senate,,DEM,Loretta Sanchez,288
-Alameda,850810,U.S. Senate,,DEM,Kamala Harris,417
-Alameda,850810,U.S. Senate,,DEM,Loretta Sanchez,220
-Alameda,850900,U.S. Senate,,DEM,Kamala Harris,411
-Alameda,850900,U.S. Senate,,DEM,Loretta Sanchez,231
-Alameda,851000,U.S. Senate,,DEM,Kamala Harris,439
-Alameda,851000,U.S. Senate,,DEM,Loretta Sanchez,272
-Alameda,851200,U.S. Senate,,DEM,Kamala Harris,317
-Alameda,851200,U.S. Senate,,DEM,Loretta Sanchez,248
-Alameda,851300,U.S. Senate,,DEM,Kamala Harris,362
-Alameda,851300,U.S. Senate,,DEM,Loretta Sanchez,219
-Alameda,851500,U.S. Senate,,DEM,Kamala Harris,302
-Alameda,851500,U.S. Senate,,DEM,Loretta Sanchez,204
-Alameda,851510,U.S. Senate,,DEM,Kamala Harris,279
-Alameda,851510,U.S. Senate,,DEM,Loretta Sanchez,148
-Alameda,851520,U.S. Senate,,DEM,Kamala Harris,378
-Alameda,851520,U.S. Senate,,DEM,Loretta Sanchez,166
-Alameda,851600,U.S. Senate,,DEM,Kamala Harris,442
-Alameda,851600,U.S. Senate,,DEM,Loretta Sanchez,361
-Alameda,851700,U.S. Senate,,DEM,Kamala Harris,569
-Alameda,851700,U.S. Senate,,DEM,Loretta Sanchez,382
-Alameda,851800,U.S. Senate,,DEM,Kamala Harris,415
-Alameda,851800,U.S. Senate,,DEM,Loretta Sanchez,209
-Alameda,852010,U.S. Senate,,DEM,Kamala Harris,371
-Alameda,852010,U.S. Senate,,DEM,Loretta Sanchez,246
-Alameda,852100,U.S. Senate,,DEM,Kamala Harris,546
-Alameda,852100,U.S. Senate,,DEM,Loretta Sanchez,422
-Alameda,866800,U.S. Senate,,DEM,Kamala Harris,227
-Alameda,866800,U.S. Senate,,DEM,Loretta Sanchez,117
-Alameda,9205510,U.S. Senate,,DEM,Kamala Harris,138
-Alameda,9205510,U.S. Senate,,DEM,Loretta Sanchez,8
-Alameda,9205550,U.S. Senate,,DEM,Kamala Harris,148
-Alameda,9205550,U.S. Senate,,DEM,Loretta Sanchez,26
-Alameda,9207630,U.S. Senate,,DEM,Kamala Harris,85
-Alameda,9207630,U.S. Senate,,DEM,Loretta Sanchez,20
-Alameda,9207640,U.S. Senate,,DEM,Kamala Harris,89
-Alameda,9207640,U.S. Senate,,DEM,Loretta Sanchez,43
-Alameda,9209910,U.S. Senate,,DEM,Kamala Harris,3
-Alameda,9209910,U.S. Senate,,DEM,Loretta Sanchez,1
-Alameda,9213000,U.S. Senate,,DEM,Kamala Harris,260
-Alameda,9213000,U.S. Senate,,DEM,Loretta Sanchez,51
-Alameda,9215630,U.S. Senate,,DEM,Kamala Harris,101
-Alameda,9215630,U.S. Senate,,DEM,Loretta Sanchez,23
-Alameda,9215810,U.S. Senate,,DEM,Kamala Harris,54
-Alameda,9215810,U.S. Senate,,DEM,Loretta Sanchez,19
-Alameda,9223100,U.S. Senate,,DEM,Kamala Harris,219
-Alameda,9223100,U.S. Senate,,DEM,Loretta Sanchez,28
-Alameda,9223110,U.S. Senate,,DEM,Kamala Harris,86
-Alameda,9223110,U.S. Senate,,DEM,Loretta Sanchez,13
-Alameda,9224300,U.S. Senate,,DEM,Kamala Harris,141
-Alameda,9224300,U.S. Senate,,DEM,Loretta Sanchez,25
-Alameda,9224420,U.S. Senate,,DEM,Kamala Harris,33
-Alameda,9224420,U.S. Senate,,DEM,Loretta Sanchez,10
-Alameda,9224440,U.S. Senate,,DEM,Kamala Harris,37
-Alameda,9224440,U.S. Senate,,DEM,Loretta Sanchez,6
-Alameda,9224810,U.S. Senate,,DEM,Kamala Harris,183
-Alameda,9224810,U.S. Senate,,DEM,Loretta Sanchez,34
-Alameda,9224910,U.S. Senate,,DEM,Kamala Harris,141
-Alameda,9224910,U.S. Senate,,DEM,Loretta Sanchez,19
-Alameda,9225500,U.S. Senate,,DEM,Kamala Harris,84
-Alameda,9225500,U.S. Senate,,DEM,Loretta Sanchez,22
-Alameda,9244910,U.S. Senate,,DEM,Kamala Harris,97
-Alameda,9244910,U.S. Senate,,DEM,Loretta Sanchez,14
-Alameda,9323400,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9323400,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9325000,U.S. Senate,,DEM,Kamala Harris,209
-Alameda,9325000,U.S. Senate,,DEM,Loretta Sanchez,44
-Alameda,9333300,U.S. Senate,,DEM,Kamala Harris,47
-Alameda,9333300,U.S. Senate,,DEM,Loretta Sanchez,15
-Alameda,9333420,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9333420,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9333910,U.S. Senate,,DEM,Kamala Harris,89
-Alameda,9333910,U.S. Senate,,DEM,Loretta Sanchez,26
-Alameda,9333920,U.S. Senate,,DEM,Kamala Harris,37
-Alameda,9333920,U.S. Senate,,DEM,Loretta Sanchez,15
-Alameda,9333930,U.S. Senate,,DEM,Kamala Harris,153
-Alameda,9333930,U.S. Senate,,DEM,Loretta Sanchez,65
-Alameda,9334510,U.S. Senate,,DEM,Kamala Harris,7
-Alameda,9334510,U.S. Senate,,DEM,Loretta Sanchez,1
-Alameda,9335110,U.S. Senate,,DEM,Kamala Harris,108
-Alameda,9335110,U.S. Senate,,DEM,Loretta Sanchez,30
-Alameda,9335600,U.S. Senate,,DEM,Kamala Harris,114
-Alameda,9335600,U.S. Senate,,DEM,Loretta Sanchez,39
-Alameda,9335800,U.S. Senate,,DEM,Kamala Harris,139
-Alameda,9335800,U.S. Senate,,DEM,Loretta Sanchez,23
-Alameda,9335910,U.S. Senate,,DEM,Kamala Harris,60
-Alameda,9335910,U.S. Senate,,DEM,Loretta Sanchez,19
-Alameda,9336300,U.S. Senate,,DEM,Kamala Harris,29
-Alameda,9336300,U.S. Senate,,DEM,Loretta Sanchez,4
-Alameda,9336810,U.S. Senate,,DEM,Kamala Harris,41
-Alameda,9336810,U.S. Senate,,DEM,Loretta Sanchez,5
-Alameda,9344020,U.S. Senate,,DEM,Kamala Harris,55
-Alameda,9344020,U.S. Senate,,DEM,Loretta Sanchez,34
-Alameda,9345710,U.S. Senate,,DEM,Kamala Harris,66
-Alameda,9345710,U.S. Senate,,DEM,Loretta Sanchez,13
-Alameda,9347210,U.S. Senate,,DEM,Kamala Harris,77
-Alameda,9347210,U.S. Senate,,DEM,Loretta Sanchez,30
-Alameda,9347220,U.S. Senate,,DEM,Kamala Harris,39
-Alameda,9347220,U.S. Senate,,DEM,Loretta Sanchez,7
-Alameda,9355210,U.S. Senate,,DEM,Kamala Harris,125
-Alameda,9355210,U.S. Senate,,DEM,Loretta Sanchez,39
-Alameda,9355220,U.S. Senate,,DEM,Kamala Harris,46
-Alameda,9355220,U.S. Senate,,DEM,Loretta Sanchez,19
-Alameda,9360900,U.S. Senate,,DEM,Kamala Harris,6
-Alameda,9360900,U.S. Senate,,DEM,Loretta Sanchez,5
-Alameda,9361100,U.S. Senate,,DEM,Kamala Harris,15
-Alameda,9361100,U.S. Senate,,DEM,Loretta Sanchez,5
-Alameda,9361210,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9361210,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9361400,U.S. Senate,,DEM,Kamala Harris,27
-Alameda,9361400,U.S. Senate,,DEM,Loretta Sanchez,12
-Alameda,9362000,U.S. Senate,,DEM,Kamala Harris,127
-Alameda,9362000,U.S. Senate,,DEM,Loretta Sanchez,96
-Alameda,9364020,U.S. Senate,,DEM,Kamala Harris,5
-Alameda,9364020,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9364030,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9364030,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9364210,U.S. Senate,,DEM,Kamala Harris,5
-Alameda,9364210,U.S. Senate,,DEM,Loretta Sanchez,1
-Alameda,9364320,U.S. Senate,,DEM,Kamala Harris,5
-Alameda,9364320,U.S. Senate,,DEM,Loretta Sanchez,4
-Alameda,9364330,U.S. Senate,,DEM,Kamala Harris,23
-Alameda,9364330,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9373000,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9373000,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9373010,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9373010,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9373020,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9373020,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9373030,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9373030,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9394000,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9394000,U.S. Senate,,DEM,Loretta Sanchez,3
-Alameda,9394100,U.S. Senate,,DEM,Kamala Harris,2
-Alameda,9394100,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9394200,U.S. Senate,,DEM,Kamala Harris,2
-Alameda,9394200,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9416220,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9416220,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9420010,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9420010,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9420020,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9420020,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9420030,U.S. Senate,,DEM,Kamala Harris,26
-Alameda,9420030,U.S. Senate,,DEM,Loretta Sanchez,40
-Alameda,9420040,U.S. Senate,,DEM,Kamala Harris,50
-Alameda,9420040,U.S. Senate,,DEM,Loretta Sanchez,16
-Alameda,9420050,U.S. Senate,,DEM,Kamala Harris,78
-Alameda,9420050,U.S. Senate,,DEM,Loretta Sanchez,54
-Alameda,9420200,U.S. Senate,,DEM,Kamala Harris,135
-Alameda,9420200,U.S. Senate,,DEM,Loretta Sanchez,58
-Alameda,9420210,U.S. Senate,,DEM,Kamala Harris,74
-Alameda,9420210,U.S. Senate,,DEM,Loretta Sanchez,63
-Alameda,9420220,U.S. Senate,,DEM,Kamala Harris,9
-Alameda,9420220,U.S. Senate,,DEM,Loretta Sanchez,1
-Alameda,9420230,U.S. Senate,,DEM,Kamala Harris,103
-Alameda,9420230,U.S. Senate,,DEM,Loretta Sanchez,117
-Alameda,9420240,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9420240,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9420250,U.S. Senate,,DEM,Kamala Harris,125
-Alameda,9420250,U.S. Senate,,DEM,Loretta Sanchez,92
-Alameda,9420300,U.S. Senate,,DEM,Kamala Harris,103
-Alameda,9420300,U.S. Senate,,DEM,Loretta Sanchez,19
-Alameda,9420310,U.S. Senate,,DEM,Kamala Harris,15
-Alameda,9420310,U.S. Senate,,DEM,Loretta Sanchez,14
-Alameda,9420320,U.S. Senate,,DEM,Kamala Harris,1
-Alameda,9420320,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9420510,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9420510,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9420610,U.S. Senate,,DEM,Kamala Harris,1
-Alameda,9420610,U.S. Senate,,DEM,Loretta Sanchez,2
-Alameda,9420800,U.S. Senate,,DEM,Kamala Harris,102
-Alameda,9420800,U.S. Senate,,DEM,Loretta Sanchez,102
-Alameda,9422930,U.S. Senate,,DEM,Kamala Harris,132
-Alameda,9422930,U.S. Senate,,DEM,Loretta Sanchez,59
-Alameda,9422940,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9422940,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9422950,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9422950,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9423620,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9423620,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9423700,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9423700,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9423800,U.S. Senate,,DEM,Kamala Harris,2
-Alameda,9423800,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9423810,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9423810,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9423820,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9423820,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9424200,U.S. Senate,,DEM,Kamala Harris,36
-Alameda,9424200,U.S. Senate,,DEM,Loretta Sanchez,10
-Alameda,9430010,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9430010,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9430020,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9430020,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9430110,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9430110,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9430120,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9430120,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9430130,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9430130,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9430140,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9430140,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9430150,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9430150,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9430160,U.S. Senate,,DEM,Kamala Harris,2
-Alameda,9430160,U.S. Senate,,DEM,Loretta Sanchez,2
-Alameda,9430410,U.S. Senate,,DEM,Kamala Harris,4
-Alameda,9430410,U.S. Senate,,DEM,Loretta Sanchez,2
-Alameda,9430420,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9430420,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9430500,U.S. Senate,,DEM,Kamala Harris,1
-Alameda,9430500,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9430510,U.S. Senate,,DEM,Kamala Harris,21
-Alameda,9430510,U.S. Senate,,DEM,Loretta Sanchez,16
-Alameda,9430710,U.S. Senate,,DEM,Kamala Harris,29
-Alameda,9430710,U.S. Senate,,DEM,Loretta Sanchez,9
-Alameda,9430720,U.S. Senate,,DEM,Kamala Harris,82
-Alameda,9430720,U.S. Senate,,DEM,Loretta Sanchez,35
-Alameda,9430800,U.S. Senate,,DEM,Kamala Harris,276
-Alameda,9430800,U.S. Senate,,DEM,Loretta Sanchez,50
-Alameda,9430820,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9430820,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9431110,U.S. Senate,,DEM,Kamala Harris,5
-Alameda,9431110,U.S. Senate,,DEM,Loretta Sanchez,1
-Alameda,9431120,U.S. Senate,,DEM,Kamala Harris,1
-Alameda,9431120,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9431200,U.S. Senate,,DEM,Kamala Harris,2
-Alameda,9431200,U.S. Senate,,DEM,Loretta Sanchez,1
-Alameda,9431210,U.S. Senate,,DEM,Kamala Harris,19
-Alameda,9431210,U.S. Senate,,DEM,Loretta Sanchez,5
-Alameda,9431300,U.S. Senate,,DEM,Kamala Harris,37
-Alameda,9431300,U.S. Senate,,DEM,Loretta Sanchez,19
-Alameda,9431310,U.S. Senate,,DEM,Kamala Harris,62
-Alameda,9431310,U.S. Senate,,DEM,Loretta Sanchez,15
-Alameda,9431400,U.S. Senate,,DEM,Kamala Harris,104
-Alameda,9431400,U.S. Senate,,DEM,Loretta Sanchez,44
-Alameda,9431500,U.S. Senate,,DEM,Kamala Harris,62
-Alameda,9431500,U.S. Senate,,DEM,Loretta Sanchez,25
-Alameda,9431610,U.S. Senate,,DEM,Kamala Harris,24
-Alameda,9431610,U.S. Senate,,DEM,Loretta Sanchez,7
-Alameda,9431620,U.S. Senate,,DEM,Kamala Harris,8
-Alameda,9431620,U.S. Senate,,DEM,Loretta Sanchez,4
-Alameda,9431700,U.S. Senate,,DEM,Kamala Harris,74
-Alameda,9431700,U.S. Senate,,DEM,Loretta Sanchez,35
-Alameda,9431900,U.S. Senate,,DEM,Kamala Harris,105
-Alameda,9431900,U.S. Senate,,DEM,Loretta Sanchez,36
-Alameda,9432910,U.S. Senate,,DEM,Kamala Harris,20
-Alameda,9432910,U.S. Senate,,DEM,Loretta Sanchez,17
-Alameda,9433620,U.S. Senate,,DEM,Kamala Harris,194
-Alameda,9433620,U.S. Senate,,DEM,Loretta Sanchez,47
-Alameda,9433630,U.S. Senate,,DEM,Kamala Harris,175
-Alameda,9433630,U.S. Senate,,DEM,Loretta Sanchez,42
-Alameda,9438120,U.S. Senate,,DEM,Kamala Harris,6
-Alameda,9438120,U.S. Senate,,DEM,Loretta Sanchez,1
-Alameda,9438140,U.S. Senate,,DEM,Kamala Harris,2
-Alameda,9438140,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9438500,U.S. Senate,,DEM,Kamala Harris,4
-Alameda,9438500,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9442610,U.S. Senate,,DEM,Kamala Harris,149
-Alameda,9442610,U.S. Senate,,DEM,Loretta Sanchez,52
-Alameda,9442810,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9442810,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9442820,U.S. Senate,,DEM,Kamala Harris,111
-Alameda,9442820,U.S. Senate,,DEM,Loretta Sanchez,56
-Alameda,9443110,U.S. Senate,,DEM,Kamala Harris,26
-Alameda,9443110,U.S. Senate,,DEM,Loretta Sanchez,14
-Alameda,9443600,U.S. Senate,,DEM,Kamala Harris,135
-Alameda,9443600,U.S. Senate,,DEM,Loretta Sanchez,107
-Alameda,9443700,U.S. Senate,,DEM,Kamala Harris,155
-Alameda,9443700,U.S. Senate,,DEM,Loretta Sanchez,81
-Alameda,9443710,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9443710,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9443720,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9443720,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9443800,U.S. Senate,,DEM,Kamala Harris,109
-Alameda,9443800,U.S. Senate,,DEM,Loretta Sanchez,84
-Alameda,9447010,U.S. Senate,,DEM,Kamala Harris,2
-Alameda,9447010,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9447020,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9447020,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9447040,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9447040,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9447100,U.S. Senate,,DEM,Kamala Harris,4
-Alameda,9447100,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9447110,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9447110,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9447120,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9447120,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9447210,U.S. Senate,,DEM,Kamala Harris,2
-Alameda,9447210,U.S. Senate,,DEM,Loretta Sanchez,5
-Alameda,9447300,U.S. Senate,,DEM,Kamala Harris,170
-Alameda,9447300,U.S. Senate,,DEM,Loretta Sanchez,60
-Alameda,9447510,U.S. Senate,,DEM,Kamala Harris,20
-Alameda,9447510,U.S. Senate,,DEM,Loretta Sanchez,10
-Alameda,9447700,U.S. Senate,,DEM,Kamala Harris,123
-Alameda,9447700,U.S. Senate,,DEM,Loretta Sanchez,30
-Alameda,9447710,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9447710,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9447720,U.S. Senate,,DEM,Kamala Harris,88
-Alameda,9447720,U.S. Senate,,DEM,Loretta Sanchez,25
-Alameda,9450920,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9450920,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9450930,U.S. Senate,,DEM,Kamala Harris,1
-Alameda,9450930,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9451500,U.S. Senate,,DEM,Kamala Harris,141
-Alameda,9451500,U.S. Senate,,DEM,Loretta Sanchez,51
-Alameda,9452000,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9452000,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9454220,U.S. Senate,,DEM,Kamala Harris,18
-Alameda,9454220,U.S. Senate,,DEM,Loretta Sanchez,7
-Alameda,9454230,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9454230,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9454600,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9454600,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9454700,U.S. Senate,,DEM,Kamala Harris,155
-Alameda,9454700,U.S. Senate,,DEM,Loretta Sanchez,68
-Alameda,9455010,U.S. Senate,,DEM,Kamala Harris,169
-Alameda,9455010,U.S. Senate,,DEM,Loretta Sanchez,78
-Alameda,9455200,U.S. Senate,,DEM,Kamala Harris,131
-Alameda,9455200,U.S. Senate,,DEM,Loretta Sanchez,63
-Alameda,9455410,U.S. Senate,,DEM,Kamala Harris,107
-Alameda,9455410,U.S. Senate,,DEM,Loretta Sanchez,46
-Alameda,9456610,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9456610,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9464000,U.S. Senate,,DEM,Kamala Harris,4
-Alameda,9464000,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9464010,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9464010,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9464020,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9464020,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9464030,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9464030,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9464100,U.S. Senate,,DEM,Kamala Harris,1
-Alameda,9464100,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9464200,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9464200,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9464300,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9464300,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9464310,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9464310,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9464320,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9464320,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9464350,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9464350,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9464360,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9464360,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9464500,U.S. Senate,,DEM,Kamala Harris,32
-Alameda,9464500,U.S. Senate,,DEM,Loretta Sanchez,7
-Alameda,9464510,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9464510,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9464520,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9464520,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9464600,U.S. Senate,,DEM,Kamala Harris,57
-Alameda,9464600,U.S. Senate,,DEM,Loretta Sanchez,47
-Alameda,9464670,U.S. Senate,,DEM,Kamala Harris,24
-Alameda,9464670,U.S. Senate,,DEM,Loretta Sanchez,5
-Alameda,9464700,U.S. Senate,,DEM,Kamala Harris,1
-Alameda,9464700,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9464710,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9464710,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9464720,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9464720,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9470100,U.S. Senate,,DEM,Kamala Harris,90
-Alameda,9470100,U.S. Senate,,DEM,Loretta Sanchez,44
-Alameda,9470310,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9470310,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9470700,U.S. Senate,,DEM,Kamala Harris,197
-Alameda,9470700,U.S. Senate,,DEM,Loretta Sanchez,79
-Alameda,9472920,U.S. Senate,,DEM,Kamala Harris,1
-Alameda,9472920,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9475010,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9475010,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9475210,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9475210,U.S. Senate,,DEM,Loretta Sanchez,2
-Alameda,9475600,U.S. Senate,,DEM,Kamala Harris,51
-Alameda,9475600,U.S. Senate,,DEM,Loretta Sanchez,30
-Alameda,9475620,U.S. Senate,,DEM,Kamala Harris,2
-Alameda,9475620,U.S. Senate,,DEM,Loretta Sanchez,2
-Alameda,9475630,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9475630,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9475640,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9475640,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9476120,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9476120,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9480010,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9480010,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9481110,U.S. Senate,,DEM,Kamala Harris,7
-Alameda,9481110,U.S. Senate,,DEM,Loretta Sanchez,4
-Alameda,9481310,U.S. Senate,,DEM,Kamala Harris,5
-Alameda,9481310,U.S. Senate,,DEM,Loretta Sanchez,13
-Alameda,9481430,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9481430,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9481520,U.S. Senate,,DEM,Kamala Harris,38
-Alameda,9481520,U.S. Senate,,DEM,Loretta Sanchez,33
-Alameda,9481530,U.S. Senate,,DEM,Kamala Harris,1
-Alameda,9481530,U.S. Senate,,DEM,Loretta Sanchez,8
-Alameda,9481540,U.S. Senate,,DEM,Kamala Harris,56
-Alameda,9481540,U.S. Senate,,DEM,Loretta Sanchez,34
-Alameda,9481550,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9481550,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9481810,U.S. Senate,,DEM,Kamala Harris,190
-Alameda,9481810,U.S. Senate,,DEM,Loretta Sanchez,89
-Alameda,9481900,U.S. Senate,,DEM,Kamala Harris,117
-Alameda,9481900,U.S. Senate,,DEM,Loretta Sanchez,79
-Alameda,9481930,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9481930,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9481940,U.S. Senate,,DEM,Kamala Harris,4
-Alameda,9481940,U.S. Senate,,DEM,Loretta Sanchez,4
-Alameda,9481950,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9481950,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9481960,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9481960,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9481970,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9481970,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9482000,U.S. Senate,,DEM,Kamala Harris,62
-Alameda,9482000,U.S. Senate,,DEM,Loretta Sanchez,28
-Alameda,9482020,U.S. Senate,,DEM,Kamala Harris,3
-Alameda,9482020,U.S. Senate,,DEM,Loretta Sanchez,4
-Alameda,9482040,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9482040,U.S. Senate,,DEM,Loretta Sanchez,2
-Alameda,9482050,U.S. Senate,,DEM,Kamala Harris,6
-Alameda,9482050,U.S. Senate,,DEM,Loretta Sanchez,6
-Alameda,9484000,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9484000,U.S. Senate,,DEM,Loretta Sanchez,1
-Alameda,9490040,U.S. Senate,,DEM,Kamala Harris,7
-Alameda,9490040,U.S. Senate,,DEM,Loretta Sanchez,2
-Alameda,9490100,U.S. Senate,,DEM,Kamala Harris,29
-Alameda,9490100,U.S. Senate,,DEM,Loretta Sanchez,17
-Alameda,9490130,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9490130,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9490200,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9490200,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9490300,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9490300,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9491010,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9491010,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9491020,U.S. Senate,,DEM,Kamala Harris,3
-Alameda,9491020,U.S. Senate,,DEM,Loretta Sanchez,1
-Alameda,9491410,U.S. Senate,,DEM,Kamala Harris,23
-Alameda,9491410,U.S. Senate,,DEM,Loretta Sanchez,2
-Alameda,9491600,U.S. Senate,,DEM,Kamala Harris,121
-Alameda,9491600,U.S. Senate,,DEM,Loretta Sanchez,57
-Alameda,9491630,U.S. Senate,,DEM,Kamala Harris,57
-Alameda,9491630,U.S. Senate,,DEM,Loretta Sanchez,33
-Alameda,9491650,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9491650,U.S. Senate,,DEM,Loretta Sanchez,1
-Alameda,9492000,U.S. Senate,,DEM,Kamala Harris,83
-Alameda,9492000,U.S. Senate,,DEM,Loretta Sanchez,46
-Alameda,9492040,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9492040,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9492110,U.S. Senate,,DEM,Kamala Harris,7
-Alameda,9492110,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9492200,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9492200,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9498100,U.S. Senate,,DEM,Kamala Harris,2
-Alameda,9498100,U.S. Senate,,DEM,Loretta Sanchez,2
-Alameda,9498200,U.S. Senate,,DEM,Kamala Harris,14
-Alameda,9498200,U.S. Senate,,DEM,Loretta Sanchez,10
-Alameda,9498220,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9498220,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9498300,U.S. Senate,,DEM,Kamala Harris,16
-Alameda,9498300,U.S. Senate,,DEM,Loretta Sanchez,6
-Alameda,9498310,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9498310,U.S. Senate,,DEM,Loretta Sanchez,1
-Alameda,9498320,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9498320,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9498340,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9498340,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9498360,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9498360,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9499000,U.S. Senate,,DEM,Kamala Harris,8
-Alameda,9499000,U.S. Senate,,DEM,Loretta Sanchez,6
-Alameda,9499010,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9499010,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9500220,U.S. Senate,,DEM,Kamala Harris,92
-Alameda,9500220,U.S. Senate,,DEM,Loretta Sanchez,35
-Alameda,9500510,U.S. Senate,,DEM,Kamala Harris,4
-Alameda,9500510,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9501710,U.S. Senate,,DEM,Kamala Harris,18
-Alameda,9501710,U.S. Senate,,DEM,Loretta Sanchez,8
-Alameda,9502910,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9502910,U.S. Senate,,DEM,Loretta Sanchez,2
-Alameda,9510100,U.S. Senate,,DEM,Kamala Harris,67
-Alameda,9510100,U.S. Senate,,DEM,Loretta Sanchez,47
-Alameda,9510110,U.S. Senate,,DEM,Kamala Harris,16
-Alameda,9510110,U.S. Senate,,DEM,Loretta Sanchez,14
-Alameda,9510120,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9510120,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9510140,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9510140,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9510150,U.S. Senate,,DEM,Kamala Harris,2
-Alameda,9510150,U.S. Senate,,DEM,Loretta Sanchez,3
-Alameda,9510300,U.S. Senate,,DEM,Kamala Harris,134
-Alameda,9510300,U.S. Senate,,DEM,Loretta Sanchez,90
-Alameda,9510320,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9510320,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9510410,U.S. Senate,,DEM,Kamala Harris,37
-Alameda,9510410,U.S. Senate,,DEM,Loretta Sanchez,32
-Alameda,9510500,U.S. Senate,,DEM,Kamala Harris,86
-Alameda,9510500,U.S. Senate,,DEM,Loretta Sanchez,51
-Alameda,9510610,U.S. Senate,,DEM,Kamala Harris,23
-Alameda,9510610,U.S. Senate,,DEM,Loretta Sanchez,9
-Alameda,9510700,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9510700,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9510720,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9510720,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9510730,U.S. Senate,,DEM,Kamala Harris,2
-Alameda,9510730,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9510800,U.S. Senate,,DEM,Kamala Harris,24
-Alameda,9510800,U.S. Senate,,DEM,Loretta Sanchez,16
-Alameda,9510810,U.S. Senate,,DEM,Kamala Harris,118
-Alameda,9510810,U.S. Senate,,DEM,Loretta Sanchez,68
-Alameda,9510840,U.S. Senate,,DEM,Kamala Harris,48
-Alameda,9510840,U.S. Senate,,DEM,Loretta Sanchez,19
-Alameda,9510890,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9510890,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9510910,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9510910,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9510920,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9510920,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9510950,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9510950,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9510960,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9510960,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9510970,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9510970,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9510980,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9510980,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9510990,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9510990,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9511000,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9511000,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9520250,U.S. Senate,,DEM,Kamala Harris,196
-Alameda,9520250,U.S. Senate,,DEM,Loretta Sanchez,54
-Alameda,9520730,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9520730,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9520900,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9520900,U.S. Senate,,DEM,Loretta Sanchez,2
-Alameda,9522160,U.S. Senate,,DEM,Kamala Harris,241
-Alameda,9522160,U.S. Senate,,DEM,Loretta Sanchez,69
-Alameda,9530200,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9530200,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9532000,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9532000,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9532100,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9532100,U.S. Senate,,DEM,Loretta Sanchez,2
-Alameda,9532200,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9532200,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9532400,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9532400,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9535000,U.S. Senate,,DEM,Kamala Harris,1
-Alameda,9535000,U.S. Senate,,DEM,Loretta Sanchez,2
-Alameda,9535020,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9535020,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9535030,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9535030,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9535040,U.S. Senate,,DEM,Kamala Harris,1
-Alameda,9535040,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9535050,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9535050,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9535060,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9535060,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9535070,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9535070,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9535090,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9535090,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9535200,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9535200,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9535300,U.S. Senate,,DEM,Kamala Harris,32
-Alameda,9535300,U.S. Senate,,DEM,Loretta Sanchez,6
-Alameda,9535400,U.S. Senate,,DEM,Kamala Harris,4
-Alameda,9535400,U.S. Senate,,DEM,Loretta Sanchez,1
-Alameda,9535500,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9535500,U.S. Senate,,DEM,Loretta Sanchez,3
-Alameda,9535600,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9535600,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9535700,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9535700,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9810900,U.S. Senate,,DEM,Kamala Harris,1
-Alameda,9810900,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9815110,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9815110,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9815120,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9815120,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9815150,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9815150,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9819020,U.S. Senate,,DEM,Kamala Harris,1
-Alameda,9819020,U.S. Senate,,DEM,Loretta Sanchez,7
-Alameda,9819100,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9819100,U.S. Senate,,DEM,Loretta Sanchez,1
-Alameda,9819110,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9819110,U.S. Senate,,DEM,Loretta Sanchez,2
-Alameda,9820000,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9820000,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9821010,U.S. Senate,,DEM,Kamala Harris,1
-Alameda,9821010,U.S. Senate,,DEM,Loretta Sanchez,1
-Alameda,9821020,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9821020,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9821310,U.S. Senate,,DEM,Kamala Harris,24
-Alameda,9821310,U.S. Senate,,DEM,Loretta Sanchez,8
-Alameda,9821720,U.S. Senate,,DEM,Kamala Harris,26
-Alameda,9821720,U.S. Senate,,DEM,Loretta Sanchez,8
-Alameda,9823030,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9823030,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9823040,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9823040,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9831220,U.S. Senate,,DEM,Kamala Harris,7
-Alameda,9831220,U.S. Senate,,DEM,Loretta Sanchez,2
-Alameda,9834020,U.S. Senate,,DEM,Kamala Harris,1
-Alameda,9834020,U.S. Senate,,DEM,Loretta Sanchez,1
-Alameda,9834030,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9834030,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9834410,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9834410,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9835700,U.S. Senate,,DEM,Kamala Harris,9
-Alameda,9835700,U.S. Senate,,DEM,Loretta Sanchez,6
-Alameda,9837020,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9837020,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9837030,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9837030,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9837410,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9837410,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9839000,U.S. Senate,,DEM,Kamala Harris,1
-Alameda,9839000,U.S. Senate,,DEM,Loretta Sanchez,2
-Alameda,9839030,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9839030,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9839060,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9839060,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9839120,U.S. Senate,,DEM,Kamala Harris,1
-Alameda,9839120,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9839200,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9839200,U.S. Senate,,DEM,Loretta Sanchez,1
-Alameda,9839210,U.S. Senate,,DEM,Kamala Harris,4
-Alameda,9839210,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9839220,U.S. Senate,,DEM,Kamala Harris,1
-Alameda,9839220,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9839230,U.S. Senate,,DEM,Kamala Harris,1
-Alameda,9839230,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9839240,U.S. Senate,,DEM,Kamala Harris,16
-Alameda,9839240,U.S. Senate,,DEM,Loretta Sanchez,18
-Alameda,9839300,U.S. Senate,,DEM,Kamala Harris,1
-Alameda,9839300,U.S. Senate,,DEM,Loretta Sanchez,3
-Alameda,9839310,U.S. Senate,,DEM,Kamala Harris,14
-Alameda,9839310,U.S. Senate,,DEM,Loretta Sanchez,1
-Alameda,9839330,U.S. Senate,,DEM,Kamala Harris,69
-Alameda,9839330,U.S. Senate,,DEM,Loretta Sanchez,10
-Alameda,9839350,U.S. Senate,,DEM,Kamala Harris,19
-Alameda,9839350,U.S. Senate,,DEM,Loretta Sanchez,4
-Alameda,9839360,U.S. Senate,,DEM,Kamala Harris,1
-Alameda,9839360,U.S. Senate,,DEM,Loretta Sanchez,2
-Alameda,9839380,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9839380,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9839400,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9839400,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9839500,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9839500,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9839520,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9839520,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9866900,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9866900,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9866910,U.S. Senate,,DEM,Kamala Harris,26
-Alameda,9866910,U.S. Senate,,DEM,Loretta Sanchez,23
-Alameda,9866920,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9866920,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9866930,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9866930,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9867100,U.S. Senate,,DEM,Kamala Harris,2
-Alameda,9867100,U.S. Senate,,DEM,Loretta Sanchez,5
-Alameda,9867110,U.S. Senate,,DEM,Kamala Harris,9
-Alameda,9867110,U.S. Senate,,DEM,Loretta Sanchez,3
-Alameda,9867200,U.S. Senate,,DEM,Kamala Harris,30
-Alameda,9867200,U.S. Senate,,DEM,Loretta Sanchez,20
-Alameda,9867320,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9867320,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9867330,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9867330,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9867400,U.S. Senate,,DEM,Kamala Harris,1
-Alameda,9867400,U.S. Senate,,DEM,Loretta Sanchez,1
-Alameda,9867410,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9867410,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9870000,U.S. Senate,,DEM,Kamala Harris,73
-Alameda,9870000,U.S. Senate,,DEM,Loretta Sanchez,52
-Alameda,9870010,U.S. Senate,,DEM,Kamala Harris,115
-Alameda,9870010,U.S. Senate,,DEM,Loretta Sanchez,62
-Alameda,9870100,U.S. Senate,,DEM,Kamala Harris,80
-Alameda,9870100,U.S. Senate,,DEM,Loretta Sanchez,56
-Alameda,9870110,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9870110,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9870120,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9870120,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9870150,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9870150,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9880200,U.S. Senate,,DEM,Kamala Harris,7
-Alameda,9880200,U.S. Senate,,DEM,Loretta Sanchez,3
-Alameda,9880220,U.S. Senate,,DEM,Kamala Harris,6
-Alameda,9880220,U.S. Senate,,DEM,Loretta Sanchez,5
-Alameda,9880400,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9880400,U.S. Senate,,DEM,Loretta Sanchez,0
-Alameda,9880500,U.S. Senate,,DEM,Kamala Harris,0
-Alameda,9880500,U.S. Senate,,DEM,Loretta Sanchez,0
+Alameda,200100,U.S. Senate,,DEM,Kamala D. Harris,535
+Alameda,200100,U.S. Senate,,DEM,Loretta L. Sanchez,79
+Alameda,200200,U.S. Senate,,DEM,Kamala D. Harris,501
+Alameda,200200,U.S. Senate,,DEM,Loretta L. Sanchez,84
+Alameda,200300,U.S. Senate,,DEM,Kamala D. Harris,388
+Alameda,200300,U.S. Senate,,DEM,Loretta L. Sanchez,75
+Alameda,200600,U.S. Senate,,DEM,Kamala D. Harris,467
+Alameda,200600,U.S. Senate,,DEM,Loretta L. Sanchez,69
+Alameda,200700,U.S. Senate,,DEM,Kamala D. Harris,469
+Alameda,200700,U.S. Senate,,DEM,Loretta L. Sanchez,71
+Alameda,200800,U.S. Senate,,DEM,Kamala D. Harris,444
+Alameda,200800,U.S. Senate,,DEM,Loretta L. Sanchez,67
+Alameda,201000,U.S. Senate,,DEM,Kamala D. Harris,443
+Alameda,201000,U.S. Senate,,DEM,Loretta L. Sanchez,69
+Alameda,201100,U.S. Senate,,DEM,Kamala D. Harris,480
+Alameda,201100,U.S. Senate,,DEM,Loretta L. Sanchez,57
+Alameda,201300,U.S. Senate,,DEM,Kamala D. Harris,454
+Alameda,201300,U.S. Senate,,DEM,Loretta L. Sanchez,68
+Alameda,201400,U.S. Senate,,DEM,Kamala D. Harris,484
+Alameda,201400,U.S. Senate,,DEM,Loretta L. Sanchez,67
+Alameda,201410,U.S. Senate,,DEM,Kamala D. Harris,403
+Alameda,201410,U.S. Senate,,DEM,Loretta L. Sanchez,61
+Alameda,201500,U.S. Senate,,DEM,Kamala D. Harris,436
+Alameda,201500,U.S. Senate,,DEM,Loretta L. Sanchez,61
+Alameda,201700,U.S. Senate,,DEM,Kamala D. Harris,377
+Alameda,201700,U.S. Senate,,DEM,Loretta L. Sanchez,82
+Alameda,201710,U.S. Senate,,DEM,Kamala D. Harris,485
+Alameda,201710,U.S. Senate,,DEM,Loretta L. Sanchez,136
+Alameda,201800,U.S. Senate,,DEM,Kamala D. Harris,522
+Alameda,201800,U.S. Senate,,DEM,Loretta L. Sanchez,84
+Alameda,201900,U.S. Senate,,DEM,Kamala D. Harris,226
+Alameda,201900,U.S. Senate,,DEM,Loretta L. Sanchez,65
+Alameda,202010,U.S. Senate,,DEM,Kamala D. Harris,138
+Alameda,202010,U.S. Senate,,DEM,Loretta L. Sanchez,33
+Alameda,202110,U.S. Senate,,DEM,Kamala D. Harris,621
+Alameda,202110,U.S. Senate,,DEM,Loretta L. Sanchez,150
+Alameda,202310,U.S. Senate,,DEM,Kamala D. Harris,422
+Alameda,202310,U.S. Senate,,DEM,Loretta L. Sanchez,76
+Alameda,202500,U.S. Senate,,DEM,Kamala D. Harris,264
+Alameda,202500,U.S. Senate,,DEM,Loretta L. Sanchez,85
+Alameda,202520,U.S. Senate,,DEM,Kamala D. Harris,290
+Alameda,202520,U.S. Senate,,DEM,Loretta L. Sanchez,84
+Alameda,202540,U.S. Senate,,DEM,Kamala D. Harris,353
+Alameda,202540,U.S. Senate,,DEM,Loretta L. Sanchez,118
+Alameda,202600,U.S. Senate,,DEM,Kamala D. Harris,316
+Alameda,202600,U.S. Senate,,DEM,Loretta L. Sanchez,141
+Alameda,202620,U.S. Senate,,DEM,Kamala D. Harris,316
+Alameda,202620,U.S. Senate,,DEM,Loretta L. Sanchez,129
+Alameda,202710,U.S. Senate,,DEM,Kamala D. Harris,394
+Alameda,202710,U.S. Senate,,DEM,Loretta L. Sanchez,90
+Alameda,202900,U.S. Senate,,DEM,Kamala D. Harris,434
+Alameda,202900,U.S. Senate,,DEM,Loretta L. Sanchez,59
+Alameda,203100,U.S. Senate,,DEM,Kamala D. Harris,517
+Alameda,203100,U.S. Senate,,DEM,Loretta L. Sanchez,69
+Alameda,203200,U.S. Senate,,DEM,Kamala D. Harris,408
+Alameda,203200,U.S. Senate,,DEM,Loretta L. Sanchez,45
+Alameda,203300,U.S. Senate,,DEM,Kamala D. Harris,525
+Alameda,203300,U.S. Senate,,DEM,Loretta L. Sanchez,73
+Alameda,203400,U.S. Senate,,DEM,Kamala D. Harris,468
+Alameda,203400,U.S. Senate,,DEM,Loretta L. Sanchez,70
+Alameda,203500,U.S. Senate,,DEM,Kamala D. Harris,744
+Alameda,203500,U.S. Senate,,DEM,Loretta L. Sanchez,143
+Alameda,203800,U.S. Senate,,DEM,Kamala D. Harris,626
+Alameda,203800,U.S. Senate,,DEM,Loretta L. Sanchez,109
+Alameda,204000,U.S. Senate,,DEM,Kamala D. Harris,184
+Alameda,204000,U.S. Senate,,DEM,Loretta L. Sanchez,28
+Alameda,204100,U.S. Senate,,DEM,Kamala D. Harris,330
+Alameda,204100,U.S. Senate,,DEM,Loretta L. Sanchez,54
+Alameda,204210,U.S. Senate,,DEM,Kamala D. Harris,437
+Alameda,204210,U.S. Senate,,DEM,Loretta L. Sanchez,135
+Alameda,204220,U.S. Senate,,DEM,Kamala D. Harris,297
+Alameda,204220,U.S. Senate,,DEM,Loretta L. Sanchez,97
+Alameda,204230,U.S. Senate,,DEM,Kamala D. Harris,427
+Alameda,204230,U.S. Senate,,DEM,Loretta L. Sanchez,64
+Alameda,204240,U.S. Senate,,DEM,Kamala D. Harris,267
+Alameda,204240,U.S. Senate,,DEM,Loretta L. Sanchez,88
+Alameda,204300,U.S. Senate,,DEM,Kamala D. Harris,477
+Alameda,204300,U.S. Senate,,DEM,Loretta L. Sanchez,76
+Alameda,204310,U.S. Senate,,DEM,Kamala D. Harris,529
+Alameda,204310,U.S. Senate,,DEM,Loretta L. Sanchez,91
+Alameda,204510,U.S. Senate,,DEM,Kamala D. Harris,443
+Alameda,204510,U.S. Senate,,DEM,Loretta L. Sanchez,121
+Alameda,204600,U.S. Senate,,DEM,Kamala D. Harris,376
+Alameda,204600,U.S. Senate,,DEM,Loretta L. Sanchez,112
+Alameda,204900,U.S. Senate,,DEM,Kamala D. Harris,271
+Alameda,204900,U.S. Senate,,DEM,Loretta L. Sanchez,126
+Alameda,204910,U.S. Senate,,DEM,Kamala D. Harris,361
+Alameda,204910,U.S. Senate,,DEM,Loretta L. Sanchez,132
+Alameda,205000,U.S. Senate,,DEM,Kamala D. Harris,489
+Alameda,205000,U.S. Senate,,DEM,Loretta L. Sanchez,53
+Alameda,205100,U.S. Senate,,DEM,Kamala D. Harris,559
+Alameda,205100,U.S. Senate,,DEM,Loretta L. Sanchez,76
+Alameda,205200,U.S. Senate,,DEM,Kamala D. Harris,620
+Alameda,205200,U.S. Senate,,DEM,Loretta L. Sanchez,82
+Alameda,205500,U.S. Senate,,DEM,Kamala D. Harris,569
+Alameda,205500,U.S. Senate,,DEM,Loretta L. Sanchez,72
+Alameda,205600,U.S. Senate,,DEM,Kamala D. Harris,841
+Alameda,205600,U.S. Senate,,DEM,Loretta L. Sanchez,127
+Alameda,205700,U.S. Senate,,DEM,Kamala D. Harris,618
+Alameda,205700,U.S. Senate,,DEM,Loretta L. Sanchez,69
+Alameda,205800,U.S. Senate,,DEM,Kamala D. Harris,513
+Alameda,205800,U.S. Senate,,DEM,Loretta L. Sanchez,61
+Alameda,205900,U.S. Senate,,DEM,Kamala D. Harris,570
+Alameda,205900,U.S. Senate,,DEM,Loretta L. Sanchez,55
+Alameda,206000,U.S. Senate,,DEM,Kamala D. Harris,450
+Alameda,206000,U.S. Senate,,DEM,Loretta L. Sanchez,50
+Alameda,206100,U.S. Senate,,DEM,Kamala D. Harris,550
+Alameda,206100,U.S. Senate,,DEM,Loretta L. Sanchez,79
+Alameda,206200,U.S. Senate,,DEM,Kamala D. Harris,455
+Alameda,206200,U.S. Senate,,DEM,Loretta L. Sanchez,68
+Alameda,206300,U.S. Senate,,DEM,Kamala D. Harris,489
+Alameda,206300,U.S. Senate,,DEM,Loretta L. Sanchez,81
+Alameda,206400,U.S. Senate,,DEM,Kamala D. Harris,487
+Alameda,206400,U.S. Senate,,DEM,Loretta L. Sanchez,66
+Alameda,206600,U.S. Senate,,DEM,Kamala D. Harris,474
+Alameda,206600,U.S. Senate,,DEM,Loretta L. Sanchez,116
+Alameda,206900,U.S. Senate,,DEM,Kamala D. Harris,267
+Alameda,206900,U.S. Senate,,DEM,Loretta L. Sanchez,57
+Alameda,207000,U.S. Senate,,DEM,Kamala D. Harris,591
+Alameda,207000,U.S. Senate,,DEM,Loretta L. Sanchez,95
+Alameda,207010,U.S. Senate,,DEM,Kamala D. Harris,558
+Alameda,207010,U.S. Senate,,DEM,Loretta L. Sanchez,81
+Alameda,207100,U.S. Senate,,DEM,Kamala D. Harris,253
+Alameda,207100,U.S. Senate,,DEM,Loretta L. Sanchez,28
+Alameda,207200,U.S. Senate,,DEM,Kamala D. Harris,467
+Alameda,207200,U.S. Senate,,DEM,Loretta L. Sanchez,51
+Alameda,207300,U.S. Senate,,DEM,Kamala D. Harris,428
+Alameda,207300,U.S. Senate,,DEM,Loretta L. Sanchez,57
+Alameda,207500,U.S. Senate,,DEM,Kamala D. Harris,592
+Alameda,207500,U.S. Senate,,DEM,Loretta L. Sanchez,103
+Alameda,207600,U.S. Senate,,DEM,Kamala D. Harris,400
+Alameda,207600,U.S. Senate,,DEM,Loretta L. Sanchez,117
+Alameda,207700,U.S. Senate,,DEM,Kamala D. Harris,703
+Alameda,207700,U.S. Senate,,DEM,Loretta L. Sanchez,207
+Alameda,208000,U.S. Senate,,DEM,Kamala D. Harris,417
+Alameda,208000,U.S. Senate,,DEM,Loretta L. Sanchez,61
+Alameda,208010,U.S. Senate,,DEM,Kamala D. Harris,729
+Alameda,208010,U.S. Senate,,DEM,Loretta L. Sanchez,132
+Alameda,208100,U.S. Senate,,DEM,Kamala D. Harris,445
+Alameda,208100,U.S. Senate,,DEM,Loretta L. Sanchez,75
+Alameda,208110,U.S. Senate,,DEM,Kamala D. Harris,402
+Alameda,208110,U.S. Senate,,DEM,Loretta L. Sanchez,73
+Alameda,208200,U.S. Senate,,DEM,Kamala D. Harris,440
+Alameda,208200,U.S. Senate,,DEM,Loretta L. Sanchez,77
+Alameda,208210,U.S. Senate,,DEM,Kamala D. Harris,518
+Alameda,208210,U.S. Senate,,DEM,Loretta L. Sanchez,71
+Alameda,208300,U.S. Senate,,DEM,Kamala D. Harris,620
+Alameda,208300,U.S. Senate,,DEM,Loretta L. Sanchez,86
+Alameda,208310,U.S. Senate,,DEM,Kamala D. Harris,472
+Alameda,208310,U.S. Senate,,DEM,Loretta L. Sanchez,97
+Alameda,208400,U.S. Senate,,DEM,Kamala D. Harris,569
+Alameda,208400,U.S. Senate,,DEM,Loretta L. Sanchez,117
+Alameda,208500,U.S. Senate,,DEM,Kamala D. Harris,531
+Alameda,208500,U.S. Senate,,DEM,Loretta L. Sanchez,83
+Alameda,208510,U.S. Senate,,DEM,Kamala D. Harris,636
+Alameda,208510,U.S. Senate,,DEM,Loretta L. Sanchez,69
+Alameda,208600,U.S. Senate,,DEM,Kamala D. Harris,531
+Alameda,208600,U.S. Senate,,DEM,Loretta L. Sanchez,81
+Alameda,208610,U.S. Senate,,DEM,Kamala D. Harris,592
+Alameda,208610,U.S. Senate,,DEM,Loretta L. Sanchez,81
+Alameda,208650,U.S. Senate,,DEM,Kamala D. Harris,272
+Alameda,208650,U.S. Senate,,DEM,Loretta L. Sanchez,46
+Alameda,208700,U.S. Senate,,DEM,Kamala D. Harris,615
+Alameda,208700,U.S. Senate,,DEM,Loretta L. Sanchez,126
+Alameda,208800,U.S. Senate,,DEM,Kamala D. Harris,608
+Alameda,208800,U.S. Senate,,DEM,Loretta L. Sanchez,110
+Alameda,208810,U.S. Senate,,DEM,Kamala D. Harris,657
+Alameda,208810,U.S. Senate,,DEM,Loretta L. Sanchez,101
+Alameda,208900,U.S. Senate,,DEM,Kamala D. Harris,575
+Alameda,208900,U.S. Senate,,DEM,Loretta L. Sanchez,117
+Alameda,208910,U.S. Senate,,DEM,Kamala D. Harris,485
+Alameda,208910,U.S. Senate,,DEM,Loretta L. Sanchez,96
+Alameda,208920,U.S. Senate,,DEM,Kamala D. Harris,320
+Alameda,208920,U.S. Senate,,DEM,Loretta L. Sanchez,50
+Alameda,209000,U.S. Senate,,DEM,Kamala D. Harris,562
+Alameda,209000,U.S. Senate,,DEM,Loretta L. Sanchez,72
+Alameda,209010,U.S. Senate,,DEM,Kamala D. Harris,577
+Alameda,209010,U.S. Senate,,DEM,Loretta L. Sanchez,101
+Alameda,209100,U.S. Senate,,DEM,Kamala D. Harris,545
+Alameda,209100,U.S. Senate,,DEM,Loretta L. Sanchez,66
+Alameda,209110,U.S. Senate,,DEM,Kamala D. Harris,501
+Alameda,209110,U.S. Senate,,DEM,Loretta L. Sanchez,67
+Alameda,209200,U.S. Senate,,DEM,Kamala D. Harris,714
+Alameda,209200,U.S. Senate,,DEM,Loretta L. Sanchez,133
+Alameda,209300,U.S. Senate,,DEM,Kamala D. Harris,819
+Alameda,209300,U.S. Senate,,DEM,Loretta L. Sanchez,140
+Alameda,209310,U.S. Senate,,DEM,Kamala D. Harris,841
+Alameda,209310,U.S. Senate,,DEM,Loretta L. Sanchez,124
+Alameda,209400,U.S. Senate,,DEM,Kamala D. Harris,703
+Alameda,209400,U.S. Senate,,DEM,Loretta L. Sanchez,86
+Alameda,209410,U.S. Senate,,DEM,Kamala D. Harris,389
+Alameda,209410,U.S. Senate,,DEM,Loretta L. Sanchez,55
+Alameda,209510,U.S. Senate,,DEM,Kamala D. Harris,789
+Alameda,209510,U.S. Senate,,DEM,Loretta L. Sanchez,94
+Alameda,209600,U.S. Senate,,DEM,Kamala D. Harris,562
+Alameda,209600,U.S. Senate,,DEM,Loretta L. Sanchez,99
+Alameda,209610,U.S. Senate,,DEM,Kamala D. Harris,378
+Alameda,209610,U.S. Senate,,DEM,Loretta L. Sanchez,77
+Alameda,209700,U.S. Senate,,DEM,Kamala D. Harris,566
+Alameda,209700,U.S. Senate,,DEM,Loretta L. Sanchez,138
+Alameda,209710,U.S. Senate,,DEM,Kamala D. Harris,555
+Alameda,209710,U.S. Senate,,DEM,Loretta L. Sanchez,117
+Alameda,209800,U.S. Senate,,DEM,Kamala D. Harris,483
+Alameda,209800,U.S. Senate,,DEM,Loretta L. Sanchez,108
+Alameda,209900,U.S. Senate,,DEM,Kamala D. Harris,617
+Alameda,209900,U.S. Senate,,DEM,Loretta L. Sanchez,117
+Alameda,213100,U.S. Senate,,DEM,Kamala D. Harris,696
+Alameda,213100,U.S. Senate,,DEM,Loretta L. Sanchez,160
+Alameda,213300,U.S. Senate,,DEM,Kamala D. Harris,811
+Alameda,213300,U.S. Senate,,DEM,Loretta L. Sanchez,228
+Alameda,213400,U.S. Senate,,DEM,Kamala D. Harris,405
+Alameda,213400,U.S. Senate,,DEM,Loretta L. Sanchez,104
+Alameda,213500,U.S. Senate,,DEM,Kamala D. Harris,886
+Alameda,213500,U.S. Senate,,DEM,Loretta L. Sanchez,175
+Alameda,213600,U.S. Senate,,DEM,Kamala D. Harris,586
+Alameda,213600,U.S. Senate,,DEM,Loretta L. Sanchez,118
+Alameda,213700,U.S. Senate,,DEM,Kamala D. Harris,503
+Alameda,213700,U.S. Senate,,DEM,Loretta L. Sanchez,92
+Alameda,213800,U.S. Senate,,DEM,Kamala D. Harris,726
+Alameda,213800,U.S. Senate,,DEM,Loretta L. Sanchez,157
+Alameda,213900,U.S. Senate,,DEM,Kamala D. Harris,403
+Alameda,213900,U.S. Senate,,DEM,Loretta L. Sanchez,80
+Alameda,214100,U.S. Senate,,DEM,Kamala D. Harris,543
+Alameda,214100,U.S. Senate,,DEM,Loretta L. Sanchez,117
+Alameda,214200,U.S. Senate,,DEM,Kamala D. Harris,760
+Alameda,214200,U.S. Senate,,DEM,Loretta L. Sanchez,159
+Alameda,214300,U.S. Senate,,DEM,Kamala D. Harris,447
+Alameda,214300,U.S. Senate,,DEM,Loretta L. Sanchez,96
+Alameda,214400,U.S. Senate,,DEM,Kamala D. Harris,502
+Alameda,214400,U.S. Senate,,DEM,Loretta L. Sanchez,99
+Alameda,214500,U.S. Senate,,DEM,Kamala D. Harris,474
+Alameda,214500,U.S. Senate,,DEM,Loretta L. Sanchez,79
+Alameda,214600,U.S. Senate,,DEM,Kamala D. Harris,727
+Alameda,214600,U.S. Senate,,DEM,Loretta L. Sanchez,114
+Alameda,214800,U.S. Senate,,DEM,Kamala D. Harris,814
+Alameda,214800,U.S. Senate,,DEM,Loretta L. Sanchez,122
+Alameda,215100,U.S. Senate,,DEM,Kamala D. Harris,797
+Alameda,215100,U.S. Senate,,DEM,Loretta L. Sanchez,101
+Alameda,215120,U.S. Senate,,DEM,Kamala D. Harris,835
+Alameda,215120,U.S. Senate,,DEM,Loretta L. Sanchez,132
+Alameda,215200,U.S. Senate,,DEM,Kamala D. Harris,516
+Alameda,215200,U.S. Senate,,DEM,Loretta L. Sanchez,74
+Alameda,215300,U.S. Senate,,DEM,Kamala D. Harris,786
+Alameda,215300,U.S. Senate,,DEM,Loretta L. Sanchez,106
+Alameda,215500,U.S. Senate,,DEM,Kamala D. Harris,543
+Alameda,215500,U.S. Senate,,DEM,Loretta L. Sanchez,91
+Alameda,215610,U.S. Senate,,DEM,Kamala D. Harris,877
+Alameda,215610,U.S. Senate,,DEM,Loretta L. Sanchez,146
+Alameda,215700,U.S. Senate,,DEM,Kamala D. Harris,631
+Alameda,215700,U.S. Senate,,DEM,Loretta L. Sanchez,116
+Alameda,215800,U.S. Senate,,DEM,Kamala D. Harris,541
+Alameda,215800,U.S. Senate,,DEM,Loretta L. Sanchez,103
+Alameda,215900,U.S. Senate,,DEM,Kamala D. Harris,369
+Alameda,215900,U.S. Senate,,DEM,Loretta L. Sanchez,75
+Alameda,223000,U.S. Senate,,DEM,Kamala D. Harris,475
+Alameda,223000,U.S. Senate,,DEM,Loretta L. Sanchez,94
+Alameda,223010,U.S. Senate,,DEM,Kamala D. Harris,673
+Alameda,223010,U.S. Senate,,DEM,Loretta L. Sanchez,103
+Alameda,223200,U.S. Senate,,DEM,Kamala D. Harris,991
+Alameda,223200,U.S. Senate,,DEM,Loretta L. Sanchez,176
+Alameda,223300,U.S. Senate,,DEM,Kamala D. Harris,670
+Alameda,223300,U.S. Senate,,DEM,Loretta L. Sanchez,94
+Alameda,223400,U.S. Senate,,DEM,Kamala D. Harris,533
+Alameda,223400,U.S. Senate,,DEM,Loretta L. Sanchez,69
+Alameda,224000,U.S. Senate,,DEM,Kamala D. Harris,759
+Alameda,224000,U.S. Senate,,DEM,Loretta L. Sanchez,124
+Alameda,224200,U.S. Senate,,DEM,Kamala D. Harris,985
+Alameda,224200,U.S. Senate,,DEM,Loretta L. Sanchez,152
+Alameda,224400,U.S. Senate,,DEM,Kamala D. Harris,327
+Alameda,224400,U.S. Senate,,DEM,Loretta L. Sanchez,81
+Alameda,224500,U.S. Senate,,DEM,Kamala D. Harris,965
+Alameda,224500,U.S. Senate,,DEM,Loretta L. Sanchez,170
+Alameda,224600,U.S. Senate,,DEM,Kamala D. Harris,692
+Alameda,224600,U.S. Senate,,DEM,Loretta L. Sanchez,87
+Alameda,224700,U.S. Senate,,DEM,Kamala D. Harris,725
+Alameda,224700,U.S. Senate,,DEM,Loretta L. Sanchez,128
+Alameda,224800,U.S. Senate,,DEM,Kamala D. Harris,374
+Alameda,224800,U.S. Senate,,DEM,Loretta L. Sanchez,50
+Alameda,225000,U.S. Senate,,DEM,Kamala D. Harris,406
+Alameda,225000,U.S. Senate,,DEM,Loretta L. Sanchez,37
+Alameda,225100,U.S. Senate,,DEM,Kamala D. Harris,613
+Alameda,225100,U.S. Senate,,DEM,Loretta L. Sanchez,70
+Alameda,225200,U.S. Senate,,DEM,Kamala D. Harris,435
+Alameda,225200,U.S. Senate,,DEM,Loretta L. Sanchez,62
+Alameda,225400,U.S. Senate,,DEM,Kamala D. Harris,930
+Alameda,225400,U.S. Senate,,DEM,Loretta L. Sanchez,199
+Alameda,225600,U.S. Senate,,DEM,Kamala D. Harris,538
+Alameda,225600,U.S. Senate,,DEM,Loretta L. Sanchez,96
+Alameda,225700,U.S. Senate,,DEM,Kamala D. Harris,708
+Alameda,225700,U.S. Senate,,DEM,Loretta L. Sanchez,133
+Alameda,225710,U.S. Senate,,DEM,Kamala D. Harris,743
+Alameda,225710,U.S. Senate,,DEM,Loretta L. Sanchez,109
+Alameda,225810,U.S. Senate,,DEM,Kamala D. Harris,501
+Alameda,225810,U.S. Senate,,DEM,Loretta L. Sanchez,77
+Alameda,225900,U.S. Senate,,DEM,Kamala D. Harris,623
+Alameda,225900,U.S. Senate,,DEM,Loretta L. Sanchez,88
+Alameda,225910,U.S. Senate,,DEM,Kamala D. Harris,958
+Alameda,225910,U.S. Senate,,DEM,Loretta L. Sanchez,136
+Alameda,226100,U.S. Senate,,DEM,Kamala D. Harris,530
+Alameda,226100,U.S. Senate,,DEM,Loretta L. Sanchez,83
+Alameda,226200,U.S. Senate,,DEM,Kamala D. Harris,756
+Alameda,226200,U.S. Senate,,DEM,Loretta L. Sanchez,79
+Alameda,226300,U.S. Senate,,DEM,Kamala D. Harris,551
+Alameda,226300,U.S. Senate,,DEM,Loretta L. Sanchez,97
+Alameda,226400,U.S. Senate,,DEM,Kamala D. Harris,503
+Alameda,226400,U.S. Senate,,DEM,Loretta L. Sanchez,75
+Alameda,244000,U.S. Senate,,DEM,Kamala D. Harris,571
+Alameda,244000,U.S. Senate,,DEM,Loretta L. Sanchez,104
+Alameda,244100,U.S. Senate,,DEM,Kamala D. Harris,843
+Alameda,244100,U.S. Senate,,DEM,Loretta L. Sanchez,157
+Alameda,244200,U.S. Senate,,DEM,Kamala D. Harris,550
+Alameda,244200,U.S. Senate,,DEM,Loretta L. Sanchez,95
+Alameda,244300,U.S. Senate,,DEM,Kamala D. Harris,848
+Alameda,244300,U.S. Senate,,DEM,Loretta L. Sanchez,160
+Alameda,244400,U.S. Senate,,DEM,Kamala D. Harris,648
+Alameda,244400,U.S. Senate,,DEM,Loretta L. Sanchez,119
+Alameda,244500,U.S. Senate,,DEM,Kamala D. Harris,540
+Alameda,244500,U.S. Senate,,DEM,Loretta L. Sanchez,113
+Alameda,244600,U.S. Senate,,DEM,Kamala D. Harris,442
+Alameda,244600,U.S. Senate,,DEM,Loretta L. Sanchez,95
+Alameda,244700,U.S. Senate,,DEM,Kamala D. Harris,587
+Alameda,244700,U.S. Senate,,DEM,Loretta L. Sanchez,145
+Alameda,244800,U.S. Senate,,DEM,Kamala D. Harris,542
+Alameda,244800,U.S. Senate,,DEM,Loretta L. Sanchez,128
+Alameda,244900,U.S. Senate,,DEM,Kamala D. Harris,406
+Alameda,244900,U.S. Senate,,DEM,Loretta L. Sanchez,90
+Alameda,245000,U.S. Senate,,DEM,Kamala D. Harris,584
+Alameda,245000,U.S. Senate,,DEM,Loretta L. Sanchez,81
+Alameda,245100,U.S. Senate,,DEM,Kamala D. Harris,597
+Alameda,245100,U.S. Senate,,DEM,Loretta L. Sanchez,82
+Alameda,245200,U.S. Senate,,DEM,Kamala D. Harris,905
+Alameda,245200,U.S. Senate,,DEM,Loretta L. Sanchez,171
+Alameda,260100,U.S. Senate,,DEM,Kamala D. Harris,438
+Alameda,260100,U.S. Senate,,DEM,Loretta L. Sanchez,171
+Alameda,260300,U.S. Senate,,DEM,Kamala D. Harris,739
+Alameda,260300,U.S. Senate,,DEM,Loretta L. Sanchez,184
+Alameda,260400,U.S. Senate,,DEM,Kamala D. Harris,451
+Alameda,260400,U.S. Senate,,DEM,Loretta L. Sanchez,102
+Alameda,260610,U.S. Senate,,DEM,Kamala D. Harris,441
+Alameda,260610,U.S. Senate,,DEM,Loretta L. Sanchez,103
+Alameda,260800,U.S. Senate,,DEM,Kamala D. Harris,471
+Alameda,260800,U.S. Senate,,DEM,Loretta L. Sanchez,122
+Alameda,260900,U.S. Senate,,DEM,Kamala D. Harris,599
+Alameda,260900,U.S. Senate,,DEM,Loretta L. Sanchez,98
+Alameda,261000,U.S. Senate,,DEM,Kamala D. Harris,630
+Alameda,261000,U.S. Senate,,DEM,Loretta L. Sanchez,122
+Alameda,261300,U.S. Senate,,DEM,Kamala D. Harris,592
+Alameda,261300,U.S. Senate,,DEM,Loretta L. Sanchez,131
+Alameda,261400,U.S. Senate,,DEM,Kamala D. Harris,453
+Alameda,261400,U.S. Senate,,DEM,Loretta L. Sanchez,100
+Alameda,261600,U.S. Senate,,DEM,Kamala D. Harris,581
+Alameda,261600,U.S. Senate,,DEM,Loretta L. Sanchez,118
+Alameda,261700,U.S. Senate,,DEM,Kamala D. Harris,482
+Alameda,261700,U.S. Senate,,DEM,Loretta L. Sanchez,99
+Alameda,262000,U.S. Senate,,DEM,Kamala D. Harris,672
+Alameda,262000,U.S. Senate,,DEM,Loretta L. Sanchez,92
+Alameda,262100,U.S. Senate,,DEM,Kamala D. Harris,528
+Alameda,262100,U.S. Senate,,DEM,Loretta L. Sanchez,106
+Alameda,280100,U.S. Senate,,DEM,Kamala D. Harris,1069
+Alameda,280100,U.S. Senate,,DEM,Loretta L. Sanchez,202
+Alameda,280500,U.S. Senate,,DEM,Kamala D. Harris,900
+Alameda,280500,U.S. Senate,,DEM,Loretta L. Sanchez,279
+Alameda,280700,U.S. Senate,,DEM,Kamala D. Harris,1059
+Alameda,280700,U.S. Senate,,DEM,Loretta L. Sanchez,238
+Alameda,281000,U.S. Senate,,DEM,Kamala D. Harris,842
+Alameda,281000,U.S. Senate,,DEM,Loretta L. Sanchez,231
+Alameda,281300,U.S. Senate,,DEM,Kamala D. Harris,764
+Alameda,281300,U.S. Senate,,DEM,Loretta L. Sanchez,170
+Alameda,281600,U.S. Senate,,DEM,Kamala D. Harris,747
+Alameda,281600,U.S. Senate,,DEM,Loretta L. Sanchez,175
+Alameda,300000,U.S. Senate,,DEM,Kamala D. Harris,713
+Alameda,300000,U.S. Senate,,DEM,Loretta L. Sanchez,205
+Alameda,300100,U.S. Senate,,DEM,Kamala D. Harris,763
+Alameda,300100,U.S. Senate,,DEM,Loretta L. Sanchez,198
+Alameda,300110,U.S. Senate,,DEM,Kamala D. Harris,505
+Alameda,300110,U.S. Senate,,DEM,Loretta L. Sanchez,127
+Alameda,300120,U.S. Senate,,DEM,Kamala D. Harris,809
+Alameda,300120,U.S. Senate,,DEM,Loretta L. Sanchez,244
+Alameda,300140,U.S. Senate,,DEM,Kamala D. Harris,687
+Alameda,300140,U.S. Senate,,DEM,Loretta L. Sanchez,195
+Alameda,300150,U.S. Senate,,DEM,Kamala D. Harris,583
+Alameda,300150,U.S. Senate,,DEM,Loretta L. Sanchez,157
+Alameda,300170,U.S. Senate,,DEM,Kamala D. Harris,347
+Alameda,300170,U.S. Senate,,DEM,Loretta L. Sanchez,111
+Alameda,300180,U.S. Senate,,DEM,Kamala D. Harris,432
+Alameda,300180,U.S. Senate,,DEM,Loretta L. Sanchez,134
+Alameda,300210,U.S. Senate,,DEM,Kamala D. Harris,461
+Alameda,300210,U.S. Senate,,DEM,Loretta L. Sanchez,149
+Alameda,300300,U.S. Senate,,DEM,Kamala D. Harris,471
+Alameda,300300,U.S. Senate,,DEM,Loretta L. Sanchez,121
+Alameda,300400,U.S. Senate,,DEM,Kamala D. Harris,885
+Alameda,300400,U.S. Senate,,DEM,Loretta L. Sanchez,271
+Alameda,301100,U.S. Senate,,DEM,Kamala D. Harris,472
+Alameda,301100,U.S. Senate,,DEM,Loretta L. Sanchez,137
+Alameda,301200,U.S. Senate,,DEM,Kamala D. Harris,495
+Alameda,301200,U.S. Senate,,DEM,Loretta L. Sanchez,110
+Alameda,301400,U.S. Senate,,DEM,Kamala D. Harris,911
+Alameda,301400,U.S. Senate,,DEM,Loretta L. Sanchez,262
+Alameda,301520,U.S. Senate,,DEM,Kamala D. Harris,897
+Alameda,301520,U.S. Senate,,DEM,Loretta L. Sanchez,249
+Alameda,301800,U.S. Senate,,DEM,Kamala D. Harris,553
+Alameda,301800,U.S. Senate,,DEM,Loretta L. Sanchez,184
+Alameda,301900,U.S. Senate,,DEM,Kamala D. Harris,555
+Alameda,301900,U.S. Senate,,DEM,Loretta L. Sanchez,140
+Alameda,302000,U.S. Senate,,DEM,Kamala D. Harris,590
+Alameda,302000,U.S. Senate,,DEM,Loretta L. Sanchez,156
+Alameda,302100,U.S. Senate,,DEM,Kamala D. Harris,391
+Alameda,302100,U.S. Senate,,DEM,Loretta L. Sanchez,107
+Alameda,302200,U.S. Senate,,DEM,Kamala D. Harris,902
+Alameda,302200,U.S. Senate,,DEM,Loretta L. Sanchez,225
+Alameda,302400,U.S. Senate,,DEM,Kamala D. Harris,401
+Alameda,302400,U.S. Senate,,DEM,Loretta L. Sanchez,154
+Alameda,302500,U.S. Senate,,DEM,Kamala D. Harris,786
+Alameda,302500,U.S. Senate,,DEM,Loretta L. Sanchez,229
+Alameda,302510,U.S. Senate,,DEM,Kamala D. Harris,475
+Alameda,302510,U.S. Senate,,DEM,Loretta L. Sanchez,146
+Alameda,302700,U.S. Senate,,DEM,Kamala D. Harris,515
+Alameda,302700,U.S. Senate,,DEM,Loretta L. Sanchez,143
+Alameda,303000,U.S. Senate,,DEM,Kamala D. Harris,478
+Alameda,303000,U.S. Senate,,DEM,Loretta L. Sanchez,156
+Alameda,303300,U.S. Senate,,DEM,Kamala D. Harris,654
+Alameda,303300,U.S. Senate,,DEM,Loretta L. Sanchez,177
+Alameda,303400,U.S. Senate,,DEM,Kamala D. Harris,438
+Alameda,303400,U.S. Senate,,DEM,Loretta L. Sanchez,140
+Alameda,303500,U.S. Senate,,DEM,Kamala D. Harris,489
+Alameda,303500,U.S. Senate,,DEM,Loretta L. Sanchez,133
+Alameda,303600,U.S. Senate,,DEM,Kamala D. Harris,853
+Alameda,303600,U.S. Senate,,DEM,Loretta L. Sanchez,248
+Alameda,303800,U.S. Senate,,DEM,Kamala D. Harris,562
+Alameda,303800,U.S. Senate,,DEM,Loretta L. Sanchez,150
+Alameda,304000,U.S. Senate,,DEM,Kamala D. Harris,523
+Alameda,304000,U.S. Senate,,DEM,Loretta L. Sanchez,168
+Alameda,304120,U.S. Senate,,DEM,Kamala D. Harris,820
+Alameda,304120,U.S. Senate,,DEM,Loretta L. Sanchez,243
+Alameda,304200,U.S. Senate,,DEM,Kamala D. Harris,443
+Alameda,304200,U.S. Senate,,DEM,Loretta L. Sanchez,121
+Alameda,304500,U.S. Senate,,DEM,Kamala D. Harris,478
+Alameda,304500,U.S. Senate,,DEM,Loretta L. Sanchez,150
+Alameda,304600,U.S. Senate,,DEM,Kamala D. Harris,605
+Alameda,304600,U.S. Senate,,DEM,Loretta L. Sanchez,197
+Alameda,304700,U.S. Senate,,DEM,Kamala D. Harris,451
+Alameda,304700,U.S. Senate,,DEM,Loretta L. Sanchez,141
+Alameda,304800,U.S. Senate,,DEM,Kamala D. Harris,518
+Alameda,304800,U.S. Senate,,DEM,Loretta L. Sanchez,171
+Alameda,304900,U.S. Senate,,DEM,Kamala D. Harris,487
+Alameda,304900,U.S. Senate,,DEM,Loretta L. Sanchez,129
+Alameda,305000,U.S. Senate,,DEM,Kamala D. Harris,407
+Alameda,305000,U.S. Senate,,DEM,Loretta L. Sanchez,116
+Alameda,305010,U.S. Senate,,DEM,Kamala D. Harris,708
+Alameda,305010,U.S. Senate,,DEM,Loretta L. Sanchez,131
+Alameda,305100,U.S. Senate,,DEM,Kamala D. Harris,654
+Alameda,305100,U.S. Senate,,DEM,Loretta L. Sanchez,186
+Alameda,305400,U.S. Senate,,DEM,Kamala D. Harris,519
+Alameda,305400,U.S. Senate,,DEM,Loretta L. Sanchez,119
+Alameda,305410,U.S. Senate,,DEM,Kamala D. Harris,423
+Alameda,305410,U.S. Senate,,DEM,Loretta L. Sanchez,152
+Alameda,305500,U.S. Senate,,DEM,Kamala D. Harris,559
+Alameda,305500,U.S. Senate,,DEM,Loretta L. Sanchez,213
+Alameda,305600,U.S. Senate,,DEM,Kamala D. Harris,581
+Alameda,305600,U.S. Senate,,DEM,Loretta L. Sanchez,175
+Alameda,305700,U.S. Senate,,DEM,Kamala D. Harris,585
+Alameda,305700,U.S. Senate,,DEM,Loretta L. Sanchez,146
+Alameda,310000,U.S. Senate,,DEM,Kamala D. Harris,667
+Alameda,310000,U.S. Senate,,DEM,Loretta L. Sanchez,111
+Alameda,310100,U.S. Senate,,DEM,Kamala D. Harris,595
+Alameda,310100,U.S. Senate,,DEM,Loretta L. Sanchez,122
+Alameda,310200,U.S. Senate,,DEM,Kamala D. Harris,559
+Alameda,310200,U.S. Senate,,DEM,Loretta L. Sanchez,107
+Alameda,310300,U.S. Senate,,DEM,Kamala D. Harris,538
+Alameda,310300,U.S. Senate,,DEM,Loretta L. Sanchez,111
+Alameda,310400,U.S. Senate,,DEM,Kamala D. Harris,573
+Alameda,310400,U.S. Senate,,DEM,Loretta L. Sanchez,120
+Alameda,310500,U.S. Senate,,DEM,Kamala D. Harris,516
+Alameda,310500,U.S. Senate,,DEM,Loretta L. Sanchez,68
+Alameda,310600,U.S. Senate,,DEM,Kamala D. Harris,586
+Alameda,310600,U.S. Senate,,DEM,Loretta L. Sanchez,75
+Alameda,310700,U.S. Senate,,DEM,Kamala D. Harris,909
+Alameda,310700,U.S. Senate,,DEM,Loretta L. Sanchez,164
+Alameda,310900,U.S. Senate,,DEM,Kamala D. Harris,951
+Alameda,310900,U.S. Senate,,DEM,Loretta L. Sanchez,149
+Alameda,311100,U.S. Senate,,DEM,Kamala D. Harris,948
+Alameda,311100,U.S. Senate,,DEM,Loretta L. Sanchez,119
+Alameda,311200,U.S. Senate,,DEM,Kamala D. Harris,844
+Alameda,311200,U.S. Senate,,DEM,Loretta L. Sanchez,111
+Alameda,311400,U.S. Senate,,DEM,Kamala D. Harris,591
+Alameda,311400,U.S. Senate,,DEM,Loretta L. Sanchez,81
+Alameda,311500,U.S. Senate,,DEM,Kamala D. Harris,1050
+Alameda,311500,U.S. Senate,,DEM,Loretta L. Sanchez,161
+Alameda,311700,U.S. Senate,,DEM,Kamala D. Harris,890
+Alameda,311700,U.S. Senate,,DEM,Loretta L. Sanchez,196
+Alameda,323000,U.S. Senate,,DEM,Kamala D. Harris,603
+Alameda,323000,U.S. Senate,,DEM,Loretta L. Sanchez,92
+Alameda,323200,U.S. Senate,,DEM,Kamala D. Harris,672
+Alameda,323200,U.S. Senate,,DEM,Loretta L. Sanchez,114
+Alameda,325100,U.S. Senate,,DEM,Kamala D. Harris,734
+Alameda,325100,U.S. Senate,,DEM,Loretta L. Sanchez,131
+Alameda,325110,U.S. Senate,,DEM,Kamala D. Harris,540
+Alameda,325110,U.S. Senate,,DEM,Loretta L. Sanchez,93
+Alameda,325200,U.S. Senate,,DEM,Kamala D. Harris,695
+Alameda,325200,U.S. Senate,,DEM,Loretta L. Sanchez,113
+Alameda,325300,U.S. Senate,,DEM,Kamala D. Harris,835
+Alameda,325300,U.S. Senate,,DEM,Loretta L. Sanchez,165
+Alameda,325400,U.S. Senate,,DEM,Kamala D. Harris,526
+Alameda,325400,U.S. Senate,,DEM,Loretta L. Sanchez,87
+Alameda,325500,U.S. Senate,,DEM,Kamala D. Harris,617
+Alameda,325500,U.S. Senate,,DEM,Loretta L. Sanchez,91
+Alameda,325510,U.S. Senate,,DEM,Kamala D. Harris,1063
+Alameda,325510,U.S. Senate,,DEM,Loretta L. Sanchez,155
+Alameda,325600,U.S. Senate,,DEM,Kamala D. Harris,561
+Alameda,325600,U.S. Senate,,DEM,Loretta L. Sanchez,63
+Alameda,325700,U.S. Senate,,DEM,Kamala D. Harris,999
+Alameda,325700,U.S. Senate,,DEM,Loretta L. Sanchez,134
+Alameda,325800,U.S. Senate,,DEM,Kamala D. Harris,992
+Alameda,325800,U.S. Senate,,DEM,Loretta L. Sanchez,146
+Alameda,333100,U.S. Senate,,DEM,Kamala D. Harris,646
+Alameda,333100,U.S. Senate,,DEM,Loretta L. Sanchez,134
+Alameda,333200,U.S. Senate,,DEM,Kamala D. Harris,749
+Alameda,333200,U.S. Senate,,DEM,Loretta L. Sanchez,155
+Alameda,333210,U.S. Senate,,DEM,Kamala D. Harris,387
+Alameda,333210,U.S. Senate,,DEM,Loretta L. Sanchez,64
+Alameda,333400,U.S. Senate,,DEM,Kamala D. Harris,325
+Alameda,333400,U.S. Senate,,DEM,Loretta L. Sanchez,104
+Alameda,333410,U.S. Senate,,DEM,Kamala D. Harris,951
+Alameda,333410,U.S. Senate,,DEM,Loretta L. Sanchez,201
+Alameda,333500,U.S. Senate,,DEM,Kamala D. Harris,875
+Alameda,333500,U.S. Senate,,DEM,Loretta L. Sanchez,138
+Alameda,333510,U.S. Senate,,DEM,Kamala D. Harris,897
+Alameda,333510,U.S. Senate,,DEM,Loretta L. Sanchez,130
+Alameda,333600,U.S. Senate,,DEM,Kamala D. Harris,271
+Alameda,333600,U.S. Senate,,DEM,Loretta L. Sanchez,37
+Alameda,333800,U.S. Senate,,DEM,Kamala D. Harris,645
+Alameda,333800,U.S. Senate,,DEM,Loretta L. Sanchez,167
+Alameda,333900,U.S. Senate,,DEM,Kamala D. Harris,498
+Alameda,333900,U.S. Senate,,DEM,Loretta L. Sanchez,127
+Alameda,334000,U.S. Senate,,DEM,Kamala D. Harris,497
+Alameda,334000,U.S. Senate,,DEM,Loretta L. Sanchez,177
+Alameda,334100,U.S. Senate,,DEM,Kamala D. Harris,757
+Alameda,334100,U.S. Senate,,DEM,Loretta L. Sanchez,164
+Alameda,334600,U.S. Senate,,DEM,Kamala D. Harris,859
+Alameda,334600,U.S. Senate,,DEM,Loretta L. Sanchez,321
+Alameda,334700,U.S. Senate,,DEM,Kamala D. Harris,255
+Alameda,334700,U.S. Senate,,DEM,Loretta L. Sanchez,159
+Alameda,335000,U.S. Senate,,DEM,Kamala D. Harris,857
+Alameda,335000,U.S. Senate,,DEM,Loretta L. Sanchez,187
+Alameda,335100,U.S. Senate,,DEM,Kamala D. Harris,657
+Alameda,335100,U.S. Senate,,DEM,Loretta L. Sanchez,167
+Alameda,335200,U.S. Senate,,DEM,Kamala D. Harris,346
+Alameda,335200,U.S. Senate,,DEM,Loretta L. Sanchez,87
+Alameda,335300,U.S. Senate,,DEM,Kamala D. Harris,665
+Alameda,335300,U.S. Senate,,DEM,Loretta L. Sanchez,141
+Alameda,335400,U.S. Senate,,DEM,Kamala D. Harris,833
+Alameda,335400,U.S. Senate,,DEM,Loretta L. Sanchez,182
+Alameda,335500,U.S. Senate,,DEM,Kamala D. Harris,342
+Alameda,335500,U.S. Senate,,DEM,Loretta L. Sanchez,89
+Alameda,335700,U.S. Senate,,DEM,Kamala D. Harris,730
+Alameda,335700,U.S. Senate,,DEM,Loretta L. Sanchez,127
+Alameda,335710,U.S. Senate,,DEM,Kamala D. Harris,575
+Alameda,335710,U.S. Senate,,DEM,Loretta L. Sanchez,112
+Alameda,335810,U.S. Senate,,DEM,Kamala D. Harris,421
+Alameda,335810,U.S. Senate,,DEM,Loretta L. Sanchez,94
+Alameda,335900,U.S. Senate,,DEM,Kamala D. Harris,449
+Alameda,335900,U.S. Senate,,DEM,Loretta L. Sanchez,89
+Alameda,336100,U.S. Senate,,DEM,Kamala D. Harris,516
+Alameda,336100,U.S. Senate,,DEM,Loretta L. Sanchez,118
+Alameda,336110,U.S. Senate,,DEM,Kamala D. Harris,426
+Alameda,336110,U.S. Senate,,DEM,Loretta L. Sanchez,117
+Alameda,336200,U.S. Senate,,DEM,Kamala D. Harris,588
+Alameda,336200,U.S. Senate,,DEM,Loretta L. Sanchez,155
+Alameda,336400,U.S. Senate,,DEM,Kamala D. Harris,424
+Alameda,336400,U.S. Senate,,DEM,Loretta L. Sanchez,122
+Alameda,336500,U.S. Senate,,DEM,Kamala D. Harris,460
+Alameda,336500,U.S. Senate,,DEM,Loretta L. Sanchez,80
+Alameda,336600,U.S. Senate,,DEM,Kamala D. Harris,701
+Alameda,336600,U.S. Senate,,DEM,Loretta L. Sanchez,136
+Alameda,336610,U.S. Senate,,DEM,Kamala D. Harris,404
+Alameda,336610,U.S. Senate,,DEM,Loretta L. Sanchez,73
+Alameda,336710,U.S. Senate,,DEM,Kamala D. Harris,879
+Alameda,336710,U.S. Senate,,DEM,Loretta L. Sanchez,152
+Alameda,336900,U.S. Senate,,DEM,Kamala D. Harris,526
+Alameda,336900,U.S. Senate,,DEM,Loretta L. Sanchez,114
+Alameda,336910,U.S. Senate,,DEM,Kamala D. Harris,407
+Alameda,336910,U.S. Senate,,DEM,Loretta L. Sanchez,62
+Alameda,337000,U.S. Senate,,DEM,Kamala D. Harris,378
+Alameda,337000,U.S. Senate,,DEM,Loretta L. Sanchez,98
+Alameda,337100,U.S. Senate,,DEM,Kamala D. Harris,201
+Alameda,337100,U.S. Senate,,DEM,Loretta L. Sanchez,45
+Alameda,337110,U.S. Senate,,DEM,Kamala D. Harris,175
+Alameda,337110,U.S. Senate,,DEM,Loretta L. Sanchez,53
+Alameda,337200,U.S. Senate,,DEM,Kamala D. Harris,274
+Alameda,337200,U.S. Senate,,DEM,Loretta L. Sanchez,75
+Alameda,344000,U.S. Senate,,DEM,Kamala D. Harris,499
+Alameda,344000,U.S. Senate,,DEM,Loretta L. Sanchez,133
+Alameda,344010,U.S. Senate,,DEM,Kamala D. Harris,354
+Alameda,344010,U.S. Senate,,DEM,Loretta L. Sanchez,124
+Alameda,344100,U.S. Senate,,DEM,Kamala D. Harris,335
+Alameda,344100,U.S. Senate,,DEM,Loretta L. Sanchez,99
+Alameda,344200,U.S. Senate,,DEM,Kamala D. Harris,699
+Alameda,344200,U.S. Senate,,DEM,Loretta L. Sanchez,136
+Alameda,344400,U.S. Senate,,DEM,Kamala D. Harris,649
+Alameda,344400,U.S. Senate,,DEM,Loretta L. Sanchez,126
+Alameda,344500,U.S. Senate,,DEM,Kamala D. Harris,927
+Alameda,344500,U.S. Senate,,DEM,Loretta L. Sanchez,161
+Alameda,344600,U.S. Senate,,DEM,Kamala D. Harris,573
+Alameda,344600,U.S. Senate,,DEM,Loretta L. Sanchez,82
+Alameda,344700,U.S. Senate,,DEM,Kamala D. Harris,448
+Alameda,344700,U.S. Senate,,DEM,Loretta L. Sanchez,60
+Alameda,344800,U.S. Senate,,DEM,Kamala D. Harris,443
+Alameda,344800,U.S. Senate,,DEM,Loretta L. Sanchez,80
+Alameda,344900,U.S. Senate,,DEM,Kamala D. Harris,605
+Alameda,344900,U.S. Senate,,DEM,Loretta L. Sanchez,76
+Alameda,345000,U.S. Senate,,DEM,Kamala D. Harris,511
+Alameda,345000,U.S. Senate,,DEM,Loretta L. Sanchez,123
+Alameda,345100,U.S. Senate,,DEM,Kamala D. Harris,638
+Alameda,345100,U.S. Senate,,DEM,Loretta L. Sanchez,117
+Alameda,345200,U.S. Senate,,DEM,Kamala D. Harris,840
+Alameda,345200,U.S. Senate,,DEM,Loretta L. Sanchez,121
+Alameda,345310,U.S. Senate,,DEM,Kamala D. Harris,658
+Alameda,345310,U.S. Senate,,DEM,Loretta L. Sanchez,93
+Alameda,345400,U.S. Senate,,DEM,Kamala D. Harris,651
+Alameda,345400,U.S. Senate,,DEM,Loretta L. Sanchez,131
+Alameda,345500,U.S. Senate,,DEM,Kamala D. Harris,477
+Alameda,345500,U.S. Senate,,DEM,Loretta L. Sanchez,81
+Alameda,345600,U.S. Senate,,DEM,Kamala D. Harris,522
+Alameda,345600,U.S. Senate,,DEM,Loretta L. Sanchez,99
+Alameda,345700,U.S. Senate,,DEM,Kamala D. Harris,588
+Alameda,345700,U.S. Senate,,DEM,Loretta L. Sanchez,81
+Alameda,345800,U.S. Senate,,DEM,Kamala D. Harris,313
+Alameda,345800,U.S. Senate,,DEM,Loretta L. Sanchez,47
+Alameda,345900,U.S. Senate,,DEM,Kamala D. Harris,471
+Alameda,345900,U.S. Senate,,DEM,Loretta L. Sanchez,79
+Alameda,346000,U.S. Senate,,DEM,Kamala D. Harris,221
+Alameda,346000,U.S. Senate,,DEM,Loretta L. Sanchez,64
+Alameda,346100,U.S. Senate,,DEM,Kamala D. Harris,472
+Alameda,346100,U.S. Senate,,DEM,Loretta L. Sanchez,157
+Alameda,346200,U.S. Senate,,DEM,Kamala D. Harris,610
+Alameda,346200,U.S. Senate,,DEM,Loretta L. Sanchez,213
+Alameda,347110,U.S. Senate,,DEM,Kamala D. Harris,229
+Alameda,347110,U.S. Senate,,DEM,Loretta L. Sanchez,63
+Alameda,347200,U.S. Senate,,DEM,Kamala D. Harris,641
+Alameda,347200,U.S. Senate,,DEM,Loretta L. Sanchez,184
+Alameda,347300,U.S. Senate,,DEM,Kamala D. Harris,614
+Alameda,347300,U.S. Senate,,DEM,Loretta L. Sanchez,91
+Alameda,353300,U.S. Senate,,DEM,Kamala D. Harris,350
+Alameda,353300,U.S. Senate,,DEM,Loretta L. Sanchez,75
+Alameda,353310,U.S. Senate,,DEM,Kamala D. Harris,653
+Alameda,353310,U.S. Senate,,DEM,Loretta L. Sanchez,178
+Alameda,353400,U.S. Senate,,DEM,Kamala D. Harris,605
+Alameda,353400,U.S. Senate,,DEM,Loretta L. Sanchez,102
+Alameda,353500,U.S. Senate,,DEM,Kamala D. Harris,710
+Alameda,353500,U.S. Senate,,DEM,Loretta L. Sanchez,118
+Alameda,353600,U.S. Senate,,DEM,Kamala D. Harris,533
+Alameda,353600,U.S. Senate,,DEM,Loretta L. Sanchez,100
+Alameda,353800,U.S. Senate,,DEM,Kamala D. Harris,338
+Alameda,353800,U.S. Senate,,DEM,Loretta L. Sanchez,77
+Alameda,353900,U.S. Senate,,DEM,Kamala D. Harris,572
+Alameda,353900,U.S. Senate,,DEM,Loretta L. Sanchez,179
+Alameda,354000,U.S. Senate,,DEM,Kamala D. Harris,595
+Alameda,354000,U.S. Senate,,DEM,Loretta L. Sanchez,230
+Alameda,354100,U.S. Senate,,DEM,Kamala D. Harris,840
+Alameda,354100,U.S. Senate,,DEM,Loretta L. Sanchez,206
+Alameda,354110,U.S. Senate,,DEM,Kamala D. Harris,389
+Alameda,354110,U.S. Senate,,DEM,Loretta L. Sanchez,93
+Alameda,354300,U.S. Senate,,DEM,Kamala D. Harris,517
+Alameda,354300,U.S. Senate,,DEM,Loretta L. Sanchez,255
+Alameda,354400,U.S. Senate,,DEM,Kamala D. Harris,432
+Alameda,354400,U.S. Senate,,DEM,Loretta L. Sanchez,154
+Alameda,354500,U.S. Senate,,DEM,Kamala D. Harris,630
+Alameda,354500,U.S. Senate,,DEM,Loretta L. Sanchez,282
+Alameda,354700,U.S. Senate,,DEM,Kamala D. Harris,409
+Alameda,354700,U.S. Senate,,DEM,Loretta L. Sanchez,220
+Alameda,354900,U.S. Senate,,DEM,Kamala D. Harris,334
+Alameda,354900,U.S. Senate,,DEM,Loretta L. Sanchez,112
+Alameda,354910,U.S. Senate,,DEM,Kamala D. Harris,389
+Alameda,354910,U.S. Senate,,DEM,Loretta L. Sanchez,158
+Alameda,355000,U.S. Senate,,DEM,Kamala D. Harris,382
+Alameda,355000,U.S. Senate,,DEM,Loretta L. Sanchez,110
+Alameda,355100,U.S. Senate,,DEM,Kamala D. Harris,526
+Alameda,355100,U.S. Senate,,DEM,Loretta L. Sanchez,237
+Alameda,356000,U.S. Senate,,DEM,Kamala D. Harris,526
+Alameda,356000,U.S. Senate,,DEM,Loretta L. Sanchez,150
+Alameda,356200,U.S. Senate,,DEM,Kamala D. Harris,405
+Alameda,356200,U.S. Senate,,DEM,Loretta L. Sanchez,234
+Alameda,356210,U.S. Senate,,DEM,Kamala D. Harris,511
+Alameda,356210,U.S. Senate,,DEM,Loretta L. Sanchez,223
+Alameda,356400,U.S. Senate,,DEM,Kamala D. Harris,188
+Alameda,356400,U.S. Senate,,DEM,Loretta L. Sanchez,150
+Alameda,356500,U.S. Senate,,DEM,Kamala D. Harris,502
+Alameda,356500,U.S. Senate,,DEM,Loretta L. Sanchez,352
+Alameda,361000,U.S. Senate,,DEM,Kamala D. Harris,420
+Alameda,361000,U.S. Senate,,DEM,Loretta L. Sanchez,205
+Alameda,361130,U.S. Senate,,DEM,Kamala D. Harris,266
+Alameda,361130,U.S. Senate,,DEM,Loretta L. Sanchez,86
+Alameda,361200,U.S. Senate,,DEM,Kamala D. Harris,529
+Alameda,361200,U.S. Senate,,DEM,Loretta L. Sanchez,150
+Alameda,361300,U.S. Senate,,DEM,Kamala D. Harris,207
+Alameda,361300,U.S. Senate,,DEM,Loretta L. Sanchez,119
+Alameda,361500,U.S. Senate,,DEM,Kamala D. Harris,459
+Alameda,361500,U.S. Senate,,DEM,Loretta L. Sanchez,210
+Alameda,362100,U.S. Senate,,DEM,Kamala D. Harris,316
+Alameda,362100,U.S. Senate,,DEM,Loretta L. Sanchez,109
+Alameda,362110,U.S. Senate,,DEM,Kamala D. Harris,569
+Alameda,362110,U.S. Senate,,DEM,Loretta L. Sanchez,198
+Alameda,362300,U.S. Senate,,DEM,Kamala D. Harris,420
+Alameda,362300,U.S. Senate,,DEM,Loretta L. Sanchez,137
+Alameda,362500,U.S. Senate,,DEM,Kamala D. Harris,179
+Alameda,362500,U.S. Senate,,DEM,Loretta L. Sanchez,73
+Alameda,362510,U.S. Senate,,DEM,Kamala D. Harris,514
+Alameda,362510,U.S. Senate,,DEM,Loretta L. Sanchez,113
+Alameda,362600,U.S. Senate,,DEM,Kamala D. Harris,580
+Alameda,362600,U.S. Senate,,DEM,Loretta L. Sanchez,122
+Alameda,362700,U.S. Senate,,DEM,Kamala D. Harris,714
+Alameda,362700,U.S. Senate,,DEM,Loretta L. Sanchez,81
+Alameda,362800,U.S. Senate,,DEM,Kamala D. Harris,617
+Alameda,362800,U.S. Senate,,DEM,Loretta L. Sanchez,80
+Alameda,362900,U.S. Senate,,DEM,Kamala D. Harris,468
+Alameda,362900,U.S. Senate,,DEM,Loretta L. Sanchez,81
+Alameda,363000,U.S. Senate,,DEM,Kamala D. Harris,631
+Alameda,363000,U.S. Senate,,DEM,Loretta L. Sanchez,162
+Alameda,363100,U.S. Senate,,DEM,Kamala D. Harris,651
+Alameda,363100,U.S. Senate,,DEM,Loretta L. Sanchez,179
+Alameda,363200,U.S. Senate,,DEM,Kamala D. Harris,315
+Alameda,363200,U.S. Senate,,DEM,Loretta L. Sanchez,124
+Alameda,363310,U.S. Senate,,DEM,Kamala D. Harris,761
+Alameda,363310,U.S. Senate,,DEM,Loretta L. Sanchez,186
+Alameda,363600,U.S. Senate,,DEM,Kamala D. Harris,651
+Alameda,363600,U.S. Senate,,DEM,Loretta L. Sanchez,181
+Alameda,364200,U.S. Senate,,DEM,Kamala D. Harris,802
+Alameda,364200,U.S. Senate,,DEM,Loretta L. Sanchez,182
+Alameda,364300,U.S. Senate,,DEM,Kamala D. Harris,421
+Alameda,364300,U.S. Senate,,DEM,Loretta L. Sanchez,69
+Alameda,364310,U.S. Senate,,DEM,Kamala D. Harris,449
+Alameda,364310,U.S. Senate,,DEM,Loretta L. Sanchez,98
+Alameda,364400,U.S. Senate,,DEM,Kamala D. Harris,865
+Alameda,364400,U.S. Senate,,DEM,Loretta L. Sanchez,155
+Alameda,364510,U.S. Senate,,DEM,Kamala D. Harris,611
+Alameda,364510,U.S. Senate,,DEM,Loretta L. Sanchez,80
+Alameda,364600,U.S. Senate,,DEM,Kamala D. Harris,699
+Alameda,364600,U.S. Senate,,DEM,Loretta L. Sanchez,167
+Alameda,364700,U.S. Senate,,DEM,Kamala D. Harris,596
+Alameda,364700,U.S. Senate,,DEM,Loretta L. Sanchez,111
+Alameda,364800,U.S. Senate,,DEM,Kamala D. Harris,425
+Alameda,364800,U.S. Senate,,DEM,Loretta L. Sanchez,91
+Alameda,364900,U.S. Senate,,DEM,Kamala D. Harris,930
+Alameda,364900,U.S. Senate,,DEM,Loretta L. Sanchez,143
+Alameda,365000,U.S. Senate,,DEM,Kamala D. Harris,372
+Alameda,365000,U.S. Senate,,DEM,Loretta L. Sanchez,68
+Alameda,365200,U.S. Senate,,DEM,Kamala D. Harris,624
+Alameda,365200,U.S. Senate,,DEM,Loretta L. Sanchez,120
+Alameda,373100,U.S. Senate,,DEM,Kamala D. Harris,349
+Alameda,373100,U.S. Senate,,DEM,Loretta L. Sanchez,119
+Alameda,373400,U.S. Senate,,DEM,Kamala D. Harris,648
+Alameda,373400,U.S. Senate,,DEM,Loretta L. Sanchez,276
+Alameda,373500,U.S. Senate,,DEM,Kamala D. Harris,366
+Alameda,373500,U.S. Senate,,DEM,Loretta L. Sanchez,183
+Alameda,373900,U.S. Senate,,DEM,Kamala D. Harris,534
+Alameda,373900,U.S. Senate,,DEM,Loretta L. Sanchez,124
+Alameda,380200,U.S. Senate,,DEM,Kamala D. Harris,825
+Alameda,380200,U.S. Senate,,DEM,Loretta L. Sanchez,217
+Alameda,380300,U.S. Senate,,DEM,Kamala D. Harris,925
+Alameda,380300,U.S. Senate,,DEM,Loretta L. Sanchez,243
+Alameda,380400,U.S. Senate,,DEM,Kamala D. Harris,850
+Alameda,380400,U.S. Senate,,DEM,Loretta L. Sanchez,196
+Alameda,380600,U.S. Senate,,DEM,Kamala D. Harris,632
+Alameda,380600,U.S. Senate,,DEM,Loretta L. Sanchez,171
+Alameda,380700,U.S. Senate,,DEM,Kamala D. Harris,666
+Alameda,380700,U.S. Senate,,DEM,Loretta L. Sanchez,212
+Alameda,400100,U.S. Senate,,DEM,Kamala D. Harris,457
+Alameda,400100,U.S. Senate,,DEM,Loretta L. Sanchez,104
+Alameda,400200,U.S. Senate,,DEM,Kamala D. Harris,603
+Alameda,400200,U.S. Senate,,DEM,Loretta L. Sanchez,66
+Alameda,400300,U.S. Senate,,DEM,Kamala D. Harris,617
+Alameda,400300,U.S. Senate,,DEM,Loretta L. Sanchez,62
+Alameda,400400,U.S. Senate,,DEM,Kamala D. Harris,394
+Alameda,400400,U.S. Senate,,DEM,Loretta L. Sanchez,68
+Alameda,400500,U.S. Senate,,DEM,Kamala D. Harris,396
+Alameda,400500,U.S. Senate,,DEM,Loretta L. Sanchez,45
+Alameda,400600,U.S. Senate,,DEM,Kamala D. Harris,513
+Alameda,400600,U.S. Senate,,DEM,Loretta L. Sanchez,71
+Alameda,400700,U.S. Senate,,DEM,Kamala D. Harris,539
+Alameda,400700,U.S. Senate,,DEM,Loretta L. Sanchez,55
+Alameda,400800,U.S. Senate,,DEM,Kamala D. Harris,471
+Alameda,400800,U.S. Senate,,DEM,Loretta L. Sanchez,69
+Alameda,400900,U.S. Senate,,DEM,Kamala D. Harris,921
+Alameda,400900,U.S. Senate,,DEM,Loretta L. Sanchez,106
+Alameda,401100,U.S. Senate,,DEM,Kamala D. Harris,804
+Alameda,401100,U.S. Senate,,DEM,Loretta L. Sanchez,123
+Alameda,410100,U.S. Senate,,DEM,Kamala D. Harris,685
+Alameda,410100,U.S. Senate,,DEM,Loretta L. Sanchez,256
+Alameda,410300,U.S. Senate,,DEM,Kamala D. Harris,521
+Alameda,410300,U.S. Senate,,DEM,Loretta L. Sanchez,235
+Alameda,410400,U.S. Senate,,DEM,Kamala D. Harris,851
+Alameda,410400,U.S. Senate,,DEM,Loretta L. Sanchez,202
+Alameda,410500,U.S. Senate,,DEM,Kamala D. Harris,370
+Alameda,410500,U.S. Senate,,DEM,Loretta L. Sanchez,150
+Alameda,410600,U.S. Senate,,DEM,Kamala D. Harris,571
+Alameda,410600,U.S. Senate,,DEM,Loretta L. Sanchez,121
+Alameda,415000,U.S. Senate,,DEM,Kamala D. Harris,351
+Alameda,415000,U.S. Senate,,DEM,Loretta L. Sanchez,223
+Alameda,415200,U.S. Senate,,DEM,Kamala D. Harris,312
+Alameda,415200,U.S. Senate,,DEM,Loretta L. Sanchez,117
+Alameda,415300,U.S. Senate,,DEM,Kamala D. Harris,482
+Alameda,415300,U.S. Senate,,DEM,Loretta L. Sanchez,217
+Alameda,415500,U.S. Senate,,DEM,Kamala D. Harris,382
+Alameda,415500,U.S. Senate,,DEM,Loretta L. Sanchez,145
+Alameda,415600,U.S. Senate,,DEM,Kamala D. Harris,422
+Alameda,415600,U.S. Senate,,DEM,Loretta L. Sanchez,171
+Alameda,415800,U.S. Senate,,DEM,Kamala D. Harris,337
+Alameda,415800,U.S. Senate,,DEM,Loretta L. Sanchez,163
+Alameda,415900,U.S. Senate,,DEM,Kamala D. Harris,264
+Alameda,415900,U.S. Senate,,DEM,Loretta L. Sanchez,84
+Alameda,420500,U.S. Senate,,DEM,Kamala D. Harris,438
+Alameda,420500,U.S. Senate,,DEM,Loretta L. Sanchez,208
+Alameda,420600,U.S. Senate,,DEM,Kamala D. Harris,637
+Alameda,420600,U.S. Senate,,DEM,Loretta L. Sanchez,251
+Alameda,420700,U.S. Senate,,DEM,Kamala D. Harris,378
+Alameda,420700,U.S. Senate,,DEM,Loretta L. Sanchez,248
+Alameda,420900,U.S. Senate,,DEM,Kamala D. Harris,284
+Alameda,420900,U.S. Senate,,DEM,Loretta L. Sanchez,171
+Alameda,421000,U.S. Senate,,DEM,Kamala D. Harris,207
+Alameda,421000,U.S. Senate,,DEM,Loretta L. Sanchez,129
+Alameda,421100,U.S. Senate,,DEM,Kamala D. Harris,435
+Alameda,421100,U.S. Senate,,DEM,Loretta L. Sanchez,185
+Alameda,421200,U.S. Senate,,DEM,Kamala D. Harris,298
+Alameda,421200,U.S. Senate,,DEM,Loretta L. Sanchez,187
+Alameda,421300,U.S. Senate,,DEM,Kamala D. Harris,323
+Alameda,421300,U.S. Senate,,DEM,Loretta L. Sanchez,222
+Alameda,421400,U.S. Senate,,DEM,Kamala D. Harris,470
+Alameda,421400,U.S. Senate,,DEM,Loretta L. Sanchez,368
+Alameda,421510,U.S. Senate,,DEM,Kamala D. Harris,376
+Alameda,421510,U.S. Senate,,DEM,Loretta L. Sanchez,278
+Alameda,421700,U.S. Senate,,DEM,Kamala D. Harris,622
+Alameda,421700,U.S. Senate,,DEM,Loretta L. Sanchez,365
+Alameda,421900,U.S. Senate,,DEM,Kamala D. Harris,478
+Alameda,421900,U.S. Senate,,DEM,Loretta L. Sanchez,320
+Alameda,422000,U.S. Senate,,DEM,Kamala D. Harris,525
+Alameda,422000,U.S. Senate,,DEM,Loretta L. Sanchez,264
+Alameda,422100,U.S. Senate,,DEM,Kamala D. Harris,621
+Alameda,422100,U.S. Senate,,DEM,Loretta L. Sanchez,282
+Alameda,422300,U.S. Senate,,DEM,Kamala D. Harris,637
+Alameda,422300,U.S. Senate,,DEM,Loretta L. Sanchez,330
+Alameda,422600,U.S. Senate,,DEM,Kamala D. Harris,670
+Alameda,422600,U.S. Senate,,DEM,Loretta L. Sanchez,371
+Alameda,422700,U.S. Senate,,DEM,Kamala D. Harris,505
+Alameda,422700,U.S. Senate,,DEM,Loretta L. Sanchez,267
+Alameda,422810,U.S. Senate,,DEM,Kamala D. Harris,417
+Alameda,422810,U.S. Senate,,DEM,Loretta L. Sanchez,212
+Alameda,422900,U.S. Senate,,DEM,Kamala D. Harris,449
+Alameda,422900,U.S. Senate,,DEM,Loretta L. Sanchez,345
+Alameda,422910,U.S. Senate,,DEM,Kamala D. Harris,635
+Alameda,422910,U.S. Senate,,DEM,Loretta L. Sanchez,322
+Alameda,422920,U.S. Senate,,DEM,Kamala D. Harris,525
+Alameda,422920,U.S. Senate,,DEM,Loretta L. Sanchez,190
+Alameda,423000,U.S. Senate,,DEM,Kamala D. Harris,350
+Alameda,423000,U.S. Senate,,DEM,Loretta L. Sanchez,244
+Alameda,423100,U.S. Senate,,DEM,Kamala D. Harris,405
+Alameda,423100,U.S. Senate,,DEM,Loretta L. Sanchez,216
+Alameda,423400,U.S. Senate,,DEM,Kamala D. Harris,361
+Alameda,423400,U.S. Senate,,DEM,Loretta L. Sanchez,143
+Alameda,423500,U.S. Senate,,DEM,Kamala D. Harris,283
+Alameda,423500,U.S. Senate,,DEM,Loretta L. Sanchez,137
+Alameda,423600,U.S. Senate,,DEM,Kamala D. Harris,325
+Alameda,423600,U.S. Senate,,DEM,Loretta L. Sanchez,126
+Alameda,423610,U.S. Senate,,DEM,Kamala D. Harris,670
+Alameda,423610,U.S. Senate,,DEM,Loretta L. Sanchez,356
+Alameda,423710,U.S. Senate,,DEM,Kamala D. Harris,475
+Alameda,423710,U.S. Senate,,DEM,Loretta L. Sanchez,221
+Alameda,424000,U.S. Senate,,DEM,Kamala D. Harris,666
+Alameda,424000,U.S. Senate,,DEM,Loretta L. Sanchez,303
+Alameda,424100,U.S. Senate,,DEM,Kamala D. Harris,292
+Alameda,424100,U.S. Senate,,DEM,Loretta L. Sanchez,165
+Alameda,424300,U.S. Senate,,DEM,Kamala D. Harris,561
+Alameda,424300,U.S. Senate,,DEM,Loretta L. Sanchez,450
+Alameda,424400,U.S. Senate,,DEM,Kamala D. Harris,548
+Alameda,424400,U.S. Senate,,DEM,Loretta L. Sanchez,276
+Alameda,430170,U.S. Senate,,DEM,Kamala D. Harris,583
+Alameda,430170,U.S. Senate,,DEM,Loretta L. Sanchez,290
+Alameda,430400,U.S. Senate,,DEM,Kamala D. Harris,173
+Alameda,430400,U.S. Senate,,DEM,Loretta L. Sanchez,112
+Alameda,430600,U.S. Senate,,DEM,Kamala D. Harris,597
+Alameda,430600,U.S. Senate,,DEM,Loretta L. Sanchez,218
+Alameda,430700,U.S. Senate,,DEM,Kamala D. Harris,381
+Alameda,430700,U.S. Senate,,DEM,Loretta L. Sanchez,135
+Alameda,430900,U.S. Senate,,DEM,Kamala D. Harris,372
+Alameda,430900,U.S. Senate,,DEM,Loretta L. Sanchez,143
+Alameda,431100,U.S. Senate,,DEM,Kamala D. Harris,537
+Alameda,431100,U.S. Senate,,DEM,Loretta L. Sanchez,208
+Alameda,431800,U.S. Senate,,DEM,Kamala D. Harris,564
+Alameda,431800,U.S. Senate,,DEM,Loretta L. Sanchez,246
+Alameda,432010,U.S. Senate,,DEM,Kamala D. Harris,689
+Alameda,432010,U.S. Senate,,DEM,Loretta L. Sanchez,344
+Alameda,432110,U.S. Senate,,DEM,Kamala D. Harris,522
+Alameda,432110,U.S. Senate,,DEM,Loretta L. Sanchez,365
+Alameda,432200,U.S. Senate,,DEM,Kamala D. Harris,429
+Alameda,432200,U.S. Senate,,DEM,Loretta L. Sanchez,239
+Alameda,432300,U.S. Senate,,DEM,Kamala D. Harris,563
+Alameda,432300,U.S. Senate,,DEM,Loretta L. Sanchez,356
+Alameda,432400,U.S. Senate,,DEM,Kamala D. Harris,508
+Alameda,432400,U.S. Senate,,DEM,Loretta L. Sanchez,283
+Alameda,432600,U.S. Senate,,DEM,Kamala D. Harris,310
+Alameda,432600,U.S. Senate,,DEM,Loretta L. Sanchez,231
+Alameda,432700,U.S. Senate,,DEM,Kamala D. Harris,667
+Alameda,432700,U.S. Senate,,DEM,Loretta L. Sanchez,302
+Alameda,432810,U.S. Senate,,DEM,Kamala D. Harris,349
+Alameda,432810,U.S. Senate,,DEM,Loretta L. Sanchez,162
+Alameda,432900,U.S. Senate,,DEM,Kamala D. Harris,506
+Alameda,432900,U.S. Senate,,DEM,Loretta L. Sanchez,204
+Alameda,433100,U.S. Senate,,DEM,Kamala D. Harris,453
+Alameda,433100,U.S. Senate,,DEM,Loretta L. Sanchez,317
+Alameda,433200,U.S. Senate,,DEM,Kamala D. Harris,358
+Alameda,433200,U.S. Senate,,DEM,Loretta L. Sanchez,169
+Alameda,433400,U.S. Senate,,DEM,Kamala D. Harris,673
+Alameda,433400,U.S. Senate,,DEM,Loretta L. Sanchez,200
+Alameda,433500,U.S. Senate,,DEM,Kamala D. Harris,420
+Alameda,433500,U.S. Senate,,DEM,Loretta L. Sanchez,259
+Alameda,433610,U.S. Senate,,DEM,Kamala D. Harris,729
+Alameda,433610,U.S. Senate,,DEM,Loretta L. Sanchez,238
+Alameda,433700,U.S. Senate,,DEM,Kamala D. Harris,687
+Alameda,433700,U.S. Senate,,DEM,Loretta L. Sanchez,239
+Alameda,433900,U.S. Senate,,DEM,Kamala D. Harris,262
+Alameda,433900,U.S. Senate,,DEM,Loretta L. Sanchez,73
+Alameda,440100,U.S. Senate,,DEM,Kamala D. Harris,486
+Alameda,440100,U.S. Senate,,DEM,Loretta L. Sanchez,311
+Alameda,440300,U.S. Senate,,DEM,Kamala D. Harris,644
+Alameda,440300,U.S. Senate,,DEM,Loretta L. Sanchez,365
+Alameda,440400,U.S. Senate,,DEM,Kamala D. Harris,711
+Alameda,440400,U.S. Senate,,DEM,Loretta L. Sanchez,421
+Alameda,440610,U.S. Senate,,DEM,Kamala D. Harris,627
+Alameda,440610,U.S. Senate,,DEM,Loretta L. Sanchez,317
+Alameda,440800,U.S. Senate,,DEM,Kamala D. Harris,291
+Alameda,440800,U.S. Senate,,DEM,Loretta L. Sanchez,154
+Alameda,440900,U.S. Senate,,DEM,Kamala D. Harris,462
+Alameda,440900,U.S. Senate,,DEM,Loretta L. Sanchez,261
+Alameda,441100,U.S. Senate,,DEM,Kamala D. Harris,727
+Alameda,441100,U.S. Senate,,DEM,Loretta L. Sanchez,382
+Alameda,441300,U.S. Senate,,DEM,Kamala D. Harris,330
+Alameda,441300,U.S. Senate,,DEM,Loretta L. Sanchez,184
+Alameda,441400,U.S. Senate,,DEM,Kamala D. Harris,400
+Alameda,441400,U.S. Senate,,DEM,Loretta L. Sanchez,226
+Alameda,442100,U.S. Senate,,DEM,Kamala D. Harris,712
+Alameda,442100,U.S. Senate,,DEM,Loretta L. Sanchez,425
+Alameda,442600,U.S. Senate,,DEM,Kamala D. Harris,289
+Alameda,442600,U.S. Senate,,DEM,Loretta L. Sanchez,109
+Alameda,442700,U.S. Senate,,DEM,Kamala D. Harris,400
+Alameda,442700,U.S. Senate,,DEM,Loretta L. Sanchez,222
+Alameda,443000,U.S. Senate,,DEM,Kamala D. Harris,424
+Alameda,443000,U.S. Senate,,DEM,Loretta L. Sanchez,219
+Alameda,443100,U.S. Senate,,DEM,Kamala D. Harris,422
+Alameda,443100,U.S. Senate,,DEM,Loretta L. Sanchez,202
+Alameda,443200,U.S. Senate,,DEM,Kamala D. Harris,292
+Alameda,443200,U.S. Senate,,DEM,Loretta L. Sanchez,165
+Alameda,443300,U.S. Senate,,DEM,Kamala D. Harris,399
+Alameda,443300,U.S. Senate,,DEM,Loretta L. Sanchez,176
+Alameda,443400,U.S. Senate,,DEM,Kamala D. Harris,576
+Alameda,443400,U.S. Senate,,DEM,Loretta L. Sanchez,226
+Alameda,443500,U.S. Senate,,DEM,Kamala D. Harris,360
+Alameda,443500,U.S. Senate,,DEM,Loretta L. Sanchez,200
+Alameda,447200,U.S. Senate,,DEM,Kamala D. Harris,824
+Alameda,447200,U.S. Senate,,DEM,Loretta L. Sanchez,265
+Alameda,447600,U.S. Senate,,DEM,Kamala D. Harris,424
+Alameda,447600,U.S. Senate,,DEM,Loretta L. Sanchez,167
+Alameda,450300,U.S. Senate,,DEM,Kamala D. Harris,411
+Alameda,450300,U.S. Senate,,DEM,Loretta L. Sanchez,210
+Alameda,450400,U.S. Senate,,DEM,Kamala D. Harris,700
+Alameda,450400,U.S. Senate,,DEM,Loretta L. Sanchez,305
+Alameda,450610,U.S. Senate,,DEM,Kamala D. Harris,416
+Alameda,450610,U.S. Senate,,DEM,Loretta L. Sanchez,155
+Alameda,450800,U.S. Senate,,DEM,Kamala D. Harris,457
+Alameda,450800,U.S. Senate,,DEM,Loretta L. Sanchez,187
+Alameda,451000,U.S. Senate,,DEM,Kamala D. Harris,596
+Alameda,451000,U.S. Senate,,DEM,Loretta L. Sanchez,306
+Alameda,451510,U.S. Senate,,DEM,Kamala D. Harris,489
+Alameda,451510,U.S. Senate,,DEM,Loretta L. Sanchez,251
+Alameda,451600,U.S. Senate,,DEM,Kamala D. Harris,500
+Alameda,451600,U.S. Senate,,DEM,Loretta L. Sanchez,250
+Alameda,451700,U.S. Senate,,DEM,Kamala D. Harris,396
+Alameda,451700,U.S. Senate,,DEM,Loretta L. Sanchez,235
+Alameda,452100,U.S. Senate,,DEM,Kamala D. Harris,457
+Alameda,452100,U.S. Senate,,DEM,Loretta L. Sanchez,233
+Alameda,452200,U.S. Senate,,DEM,Kamala D. Harris,771
+Alameda,452200,U.S. Senate,,DEM,Loretta L. Sanchez,316
+Alameda,452400,U.S. Senate,,DEM,Kamala D. Harris,429
+Alameda,452400,U.S. Senate,,DEM,Loretta L. Sanchez,272
+Alameda,452500,U.S. Senate,,DEM,Kamala D. Harris,356
+Alameda,452500,U.S. Senate,,DEM,Loretta L. Sanchez,163
+Alameda,453100,U.S. Senate,,DEM,Kamala D. Harris,545
+Alameda,453100,U.S. Senate,,DEM,Loretta L. Sanchez,175
+Alameda,453300,U.S. Senate,,DEM,Kamala D. Harris,288
+Alameda,453300,U.S. Senate,,DEM,Loretta L. Sanchez,169
+Alameda,453400,U.S. Senate,,DEM,Kamala D. Harris,471
+Alameda,453400,U.S. Senate,,DEM,Loretta L. Sanchez,185
+Alameda,453500,U.S. Senate,,DEM,Kamala D. Harris,526
+Alameda,453500,U.S. Senate,,DEM,Loretta L. Sanchez,281
+Alameda,453900,U.S. Senate,,DEM,Kamala D. Harris,528
+Alameda,453900,U.S. Senate,,DEM,Loretta L. Sanchez,268
+Alameda,453920,U.S. Senate,,DEM,Kamala D. Harris,411
+Alameda,453920,U.S. Senate,,DEM,Loretta L. Sanchez,155
+Alameda,454100,U.S. Senate,,DEM,Kamala D. Harris,478
+Alameda,454100,U.S. Senate,,DEM,Loretta L. Sanchez,216
+Alameda,454500,U.S. Senate,,DEM,Kamala D. Harris,404
+Alameda,454500,U.S. Senate,,DEM,Loretta L. Sanchez,170
+Alameda,455000,U.S. Senate,,DEM,Kamala D. Harris,288
+Alameda,455000,U.S. Senate,,DEM,Loretta L. Sanchez,93
+Alameda,455100,U.S. Senate,,DEM,Kamala D. Harris,403
+Alameda,455100,U.S. Senate,,DEM,Loretta L. Sanchez,147
+Alameda,455300,U.S. Senate,,DEM,Kamala D. Harris,401
+Alameda,455300,U.S. Senate,,DEM,Loretta L. Sanchez,214
+Alameda,455400,U.S. Senate,,DEM,Kamala D. Harris,464
+Alameda,455400,U.S. Senate,,DEM,Loretta L. Sanchez,186
+Alameda,455500,U.S. Senate,,DEM,Kamala D. Harris,261
+Alameda,455500,U.S. Senate,,DEM,Loretta L. Sanchez,149
+Alameda,455700,U.S. Senate,,DEM,Kamala D. Harris,299
+Alameda,455700,U.S. Senate,,DEM,Loretta L. Sanchez,92
+Alameda,455900,U.S. Senate,,DEM,Kamala D. Harris,771
+Alameda,455900,U.S. Senate,,DEM,Loretta L. Sanchez,344
+Alameda,456200,U.S. Senate,,DEM,Kamala D. Harris,525
+Alameda,456200,U.S. Senate,,DEM,Loretta L. Sanchez,199
+Alameda,456500,U.S. Senate,,DEM,Kamala D. Harris,429
+Alameda,456500,U.S. Senate,,DEM,Loretta L. Sanchez,144
+Alameda,456600,U.S. Senate,,DEM,Kamala D. Harris,560
+Alameda,456600,U.S. Senate,,DEM,Loretta L. Sanchez,171
+Alameda,456900,U.S. Senate,,DEM,Kamala D. Harris,385
+Alameda,456900,U.S. Senate,,DEM,Loretta L. Sanchez,117
+Alameda,457100,U.S. Senate,,DEM,Kamala D. Harris,488
+Alameda,457100,U.S. Senate,,DEM,Loretta L. Sanchez,136
+Alameda,457300,U.S. Senate,,DEM,Kamala D. Harris,551
+Alameda,457300,U.S. Senate,,DEM,Loretta L. Sanchez,171
+Alameda,457400,U.S. Senate,,DEM,Kamala D. Harris,490
+Alameda,457400,U.S. Senate,,DEM,Loretta L. Sanchez,131
+Alameda,457500,U.S. Senate,,DEM,Kamala D. Harris,702
+Alameda,457500,U.S. Senate,,DEM,Loretta L. Sanchez,256
+Alameda,457700,U.S. Senate,,DEM,Kamala D. Harris,519
+Alameda,457700,U.S. Senate,,DEM,Loretta L. Sanchez,154
+Alameda,457900,U.S. Senate,,DEM,Kamala D. Harris,420
+Alameda,457900,U.S. Senate,,DEM,Loretta L. Sanchez,129
+Alameda,458200,U.S. Senate,,DEM,Kamala D. Harris,553
+Alameda,458200,U.S. Senate,,DEM,Loretta L. Sanchez,238
+Alameda,458300,U.S. Senate,,DEM,Kamala D. Harris,610
+Alameda,458300,U.S. Senate,,DEM,Loretta L. Sanchez,251
+Alameda,458500,U.S. Senate,,DEM,Kamala D. Harris,394
+Alameda,458500,U.S. Senate,,DEM,Loretta L. Sanchez,95
+Alameda,458800,U.S. Senate,,DEM,Kamala D. Harris,358
+Alameda,458800,U.S. Senate,,DEM,Loretta L. Sanchez,272
+Alameda,458900,U.S. Senate,,DEM,Kamala D. Harris,253
+Alameda,458900,U.S. Senate,,DEM,Loretta L. Sanchez,177
+Alameda,470400,U.S. Senate,,DEM,Kamala D. Harris,515
+Alameda,470400,U.S. Senate,,DEM,Loretta L. Sanchez,272
+Alameda,470600,U.S. Senate,,DEM,Kamala D. Harris,451
+Alameda,470600,U.S. Senate,,DEM,Loretta L. Sanchez,171
+Alameda,470900,U.S. Senate,,DEM,Kamala D. Harris,579
+Alameda,470900,U.S. Senate,,DEM,Loretta L. Sanchez,234
+Alameda,471300,U.S. Senate,,DEM,Kamala D. Harris,411
+Alameda,471300,U.S. Senate,,DEM,Loretta L. Sanchez,192
+Alameda,471800,U.S. Senate,,DEM,Kamala D. Harris,426
+Alameda,471800,U.S. Senate,,DEM,Loretta L. Sanchez,195
+Alameda,471900,U.S. Senate,,DEM,Kamala D. Harris,462
+Alameda,471900,U.S. Senate,,DEM,Loretta L. Sanchez,174
+Alameda,472000,U.S. Senate,,DEM,Kamala D. Harris,557
+Alameda,472000,U.S. Senate,,DEM,Loretta L. Sanchez,211
+Alameda,472200,U.S. Senate,,DEM,Kamala D. Harris,561
+Alameda,472200,U.S. Senate,,DEM,Loretta L. Sanchez,258
+Alameda,472300,U.S. Senate,,DEM,Kamala D. Harris,427
+Alameda,472300,U.S. Senate,,DEM,Loretta L. Sanchez,184
+Alameda,472400,U.S. Senate,,DEM,Kamala D. Harris,473
+Alameda,472400,U.S. Senate,,DEM,Loretta L. Sanchez,216
+Alameda,472500,U.S. Senate,,DEM,Kamala D. Harris,598
+Alameda,472500,U.S. Senate,,DEM,Loretta L. Sanchez,266
+Alameda,473300,U.S. Senate,,DEM,Kamala D. Harris,644
+Alameda,473300,U.S. Senate,,DEM,Loretta L. Sanchez,265
+Alameda,473400,U.S. Senate,,DEM,Kamala D. Harris,481
+Alameda,473400,U.S. Senate,,DEM,Loretta L. Sanchez,200
+Alameda,473500,U.S. Senate,,DEM,Kamala D. Harris,626
+Alameda,473500,U.S. Senate,,DEM,Loretta L. Sanchez,275
+Alameda,473600,U.S. Senate,,DEM,Kamala D. Harris,228
+Alameda,473600,U.S. Senate,,DEM,Loretta L. Sanchez,110
+Alameda,473800,U.S. Senate,,DEM,Kamala D. Harris,551
+Alameda,473800,U.S. Senate,,DEM,Loretta L. Sanchez,254
+Alameda,473900,U.S. Senate,,DEM,Kamala D. Harris,630
+Alameda,473900,U.S. Senate,,DEM,Loretta L. Sanchez,243
+Alameda,474010,U.S. Senate,,DEM,Kamala D. Harris,450
+Alameda,474010,U.S. Senate,,DEM,Loretta L. Sanchez,180
+Alameda,474020,U.S. Senate,,DEM,Kamala D. Harris,607
+Alameda,474020,U.S. Senate,,DEM,Loretta L. Sanchez,246
+Alameda,474300,U.S. Senate,,DEM,Kamala D. Harris,446
+Alameda,474300,U.S. Senate,,DEM,Loretta L. Sanchez,159
+Alameda,474500,U.S. Senate,,DEM,Kamala D. Harris,625
+Alameda,474500,U.S. Senate,,DEM,Loretta L. Sanchez,238
+Alameda,474600,U.S. Senate,,DEM,Kamala D. Harris,371
+Alameda,474600,U.S. Senate,,DEM,Loretta L. Sanchez,163
+Alameda,474700,U.S. Senate,,DEM,Kamala D. Harris,296
+Alameda,474700,U.S. Senate,,DEM,Loretta L. Sanchez,142
+Alameda,474900,U.S. Senate,,DEM,Kamala D. Harris,614
+Alameda,474900,U.S. Senate,,DEM,Loretta L. Sanchez,272
+Alameda,475000,U.S. Senate,,DEM,Kamala D. Harris,403
+Alameda,475000,U.S. Senate,,DEM,Loretta L. Sanchez,148
+Alameda,475100,U.S. Senate,,DEM,Kamala D. Harris,382
+Alameda,475100,U.S. Senate,,DEM,Loretta L. Sanchez,154
+Alameda,475200,U.S. Senate,,DEM,Kamala D. Harris,465
+Alameda,475200,U.S. Senate,,DEM,Loretta L. Sanchez,235
+Alameda,475500,U.S. Senate,,DEM,Kamala D. Harris,504
+Alameda,475500,U.S. Senate,,DEM,Loretta L. Sanchez,172
+Alameda,475520,U.S. Senate,,DEM,Kamala D. Harris,472
+Alameda,475520,U.S. Senate,,DEM,Loretta L. Sanchez,180
+Alameda,475540,U.S. Senate,,DEM,Kamala D. Harris,485
+Alameda,475540,U.S. Senate,,DEM,Loretta L. Sanchez,191
+Alameda,476100,U.S. Senate,,DEM,Kamala D. Harris,642
+Alameda,476100,U.S. Senate,,DEM,Loretta L. Sanchez,210
+Alameda,476110,U.S. Senate,,DEM,Kamala D. Harris,488
+Alameda,476110,U.S. Senate,,DEM,Loretta L. Sanchez,144
+Alameda,481200,U.S. Senate,,DEM,Kamala D. Harris,593
+Alameda,481200,U.S. Senate,,DEM,Loretta L. Sanchez,459
+Alameda,481410,U.S. Senate,,DEM,Kamala D. Harris,198
+Alameda,481410,U.S. Senate,,DEM,Loretta L. Sanchez,135
+Alameda,481500,U.S. Senate,,DEM,Kamala D. Harris,386
+Alameda,481500,U.S. Senate,,DEM,Loretta L. Sanchez,242
+Alameda,481800,U.S. Senate,,DEM,Kamala D. Harris,521
+Alameda,481800,U.S. Senate,,DEM,Loretta L. Sanchez,298
+Alameda,483000,U.S. Senate,,DEM,Kamala D. Harris,279
+Alameda,483000,U.S. Senate,,DEM,Loretta L. Sanchez,189
+Alameda,491000,U.S. Senate,,DEM,Kamala D. Harris,439
+Alameda,491000,U.S. Senate,,DEM,Loretta L. Sanchez,181
+Alameda,491100,U.S. Senate,,DEM,Kamala D. Harris,818
+Alameda,491100,U.S. Senate,,DEM,Loretta L. Sanchez,255
+Alameda,491200,U.S. Senate,,DEM,Kamala D. Harris,709
+Alameda,491200,U.S. Senate,,DEM,Loretta L. Sanchez,317
+Alameda,491300,U.S. Senate,,DEM,Kamala D. Harris,722
+Alameda,491300,U.S. Senate,,DEM,Loretta L. Sanchez,244
+Alameda,491500,U.S. Senate,,DEM,Kamala D. Harris,441
+Alameda,491500,U.S. Senate,,DEM,Loretta L. Sanchez,169
+Alameda,500100,U.S. Senate,,DEM,Kamala D. Harris,552
+Alameda,500100,U.S. Senate,,DEM,Loretta L. Sanchez,290
+Alameda,500110,U.S. Senate,,DEM,Kamala D. Harris,476
+Alameda,500110,U.S. Senate,,DEM,Loretta L. Sanchez,284
+Alameda,500120,U.S. Senate,,DEM,Kamala D. Harris,249
+Alameda,500120,U.S. Senate,,DEM,Loretta L. Sanchez,177
+Alameda,500130,U.S. Senate,,DEM,Kamala D. Harris,564
+Alameda,500130,U.S. Senate,,DEM,Loretta L. Sanchez,240
+Alameda,500140,U.S. Senate,,DEM,Kamala D. Harris,573
+Alameda,500140,U.S. Senate,,DEM,Loretta L. Sanchez,273
+Alameda,500200,U.S. Senate,,DEM,Kamala D. Harris,395
+Alameda,500200,U.S. Senate,,DEM,Loretta L. Sanchez,212
+Alameda,500210,U.S. Senate,,DEM,Kamala D. Harris,335
+Alameda,500210,U.S. Senate,,DEM,Loretta L. Sanchez,189
+Alameda,500230,U.S. Senate,,DEM,Kamala D. Harris,296
+Alameda,500230,U.S. Senate,,DEM,Loretta L. Sanchez,179
+Alameda,500300,U.S. Senate,,DEM,Kamala D. Harris,354
+Alameda,500300,U.S. Senate,,DEM,Loretta L. Sanchez,182
+Alameda,500310,U.S. Senate,,DEM,Kamala D. Harris,564
+Alameda,500310,U.S. Senate,,DEM,Loretta L. Sanchez,290
+Alameda,500320,U.S. Senate,,DEM,Kamala D. Harris,363
+Alameda,500320,U.S. Senate,,DEM,Loretta L. Sanchez,167
+Alameda,500340,U.S. Senate,,DEM,Kamala D. Harris,338
+Alameda,500340,U.S. Senate,,DEM,Loretta L. Sanchez,153
+Alameda,500400,U.S. Senate,,DEM,Kamala D. Harris,717
+Alameda,500400,U.S. Senate,,DEM,Loretta L. Sanchez,367
+Alameda,500410,U.S. Senate,,DEM,Kamala D. Harris,667
+Alameda,500410,U.S. Senate,,DEM,Loretta L. Sanchez,281
+Alameda,500500,U.S. Senate,,DEM,Kamala D. Harris,447
+Alameda,500500,U.S. Senate,,DEM,Loretta L. Sanchez,233
+Alameda,500600,U.S. Senate,,DEM,Kamala D. Harris,355
+Alameda,500600,U.S. Senate,,DEM,Loretta L. Sanchez,203
+Alameda,500700,U.S. Senate,,DEM,Kamala D. Harris,503
+Alameda,500700,U.S. Senate,,DEM,Loretta L. Sanchez,268
+Alameda,500910,U.S. Senate,,DEM,Kamala D. Harris,287
+Alameda,500910,U.S. Senate,,DEM,Loretta L. Sanchez,152
+Alameda,501000,U.S. Senate,,DEM,Kamala D. Harris,455
+Alameda,501000,U.S. Senate,,DEM,Loretta L. Sanchez,226
+Alameda,501200,U.S. Senate,,DEM,Kamala D. Harris,326
+Alameda,501200,U.S. Senate,,DEM,Loretta L. Sanchez,128
+Alameda,501300,U.S. Senate,,DEM,Kamala D. Harris,449
+Alameda,501300,U.S. Senate,,DEM,Loretta L. Sanchez,203
+Alameda,501400,U.S. Senate,,DEM,Kamala D. Harris,620
+Alameda,501400,U.S. Senate,,DEM,Loretta L. Sanchez,244
+Alameda,501410,U.S. Senate,,DEM,Kamala D. Harris,354
+Alameda,501410,U.S. Senate,,DEM,Loretta L. Sanchez,168
+Alameda,501600,U.S. Senate,,DEM,Kamala D. Harris,579
+Alameda,501600,U.S. Senate,,DEM,Loretta L. Sanchez,307
+Alameda,501610,U.S. Senate,,DEM,Kamala D. Harris,637
+Alameda,501610,U.S. Senate,,DEM,Loretta L. Sanchez,274
+Alameda,501620,U.S. Senate,,DEM,Kamala D. Harris,411
+Alameda,501620,U.S. Senate,,DEM,Loretta L. Sanchez,195
+Alameda,501630,U.S. Senate,,DEM,Kamala D. Harris,501
+Alameda,501630,U.S. Senate,,DEM,Loretta L. Sanchez,220
+Alameda,501640,U.S. Senate,,DEM,Kamala D. Harris,472
+Alameda,501640,U.S. Senate,,DEM,Loretta L. Sanchez,243
+Alameda,501800,U.S. Senate,,DEM,Kamala D. Harris,427
+Alameda,501800,U.S. Senate,,DEM,Loretta L. Sanchez,206
+Alameda,501830,U.S. Senate,,DEM,Kamala D. Harris,493
+Alameda,501830,U.S. Senate,,DEM,Loretta L. Sanchez,249
+Alameda,501840,U.S. Senate,,DEM,Kamala D. Harris,388
+Alameda,501840,U.S. Senate,,DEM,Loretta L. Sanchez,207
+Alameda,501910,U.S. Senate,,DEM,Kamala D. Harris,443
+Alameda,501910,U.S. Senate,,DEM,Loretta L. Sanchez,172
+Alameda,502000,U.S. Senate,,DEM,Kamala D. Harris,358
+Alameda,502000,U.S. Senate,,DEM,Loretta L. Sanchez,148
+Alameda,502010,U.S. Senate,,DEM,Kamala D. Harris,319
+Alameda,502010,U.S. Senate,,DEM,Loretta L. Sanchez,134
+Alameda,502020,U.S. Senate,,DEM,Kamala D. Harris,689
+Alameda,502020,U.S. Senate,,DEM,Loretta L. Sanchez,307
+Alameda,502030,U.S. Senate,,DEM,Kamala D. Harris,276
+Alameda,502030,U.S. Senate,,DEM,Loretta L. Sanchez,156
+Alameda,502100,U.S. Senate,,DEM,Kamala D. Harris,359
+Alameda,502100,U.S. Senate,,DEM,Loretta L. Sanchez,180
+Alameda,502200,U.S. Senate,,DEM,Kamala D. Harris,397
+Alameda,502200,U.S. Senate,,DEM,Loretta L. Sanchez,134
+Alameda,502210,U.S. Senate,,DEM,Kamala D. Harris,339
+Alameda,502210,U.S. Senate,,DEM,Loretta L. Sanchez,202
+Alameda,502220,U.S. Senate,,DEM,Kamala D. Harris,555
+Alameda,502220,U.S. Senate,,DEM,Loretta L. Sanchez,257
+Alameda,502400,U.S. Senate,,DEM,Kamala D. Harris,381
+Alameda,502400,U.S. Senate,,DEM,Loretta L. Sanchez,192
+Alameda,502410,U.S. Senate,,DEM,Kamala D. Harris,286
+Alameda,502410,U.S. Senate,,DEM,Loretta L. Sanchez,145
+Alameda,502500,U.S. Senate,,DEM,Kamala D. Harris,288
+Alameda,502500,U.S. Senate,,DEM,Loretta L. Sanchez,221
+Alameda,502600,U.S. Senate,,DEM,Kamala D. Harris,438
+Alameda,502600,U.S. Senate,,DEM,Loretta L. Sanchez,252
+Alameda,502710,U.S. Senate,,DEM,Kamala D. Harris,335
+Alameda,502710,U.S. Senate,,DEM,Loretta L. Sanchez,175
+Alameda,502720,U.S. Senate,,DEM,Kamala D. Harris,403
+Alameda,502720,U.S. Senate,,DEM,Loretta L. Sanchez,221
+Alameda,502740,U.S. Senate,,DEM,Kamala D. Harris,414
+Alameda,502740,U.S. Senate,,DEM,Loretta L. Sanchez,209
+Alameda,502800,U.S. Senate,,DEM,Kamala D. Harris,355
+Alameda,502800,U.S. Senate,,DEM,Loretta L. Sanchez,184
+Alameda,502900,U.S. Senate,,DEM,Kamala D. Harris,407
+Alameda,502900,U.S. Senate,,DEM,Loretta L. Sanchez,203
+Alameda,502920,U.S. Senate,,DEM,Kamala D. Harris,480
+Alameda,502920,U.S. Senate,,DEM,Loretta L. Sanchez,192
+Alameda,520110,U.S. Senate,,DEM,Kamala D. Harris,417
+Alameda,520110,U.S. Senate,,DEM,Loretta L. Sanchez,150
+Alameda,520210,U.S. Senate,,DEM,Kamala D. Harris,465
+Alameda,520210,U.S. Senate,,DEM,Loretta L. Sanchez,206
+Alameda,520220,U.S. Senate,,DEM,Kamala D. Harris,495
+Alameda,520220,U.S. Senate,,DEM,Loretta L. Sanchez,238
+Alameda,520230,U.S. Senate,,DEM,Kamala D. Harris,489
+Alameda,520230,U.S. Senate,,DEM,Loretta L. Sanchez,174
+Alameda,520240,U.S. Senate,,DEM,Kamala D. Harris,635
+Alameda,520240,U.S. Senate,,DEM,Loretta L. Sanchez,246
+Alameda,520300,U.S. Senate,,DEM,Kamala D. Harris,506
+Alameda,520300,U.S. Senate,,DEM,Loretta L. Sanchez,253
+Alameda,520310,U.S. Senate,,DEM,Kamala D. Harris,344
+Alameda,520310,U.S. Senate,,DEM,Loretta L. Sanchez,122
+Alameda,520320,U.S. Senate,,DEM,Kamala D. Harris,446
+Alameda,520320,U.S. Senate,,DEM,Loretta L. Sanchez,208
+Alameda,520400,U.S. Senate,,DEM,Kamala D. Harris,563
+Alameda,520400,U.S. Senate,,DEM,Loretta L. Sanchez,246
+Alameda,520420,U.S. Senate,,DEM,Kamala D. Harris,558
+Alameda,520420,U.S. Senate,,DEM,Loretta L. Sanchez,228
+Alameda,520500,U.S. Senate,,DEM,Kamala D. Harris,364
+Alameda,520500,U.S. Senate,,DEM,Loretta L. Sanchez,121
+Alameda,520600,U.S. Senate,,DEM,Kamala D. Harris,741
+Alameda,520600,U.S. Senate,,DEM,Loretta L. Sanchez,233
+Alameda,520610,U.S. Senate,,DEM,Kamala D. Harris,439
+Alameda,520610,U.S. Senate,,DEM,Loretta L. Sanchez,173
+Alameda,520630,U.S. Senate,,DEM,Kamala D. Harris,309
+Alameda,520630,U.S. Senate,,DEM,Loretta L. Sanchez,121
+Alameda,520700,U.S. Senate,,DEM,Kamala D. Harris,683
+Alameda,520700,U.S. Senate,,DEM,Loretta L. Sanchez,282
+Alameda,520710,U.S. Senate,,DEM,Kamala D. Harris,387
+Alameda,520710,U.S. Senate,,DEM,Loretta L. Sanchez,155
+Alameda,520810,U.S. Senate,,DEM,Kamala D. Harris,354
+Alameda,520810,U.S. Senate,,DEM,Loretta L. Sanchez,128
+Alameda,520820,U.S. Senate,,DEM,Kamala D. Harris,607
+Alameda,520820,U.S. Senate,,DEM,Loretta L. Sanchez,227
+Alameda,520840,U.S. Senate,,DEM,Kamala D. Harris,598
+Alameda,520840,U.S. Senate,,DEM,Loretta L. Sanchez,231
+Alameda,520860,U.S. Senate,,DEM,Kamala D. Harris,535
+Alameda,520860,U.S. Senate,,DEM,Loretta L. Sanchez,179
+Alameda,520870,U.S. Senate,,DEM,Kamala D. Harris,469
+Alameda,520870,U.S. Senate,,DEM,Loretta L. Sanchez,176
+Alameda,521100,U.S. Senate,,DEM,Kamala D. Harris,685
+Alameda,521100,U.S. Senate,,DEM,Loretta L. Sanchez,304
+Alameda,521110,U.S. Senate,,DEM,Kamala D. Harris,511
+Alameda,521110,U.S. Senate,,DEM,Loretta L. Sanchez,185
+Alameda,521300,U.S. Senate,,DEM,Kamala D. Harris,572
+Alameda,521300,U.S. Senate,,DEM,Loretta L. Sanchez,205
+Alameda,521500,U.S. Senate,,DEM,Kamala D. Harris,485
+Alameda,521500,U.S. Senate,,DEM,Loretta L. Sanchez,180
+Alameda,522000,U.S. Senate,,DEM,Kamala D. Harris,402
+Alameda,522000,U.S. Senate,,DEM,Loretta L. Sanchez,136
+Alameda,522020,U.S. Senate,,DEM,Kamala D. Harris,443
+Alameda,522020,U.S. Senate,,DEM,Loretta L. Sanchez,155
+Alameda,522110,U.S. Senate,,DEM,Kamala D. Harris,828
+Alameda,522110,U.S. Senate,,DEM,Loretta L. Sanchez,287
+Alameda,522120,U.S. Senate,,DEM,Kamala D. Harris,591
+Alameda,522120,U.S. Senate,,DEM,Loretta L. Sanchez,236
+Alameda,522130,U.S. Senate,,DEM,Kamala D. Harris,420
+Alameda,522130,U.S. Senate,,DEM,Loretta L. Sanchez,130
+Alameda,522140,U.S. Senate,,DEM,Kamala D. Harris,352
+Alameda,522140,U.S. Senate,,DEM,Loretta L. Sanchez,115
+Alameda,522150,U.S. Senate,,DEM,Kamala D. Harris,742
+Alameda,522150,U.S. Senate,,DEM,Loretta L. Sanchez,287
+Alameda,522200,U.S. Senate,,DEM,Kamala D. Harris,329
+Alameda,522200,U.S. Senate,,DEM,Loretta L. Sanchez,117
+Alameda,522400,U.S. Senate,,DEM,Kamala D. Harris,331
+Alameda,522400,U.S. Senate,,DEM,Loretta L. Sanchez,127
+Alameda,523100,U.S. Senate,,DEM,Kamala D. Harris,276
+Alameda,523100,U.S. Senate,,DEM,Loretta L. Sanchez,84
+Alameda,523110,U.S. Senate,,DEM,Kamala D. Harris,779
+Alameda,523110,U.S. Senate,,DEM,Loretta L. Sanchez,341
+Alameda,523120,U.S. Senate,,DEM,Kamala D. Harris,335
+Alameda,523120,U.S. Senate,,DEM,Loretta L. Sanchez,117
+Alameda,523300,U.S. Senate,,DEM,Kamala D. Harris,791
+Alameda,523300,U.S. Senate,,DEM,Loretta L. Sanchez,300
+Alameda,523700,U.S. Senate,,DEM,Kamala D. Harris,397
+Alameda,523700,U.S. Senate,,DEM,Loretta L. Sanchez,168
+Alameda,523710,U.S. Senate,,DEM,Kamala D. Harris,377
+Alameda,523710,U.S. Senate,,DEM,Loretta L. Sanchez,131
+Alameda,523720,U.S. Senate,,DEM,Kamala D. Harris,413
+Alameda,523720,U.S. Senate,,DEM,Loretta L. Sanchez,175
+Alameda,523800,U.S. Senate,,DEM,Kamala D. Harris,434
+Alameda,523800,U.S. Senate,,DEM,Loretta L. Sanchez,141
+Alameda,540300,U.S. Senate,,DEM,Kamala D. Harris,731
+Alameda,540300,U.S. Senate,,DEM,Loretta L. Sanchez,343
+Alameda,540400,U.S. Senate,,DEM,Kamala D. Harris,343
+Alameda,540400,U.S. Senate,,DEM,Loretta L. Sanchez,89
+Alameda,540500,U.S. Senate,,DEM,Kamala D. Harris,447
+Alameda,540500,U.S. Senate,,DEM,Loretta L. Sanchez,201
+Alameda,540600,U.S. Senate,,DEM,Kamala D. Harris,670
+Alameda,540600,U.S. Senate,,DEM,Loretta L. Sanchez,334
+Alameda,540700,U.S. Senate,,DEM,Kamala D. Harris,448
+Alameda,540700,U.S. Senate,,DEM,Loretta L. Sanchez,208
+Alameda,540800,U.S. Senate,,DEM,Kamala D. Harris,676
+Alameda,540800,U.S. Senate,,DEM,Loretta L. Sanchez,343
+Alameda,541100,U.S. Senate,,DEM,Kamala D. Harris,490
+Alameda,541100,U.S. Senate,,DEM,Loretta L. Sanchez,320
+Alameda,542000,U.S. Senate,,DEM,Kamala D. Harris,703
+Alameda,542000,U.S. Senate,,DEM,Loretta L. Sanchez,300
+Alameda,542200,U.S. Senate,,DEM,Kamala D. Harris,454
+Alameda,542200,U.S. Senate,,DEM,Loretta L. Sanchez,240
+Alameda,543300,U.S. Senate,,DEM,Kamala D. Harris,640
+Alameda,543300,U.S. Senate,,DEM,Loretta L. Sanchez,261
+Alameda,544400,U.S. Senate,,DEM,Kamala D. Harris,531
+Alameda,544400,U.S. Senate,,DEM,Loretta L. Sanchez,222
+Alameda,545000,U.S. Senate,,DEM,Kamala D. Harris,702
+Alameda,545000,U.S. Senate,,DEM,Loretta L. Sanchez,250
+Alameda,546000,U.S. Senate,,DEM,Kamala D. Harris,475
+Alameda,546000,U.S. Senate,,DEM,Loretta L. Sanchez,180
+Alameda,546100,U.S. Senate,,DEM,Kamala D. Harris,667
+Alameda,546100,U.S. Senate,,DEM,Loretta L. Sanchez,227
+Alameda,546600,U.S. Senate,,DEM,Kamala D. Harris,611
+Alameda,546600,U.S. Senate,,DEM,Loretta L. Sanchez,228
+Alameda,547700,U.S. Senate,,DEM,Kamala D. Harris,675
+Alameda,547700,U.S. Senate,,DEM,Loretta L. Sanchez,167
+Alameda,547710,U.S. Senate,,DEM,Kamala D. Harris,1069
+Alameda,547710,U.S. Senate,,DEM,Loretta L. Sanchez,253
+Alameda,547740,U.S. Senate,,DEM,Kamala D. Harris,509
+Alameda,547740,U.S. Senate,,DEM,Loretta L. Sanchez,158
+Alameda,547750,U.S. Senate,,DEM,Kamala D. Harris,595
+Alameda,547750,U.S. Senate,,DEM,Loretta L. Sanchez,156
+Alameda,547760,U.S. Senate,,DEM,Kamala D. Harris,560
+Alameda,547760,U.S. Senate,,DEM,Loretta L. Sanchez,166
+Alameda,547780,U.S. Senate,,DEM,Kamala D. Harris,549
+Alameda,547780,U.S. Senate,,DEM,Loretta L. Sanchez,198
+Alameda,547790,U.S. Senate,,DEM,Kamala D. Harris,440
+Alameda,547790,U.S. Senate,,DEM,Loretta L. Sanchez,151
+Alameda,821100,U.S. Senate,,DEM,Kamala D. Harris,639
+Alameda,821100,U.S. Senate,,DEM,Loretta L. Sanchez,211
+Alameda,821110,U.S. Senate,,DEM,Kamala D. Harris,450
+Alameda,821110,U.S. Senate,,DEM,Loretta L. Sanchez,206
+Alameda,821140,U.S. Senate,,DEM,Kamala D. Harris,465
+Alameda,821140,U.S. Senate,,DEM,Loretta L. Sanchez,143
+Alameda,821200,U.S. Senate,,DEM,Kamala D. Harris,654
+Alameda,821200,U.S. Senate,,DEM,Loretta L. Sanchez,249
+Alameda,821210,U.S. Senate,,DEM,Kamala D. Harris,639
+Alameda,821210,U.S. Senate,,DEM,Loretta L. Sanchez,320
+Alameda,821400,U.S. Senate,,DEM,Kamala D. Harris,412
+Alameda,821400,U.S. Senate,,DEM,Loretta L. Sanchez,179
+Alameda,821500,U.S. Senate,,DEM,Kamala D. Harris,483
+Alameda,821500,U.S. Senate,,DEM,Loretta L. Sanchez,167
+Alameda,821600,U.S. Senate,,DEM,Kamala D. Harris,378
+Alameda,821600,U.S. Senate,,DEM,Loretta L. Sanchez,271
+Alameda,821710,U.S. Senate,,DEM,Kamala D. Harris,338
+Alameda,821710,U.S. Senate,,DEM,Loretta L. Sanchez,165
+Alameda,821730,U.S. Senate,,DEM,Kamala D. Harris,703
+Alameda,821730,U.S. Senate,,DEM,Loretta L. Sanchez,309
+Alameda,821800,U.S. Senate,,DEM,Kamala D. Harris,464
+Alameda,821800,U.S. Senate,,DEM,Loretta L. Sanchez,174
+Alameda,821810,U.S. Senate,,DEM,Kamala D. Harris,316
+Alameda,821810,U.S. Senate,,DEM,Loretta L. Sanchez,133
+Alameda,821900,U.S. Senate,,DEM,Kamala D. Harris,472
+Alameda,821900,U.S. Senate,,DEM,Loretta L. Sanchez,196
+Alameda,821910,U.S. Senate,,DEM,Kamala D. Harris,354
+Alameda,821910,U.S. Senate,,DEM,Loretta L. Sanchez,109
+Alameda,822000,U.S. Senate,,DEM,Kamala D. Harris,625
+Alameda,822000,U.S. Senate,,DEM,Loretta L. Sanchez,183
+Alameda,822010,U.S. Senate,,DEM,Kamala D. Harris,643
+Alameda,822010,U.S. Senate,,DEM,Loretta L. Sanchez,190
+Alameda,822200,U.S. Senate,,DEM,Kamala D. Harris,483
+Alameda,822200,U.S. Senate,,DEM,Loretta L. Sanchez,152
+Alameda,823000,U.S. Senate,,DEM,Kamala D. Harris,427
+Alameda,823000,U.S. Senate,,DEM,Loretta L. Sanchez,249
+Alameda,823100,U.S. Senate,,DEM,Kamala D. Harris,346
+Alameda,823100,U.S. Senate,,DEM,Loretta L. Sanchez,340
+Alameda,823200,U.S. Senate,,DEM,Kamala D. Harris,584
+Alameda,823200,U.S. Senate,,DEM,Loretta L. Sanchez,493
+Alameda,823400,U.S. Senate,,DEM,Kamala D. Harris,490
+Alameda,823400,U.S. Senate,,DEM,Loretta L. Sanchez,168
+Alameda,823500,U.S. Senate,,DEM,Kamala D. Harris,356
+Alameda,823500,U.S. Senate,,DEM,Loretta L. Sanchez,171
+Alameda,823510,U.S. Senate,,DEM,Kamala D. Harris,406
+Alameda,823510,U.S. Senate,,DEM,Loretta L. Sanchez,262
+Alameda,823600,U.S. Senate,,DEM,Kamala D. Harris,666
+Alameda,823600,U.S. Senate,,DEM,Loretta L. Sanchez,234
+Alameda,823610,U.S. Senate,,DEM,Kamala D. Harris,344
+Alameda,823610,U.S. Senate,,DEM,Loretta L. Sanchez,164
+Alameda,823700,U.S. Senate,,DEM,Kamala D. Harris,713
+Alameda,823700,U.S. Senate,,DEM,Loretta L. Sanchez,213
+Alameda,823710,U.S. Senate,,DEM,Kamala D. Harris,338
+Alameda,823710,U.S. Senate,,DEM,Loretta L. Sanchez,117
+Alameda,823720,U.S. Senate,,DEM,Kamala D. Harris,453
+Alameda,823720,U.S. Senate,,DEM,Loretta L. Sanchez,138
+Alameda,823730,U.S. Senate,,DEM,Kamala D. Harris,647
+Alameda,823730,U.S. Senate,,DEM,Loretta L. Sanchez,276
+Alameda,823800,U.S. Senate,,DEM,Kamala D. Harris,585
+Alameda,823800,U.S. Senate,,DEM,Loretta L. Sanchez,208
+Alameda,823810,U.S. Senate,,DEM,Kamala D. Harris,458
+Alameda,823810,U.S. Senate,,DEM,Loretta L. Sanchez,179
+Alameda,823900,U.S. Senate,,DEM,Kamala D. Harris,425
+Alameda,823900,U.S. Senate,,DEM,Loretta L. Sanchez,148
+Alameda,830100,U.S. Senate,,DEM,Kamala D. Harris,348
+Alameda,830100,U.S. Senate,,DEM,Loretta L. Sanchez,87
+Alameda,830200,U.S. Senate,,DEM,Kamala D. Harris,697
+Alameda,830200,U.S. Senate,,DEM,Loretta L. Sanchez,225
+Alameda,830210,U.S. Senate,,DEM,Kamala D. Harris,769
+Alameda,830210,U.S. Senate,,DEM,Loretta L. Sanchez,176
+Alameda,830300,U.S. Senate,,DEM,Kamala D. Harris,800
+Alameda,830300,U.S. Senate,,DEM,Loretta L. Sanchez,200
+Alameda,830500,U.S. Senate,,DEM,Kamala D. Harris,795
+Alameda,830500,U.S. Senate,,DEM,Loretta L. Sanchez,187
+Alameda,830700,U.S. Senate,,DEM,Kamala D. Harris,678
+Alameda,830700,U.S. Senate,,DEM,Loretta L. Sanchez,170
+Alameda,831000,U.S. Senate,,DEM,Kamala D. Harris,397
+Alameda,831000,U.S. Senate,,DEM,Loretta L. Sanchez,175
+Alameda,831100,U.S. Senate,,DEM,Kamala D. Harris,343
+Alameda,831100,U.S. Senate,,DEM,Loretta L. Sanchez,139
+Alameda,831200,U.S. Senate,,DEM,Kamala D. Harris,573
+Alameda,831200,U.S. Senate,,DEM,Loretta L. Sanchez,195
+Alameda,831210,U.S. Senate,,DEM,Kamala D. Harris,320
+Alameda,831210,U.S. Senate,,DEM,Loretta L. Sanchez,140
+Alameda,831230,U.S. Senate,,DEM,Kamala D. Harris,476
+Alameda,831230,U.S. Senate,,DEM,Loretta L. Sanchez,158
+Alameda,831300,U.S. Senate,,DEM,Kamala D. Harris,691
+Alameda,831300,U.S. Senate,,DEM,Loretta L. Sanchez,241
+Alameda,831400,U.S. Senate,,DEM,Kamala D. Harris,377
+Alameda,831400,U.S. Senate,,DEM,Loretta L. Sanchez,144
+Alameda,831410,U.S. Senate,,DEM,Kamala D. Harris,434
+Alameda,831410,U.S. Senate,,DEM,Loretta L. Sanchez,186
+Alameda,831500,U.S. Senate,,DEM,Kamala D. Harris,668
+Alameda,831500,U.S. Senate,,DEM,Loretta L. Sanchez,252
+Alameda,831510,U.S. Senate,,DEM,Kamala D. Harris,378
+Alameda,831510,U.S. Senate,,DEM,Loretta L. Sanchez,147
+Alameda,831610,U.S. Senate,,DEM,Kamala D. Harris,583
+Alameda,831610,U.S. Senate,,DEM,Loretta L. Sanchez,236
+Alameda,831700,U.S. Senate,,DEM,Kamala D. Harris,478
+Alameda,831700,U.S. Senate,,DEM,Loretta L. Sanchez,145
+Alameda,831710,U.S. Senate,,DEM,Kamala D. Harris,615
+Alameda,831710,U.S. Senate,,DEM,Loretta L. Sanchez,225
+Alameda,831810,U.S. Senate,,DEM,Kamala D. Harris,663
+Alameda,831810,U.S. Senate,,DEM,Loretta L. Sanchez,275
+Alameda,831830,U.S. Senate,,DEM,Kamala D. Harris,422
+Alameda,831830,U.S. Senate,,DEM,Loretta L. Sanchez,223
+Alameda,831900,U.S. Senate,,DEM,Kamala D. Harris,633
+Alameda,831900,U.S. Senate,,DEM,Loretta L. Sanchez,278
+Alameda,831920,U.S. Senate,,DEM,Kamala D. Harris,649
+Alameda,831920,U.S. Senate,,DEM,Loretta L. Sanchez,292
+Alameda,832000,U.S. Senate,,DEM,Kamala D. Harris,592
+Alameda,832000,U.S. Senate,,DEM,Loretta L. Sanchez,213
+Alameda,832010,U.S. Senate,,DEM,Kamala D. Harris,419
+Alameda,832010,U.S. Senate,,DEM,Loretta L. Sanchez,207
+Alameda,832200,U.S. Senate,,DEM,Kamala D. Harris,600
+Alameda,832200,U.S. Senate,,DEM,Loretta L. Sanchez,242
+Alameda,832210,U.S. Senate,,DEM,Kamala D. Harris,639
+Alameda,832210,U.S. Senate,,DEM,Loretta L. Sanchez,232
+Alameda,832300,U.S. Senate,,DEM,Kamala D. Harris,640
+Alameda,832300,U.S. Senate,,DEM,Loretta L. Sanchez,288
+Alameda,832500,U.S. Senate,,DEM,Kamala D. Harris,589
+Alameda,832500,U.S. Senate,,DEM,Loretta L. Sanchez,261
+Alameda,832510,U.S. Senate,,DEM,Kamala D. Harris,567
+Alameda,832510,U.S. Senate,,DEM,Loretta L. Sanchez,255
+Alameda,832600,U.S. Senate,,DEM,Kamala D. Harris,407
+Alameda,832600,U.S. Senate,,DEM,Loretta L. Sanchez,165
+Alameda,832620,U.S. Senate,,DEM,Kamala D. Harris,438
+Alameda,832620,U.S. Senate,,DEM,Loretta L. Sanchez,231
+Alameda,832800,U.S. Senate,,DEM,Kamala D. Harris,537
+Alameda,832800,U.S. Senate,,DEM,Loretta L. Sanchez,278
+Alameda,832810,U.S. Senate,,DEM,Kamala D. Harris,306
+Alameda,832810,U.S. Senate,,DEM,Loretta L. Sanchez,168
+Alameda,832900,U.S. Senate,,DEM,Kamala D. Harris,650
+Alameda,832900,U.S. Senate,,DEM,Loretta L. Sanchez,310
+Alameda,833000,U.S. Senate,,DEM,Kamala D. Harris,628
+Alameda,833000,U.S. Senate,,DEM,Loretta L. Sanchez,436
+Alameda,833100,U.S. Senate,,DEM,Kamala D. Harris,602
+Alameda,833100,U.S. Senate,,DEM,Loretta L. Sanchez,348
+Alameda,833200,U.S. Senate,,DEM,Kamala D. Harris,581
+Alameda,833200,U.S. Senate,,DEM,Loretta L. Sanchez,227
+Alameda,833210,U.S. Senate,,DEM,Kamala D. Harris,361
+Alameda,833210,U.S. Senate,,DEM,Loretta L. Sanchez,184
+Alameda,833300,U.S. Senate,,DEM,Kamala D. Harris,327
+Alameda,833300,U.S. Senate,,DEM,Loretta L. Sanchez,194
+Alameda,833310,U.S. Senate,,DEM,Kamala D. Harris,304
+Alameda,833310,U.S. Senate,,DEM,Loretta L. Sanchez,154
+Alameda,833400,U.S. Senate,,DEM,Kamala D. Harris,387
+Alameda,833400,U.S. Senate,,DEM,Loretta L. Sanchez,158
+Alameda,833410,U.S. Senate,,DEM,Kamala D. Harris,440
+Alameda,833410,U.S. Senate,,DEM,Loretta L. Sanchez,202
+Alameda,833500,U.S. Senate,,DEM,Kamala D. Harris,701
+Alameda,833500,U.S. Senate,,DEM,Loretta L. Sanchez,360
+Alameda,833610,U.S. Senate,,DEM,Kamala D. Harris,444
+Alameda,833610,U.S. Senate,,DEM,Loretta L. Sanchez,318
+Alameda,833700,U.S. Senate,,DEM,Kamala D. Harris,311
+Alameda,833700,U.S. Senate,,DEM,Loretta L. Sanchez,153
+Alameda,833710,U.S. Senate,,DEM,Kamala D. Harris,544
+Alameda,833710,U.S. Senate,,DEM,Loretta L. Sanchez,338
+Alameda,834000,U.S. Senate,,DEM,Kamala D. Harris,709
+Alameda,834000,U.S. Senate,,DEM,Loretta L. Sanchez,290
+Alameda,834200,U.S. Senate,,DEM,Kamala D. Harris,739
+Alameda,834200,U.S. Senate,,DEM,Loretta L. Sanchez,318
+Alameda,834400,U.S. Senate,,DEM,Kamala D. Harris,513
+Alameda,834400,U.S. Senate,,DEM,Loretta L. Sanchez,209
+Alameda,834600,U.S. Senate,,DEM,Kamala D. Harris,550
+Alameda,834600,U.S. Senate,,DEM,Loretta L. Sanchez,215
+Alameda,834700,U.S. Senate,,DEM,Kamala D. Harris,795
+Alameda,834700,U.S. Senate,,DEM,Loretta L. Sanchez,248
+Alameda,835000,U.S. Senate,,DEM,Kamala D. Harris,565
+Alameda,835000,U.S. Senate,,DEM,Loretta L. Sanchez,189
+Alameda,835100,U.S. Senate,,DEM,Kamala D. Harris,544
+Alameda,835100,U.S. Senate,,DEM,Loretta L. Sanchez,201
+Alameda,835300,U.S. Senate,,DEM,Kamala D. Harris,496
+Alameda,835300,U.S. Senate,,DEM,Loretta L. Sanchez,162
+Alameda,835310,U.S. Senate,,DEM,Kamala D. Harris,611
+Alameda,835310,U.S. Senate,,DEM,Loretta L. Sanchez,283
+Alameda,835500,U.S. Senate,,DEM,Kamala D. Harris,394
+Alameda,835500,U.S. Senate,,DEM,Loretta L. Sanchez,116
+Alameda,835600,U.S. Senate,,DEM,Kamala D. Harris,438
+Alameda,835600,U.S. Senate,,DEM,Loretta L. Sanchez,164
+Alameda,835610,U.S. Senate,,DEM,Kamala D. Harris,337
+Alameda,835610,U.S. Senate,,DEM,Loretta L. Sanchez,106
+Alameda,835730,U.S. Senate,,DEM,Kamala D. Harris,495
+Alameda,835730,U.S. Senate,,DEM,Loretta L. Sanchez,148
+Alameda,835800,U.S. Senate,,DEM,Kamala D. Harris,589
+Alameda,835800,U.S. Senate,,DEM,Loretta L. Sanchez,364
+Alameda,835820,U.S. Senate,,DEM,Kamala D. Harris,677
+Alameda,835820,U.S. Senate,,DEM,Loretta L. Sanchez,230
+Alameda,835900,U.S. Senate,,DEM,Kamala D. Harris,584
+Alameda,835900,U.S. Senate,,DEM,Loretta L. Sanchez,292
+Alameda,836000,U.S. Senate,,DEM,Kamala D. Harris,630
+Alameda,836000,U.S. Senate,,DEM,Loretta L. Sanchez,181
+Alameda,836110,U.S. Senate,,DEM,Kamala D. Harris,747
+Alameda,836110,U.S. Senate,,DEM,Loretta L. Sanchez,191
+Alameda,836200,U.S. Senate,,DEM,Kamala D. Harris,773
+Alameda,836200,U.S. Senate,,DEM,Loretta L. Sanchez,208
+Alameda,836210,U.S. Senate,,DEM,Kamala D. Harris,489
+Alameda,836210,U.S. Senate,,DEM,Loretta L. Sanchez,135
+Alameda,836400,U.S. Senate,,DEM,Kamala D. Harris,420
+Alameda,836400,U.S. Senate,,DEM,Loretta L. Sanchez,120
+Alameda,836500,U.S. Senate,,DEM,Kamala D. Harris,694
+Alameda,836500,U.S. Senate,,DEM,Loretta L. Sanchez,202
+Alameda,836600,U.S. Senate,,DEM,Kamala D. Harris,698
+Alameda,836600,U.S. Senate,,DEM,Loretta L. Sanchez,220
+Alameda,837000,U.S. Senate,,DEM,Kamala D. Harris,493
+Alameda,837000,U.S. Senate,,DEM,Loretta L. Sanchez,161
+Alameda,837100,U.S. Senate,,DEM,Kamala D. Harris,572
+Alameda,837100,U.S. Senate,,DEM,Loretta L. Sanchez,163
+Alameda,837200,U.S. Senate,,DEM,Kamala D. Harris,318
+Alameda,837200,U.S. Senate,,DEM,Loretta L. Sanchez,102
+Alameda,837300,U.S. Senate,,DEM,Kamala D. Harris,651
+Alameda,837300,U.S. Senate,,DEM,Loretta L. Sanchez,174
+Alameda,837400,U.S. Senate,,DEM,Kamala D. Harris,580
+Alameda,837400,U.S. Senate,,DEM,Loretta L. Sanchez,134
+Alameda,837500,U.S. Senate,,DEM,Kamala D. Harris,414
+Alameda,837500,U.S. Senate,,DEM,Loretta L. Sanchez,134
+Alameda,837600,U.S. Senate,,DEM,Kamala D. Harris,538
+Alameda,837600,U.S. Senate,,DEM,Loretta L. Sanchez,190
+Alameda,837700,U.S. Senate,,DEM,Kamala D. Harris,595
+Alameda,837700,U.S. Senate,,DEM,Loretta L. Sanchez,140
+Alameda,837710,U.S. Senate,,DEM,Kamala D. Harris,346
+Alameda,837710,U.S. Senate,,DEM,Loretta L. Sanchez,79
+Alameda,837800,U.S. Senate,,DEM,Kamala D. Harris,380
+Alameda,837800,U.S. Senate,,DEM,Loretta L. Sanchez,104
+Alameda,837900,U.S. Senate,,DEM,Kamala D. Harris,297
+Alameda,837900,U.S. Senate,,DEM,Loretta L. Sanchez,100
+Alameda,838000,U.S. Senate,,DEM,Kamala D. Harris,714
+Alameda,838000,U.S. Senate,,DEM,Loretta L. Sanchez,228
+Alameda,838110,U.S. Senate,,DEM,Kamala D. Harris,848
+Alameda,838110,U.S. Senate,,DEM,Loretta L. Sanchez,177
+Alameda,838300,U.S. Senate,,DEM,Kamala D. Harris,588
+Alameda,838300,U.S. Senate,,DEM,Loretta L. Sanchez,236
+Alameda,838500,U.S. Senate,,DEM,Kamala D. Harris,763
+Alameda,838500,U.S. Senate,,DEM,Loretta L. Sanchez,310
+Alameda,838600,U.S. Senate,,DEM,Kamala D. Harris,551
+Alameda,838600,U.S. Senate,,DEM,Loretta L. Sanchez,176
+Alameda,838700,U.S. Senate,,DEM,Kamala D. Harris,557
+Alameda,838700,U.S. Senate,,DEM,Loretta L. Sanchez,229
+Alameda,839530,U.S. Senate,,DEM,Kamala D. Harris,434
+Alameda,839530,U.S. Senate,,DEM,Loretta L. Sanchez,176
+Alameda,850300,U.S. Senate,,DEM,Kamala D. Harris,654
+Alameda,850300,U.S. Senate,,DEM,Loretta L. Sanchez,383
+Alameda,850320,U.S. Senate,,DEM,Kamala D. Harris,234
+Alameda,850320,U.S. Senate,,DEM,Loretta L. Sanchez,130
+Alameda,850330,U.S. Senate,,DEM,Kamala D. Harris,449
+Alameda,850330,U.S. Senate,,DEM,Loretta L. Sanchez,162
+Alameda,850400,U.S. Senate,,DEM,Kamala D. Harris,276
+Alameda,850400,U.S. Senate,,DEM,Loretta L. Sanchez,172
+Alameda,850410,U.S. Senate,,DEM,Kamala D. Harris,349
+Alameda,850410,U.S. Senate,,DEM,Loretta L. Sanchez,237
+Alameda,850500,U.S. Senate,,DEM,Kamala D. Harris,506
+Alameda,850500,U.S. Senate,,DEM,Loretta L. Sanchez,309
+Alameda,850600,U.S. Senate,,DEM,Kamala D. Harris,493
+Alameda,850600,U.S. Senate,,DEM,Loretta L. Sanchez,389
+Alameda,850800,U.S. Senate,,DEM,Kamala D. Harris,276
+Alameda,850800,U.S. Senate,,DEM,Loretta L. Sanchez,288
+Alameda,850810,U.S. Senate,,DEM,Kamala D. Harris,417
+Alameda,850810,U.S. Senate,,DEM,Loretta L. Sanchez,220
+Alameda,850900,U.S. Senate,,DEM,Kamala D. Harris,411
+Alameda,850900,U.S. Senate,,DEM,Loretta L. Sanchez,231
+Alameda,851000,U.S. Senate,,DEM,Kamala D. Harris,439
+Alameda,851000,U.S. Senate,,DEM,Loretta L. Sanchez,272
+Alameda,851200,U.S. Senate,,DEM,Kamala D. Harris,317
+Alameda,851200,U.S. Senate,,DEM,Loretta L. Sanchez,248
+Alameda,851300,U.S. Senate,,DEM,Kamala D. Harris,362
+Alameda,851300,U.S. Senate,,DEM,Loretta L. Sanchez,219
+Alameda,851500,U.S. Senate,,DEM,Kamala D. Harris,302
+Alameda,851500,U.S. Senate,,DEM,Loretta L. Sanchez,204
+Alameda,851510,U.S. Senate,,DEM,Kamala D. Harris,279
+Alameda,851510,U.S. Senate,,DEM,Loretta L. Sanchez,148
+Alameda,851520,U.S. Senate,,DEM,Kamala D. Harris,378
+Alameda,851520,U.S. Senate,,DEM,Loretta L. Sanchez,166
+Alameda,851600,U.S. Senate,,DEM,Kamala D. Harris,442
+Alameda,851600,U.S. Senate,,DEM,Loretta L. Sanchez,361
+Alameda,851700,U.S. Senate,,DEM,Kamala D. Harris,569
+Alameda,851700,U.S. Senate,,DEM,Loretta L. Sanchez,382
+Alameda,851800,U.S. Senate,,DEM,Kamala D. Harris,415
+Alameda,851800,U.S. Senate,,DEM,Loretta L. Sanchez,209
+Alameda,852010,U.S. Senate,,DEM,Kamala D. Harris,371
+Alameda,852010,U.S. Senate,,DEM,Loretta L. Sanchez,246
+Alameda,852100,U.S. Senate,,DEM,Kamala D. Harris,546
+Alameda,852100,U.S. Senate,,DEM,Loretta L. Sanchez,422
+Alameda,866800,U.S. Senate,,DEM,Kamala D. Harris,227
+Alameda,866800,U.S. Senate,,DEM,Loretta L. Sanchez,117
+Alameda,9205510,U.S. Senate,,DEM,Kamala D. Harris,138
+Alameda,9205510,U.S. Senate,,DEM,Loretta L. Sanchez,8
+Alameda,9205550,U.S. Senate,,DEM,Kamala D. Harris,148
+Alameda,9205550,U.S. Senate,,DEM,Loretta L. Sanchez,26
+Alameda,9207630,U.S. Senate,,DEM,Kamala D. Harris,85
+Alameda,9207630,U.S. Senate,,DEM,Loretta L. Sanchez,20
+Alameda,9207640,U.S. Senate,,DEM,Kamala D. Harris,89
+Alameda,9207640,U.S. Senate,,DEM,Loretta L. Sanchez,43
+Alameda,9209910,U.S. Senate,,DEM,Kamala D. Harris,3
+Alameda,9209910,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Alameda,9213000,U.S. Senate,,DEM,Kamala D. Harris,260
+Alameda,9213000,U.S. Senate,,DEM,Loretta L. Sanchez,51
+Alameda,9215630,U.S. Senate,,DEM,Kamala D. Harris,101
+Alameda,9215630,U.S. Senate,,DEM,Loretta L. Sanchez,23
+Alameda,9215810,U.S. Senate,,DEM,Kamala D. Harris,54
+Alameda,9215810,U.S. Senate,,DEM,Loretta L. Sanchez,19
+Alameda,9223100,U.S. Senate,,DEM,Kamala D. Harris,219
+Alameda,9223100,U.S. Senate,,DEM,Loretta L. Sanchez,28
+Alameda,9223110,U.S. Senate,,DEM,Kamala D. Harris,86
+Alameda,9223110,U.S. Senate,,DEM,Loretta L. Sanchez,13
+Alameda,9224300,U.S. Senate,,DEM,Kamala D. Harris,141
+Alameda,9224300,U.S. Senate,,DEM,Loretta L. Sanchez,25
+Alameda,9224420,U.S. Senate,,DEM,Kamala D. Harris,33
+Alameda,9224420,U.S. Senate,,DEM,Loretta L. Sanchez,10
+Alameda,9224440,U.S. Senate,,DEM,Kamala D. Harris,37
+Alameda,9224440,U.S. Senate,,DEM,Loretta L. Sanchez,6
+Alameda,9224810,U.S. Senate,,DEM,Kamala D. Harris,183
+Alameda,9224810,U.S. Senate,,DEM,Loretta L. Sanchez,34
+Alameda,9224910,U.S. Senate,,DEM,Kamala D. Harris,141
+Alameda,9224910,U.S. Senate,,DEM,Loretta L. Sanchez,19
+Alameda,9225500,U.S. Senate,,DEM,Kamala D. Harris,84
+Alameda,9225500,U.S. Senate,,DEM,Loretta L. Sanchez,22
+Alameda,9244910,U.S. Senate,,DEM,Kamala D. Harris,97
+Alameda,9244910,U.S. Senate,,DEM,Loretta L. Sanchez,14
+Alameda,9323400,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9323400,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9325000,U.S. Senate,,DEM,Kamala D. Harris,209
+Alameda,9325000,U.S. Senate,,DEM,Loretta L. Sanchez,44
+Alameda,9333300,U.S. Senate,,DEM,Kamala D. Harris,47
+Alameda,9333300,U.S. Senate,,DEM,Loretta L. Sanchez,15
+Alameda,9333420,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9333420,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9333910,U.S. Senate,,DEM,Kamala D. Harris,89
+Alameda,9333910,U.S. Senate,,DEM,Loretta L. Sanchez,26
+Alameda,9333920,U.S. Senate,,DEM,Kamala D. Harris,37
+Alameda,9333920,U.S. Senate,,DEM,Loretta L. Sanchez,15
+Alameda,9333930,U.S. Senate,,DEM,Kamala D. Harris,153
+Alameda,9333930,U.S. Senate,,DEM,Loretta L. Sanchez,65
+Alameda,9334510,U.S. Senate,,DEM,Kamala D. Harris,7
+Alameda,9334510,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Alameda,9335110,U.S. Senate,,DEM,Kamala D. Harris,108
+Alameda,9335110,U.S. Senate,,DEM,Loretta L. Sanchez,30
+Alameda,9335600,U.S. Senate,,DEM,Kamala D. Harris,114
+Alameda,9335600,U.S. Senate,,DEM,Loretta L. Sanchez,39
+Alameda,9335800,U.S. Senate,,DEM,Kamala D. Harris,139
+Alameda,9335800,U.S. Senate,,DEM,Loretta L. Sanchez,23
+Alameda,9335910,U.S. Senate,,DEM,Kamala D. Harris,60
+Alameda,9335910,U.S. Senate,,DEM,Loretta L. Sanchez,19
+Alameda,9336300,U.S. Senate,,DEM,Kamala D. Harris,29
+Alameda,9336300,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Alameda,9336810,U.S. Senate,,DEM,Kamala D. Harris,41
+Alameda,9336810,U.S. Senate,,DEM,Loretta L. Sanchez,5
+Alameda,9344020,U.S. Senate,,DEM,Kamala D. Harris,55
+Alameda,9344020,U.S. Senate,,DEM,Loretta L. Sanchez,34
+Alameda,9345710,U.S. Senate,,DEM,Kamala D. Harris,66
+Alameda,9345710,U.S. Senate,,DEM,Loretta L. Sanchez,13
+Alameda,9347210,U.S. Senate,,DEM,Kamala D. Harris,77
+Alameda,9347210,U.S. Senate,,DEM,Loretta L. Sanchez,30
+Alameda,9347220,U.S. Senate,,DEM,Kamala D. Harris,39
+Alameda,9347220,U.S. Senate,,DEM,Loretta L. Sanchez,7
+Alameda,9355210,U.S. Senate,,DEM,Kamala D. Harris,125
+Alameda,9355210,U.S. Senate,,DEM,Loretta L. Sanchez,39
+Alameda,9355220,U.S. Senate,,DEM,Kamala D. Harris,46
+Alameda,9355220,U.S. Senate,,DEM,Loretta L. Sanchez,19
+Alameda,9360900,U.S. Senate,,DEM,Kamala D. Harris,6
+Alameda,9360900,U.S. Senate,,DEM,Loretta L. Sanchez,5
+Alameda,9361100,U.S. Senate,,DEM,Kamala D. Harris,15
+Alameda,9361100,U.S. Senate,,DEM,Loretta L. Sanchez,5
+Alameda,9361210,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9361210,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9361400,U.S. Senate,,DEM,Kamala D. Harris,27
+Alameda,9361400,U.S. Senate,,DEM,Loretta L. Sanchez,12
+Alameda,9362000,U.S. Senate,,DEM,Kamala D. Harris,127
+Alameda,9362000,U.S. Senate,,DEM,Loretta L. Sanchez,96
+Alameda,9364020,U.S. Senate,,DEM,Kamala D. Harris,5
+Alameda,9364020,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9364030,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9364030,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9364210,U.S. Senate,,DEM,Kamala D. Harris,5
+Alameda,9364210,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Alameda,9364320,U.S. Senate,,DEM,Kamala D. Harris,5
+Alameda,9364320,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Alameda,9364330,U.S. Senate,,DEM,Kamala D. Harris,23
+Alameda,9364330,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9373000,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9373000,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9373010,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9373010,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9373020,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9373020,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9373030,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9373030,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9394000,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9394000,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Alameda,9394100,U.S. Senate,,DEM,Kamala D. Harris,2
+Alameda,9394100,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9394200,U.S. Senate,,DEM,Kamala D. Harris,2
+Alameda,9394200,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9416220,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9416220,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9420010,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9420010,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9420020,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9420020,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9420030,U.S. Senate,,DEM,Kamala D. Harris,26
+Alameda,9420030,U.S. Senate,,DEM,Loretta L. Sanchez,40
+Alameda,9420040,U.S. Senate,,DEM,Kamala D. Harris,50
+Alameda,9420040,U.S. Senate,,DEM,Loretta L. Sanchez,16
+Alameda,9420050,U.S. Senate,,DEM,Kamala D. Harris,78
+Alameda,9420050,U.S. Senate,,DEM,Loretta L. Sanchez,54
+Alameda,9420200,U.S. Senate,,DEM,Kamala D. Harris,135
+Alameda,9420200,U.S. Senate,,DEM,Loretta L. Sanchez,58
+Alameda,9420210,U.S. Senate,,DEM,Kamala D. Harris,74
+Alameda,9420210,U.S. Senate,,DEM,Loretta L. Sanchez,63
+Alameda,9420220,U.S. Senate,,DEM,Kamala D. Harris,9
+Alameda,9420220,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Alameda,9420230,U.S. Senate,,DEM,Kamala D. Harris,103
+Alameda,9420230,U.S. Senate,,DEM,Loretta L. Sanchez,117
+Alameda,9420240,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9420240,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9420250,U.S. Senate,,DEM,Kamala D. Harris,125
+Alameda,9420250,U.S. Senate,,DEM,Loretta L. Sanchez,92
+Alameda,9420300,U.S. Senate,,DEM,Kamala D. Harris,103
+Alameda,9420300,U.S. Senate,,DEM,Loretta L. Sanchez,19
+Alameda,9420310,U.S. Senate,,DEM,Kamala D. Harris,15
+Alameda,9420310,U.S. Senate,,DEM,Loretta L. Sanchez,14
+Alameda,9420320,U.S. Senate,,DEM,Kamala D. Harris,1
+Alameda,9420320,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9420510,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9420510,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9420610,U.S. Senate,,DEM,Kamala D. Harris,1
+Alameda,9420610,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Alameda,9420800,U.S. Senate,,DEM,Kamala D. Harris,102
+Alameda,9420800,U.S. Senate,,DEM,Loretta L. Sanchez,102
+Alameda,9422930,U.S. Senate,,DEM,Kamala D. Harris,132
+Alameda,9422930,U.S. Senate,,DEM,Loretta L. Sanchez,59
+Alameda,9422940,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9422940,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9422950,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9422950,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9423620,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9423620,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9423700,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9423700,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9423800,U.S. Senate,,DEM,Kamala D. Harris,2
+Alameda,9423800,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9423810,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9423810,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9423820,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9423820,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9424200,U.S. Senate,,DEM,Kamala D. Harris,36
+Alameda,9424200,U.S. Senate,,DEM,Loretta L. Sanchez,10
+Alameda,9430010,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9430010,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9430020,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9430020,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9430110,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9430110,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9430120,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9430120,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9430130,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9430130,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9430140,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9430140,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9430150,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9430150,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9430160,U.S. Senate,,DEM,Kamala D. Harris,2
+Alameda,9430160,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Alameda,9430410,U.S. Senate,,DEM,Kamala D. Harris,4
+Alameda,9430410,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Alameda,9430420,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9430420,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9430500,U.S. Senate,,DEM,Kamala D. Harris,1
+Alameda,9430500,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9430510,U.S. Senate,,DEM,Kamala D. Harris,21
+Alameda,9430510,U.S. Senate,,DEM,Loretta L. Sanchez,16
+Alameda,9430710,U.S. Senate,,DEM,Kamala D. Harris,29
+Alameda,9430710,U.S. Senate,,DEM,Loretta L. Sanchez,9
+Alameda,9430720,U.S. Senate,,DEM,Kamala D. Harris,82
+Alameda,9430720,U.S. Senate,,DEM,Loretta L. Sanchez,35
+Alameda,9430800,U.S. Senate,,DEM,Kamala D. Harris,276
+Alameda,9430800,U.S. Senate,,DEM,Loretta L. Sanchez,50
+Alameda,9430820,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9430820,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9431110,U.S. Senate,,DEM,Kamala D. Harris,5
+Alameda,9431110,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Alameda,9431120,U.S. Senate,,DEM,Kamala D. Harris,1
+Alameda,9431120,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9431200,U.S. Senate,,DEM,Kamala D. Harris,2
+Alameda,9431200,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Alameda,9431210,U.S. Senate,,DEM,Kamala D. Harris,19
+Alameda,9431210,U.S. Senate,,DEM,Loretta L. Sanchez,5
+Alameda,9431300,U.S. Senate,,DEM,Kamala D. Harris,37
+Alameda,9431300,U.S. Senate,,DEM,Loretta L. Sanchez,19
+Alameda,9431310,U.S. Senate,,DEM,Kamala D. Harris,62
+Alameda,9431310,U.S. Senate,,DEM,Loretta L. Sanchez,15
+Alameda,9431400,U.S. Senate,,DEM,Kamala D. Harris,104
+Alameda,9431400,U.S. Senate,,DEM,Loretta L. Sanchez,44
+Alameda,9431500,U.S. Senate,,DEM,Kamala D. Harris,62
+Alameda,9431500,U.S. Senate,,DEM,Loretta L. Sanchez,25
+Alameda,9431610,U.S. Senate,,DEM,Kamala D. Harris,24
+Alameda,9431610,U.S. Senate,,DEM,Loretta L. Sanchez,7
+Alameda,9431620,U.S. Senate,,DEM,Kamala D. Harris,8
+Alameda,9431620,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Alameda,9431700,U.S. Senate,,DEM,Kamala D. Harris,74
+Alameda,9431700,U.S. Senate,,DEM,Loretta L. Sanchez,35
+Alameda,9431900,U.S. Senate,,DEM,Kamala D. Harris,105
+Alameda,9431900,U.S. Senate,,DEM,Loretta L. Sanchez,36
+Alameda,9432910,U.S. Senate,,DEM,Kamala D. Harris,20
+Alameda,9432910,U.S. Senate,,DEM,Loretta L. Sanchez,17
+Alameda,9433620,U.S. Senate,,DEM,Kamala D. Harris,194
+Alameda,9433620,U.S. Senate,,DEM,Loretta L. Sanchez,47
+Alameda,9433630,U.S. Senate,,DEM,Kamala D. Harris,175
+Alameda,9433630,U.S. Senate,,DEM,Loretta L. Sanchez,42
+Alameda,9438120,U.S. Senate,,DEM,Kamala D. Harris,6
+Alameda,9438120,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Alameda,9438140,U.S. Senate,,DEM,Kamala D. Harris,2
+Alameda,9438140,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9438500,U.S. Senate,,DEM,Kamala D. Harris,4
+Alameda,9438500,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9442610,U.S. Senate,,DEM,Kamala D. Harris,149
+Alameda,9442610,U.S. Senate,,DEM,Loretta L. Sanchez,52
+Alameda,9442810,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9442810,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9442820,U.S. Senate,,DEM,Kamala D. Harris,111
+Alameda,9442820,U.S. Senate,,DEM,Loretta L. Sanchez,56
+Alameda,9443110,U.S. Senate,,DEM,Kamala D. Harris,26
+Alameda,9443110,U.S. Senate,,DEM,Loretta L. Sanchez,14
+Alameda,9443600,U.S. Senate,,DEM,Kamala D. Harris,135
+Alameda,9443600,U.S. Senate,,DEM,Loretta L. Sanchez,107
+Alameda,9443700,U.S. Senate,,DEM,Kamala D. Harris,155
+Alameda,9443700,U.S. Senate,,DEM,Loretta L. Sanchez,81
+Alameda,9443710,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9443710,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9443720,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9443720,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9443800,U.S. Senate,,DEM,Kamala D. Harris,109
+Alameda,9443800,U.S. Senate,,DEM,Loretta L. Sanchez,84
+Alameda,9447010,U.S. Senate,,DEM,Kamala D. Harris,2
+Alameda,9447010,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9447020,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9447020,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9447040,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9447040,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9447100,U.S. Senate,,DEM,Kamala D. Harris,4
+Alameda,9447100,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9447110,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9447110,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9447120,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9447120,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9447210,U.S. Senate,,DEM,Kamala D. Harris,2
+Alameda,9447210,U.S. Senate,,DEM,Loretta L. Sanchez,5
+Alameda,9447300,U.S. Senate,,DEM,Kamala D. Harris,170
+Alameda,9447300,U.S. Senate,,DEM,Loretta L. Sanchez,60
+Alameda,9447510,U.S. Senate,,DEM,Kamala D. Harris,20
+Alameda,9447510,U.S. Senate,,DEM,Loretta L. Sanchez,10
+Alameda,9447700,U.S. Senate,,DEM,Kamala D. Harris,123
+Alameda,9447700,U.S. Senate,,DEM,Loretta L. Sanchez,30
+Alameda,9447710,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9447710,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9447720,U.S. Senate,,DEM,Kamala D. Harris,88
+Alameda,9447720,U.S. Senate,,DEM,Loretta L. Sanchez,25
+Alameda,9450920,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9450920,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9450930,U.S. Senate,,DEM,Kamala D. Harris,1
+Alameda,9450930,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9451500,U.S. Senate,,DEM,Kamala D. Harris,141
+Alameda,9451500,U.S. Senate,,DEM,Loretta L. Sanchez,51
+Alameda,9452000,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9452000,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9454220,U.S. Senate,,DEM,Kamala D. Harris,18
+Alameda,9454220,U.S. Senate,,DEM,Loretta L. Sanchez,7
+Alameda,9454230,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9454230,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9454600,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9454600,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9454700,U.S. Senate,,DEM,Kamala D. Harris,155
+Alameda,9454700,U.S. Senate,,DEM,Loretta L. Sanchez,68
+Alameda,9455010,U.S. Senate,,DEM,Kamala D. Harris,169
+Alameda,9455010,U.S. Senate,,DEM,Loretta L. Sanchez,78
+Alameda,9455200,U.S. Senate,,DEM,Kamala D. Harris,131
+Alameda,9455200,U.S. Senate,,DEM,Loretta L. Sanchez,63
+Alameda,9455410,U.S. Senate,,DEM,Kamala D. Harris,107
+Alameda,9455410,U.S. Senate,,DEM,Loretta L. Sanchez,46
+Alameda,9456610,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9456610,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9464000,U.S. Senate,,DEM,Kamala D. Harris,4
+Alameda,9464000,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9464010,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9464010,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9464020,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9464020,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9464030,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9464030,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9464100,U.S. Senate,,DEM,Kamala D. Harris,1
+Alameda,9464100,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9464200,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9464200,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9464300,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9464300,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9464310,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9464310,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9464320,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9464320,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9464350,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9464350,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9464360,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9464360,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9464500,U.S. Senate,,DEM,Kamala D. Harris,32
+Alameda,9464500,U.S. Senate,,DEM,Loretta L. Sanchez,7
+Alameda,9464510,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9464510,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9464520,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9464520,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9464600,U.S. Senate,,DEM,Kamala D. Harris,57
+Alameda,9464600,U.S. Senate,,DEM,Loretta L. Sanchez,47
+Alameda,9464670,U.S. Senate,,DEM,Kamala D. Harris,24
+Alameda,9464670,U.S. Senate,,DEM,Loretta L. Sanchez,5
+Alameda,9464700,U.S. Senate,,DEM,Kamala D. Harris,1
+Alameda,9464700,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9464710,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9464710,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9464720,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9464720,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9470100,U.S. Senate,,DEM,Kamala D. Harris,90
+Alameda,9470100,U.S. Senate,,DEM,Loretta L. Sanchez,44
+Alameda,9470310,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9470310,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9470700,U.S. Senate,,DEM,Kamala D. Harris,197
+Alameda,9470700,U.S. Senate,,DEM,Loretta L. Sanchez,79
+Alameda,9472920,U.S. Senate,,DEM,Kamala D. Harris,1
+Alameda,9472920,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9475010,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9475010,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9475210,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9475210,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Alameda,9475600,U.S. Senate,,DEM,Kamala D. Harris,51
+Alameda,9475600,U.S. Senate,,DEM,Loretta L. Sanchez,30
+Alameda,9475620,U.S. Senate,,DEM,Kamala D. Harris,2
+Alameda,9475620,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Alameda,9475630,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9475630,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9475640,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9475640,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9476120,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9476120,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9480010,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9480010,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9481110,U.S. Senate,,DEM,Kamala D. Harris,7
+Alameda,9481110,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Alameda,9481310,U.S. Senate,,DEM,Kamala D. Harris,5
+Alameda,9481310,U.S. Senate,,DEM,Loretta L. Sanchez,13
+Alameda,9481430,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9481430,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9481520,U.S. Senate,,DEM,Kamala D. Harris,38
+Alameda,9481520,U.S. Senate,,DEM,Loretta L. Sanchez,33
+Alameda,9481530,U.S. Senate,,DEM,Kamala D. Harris,1
+Alameda,9481530,U.S. Senate,,DEM,Loretta L. Sanchez,8
+Alameda,9481540,U.S. Senate,,DEM,Kamala D. Harris,56
+Alameda,9481540,U.S. Senate,,DEM,Loretta L. Sanchez,34
+Alameda,9481550,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9481550,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9481810,U.S. Senate,,DEM,Kamala D. Harris,190
+Alameda,9481810,U.S. Senate,,DEM,Loretta L. Sanchez,89
+Alameda,9481900,U.S. Senate,,DEM,Kamala D. Harris,117
+Alameda,9481900,U.S. Senate,,DEM,Loretta L. Sanchez,79
+Alameda,9481930,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9481930,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9481940,U.S. Senate,,DEM,Kamala D. Harris,4
+Alameda,9481940,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Alameda,9481950,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9481950,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9481960,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9481960,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9481970,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9481970,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9482000,U.S. Senate,,DEM,Kamala D. Harris,62
+Alameda,9482000,U.S. Senate,,DEM,Loretta L. Sanchez,28
+Alameda,9482020,U.S. Senate,,DEM,Kamala D. Harris,3
+Alameda,9482020,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Alameda,9482040,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9482040,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Alameda,9482050,U.S. Senate,,DEM,Kamala D. Harris,6
+Alameda,9482050,U.S. Senate,,DEM,Loretta L. Sanchez,6
+Alameda,9484000,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9484000,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Alameda,9490040,U.S. Senate,,DEM,Kamala D. Harris,7
+Alameda,9490040,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Alameda,9490100,U.S. Senate,,DEM,Kamala D. Harris,29
+Alameda,9490100,U.S. Senate,,DEM,Loretta L. Sanchez,17
+Alameda,9490130,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9490130,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9490200,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9490200,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9490300,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9490300,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9491010,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9491010,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9491020,U.S. Senate,,DEM,Kamala D. Harris,3
+Alameda,9491020,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Alameda,9491410,U.S. Senate,,DEM,Kamala D. Harris,23
+Alameda,9491410,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Alameda,9491600,U.S. Senate,,DEM,Kamala D. Harris,121
+Alameda,9491600,U.S. Senate,,DEM,Loretta L. Sanchez,57
+Alameda,9491630,U.S. Senate,,DEM,Kamala D. Harris,57
+Alameda,9491630,U.S. Senate,,DEM,Loretta L. Sanchez,33
+Alameda,9491650,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9491650,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Alameda,9492000,U.S. Senate,,DEM,Kamala D. Harris,83
+Alameda,9492000,U.S. Senate,,DEM,Loretta L. Sanchez,46
+Alameda,9492040,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9492040,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9492110,U.S. Senate,,DEM,Kamala D. Harris,7
+Alameda,9492110,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9492200,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9492200,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9498100,U.S. Senate,,DEM,Kamala D. Harris,2
+Alameda,9498100,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Alameda,9498200,U.S. Senate,,DEM,Kamala D. Harris,14
+Alameda,9498200,U.S. Senate,,DEM,Loretta L. Sanchez,10
+Alameda,9498220,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9498220,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9498300,U.S. Senate,,DEM,Kamala D. Harris,16
+Alameda,9498300,U.S. Senate,,DEM,Loretta L. Sanchez,6
+Alameda,9498310,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9498310,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Alameda,9498320,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9498320,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9498340,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9498340,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9498360,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9498360,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9499000,U.S. Senate,,DEM,Kamala D. Harris,8
+Alameda,9499000,U.S. Senate,,DEM,Loretta L. Sanchez,6
+Alameda,9499010,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9499010,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9500220,U.S. Senate,,DEM,Kamala D. Harris,92
+Alameda,9500220,U.S. Senate,,DEM,Loretta L. Sanchez,35
+Alameda,9500510,U.S. Senate,,DEM,Kamala D. Harris,4
+Alameda,9500510,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9501710,U.S. Senate,,DEM,Kamala D. Harris,18
+Alameda,9501710,U.S. Senate,,DEM,Loretta L. Sanchez,8
+Alameda,9502910,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9502910,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Alameda,9510100,U.S. Senate,,DEM,Kamala D. Harris,67
+Alameda,9510100,U.S. Senate,,DEM,Loretta L. Sanchez,47
+Alameda,9510110,U.S. Senate,,DEM,Kamala D. Harris,16
+Alameda,9510110,U.S. Senate,,DEM,Loretta L. Sanchez,14
+Alameda,9510120,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9510120,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9510140,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9510140,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9510150,U.S. Senate,,DEM,Kamala D. Harris,2
+Alameda,9510150,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Alameda,9510300,U.S. Senate,,DEM,Kamala D. Harris,134
+Alameda,9510300,U.S. Senate,,DEM,Loretta L. Sanchez,90
+Alameda,9510320,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9510320,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9510410,U.S. Senate,,DEM,Kamala D. Harris,37
+Alameda,9510410,U.S. Senate,,DEM,Loretta L. Sanchez,32
+Alameda,9510500,U.S. Senate,,DEM,Kamala D. Harris,86
+Alameda,9510500,U.S. Senate,,DEM,Loretta L. Sanchez,51
+Alameda,9510610,U.S. Senate,,DEM,Kamala D. Harris,23
+Alameda,9510610,U.S. Senate,,DEM,Loretta L. Sanchez,9
+Alameda,9510700,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9510700,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9510720,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9510720,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9510730,U.S. Senate,,DEM,Kamala D. Harris,2
+Alameda,9510730,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9510800,U.S. Senate,,DEM,Kamala D. Harris,24
+Alameda,9510800,U.S. Senate,,DEM,Loretta L. Sanchez,16
+Alameda,9510810,U.S. Senate,,DEM,Kamala D. Harris,118
+Alameda,9510810,U.S. Senate,,DEM,Loretta L. Sanchez,68
+Alameda,9510840,U.S. Senate,,DEM,Kamala D. Harris,48
+Alameda,9510840,U.S. Senate,,DEM,Loretta L. Sanchez,19
+Alameda,9510890,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9510890,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9510910,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9510910,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9510920,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9510920,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9510950,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9510950,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9510960,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9510960,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9510970,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9510970,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9510980,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9510980,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9510990,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9510990,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9511000,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9511000,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9520250,U.S. Senate,,DEM,Kamala D. Harris,196
+Alameda,9520250,U.S. Senate,,DEM,Loretta L. Sanchez,54
+Alameda,9520730,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9520730,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9520900,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9520900,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Alameda,9522160,U.S. Senate,,DEM,Kamala D. Harris,241
+Alameda,9522160,U.S. Senate,,DEM,Loretta L. Sanchez,69
+Alameda,9530200,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9530200,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9532000,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9532000,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9532100,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9532100,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Alameda,9532200,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9532200,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9532400,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9532400,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9535000,U.S. Senate,,DEM,Kamala D. Harris,1
+Alameda,9535000,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Alameda,9535020,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9535020,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9535030,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9535030,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9535040,U.S. Senate,,DEM,Kamala D. Harris,1
+Alameda,9535040,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9535050,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9535050,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9535060,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9535060,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9535070,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9535070,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9535090,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9535090,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9535200,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9535200,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9535300,U.S. Senate,,DEM,Kamala D. Harris,32
+Alameda,9535300,U.S. Senate,,DEM,Loretta L. Sanchez,6
+Alameda,9535400,U.S. Senate,,DEM,Kamala D. Harris,4
+Alameda,9535400,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Alameda,9535500,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9535500,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Alameda,9535600,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9535600,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9535700,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9535700,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9810900,U.S. Senate,,DEM,Kamala D. Harris,1
+Alameda,9810900,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9815110,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9815110,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9815120,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9815120,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9815150,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9815150,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9819020,U.S. Senate,,DEM,Kamala D. Harris,1
+Alameda,9819020,U.S. Senate,,DEM,Loretta L. Sanchez,7
+Alameda,9819100,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9819100,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Alameda,9819110,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9819110,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Alameda,9820000,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9820000,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9821010,U.S. Senate,,DEM,Kamala D. Harris,1
+Alameda,9821010,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Alameda,9821020,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9821020,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9821310,U.S. Senate,,DEM,Kamala D. Harris,24
+Alameda,9821310,U.S. Senate,,DEM,Loretta L. Sanchez,8
+Alameda,9821720,U.S. Senate,,DEM,Kamala D. Harris,26
+Alameda,9821720,U.S. Senate,,DEM,Loretta L. Sanchez,8
+Alameda,9823030,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9823030,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9823040,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9823040,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9831220,U.S. Senate,,DEM,Kamala D. Harris,7
+Alameda,9831220,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Alameda,9834020,U.S. Senate,,DEM,Kamala D. Harris,1
+Alameda,9834020,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Alameda,9834030,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9834030,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9834410,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9834410,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9835700,U.S. Senate,,DEM,Kamala D. Harris,9
+Alameda,9835700,U.S. Senate,,DEM,Loretta L. Sanchez,6
+Alameda,9837020,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9837020,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9837030,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9837030,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9837410,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9837410,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9839000,U.S. Senate,,DEM,Kamala D. Harris,1
+Alameda,9839000,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Alameda,9839030,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9839030,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9839060,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9839060,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9839120,U.S. Senate,,DEM,Kamala D. Harris,1
+Alameda,9839120,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9839200,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9839200,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Alameda,9839210,U.S. Senate,,DEM,Kamala D. Harris,4
+Alameda,9839210,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9839220,U.S. Senate,,DEM,Kamala D. Harris,1
+Alameda,9839220,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9839230,U.S. Senate,,DEM,Kamala D. Harris,1
+Alameda,9839230,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9839240,U.S. Senate,,DEM,Kamala D. Harris,16
+Alameda,9839240,U.S. Senate,,DEM,Loretta L. Sanchez,18
+Alameda,9839300,U.S. Senate,,DEM,Kamala D. Harris,1
+Alameda,9839300,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Alameda,9839310,U.S. Senate,,DEM,Kamala D. Harris,14
+Alameda,9839310,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Alameda,9839330,U.S. Senate,,DEM,Kamala D. Harris,69
+Alameda,9839330,U.S. Senate,,DEM,Loretta L. Sanchez,10
+Alameda,9839350,U.S. Senate,,DEM,Kamala D. Harris,19
+Alameda,9839350,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Alameda,9839360,U.S. Senate,,DEM,Kamala D. Harris,1
+Alameda,9839360,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Alameda,9839380,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9839380,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9839400,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9839400,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9839500,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9839500,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9839520,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9839520,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9866900,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9866900,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9866910,U.S. Senate,,DEM,Kamala D. Harris,26
+Alameda,9866910,U.S. Senate,,DEM,Loretta L. Sanchez,23
+Alameda,9866920,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9866920,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9866930,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9866930,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9867100,U.S. Senate,,DEM,Kamala D. Harris,2
+Alameda,9867100,U.S. Senate,,DEM,Loretta L. Sanchez,5
+Alameda,9867110,U.S. Senate,,DEM,Kamala D. Harris,9
+Alameda,9867110,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Alameda,9867200,U.S. Senate,,DEM,Kamala D. Harris,30
+Alameda,9867200,U.S. Senate,,DEM,Loretta L. Sanchez,20
+Alameda,9867320,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9867320,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9867330,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9867330,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9867400,U.S. Senate,,DEM,Kamala D. Harris,1
+Alameda,9867400,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Alameda,9867410,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9867410,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9870000,U.S. Senate,,DEM,Kamala D. Harris,73
+Alameda,9870000,U.S. Senate,,DEM,Loretta L. Sanchez,52
+Alameda,9870010,U.S. Senate,,DEM,Kamala D. Harris,115
+Alameda,9870010,U.S. Senate,,DEM,Loretta L. Sanchez,62
+Alameda,9870100,U.S. Senate,,DEM,Kamala D. Harris,80
+Alameda,9870100,U.S. Senate,,DEM,Loretta L. Sanchez,56
+Alameda,9870110,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9870110,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9870120,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9870120,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9870150,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9870150,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9880200,U.S. Senate,,DEM,Kamala D. Harris,7
+Alameda,9880200,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Alameda,9880220,U.S. Senate,,DEM,Kamala D. Harris,6
+Alameda,9880220,U.S. Senate,,DEM,Loretta L. Sanchez,5
+Alameda,9880400,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9880400,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Alameda,9880500,U.S. Senate,,DEM,Kamala D. Harris,0
+Alameda,9880500,U.S. Senate,,DEM,Loretta L. Sanchez,0

--- a/2016/20161108__ca__general__alpine__precinct.csv
+++ b/2016/20161108__ca__general__alpine__precinct.csv
@@ -199,13 +199,13 @@ Alpine,4,Proposition 67,,N/A,Yes,80
 Alpine,4,Proposition 67,,N/A,No,46
 Alpine,5,Proposition 67,,N/A,Yes,73
 Alpine,5,Proposition 67,,N/A,No,75
-Alpine,1,U.S. Senate,,DEM,Kamala Harris,58
-Alpine,1,U.S. Senate,,DEM,Loretta Sanchez,36
-Alpine,2,U.S. Senate,,DEM,Kamala Harris,81
-Alpine,2,U.S. Senate,,DEM,Loretta Sanchez,27
-Alpine,3,U.S. Senate,,DEM,Kamala Harris,35
-Alpine,3,U.S. Senate,,DEM,Loretta Sanchez,31
-Alpine,4,U.S. Senate,,DEM,Kamala Harris,87
-Alpine,4,U.S. Senate,,DEM,Loretta Sanchez,22
-Alpine,5,U.S. Senate,,DEM,Kamala Harris,81
-Alpine,5,U.S. Senate,,DEM,Loretta Sanchez,17
+Alpine,1,U.S. Senate,,DEM,Kamala D. Harris,58
+Alpine,1,U.S. Senate,,DEM,Loretta L. Sanchez,36
+Alpine,2,U.S. Senate,,DEM,Kamala D. Harris,81
+Alpine,2,U.S. Senate,,DEM,Loretta L. Sanchez,27
+Alpine,3,U.S. Senate,,DEM,Kamala D. Harris,35
+Alpine,3,U.S. Senate,,DEM,Loretta L. Sanchez,31
+Alpine,4,U.S. Senate,,DEM,Kamala D. Harris,87
+Alpine,4,U.S. Senate,,DEM,Loretta L. Sanchez,22
+Alpine,5,U.S. Senate,,DEM,Kamala D. Harris,81
+Alpine,5,U.S. Senate,,DEM,Loretta L. Sanchez,17

--- a/2016/20161108__ca__general__amador__precinct.csv
+++ b/2016/20161108__ca__general__amador__precinct.csv
@@ -1199,63 +1199,63 @@ Amador,CP30,Proposition 67,,N/A,Yes,282
 Amador,CP30,Proposition 67,,N/A,No,622
 Amador,CP83,Proposition 67,,N/A,Yes,25
 Amador,CP83,Proposition 67,,N/A,No,22
-Amador,CP01,U.S. Senate,,DEM,Kamala Harris,449
-Amador,CP01,U.S. Senate,,DEM,Loretta Sanchez,225
-Amador,CP02,U.S. Senate,,DEM,Kamala Harris,407
-Amador,CP02,U.S. Senate,,DEM,Loretta Sanchez,211
-Amador,CP03,U.S. Senate,,DEM,Kamala Harris,280
-Amador,CP03,U.S. Senate,,DEM,Loretta Sanchez,106
-Amador,CP04,U.S. Senate,,DEM,Kamala Harris,373
-Amador,CP04,U.S. Senate,,DEM,Loretta Sanchez,222
-Amador,CP05,U.S. Senate,,DEM,Kamala Harris,223
-Amador,CP05,U.S. Senate,,DEM,Loretta Sanchez,116
-Amador,CP06,U.S. Senate,,DEM,Kamala Harris,610
-Amador,CP06,U.S. Senate,,DEM,Loretta Sanchez,349
-Amador,CP07,U.S. Senate,,DEM,Kamala Harris,357
-Amador,CP07,U.S. Senate,,DEM,Loretta Sanchez,228
-Amador,CP08,U.S. Senate,,DEM,Kamala Harris,86
-Amador,CP08,U.S. Senate,,DEM,Loretta Sanchez,65
-Amador,CP09,U.S. Senate,,DEM,Kamala Harris,124
-Amador,CP09,U.S. Senate,,DEM,Loretta Sanchez,111
-Amador,CP10,U.S. Senate,,DEM,Kamala Harris,212
-Amador,CP10,U.S. Senate,,DEM,Loretta Sanchez,170
-Amador,CP11,U.S. Senate,,DEM,Kamala Harris,74
-Amador,CP11,U.S. Senate,,DEM,Loretta Sanchez,27
-Amador,CP12,U.S. Senate,,DEM,Kamala Harris,195
-Amador,CP12,U.S. Senate,,DEM,Loretta Sanchez,113
-Amador,CP13,U.S. Senate,,DEM,Kamala Harris,153
-Amador,CP13,U.S. Senate,,DEM,Loretta Sanchez,70
-Amador,CP14,U.S. Senate,,DEM,Kamala Harris,330
-Amador,CP14,U.S. Senate,,DEM,Loretta Sanchez,216
-Amador,CP15,U.S. Senate,,DEM,Kamala Harris,294
-Amador,CP15,U.S. Senate,,DEM,Loretta Sanchez,141
-Amador,CP16,U.S. Senate,,DEM,Kamala Harris,342
-Amador,CP16,U.S. Senate,,DEM,Loretta Sanchez,163
-Amador,CP17,U.S. Senate,,DEM,Kamala Harris,301
-Amador,CP17,U.S. Senate,,DEM,Loretta Sanchez,161
-Amador,CP18,U.S. Senate,,DEM,Kamala Harris,408
-Amador,CP18,U.S. Senate,,DEM,Loretta Sanchez,221
-Amador,CP19,U.S. Senate,,DEM,Kamala Harris,452
-Amador,CP19,U.S. Senate,,DEM,Loretta Sanchez,224
-Amador,CP20,U.S. Senate,,DEM,Kamala Harris,296
-Amador,CP20,U.S. Senate,,DEM,Loretta Sanchez,159
-Amador,CP21,U.S. Senate,,DEM,Kamala Harris,418
-Amador,CP21,U.S. Senate,,DEM,Loretta Sanchez,218
-Amador,CP22,U.S. Senate,,DEM,Kamala Harris,214
-Amador,CP22,U.S. Senate,,DEM,Loretta Sanchez,144
-Amador,CP23,U.S. Senate,,DEM,Kamala Harris,493
-Amador,CP23,U.S. Senate,,DEM,Loretta Sanchez,234
-Amador,CP25,U.S. Senate,,DEM,Kamala Harris,293
-Amador,CP25,U.S. Senate,,DEM,Loretta Sanchez,128
-Amador,CP26,U.S. Senate,,DEM,Kamala Harris,233
-Amador,CP26,U.S. Senate,,DEM,Loretta Sanchez,115
-Amador,CP27,U.S. Senate,,DEM,Kamala Harris,198
-Amador,CP27,U.S. Senate,,DEM,Loretta Sanchez,179
-Amador,CP28,U.S. Senate,,DEM,Kamala Harris,228
-Amador,CP28,U.S. Senate,,DEM,Loretta Sanchez,149
-Amador,CP29,U.S. Senate,,DEM,Kamala Harris,203
-Amador,CP29,U.S. Senate,,DEM,Loretta Sanchez,125
-Amador,CP30,U.S. Senate,,DEM,Kamala Harris,414
-Amador,CP30,U.S. Senate,,DEM,Loretta Sanchez,272
-Amador,CP83,U.S. Senate,,DEM,Kamala Harris,30
-Amador,CP83,U.S. Senate,,DEM,Loretta Sanchez,10
+Amador,CP01,U.S. Senate,,DEM,Kamala D. Harris,449
+Amador,CP01,U.S. Senate,,DEM,Loretta L. Sanchez,225
+Amador,CP02,U.S. Senate,,DEM,Kamala D. Harris,407
+Amador,CP02,U.S. Senate,,DEM,Loretta L. Sanchez,211
+Amador,CP03,U.S. Senate,,DEM,Kamala D. Harris,280
+Amador,CP03,U.S. Senate,,DEM,Loretta L. Sanchez,106
+Amador,CP04,U.S. Senate,,DEM,Kamala D. Harris,373
+Amador,CP04,U.S. Senate,,DEM,Loretta L. Sanchez,222
+Amador,CP05,U.S. Senate,,DEM,Kamala D. Harris,223
+Amador,CP05,U.S. Senate,,DEM,Loretta L. Sanchez,116
+Amador,CP06,U.S. Senate,,DEM,Kamala D. Harris,610
+Amador,CP06,U.S. Senate,,DEM,Loretta L. Sanchez,349
+Amador,CP07,U.S. Senate,,DEM,Kamala D. Harris,357
+Amador,CP07,U.S. Senate,,DEM,Loretta L. Sanchez,228
+Amador,CP08,U.S. Senate,,DEM,Kamala D. Harris,86
+Amador,CP08,U.S. Senate,,DEM,Loretta L. Sanchez,65
+Amador,CP09,U.S. Senate,,DEM,Kamala D. Harris,124
+Amador,CP09,U.S. Senate,,DEM,Loretta L. Sanchez,111
+Amador,CP10,U.S. Senate,,DEM,Kamala D. Harris,212
+Amador,CP10,U.S. Senate,,DEM,Loretta L. Sanchez,170
+Amador,CP11,U.S. Senate,,DEM,Kamala D. Harris,74
+Amador,CP11,U.S. Senate,,DEM,Loretta L. Sanchez,27
+Amador,CP12,U.S. Senate,,DEM,Kamala D. Harris,195
+Amador,CP12,U.S. Senate,,DEM,Loretta L. Sanchez,113
+Amador,CP13,U.S. Senate,,DEM,Kamala D. Harris,153
+Amador,CP13,U.S. Senate,,DEM,Loretta L. Sanchez,70
+Amador,CP14,U.S. Senate,,DEM,Kamala D. Harris,330
+Amador,CP14,U.S. Senate,,DEM,Loretta L. Sanchez,216
+Amador,CP15,U.S. Senate,,DEM,Kamala D. Harris,294
+Amador,CP15,U.S. Senate,,DEM,Loretta L. Sanchez,141
+Amador,CP16,U.S. Senate,,DEM,Kamala D. Harris,342
+Amador,CP16,U.S. Senate,,DEM,Loretta L. Sanchez,163
+Amador,CP17,U.S. Senate,,DEM,Kamala D. Harris,301
+Amador,CP17,U.S. Senate,,DEM,Loretta L. Sanchez,161
+Amador,CP18,U.S. Senate,,DEM,Kamala D. Harris,408
+Amador,CP18,U.S. Senate,,DEM,Loretta L. Sanchez,221
+Amador,CP19,U.S. Senate,,DEM,Kamala D. Harris,452
+Amador,CP19,U.S. Senate,,DEM,Loretta L. Sanchez,224
+Amador,CP20,U.S. Senate,,DEM,Kamala D. Harris,296
+Amador,CP20,U.S. Senate,,DEM,Loretta L. Sanchez,159
+Amador,CP21,U.S. Senate,,DEM,Kamala D. Harris,418
+Amador,CP21,U.S. Senate,,DEM,Loretta L. Sanchez,218
+Amador,CP22,U.S. Senate,,DEM,Kamala D. Harris,214
+Amador,CP22,U.S. Senate,,DEM,Loretta L. Sanchez,144
+Amador,CP23,U.S. Senate,,DEM,Kamala D. Harris,493
+Amador,CP23,U.S. Senate,,DEM,Loretta L. Sanchez,234
+Amador,CP25,U.S. Senate,,DEM,Kamala D. Harris,293
+Amador,CP25,U.S. Senate,,DEM,Loretta L. Sanchez,128
+Amador,CP26,U.S. Senate,,DEM,Kamala D. Harris,233
+Amador,CP26,U.S. Senate,,DEM,Loretta L. Sanchez,115
+Amador,CP27,U.S. Senate,,DEM,Kamala D. Harris,198
+Amador,CP27,U.S. Senate,,DEM,Loretta L. Sanchez,179
+Amador,CP28,U.S. Senate,,DEM,Kamala D. Harris,228
+Amador,CP28,U.S. Senate,,DEM,Loretta L. Sanchez,149
+Amador,CP29,U.S. Senate,,DEM,Kamala D. Harris,203
+Amador,CP29,U.S. Senate,,DEM,Loretta L. Sanchez,125
+Amador,CP30,U.S. Senate,,DEM,Kamala D. Harris,414
+Amador,CP30,U.S. Senate,,DEM,Loretta L. Sanchez,272
+Amador,CP83,U.S. Senate,,DEM,Kamala D. Harris,30
+Amador,CP83,U.S. Senate,,DEM,Loretta L. Sanchez,10

--- a/2016/20161108__ca__general__butte__precinct.csv
+++ b/2016/20161108__ca__general__butte__precinct.csv
@@ -5639,285 +5639,285 @@ Butte,5911,Proposition 67,,N/A,Yes,9
 Butte,5911,Proposition 67,,N/A,No,9
 Butte,5912,Proposition 67,,N/A,Yes,2
 Butte,5912,Proposition 67,,N/A,No,2
-Butte,1101,U.S. Senate,,DEM,Kamala Harris,294
-Butte,1101,U.S. Senate,,DEM,Loretta Sanchez,225
-Butte,1102,U.S. Senate,,DEM,Kamala Harris,398
-Butte,1102,U.S. Senate,,DEM,Loretta Sanchez,312
-Butte,1103,U.S. Senate,,DEM,Kamala Harris,454
-Butte,1103,U.S. Senate,,DEM,Loretta Sanchez,310
-Butte,1104,U.S. Senate,,DEM,Kamala Harris,427
-Butte,1104,U.S. Senate,,DEM,Loretta Sanchez,368
-Butte,1105,U.S. Senate,,DEM,Kamala Harris,300
-Butte,1105,U.S. Senate,,DEM,Loretta Sanchez,230
-Butte,1106,U.S. Senate,,DEM,Kamala Harris,284
-Butte,1106,U.S. Senate,,DEM,Loretta Sanchez,242
-Butte,1801,U.S. Senate,,DEM,Kamala Harris,426
-Butte,1801,U.S. Senate,,DEM,Loretta Sanchez,374
-Butte,1802,U.S. Senate,,DEM,Kamala Harris,304
-Butte,1802,U.S. Senate,,DEM,Loretta Sanchez,240
-Butte,1803,U.S. Senate,,DEM,Kamala Harris,230
-Butte,1803,U.S. Senate,,DEM,Loretta Sanchez,233
-Butte,1804,U.S. Senate,,DEM,Kamala Harris,305
-Butte,1804,U.S. Senate,,DEM,Loretta Sanchez,279
-Butte,1805,U.S. Senate,,DEM,Kamala Harris,458
-Butte,1805,U.S. Senate,,DEM,Loretta Sanchez,355
-Butte,1806,U.S. Senate,,DEM,Kamala Harris,347
-Butte,1806,U.S. Senate,,DEM,Loretta Sanchez,274
-Butte,1807,U.S. Senate,,DEM,Kamala Harris,285
-Butte,1807,U.S. Senate,,DEM,Loretta Sanchez,309
-Butte,1808,U.S. Senate,,DEM,Kamala Harris,331
-Butte,1808,U.S. Senate,,DEM,Loretta Sanchez,324
-Butte,1809,U.S. Senate,,DEM,Kamala Harris,353
-Butte,1809,U.S. Senate,,DEM,Loretta Sanchez,333
-Butte,1810,U.S. Senate,,DEM,Kamala Harris,192
-Butte,1810,U.S. Senate,,DEM,Loretta Sanchez,151
-Butte,1811,U.S. Senate,,DEM,Kamala Harris,317
-Butte,1811,U.S. Senate,,DEM,Loretta Sanchez,301
-Butte,1812,U.S. Senate,,DEM,Kamala Harris,274
-Butte,1812,U.S. Senate,,DEM,Loretta Sanchez,231
-Butte,1901,U.S. Senate,,DEM,Kamala Harris,70
-Butte,1901,U.S. Senate,,DEM,Loretta Sanchez,53
-Butte,1902,U.S. Senate,,DEM,Kamala Harris,4
-Butte,1902,U.S. Senate,,DEM,Loretta Sanchez,4
-Butte,1903,U.S. Senate,,DEM,Kamala Harris,0
-Butte,1903,U.S. Senate,,DEM,Loretta Sanchez,0
-Butte,1904,U.S. Senate,,DEM,Kamala Harris,0
-Butte,1904,U.S. Senate,,DEM,Loretta Sanchez,0
-Butte,1905,U.S. Senate,,DEM,Kamala Harris,128
-Butte,1905,U.S. Senate,,DEM,Loretta Sanchez,90
-Butte,1906,U.S. Senate,,DEM,Kamala Harris,137
-Butte,1906,U.S. Senate,,DEM,Loretta Sanchez,119
-Butte,1907,U.S. Senate,,DEM,Kamala Harris,45
-Butte,1907,U.S. Senate,,DEM,Loretta Sanchez,46
-Butte,1908,U.S. Senate,,DEM,Kamala Harris,172
-Butte,1908,U.S. Senate,,DEM,Loretta Sanchez,107
-Butte,1909,U.S. Senate,,DEM,Kamala Harris,139
-Butte,1909,U.S. Senate,,DEM,Loretta Sanchez,128
-Butte,1910,U.S. Senate,,DEM,Kamala Harris,85
-Butte,1910,U.S. Senate,,DEM,Loretta Sanchez,116
-Butte,1911,U.S. Senate,,DEM,Kamala Harris,18
-Butte,1911,U.S. Senate,,DEM,Loretta Sanchez,27
-Butte,1912,U.S. Senate,,DEM,Kamala Harris,34
-Butte,1912,U.S. Senate,,DEM,Loretta Sanchez,41
-Butte,1913,U.S. Senate,,DEM,Kamala Harris,18
-Butte,1913,U.S. Senate,,DEM,Loretta Sanchez,16
-Butte,1914,U.S. Senate,,DEM,Kamala Harris,24
-Butte,1914,U.S. Senate,,DEM,Loretta Sanchez,33
-Butte,2201,U.S. Senate,,DEM,Kamala Harris,575
-Butte,2201,U.S. Senate,,DEM,Loretta Sanchez,351
-Butte,2202,U.S. Senate,,DEM,Kamala Harris,384
-Butte,2202,U.S. Senate,,DEM,Loretta Sanchez,196
-Butte,2203,U.S. Senate,,DEM,Kamala Harris,396
-Butte,2203,U.S. Senate,,DEM,Loretta Sanchez,264
-Butte,2204,U.S. Senate,,DEM,Kamala Harris,707
-Butte,2204,U.S. Senate,,DEM,Loretta Sanchez,481
-Butte,2205,U.S. Senate,,DEM,Kamala Harris,442
-Butte,2205,U.S. Senate,,DEM,Loretta Sanchez,240
-Butte,2206,U.S. Senate,,DEM,Kamala Harris,209
-Butte,2206,U.S. Senate,,DEM,Loretta Sanchez,160
-Butte,2207,U.S. Senate,,DEM,Kamala Harris,126
-Butte,2207,U.S. Senate,,DEM,Loretta Sanchez,121
-Butte,2208,U.S. Senate,,DEM,Kamala Harris,386
-Butte,2208,U.S. Senate,,DEM,Loretta Sanchez,367
-Butte,2209,U.S. Senate,,DEM,Kamala Harris,357
-Butte,2209,U.S. Senate,,DEM,Loretta Sanchez,346
-Butte,2210,U.S. Senate,,DEM,Kamala Harris,235
-Butte,2210,U.S. Senate,,DEM,Loretta Sanchez,262
-Butte,2211,U.S. Senate,,DEM,Kamala Harris,579
-Butte,2211,U.S. Senate,,DEM,Loretta Sanchez,273
-Butte,2212,U.S. Senate,,DEM,Kamala Harris,425
-Butte,2212,U.S. Senate,,DEM,Loretta Sanchez,263
-Butte,2213,U.S. Senate,,DEM,Kamala Harris,500
-Butte,2213,U.S. Senate,,DEM,Loretta Sanchez,275
-Butte,2214,U.S. Senate,,DEM,Kamala Harris,406
-Butte,2214,U.S. Senate,,DEM,Loretta Sanchez,239
-Butte,2215,U.S. Senate,,DEM,Kamala Harris,448
-Butte,2215,U.S. Senate,,DEM,Loretta Sanchez,278
-Butte,2216,U.S. Senate,,DEM,Kamala Harris,343
-Butte,2216,U.S. Senate,,DEM,Loretta Sanchez,277
-Butte,2801,U.S. Senate,,DEM,Kamala Harris,575
-Butte,2801,U.S. Senate,,DEM,Loretta Sanchez,366
-Butte,2802,U.S. Senate,,DEM,Kamala Harris,375
-Butte,2802,U.S. Senate,,DEM,Loretta Sanchez,172
-Butte,2803,U.S. Senate,,DEM,Kamala Harris,192
-Butte,2803,U.S. Senate,,DEM,Loretta Sanchez,120
-Butte,2804,U.S. Senate,,DEM,Kamala Harris,245
-Butte,2804,U.S. Senate,,DEM,Loretta Sanchez,209
-Butte,2805,U.S. Senate,,DEM,Kamala Harris,363
-Butte,2805,U.S. Senate,,DEM,Loretta Sanchez,296
-Butte,2806,U.S. Senate,,DEM,Kamala Harris,423
-Butte,2806,U.S. Senate,,DEM,Loretta Sanchez,343
-Butte,2901,U.S. Senate,,DEM,Kamala Harris,189
-Butte,2901,U.S. Senate,,DEM,Loretta Sanchez,106
-Butte,2902,U.S. Senate,,DEM,Kamala Harris,184
-Butte,2902,U.S. Senate,,DEM,Loretta Sanchez,112
-Butte,2903,U.S. Senate,,DEM,Kamala Harris,0
-Butte,2903,U.S. Senate,,DEM,Loretta Sanchez,1
-Butte,3201,U.S. Senate,,DEM,Kamala Harris,606
-Butte,3201,U.S. Senate,,DEM,Loretta Sanchez,334
-Butte,3202,U.S. Senate,,DEM,Kamala Harris,962
-Butte,3202,U.S. Senate,,DEM,Loretta Sanchez,513
-Butte,3203,U.S. Senate,,DEM,Kamala Harris,705
-Butte,3203,U.S. Senate,,DEM,Loretta Sanchez,437
-Butte,3204,U.S. Senate,,DEM,Kamala Harris,564
-Butte,3204,U.S. Senate,,DEM,Loretta Sanchez,312
-Butte,3205,U.S. Senate,,DEM,Kamala Harris,647
-Butte,3205,U.S. Senate,,DEM,Loretta Sanchez,332
-Butte,3206,U.S. Senate,,DEM,Kamala Harris,804
-Butte,3206,U.S. Senate,,DEM,Loretta Sanchez,327
-Butte,3207,U.S. Senate,,DEM,Kamala Harris,654
-Butte,3207,U.S. Senate,,DEM,Loretta Sanchez,263
-Butte,3208,U.S. Senate,,DEM,Kamala Harris,873
-Butte,3208,U.S. Senate,,DEM,Loretta Sanchez,455
-Butte,3209,U.S. Senate,,DEM,Kamala Harris,611
-Butte,3209,U.S. Senate,,DEM,Loretta Sanchez,244
-Butte,3210,U.S. Senate,,DEM,Kamala Harris,766
-Butte,3210,U.S. Senate,,DEM,Loretta Sanchez,381
-Butte,3211,U.S. Senate,,DEM,Kamala Harris,384
-Butte,3211,U.S. Senate,,DEM,Loretta Sanchez,272
-Butte,3212,U.S. Senate,,DEM,Kamala Harris,448
-Butte,3212,U.S. Senate,,DEM,Loretta Sanchez,305
-Butte,3213,U.S. Senate,,DEM,Kamala Harris,498
-Butte,3213,U.S. Senate,,DEM,Loretta Sanchez,315
-Butte,3214,U.S. Senate,,DEM,Kamala Harris,352
-Butte,3214,U.S. Senate,,DEM,Loretta Sanchez,144
-Butte,3215,U.S. Senate,,DEM,Kamala Harris,518
-Butte,3215,U.S. Senate,,DEM,Loretta Sanchez,285
-Butte,3216,U.S. Senate,,DEM,Kamala Harris,233
-Butte,3216,U.S. Senate,,DEM,Loretta Sanchez,209
-Butte,3801,U.S. Senate,,DEM,Kamala Harris,380
-Butte,3801,U.S. Senate,,DEM,Loretta Sanchez,289
-Butte,3802,U.S. Senate,,DEM,Kamala Harris,338
-Butte,3802,U.S. Senate,,DEM,Loretta Sanchez,213
-Butte,3901,U.S. Senate,,DEM,Kamala Harris,2
-Butte,3901,U.S. Senate,,DEM,Loretta Sanchez,0
-Butte,3902,U.S. Senate,,DEM,Kamala Harris,155
-Butte,3902,U.S. Senate,,DEM,Loretta Sanchez,66
-Butte,3903,U.S. Senate,,DEM,Kamala Harris,5
-Butte,3903,U.S. Senate,,DEM,Loretta Sanchez,3
-Butte,3904,U.S. Senate,,DEM,Kamala Harris,190
-Butte,3904,U.S. Senate,,DEM,Loretta Sanchez,127
-Butte,3905,U.S. Senate,,DEM,Kamala Harris,84
-Butte,3905,U.S. Senate,,DEM,Loretta Sanchez,63
-Butte,3906,U.S. Senate,,DEM,Kamala Harris,6
-Butte,3906,U.S. Senate,,DEM,Loretta Sanchez,4
-Butte,3907,U.S. Senate,,DEM,Kamala Harris,15
-Butte,3907,U.S. Senate,,DEM,Loretta Sanchez,3
-Butte,4201,U.S. Senate,,DEM,Kamala Harris,395
-Butte,4201,U.S. Senate,,DEM,Loretta Sanchez,320
-Butte,4202,U.S. Senate,,DEM,Kamala Harris,695
-Butte,4202,U.S. Senate,,DEM,Loretta Sanchez,363
-Butte,4203,U.S. Senate,,DEM,Kamala Harris,460
-Butte,4203,U.S. Senate,,DEM,Loretta Sanchez,321
-Butte,4204,U.S. Senate,,DEM,Kamala Harris,725
-Butte,4204,U.S. Senate,,DEM,Loretta Sanchez,445
-Butte,4301,U.S. Senate,,DEM,Kamala Harris,421
-Butte,4301,U.S. Senate,,DEM,Loretta Sanchez,549
-Butte,4302,U.S. Senate,,DEM,Kamala Harris,308
-Butte,4302,U.S. Senate,,DEM,Loretta Sanchez,416
-Butte,4401,U.S. Senate,,DEM,Kamala Harris,219
-Butte,4401,U.S. Senate,,DEM,Loretta Sanchez,262
-Butte,4801,U.S. Senate,,DEM,Kamala Harris,388
-Butte,4801,U.S. Senate,,DEM,Loretta Sanchez,373
-Butte,4802,U.S. Senate,,DEM,Kamala Harris,370
-Butte,4802,U.S. Senate,,DEM,Loretta Sanchez,341
-Butte,4803,U.S. Senate,,DEM,Kamala Harris,260
-Butte,4803,U.S. Senate,,DEM,Loretta Sanchez,242
-Butte,4804,U.S. Senate,,DEM,Kamala Harris,353
-Butte,4804,U.S. Senate,,DEM,Loretta Sanchez,348
-Butte,4805,U.S. Senate,,DEM,Kamala Harris,286
-Butte,4805,U.S. Senate,,DEM,Loretta Sanchez,234
-Butte,4806,U.S. Senate,,DEM,Kamala Harris,576
-Butte,4806,U.S. Senate,,DEM,Loretta Sanchez,516
-Butte,4807,U.S. Senate,,DEM,Kamala Harris,160
-Butte,4807,U.S. Senate,,DEM,Loretta Sanchez,187
-Butte,4808,U.S. Senate,,DEM,Kamala Harris,783
-Butte,4808,U.S. Senate,,DEM,Loretta Sanchez,490
-Butte,4901,U.S. Senate,,DEM,Kamala Harris,152
-Butte,4901,U.S. Senate,,DEM,Loretta Sanchez,99
-Butte,4902,U.S. Senate,,DEM,Kamala Harris,0
-Butte,4902,U.S. Senate,,DEM,Loretta Sanchez,0
-Butte,4903,U.S. Senate,,DEM,Kamala Harris,0
-Butte,4903,U.S. Senate,,DEM,Loretta Sanchez,0
-Butte,4904,U.S. Senate,,DEM,Kamala Harris,73
-Butte,4904,U.S. Senate,,DEM,Loretta Sanchez,35
-Butte,4905,U.S. Senate,,DEM,Kamala Harris,46
-Butte,4905,U.S. Senate,,DEM,Loretta Sanchez,69
-Butte,4906,U.S. Senate,,DEM,Kamala Harris,0
-Butte,4906,U.S. Senate,,DEM,Loretta Sanchez,0
-Butte,4907,U.S. Senate,,DEM,Kamala Harris,34
-Butte,4907,U.S. Senate,,DEM,Loretta Sanchez,36
-Butte,4908,U.S. Senate,,DEM,Kamala Harris,93
-Butte,4908,U.S. Senate,,DEM,Loretta Sanchez,74
-Butte,4909,U.S. Senate,,DEM,Kamala Harris,4
-Butte,4909,U.S. Senate,,DEM,Loretta Sanchez,8
-Butte,4910,U.S. Senate,,DEM,Kamala Harris,44
-Butte,4910,U.S. Senate,,DEM,Loretta Sanchez,46
-Butte,4911,U.S. Senate,,DEM,Kamala Harris,31
-Butte,4911,U.S. Senate,,DEM,Loretta Sanchez,49
-Butte,4912,U.S. Senate,,DEM,Kamala Harris,0
-Butte,4912,U.S. Senate,,DEM,Loretta Sanchez,0
-Butte,5201,U.S. Senate,,DEM,Kamala Harris,549
-Butte,5201,U.S. Senate,,DEM,Loretta Sanchez,346
-Butte,5501,U.S. Senate,,DEM,Kamala Harris,282
-Butte,5501,U.S. Senate,,DEM,Loretta Sanchez,216
-Butte,5502,U.S. Senate,,DEM,Kamala Harris,354
-Butte,5502,U.S. Senate,,DEM,Loretta Sanchez,231
-Butte,5503,U.S. Senate,,DEM,Kamala Harris,328
-Butte,5503,U.S. Senate,,DEM,Loretta Sanchez,195
-Butte,5504,U.S. Senate,,DEM,Kamala Harris,288
-Butte,5504,U.S. Senate,,DEM,Loretta Sanchez,234
-Butte,5505,U.S. Senate,,DEM,Kamala Harris,631
-Butte,5505,U.S. Senate,,DEM,Loretta Sanchez,466
-Butte,5506,U.S. Senate,,DEM,Kamala Harris,592
-Butte,5506,U.S. Senate,,DEM,Loretta Sanchez,420
-Butte,5507,U.S. Senate,,DEM,Kamala Harris,266
-Butte,5507,U.S. Senate,,DEM,Loretta Sanchez,178
-Butte,5508,U.S. Senate,,DEM,Kamala Harris,283
-Butte,5508,U.S. Senate,,DEM,Loretta Sanchez,189
-Butte,5509,U.S. Senate,,DEM,Kamala Harris,532
-Butte,5509,U.S. Senate,,DEM,Loretta Sanchez,403
-Butte,5510,U.S. Senate,,DEM,Kamala Harris,601
-Butte,5510,U.S. Senate,,DEM,Loretta Sanchez,395
-Butte,5511,U.S. Senate,,DEM,Kamala Harris,594
-Butte,5511,U.S. Senate,,DEM,Loretta Sanchez,394
-Butte,5512,U.S. Senate,,DEM,Kamala Harris,455
-Butte,5512,U.S. Senate,,DEM,Loretta Sanchez,326
-Butte,5513,U.S. Senate,,DEM,Kamala Harris,540
-Butte,5513,U.S. Senate,,DEM,Loretta Sanchez,411
-Butte,5801,U.S. Senate,,DEM,Kamala Harris,326
-Butte,5801,U.S. Senate,,DEM,Loretta Sanchez,263
-Butte,5802,U.S. Senate,,DEM,Kamala Harris,472
-Butte,5802,U.S. Senate,,DEM,Loretta Sanchez,355
-Butte,5803,U.S. Senate,,DEM,Kamala Harris,384
-Butte,5803,U.S. Senate,,DEM,Loretta Sanchez,260
-Butte,5804,U.S. Senate,,DEM,Kamala Harris,346
-Butte,5804,U.S. Senate,,DEM,Loretta Sanchez,285
-Butte,5805,U.S. Senate,,DEM,Kamala Harris,663
-Butte,5805,U.S. Senate,,DEM,Loretta Sanchez,517
-Butte,5806,U.S. Senate,,DEM,Kamala Harris,165
-Butte,5806,U.S. Senate,,DEM,Loretta Sanchez,132
-Butte,5901,U.S. Senate,,DEM,Kamala Harris,0
-Butte,5901,U.S. Senate,,DEM,Loretta Sanchez,0
-Butte,5902,U.S. Senate,,DEM,Kamala Harris,89
-Butte,5902,U.S. Senate,,DEM,Loretta Sanchez,52
-Butte,5903,U.S. Senate,,DEM,Kamala Harris,141
-Butte,5903,U.S. Senate,,DEM,Loretta Sanchez,102
-Butte,5904,U.S. Senate,,DEM,Kamala Harris,167
-Butte,5904,U.S. Senate,,DEM,Loretta Sanchez,115
-Butte,5905,U.S. Senate,,DEM,Kamala Harris,282
-Butte,5905,U.S. Senate,,DEM,Loretta Sanchez,152
-Butte,5906,U.S. Senate,,DEM,Kamala Harris,149
-Butte,5906,U.S. Senate,,DEM,Loretta Sanchez,73
-Butte,5907,U.S. Senate,,DEM,Kamala Harris,252
-Butte,5907,U.S. Senate,,DEM,Loretta Sanchez,146
-Butte,5908,U.S. Senate,,DEM,Kamala Harris,140
-Butte,5908,U.S. Senate,,DEM,Loretta Sanchez,95
-Butte,5909,U.S. Senate,,DEM,Kamala Harris,16
-Butte,5909,U.S. Senate,,DEM,Loretta Sanchez,5
-Butte,5910,U.S. Senate,,DEM,Kamala Harris,7
-Butte,5910,U.S. Senate,,DEM,Loretta Sanchez,3
-Butte,5911,U.S. Senate,,DEM,Kamala Harris,1
-Butte,5911,U.S. Senate,,DEM,Loretta Sanchez,12
-Butte,5912,U.S. Senate,,DEM,Kamala Harris,3
-Butte,5912,U.S. Senate,,DEM,Loretta Sanchez,1
+Butte,1101,U.S. Senate,,DEM,Kamala D. Harris,294
+Butte,1101,U.S. Senate,,DEM,Loretta L. Sanchez,225
+Butte,1102,U.S. Senate,,DEM,Kamala D. Harris,398
+Butte,1102,U.S. Senate,,DEM,Loretta L. Sanchez,312
+Butte,1103,U.S. Senate,,DEM,Kamala D. Harris,454
+Butte,1103,U.S. Senate,,DEM,Loretta L. Sanchez,310
+Butte,1104,U.S. Senate,,DEM,Kamala D. Harris,427
+Butte,1104,U.S. Senate,,DEM,Loretta L. Sanchez,368
+Butte,1105,U.S. Senate,,DEM,Kamala D. Harris,300
+Butte,1105,U.S. Senate,,DEM,Loretta L. Sanchez,230
+Butte,1106,U.S. Senate,,DEM,Kamala D. Harris,284
+Butte,1106,U.S. Senate,,DEM,Loretta L. Sanchez,242
+Butte,1801,U.S. Senate,,DEM,Kamala D. Harris,426
+Butte,1801,U.S. Senate,,DEM,Loretta L. Sanchez,374
+Butte,1802,U.S. Senate,,DEM,Kamala D. Harris,304
+Butte,1802,U.S. Senate,,DEM,Loretta L. Sanchez,240
+Butte,1803,U.S. Senate,,DEM,Kamala D. Harris,230
+Butte,1803,U.S. Senate,,DEM,Loretta L. Sanchez,233
+Butte,1804,U.S. Senate,,DEM,Kamala D. Harris,305
+Butte,1804,U.S. Senate,,DEM,Loretta L. Sanchez,279
+Butte,1805,U.S. Senate,,DEM,Kamala D. Harris,458
+Butte,1805,U.S. Senate,,DEM,Loretta L. Sanchez,355
+Butte,1806,U.S. Senate,,DEM,Kamala D. Harris,347
+Butte,1806,U.S. Senate,,DEM,Loretta L. Sanchez,274
+Butte,1807,U.S. Senate,,DEM,Kamala D. Harris,285
+Butte,1807,U.S. Senate,,DEM,Loretta L. Sanchez,309
+Butte,1808,U.S. Senate,,DEM,Kamala D. Harris,331
+Butte,1808,U.S. Senate,,DEM,Loretta L. Sanchez,324
+Butte,1809,U.S. Senate,,DEM,Kamala D. Harris,353
+Butte,1809,U.S. Senate,,DEM,Loretta L. Sanchez,333
+Butte,1810,U.S. Senate,,DEM,Kamala D. Harris,192
+Butte,1810,U.S. Senate,,DEM,Loretta L. Sanchez,151
+Butte,1811,U.S. Senate,,DEM,Kamala D. Harris,317
+Butte,1811,U.S. Senate,,DEM,Loretta L. Sanchez,301
+Butte,1812,U.S. Senate,,DEM,Kamala D. Harris,274
+Butte,1812,U.S. Senate,,DEM,Loretta L. Sanchez,231
+Butte,1901,U.S. Senate,,DEM,Kamala D. Harris,70
+Butte,1901,U.S. Senate,,DEM,Loretta L. Sanchez,53
+Butte,1902,U.S. Senate,,DEM,Kamala D. Harris,4
+Butte,1902,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Butte,1903,U.S. Senate,,DEM,Kamala D. Harris,0
+Butte,1903,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Butte,1904,U.S. Senate,,DEM,Kamala D. Harris,0
+Butte,1904,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Butte,1905,U.S. Senate,,DEM,Kamala D. Harris,128
+Butte,1905,U.S. Senate,,DEM,Loretta L. Sanchez,90
+Butte,1906,U.S. Senate,,DEM,Kamala D. Harris,137
+Butte,1906,U.S. Senate,,DEM,Loretta L. Sanchez,119
+Butte,1907,U.S. Senate,,DEM,Kamala D. Harris,45
+Butte,1907,U.S. Senate,,DEM,Loretta L. Sanchez,46
+Butte,1908,U.S. Senate,,DEM,Kamala D. Harris,172
+Butte,1908,U.S. Senate,,DEM,Loretta L. Sanchez,107
+Butte,1909,U.S. Senate,,DEM,Kamala D. Harris,139
+Butte,1909,U.S. Senate,,DEM,Loretta L. Sanchez,128
+Butte,1910,U.S. Senate,,DEM,Kamala D. Harris,85
+Butte,1910,U.S. Senate,,DEM,Loretta L. Sanchez,116
+Butte,1911,U.S. Senate,,DEM,Kamala D. Harris,18
+Butte,1911,U.S. Senate,,DEM,Loretta L. Sanchez,27
+Butte,1912,U.S. Senate,,DEM,Kamala D. Harris,34
+Butte,1912,U.S. Senate,,DEM,Loretta L. Sanchez,41
+Butte,1913,U.S. Senate,,DEM,Kamala D. Harris,18
+Butte,1913,U.S. Senate,,DEM,Loretta L. Sanchez,16
+Butte,1914,U.S. Senate,,DEM,Kamala D. Harris,24
+Butte,1914,U.S. Senate,,DEM,Loretta L. Sanchez,33
+Butte,2201,U.S. Senate,,DEM,Kamala D. Harris,575
+Butte,2201,U.S. Senate,,DEM,Loretta L. Sanchez,351
+Butte,2202,U.S. Senate,,DEM,Kamala D. Harris,384
+Butte,2202,U.S. Senate,,DEM,Loretta L. Sanchez,196
+Butte,2203,U.S. Senate,,DEM,Kamala D. Harris,396
+Butte,2203,U.S. Senate,,DEM,Loretta L. Sanchez,264
+Butte,2204,U.S. Senate,,DEM,Kamala D. Harris,707
+Butte,2204,U.S. Senate,,DEM,Loretta L. Sanchez,481
+Butte,2205,U.S. Senate,,DEM,Kamala D. Harris,442
+Butte,2205,U.S. Senate,,DEM,Loretta L. Sanchez,240
+Butte,2206,U.S. Senate,,DEM,Kamala D. Harris,209
+Butte,2206,U.S. Senate,,DEM,Loretta L. Sanchez,160
+Butte,2207,U.S. Senate,,DEM,Kamala D. Harris,126
+Butte,2207,U.S. Senate,,DEM,Loretta L. Sanchez,121
+Butte,2208,U.S. Senate,,DEM,Kamala D. Harris,386
+Butte,2208,U.S. Senate,,DEM,Loretta L. Sanchez,367
+Butte,2209,U.S. Senate,,DEM,Kamala D. Harris,357
+Butte,2209,U.S. Senate,,DEM,Loretta L. Sanchez,346
+Butte,2210,U.S. Senate,,DEM,Kamala D. Harris,235
+Butte,2210,U.S. Senate,,DEM,Loretta L. Sanchez,262
+Butte,2211,U.S. Senate,,DEM,Kamala D. Harris,579
+Butte,2211,U.S. Senate,,DEM,Loretta L. Sanchez,273
+Butte,2212,U.S. Senate,,DEM,Kamala D. Harris,425
+Butte,2212,U.S. Senate,,DEM,Loretta L. Sanchez,263
+Butte,2213,U.S. Senate,,DEM,Kamala D. Harris,500
+Butte,2213,U.S. Senate,,DEM,Loretta L. Sanchez,275
+Butte,2214,U.S. Senate,,DEM,Kamala D. Harris,406
+Butte,2214,U.S. Senate,,DEM,Loretta L. Sanchez,239
+Butte,2215,U.S. Senate,,DEM,Kamala D. Harris,448
+Butte,2215,U.S. Senate,,DEM,Loretta L. Sanchez,278
+Butte,2216,U.S. Senate,,DEM,Kamala D. Harris,343
+Butte,2216,U.S. Senate,,DEM,Loretta L. Sanchez,277
+Butte,2801,U.S. Senate,,DEM,Kamala D. Harris,575
+Butte,2801,U.S. Senate,,DEM,Loretta L. Sanchez,366
+Butte,2802,U.S. Senate,,DEM,Kamala D. Harris,375
+Butte,2802,U.S. Senate,,DEM,Loretta L. Sanchez,172
+Butte,2803,U.S. Senate,,DEM,Kamala D. Harris,192
+Butte,2803,U.S. Senate,,DEM,Loretta L. Sanchez,120
+Butte,2804,U.S. Senate,,DEM,Kamala D. Harris,245
+Butte,2804,U.S. Senate,,DEM,Loretta L. Sanchez,209
+Butte,2805,U.S. Senate,,DEM,Kamala D. Harris,363
+Butte,2805,U.S. Senate,,DEM,Loretta L. Sanchez,296
+Butte,2806,U.S. Senate,,DEM,Kamala D. Harris,423
+Butte,2806,U.S. Senate,,DEM,Loretta L. Sanchez,343
+Butte,2901,U.S. Senate,,DEM,Kamala D. Harris,189
+Butte,2901,U.S. Senate,,DEM,Loretta L. Sanchez,106
+Butte,2902,U.S. Senate,,DEM,Kamala D. Harris,184
+Butte,2902,U.S. Senate,,DEM,Loretta L. Sanchez,112
+Butte,2903,U.S. Senate,,DEM,Kamala D. Harris,0
+Butte,2903,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Butte,3201,U.S. Senate,,DEM,Kamala D. Harris,606
+Butte,3201,U.S. Senate,,DEM,Loretta L. Sanchez,334
+Butte,3202,U.S. Senate,,DEM,Kamala D. Harris,962
+Butte,3202,U.S. Senate,,DEM,Loretta L. Sanchez,513
+Butte,3203,U.S. Senate,,DEM,Kamala D. Harris,705
+Butte,3203,U.S. Senate,,DEM,Loretta L. Sanchez,437
+Butte,3204,U.S. Senate,,DEM,Kamala D. Harris,564
+Butte,3204,U.S. Senate,,DEM,Loretta L. Sanchez,312
+Butte,3205,U.S. Senate,,DEM,Kamala D. Harris,647
+Butte,3205,U.S. Senate,,DEM,Loretta L. Sanchez,332
+Butte,3206,U.S. Senate,,DEM,Kamala D. Harris,804
+Butte,3206,U.S. Senate,,DEM,Loretta L. Sanchez,327
+Butte,3207,U.S. Senate,,DEM,Kamala D. Harris,654
+Butte,3207,U.S. Senate,,DEM,Loretta L. Sanchez,263
+Butte,3208,U.S. Senate,,DEM,Kamala D. Harris,873
+Butte,3208,U.S. Senate,,DEM,Loretta L. Sanchez,455
+Butte,3209,U.S. Senate,,DEM,Kamala D. Harris,611
+Butte,3209,U.S. Senate,,DEM,Loretta L. Sanchez,244
+Butte,3210,U.S. Senate,,DEM,Kamala D. Harris,766
+Butte,3210,U.S. Senate,,DEM,Loretta L. Sanchez,381
+Butte,3211,U.S. Senate,,DEM,Kamala D. Harris,384
+Butte,3211,U.S. Senate,,DEM,Loretta L. Sanchez,272
+Butte,3212,U.S. Senate,,DEM,Kamala D. Harris,448
+Butte,3212,U.S. Senate,,DEM,Loretta L. Sanchez,305
+Butte,3213,U.S. Senate,,DEM,Kamala D. Harris,498
+Butte,3213,U.S. Senate,,DEM,Loretta L. Sanchez,315
+Butte,3214,U.S. Senate,,DEM,Kamala D. Harris,352
+Butte,3214,U.S. Senate,,DEM,Loretta L. Sanchez,144
+Butte,3215,U.S. Senate,,DEM,Kamala D. Harris,518
+Butte,3215,U.S. Senate,,DEM,Loretta L. Sanchez,285
+Butte,3216,U.S. Senate,,DEM,Kamala D. Harris,233
+Butte,3216,U.S. Senate,,DEM,Loretta L. Sanchez,209
+Butte,3801,U.S. Senate,,DEM,Kamala D. Harris,380
+Butte,3801,U.S. Senate,,DEM,Loretta L. Sanchez,289
+Butte,3802,U.S. Senate,,DEM,Kamala D. Harris,338
+Butte,3802,U.S. Senate,,DEM,Loretta L. Sanchez,213
+Butte,3901,U.S. Senate,,DEM,Kamala D. Harris,2
+Butte,3901,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Butte,3902,U.S. Senate,,DEM,Kamala D. Harris,155
+Butte,3902,U.S. Senate,,DEM,Loretta L. Sanchez,66
+Butte,3903,U.S. Senate,,DEM,Kamala D. Harris,5
+Butte,3903,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Butte,3904,U.S. Senate,,DEM,Kamala D. Harris,190
+Butte,3904,U.S. Senate,,DEM,Loretta L. Sanchez,127
+Butte,3905,U.S. Senate,,DEM,Kamala D. Harris,84
+Butte,3905,U.S. Senate,,DEM,Loretta L. Sanchez,63
+Butte,3906,U.S. Senate,,DEM,Kamala D. Harris,6
+Butte,3906,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Butte,3907,U.S. Senate,,DEM,Kamala D. Harris,15
+Butte,3907,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Butte,4201,U.S. Senate,,DEM,Kamala D. Harris,395
+Butte,4201,U.S. Senate,,DEM,Loretta L. Sanchez,320
+Butte,4202,U.S. Senate,,DEM,Kamala D. Harris,695
+Butte,4202,U.S. Senate,,DEM,Loretta L. Sanchez,363
+Butte,4203,U.S. Senate,,DEM,Kamala D. Harris,460
+Butte,4203,U.S. Senate,,DEM,Loretta L. Sanchez,321
+Butte,4204,U.S. Senate,,DEM,Kamala D. Harris,725
+Butte,4204,U.S. Senate,,DEM,Loretta L. Sanchez,445
+Butte,4301,U.S. Senate,,DEM,Kamala D. Harris,421
+Butte,4301,U.S. Senate,,DEM,Loretta L. Sanchez,549
+Butte,4302,U.S. Senate,,DEM,Kamala D. Harris,308
+Butte,4302,U.S. Senate,,DEM,Loretta L. Sanchez,416
+Butte,4401,U.S. Senate,,DEM,Kamala D. Harris,219
+Butte,4401,U.S. Senate,,DEM,Loretta L. Sanchez,262
+Butte,4801,U.S. Senate,,DEM,Kamala D. Harris,388
+Butte,4801,U.S. Senate,,DEM,Loretta L. Sanchez,373
+Butte,4802,U.S. Senate,,DEM,Kamala D. Harris,370
+Butte,4802,U.S. Senate,,DEM,Loretta L. Sanchez,341
+Butte,4803,U.S. Senate,,DEM,Kamala D. Harris,260
+Butte,4803,U.S. Senate,,DEM,Loretta L. Sanchez,242
+Butte,4804,U.S. Senate,,DEM,Kamala D. Harris,353
+Butte,4804,U.S. Senate,,DEM,Loretta L. Sanchez,348
+Butte,4805,U.S. Senate,,DEM,Kamala D. Harris,286
+Butte,4805,U.S. Senate,,DEM,Loretta L. Sanchez,234
+Butte,4806,U.S. Senate,,DEM,Kamala D. Harris,576
+Butte,4806,U.S. Senate,,DEM,Loretta L. Sanchez,516
+Butte,4807,U.S. Senate,,DEM,Kamala D. Harris,160
+Butte,4807,U.S. Senate,,DEM,Loretta L. Sanchez,187
+Butte,4808,U.S. Senate,,DEM,Kamala D. Harris,783
+Butte,4808,U.S. Senate,,DEM,Loretta L. Sanchez,490
+Butte,4901,U.S. Senate,,DEM,Kamala D. Harris,152
+Butte,4901,U.S. Senate,,DEM,Loretta L. Sanchez,99
+Butte,4902,U.S. Senate,,DEM,Kamala D. Harris,0
+Butte,4902,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Butte,4903,U.S. Senate,,DEM,Kamala D. Harris,0
+Butte,4903,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Butte,4904,U.S. Senate,,DEM,Kamala D. Harris,73
+Butte,4904,U.S. Senate,,DEM,Loretta L. Sanchez,35
+Butte,4905,U.S. Senate,,DEM,Kamala D. Harris,46
+Butte,4905,U.S. Senate,,DEM,Loretta L. Sanchez,69
+Butte,4906,U.S. Senate,,DEM,Kamala D. Harris,0
+Butte,4906,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Butte,4907,U.S. Senate,,DEM,Kamala D. Harris,34
+Butte,4907,U.S. Senate,,DEM,Loretta L. Sanchez,36
+Butte,4908,U.S. Senate,,DEM,Kamala D. Harris,93
+Butte,4908,U.S. Senate,,DEM,Loretta L. Sanchez,74
+Butte,4909,U.S. Senate,,DEM,Kamala D. Harris,4
+Butte,4909,U.S. Senate,,DEM,Loretta L. Sanchez,8
+Butte,4910,U.S. Senate,,DEM,Kamala D. Harris,44
+Butte,4910,U.S. Senate,,DEM,Loretta L. Sanchez,46
+Butte,4911,U.S. Senate,,DEM,Kamala D. Harris,31
+Butte,4911,U.S. Senate,,DEM,Loretta L. Sanchez,49
+Butte,4912,U.S. Senate,,DEM,Kamala D. Harris,0
+Butte,4912,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Butte,5201,U.S. Senate,,DEM,Kamala D. Harris,549
+Butte,5201,U.S. Senate,,DEM,Loretta L. Sanchez,346
+Butte,5501,U.S. Senate,,DEM,Kamala D. Harris,282
+Butte,5501,U.S. Senate,,DEM,Loretta L. Sanchez,216
+Butte,5502,U.S. Senate,,DEM,Kamala D. Harris,354
+Butte,5502,U.S. Senate,,DEM,Loretta L. Sanchez,231
+Butte,5503,U.S. Senate,,DEM,Kamala D. Harris,328
+Butte,5503,U.S. Senate,,DEM,Loretta L. Sanchez,195
+Butte,5504,U.S. Senate,,DEM,Kamala D. Harris,288
+Butte,5504,U.S. Senate,,DEM,Loretta L. Sanchez,234
+Butte,5505,U.S. Senate,,DEM,Kamala D. Harris,631
+Butte,5505,U.S. Senate,,DEM,Loretta L. Sanchez,466
+Butte,5506,U.S. Senate,,DEM,Kamala D. Harris,592
+Butte,5506,U.S. Senate,,DEM,Loretta L. Sanchez,420
+Butte,5507,U.S. Senate,,DEM,Kamala D. Harris,266
+Butte,5507,U.S. Senate,,DEM,Loretta L. Sanchez,178
+Butte,5508,U.S. Senate,,DEM,Kamala D. Harris,283
+Butte,5508,U.S. Senate,,DEM,Loretta L. Sanchez,189
+Butte,5509,U.S. Senate,,DEM,Kamala D. Harris,532
+Butte,5509,U.S. Senate,,DEM,Loretta L. Sanchez,403
+Butte,5510,U.S. Senate,,DEM,Kamala D. Harris,601
+Butte,5510,U.S. Senate,,DEM,Loretta L. Sanchez,395
+Butte,5511,U.S. Senate,,DEM,Kamala D. Harris,594
+Butte,5511,U.S. Senate,,DEM,Loretta L. Sanchez,394
+Butte,5512,U.S. Senate,,DEM,Kamala D. Harris,455
+Butte,5512,U.S. Senate,,DEM,Loretta L. Sanchez,326
+Butte,5513,U.S. Senate,,DEM,Kamala D. Harris,540
+Butte,5513,U.S. Senate,,DEM,Loretta L. Sanchez,411
+Butte,5801,U.S. Senate,,DEM,Kamala D. Harris,326
+Butte,5801,U.S. Senate,,DEM,Loretta L. Sanchez,263
+Butte,5802,U.S. Senate,,DEM,Kamala D. Harris,472
+Butte,5802,U.S. Senate,,DEM,Loretta L. Sanchez,355
+Butte,5803,U.S. Senate,,DEM,Kamala D. Harris,384
+Butte,5803,U.S. Senate,,DEM,Loretta L. Sanchez,260
+Butte,5804,U.S. Senate,,DEM,Kamala D. Harris,346
+Butte,5804,U.S. Senate,,DEM,Loretta L. Sanchez,285
+Butte,5805,U.S. Senate,,DEM,Kamala D. Harris,663
+Butte,5805,U.S. Senate,,DEM,Loretta L. Sanchez,517
+Butte,5806,U.S. Senate,,DEM,Kamala D. Harris,165
+Butte,5806,U.S. Senate,,DEM,Loretta L. Sanchez,132
+Butte,5901,U.S. Senate,,DEM,Kamala D. Harris,0
+Butte,5901,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Butte,5902,U.S. Senate,,DEM,Kamala D. Harris,89
+Butte,5902,U.S. Senate,,DEM,Loretta L. Sanchez,52
+Butte,5903,U.S. Senate,,DEM,Kamala D. Harris,141
+Butte,5903,U.S. Senate,,DEM,Loretta L. Sanchez,102
+Butte,5904,U.S. Senate,,DEM,Kamala D. Harris,167
+Butte,5904,U.S. Senate,,DEM,Loretta L. Sanchez,115
+Butte,5905,U.S. Senate,,DEM,Kamala D. Harris,282
+Butte,5905,U.S. Senate,,DEM,Loretta L. Sanchez,152
+Butte,5906,U.S. Senate,,DEM,Kamala D. Harris,149
+Butte,5906,U.S. Senate,,DEM,Loretta L. Sanchez,73
+Butte,5907,U.S. Senate,,DEM,Kamala D. Harris,252
+Butte,5907,U.S. Senate,,DEM,Loretta L. Sanchez,146
+Butte,5908,U.S. Senate,,DEM,Kamala D. Harris,140
+Butte,5908,U.S. Senate,,DEM,Loretta L. Sanchez,95
+Butte,5909,U.S. Senate,,DEM,Kamala D. Harris,16
+Butte,5909,U.S. Senate,,DEM,Loretta L. Sanchez,5
+Butte,5910,U.S. Senate,,DEM,Kamala D. Harris,7
+Butte,5910,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Butte,5911,U.S. Senate,,DEM,Kamala D. Harris,1
+Butte,5911,U.S. Senate,,DEM,Loretta L. Sanchez,12
+Butte,5912,U.S. Senate,,DEM,Kamala D. Harris,3
+Butte,5912,U.S. Senate,,DEM,Loretta L. Sanchez,1

--- a/2016/20161108__ca__general__calaveras__precinct.csv
+++ b/2016/20161108__ca__general__calaveras__precinct.csv
@@ -1159,61 +1159,61 @@ Calaveras,560,Proposition 67,,N/A,Yes,277
 Calaveras,560,Proposition 67,,N/A,No,540
 Calaveras,570,Proposition 67,,N/A,Yes,274
 Calaveras,570,Proposition 67,,N/A,No,531
-Calaveras,110,U.S. Senate,,DEM,Kamala Harris,376
-Calaveras,110,U.S. Senate,,DEM,Loretta Sanchez,212
-Calaveras,120,U.S. Senate,,DEM,Kamala Harris,435
-Calaveras,120,U.S. Senate,,DEM,Loretta Sanchez,274
-Calaveras,140,U.S. Senate,,DEM,Kamala Harris,352
-Calaveras,140,U.S. Senate,,DEM,Loretta Sanchez,248
-Calaveras,150,U.S. Senate,,DEM,Kamala Harris,268
-Calaveras,150,U.S. Senate,,DEM,Loretta Sanchez,164
-Calaveras,160,U.S. Senate,,DEM,Kamala Harris,274
-Calaveras,160,U.S. Senate,,DEM,Loretta Sanchez,224
-Calaveras,170,U.S. Senate,,DEM,Kamala Harris,335
-Calaveras,170,U.S. Senate,,DEM,Loretta Sanchez,278
-Calaveras,210,U.S. Senate,,DEM,Kamala Harris,247
-Calaveras,210,U.S. Senate,,DEM,Loretta Sanchez,126
-Calaveras,215,U.S. Senate,,DEM,Kamala Harris,383
-Calaveras,215,U.S. Senate,,DEM,Loretta Sanchez,183
-Calaveras,220,U.S. Senate,,DEM,Kamala Harris,347
-Calaveras,220,U.S. Senate,,DEM,Loretta Sanchez,200
-Calaveras,230,U.S. Senate,,DEM,Kamala Harris,194
-Calaveras,230,U.S. Senate,,DEM,Loretta Sanchez,116
-Calaveras,240,U.S. Senate,,DEM,Kamala Harris,340
-Calaveras,240,U.S. Senate,,DEM,Loretta Sanchez,209
-Calaveras,250,U.S. Senate,,DEM,Kamala Harris,280
-Calaveras,250,U.S. Senate,,DEM,Loretta Sanchez,132
-Calaveras,260,U.S. Senate,,DEM,Kamala Harris,306
-Calaveras,260,U.S. Senate,,DEM,Loretta Sanchez,150
-Calaveras,310,U.S. Senate,,DEM,Kamala Harris,509
-Calaveras,310,U.S. Senate,,DEM,Loretta Sanchez,201
-Calaveras,320,U.S. Senate,,DEM,Kamala Harris,352
-Calaveras,320,U.S. Senate,,DEM,Loretta Sanchez,150
-Calaveras,330,U.S. Senate,,DEM,Kamala Harris,404
-Calaveras,330,U.S. Senate,,DEM,Loretta Sanchez,167
-Calaveras,350,U.S. Senate,,DEM,Kamala Harris,607
-Calaveras,350,U.S. Senate,,DEM,Loretta Sanchez,223
-Calaveras,360,U.S. Senate,,DEM,Kamala Harris,490
-Calaveras,360,U.S. Senate,,DEM,Loretta Sanchez,188
-Calaveras,370,U.S. Senate,,DEM,Kamala Harris,406
-Calaveras,370,U.S. Senate,,DEM,Loretta Sanchez,204
-Calaveras,410,U.S. Senate,,DEM,Kamala Harris,496
-Calaveras,410,U.S. Senate,,DEM,Loretta Sanchez,251
-Calaveras,420,U.S. Senate,,DEM,Kamala Harris,401
-Calaveras,420,U.S. Senate,,DEM,Loretta Sanchez,197
-Calaveras,430,U.S. Senate,,DEM,Kamala Harris,575
-Calaveras,430,U.S. Senate,,DEM,Loretta Sanchez,228
-Calaveras,440,U.S. Senate,,DEM,Kamala Harris,452
-Calaveras,440,U.S. Senate,,DEM,Loretta Sanchez,286
-Calaveras,450,U.S. Senate,,DEM,Kamala Harris,537
-Calaveras,450,U.S. Senate,,DEM,Loretta Sanchez,303
-Calaveras,530,U.S. Senate,,DEM,Kamala Harris,297
-Calaveras,530,U.S. Senate,,DEM,Loretta Sanchez,255
-Calaveras,540,U.S. Senate,,DEM,Kamala Harris,410
-Calaveras,540,U.S. Senate,,DEM,Loretta Sanchez,259
-Calaveras,550,U.S. Senate,,DEM,Kamala Harris,519
-Calaveras,550,U.S. Senate,,DEM,Loretta Sanchez,325
-Calaveras,560,U.S. Senate,,DEM,Kamala Harris,328
-Calaveras,560,U.S. Senate,,DEM,Loretta Sanchez,284
-Calaveras,570,U.S. Senate,,DEM,Kamala Harris,339
-Calaveras,570,U.S. Senate,,DEM,Loretta Sanchez,265
+Calaveras,110,U.S. Senate,,DEM,Kamala D. Harris,376
+Calaveras,110,U.S. Senate,,DEM,Loretta L. Sanchez,212
+Calaveras,120,U.S. Senate,,DEM,Kamala D. Harris,435
+Calaveras,120,U.S. Senate,,DEM,Loretta L. Sanchez,274
+Calaveras,140,U.S. Senate,,DEM,Kamala D. Harris,352
+Calaveras,140,U.S. Senate,,DEM,Loretta L. Sanchez,248
+Calaveras,150,U.S. Senate,,DEM,Kamala D. Harris,268
+Calaveras,150,U.S. Senate,,DEM,Loretta L. Sanchez,164
+Calaveras,160,U.S. Senate,,DEM,Kamala D. Harris,274
+Calaveras,160,U.S. Senate,,DEM,Loretta L. Sanchez,224
+Calaveras,170,U.S. Senate,,DEM,Kamala D. Harris,335
+Calaveras,170,U.S. Senate,,DEM,Loretta L. Sanchez,278
+Calaveras,210,U.S. Senate,,DEM,Kamala D. Harris,247
+Calaveras,210,U.S. Senate,,DEM,Loretta L. Sanchez,126
+Calaveras,215,U.S. Senate,,DEM,Kamala D. Harris,383
+Calaveras,215,U.S. Senate,,DEM,Loretta L. Sanchez,183
+Calaveras,220,U.S. Senate,,DEM,Kamala D. Harris,347
+Calaveras,220,U.S. Senate,,DEM,Loretta L. Sanchez,200
+Calaveras,230,U.S. Senate,,DEM,Kamala D. Harris,194
+Calaveras,230,U.S. Senate,,DEM,Loretta L. Sanchez,116
+Calaveras,240,U.S. Senate,,DEM,Kamala D. Harris,340
+Calaveras,240,U.S. Senate,,DEM,Loretta L. Sanchez,209
+Calaveras,250,U.S. Senate,,DEM,Kamala D. Harris,280
+Calaveras,250,U.S. Senate,,DEM,Loretta L. Sanchez,132
+Calaveras,260,U.S. Senate,,DEM,Kamala D. Harris,306
+Calaveras,260,U.S. Senate,,DEM,Loretta L. Sanchez,150
+Calaveras,310,U.S. Senate,,DEM,Kamala D. Harris,509
+Calaveras,310,U.S. Senate,,DEM,Loretta L. Sanchez,201
+Calaveras,320,U.S. Senate,,DEM,Kamala D. Harris,352
+Calaveras,320,U.S. Senate,,DEM,Loretta L. Sanchez,150
+Calaveras,330,U.S. Senate,,DEM,Kamala D. Harris,404
+Calaveras,330,U.S. Senate,,DEM,Loretta L. Sanchez,167
+Calaveras,350,U.S. Senate,,DEM,Kamala D. Harris,607
+Calaveras,350,U.S. Senate,,DEM,Loretta L. Sanchez,223
+Calaveras,360,U.S. Senate,,DEM,Kamala D. Harris,490
+Calaveras,360,U.S. Senate,,DEM,Loretta L. Sanchez,188
+Calaveras,370,U.S. Senate,,DEM,Kamala D. Harris,406
+Calaveras,370,U.S. Senate,,DEM,Loretta L. Sanchez,204
+Calaveras,410,U.S. Senate,,DEM,Kamala D. Harris,496
+Calaveras,410,U.S. Senate,,DEM,Loretta L. Sanchez,251
+Calaveras,420,U.S. Senate,,DEM,Kamala D. Harris,401
+Calaveras,420,U.S. Senate,,DEM,Loretta L. Sanchez,197
+Calaveras,430,U.S. Senate,,DEM,Kamala D. Harris,575
+Calaveras,430,U.S. Senate,,DEM,Loretta L. Sanchez,228
+Calaveras,440,U.S. Senate,,DEM,Kamala D. Harris,452
+Calaveras,440,U.S. Senate,,DEM,Loretta L. Sanchez,286
+Calaveras,450,U.S. Senate,,DEM,Kamala D. Harris,537
+Calaveras,450,U.S. Senate,,DEM,Loretta L. Sanchez,303
+Calaveras,530,U.S. Senate,,DEM,Kamala D. Harris,297
+Calaveras,530,U.S. Senate,,DEM,Loretta L. Sanchez,255
+Calaveras,540,U.S. Senate,,DEM,Kamala D. Harris,410
+Calaveras,540,U.S. Senate,,DEM,Loretta L. Sanchez,259
+Calaveras,550,U.S. Senate,,DEM,Kamala D. Harris,519
+Calaveras,550,U.S. Senate,,DEM,Loretta L. Sanchez,325
+Calaveras,560,U.S. Senate,,DEM,Kamala D. Harris,328
+Calaveras,560,U.S. Senate,,DEM,Loretta L. Sanchez,284
+Calaveras,570,U.S. Senate,,DEM,Kamala D. Harris,339
+Calaveras,570,U.S. Senate,,DEM,Loretta L. Sanchez,265

--- a/2016/20161108__ca__general__colusa__precinct.csv
+++ b/2016/20161108__ca__general__colusa__precinct.csv
@@ -679,37 +679,37 @@ Colusa,512,Proposition 67,,N/A,Yes,154
 Colusa,512,Proposition 67,,N/A,No,271
 Colusa,513,Proposition 67,,N/A,Yes,163
 Colusa,513,Proposition 67,,N/A,No,283
-Colusa,105,U.S. Senate,,DEM,Kamala Harris,289
-Colusa,105,U.S. Senate,,DEM,Loretta Sanchez,243
-Colusa,106,U.S. Senate,,DEM,Kamala Harris,289
-Colusa,106,U.S. Senate,,DEM,Loretta Sanchez,324
-Colusa,202,U.S. Senate,,DEM,Kamala Harris,76
-Colusa,202,U.S. Senate,,DEM,Loretta Sanchez,53
-Colusa,203,U.S. Senate,,DEM,Kamala Harris,55
-Colusa,203,U.S. Senate,,DEM,Loretta Sanchez,74
-Colusa,213,U.S. Senate,,DEM,Kamala Harris,226
-Colusa,213,U.S. Senate,,DEM,Loretta Sanchez,225
-Colusa,214,U.S. Senate,,DEM,Kamala Harris,248
-Colusa,214,U.S. Senate,,DEM,Loretta Sanchez,183
-Colusa,301,U.S. Senate,,DEM,Kamala Harris,125
-Colusa,301,U.S. Senate,,DEM,Loretta Sanchez,91
-Colusa,323,U.S. Senate,,DEM,Kamala Harris,121
-Colusa,323,U.S. Senate,,DEM,Loretta Sanchez,181
-Colusa,324,U.S. Senate,,DEM,Kamala Harris,165
-Colusa,324,U.S. Senate,,DEM,Loretta Sanchez,194
-Colusa,401,U.S. Senate,,DEM,Kamala Harris,201
-Colusa,401,U.S. Senate,,DEM,Loretta Sanchez,183
-Colusa,405C,U.S. Senate,,DEM,Kamala Harris,106
-Colusa,405C,U.S. Senate,,DEM,Loretta Sanchez,73
-Colusa,407,U.S. Senate,,DEM,Kamala Harris,28
-Colusa,407,U.S. Senate,,DEM,Loretta Sanchez,17
-Colusa,427,U.S. Senate,,DEM,Kamala Harris,77
-Colusa,427,U.S. Senate,,DEM,Loretta Sanchez,152
-Colusa,500,U.S. Senate,,DEM,Kamala Harris,194
-Colusa,500,U.S. Senate,,DEM,Loretta Sanchez,151
-Colusa,505,U.S. Senate,,DEM,Kamala Harris,46
-Colusa,505,U.S. Senate,,DEM,Loretta Sanchez,44
-Colusa,512,U.S. Senate,,DEM,Kamala Harris,189
-Colusa,512,U.S. Senate,,DEM,Loretta Sanchez,169
-Colusa,513,U.S. Senate,,DEM,Kamala Harris,204
-Colusa,513,U.S. Senate,,DEM,Loretta Sanchez,145
+Colusa,105,U.S. Senate,,DEM,Kamala D. Harris,289
+Colusa,105,U.S. Senate,,DEM,Loretta L. Sanchez,243
+Colusa,106,U.S. Senate,,DEM,Kamala D. Harris,289
+Colusa,106,U.S. Senate,,DEM,Loretta L. Sanchez,324
+Colusa,202,U.S. Senate,,DEM,Kamala D. Harris,76
+Colusa,202,U.S. Senate,,DEM,Loretta L. Sanchez,53
+Colusa,203,U.S. Senate,,DEM,Kamala D. Harris,55
+Colusa,203,U.S. Senate,,DEM,Loretta L. Sanchez,74
+Colusa,213,U.S. Senate,,DEM,Kamala D. Harris,226
+Colusa,213,U.S. Senate,,DEM,Loretta L. Sanchez,225
+Colusa,214,U.S. Senate,,DEM,Kamala D. Harris,248
+Colusa,214,U.S. Senate,,DEM,Loretta L. Sanchez,183
+Colusa,301,U.S. Senate,,DEM,Kamala D. Harris,125
+Colusa,301,U.S. Senate,,DEM,Loretta L. Sanchez,91
+Colusa,323,U.S. Senate,,DEM,Kamala D. Harris,121
+Colusa,323,U.S. Senate,,DEM,Loretta L. Sanchez,181
+Colusa,324,U.S. Senate,,DEM,Kamala D. Harris,165
+Colusa,324,U.S. Senate,,DEM,Loretta L. Sanchez,194
+Colusa,401,U.S. Senate,,DEM,Kamala D. Harris,201
+Colusa,401,U.S. Senate,,DEM,Loretta L. Sanchez,183
+Colusa,405C,U.S. Senate,,DEM,Kamala D. Harris,106
+Colusa,405C,U.S. Senate,,DEM,Loretta L. Sanchez,73
+Colusa,407,U.S. Senate,,DEM,Kamala D. Harris,28
+Colusa,407,U.S. Senate,,DEM,Loretta L. Sanchez,17
+Colusa,427,U.S. Senate,,DEM,Kamala D. Harris,77
+Colusa,427,U.S. Senate,,DEM,Loretta L. Sanchez,152
+Colusa,500,U.S. Senate,,DEM,Kamala D. Harris,194
+Colusa,500,U.S. Senate,,DEM,Loretta L. Sanchez,151
+Colusa,505,U.S. Senate,,DEM,Kamala D. Harris,46
+Colusa,505,U.S. Senate,,DEM,Loretta L. Sanchez,44
+Colusa,512,U.S. Senate,,DEM,Kamala D. Harris,189
+Colusa,512,U.S. Senate,,DEM,Loretta L. Sanchez,169
+Colusa,513,U.S. Senate,,DEM,Kamala D. Harris,204
+Colusa,513,U.S. Senate,,DEM,Loretta L. Sanchez,145

--- a/2016/20161108__ca__general__contra_costa__precinct.csv
+++ b/2016/20161108__ca__general__contra_costa__precinct.csv
@@ -26239,1315 +26239,1315 @@ Contra Costa,WalnutKnolls103,Proposition 67,,N/A,Yes,371
 Contra Costa,WalnutKnolls103,Proposition 67,,N/A,No,201
 Contra Costa,WalnutKnolls801,Proposition 67,,N/A,Yes,86
 Contra Costa,WalnutKnolls801,Proposition 67,,N/A,No,54
-Contra Costa,Alamo101,U.S. Senate,,DEM,Kamala Harris,327
-Contra Costa,Alamo101,U.S. Senate,,DEM,Loretta Sanchez,215
-Contra Costa,Alamo102,U.S. Senate,,DEM,Kamala Harris,729
-Contra Costa,Alamo102,U.S. Senate,,DEM,Loretta Sanchez,316
-Contra Costa,Alamo103,U.S. Senate,,DEM,Kamala Harris,433
-Contra Costa,Alamo103,U.S. Senate,,DEM,Loretta Sanchez,236
-Contra Costa,Alamo104,U.S. Senate,,DEM,Kamala Harris,437
-Contra Costa,Alamo104,U.S. Senate,,DEM,Loretta Sanchez,260
-Contra Costa,Alamo105,U.S. Senate,,DEM,Kamala Harris,251
-Contra Costa,Alamo105,U.S. Senate,,DEM,Loretta Sanchez,150
-Contra Costa,Alamo106,U.S. Senate,,DEM,Kamala Harris,453
-Contra Costa,Alamo106,U.S. Senate,,DEM,Loretta Sanchez,218
-Contra Costa,Alamo107,U.S. Senate,,DEM,Kamala Harris,422
-Contra Costa,Alamo107,U.S. Senate,,DEM,Loretta Sanchez,134
-Contra Costa,Alamo108,U.S. Senate,,DEM,Kamala Harris,400
-Contra Costa,Alamo108,U.S. Senate,,DEM,Loretta Sanchez,152
-Contra Costa,Alamo109,U.S. Senate,,DEM,Kamala Harris,433
-Contra Costa,Alamo109,U.S. Senate,,DEM,Loretta Sanchez,226
-Contra Costa,Alamo110,U.S. Senate,,DEM,Kamala Harris,441
-Contra Costa,Alamo110,U.S. Senate,,DEM,Loretta Sanchez,238
-Contra Costa,Alamo111,U.S. Senate,,DEM,Kamala Harris,416
-Contra Costa,Alamo111,U.S. Senate,,DEM,Loretta Sanchez,238
-Contra Costa,Alamo112,U.S. Senate,,DEM,Kamala Harris,272
-Contra Costa,Alamo112,U.S. Senate,,DEM,Loretta Sanchez,162
-Contra Costa,Alhambra101,U.S. Senate,,DEM,Kamala Harris,262
-Contra Costa,Alhambra101,U.S. Senate,,DEM,Loretta Sanchez,135
-Contra Costa,Alhambra801,U.S. Senate,,DEM,Kamala Harris,16
-Contra Costa,Alhambra801,U.S. Senate,,DEM,Loretta Sanchez,12
-Contra Costa,Alhambra802,U.S. Senate,,DEM,Kamala Harris,27
-Contra Costa,Alhambra802,U.S. Senate,,DEM,Loretta Sanchez,15
-Contra Costa,Alhambra803,U.S. Senate,,DEM,Kamala Harris,8
-Contra Costa,Alhambra803,U.S. Senate,,DEM,Loretta Sanchez,3
-Contra Costa,Alhambra804,U.S. Senate,,DEM,Kamala Harris,81
-Contra Costa,Alhambra804,U.S. Senate,,DEM,Loretta Sanchez,23
-Contra Costa,Alhambra805,U.S. Senate,,DEM,Kamala Harris,32
-Contra Costa,Alhambra805,U.S. Senate,,DEM,Loretta Sanchez,15
-Contra Costa,Alhambra806,U.S. Senate,,DEM,Kamala Harris,1
-Contra Costa,Alhambra806,U.S. Senate,,DEM,Loretta Sanchez,0
-Contra Costa,Antioch101,U.S. Senate,,DEM,Kamala Harris,479
-Contra Costa,Antioch101,U.S. Senate,,DEM,Loretta Sanchez,273
-Contra Costa,Antioch102,U.S. Senate,,DEM,Kamala Harris,383
-Contra Costa,Antioch102,U.S. Senate,,DEM,Loretta Sanchez,271
-Contra Costa,Antioch103,U.S. Senate,,DEM,Kamala Harris,342
-Contra Costa,Antioch103,U.S. Senate,,DEM,Loretta Sanchez,246
-Contra Costa,Antioch104,U.S. Senate,,DEM,Kamala Harris,442
-Contra Costa,Antioch104,U.S. Senate,,DEM,Loretta Sanchez,308
-Contra Costa,Antioch105,U.S. Senate,,DEM,Kamala Harris,443
-Contra Costa,Antioch105,U.S. Senate,,DEM,Loretta Sanchez,196
-Contra Costa,Antioch106,U.S. Senate,,DEM,Kamala Harris,397
-Contra Costa,Antioch106,U.S. Senate,,DEM,Loretta Sanchez,191
-Contra Costa,Antioch107,U.S. Senate,,DEM,Kamala Harris,412
-Contra Costa,Antioch107,U.S. Senate,,DEM,Loretta Sanchez,237
-Contra Costa,Antioch108,U.S. Senate,,DEM,Kamala Harris,522
-Contra Costa,Antioch108,U.S. Senate,,DEM,Loretta Sanchez,335
-Contra Costa,Antioch109,U.S. Senate,,DEM,Kamala Harris,514
-Contra Costa,Antioch109,U.S. Senate,,DEM,Loretta Sanchez,234
-Contra Costa,Antioch110,U.S. Senate,,DEM,Kamala Harris,449
-Contra Costa,Antioch110,U.S. Senate,,DEM,Loretta Sanchez,269
-Contra Costa,Antioch111,U.S. Senate,,DEM,Kamala Harris,534
-Contra Costa,Antioch111,U.S. Senate,,DEM,Loretta Sanchez,300
-Contra Costa,Antioch112,U.S. Senate,,DEM,Kamala Harris,317
-Contra Costa,Antioch112,U.S. Senate,,DEM,Loretta Sanchez,199
-Contra Costa,Antioch113,U.S. Senate,,DEM,Kamala Harris,459
-Contra Costa,Antioch113,U.S. Senate,,DEM,Loretta Sanchez,336
-Contra Costa,Antioch114,U.S. Senate,,DEM,Kamala Harris,333
-Contra Costa,Antioch114,U.S. Senate,,DEM,Loretta Sanchez,187
-Contra Costa,Antioch115,U.S. Senate,,DEM,Kamala Harris,376
-Contra Costa,Antioch115,U.S. Senate,,DEM,Loretta Sanchez,270
-Contra Costa,Antioch116,U.S. Senate,,DEM,Kamala Harris,243
-Contra Costa,Antioch116,U.S. Senate,,DEM,Loretta Sanchez,200
-Contra Costa,Antioch117,U.S. Senate,,DEM,Kamala Harris,430
-Contra Costa,Antioch117,U.S. Senate,,DEM,Loretta Sanchez,262
-Contra Costa,Antioch118,U.S. Senate,,DEM,Kamala Harris,289
-Contra Costa,Antioch118,U.S. Senate,,DEM,Loretta Sanchez,215
-Contra Costa,Antioch119,U.S. Senate,,DEM,Kamala Harris,540
-Contra Costa,Antioch119,U.S. Senate,,DEM,Loretta Sanchez,299
-Contra Costa,Antioch120,U.S. Senate,,DEM,Kamala Harris,536
-Contra Costa,Antioch120,U.S. Senate,,DEM,Loretta Sanchez,301
-Contra Costa,Antioch121,U.S. Senate,,DEM,Kamala Harris,407
-Contra Costa,Antioch121,U.S. Senate,,DEM,Loretta Sanchez,221
-Contra Costa,Antioch122,U.S. Senate,,DEM,Kamala Harris,623
-Contra Costa,Antioch122,U.S. Senate,,DEM,Loretta Sanchez,292
-Contra Costa,Antioch123,U.S. Senate,,DEM,Kamala Harris,567
-Contra Costa,Antioch123,U.S. Senate,,DEM,Loretta Sanchez,330
-Contra Costa,Antioch124,U.S. Senate,,DEM,Kamala Harris,532
-Contra Costa,Antioch124,U.S. Senate,,DEM,Loretta Sanchez,229
-Contra Costa,Antioch125,U.S. Senate,,DEM,Kamala Harris,395
-Contra Costa,Antioch125,U.S. Senate,,DEM,Loretta Sanchez,231
-Contra Costa,Antioch126,U.S. Senate,,DEM,Kamala Harris,625
-Contra Costa,Antioch126,U.S. Senate,,DEM,Loretta Sanchez,343
-Contra Costa,Antioch127,U.S. Senate,,DEM,Kamala Harris,441
-Contra Costa,Antioch127,U.S. Senate,,DEM,Loretta Sanchez,238
-Contra Costa,Antioch128,U.S. Senate,,DEM,Kamala Harris,371
-Contra Costa,Antioch128,U.S. Senate,,DEM,Loretta Sanchez,217
-Contra Costa,Antioch129,U.S. Senate,,DEM,Kamala Harris,255
-Contra Costa,Antioch129,U.S. Senate,,DEM,Loretta Sanchez,144
-Contra Costa,Antioch130,U.S. Senate,,DEM,Kamala Harris,325
-Contra Costa,Antioch130,U.S. Senate,,DEM,Loretta Sanchez,206
-Contra Costa,Antioch131,U.S. Senate,,DEM,Kamala Harris,489
-Contra Costa,Antioch131,U.S. Senate,,DEM,Loretta Sanchez,252
-Contra Costa,Antioch132,U.S. Senate,,DEM,Kamala Harris,356
-Contra Costa,Antioch132,U.S. Senate,,DEM,Loretta Sanchez,210
-Contra Costa,Antioch133,U.S. Senate,,DEM,Kamala Harris,476
-Contra Costa,Antioch133,U.S. Senate,,DEM,Loretta Sanchez,238
-Contra Costa,Antioch134,U.S. Senate,,DEM,Kamala Harris,481
-Contra Costa,Antioch134,U.S. Senate,,DEM,Loretta Sanchez,235
-Contra Costa,Antioch135,U.S. Senate,,DEM,Kamala Harris,380
-Contra Costa,Antioch135,U.S. Senate,,DEM,Loretta Sanchez,230
-Contra Costa,Antioch136,U.S. Senate,,DEM,Kamala Harris,719
-Contra Costa,Antioch136,U.S. Senate,,DEM,Loretta Sanchez,325
-Contra Costa,Antioch137,U.S. Senate,,DEM,Kamala Harris,435
-Contra Costa,Antioch137,U.S. Senate,,DEM,Loretta Sanchez,225
-Contra Costa,Antioch138,U.S. Senate,,DEM,Kamala Harris,598
-Contra Costa,Antioch138,U.S. Senate,,DEM,Loretta Sanchez,289
-Contra Costa,Antioch139,U.S. Senate,,DEM,Kamala Harris,479
-Contra Costa,Antioch139,U.S. Senate,,DEM,Loretta Sanchez,239
-Contra Costa,Antioch140,U.S. Senate,,DEM,Kamala Harris,587
-Contra Costa,Antioch140,U.S. Senate,,DEM,Loretta Sanchez,285
-Contra Costa,Antioch141,U.S. Senate,,DEM,Kamala Harris,610
-Contra Costa,Antioch141,U.S. Senate,,DEM,Loretta Sanchez,246
-Contra Costa,Antioch142,U.S. Senate,,DEM,Kamala Harris,371
-Contra Costa,Antioch142,U.S. Senate,,DEM,Loretta Sanchez,131
-Contra Costa,Antioch143,U.S. Senate,,DEM,Kamala Harris,601
-Contra Costa,Antioch143,U.S. Senate,,DEM,Loretta Sanchez,238
-Contra Costa,Antioch144,U.S. Senate,,DEM,Kamala Harris,330
-Contra Costa,Antioch144,U.S. Senate,,DEM,Loretta Sanchez,154
-Contra Costa,Antioch145,U.S. Senate,,DEM,Kamala Harris,364
-Contra Costa,Antioch145,U.S. Senate,,DEM,Loretta Sanchez,199
-Contra Costa,Antioch146,U.S. Senate,,DEM,Kamala Harris,355
-Contra Costa,Antioch146,U.S. Senate,,DEM,Loretta Sanchez,229
-Contra Costa,Antioch147,U.S. Senate,,DEM,Kamala Harris,445
-Contra Costa,Antioch147,U.S. Senate,,DEM,Loretta Sanchez,277
-Contra Costa,Antioch801,U.S. Senate,,DEM,Kamala Harris,1
-Contra Costa,Antioch801,U.S. Senate,,DEM,Loretta Sanchez,2
-Contra Costa,Antioch802,U.S. Senate,,DEM,Kamala Harris,14
-Contra Costa,Antioch802,U.S. Senate,,DEM,Loretta Sanchez,0
-Contra Costa,AyersRanch101,U.S. Senate,,DEM,Kamala Harris,210
-Contra Costa,AyersRanch101,U.S. Senate,,DEM,Loretta Sanchez,150
-Contra Costa,BayPoint101,U.S. Senate,,DEM,Kamala Harris,489
-Contra Costa,BayPoint101,U.S. Senate,,DEM,Loretta Sanchez,357
-Contra Costa,BayPoint102,U.S. Senate,,DEM,Kamala Harris,130
-Contra Costa,BayPoint102,U.S. Senate,,DEM,Loretta Sanchez,96
-Contra Costa,BayPoint103,U.S. Senate,,DEM,Kamala Harris,340
-Contra Costa,BayPoint103,U.S. Senate,,DEM,Loretta Sanchez,273
-Contra Costa,BayPoint104,U.S. Senate,,DEM,Kamala Harris,519
-Contra Costa,BayPoint104,U.S. Senate,,DEM,Loretta Sanchez,362
-Contra Costa,BayPoint105,U.S. Senate,,DEM,Kamala Harris,306
-Contra Costa,BayPoint105,U.S. Senate,,DEM,Loretta Sanchez,402
-Contra Costa,BayPoint106,U.S. Senate,,DEM,Kamala Harris,407
-Contra Costa,BayPoint106,U.S. Senate,,DEM,Loretta Sanchez,284
-Contra Costa,BayPoint107,U.S. Senate,,DEM,Kamala Harris,435
-Contra Costa,BayPoint107,U.S. Senate,,DEM,Loretta Sanchez,270
-Contra Costa,BayPoint801,U.S. Senate,,DEM,Kamala Harris,3
-Contra Costa,BayPoint801,U.S. Senate,,DEM,Loretta Sanchez,0
-Contra Costa,BayPoint802,U.S. Senate,,DEM,Kamala Harris,1
-Contra Costa,BayPoint802,U.S. Senate,,DEM,Loretta Sanchez,1
-Contra Costa,BethelIsland101,U.S. Senate,,DEM,Kamala Harris,521
-Contra Costa,BethelIsland101,U.S. Senate,,DEM,Loretta Sanchez,354
-Contra Costa,BethelIsland801,U.S. Senate,,DEM,Kamala Harris,0
-Contra Costa,BethelIsland801,U.S. Senate,,DEM,Loretta Sanchez,0
-Contra Costa,BlackDiamond801,U.S. Senate,,DEM,Kamala Harris,6
-Contra Costa,BlackDiamond801,U.S. Senate,,DEM,Loretta Sanchez,3
-Contra Costa,BlackDiamond802,U.S. Senate,,DEM,Kamala Harris,86
-Contra Costa,BlackDiamond802,U.S. Senate,,DEM,Loretta Sanchez,75
-Contra Costa,BlackDiamond803,U.S. Senate,,DEM,Kamala Harris,1
-Contra Costa,BlackDiamond803,U.S. Senate,,DEM,Loretta Sanchez,1
-Contra Costa,BlackDiamond804,U.S. Senate,,DEM,Kamala Harris,1
-Contra Costa,BlackDiamond804,U.S. Senate,,DEM,Loretta Sanchez,0
-Contra Costa,BlackHawk101,U.S. Senate,,DEM,Kamala Harris,516
-Contra Costa,BlackHawk101,U.S. Senate,,DEM,Loretta Sanchez,343
-Contra Costa,BlackHawk102,U.S. Senate,,DEM,Kamala Harris,533
-Contra Costa,BlackHawk102,U.S. Senate,,DEM,Loretta Sanchez,263
-Contra Costa,BlackHawk103,U.S. Senate,,DEM,Kamala Harris,379
-Contra Costa,BlackHawk103,U.S. Senate,,DEM,Loretta Sanchez,207
-Contra Costa,BlackHawk104,U.S. Senate,,DEM,Kamala Harris,984
-Contra Costa,BlackHawk104,U.S. Senate,,DEM,Loretta Sanchez,347
-Contra Costa,BlackHawk105,U.S. Senate,,DEM,Kamala Harris,317
-Contra Costa,BlackHawk105,U.S. Senate,,DEM,Loretta Sanchez,214
-Contra Costa,BlackHawk106,U.S. Senate,,DEM,Kamala Harris,517
-Contra Costa,BlackHawk106,U.S. Senate,,DEM,Loretta Sanchez,222
-Contra Costa,BlackHawk107,U.S. Senate,,DEM,Kamala Harris,538
-Contra Costa,BlackHawk107,U.S. Senate,,DEM,Loretta Sanchez,222
-Contra Costa,Brentwood101,U.S. Senate,,DEM,Kamala Harris,710
-Contra Costa,Brentwood101,U.S. Senate,,DEM,Loretta Sanchez,464
-Contra Costa,Brentwood102,U.S. Senate,,DEM,Kamala Harris,327
-Contra Costa,Brentwood102,U.S. Senate,,DEM,Loretta Sanchez,178
-Contra Costa,Brentwood103,U.S. Senate,,DEM,Kamala Harris,522
-Contra Costa,Brentwood103,U.S. Senate,,DEM,Loretta Sanchez,302
-Contra Costa,Brentwood104,U.S. Senate,,DEM,Kamala Harris,294
-Contra Costa,Brentwood104,U.S. Senate,,DEM,Loretta Sanchez,191
-Contra Costa,Brentwood105,U.S. Senate,,DEM,Kamala Harris,151
-Contra Costa,Brentwood105,U.S. Senate,,DEM,Loretta Sanchez,182
-Contra Costa,Brentwood106,U.S. Senate,,DEM,Kamala Harris,627
-Contra Costa,Brentwood106,U.S. Senate,,DEM,Loretta Sanchez,339
-Contra Costa,Brentwood107,U.S. Senate,,DEM,Kamala Harris,482
-Contra Costa,Brentwood107,U.S. Senate,,DEM,Loretta Sanchez,393
-Contra Costa,Brentwood108,U.S. Senate,,DEM,Kamala Harris,377
-Contra Costa,Brentwood108,U.S. Senate,,DEM,Loretta Sanchez,284
-Contra Costa,Brentwood109,U.S. Senate,,DEM,Kamala Harris,493
-Contra Costa,Brentwood109,U.S. Senate,,DEM,Loretta Sanchez,299
-Contra Costa,Brentwood110,U.S. Senate,,DEM,Kamala Harris,449
-Contra Costa,Brentwood110,U.S. Senate,,DEM,Loretta Sanchez,266
-Contra Costa,Brentwood111,U.S. Senate,,DEM,Kamala Harris,473
-Contra Costa,Brentwood111,U.S. Senate,,DEM,Loretta Sanchez,335
-Contra Costa,Brentwood112,U.S. Senate,,DEM,Kamala Harris,617
-Contra Costa,Brentwood112,U.S. Senate,,DEM,Loretta Sanchez,437
-Contra Costa,Brentwood113,U.S. Senate,,DEM,Kamala Harris,600
-Contra Costa,Brentwood113,U.S. Senate,,DEM,Loretta Sanchez,370
-Contra Costa,Brentwood114,U.S. Senate,,DEM,Kamala Harris,275
-Contra Costa,Brentwood114,U.S. Senate,,DEM,Loretta Sanchez,170
-Contra Costa,Brentwood115,U.S. Senate,,DEM,Kamala Harris,333
-Contra Costa,Brentwood115,U.S. Senate,,DEM,Loretta Sanchez,172
-Contra Costa,Brentwood116,U.S. Senate,,DEM,Kamala Harris,689
-Contra Costa,Brentwood116,U.S. Senate,,DEM,Loretta Sanchez,363
-Contra Costa,Brentwood117,U.S. Senate,,DEM,Kamala Harris,188
-Contra Costa,Brentwood117,U.S. Senate,,DEM,Loretta Sanchez,139
-Contra Costa,Brentwood118,U.S. Senate,,DEM,Kamala Harris,412
-Contra Costa,Brentwood118,U.S. Senate,,DEM,Loretta Sanchez,284
-Contra Costa,Brentwood119,U.S. Senate,,DEM,Kamala Harris,447
-Contra Costa,Brentwood119,U.S. Senate,,DEM,Loretta Sanchez,339
-Contra Costa,Brentwood120,U.S. Senate,,DEM,Kamala Harris,608
-Contra Costa,Brentwood120,U.S. Senate,,DEM,Loretta Sanchez,398
-Contra Costa,Brentwood121,U.S. Senate,,DEM,Kamala Harris,268
-Contra Costa,Brentwood121,U.S. Senate,,DEM,Loretta Sanchez,112
-Contra Costa,Brentwood122,U.S. Senate,,DEM,Kamala Harris,324
-Contra Costa,Brentwood122,U.S. Senate,,DEM,Loretta Sanchez,206
-Contra Costa,Brentwood123,U.S. Senate,,DEM,Kamala Harris,394
-Contra Costa,Brentwood123,U.S. Senate,,DEM,Loretta Sanchez,240
-Contra Costa,Brentwood124,U.S. Senate,,DEM,Kamala Harris,502
-Contra Costa,Brentwood124,U.S. Senate,,DEM,Loretta Sanchez,346
-Contra Costa,Brentwood125,U.S. Senate,,DEM,Kamala Harris,85
-Contra Costa,Brentwood125,U.S. Senate,,DEM,Loretta Sanchez,63
-Contra Costa,Brentwood126,U.S. Senate,,DEM,Kamala Harris,422
-Contra Costa,Brentwood126,U.S. Senate,,DEM,Loretta Sanchez,224
-Contra Costa,Brentwood127,U.S. Senate,,DEM,Kamala Harris,772
-Contra Costa,Brentwood127,U.S. Senate,,DEM,Loretta Sanchez,375
-Contra Costa,Brentwood128,U.S. Senate,,DEM,Kamala Harris,622
-Contra Costa,Brentwood128,U.S. Senate,,DEM,Loretta Sanchez,206
-Contra Costa,Brentwood801,U.S. Senate,,DEM,Kamala Harris,3
-Contra Costa,Brentwood801,U.S. Senate,,DEM,Loretta Sanchez,1
-Contra Costa,Brentwood802,U.S. Senate,,DEM,Kamala Harris,36
-Contra Costa,Brentwood802,U.S. Senate,,DEM,Loretta Sanchez,27
-Contra Costa,BrionesHills101,U.S. Senate,,DEM,Kamala Harris,328
-Contra Costa,BrionesHills101,U.S. Senate,,DEM,Loretta Sanchez,159
-Contra Costa,BrionesHills102,U.S. Senate,,DEM,Kamala Harris,398
-Contra Costa,BrionesHills102,U.S. Senate,,DEM,Loretta Sanchez,115
-Contra Costa,BrionesHills103,U.S. Senate,,DEM,Kamala Harris,518
-Contra Costa,BrionesHills103,U.S. Senate,,DEM,Loretta Sanchez,174
-Contra Costa,BrionesHills801,U.S. Senate,,DEM,Kamala Harris,2
-Contra Costa,BrionesHills801,U.S. Senate,,DEM,Loretta Sanchez,0
-Contra Costa,BrionesValley101,U.S. Senate,,DEM,Kamala Harris,166
-Contra Costa,BrionesValley101,U.S. Senate,,DEM,Loretta Sanchez,104
-Contra Costa,BrionesValley801,U.S. Senate,,DEM,Kamala Harris,95
-Contra Costa,BrionesValley801,U.S. Senate,,DEM,Loretta Sanchez,47
-Contra Costa,Byron101,U.S. Senate,,DEM,Kamala Harris,147
-Contra Costa,Byron101,U.S. Senate,,DEM,Loretta Sanchez,140
-Contra Costa,Byron801,U.S. Senate,,DEM,Kamala Harris,43
-Contra Costa,Byron801,U.S. Senate,,DEM,Loretta Sanchez,54
-Contra Costa,Byron802,U.S. Senate,,DEM,Kamala Harris,19
-Contra Costa,Byron802,U.S. Senate,,DEM,Loretta Sanchez,16
-Contra Costa,Byron803,U.S. Senate,,DEM,Kamala Harris,1
-Contra Costa,Byron803,U.S. Senate,,DEM,Loretta Sanchez,0
-Contra Costa,Caldecott801,U.S. Senate,,DEM,Kamala Harris,9
-Contra Costa,Caldecott801,U.S. Senate,,DEM,Loretta Sanchez,1
-Contra Costa,Canyon801,U.S. Senate,,DEM,Kamala Harris,123
-Contra Costa,Canyon801,U.S. Senate,,DEM,Loretta Sanchez,29
-Contra Costa,CastleRock101,U.S. Senate,,DEM,Kamala Harris,217
-Contra Costa,CastleRock101,U.S. Senate,,DEM,Loretta Sanchez,111
-Contra Costa,Clayton101,U.S. Senate,,DEM,Kamala Harris,562
-Contra Costa,Clayton101,U.S. Senate,,DEM,Loretta Sanchez,254
-Contra Costa,Clayton102,U.S. Senate,,DEM,Kamala Harris,551
-Contra Costa,Clayton102,U.S. Senate,,DEM,Loretta Sanchez,311
-Contra Costa,Clayton103,U.S. Senate,,DEM,Kamala Harris,359
-Contra Costa,Clayton103,U.S. Senate,,DEM,Loretta Sanchez,168
-Contra Costa,Clayton104,U.S. Senate,,DEM,Kamala Harris,437
-Contra Costa,Clayton104,U.S. Senate,,DEM,Loretta Sanchez,237
-Contra Costa,Clayton105,U.S. Senate,,DEM,Kamala Harris,648
-Contra Costa,Clayton105,U.S. Senate,,DEM,Loretta Sanchez,308
-Contra Costa,Clayton106,U.S. Senate,,DEM,Kamala Harris,390
-Contra Costa,Clayton106,U.S. Senate,,DEM,Loretta Sanchez,206
-Contra Costa,Clayton107,U.S. Senate,,DEM,Kamala Harris,655
-Contra Costa,Clayton107,U.S. Senate,,DEM,Loretta Sanchez,295
-Contra Costa,Clyde101,U.S. Senate,,DEM,Kamala Harris,213
-Contra Costa,Clyde101,U.S. Senate,,DEM,Loretta Sanchez,82
-Contra Costa,Concord101,U.S. Senate,,DEM,Kamala Harris,255
-Contra Costa,Concord101,U.S. Senate,,DEM,Loretta Sanchez,166
-Contra Costa,Concord102,U.S. Senate,,DEM,Kamala Harris,388
-Contra Costa,Concord102,U.S. Senate,,DEM,Loretta Sanchez,220
-Contra Costa,Concord103,U.S. Senate,,DEM,Kamala Harris,462
-Contra Costa,Concord103,U.S. Senate,,DEM,Loretta Sanchez,217
-Contra Costa,Concord104,U.S. Senate,,DEM,Kamala Harris,401
-Contra Costa,Concord104,U.S. Senate,,DEM,Loretta Sanchez,208
-Contra Costa,Concord105,U.S. Senate,,DEM,Kamala Harris,422
-Contra Costa,Concord105,U.S. Senate,,DEM,Loretta Sanchez,256
-Contra Costa,Concord106,U.S. Senate,,DEM,Kamala Harris,442
-Contra Costa,Concord106,U.S. Senate,,DEM,Loretta Sanchez,227
-Contra Costa,Concord107,U.S. Senate,,DEM,Kamala Harris,517
-Contra Costa,Concord107,U.S. Senate,,DEM,Loretta Sanchez,313
-Contra Costa,Concord108,U.S. Senate,,DEM,Kamala Harris,418
-Contra Costa,Concord108,U.S. Senate,,DEM,Loretta Sanchez,204
-Contra Costa,Concord109,U.S. Senate,,DEM,Kamala Harris,476
-Contra Costa,Concord109,U.S. Senate,,DEM,Loretta Sanchez,216
-Contra Costa,Concord110,U.S. Senate,,DEM,Kamala Harris,408
-Contra Costa,Concord110,U.S. Senate,,DEM,Loretta Sanchez,187
-Contra Costa,Concord111,U.S. Senate,,DEM,Kamala Harris,451
-Contra Costa,Concord111,U.S. Senate,,DEM,Loretta Sanchez,204
-Contra Costa,Concord112,U.S. Senate,,DEM,Kamala Harris,455
-Contra Costa,Concord112,U.S. Senate,,DEM,Loretta Sanchez,216
-Contra Costa,Concord113,U.S. Senate,,DEM,Kamala Harris,476
-Contra Costa,Concord113,U.S. Senate,,DEM,Loretta Sanchez,221
-Contra Costa,Concord114,U.S. Senate,,DEM,Kamala Harris,400
-Contra Costa,Concord114,U.S. Senate,,DEM,Loretta Sanchez,166
-Contra Costa,Concord115,U.S. Senate,,DEM,Kamala Harris,678
-Contra Costa,Concord115,U.S. Senate,,DEM,Loretta Sanchez,305
-Contra Costa,Concord116,U.S. Senate,,DEM,Kamala Harris,538
-Contra Costa,Concord116,U.S. Senate,,DEM,Loretta Sanchez,288
-Contra Costa,Concord117,U.S. Senate,,DEM,Kamala Harris,428
-Contra Costa,Concord117,U.S. Senate,,DEM,Loretta Sanchez,284
-Contra Costa,Concord118,U.S. Senate,,DEM,Kamala Harris,599
-Contra Costa,Concord118,U.S. Senate,,DEM,Loretta Sanchez,362
-Contra Costa,Concord119,U.S. Senate,,DEM,Kamala Harris,452
-Contra Costa,Concord119,U.S. Senate,,DEM,Loretta Sanchez,226
-Contra Costa,Concord120,U.S. Senate,,DEM,Kamala Harris,489
-Contra Costa,Concord120,U.S. Senate,,DEM,Loretta Sanchez,242
-Contra Costa,Concord121,U.S. Senate,,DEM,Kamala Harris,459
-Contra Costa,Concord121,U.S. Senate,,DEM,Loretta Sanchez,212
-Contra Costa,Concord122,U.S. Senate,,DEM,Kamala Harris,391
-Contra Costa,Concord122,U.S. Senate,,DEM,Loretta Sanchez,156
-Contra Costa,Concord123,U.S. Senate,,DEM,Kamala Harris,519
-Contra Costa,Concord123,U.S. Senate,,DEM,Loretta Sanchez,246
-Contra Costa,Concord124,U.S. Senate,,DEM,Kamala Harris,523
-Contra Costa,Concord124,U.S. Senate,,DEM,Loretta Sanchez,232
-Contra Costa,Concord125,U.S. Senate,,DEM,Kamala Harris,447
-Contra Costa,Concord125,U.S. Senate,,DEM,Loretta Sanchez,206
-Contra Costa,Concord126,U.S. Senate,,DEM,Kamala Harris,609
-Contra Costa,Concord126,U.S. Senate,,DEM,Loretta Sanchez,330
-Contra Costa,Concord127,U.S. Senate,,DEM,Kamala Harris,295
-Contra Costa,Concord127,U.S. Senate,,DEM,Loretta Sanchez,136
-Contra Costa,Concord128,U.S. Senate,,DEM,Kamala Harris,580
-Contra Costa,Concord128,U.S. Senate,,DEM,Loretta Sanchez,251
-Contra Costa,Concord129,U.S. Senate,,DEM,Kamala Harris,402
-Contra Costa,Concord129,U.S. Senate,,DEM,Loretta Sanchez,202
-Contra Costa,Concord130,U.S. Senate,,DEM,Kamala Harris,268
-Contra Costa,Concord130,U.S. Senate,,DEM,Loretta Sanchez,126
-Contra Costa,Concord131,U.S. Senate,,DEM,Kamala Harris,382
-Contra Costa,Concord131,U.S. Senate,,DEM,Loretta Sanchez,163
-Contra Costa,Concord132,U.S. Senate,,DEM,Kamala Harris,372
-Contra Costa,Concord132,U.S. Senate,,DEM,Loretta Sanchez,141
-Contra Costa,Concord133,U.S. Senate,,DEM,Kamala Harris,449
-Contra Costa,Concord133,U.S. Senate,,DEM,Loretta Sanchez,215
-Contra Costa,Concord134,U.S. Senate,,DEM,Kamala Harris,457
-Contra Costa,Concord134,U.S. Senate,,DEM,Loretta Sanchez,231
-Contra Costa,Concord135,U.S. Senate,,DEM,Kamala Harris,422
-Contra Costa,Concord135,U.S. Senate,,DEM,Loretta Sanchez,250
-Contra Costa,Concord136,U.S. Senate,,DEM,Kamala Harris,701
-Contra Costa,Concord136,U.S. Senate,,DEM,Loretta Sanchez,351
-Contra Costa,Concord137,U.S. Senate,,DEM,Kamala Harris,363
-Contra Costa,Concord137,U.S. Senate,,DEM,Loretta Sanchez,165
-Contra Costa,Concord138,U.S. Senate,,DEM,Kamala Harris,490
-Contra Costa,Concord138,U.S. Senate,,DEM,Loretta Sanchez,217
-Contra Costa,Concord139,U.S. Senate,,DEM,Kamala Harris,406
-Contra Costa,Concord139,U.S. Senate,,DEM,Loretta Sanchez,214
-Contra Costa,Concord140,U.S. Senate,,DEM,Kamala Harris,371
-Contra Costa,Concord140,U.S. Senate,,DEM,Loretta Sanchez,145
-Contra Costa,Concord141,U.S. Senate,,DEM,Kamala Harris,359
-Contra Costa,Concord141,U.S. Senate,,DEM,Loretta Sanchez,207
-Contra Costa,Concord142,U.S. Senate,,DEM,Kamala Harris,372
-Contra Costa,Concord142,U.S. Senate,,DEM,Loretta Sanchez,158
-Contra Costa,Concord143,U.S. Senate,,DEM,Kamala Harris,646
-Contra Costa,Concord143,U.S. Senate,,DEM,Loretta Sanchez,232
-Contra Costa,Concord144,U.S. Senate,,DEM,Kamala Harris,612
-Contra Costa,Concord144,U.S. Senate,,DEM,Loretta Sanchez,217
-Contra Costa,Concord145,U.S. Senate,,DEM,Kamala Harris,372
-Contra Costa,Concord145,U.S. Senate,,DEM,Loretta Sanchez,281
-Contra Costa,Concord146,U.S. Senate,,DEM,Kamala Harris,336
-Contra Costa,Concord146,U.S. Senate,,DEM,Loretta Sanchez,239
-Contra Costa,Concord147,U.S. Senate,,DEM,Kamala Harris,460
-Contra Costa,Concord147,U.S. Senate,,DEM,Loretta Sanchez,223
-Contra Costa,Concord148,U.S. Senate,,DEM,Kamala Harris,602
-Contra Costa,Concord148,U.S. Senate,,DEM,Loretta Sanchez,284
-Contra Costa,Concord149,U.S. Senate,,DEM,Kamala Harris,458
-Contra Costa,Concord149,U.S. Senate,,DEM,Loretta Sanchez,198
-Contra Costa,Concord150,U.S. Senate,,DEM,Kamala Harris,510
-Contra Costa,Concord150,U.S. Senate,,DEM,Loretta Sanchez,214
-Contra Costa,Concord151,U.S. Senate,,DEM,Kamala Harris,226
-Contra Costa,Concord151,U.S. Senate,,DEM,Loretta Sanchez,106
-Contra Costa,Concord152,U.S. Senate,,DEM,Kamala Harris,446
-Contra Costa,Concord152,U.S. Senate,,DEM,Loretta Sanchez,208
-Contra Costa,Concord153,U.S. Senate,,DEM,Kamala Harris,487
-Contra Costa,Concord153,U.S. Senate,,DEM,Loretta Sanchez,177
-Contra Costa,Concord154,U.S. Senate,,DEM,Kamala Harris,324
-Contra Costa,Concord154,U.S. Senate,,DEM,Loretta Sanchez,142
-Contra Costa,Concord155,U.S. Senate,,DEM,Kamala Harris,356
-Contra Costa,Concord155,U.S. Senate,,DEM,Loretta Sanchez,176
-Contra Costa,Concord156,U.S. Senate,,DEM,Kamala Harris,407
-Contra Costa,Concord156,U.S. Senate,,DEM,Loretta Sanchez,223
-Contra Costa,Concord157,U.S. Senate,,DEM,Kamala Harris,400
-Contra Costa,Concord157,U.S. Senate,,DEM,Loretta Sanchez,178
-Contra Costa,Concord158,U.S. Senate,,DEM,Kamala Harris,458
-Contra Costa,Concord158,U.S. Senate,,DEM,Loretta Sanchez,214
-Contra Costa,Concord159,U.S. Senate,,DEM,Kamala Harris,545
-Contra Costa,Concord159,U.S. Senate,,DEM,Loretta Sanchez,211
-Contra Costa,Concord160,U.S. Senate,,DEM,Kamala Harris,373
-Contra Costa,Concord160,U.S. Senate,,DEM,Loretta Sanchez,193
-Contra Costa,Concord161,U.S. Senate,,DEM,Kamala Harris,456
-Contra Costa,Concord161,U.S. Senate,,DEM,Loretta Sanchez,188
-Contra Costa,Concord163,U.S. Senate,,DEM,Kamala Harris,635
-Contra Costa,Concord163,U.S. Senate,,DEM,Loretta Sanchez,375
-Contra Costa,Concord164,U.S. Senate,,DEM,Kamala Harris,465
-Contra Costa,Concord164,U.S. Senate,,DEM,Loretta Sanchez,227
-Contra Costa,Concord801,U.S. Senate,,DEM,Kamala Harris,12
-Contra Costa,Concord801,U.S. Senate,,DEM,Loretta Sanchez,1
-Contra Costa,Concord802,U.S. Senate,,DEM,Kamala Harris,2
-Contra Costa,Concord802,U.S. Senate,,DEM,Loretta Sanchez,4
-Contra Costa,Concord803,U.S. Senate,,DEM,Kamala Harris,0
-Contra Costa,Concord803,U.S. Senate,,DEM,Loretta Sanchez,0
-Contra Costa,Crockett101,U.S. Senate,,DEM,Kamala Harris,752
-Contra Costa,Crockett101,U.S. Senate,,DEM,Loretta Sanchez,238
-Contra Costa,Crockett102,U.S. Senate,,DEM,Kamala Harris,369
-Contra Costa,Crockett102,U.S. Senate,,DEM,Loretta Sanchez,164
-Contra Costa,Crockett801,U.S. Senate,,DEM,Kamala Harris,0
-Contra Costa,Crockett801,U.S. Senate,,DEM,Loretta Sanchez,1
-Contra Costa,Danville101,U.S. Senate,,DEM,Kamala Harris,328
-Contra Costa,Danville101,U.S. Senate,,DEM,Loretta Sanchez,177
-Contra Costa,Danville102,U.S. Senate,,DEM,Kamala Harris,257
-Contra Costa,Danville102,U.S. Senate,,DEM,Loretta Sanchez,140
-Contra Costa,Danville103,U.S. Senate,,DEM,Kamala Harris,482
-Contra Costa,Danville103,U.S. Senate,,DEM,Loretta Sanchez,214
-Contra Costa,Danville104,U.S. Senate,,DEM,Kamala Harris,649
-Contra Costa,Danville104,U.S. Senate,,DEM,Loretta Sanchez,236
-Contra Costa,Danville105,U.S. Senate,,DEM,Kamala Harris,619
-Contra Costa,Danville105,U.S. Senate,,DEM,Loretta Sanchez,294
-Contra Costa,Danville106,U.S. Senate,,DEM,Kamala Harris,529
-Contra Costa,Danville106,U.S. Senate,,DEM,Loretta Sanchez,248
-Contra Costa,Danville107,U.S. Senate,,DEM,Kamala Harris,710
-Contra Costa,Danville107,U.S. Senate,,DEM,Loretta Sanchez,294
-Contra Costa,Danville108,U.S. Senate,,DEM,Kamala Harris,607
-Contra Costa,Danville108,U.S. Senate,,DEM,Loretta Sanchez,301
-Contra Costa,Danville109,U.S. Senate,,DEM,Kamala Harris,388
-Contra Costa,Danville109,U.S. Senate,,DEM,Loretta Sanchez,155
-Contra Costa,Danville110,U.S. Senate,,DEM,Kamala Harris,241
-Contra Costa,Danville110,U.S. Senate,,DEM,Loretta Sanchez,106
-Contra Costa,Danville111,U.S. Senate,,DEM,Kamala Harris,329
-Contra Costa,Danville111,U.S. Senate,,DEM,Loretta Sanchez,124
-Contra Costa,Danville112,U.S. Senate,,DEM,Kamala Harris,528
-Contra Costa,Danville112,U.S. Senate,,DEM,Loretta Sanchez,252
-Contra Costa,Danville113,U.S. Senate,,DEM,Kamala Harris,418
-Contra Costa,Danville113,U.S. Senate,,DEM,Loretta Sanchez,163
-Contra Costa,Danville114,U.S. Senate,,DEM,Kamala Harris,542
-Contra Costa,Danville114,U.S. Senate,,DEM,Loretta Sanchez,264
-Contra Costa,Danville115,U.S. Senate,,DEM,Kamala Harris,420
-Contra Costa,Danville115,U.S. Senate,,DEM,Loretta Sanchez,176
-Contra Costa,Danville116,U.S. Senate,,DEM,Kamala Harris,303
-Contra Costa,Danville116,U.S. Senate,,DEM,Loretta Sanchez,156
-Contra Costa,Danville117,U.S. Senate,,DEM,Kamala Harris,498
-Contra Costa,Danville117,U.S. Senate,,DEM,Loretta Sanchez,228
-Contra Costa,Danville118,U.S. Senate,,DEM,Kamala Harris,502
-Contra Costa,Danville118,U.S. Senate,,DEM,Loretta Sanchez,189
-Contra Costa,Danville119,U.S. Senate,,DEM,Kamala Harris,741
-Contra Costa,Danville119,U.S. Senate,,DEM,Loretta Sanchez,293
-Contra Costa,Danville120,U.S. Senate,,DEM,Kamala Harris,635
-Contra Costa,Danville120,U.S. Senate,,DEM,Loretta Sanchez,246
-Contra Costa,Danville121,U.S. Senate,,DEM,Kamala Harris,312
-Contra Costa,Danville121,U.S. Senate,,DEM,Loretta Sanchez,145
-Contra Costa,Danville122,U.S. Senate,,DEM,Kamala Harris,407
-Contra Costa,Danville122,U.S. Senate,,DEM,Loretta Sanchez,167
-Contra Costa,Danville123,U.S. Senate,,DEM,Kamala Harris,431
-Contra Costa,Danville123,U.S. Senate,,DEM,Loretta Sanchez,180
-Contra Costa,Danville124,U.S. Senate,,DEM,Kamala Harris,337
-Contra Costa,Danville124,U.S. Senate,,DEM,Loretta Sanchez,129
-Contra Costa,Danville125,U.S. Senate,,DEM,Kamala Harris,234
-Contra Costa,Danville125,U.S. Senate,,DEM,Loretta Sanchez,98
-Contra Costa,Danville126,U.S. Senate,,DEM,Kamala Harris,709
-Contra Costa,Danville126,U.S. Senate,,DEM,Loretta Sanchez,309
-Contra Costa,Danville127,U.S. Senate,,DEM,Kamala Harris,431
-Contra Costa,Danville127,U.S. Senate,,DEM,Loretta Sanchez,202
-Contra Costa,Danville128,U.S. Senate,,DEM,Kamala Harris,320
-Contra Costa,Danville128,U.S. Senate,,DEM,Loretta Sanchez,142
-Contra Costa,Danville129,U.S. Senate,,DEM,Kamala Harris,537
-Contra Costa,Danville129,U.S. Senate,,DEM,Loretta Sanchez,238
-Contra Costa,Danville130,U.S. Senate,,DEM,Kamala Harris,407
-Contra Costa,Danville130,U.S. Senate,,DEM,Loretta Sanchez,156
-Contra Costa,Diablo101,U.S. Senate,,DEM,Kamala Harris,345
-Contra Costa,Diablo101,U.S. Senate,,DEM,Loretta Sanchez,195
-Contra Costa,DiscoveryBay101,U.S. Senate,,DEM,Kamala Harris,518
-Contra Costa,DiscoveryBay101,U.S. Senate,,DEM,Loretta Sanchez,274
-Contra Costa,DiscoveryBay102,U.S. Senate,,DEM,Kamala Harris,581
-Contra Costa,DiscoveryBay102,U.S. Senate,,DEM,Loretta Sanchez,347
-Contra Costa,DiscoveryBay103,U.S. Senate,,DEM,Kamala Harris,270
-Contra Costa,DiscoveryBay103,U.S. Senate,,DEM,Loretta Sanchez,176
-Contra Costa,DiscoveryBay104,U.S. Senate,,DEM,Kamala Harris,462
-Contra Costa,DiscoveryBay104,U.S. Senate,,DEM,Loretta Sanchez,299
-Contra Costa,DiscoveryBay105,U.S. Senate,,DEM,Kamala Harris,203
-Contra Costa,DiscoveryBay105,U.S. Senate,,DEM,Loretta Sanchez,142
-Contra Costa,DiscoveryBay106,U.S. Senate,,DEM,Kamala Harris,590
-Contra Costa,DiscoveryBay106,U.S. Senate,,DEM,Loretta Sanchez,398
-Contra Costa,DiscoveryBay107,U.S. Senate,,DEM,Kamala Harris,408
-Contra Costa,DiscoveryBay107,U.S. Senate,,DEM,Loretta Sanchez,239
-Contra Costa,DiscoveryBay801,U.S. Senate,,DEM,Kamala Harris,54
-Contra Costa,DiscoveryBay801,U.S. Senate,,DEM,Loretta Sanchez,58
-Contra Costa,EastRichmond101,U.S. Senate,,DEM,Kamala Harris,746
-Contra Costa,EastRichmond101,U.S. Senate,,DEM,Loretta Sanchez,197
-Contra Costa,EastRichmond102,U.S. Senate,,DEM,Kamala Harris,809
-Contra Costa,EastRichmond102,U.S. Senate,,DEM,Loretta Sanchez,152
-Contra Costa,EastRichmond103,U.S. Senate,,DEM,Kamala Harris,309
-Contra Costa,EastRichmond103,U.S. Senate,,DEM,Loretta Sanchez,95
-Contra Costa,EastRichmond801,U.S. Senate,,DEM,Kamala Harris,34
-Contra Costa,EastRichmond801,U.S. Senate,,DEM,Loretta Sanchez,5
-Contra Costa,ElCerrito101,U.S. Senate,,DEM,Kamala Harris,883
-Contra Costa,ElCerrito101,U.S. Senate,,DEM,Loretta Sanchez,191
-Contra Costa,ElCerrito102,U.S. Senate,,DEM,Kamala Harris,861
-Contra Costa,ElCerrito102,U.S. Senate,,DEM,Loretta Sanchez,177
-Contra Costa,ElCerrito103,U.S. Senate,,DEM,Kamala Harris,557
-Contra Costa,ElCerrito103,U.S. Senate,,DEM,Loretta Sanchez,177
-Contra Costa,ElCerrito104,U.S. Senate,,DEM,Kamala Harris,800
-Contra Costa,ElCerrito104,U.S. Senate,,DEM,Loretta Sanchez,223
-Contra Costa,ElCerrito105,U.S. Senate,,DEM,Kamala Harris,646
-Contra Costa,ElCerrito105,U.S. Senate,,DEM,Loretta Sanchez,162
-Contra Costa,ElCerrito106,U.S. Senate,,DEM,Kamala Harris,1010
-Contra Costa,ElCerrito106,U.S. Senate,,DEM,Loretta Sanchez,245
-Contra Costa,ElCerrito107,U.S. Senate,,DEM,Kamala Harris,510
-Contra Costa,ElCerrito107,U.S. Senate,,DEM,Loretta Sanchez,134
-Contra Costa,ElCerrito108,U.S. Senate,,DEM,Kamala Harris,617
-Contra Costa,ElCerrito108,U.S. Senate,,DEM,Loretta Sanchez,132
-Contra Costa,ElCerrito109,U.S. Senate,,DEM,Kamala Harris,780
-Contra Costa,ElCerrito109,U.S. Senate,,DEM,Loretta Sanchez,192
-Contra Costa,ElCerrito110,U.S. Senate,,DEM,Kamala Harris,800
-Contra Costa,ElCerrito110,U.S. Senate,,DEM,Loretta Sanchez,158
-Contra Costa,ElCerrito111,U.S. Senate,,DEM,Kamala Harris,653
-Contra Costa,ElCerrito111,U.S. Senate,,DEM,Loretta Sanchez,130
-Contra Costa,ElCerrito112,U.S. Senate,,DEM,Kamala Harris,969
-Contra Costa,ElCerrito112,U.S. Senate,,DEM,Loretta Sanchez,266
-Contra Costa,ElCerrito113,U.S. Senate,,DEM,Kamala Harris,952
-Contra Costa,ElCerrito113,U.S. Senate,,DEM,Loretta Sanchez,178
-Contra Costa,ElSobrante101,U.S. Senate,,DEM,Kamala Harris,539
-Contra Costa,ElSobrante101,U.S. Senate,,DEM,Loretta Sanchez,235
-Contra Costa,ElSobrante102,U.S. Senate,,DEM,Kamala Harris,640
-Contra Costa,ElSobrante102,U.S. Senate,,DEM,Loretta Sanchez,214
-Contra Costa,ElSobrante103,U.S. Senate,,DEM,Kamala Harris,455
-Contra Costa,ElSobrante103,U.S. Senate,,DEM,Loretta Sanchez,209
-Contra Costa,ElSobrante104,U.S. Senate,,DEM,Kamala Harris,733
-Contra Costa,ElSobrante104,U.S. Senate,,DEM,Loretta Sanchez,305
-Contra Costa,ElSobrante105,U.S. Senate,,DEM,Kamala Harris,551
-Contra Costa,ElSobrante105,U.S. Senate,,DEM,Loretta Sanchez,279
-Contra Costa,ElSobrante106,U.S. Senate,,DEM,Kamala Harris,507
-Contra Costa,ElSobrante106,U.S. Senate,,DEM,Loretta Sanchez,226
-Contra Costa,ElSobrante801,U.S. Senate,,DEM,Kamala Harris,2
-Contra Costa,ElSobrante801,U.S. Senate,,DEM,Loretta Sanchez,0
-Contra Costa,ElSobrante802,U.S. Senate,,DEM,Kamala Harris,105
-Contra Costa,ElSobrante802,U.S. Senate,,DEM,Loretta Sanchez,35
-Contra Costa,ElSobrante803,U.S. Senate,,DEM,Kamala Harris,7
-Contra Costa,ElSobrante803,U.S. Senate,,DEM,Loretta Sanchez,7
-Contra Costa,Fairgrounds801,U.S. Senate,,DEM,Kamala Harris,0
-Contra Costa,Fairgrounds801,U.S. Senate,,DEM,Loretta Sanchez,0
-Contra Costa,Giant101,U.S. Senate,,DEM,Kamala Harris,246
-Contra Costa,Giant101,U.S. Senate,,DEM,Loretta Sanchez,300
-Contra Costa,Giant102,U.S. Senate,,DEM,Kamala Harris,560
-Contra Costa,Giant102,U.S. Senate,,DEM,Loretta Sanchez,347
-Contra Costa,Giant103,U.S. Senate,,DEM,Kamala Harris,485
-Contra Costa,Giant103,U.S. Senate,,DEM,Loretta Sanchez,319
-Contra Costa,Giant104,U.S. Senate,,DEM,Kamala Harris,562
-Contra Costa,Giant104,U.S. Senate,,DEM,Loretta Sanchez,297
-Contra Costa,Hercules101,U.S. Senate,,DEM,Kamala Harris,707
-Contra Costa,Hercules101,U.S. Senate,,DEM,Loretta Sanchez,243
-Contra Costa,Hercules102,U.S. Senate,,DEM,Kamala Harris,653
-Contra Costa,Hercules102,U.S. Senate,,DEM,Loretta Sanchez,248
-Contra Costa,Hercules103,U.S. Senate,,DEM,Kamala Harris,362
-Contra Costa,Hercules103,U.S. Senate,,DEM,Loretta Sanchez,130
-Contra Costa,Hercules104,U.S. Senate,,DEM,Kamala Harris,542
-Contra Costa,Hercules104,U.S. Senate,,DEM,Loretta Sanchez,222
-Contra Costa,Hercules105,U.S. Senate,,DEM,Kamala Harris,326
-Contra Costa,Hercules105,U.S. Senate,,DEM,Loretta Sanchez,129
-Contra Costa,Hercules106,U.S. Senate,,DEM,Kamala Harris,472
-Contra Costa,Hercules106,U.S. Senate,,DEM,Loretta Sanchez,211
-Contra Costa,Hercules107,U.S. Senate,,DEM,Kamala Harris,613
-Contra Costa,Hercules107,U.S. Senate,,DEM,Loretta Sanchez,215
-Contra Costa,Hercules108,U.S. Senate,,DEM,Kamala Harris,508
-Contra Costa,Hercules108,U.S. Senate,,DEM,Loretta Sanchez,194
-Contra Costa,Hercules109,U.S. Senate,,DEM,Kamala Harris,648
-Contra Costa,Hercules109,U.S. Senate,,DEM,Loretta Sanchez,189
-Contra Costa,Hercules110,U.S. Senate,,DEM,Kamala Harris,439
-Contra Costa,Hercules110,U.S. Senate,,DEM,Loretta Sanchez,209
-Contra Costa,Hercules111,U.S. Senate,,DEM,Kamala Harris,498
-Contra Costa,Hercules111,U.S. Senate,,DEM,Loretta Sanchez,198
-Contra Costa,Hercules113,U.S. Senate,,DEM,Kamala Harris,793
-Contra Costa,Hercules113,U.S. Senate,,DEM,Loretta Sanchez,268
-Contra Costa,Hercules114,U.S. Senate,,DEM,Kamala Harris,468
-Contra Costa,Hercules114,U.S. Senate,,DEM,Loretta Sanchez,182
-Contra Costa,Kensington101,U.S. Senate,,DEM,Kamala Harris,511
-Contra Costa,Kensington101,U.S. Senate,,DEM,Loretta Sanchez,114
-Contra Costa,Kensington102,U.S. Senate,,DEM,Kamala Harris,616
-Contra Costa,Kensington102,U.S. Senate,,DEM,Loretta Sanchez,121
-Contra Costa,Kensington103,U.S. Senate,,DEM,Kamala Harris,947
-Contra Costa,Kensington103,U.S. Senate,,DEM,Loretta Sanchez,175
-Contra Costa,Kensington104,U.S. Senate,,DEM,Kamala Harris,836
-Contra Costa,Kensington104,U.S. Senate,,DEM,Loretta Sanchez,127
-Contra Costa,Kensington801,U.S. Senate,,DEM,Kamala Harris,0
-Contra Costa,Kensington801,U.S. Senate,,DEM,Loretta Sanchez,1
-Contra Costa,Kensington802,U.S. Senate,,DEM,Kamala Harris,4
-Contra Costa,Kensington802,U.S. Senate,,DEM,Loretta Sanchez,0
-Contra Costa,Knightsen101,U.S. Senate,,DEM,Kamala Harris,258
-Contra Costa,Knightsen101,U.S. Senate,,DEM,Loretta Sanchez,248
-Contra Costa,Knightsen801,U.S. Senate,,DEM,Kamala Harris,19
-Contra Costa,Knightsen801,U.S. Senate,,DEM,Loretta Sanchez,17
-Contra Costa,Knightsen802,U.S. Senate,,DEM,Kamala Harris,4
-Contra Costa,Knightsen802,U.S. Senate,,DEM,Loretta Sanchez,2
-Contra Costa,Knightsen803,U.S. Senate,,DEM,Kamala Harris,39
-Contra Costa,Knightsen803,U.S. Senate,,DEM,Loretta Sanchez,36
-Contra Costa,Knightsen804,U.S. Senate,,DEM,Kamala Harris,31
-Contra Costa,Knightsen804,U.S. Senate,,DEM,Loretta Sanchez,29
-Contra Costa,Lafayette101,U.S. Senate,,DEM,Kamala Harris,665
-Contra Costa,Lafayette101,U.S. Senate,,DEM,Loretta Sanchez,231
-Contra Costa,Lafayette102,U.S. Senate,,DEM,Kamala Harris,504
-Contra Costa,Lafayette102,U.S. Senate,,DEM,Loretta Sanchez,208
-Contra Costa,Lafayette103,U.S. Senate,,DEM,Kamala Harris,503
-Contra Costa,Lafayette103,U.S. Senate,,DEM,Loretta Sanchez,169
-Contra Costa,Lafayette104,U.S. Senate,,DEM,Kamala Harris,636
-Contra Costa,Lafayette104,U.S. Senate,,DEM,Loretta Sanchez,199
-Contra Costa,Lafayette105,U.S. Senate,,DEM,Kamala Harris,471
-Contra Costa,Lafayette105,U.S. Senate,,DEM,Loretta Sanchez,172
-Contra Costa,Lafayette106,U.S. Senate,,DEM,Kamala Harris,484
-Contra Costa,Lafayette106,U.S. Senate,,DEM,Loretta Sanchez,149
-Contra Costa,Lafayette107,U.S. Senate,,DEM,Kamala Harris,750
-Contra Costa,Lafayette107,U.S. Senate,,DEM,Loretta Sanchez,211
-Contra Costa,Lafayette108,U.S. Senate,,DEM,Kamala Harris,783
-Contra Costa,Lafayette108,U.S. Senate,,DEM,Loretta Sanchez,261
-Contra Costa,Lafayette109,U.S. Senate,,DEM,Kamala Harris,817
-Contra Costa,Lafayette109,U.S. Senate,,DEM,Loretta Sanchez,232
-Contra Costa,Lafayette110,U.S. Senate,,DEM,Kamala Harris,444
-Contra Costa,Lafayette110,U.S. Senate,,DEM,Loretta Sanchez,160
-Contra Costa,Lafayette111,U.S. Senate,,DEM,Kamala Harris,511
-Contra Costa,Lafayette111,U.S. Senate,,DEM,Loretta Sanchez,151
-Contra Costa,Lafayette112,U.S. Senate,,DEM,Kamala Harris,240
-Contra Costa,Lafayette112,U.S. Senate,,DEM,Loretta Sanchez,78
-Contra Costa,Lafayette113,U.S. Senate,,DEM,Kamala Harris,549
-Contra Costa,Lafayette113,U.S. Senate,,DEM,Loretta Sanchez,179
-Contra Costa,Lafayette114,U.S. Senate,,DEM,Kamala Harris,518
-Contra Costa,Lafayette114,U.S. Senate,,DEM,Loretta Sanchez,137
-Contra Costa,Lafayette115,U.S. Senate,,DEM,Kamala Harris,433
-Contra Costa,Lafayette115,U.S. Senate,,DEM,Loretta Sanchez,132
-Contra Costa,Lafayette116,U.S. Senate,,DEM,Kamala Harris,673
-Contra Costa,Lafayette116,U.S. Senate,,DEM,Loretta Sanchez,222
-Contra Costa,Lafayette117,U.S. Senate,,DEM,Kamala Harris,793
-Contra Costa,Lafayette117,U.S. Senate,,DEM,Loretta Sanchez,223
-Contra Costa,LasTrampas801,U.S. Senate,,DEM,Kamala Harris,28
-Contra Costa,LasTrampas801,U.S. Senate,,DEM,Loretta Sanchez,13
-Contra Costa,MarshCreek801,U.S. Senate,,DEM,Kamala Harris,68
-Contra Costa,MarshCreek801,U.S. Senate,,DEM,Loretta Sanchez,72
-Contra Costa,MarshCreek802,U.S. Senate,,DEM,Kamala Harris,6
-Contra Costa,MarshCreek802,U.S. Senate,,DEM,Loretta Sanchez,14
-Contra Costa,MarshCreek803,U.S. Senate,,DEM,Kamala Harris,12
-Contra Costa,MarshCreek803,U.S. Senate,,DEM,Loretta Sanchez,7
-Contra Costa,Martinez101,U.S. Senate,,DEM,Kamala Harris,601
-Contra Costa,Martinez101,U.S. Senate,,DEM,Loretta Sanchez,244
-Contra Costa,Martinez102,U.S. Senate,,DEM,Kamala Harris,634
-Contra Costa,Martinez102,U.S. Senate,,DEM,Loretta Sanchez,230
-Contra Costa,Martinez103,U.S. Senate,,DEM,Kamala Harris,291
-Contra Costa,Martinez103,U.S. Senate,,DEM,Loretta Sanchez,129
-Contra Costa,Martinez104,U.S. Senate,,DEM,Kamala Harris,561
-Contra Costa,Martinez104,U.S. Senate,,DEM,Loretta Sanchez,217
-Contra Costa,Martinez105,U.S. Senate,,DEM,Kamala Harris,364
-Contra Costa,Martinez105,U.S. Senate,,DEM,Loretta Sanchez,147
-Contra Costa,Martinez106,U.S. Senate,,DEM,Kamala Harris,394
-Contra Costa,Martinez106,U.S. Senate,,DEM,Loretta Sanchez,197
-Contra Costa,Martinez107,U.S. Senate,,DEM,Kamala Harris,475
-Contra Costa,Martinez107,U.S. Senate,,DEM,Loretta Sanchez,236
-Contra Costa,Martinez108,U.S. Senate,,DEM,Kamala Harris,510
-Contra Costa,Martinez108,U.S. Senate,,DEM,Loretta Sanchez,233
-Contra Costa,Martinez109,U.S. Senate,,DEM,Kamala Harris,597
-Contra Costa,Martinez109,U.S. Senate,,DEM,Loretta Sanchez,250
-Contra Costa,Martinez110,U.S. Senate,,DEM,Kamala Harris,699
-Contra Costa,Martinez110,U.S. Senate,,DEM,Loretta Sanchez,296
-Contra Costa,Martinez111,U.S. Senate,,DEM,Kamala Harris,632
-Contra Costa,Martinez111,U.S. Senate,,DEM,Loretta Sanchez,310
-Contra Costa,Martinez112,U.S. Senate,,DEM,Kamala Harris,459
-Contra Costa,Martinez112,U.S. Senate,,DEM,Loretta Sanchez,158
-Contra Costa,Martinez113,U.S. Senate,,DEM,Kamala Harris,213
-Contra Costa,Martinez113,U.S. Senate,,DEM,Loretta Sanchez,73
-Contra Costa,Martinez114,U.S. Senate,,DEM,Kamala Harris,311
-Contra Costa,Martinez114,U.S. Senate,,DEM,Loretta Sanchez,133
-Contra Costa,Martinez115,U.S. Senate,,DEM,Kamala Harris,645
-Contra Costa,Martinez115,U.S. Senate,,DEM,Loretta Sanchez,284
-Contra Costa,Martinez116,U.S. Senate,,DEM,Kamala Harris,524
-Contra Costa,Martinez116,U.S. Senate,,DEM,Loretta Sanchez,228
-Contra Costa,Martinez117,U.S. Senate,,DEM,Kamala Harris,323
-Contra Costa,Martinez117,U.S. Senate,,DEM,Loretta Sanchez,127
-Contra Costa,Martinez118,U.S. Senate,,DEM,Kamala Harris,380
-Contra Costa,Martinez118,U.S. Senate,,DEM,Loretta Sanchez,190
-Contra Costa,Martinez119,U.S. Senate,,DEM,Kamala Harris,738
-Contra Costa,Martinez119,U.S. Senate,,DEM,Loretta Sanchez,324
-Contra Costa,Martinez120,U.S. Senate,,DEM,Kamala Harris,548
-Contra Costa,Martinez120,U.S. Senate,,DEM,Loretta Sanchez,217
-Contra Costa,Martinez121,U.S. Senate,,DEM,Kamala Harris,275
-Contra Costa,Martinez121,U.S. Senate,,DEM,Loretta Sanchez,130
-Contra Costa,Martinez122,U.S. Senate,,DEM,Kamala Harris,455
-Contra Costa,Martinez122,U.S. Senate,,DEM,Loretta Sanchez,186
-Contra Costa,Martinez123,U.S. Senate,,DEM,Kamala Harris,444
-Contra Costa,Martinez123,U.S. Senate,,DEM,Loretta Sanchez,206
-Contra Costa,Martinez124,U.S. Senate,,DEM,Kamala Harris,161
-Contra Costa,Martinez124,U.S. Senate,,DEM,Loretta Sanchez,57
-Contra Costa,Martinez801,U.S. Senate,,DEM,Kamala Harris,1
-Contra Costa,Martinez801,U.S. Senate,,DEM,Loretta Sanchez,0
-Contra Costa,Martinez802,U.S. Senate,,DEM,Kamala Harris,79
-Contra Costa,Martinez802,U.S. Senate,,DEM,Loretta Sanchez,54
-Contra Costa,Martinez803,U.S. Senate,,DEM,Kamala Harris,22
-Contra Costa,Martinez803,U.S. Senate,,DEM,Loretta Sanchez,11
-Contra Costa,Moraga101,U.S. Senate,,DEM,Kamala Harris,818
-Contra Costa,Moraga101,U.S. Senate,,DEM,Loretta Sanchez,292
-Contra Costa,Moraga102,U.S. Senate,,DEM,Kamala Harris,504
-Contra Costa,Moraga102,U.S. Senate,,DEM,Loretta Sanchez,202
-Contra Costa,Moraga103,U.S. Senate,,DEM,Kamala Harris,728
-Contra Costa,Moraga103,U.S. Senate,,DEM,Loretta Sanchez,226
-Contra Costa,Moraga104,U.S. Senate,,DEM,Kamala Harris,736
-Contra Costa,Moraga104,U.S. Senate,,DEM,Loretta Sanchez,288
-Contra Costa,Moraga105,U.S. Senate,,DEM,Kamala Harris,771
-Contra Costa,Moraga105,U.S. Senate,,DEM,Loretta Sanchez,237
-Contra Costa,Moraga106,U.S. Senate,,DEM,Kamala Harris,781
-Contra Costa,Moraga106,U.S. Senate,,DEM,Loretta Sanchez,253
-Contra Costa,Moraga107,U.S. Senate,,DEM,Kamala Harris,830
-Contra Costa,Moraga107,U.S. Senate,,DEM,Loretta Sanchez,290
-Contra Costa,Moraga108,U.S. Senate,,DEM,Kamala Harris,528
-Contra Costa,Moraga108,U.S. Senate,,DEM,Loretta Sanchez,208
-Contra Costa,MountDiablo101,U.S. Senate,,DEM,Kamala Harris,202
-Contra Costa,MountDiablo101,U.S. Senate,,DEM,Loretta Sanchez,89
-Contra Costa,MountDiablo801,U.S. Senate,,DEM,Kamala Harris,4
-Contra Costa,MountDiablo801,U.S. Senate,,DEM,Loretta Sanchez,3
-Contra Costa,MountDiablo802,U.S. Senate,,DEM,Kamala Harris,3
-Contra Costa,MountDiablo802,U.S. Senate,,DEM,Loretta Sanchez,2
-Contra Costa,MountainView101,U.S. Senate,,DEM,Kamala Harris,293
-Contra Costa,MountainView101,U.S. Senate,,DEM,Loretta Sanchez,141
-Contra Costa,MountainView102,U.S. Senate,,DEM,Kamala Harris,333
-Contra Costa,MountainView102,U.S. Senate,,DEM,Loretta Sanchez,139
-Contra Costa,Nichols801,U.S. Senate,,DEM,Kamala Harris,1
-Contra Costa,Nichols801,U.S. Senate,,DEM,Loretta Sanchez,1
-Contra Costa,NorrisCanyon101,U.S. Senate,,DEM,Kamala Harris,314
-Contra Costa,NorrisCanyon101,U.S. Senate,,DEM,Loretta Sanchez,108
-Contra Costa,NorthRichmond101,U.S. Senate,,DEM,Kamala Harris,488
-Contra Costa,NorthRichmond101,U.S. Senate,,DEM,Loretta Sanchez,254
-Contra Costa,NortonValley801,U.S. Senate,,DEM,Kamala Harris,3
-Contra Costa,NortonValley801,U.S. Senate,,DEM,Loretta Sanchez,4
-Contra Costa,NortonValley802,U.S. Senate,,DEM,Kamala Harris,3
-Contra Costa,NortonValley802,U.S. Senate,,DEM,Loretta Sanchez,4
-Contra Costa,Oakley101,U.S. Senate,,DEM,Kamala Harris,613
-Contra Costa,Oakley101,U.S. Senate,,DEM,Loretta Sanchez,422
-Contra Costa,Oakley102,U.S. Senate,,DEM,Kamala Harris,355
-Contra Costa,Oakley102,U.S. Senate,,DEM,Loretta Sanchez,311
-Contra Costa,Oakley103,U.S. Senate,,DEM,Kamala Harris,430
-Contra Costa,Oakley103,U.S. Senate,,DEM,Loretta Sanchez,289
-Contra Costa,Oakley104,U.S. Senate,,DEM,Kamala Harris,406
-Contra Costa,Oakley104,U.S. Senate,,DEM,Loretta Sanchez,238
-Contra Costa,Oakley105,U.S. Senate,,DEM,Kamala Harris,433
-Contra Costa,Oakley105,U.S. Senate,,DEM,Loretta Sanchez,251
-Contra Costa,Oakley106,U.S. Senate,,DEM,Kamala Harris,440
-Contra Costa,Oakley106,U.S. Senate,,DEM,Loretta Sanchez,318
-Contra Costa,Oakley107,U.S. Senate,,DEM,Kamala Harris,565
-Contra Costa,Oakley107,U.S. Senate,,DEM,Loretta Sanchez,398
-Contra Costa,Oakley108,U.S. Senate,,DEM,Kamala Harris,305
-Contra Costa,Oakley108,U.S. Senate,,DEM,Loretta Sanchez,248
-Contra Costa,Oakley109,U.S. Senate,,DEM,Kamala Harris,324
-Contra Costa,Oakley109,U.S. Senate,,DEM,Loretta Sanchez,256
-Contra Costa,Oakley110,U.S. Senate,,DEM,Kamala Harris,372
-Contra Costa,Oakley110,U.S. Senate,,DEM,Loretta Sanchez,255
-Contra Costa,Oakley111,U.S. Senate,,DEM,Kamala Harris,296
-Contra Costa,Oakley111,U.S. Senate,,DEM,Loretta Sanchez,223
-Contra Costa,Oakley112,U.S. Senate,,DEM,Kamala Harris,293
-Contra Costa,Oakley112,U.S. Senate,,DEM,Loretta Sanchez,186
-Contra Costa,Oakley113,U.S. Senate,,DEM,Kamala Harris,526
-Contra Costa,Oakley113,U.S. Senate,,DEM,Loretta Sanchez,363
-Contra Costa,Oakley114,U.S. Senate,,DEM,Kamala Harris,416
-Contra Costa,Oakley114,U.S. Senate,,DEM,Loretta Sanchez,310
-Contra Costa,Oakley115,U.S. Senate,,DEM,Kamala Harris,395
-Contra Costa,Oakley115,U.S. Senate,,DEM,Loretta Sanchez,280
-Contra Costa,Oakley116,U.S. Senate,,DEM,Kamala Harris,480
-Contra Costa,Oakley116,U.S. Senate,,DEM,Loretta Sanchez,339
-Contra Costa,Oakley117,U.S. Senate,,DEM,Kamala Harris,283
-Contra Costa,Oakley117,U.S. Senate,,DEM,Loretta Sanchez,266
-Contra Costa,Oakley801,U.S. Senate,,DEM,Kamala Harris,3
-Contra Costa,Oakley801,U.S. Senate,,DEM,Loretta Sanchez,1
-Contra Costa,Oleum801,U.S. Senate,,DEM,Kamala Harris,6
-Contra Costa,Oleum801,U.S. Senate,,DEM,Loretta Sanchez,3
-Contra Costa,Oleum802,U.S. Senate,,DEM,Kamala Harris,10
-Contra Costa,Oleum802,U.S. Senate,,DEM,Loretta Sanchez,3
-Contra Costa,Orinda101,U.S. Senate,,DEM,Kamala Harris,946
-Contra Costa,Orinda101,U.S. Senate,,DEM,Loretta Sanchez,256
-Contra Costa,Orinda102,U.S. Senate,,DEM,Kamala Harris,442
-Contra Costa,Orinda102,U.S. Senate,,DEM,Loretta Sanchez,125
-Contra Costa,Orinda103,U.S. Senate,,DEM,Kamala Harris,564
-Contra Costa,Orinda103,U.S. Senate,,DEM,Loretta Sanchez,185
-Contra Costa,Orinda104,U.S. Senate,,DEM,Kamala Harris,357
-Contra Costa,Orinda104,U.S. Senate,,DEM,Loretta Sanchez,99
-Contra Costa,Orinda105,U.S. Senate,,DEM,Kamala Harris,677
-Contra Costa,Orinda105,U.S. Senate,,DEM,Loretta Sanchez,234
-Contra Costa,Orinda106,U.S. Senate,,DEM,Kamala Harris,1082
-Contra Costa,Orinda106,U.S. Senate,,DEM,Loretta Sanchez,308
-Contra Costa,Orinda107,U.S. Senate,,DEM,Kamala Harris,854
-Contra Costa,Orinda107,U.S. Senate,,DEM,Loretta Sanchez,243
-Contra Costa,Orinda108,U.S. Senate,,DEM,Kamala Harris,771
-Contra Costa,Orinda108,U.S. Senate,,DEM,Loretta Sanchez,235
-Contra Costa,Orinda109,U.S. Senate,,DEM,Kamala Harris,460
-Contra Costa,Orinda109,U.S. Senate,,DEM,Loretta Sanchez,192
-Contra Costa,Orinda110,U.S. Senate,,DEM,Kamala Harris,283
-Contra Costa,Orinda110,U.S. Senate,,DEM,Loretta Sanchez,75
-Contra Costa,Orinda111,U.S. Senate,,DEM,Kamala Harris,846
-Contra Costa,Orinda111,U.S. Senate,,DEM,Loretta Sanchez,240
-Contra Costa,Orinda112,U.S. Senate,,DEM,Kamala Harris,591
-Contra Costa,Orinda112,U.S. Senate,,DEM,Loretta Sanchez,173
-Contra Costa,Orinda801,U.S. Senate,,DEM,Kamala Harris,3
-Contra Costa,Orinda801,U.S. Senate,,DEM,Loretta Sanchez,0
-Contra Costa,Pacheco101,U.S. Senate,,DEM,Kamala Harris,642
-Contra Costa,Pacheco101,U.S. Senate,,DEM,Loretta Sanchez,295
-Contra Costa,Pacheco102,U.S. Senate,,DEM,Kamala Harris,307
-Contra Costa,Pacheco102,U.S. Senate,,DEM,Loretta Sanchez,175
-Contra Costa,Pacheco801,U.S. Senate,,DEM,Kamala Harris,1
-Contra Costa,Pacheco801,U.S. Senate,,DEM,Loretta Sanchez,0
-Contra Costa,Pacheco802,U.S. Senate,,DEM,Kamala Harris,46
-Contra Costa,Pacheco802,U.S. Senate,,DEM,Loretta Sanchez,39
-Contra Costa,Pacheco803,U.S. Senate,,DEM,Kamala Harris,0
-Contra Costa,Pacheco803,U.S. Senate,,DEM,Loretta Sanchez,2
-Contra Costa,Pinole102,U.S. Senate,,DEM,Kamala Harris,437
-Contra Costa,Pinole102,U.S. Senate,,DEM,Loretta Sanchez,192
-Contra Costa,Pinole103,U.S. Senate,,DEM,Kamala Harris,509
-Contra Costa,Pinole103,U.S. Senate,,DEM,Loretta Sanchez,199
-Contra Costa,Pinole104,U.S. Senate,,DEM,Kamala Harris,341
-Contra Costa,Pinole104,U.S. Senate,,DEM,Loretta Sanchez,179
-Contra Costa,Pinole105,U.S. Senate,,DEM,Kamala Harris,551
-Contra Costa,Pinole105,U.S. Senate,,DEM,Loretta Sanchez,211
-Contra Costa,Pinole106,U.S. Senate,,DEM,Kamala Harris,410
-Contra Costa,Pinole106,U.S. Senate,,DEM,Loretta Sanchez,185
-Contra Costa,Pinole107,U.S. Senate,,DEM,Kamala Harris,353
-Contra Costa,Pinole107,U.S. Senate,,DEM,Loretta Sanchez,193
-Contra Costa,Pinole108,U.S. Senate,,DEM,Kamala Harris,542
-Contra Costa,Pinole108,U.S. Senate,,DEM,Loretta Sanchez,215
-Contra Costa,Pinole109,U.S. Senate,,DEM,Kamala Harris,325
-Contra Costa,Pinole109,U.S. Senate,,DEM,Loretta Sanchez,161
-Contra Costa,Pinole110,U.S. Senate,,DEM,Kamala Harris,535
-Contra Costa,Pinole110,U.S. Senate,,DEM,Loretta Sanchez,287
-Contra Costa,Pinole111,U.S. Senate,,DEM,Kamala Harris,524
-Contra Costa,Pinole111,U.S. Senate,,DEM,Loretta Sanchez,240
-Contra Costa,Pinole112,U.S. Senate,,DEM,Kamala Harris,522
-Contra Costa,Pinole112,U.S. Senate,,DEM,Loretta Sanchez,245
-Contra Costa,Pinole801,U.S. Senate,,DEM,Kamala Harris,2
-Contra Costa,Pinole801,U.S. Senate,,DEM,Loretta Sanchez,10
-Contra Costa,Pinole802,U.S. Senate,,DEM,Kamala Harris,110
-Contra Costa,Pinole802,U.S. Senate,,DEM,Loretta Sanchez,68
-Contra Costa,Pinole803,U.S. Senate,,DEM,Kamala Harris,47
-Contra Costa,Pinole803,U.S. Senate,,DEM,Loretta Sanchez,11
-Contra Costa,Pittsburg101,U.S. Senate,,DEM,Kamala Harris,892
-Contra Costa,Pittsburg101,U.S. Senate,,DEM,Loretta Sanchez,374
-Contra Costa,Pittsburg102,U.S. Senate,,DEM,Kamala Harris,376
-Contra Costa,Pittsburg102,U.S. Senate,,DEM,Loretta Sanchez,191
-Contra Costa,Pittsburg103,U.S. Senate,,DEM,Kamala Harris,432
-Contra Costa,Pittsburg103,U.S. Senate,,DEM,Loretta Sanchez,170
-Contra Costa,Pittsburg104,U.S. Senate,,DEM,Kamala Harris,518
-Contra Costa,Pittsburg104,U.S. Senate,,DEM,Loretta Sanchez,235
-Contra Costa,Pittsburg105,U.S. Senate,,DEM,Kamala Harris,194
-Contra Costa,Pittsburg105,U.S. Senate,,DEM,Loretta Sanchez,119
-Contra Costa,Pittsburg106,U.S. Senate,,DEM,Kamala Harris,401
-Contra Costa,Pittsburg106,U.S. Senate,,DEM,Loretta Sanchez,227
-Contra Costa,Pittsburg107,U.S. Senate,,DEM,Kamala Harris,432
-Contra Costa,Pittsburg107,U.S. Senate,,DEM,Loretta Sanchez,273
-Contra Costa,Pittsburg108,U.S. Senate,,DEM,Kamala Harris,535
-Contra Costa,Pittsburg108,U.S. Senate,,DEM,Loretta Sanchez,212
-Contra Costa,Pittsburg109,U.S. Senate,,DEM,Kamala Harris,334
-Contra Costa,Pittsburg109,U.S. Senate,,DEM,Loretta Sanchez,253
-Contra Costa,Pittsburg110,U.S. Senate,,DEM,Kamala Harris,363
-Contra Costa,Pittsburg110,U.S. Senate,,DEM,Loretta Sanchez,241
-Contra Costa,Pittsburg111,U.S. Senate,,DEM,Kamala Harris,393
-Contra Costa,Pittsburg111,U.S. Senate,,DEM,Loretta Sanchez,211
-Contra Costa,Pittsburg112,U.S. Senate,,DEM,Kamala Harris,379
-Contra Costa,Pittsburg112,U.S. Senate,,DEM,Loretta Sanchez,182
-Contra Costa,Pittsburg113,U.S. Senate,,DEM,Kamala Harris,307
-Contra Costa,Pittsburg113,U.S. Senate,,DEM,Loretta Sanchez,227
-Contra Costa,Pittsburg114,U.S. Senate,,DEM,Kamala Harris,460
-Contra Costa,Pittsburg114,U.S. Senate,,DEM,Loretta Sanchez,241
-Contra Costa,Pittsburg115,U.S. Senate,,DEM,Kamala Harris,419
-Contra Costa,Pittsburg115,U.S. Senate,,DEM,Loretta Sanchez,285
-Contra Costa,Pittsburg116,U.S. Senate,,DEM,Kamala Harris,372
-Contra Costa,Pittsburg116,U.S. Senate,,DEM,Loretta Sanchez,187
-Contra Costa,Pittsburg117,U.S. Senate,,DEM,Kamala Harris,664
-Contra Costa,Pittsburg117,U.S. Senate,,DEM,Loretta Sanchez,305
-Contra Costa,Pittsburg118,U.S. Senate,,DEM,Kamala Harris,376
-Contra Costa,Pittsburg118,U.S. Senate,,DEM,Loretta Sanchez,210
-Contra Costa,Pittsburg119,U.S. Senate,,DEM,Kamala Harris,676
-Contra Costa,Pittsburg119,U.S. Senate,,DEM,Loretta Sanchez,330
-Contra Costa,Pittsburg120,U.S. Senate,,DEM,Kamala Harris,638
-Contra Costa,Pittsburg120,U.S. Senate,,DEM,Loretta Sanchez,318
-Contra Costa,Pittsburg121,U.S. Senate,,DEM,Kamala Harris,341
-Contra Costa,Pittsburg121,U.S. Senate,,DEM,Loretta Sanchez,144
-Contra Costa,Pittsburg122,U.S. Senate,,DEM,Kamala Harris,266
-Contra Costa,Pittsburg122,U.S. Senate,,DEM,Loretta Sanchez,225
-Contra Costa,Pittsburg123,U.S. Senate,,DEM,Kamala Harris,231
-Contra Costa,Pittsburg123,U.S. Senate,,DEM,Loretta Sanchez,130
-Contra Costa,Pittsburg124,U.S. Senate,,DEM,Kamala Harris,245
-Contra Costa,Pittsburg124,U.S. Senate,,DEM,Loretta Sanchez,125
-Contra Costa,Pittsburg125,U.S. Senate,,DEM,Kamala Harris,437
-Contra Costa,Pittsburg125,U.S. Senate,,DEM,Loretta Sanchez,229
-Contra Costa,Pittsburg126,U.S. Senate,,DEM,Kamala Harris,363
-Contra Costa,Pittsburg126,U.S. Senate,,DEM,Loretta Sanchez,228
-Contra Costa,Pittsburg127,U.S. Senate,,DEM,Kamala Harris,319
-Contra Costa,Pittsburg127,U.S. Senate,,DEM,Loretta Sanchez,96
-Contra Costa,Pittsburg128,U.S. Senate,,DEM,Kamala Harris,412
-Contra Costa,Pittsburg128,U.S. Senate,,DEM,Loretta Sanchez,264
-Contra Costa,Pittsburg129,U.S. Senate,,DEM,Kamala Harris,759
-Contra Costa,Pittsburg129,U.S. Senate,,DEM,Loretta Sanchez,300
-Contra Costa,Pittsburg130,U.S. Senate,,DEM,Kamala Harris,291
-Contra Costa,Pittsburg130,U.S. Senate,,DEM,Loretta Sanchez,252
-Contra Costa,Pittsburg131,U.S. Senate,,DEM,Kamala Harris,379
-Contra Costa,Pittsburg131,U.S. Senate,,DEM,Loretta Sanchez,195
-Contra Costa,Pittsburg801,U.S. Senate,,DEM,Kamala Harris,1
-Contra Costa,Pittsburg801,U.S. Senate,,DEM,Loretta Sanchez,2
-Contra Costa,Pittsburg802,U.S. Senate,,DEM,Kamala Harris,0
-Contra Costa,Pittsburg802,U.S. Senate,,DEM,Loretta Sanchez,0
-Contra Costa,PleasantHill101,U.S. Senate,,DEM,Kamala Harris,538
-Contra Costa,PleasantHill101,U.S. Senate,,DEM,Loretta Sanchez,192
-Contra Costa,PleasantHill102,U.S. Senate,,DEM,Kamala Harris,398
-Contra Costa,PleasantHill102,U.S. Senate,,DEM,Loretta Sanchez,183
-Contra Costa,PleasantHill103,U.S. Senate,,DEM,Kamala Harris,393
-Contra Costa,PleasantHill103,U.S. Senate,,DEM,Loretta Sanchez,184
-Contra Costa,PleasantHill104,U.S. Senate,,DEM,Kamala Harris,780
-Contra Costa,PleasantHill104,U.S. Senate,,DEM,Loretta Sanchez,281
-Contra Costa,PleasantHill105,U.S. Senate,,DEM,Kamala Harris,440
-Contra Costa,PleasantHill105,U.S. Senate,,DEM,Loretta Sanchez,192
-Contra Costa,PleasantHill106,U.S. Senate,,DEM,Kamala Harris,660
-Contra Costa,PleasantHill106,U.S. Senate,,DEM,Loretta Sanchez,265
-Contra Costa,PleasantHill107,U.S. Senate,,DEM,Kamala Harris,631
-Contra Costa,PleasantHill107,U.S. Senate,,DEM,Loretta Sanchez,230
-Contra Costa,PleasantHill108,U.S. Senate,,DEM,Kamala Harris,664
-Contra Costa,PleasantHill108,U.S. Senate,,DEM,Loretta Sanchez,263
-Contra Costa,PleasantHill109,U.S. Senate,,DEM,Kamala Harris,583
-Contra Costa,PleasantHill109,U.S. Senate,,DEM,Loretta Sanchez,206
-Contra Costa,PleasantHill110,U.S. Senate,,DEM,Kamala Harris,567
-Contra Costa,PleasantHill110,U.S. Senate,,DEM,Loretta Sanchez,205
-Contra Costa,PleasantHill111,U.S. Senate,,DEM,Kamala Harris,583
-Contra Costa,PleasantHill111,U.S. Senate,,DEM,Loretta Sanchez,225
-Contra Costa,PleasantHill112,U.S. Senate,,DEM,Kamala Harris,452
-Contra Costa,PleasantHill112,U.S. Senate,,DEM,Loretta Sanchez,141
-Contra Costa,PleasantHill113,U.S. Senate,,DEM,Kamala Harris,588
-Contra Costa,PleasantHill113,U.S. Senate,,DEM,Loretta Sanchez,169
-Contra Costa,PleasantHill114,U.S. Senate,,DEM,Kamala Harris,651
-Contra Costa,PleasantHill114,U.S. Senate,,DEM,Loretta Sanchez,238
-Contra Costa,PleasantHill115,U.S. Senate,,DEM,Kamala Harris,655
-Contra Costa,PleasantHill115,U.S. Senate,,DEM,Loretta Sanchez,260
-Contra Costa,PleasantHill116,U.S. Senate,,DEM,Kamala Harris,472
-Contra Costa,PleasantHill116,U.S. Senate,,DEM,Loretta Sanchez,190
-Contra Costa,PleasantHill117,U.S. Senate,,DEM,Kamala Harris,542
-Contra Costa,PleasantHill117,U.S. Senate,,DEM,Loretta Sanchez,203
-Contra Costa,PleasantHill118,U.S. Senate,,DEM,Kamala Harris,434
-Contra Costa,PleasantHill118,U.S. Senate,,DEM,Loretta Sanchez,196
-Contra Costa,PleasantHill119,U.S. Senate,,DEM,Kamala Harris,510
-Contra Costa,PleasantHill119,U.S. Senate,,DEM,Loretta Sanchez,182
-Contra Costa,PortCosta801,U.S. Senate,,DEM,Kamala Harris,80
-Contra Costa,PortCosta801,U.S. Senate,,DEM,Loretta Sanchez,25
-Contra Costa,Richmond101,U.S. Senate,,DEM,Kamala Harris,644
-Contra Costa,Richmond101,U.S. Senate,,DEM,Loretta Sanchez,183
-Contra Costa,Richmond102,U.S. Senate,,DEM,Kamala Harris,393
-Contra Costa,Richmond102,U.S. Senate,,DEM,Loretta Sanchez,91
-Contra Costa,Richmond103,U.S. Senate,,DEM,Kamala Harris,523
-Contra Costa,Richmond103,U.S. Senate,,DEM,Loretta Sanchez,122
-Contra Costa,Richmond104,U.S. Senate,,DEM,Kamala Harris,715
-Contra Costa,Richmond104,U.S. Senate,,DEM,Loretta Sanchez,171
-Contra Costa,Richmond105,U.S. Senate,,DEM,Kamala Harris,861
-Contra Costa,Richmond105,U.S. Senate,,DEM,Loretta Sanchez,192
-Contra Costa,Richmond106,U.S. Senate,,DEM,Kamala Harris,507
-Contra Costa,Richmond106,U.S. Senate,,DEM,Loretta Sanchez,147
-Contra Costa,Richmond107,U.S. Senate,,DEM,Kamala Harris,147
-Contra Costa,Richmond107,U.S. Senate,,DEM,Loretta Sanchez,45
-Contra Costa,Richmond108,U.S. Senate,,DEM,Kamala Harris,611
-Contra Costa,Richmond108,U.S. Senate,,DEM,Loretta Sanchez,138
-Contra Costa,Richmond109,U.S. Senate,,DEM,Kamala Harris,499
-Contra Costa,Richmond109,U.S. Senate,,DEM,Loretta Sanchez,95
-Contra Costa,Richmond110,U.S. Senate,,DEM,Kamala Harris,413
-Contra Costa,Richmond110,U.S. Senate,,DEM,Loretta Sanchez,110
-Contra Costa,Richmond111,U.S. Senate,,DEM,Kamala Harris,466
-Contra Costa,Richmond111,U.S. Senate,,DEM,Loretta Sanchez,105
-Contra Costa,Richmond112,U.S. Senate,,DEM,Kamala Harris,466
-Contra Costa,Richmond112,U.S. Senate,,DEM,Loretta Sanchez,107
-Contra Costa,Richmond113,U.S. Senate,,DEM,Kamala Harris,632
-Contra Costa,Richmond113,U.S. Senate,,DEM,Loretta Sanchez,181
-Contra Costa,Richmond114,U.S. Senate,,DEM,Kamala Harris,518
-Contra Costa,Richmond114,U.S. Senate,,DEM,Loretta Sanchez,200
-Contra Costa,Richmond115,U.S. Senate,,DEM,Kamala Harris,522
-Contra Costa,Richmond115,U.S. Senate,,DEM,Loretta Sanchez,145
-Contra Costa,Richmond116,U.S. Senate,,DEM,Kamala Harris,664
-Contra Costa,Richmond116,U.S. Senate,,DEM,Loretta Sanchez,209
-Contra Costa,Richmond117,U.S. Senate,,DEM,Kamala Harris,386
-Contra Costa,Richmond117,U.S. Senate,,DEM,Loretta Sanchez,159
-Contra Costa,Richmond118,U.S. Senate,,DEM,Kamala Harris,432
-Contra Costa,Richmond118,U.S. Senate,,DEM,Loretta Sanchez,303
-Contra Costa,Richmond119,U.S. Senate,,DEM,Kamala Harris,530
-Contra Costa,Richmond119,U.S. Senate,,DEM,Loretta Sanchez,279
-Contra Costa,Richmond120,U.S. Senate,,DEM,Kamala Harris,299
-Contra Costa,Richmond120,U.S. Senate,,DEM,Loretta Sanchez,172
-Contra Costa,Richmond121,U.S. Senate,,DEM,Kamala Harris,345
-Contra Costa,Richmond121,U.S. Senate,,DEM,Loretta Sanchez,310
-Contra Costa,Richmond122,U.S. Senate,,DEM,Kamala Harris,678
-Contra Costa,Richmond122,U.S. Senate,,DEM,Loretta Sanchez,249
-Contra Costa,Richmond123,U.S. Senate,,DEM,Kamala Harris,706
-Contra Costa,Richmond123,U.S. Senate,,DEM,Loretta Sanchez,279
-Contra Costa,Richmond124,U.S. Senate,,DEM,Kamala Harris,432
-Contra Costa,Richmond124,U.S. Senate,,DEM,Loretta Sanchez,111
-Contra Costa,Richmond125,U.S. Senate,,DEM,Kamala Harris,424
-Contra Costa,Richmond125,U.S. Senate,,DEM,Loretta Sanchez,227
-Contra Costa,Richmond126,U.S. Senate,,DEM,Kamala Harris,734
-Contra Costa,Richmond126,U.S. Senate,,DEM,Loretta Sanchez,388
-Contra Costa,Richmond127,U.S. Senate,,DEM,Kamala Harris,276
-Contra Costa,Richmond127,U.S. Senate,,DEM,Loretta Sanchez,222
-Contra Costa,Richmond128,U.S. Senate,,DEM,Kamala Harris,408
-Contra Costa,Richmond128,U.S. Senate,,DEM,Loretta Sanchez,280
-Contra Costa,Richmond129,U.S. Senate,,DEM,Kamala Harris,462
-Contra Costa,Richmond129,U.S. Senate,,DEM,Loretta Sanchez,438
-Contra Costa,Richmond130,U.S. Senate,,DEM,Kamala Harris,393
-Contra Costa,Richmond130,U.S. Senate,,DEM,Loretta Sanchez,231
-Contra Costa,Richmond131,U.S. Senate,,DEM,Kamala Harris,394
-Contra Costa,Richmond131,U.S. Senate,,DEM,Loretta Sanchez,149
-Contra Costa,Richmond132,U.S. Senate,,DEM,Kamala Harris,468
-Contra Costa,Richmond132,U.S. Senate,,DEM,Loretta Sanchez,160
-Contra Costa,Richmond133,U.S. Senate,,DEM,Kamala Harris,596
-Contra Costa,Richmond133,U.S. Senate,,DEM,Loretta Sanchez,116
-Contra Costa,Richmond134,U.S. Senate,,DEM,Kamala Harris,766
-Contra Costa,Richmond134,U.S. Senate,,DEM,Loretta Sanchez,234
-Contra Costa,Richmond135,U.S. Senate,,DEM,Kamala Harris,860
-Contra Costa,Richmond135,U.S. Senate,,DEM,Loretta Sanchez,257
-Contra Costa,Richmond136,U.S. Senate,,DEM,Kamala Harris,680
-Contra Costa,Richmond136,U.S. Senate,,DEM,Loretta Sanchez,244
-Contra Costa,Richmond137,U.S. Senate,,DEM,Kamala Harris,525
-Contra Costa,Richmond137,U.S. Senate,,DEM,Loretta Sanchez,142
-Contra Costa,Richmond138,U.S. Senate,,DEM,Kamala Harris,269
-Contra Costa,Richmond138,U.S. Senate,,DEM,Loretta Sanchez,128
-Contra Costa,Richmond139,U.S. Senate,,DEM,Kamala Harris,724
-Contra Costa,Richmond139,U.S. Senate,,DEM,Loretta Sanchez,293
-Contra Costa,Richmond140,U.S. Senate,,DEM,Kamala Harris,398
-Contra Costa,Richmond140,U.S. Senate,,DEM,Loretta Sanchez,136
-Contra Costa,Richmond141,U.S. Senate,,DEM,Kamala Harris,834
-Contra Costa,Richmond141,U.S. Senate,,DEM,Loretta Sanchez,253
-Contra Costa,Richmond142,U.S. Senate,,DEM,Kamala Harris,755
-Contra Costa,Richmond142,U.S. Senate,,DEM,Loretta Sanchez,241
-Contra Costa,Richmond143,U.S. Senate,,DEM,Kamala Harris,665
-Contra Costa,Richmond143,U.S. Senate,,DEM,Loretta Sanchez,307
-Contra Costa,Richmond144,U.S. Senate,,DEM,Kamala Harris,655
-Contra Costa,Richmond144,U.S. Senate,,DEM,Loretta Sanchez,167
-Contra Costa,Richmond145,U.S. Senate,,DEM,Kamala Harris,811
-Contra Costa,Richmond145,U.S. Senate,,DEM,Loretta Sanchez,156
-Contra Costa,Richmond146,U.S. Senate,,DEM,Kamala Harris,135
-Contra Costa,Richmond146,U.S. Senate,,DEM,Loretta Sanchez,88
-Contra Costa,Richmond801,U.S. Senate,,DEM,Kamala Harris,20
-Contra Costa,Richmond801,U.S. Senate,,DEM,Loretta Sanchez,6
-Contra Costa,Richmond802,U.S. Senate,,DEM,Kamala Harris,30
-Contra Costa,Richmond802,U.S. Senate,,DEM,Loretta Sanchez,10
-Contra Costa,Richmond803,U.S. Senate,,DEM,Kamala Harris,100
-Contra Costa,Richmond803,U.S. Senate,,DEM,Loretta Sanchez,57
-Contra Costa,Richmond804,U.S. Senate,,DEM,Kamala Harris,112
-Contra Costa,Richmond804,U.S. Senate,,DEM,Loretta Sanchez,28
-Contra Costa,Richmond805,U.S. Senate,,DEM,Kamala Harris,76
-Contra Costa,Richmond805,U.S. Senate,,DEM,Loretta Sanchez,14
-Contra Costa,Richmond806,U.S. Senate,,DEM,Kamala Harris,111
-Contra Costa,Richmond806,U.S. Senate,,DEM,Loretta Sanchez,45
-Contra Costa,Richmond807,U.S. Senate,,DEM,Kamala Harris,0
-Contra Costa,Richmond807,U.S. Senate,,DEM,Loretta Sanchez,0
-Contra Costa,Rodeo101,U.S. Senate,,DEM,Kamala Harris,427
-Contra Costa,Rodeo101,U.S. Senate,,DEM,Loretta Sanchez,188
-Contra Costa,Rodeo102,U.S. Senate,,DEM,Kamala Harris,516
-Contra Costa,Rodeo102,U.S. Senate,,DEM,Loretta Sanchez,226
-Contra Costa,Rodeo103,U.S. Senate,,DEM,Kamala Harris,585
-Contra Costa,Rodeo103,U.S. Senate,,DEM,Loretta Sanchez,266
-Contra Costa,Rodeo104,U.S. Senate,,DEM,Kamala Harris,574
-Contra Costa,Rodeo104,U.S. Senate,,DEM,Loretta Sanchez,238
-Contra Costa,Rollingwood101,U.S. Senate,,DEM,Kamala Harris,379
-Contra Costa,Rollingwood101,U.S. Senate,,DEM,Loretta Sanchez,439
-Contra Costa,SaintMarys801,U.S. Senate,,DEM,Kamala Harris,77
-Contra Costa,SaintMarys801,U.S. Senate,,DEM,Loretta Sanchez,22
-Contra Costa,SanPablo101,U.S. Senate,,DEM,Kamala Harris,354
-Contra Costa,SanPablo101,U.S. Senate,,DEM,Loretta Sanchez,441
-Contra Costa,SanPablo102,U.S. Senate,,DEM,Kamala Harris,330
-Contra Costa,SanPablo102,U.S. Senate,,DEM,Loretta Sanchez,364
-Contra Costa,SanPablo103,U.S. Senate,,DEM,Kamala Harris,284
-Contra Costa,SanPablo103,U.S. Senate,,DEM,Loretta Sanchez,228
-Contra Costa,SanPablo104,U.S. Senate,,DEM,Kamala Harris,459
-Contra Costa,SanPablo104,U.S. Senate,,DEM,Loretta Sanchez,151
-Contra Costa,SanPablo105,U.S. Senate,,DEM,Kamala Harris,326
-Contra Costa,SanPablo105,U.S. Senate,,DEM,Loretta Sanchez,146
-Contra Costa,SanPablo106,U.S. Senate,,DEM,Kamala Harris,654
-Contra Costa,SanPablo106,U.S. Senate,,DEM,Loretta Sanchez,234
-Contra Costa,SanPablo107,U.S. Senate,,DEM,Kamala Harris,379
-Contra Costa,SanPablo107,U.S. Senate,,DEM,Loretta Sanchez,285
-Contra Costa,SanPablo108,U.S. Senate,,DEM,Kamala Harris,383
-Contra Costa,SanPablo108,U.S. Senate,,DEM,Loretta Sanchez,294
-Contra Costa,SanPablo109,U.S. Senate,,DEM,Kamala Harris,228
-Contra Costa,SanPablo109,U.S. Senate,,DEM,Loretta Sanchez,220
-Contra Costa,SanPablo110,U.S. Senate,,DEM,Kamala Harris,429
-Contra Costa,SanPablo110,U.S. Senate,,DEM,Loretta Sanchez,389
-Contra Costa,SanRamon101,U.S. Senate,,DEM,Kamala Harris,802
-Contra Costa,SanRamon101,U.S. Senate,,DEM,Loretta Sanchez,316
-Contra Costa,SanRamon102,U.S. Senate,,DEM,Kamala Harris,567
-Contra Costa,SanRamon102,U.S. Senate,,DEM,Loretta Sanchez,238
-Contra Costa,SanRamon103,U.S. Senate,,DEM,Kamala Harris,499
-Contra Costa,SanRamon103,U.S. Senate,,DEM,Loretta Sanchez,250
-Contra Costa,SanRamon104,U.S. Senate,,DEM,Kamala Harris,524
-Contra Costa,SanRamon104,U.S. Senate,,DEM,Loretta Sanchez,202
-Contra Costa,SanRamon105,U.S. Senate,,DEM,Kamala Harris,413
-Contra Costa,SanRamon105,U.S. Senate,,DEM,Loretta Sanchez,154
-Contra Costa,SanRamon106,U.S. Senate,,DEM,Kamala Harris,560
-Contra Costa,SanRamon106,U.S. Senate,,DEM,Loretta Sanchez,210
-Contra Costa,SanRamon107,U.S. Senate,,DEM,Kamala Harris,543
-Contra Costa,SanRamon107,U.S. Senate,,DEM,Loretta Sanchez,220
-Contra Costa,SanRamon108,U.S. Senate,,DEM,Kamala Harris,598
-Contra Costa,SanRamon108,U.S. Senate,,DEM,Loretta Sanchez,196
-Contra Costa,SanRamon109,U.S. Senate,,DEM,Kamala Harris,538
-Contra Costa,SanRamon109,U.S. Senate,,DEM,Loretta Sanchez,190
-Contra Costa,SanRamon110,U.S. Senate,,DEM,Kamala Harris,467
-Contra Costa,SanRamon110,U.S. Senate,,DEM,Loretta Sanchez,241
-Contra Costa,SanRamon111,U.S. Senate,,DEM,Kamala Harris,717
-Contra Costa,SanRamon111,U.S. Senate,,DEM,Loretta Sanchez,278
-Contra Costa,SanRamon112,U.S. Senate,,DEM,Kamala Harris,556
-Contra Costa,SanRamon112,U.S. Senate,,DEM,Loretta Sanchez,271
-Contra Costa,SanRamon113,U.S. Senate,,DEM,Kamala Harris,456
-Contra Costa,SanRamon113,U.S. Senate,,DEM,Loretta Sanchez,203
-Contra Costa,SanRamon114,U.S. Senate,,DEM,Kamala Harris,741
-Contra Costa,SanRamon114,U.S. Senate,,DEM,Loretta Sanchez,370
-Contra Costa,SanRamon115,U.S. Senate,,DEM,Kamala Harris,592
-Contra Costa,SanRamon115,U.S. Senate,,DEM,Loretta Sanchez,235
-Contra Costa,SanRamon116,U.S. Senate,,DEM,Kamala Harris,479
-Contra Costa,SanRamon116,U.S. Senate,,DEM,Loretta Sanchez,245
-Contra Costa,SanRamon117,U.S. Senate,,DEM,Kamala Harris,735
-Contra Costa,SanRamon117,U.S. Senate,,DEM,Loretta Sanchez,257
-Contra Costa,SanRamon118,U.S. Senate,,DEM,Kamala Harris,419
-Contra Costa,SanRamon118,U.S. Senate,,DEM,Loretta Sanchez,179
-Contra Costa,SanRamon119,U.S. Senate,,DEM,Kamala Harris,427
-Contra Costa,SanRamon119,U.S. Senate,,DEM,Loretta Sanchez,146
-Contra Costa,SanRamon120,U.S. Senate,,DEM,Kamala Harris,510
-Contra Costa,SanRamon120,U.S. Senate,,DEM,Loretta Sanchez,244
-Contra Costa,SanRamon121,U.S. Senate,,DEM,Kamala Harris,252
-Contra Costa,SanRamon121,U.S. Senate,,DEM,Loretta Sanchez,129
-Contra Costa,SanRamon122,U.S. Senate,,DEM,Kamala Harris,889
-Contra Costa,SanRamon122,U.S. Senate,,DEM,Loretta Sanchez,153
-Contra Costa,SanRamon123,U.S. Senate,,DEM,Kamala Harris,812
-Contra Costa,SanRamon123,U.S. Senate,,DEM,Loretta Sanchez,190
-Contra Costa,SanRamon124,U.S. Senate,,DEM,Kamala Harris,812
-Contra Costa,SanRamon124,U.S. Senate,,DEM,Loretta Sanchez,229
-Contra Costa,SanRamon125,U.S. Senate,,DEM,Kamala Harris,448
-Contra Costa,SanRamon125,U.S. Senate,,DEM,Loretta Sanchez,177
-Contra Costa,SanRamon126,U.S. Senate,,DEM,Kamala Harris,469
-Contra Costa,SanRamon126,U.S. Senate,,DEM,Loretta Sanchez,188
-Contra Costa,SanRamon127,U.S. Senate,,DEM,Kamala Harris,849
-Contra Costa,SanRamon127,U.S. Senate,,DEM,Loretta Sanchez,188
-Contra Costa,SanRamon128,U.S. Senate,,DEM,Kamala Harris,625
-Contra Costa,SanRamon128,U.S. Senate,,DEM,Loretta Sanchez,261
-Contra Costa,SanRamon129,U.S. Senate,,DEM,Kamala Harris,306
-Contra Costa,SanRamon129,U.S. Senate,,DEM,Loretta Sanchez,130
-Contra Costa,SanRamon130,U.S. Senate,,DEM,Kamala Harris,391
-Contra Costa,SanRamon130,U.S. Senate,,DEM,Loretta Sanchez,167
-Contra Costa,SanRamon131,U.S. Senate,,DEM,Kamala Harris,870
-Contra Costa,SanRamon131,U.S. Senate,,DEM,Loretta Sanchez,202
-Contra Costa,SanRamon132,U.S. Senate,,DEM,Kamala Harris,462
-Contra Costa,SanRamon132,U.S. Senate,,DEM,Loretta Sanchez,131
-Contra Costa,SanRamon133,U.S. Senate,,DEM,Kamala Harris,628
-Contra Costa,SanRamon133,U.S. Senate,,DEM,Loretta Sanchez,170
-Contra Costa,SanRamon134,U.S. Senate,,DEM,Kamala Harris,1074
-Contra Costa,SanRamon134,U.S. Senate,,DEM,Loretta Sanchez,290
-Contra Costa,SanRamon801,U.S. Senate,,DEM,Kamala Harris,2
-Contra Costa,SanRamon801,U.S. Senate,,DEM,Loretta Sanchez,0
-Contra Costa,Saranap101,U.S. Senate,,DEM,Kamala Harris,362
-Contra Costa,Saranap101,U.S. Senate,,DEM,Loretta Sanchez,89
-Contra Costa,Saranap102,U.S. Senate,,DEM,Kamala Harris,668
-Contra Costa,Saranap102,U.S. Senate,,DEM,Loretta Sanchez,226
-Contra Costa,Saranap103,U.S. Senate,,DEM,Kamala Harris,659
-Contra Costa,Saranap103,U.S. Senate,,DEM,Loretta Sanchez,164
-Contra Costa,Saranap105,U.S. Senate,,DEM,Kamala Harris,367
-Contra Costa,Saranap105,U.S. Senate,,DEM,Loretta Sanchez,115
-Contra Costa,Saranap106,U.S. Senate,,DEM,Kamala Harris,447
-Contra Costa,Saranap106,U.S. Senate,,DEM,Loretta Sanchez,165
-Contra Costa,Saranap801,U.S. Senate,,DEM,Kamala Harris,2
-Contra Costa,Saranap801,U.S. Senate,,DEM,Loretta Sanchez,0
-Contra Costa,Saranap802,U.S. Senate,,DEM,Kamala Harris,132
-Contra Costa,Saranap802,U.S. Senate,,DEM,Loretta Sanchez,33
-Contra Costa,ShellRidge101,U.S. Senate,,DEM,Kamala Harris,122
-Contra Costa,ShellRidge101,U.S. Senate,,DEM,Loretta Sanchez,41
-Contra Costa,ShellRidge102,U.S. Senate,,DEM,Kamala Harris,252
-Contra Costa,ShellRidge102,U.S. Senate,,DEM,Loretta Sanchez,97
-Contra Costa,Tassajara101,U.S. Senate,,DEM,Kamala Harris,108
-Contra Costa,Tassajara101,U.S. Senate,,DEM,Loretta Sanchez,77
-Contra Costa,Tassajara801,U.S. Senate,,DEM,Kamala Harris,0
-Contra Costa,Tassajara801,U.S. Senate,,DEM,Loretta Sanchez,1
-Contra Costa,Tassajara802,U.S. Senate,,DEM,Kamala Harris,65
-Contra Costa,Tassajara802,U.S. Senate,,DEM,Loretta Sanchez,44
-Contra Costa,Tassajara803,U.S. Senate,,DEM,Kamala Harris,13
-Contra Costa,Tassajara803,U.S. Senate,,DEM,Loretta Sanchez,20
-Contra Costa,Tassajara804,U.S. Senate,,DEM,Kamala Harris,26
-Contra Costa,Tassajara804,U.S. Senate,,DEM,Loretta Sanchez,7
-Contra Costa,Tesoro801,U.S. Senate,,DEM,Kamala Harris,0
-Contra Costa,Tesoro801,U.S. Senate,,DEM,Loretta Sanchez,0
-Contra Costa,Viera801,U.S. Senate,,DEM,Kamala Harris,8
-Contra Costa,Viera801,U.S. Senate,,DEM,Loretta Sanchez,2
-Contra Costa,VineHill101,U.S. Senate,,DEM,Kamala Harris,493
-Contra Costa,VineHill101,U.S. Senate,,DEM,Loretta Sanchez,249
-Contra Costa,VineHill102,U.S. Senate,,DEM,Kamala Harris,230
-Contra Costa,VineHill102,U.S. Senate,,DEM,Loretta Sanchez,193
-Contra Costa,VineHill801,U.S. Senate,,DEM,Kamala Harris,75
-Contra Costa,VineHill801,U.S. Senate,,DEM,Loretta Sanchez,30
-Contra Costa,VineHill802,U.S. Senate,,DEM,Kamala Harris,54
-Contra Costa,VineHill802,U.S. Senate,,DEM,Loretta Sanchez,17
-Contra Costa,Waldon101,U.S. Senate,,DEM,Kamala Harris,485
-Contra Costa,Waldon101,U.S. Senate,,DEM,Loretta Sanchez,179
-Contra Costa,Waldon102,U.S. Senate,,DEM,Kamala Harris,776
-Contra Costa,Waldon102,U.S. Senate,,DEM,Loretta Sanchez,317
-Contra Costa,Waldon103,U.S. Senate,,DEM,Kamala Harris,476
-Contra Costa,Waldon103,U.S. Senate,,DEM,Loretta Sanchez,200
-Contra Costa,Waldon801,U.S. Senate,,DEM,Kamala Harris,58
-Contra Costa,Waldon801,U.S. Senate,,DEM,Loretta Sanchez,21
-Contra Costa,WalnutCreek101,U.S. Senate,,DEM,Kamala Harris,809
-Contra Costa,WalnutCreek101,U.S. Senate,,DEM,Loretta Sanchez,250
-Contra Costa,WalnutCreek102,U.S. Senate,,DEM,Kamala Harris,647
-Contra Costa,WalnutCreek102,U.S. Senate,,DEM,Loretta Sanchez,219
-Contra Costa,WalnutCreek103,U.S. Senate,,DEM,Kamala Harris,1009
-Contra Costa,WalnutCreek103,U.S. Senate,,DEM,Loretta Sanchez,298
-Contra Costa,WalnutCreek104,U.S. Senate,,DEM,Kamala Harris,255
-Contra Costa,WalnutCreek104,U.S. Senate,,DEM,Loretta Sanchez,67
-Contra Costa,WalnutCreek105,U.S. Senate,,DEM,Kamala Harris,570
-Contra Costa,WalnutCreek105,U.S. Senate,,DEM,Loretta Sanchez,207
-Contra Costa,WalnutCreek106,U.S. Senate,,DEM,Kamala Harris,838
-Contra Costa,WalnutCreek106,U.S. Senate,,DEM,Loretta Sanchez,298
-Contra Costa,WalnutCreek107,U.S. Senate,,DEM,Kamala Harris,236
-Contra Costa,WalnutCreek107,U.S. Senate,,DEM,Loretta Sanchez,90
-Contra Costa,WalnutCreek108,U.S. Senate,,DEM,Kamala Harris,346
-Contra Costa,WalnutCreek108,U.S. Senate,,DEM,Loretta Sanchez,127
-Contra Costa,WalnutCreek109,U.S. Senate,,DEM,Kamala Harris,237
-Contra Costa,WalnutCreek109,U.S. Senate,,DEM,Loretta Sanchez,113
-Contra Costa,WalnutCreek110,U.S. Senate,,DEM,Kamala Harris,598
-Contra Costa,WalnutCreek110,U.S. Senate,,DEM,Loretta Sanchez,208
-Contra Costa,WalnutCreek111,U.S. Senate,,DEM,Kamala Harris,578
-Contra Costa,WalnutCreek111,U.S. Senate,,DEM,Loretta Sanchez,246
-Contra Costa,WalnutCreek112,U.S. Senate,,DEM,Kamala Harris,471
-Contra Costa,WalnutCreek112,U.S. Senate,,DEM,Loretta Sanchez,183
-Contra Costa,WalnutCreek113,U.S. Senate,,DEM,Kamala Harris,620
-Contra Costa,WalnutCreek113,U.S. Senate,,DEM,Loretta Sanchez,199
-Contra Costa,WalnutCreek114,U.S. Senate,,DEM,Kamala Harris,225
-Contra Costa,WalnutCreek114,U.S. Senate,,DEM,Loretta Sanchez,71
-Contra Costa,WalnutCreek115,U.S. Senate,,DEM,Kamala Harris,374
-Contra Costa,WalnutCreek115,U.S. Senate,,DEM,Loretta Sanchez,128
-Contra Costa,WalnutCreek116,U.S. Senate,,DEM,Kamala Harris,337
-Contra Costa,WalnutCreek116,U.S. Senate,,DEM,Loretta Sanchez,141
-Contra Costa,WalnutCreek117,U.S. Senate,,DEM,Kamala Harris,648
-Contra Costa,WalnutCreek117,U.S. Senate,,DEM,Loretta Sanchez,274
-Contra Costa,WalnutCreek118,U.S. Senate,,DEM,Kamala Harris,285
-Contra Costa,WalnutCreek118,U.S. Senate,,DEM,Loretta Sanchez,121
-Contra Costa,WalnutCreek119,U.S. Senate,,DEM,Kamala Harris,637
-Contra Costa,WalnutCreek119,U.S. Senate,,DEM,Loretta Sanchez,205
-Contra Costa,WalnutCreek120,U.S. Senate,,DEM,Kamala Harris,726
-Contra Costa,WalnutCreek120,U.S. Senate,,DEM,Loretta Sanchez,224
-Contra Costa,WalnutCreek121,U.S. Senate,,DEM,Kamala Harris,731
-Contra Costa,WalnutCreek121,U.S. Senate,,DEM,Loretta Sanchez,214
-Contra Costa,WalnutCreek122,U.S. Senate,,DEM,Kamala Harris,471
-Contra Costa,WalnutCreek122,U.S. Senate,,DEM,Loretta Sanchez,139
-Contra Costa,WalnutCreek123,U.S. Senate,,DEM,Kamala Harris,540
-Contra Costa,WalnutCreek123,U.S. Senate,,DEM,Loretta Sanchez,258
-Contra Costa,WalnutCreek124,U.S. Senate,,DEM,Kamala Harris,425
-Contra Costa,WalnutCreek124,U.S. Senate,,DEM,Loretta Sanchez,157
-Contra Costa,WalnutCreek125,U.S. Senate,,DEM,Kamala Harris,597
-Contra Costa,WalnutCreek125,U.S. Senate,,DEM,Loretta Sanchez,249
-Contra Costa,WalnutCreek126,U.S. Senate,,DEM,Kamala Harris,720
-Contra Costa,WalnutCreek126,U.S. Senate,,DEM,Loretta Sanchez,260
-Contra Costa,WalnutCreek127,U.S. Senate,,DEM,Kamala Harris,614
-Contra Costa,WalnutCreek127,U.S. Senate,,DEM,Loretta Sanchez,173
-Contra Costa,WalnutCreek129,U.S. Senate,,DEM,Kamala Harris,683
-Contra Costa,WalnutCreek129,U.S. Senate,,DEM,Loretta Sanchez,156
-Contra Costa,WalnutCreek130,U.S. Senate,,DEM,Kamala Harris,430
-Contra Costa,WalnutCreek130,U.S. Senate,,DEM,Loretta Sanchez,152
-Contra Costa,WalnutCreek131,U.S. Senate,,DEM,Kamala Harris,518
-Contra Costa,WalnutCreek131,U.S. Senate,,DEM,Loretta Sanchez,193
-Contra Costa,WalnutCreek132,U.S. Senate,,DEM,Kamala Harris,472
-Contra Costa,WalnutCreek132,U.S. Senate,,DEM,Loretta Sanchez,227
-Contra Costa,WalnutCreek133,U.S. Senate,,DEM,Kamala Harris,564
-Contra Costa,WalnutCreek133,U.S. Senate,,DEM,Loretta Sanchez,222
-Contra Costa,WalnutCreek134,U.S. Senate,,DEM,Kamala Harris,522
-Contra Costa,WalnutCreek134,U.S. Senate,,DEM,Loretta Sanchez,222
-Contra Costa,WalnutCreek135,U.S. Senate,,DEM,Kamala Harris,623
-Contra Costa,WalnutCreek135,U.S. Senate,,DEM,Loretta Sanchez,260
-Contra Costa,WalnutCreek136,U.S. Senate,,DEM,Kamala Harris,257
-Contra Costa,WalnutCreek136,U.S. Senate,,DEM,Loretta Sanchez,84
-Contra Costa,WalnutCreek137,U.S. Senate,,DEM,Kamala Harris,744
-Contra Costa,WalnutCreek137,U.S. Senate,,DEM,Loretta Sanchez,259
-Contra Costa,WalnutCreek138,U.S. Senate,,DEM,Kamala Harris,555
-Contra Costa,WalnutCreek138,U.S. Senate,,DEM,Loretta Sanchez,207
-Contra Costa,WalnutCreek139,U.S. Senate,,DEM,Kamala Harris,553
-Contra Costa,WalnutCreek139,U.S. Senate,,DEM,Loretta Sanchez,213
-Contra Costa,WalnutCreek140,U.S. Senate,,DEM,Kamala Harris,557
-Contra Costa,WalnutCreek140,U.S. Senate,,DEM,Loretta Sanchez,232
-Contra Costa,WalnutCreek141,U.S. Senate,,DEM,Kamala Harris,619
-Contra Costa,WalnutCreek141,U.S. Senate,,DEM,Loretta Sanchez,258
-Contra Costa,WalnutCreek142,U.S. Senate,,DEM,Kamala Harris,786
-Contra Costa,WalnutCreek142,U.S. Senate,,DEM,Loretta Sanchez,288
-Contra Costa,WalnutCreek143,U.S. Senate,,DEM,Kamala Harris,517
-Contra Costa,WalnutCreek143,U.S. Senate,,DEM,Loretta Sanchez,211
-Contra Costa,WalnutCreek144,U.S. Senate,,DEM,Kamala Harris,529
-Contra Costa,WalnutCreek144,U.S. Senate,,DEM,Loretta Sanchez,199
-Contra Costa,WalnutCreek801,U.S. Senate,,DEM,Kamala Harris,124
-Contra Costa,WalnutCreek801,U.S. Senate,,DEM,Loretta Sanchez,44
-Contra Costa,WalnutCreek802,U.S. Senate,,DEM,Kamala Harris,2
-Contra Costa,WalnutCreek802,U.S. Senate,,DEM,Loretta Sanchez,0
-Contra Costa,WalnutCreek803,U.S. Senate,,DEM,Kamala Harris,39
-Contra Costa,WalnutCreek803,U.S. Senate,,DEM,Loretta Sanchez,19
-Contra Costa,WalnutCreek804,U.S. Senate,,DEM,Kamala Harris,141
-Contra Costa,WalnutCreek804,U.S. Senate,,DEM,Loretta Sanchez,43
-Contra Costa,WalnutCreek805,U.S. Senate,,DEM,Kamala Harris,0
-Contra Costa,WalnutCreek805,U.S. Senate,,DEM,Loretta Sanchez,1
-Contra Costa,WalnutKnolls101,U.S. Senate,,DEM,Kamala Harris,603
-Contra Costa,WalnutKnolls101,U.S. Senate,,DEM,Loretta Sanchez,207
-Contra Costa,WalnutKnolls102,U.S. Senate,,DEM,Kamala Harris,437
-Contra Costa,WalnutKnolls102,U.S. Senate,,DEM,Loretta Sanchez,146
-Contra Costa,WalnutKnolls103,U.S. Senate,,DEM,Kamala Harris,364
-Contra Costa,WalnutKnolls103,U.S. Senate,,DEM,Loretta Sanchez,131
-Contra Costa,WalnutKnolls801,U.S. Senate,,DEM,Kamala Harris,79
-Contra Costa,WalnutKnolls801,U.S. Senate,,DEM,Loretta Sanchez,44
+Contra Costa,Alamo101,U.S. Senate,,DEM,Kamala D. Harris,327
+Contra Costa,Alamo101,U.S. Senate,,DEM,Loretta L. Sanchez,215
+Contra Costa,Alamo102,U.S. Senate,,DEM,Kamala D. Harris,729
+Contra Costa,Alamo102,U.S. Senate,,DEM,Loretta L. Sanchez,316
+Contra Costa,Alamo103,U.S. Senate,,DEM,Kamala D. Harris,433
+Contra Costa,Alamo103,U.S. Senate,,DEM,Loretta L. Sanchez,236
+Contra Costa,Alamo104,U.S. Senate,,DEM,Kamala D. Harris,437
+Contra Costa,Alamo104,U.S. Senate,,DEM,Loretta L. Sanchez,260
+Contra Costa,Alamo105,U.S. Senate,,DEM,Kamala D. Harris,251
+Contra Costa,Alamo105,U.S. Senate,,DEM,Loretta L. Sanchez,150
+Contra Costa,Alamo106,U.S. Senate,,DEM,Kamala D. Harris,453
+Contra Costa,Alamo106,U.S. Senate,,DEM,Loretta L. Sanchez,218
+Contra Costa,Alamo107,U.S. Senate,,DEM,Kamala D. Harris,422
+Contra Costa,Alamo107,U.S. Senate,,DEM,Loretta L. Sanchez,134
+Contra Costa,Alamo108,U.S. Senate,,DEM,Kamala D. Harris,400
+Contra Costa,Alamo108,U.S. Senate,,DEM,Loretta L. Sanchez,152
+Contra Costa,Alamo109,U.S. Senate,,DEM,Kamala D. Harris,433
+Contra Costa,Alamo109,U.S. Senate,,DEM,Loretta L. Sanchez,226
+Contra Costa,Alamo110,U.S. Senate,,DEM,Kamala D. Harris,441
+Contra Costa,Alamo110,U.S. Senate,,DEM,Loretta L. Sanchez,238
+Contra Costa,Alamo111,U.S. Senate,,DEM,Kamala D. Harris,416
+Contra Costa,Alamo111,U.S. Senate,,DEM,Loretta L. Sanchez,238
+Contra Costa,Alamo112,U.S. Senate,,DEM,Kamala D. Harris,272
+Contra Costa,Alamo112,U.S. Senate,,DEM,Loretta L. Sanchez,162
+Contra Costa,Alhambra101,U.S. Senate,,DEM,Kamala D. Harris,262
+Contra Costa,Alhambra101,U.S. Senate,,DEM,Loretta L. Sanchez,135
+Contra Costa,Alhambra801,U.S. Senate,,DEM,Kamala D. Harris,16
+Contra Costa,Alhambra801,U.S. Senate,,DEM,Loretta L. Sanchez,12
+Contra Costa,Alhambra802,U.S. Senate,,DEM,Kamala D. Harris,27
+Contra Costa,Alhambra802,U.S. Senate,,DEM,Loretta L. Sanchez,15
+Contra Costa,Alhambra803,U.S. Senate,,DEM,Kamala D. Harris,8
+Contra Costa,Alhambra803,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Contra Costa,Alhambra804,U.S. Senate,,DEM,Kamala D. Harris,81
+Contra Costa,Alhambra804,U.S. Senate,,DEM,Loretta L. Sanchez,23
+Contra Costa,Alhambra805,U.S. Senate,,DEM,Kamala D. Harris,32
+Contra Costa,Alhambra805,U.S. Senate,,DEM,Loretta L. Sanchez,15
+Contra Costa,Alhambra806,U.S. Senate,,DEM,Kamala D. Harris,1
+Contra Costa,Alhambra806,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Contra Costa,Antioch101,U.S. Senate,,DEM,Kamala D. Harris,479
+Contra Costa,Antioch101,U.S. Senate,,DEM,Loretta L. Sanchez,273
+Contra Costa,Antioch102,U.S. Senate,,DEM,Kamala D. Harris,383
+Contra Costa,Antioch102,U.S. Senate,,DEM,Loretta L. Sanchez,271
+Contra Costa,Antioch103,U.S. Senate,,DEM,Kamala D. Harris,342
+Contra Costa,Antioch103,U.S. Senate,,DEM,Loretta L. Sanchez,246
+Contra Costa,Antioch104,U.S. Senate,,DEM,Kamala D. Harris,442
+Contra Costa,Antioch104,U.S. Senate,,DEM,Loretta L. Sanchez,308
+Contra Costa,Antioch105,U.S. Senate,,DEM,Kamala D. Harris,443
+Contra Costa,Antioch105,U.S. Senate,,DEM,Loretta L. Sanchez,196
+Contra Costa,Antioch106,U.S. Senate,,DEM,Kamala D. Harris,397
+Contra Costa,Antioch106,U.S. Senate,,DEM,Loretta L. Sanchez,191
+Contra Costa,Antioch107,U.S. Senate,,DEM,Kamala D. Harris,412
+Contra Costa,Antioch107,U.S. Senate,,DEM,Loretta L. Sanchez,237
+Contra Costa,Antioch108,U.S. Senate,,DEM,Kamala D. Harris,522
+Contra Costa,Antioch108,U.S. Senate,,DEM,Loretta L. Sanchez,335
+Contra Costa,Antioch109,U.S. Senate,,DEM,Kamala D. Harris,514
+Contra Costa,Antioch109,U.S. Senate,,DEM,Loretta L. Sanchez,234
+Contra Costa,Antioch110,U.S. Senate,,DEM,Kamala D. Harris,449
+Contra Costa,Antioch110,U.S. Senate,,DEM,Loretta L. Sanchez,269
+Contra Costa,Antioch111,U.S. Senate,,DEM,Kamala D. Harris,534
+Contra Costa,Antioch111,U.S. Senate,,DEM,Loretta L. Sanchez,300
+Contra Costa,Antioch112,U.S. Senate,,DEM,Kamala D. Harris,317
+Contra Costa,Antioch112,U.S. Senate,,DEM,Loretta L. Sanchez,199
+Contra Costa,Antioch113,U.S. Senate,,DEM,Kamala D. Harris,459
+Contra Costa,Antioch113,U.S. Senate,,DEM,Loretta L. Sanchez,336
+Contra Costa,Antioch114,U.S. Senate,,DEM,Kamala D. Harris,333
+Contra Costa,Antioch114,U.S. Senate,,DEM,Loretta L. Sanchez,187
+Contra Costa,Antioch115,U.S. Senate,,DEM,Kamala D. Harris,376
+Contra Costa,Antioch115,U.S. Senate,,DEM,Loretta L. Sanchez,270
+Contra Costa,Antioch116,U.S. Senate,,DEM,Kamala D. Harris,243
+Contra Costa,Antioch116,U.S. Senate,,DEM,Loretta L. Sanchez,200
+Contra Costa,Antioch117,U.S. Senate,,DEM,Kamala D. Harris,430
+Contra Costa,Antioch117,U.S. Senate,,DEM,Loretta L. Sanchez,262
+Contra Costa,Antioch118,U.S. Senate,,DEM,Kamala D. Harris,289
+Contra Costa,Antioch118,U.S. Senate,,DEM,Loretta L. Sanchez,215
+Contra Costa,Antioch119,U.S. Senate,,DEM,Kamala D. Harris,540
+Contra Costa,Antioch119,U.S. Senate,,DEM,Loretta L. Sanchez,299
+Contra Costa,Antioch120,U.S. Senate,,DEM,Kamala D. Harris,536
+Contra Costa,Antioch120,U.S. Senate,,DEM,Loretta L. Sanchez,301
+Contra Costa,Antioch121,U.S. Senate,,DEM,Kamala D. Harris,407
+Contra Costa,Antioch121,U.S. Senate,,DEM,Loretta L. Sanchez,221
+Contra Costa,Antioch122,U.S. Senate,,DEM,Kamala D. Harris,623
+Contra Costa,Antioch122,U.S. Senate,,DEM,Loretta L. Sanchez,292
+Contra Costa,Antioch123,U.S. Senate,,DEM,Kamala D. Harris,567
+Contra Costa,Antioch123,U.S. Senate,,DEM,Loretta L. Sanchez,330
+Contra Costa,Antioch124,U.S. Senate,,DEM,Kamala D. Harris,532
+Contra Costa,Antioch124,U.S. Senate,,DEM,Loretta L. Sanchez,229
+Contra Costa,Antioch125,U.S. Senate,,DEM,Kamala D. Harris,395
+Contra Costa,Antioch125,U.S. Senate,,DEM,Loretta L. Sanchez,231
+Contra Costa,Antioch126,U.S. Senate,,DEM,Kamala D. Harris,625
+Contra Costa,Antioch126,U.S. Senate,,DEM,Loretta L. Sanchez,343
+Contra Costa,Antioch127,U.S. Senate,,DEM,Kamala D. Harris,441
+Contra Costa,Antioch127,U.S. Senate,,DEM,Loretta L. Sanchez,238
+Contra Costa,Antioch128,U.S. Senate,,DEM,Kamala D. Harris,371
+Contra Costa,Antioch128,U.S. Senate,,DEM,Loretta L. Sanchez,217
+Contra Costa,Antioch129,U.S. Senate,,DEM,Kamala D. Harris,255
+Contra Costa,Antioch129,U.S. Senate,,DEM,Loretta L. Sanchez,144
+Contra Costa,Antioch130,U.S. Senate,,DEM,Kamala D. Harris,325
+Contra Costa,Antioch130,U.S. Senate,,DEM,Loretta L. Sanchez,206
+Contra Costa,Antioch131,U.S. Senate,,DEM,Kamala D. Harris,489
+Contra Costa,Antioch131,U.S. Senate,,DEM,Loretta L. Sanchez,252
+Contra Costa,Antioch132,U.S. Senate,,DEM,Kamala D. Harris,356
+Contra Costa,Antioch132,U.S. Senate,,DEM,Loretta L. Sanchez,210
+Contra Costa,Antioch133,U.S. Senate,,DEM,Kamala D. Harris,476
+Contra Costa,Antioch133,U.S. Senate,,DEM,Loretta L. Sanchez,238
+Contra Costa,Antioch134,U.S. Senate,,DEM,Kamala D. Harris,481
+Contra Costa,Antioch134,U.S. Senate,,DEM,Loretta L. Sanchez,235
+Contra Costa,Antioch135,U.S. Senate,,DEM,Kamala D. Harris,380
+Contra Costa,Antioch135,U.S. Senate,,DEM,Loretta L. Sanchez,230
+Contra Costa,Antioch136,U.S. Senate,,DEM,Kamala D. Harris,719
+Contra Costa,Antioch136,U.S. Senate,,DEM,Loretta L. Sanchez,325
+Contra Costa,Antioch137,U.S. Senate,,DEM,Kamala D. Harris,435
+Contra Costa,Antioch137,U.S. Senate,,DEM,Loretta L. Sanchez,225
+Contra Costa,Antioch138,U.S. Senate,,DEM,Kamala D. Harris,598
+Contra Costa,Antioch138,U.S. Senate,,DEM,Loretta L. Sanchez,289
+Contra Costa,Antioch139,U.S. Senate,,DEM,Kamala D. Harris,479
+Contra Costa,Antioch139,U.S. Senate,,DEM,Loretta L. Sanchez,239
+Contra Costa,Antioch140,U.S. Senate,,DEM,Kamala D. Harris,587
+Contra Costa,Antioch140,U.S. Senate,,DEM,Loretta L. Sanchez,285
+Contra Costa,Antioch141,U.S. Senate,,DEM,Kamala D. Harris,610
+Contra Costa,Antioch141,U.S. Senate,,DEM,Loretta L. Sanchez,246
+Contra Costa,Antioch142,U.S. Senate,,DEM,Kamala D. Harris,371
+Contra Costa,Antioch142,U.S. Senate,,DEM,Loretta L. Sanchez,131
+Contra Costa,Antioch143,U.S. Senate,,DEM,Kamala D. Harris,601
+Contra Costa,Antioch143,U.S. Senate,,DEM,Loretta L. Sanchez,238
+Contra Costa,Antioch144,U.S. Senate,,DEM,Kamala D. Harris,330
+Contra Costa,Antioch144,U.S. Senate,,DEM,Loretta L. Sanchez,154
+Contra Costa,Antioch145,U.S. Senate,,DEM,Kamala D. Harris,364
+Contra Costa,Antioch145,U.S. Senate,,DEM,Loretta L. Sanchez,199
+Contra Costa,Antioch146,U.S. Senate,,DEM,Kamala D. Harris,355
+Contra Costa,Antioch146,U.S. Senate,,DEM,Loretta L. Sanchez,229
+Contra Costa,Antioch147,U.S. Senate,,DEM,Kamala D. Harris,445
+Contra Costa,Antioch147,U.S. Senate,,DEM,Loretta L. Sanchez,277
+Contra Costa,Antioch801,U.S. Senate,,DEM,Kamala D. Harris,1
+Contra Costa,Antioch801,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Contra Costa,Antioch802,U.S. Senate,,DEM,Kamala D. Harris,14
+Contra Costa,Antioch802,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Contra Costa,AyersRanch101,U.S. Senate,,DEM,Kamala D. Harris,210
+Contra Costa,AyersRanch101,U.S. Senate,,DEM,Loretta L. Sanchez,150
+Contra Costa,BayPoint101,U.S. Senate,,DEM,Kamala D. Harris,489
+Contra Costa,BayPoint101,U.S. Senate,,DEM,Loretta L. Sanchez,357
+Contra Costa,BayPoint102,U.S. Senate,,DEM,Kamala D. Harris,130
+Contra Costa,BayPoint102,U.S. Senate,,DEM,Loretta L. Sanchez,96
+Contra Costa,BayPoint103,U.S. Senate,,DEM,Kamala D. Harris,340
+Contra Costa,BayPoint103,U.S. Senate,,DEM,Loretta L. Sanchez,273
+Contra Costa,BayPoint104,U.S. Senate,,DEM,Kamala D. Harris,519
+Contra Costa,BayPoint104,U.S. Senate,,DEM,Loretta L. Sanchez,362
+Contra Costa,BayPoint105,U.S. Senate,,DEM,Kamala D. Harris,306
+Contra Costa,BayPoint105,U.S. Senate,,DEM,Loretta L. Sanchez,402
+Contra Costa,BayPoint106,U.S. Senate,,DEM,Kamala D. Harris,407
+Contra Costa,BayPoint106,U.S. Senate,,DEM,Loretta L. Sanchez,284
+Contra Costa,BayPoint107,U.S. Senate,,DEM,Kamala D. Harris,435
+Contra Costa,BayPoint107,U.S. Senate,,DEM,Loretta L. Sanchez,270
+Contra Costa,BayPoint801,U.S. Senate,,DEM,Kamala D. Harris,3
+Contra Costa,BayPoint801,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Contra Costa,BayPoint802,U.S. Senate,,DEM,Kamala D. Harris,1
+Contra Costa,BayPoint802,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Contra Costa,BethelIsland101,U.S. Senate,,DEM,Kamala D. Harris,521
+Contra Costa,BethelIsland101,U.S. Senate,,DEM,Loretta L. Sanchez,354
+Contra Costa,BethelIsland801,U.S. Senate,,DEM,Kamala D. Harris,0
+Contra Costa,BethelIsland801,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Contra Costa,BlackDiamond801,U.S. Senate,,DEM,Kamala D. Harris,6
+Contra Costa,BlackDiamond801,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Contra Costa,BlackDiamond802,U.S. Senate,,DEM,Kamala D. Harris,86
+Contra Costa,BlackDiamond802,U.S. Senate,,DEM,Loretta L. Sanchez,75
+Contra Costa,BlackDiamond803,U.S. Senate,,DEM,Kamala D. Harris,1
+Contra Costa,BlackDiamond803,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Contra Costa,BlackDiamond804,U.S. Senate,,DEM,Kamala D. Harris,1
+Contra Costa,BlackDiamond804,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Contra Costa,BlackHawk101,U.S. Senate,,DEM,Kamala D. Harris,516
+Contra Costa,BlackHawk101,U.S. Senate,,DEM,Loretta L. Sanchez,343
+Contra Costa,BlackHawk102,U.S. Senate,,DEM,Kamala D. Harris,533
+Contra Costa,BlackHawk102,U.S. Senate,,DEM,Loretta L. Sanchez,263
+Contra Costa,BlackHawk103,U.S. Senate,,DEM,Kamala D. Harris,379
+Contra Costa,BlackHawk103,U.S. Senate,,DEM,Loretta L. Sanchez,207
+Contra Costa,BlackHawk104,U.S. Senate,,DEM,Kamala D. Harris,984
+Contra Costa,BlackHawk104,U.S. Senate,,DEM,Loretta L. Sanchez,347
+Contra Costa,BlackHawk105,U.S. Senate,,DEM,Kamala D. Harris,317
+Contra Costa,BlackHawk105,U.S. Senate,,DEM,Loretta L. Sanchez,214
+Contra Costa,BlackHawk106,U.S. Senate,,DEM,Kamala D. Harris,517
+Contra Costa,BlackHawk106,U.S. Senate,,DEM,Loretta L. Sanchez,222
+Contra Costa,BlackHawk107,U.S. Senate,,DEM,Kamala D. Harris,538
+Contra Costa,BlackHawk107,U.S. Senate,,DEM,Loretta L. Sanchez,222
+Contra Costa,Brentwood101,U.S. Senate,,DEM,Kamala D. Harris,710
+Contra Costa,Brentwood101,U.S. Senate,,DEM,Loretta L. Sanchez,464
+Contra Costa,Brentwood102,U.S. Senate,,DEM,Kamala D. Harris,327
+Contra Costa,Brentwood102,U.S. Senate,,DEM,Loretta L. Sanchez,178
+Contra Costa,Brentwood103,U.S. Senate,,DEM,Kamala D. Harris,522
+Contra Costa,Brentwood103,U.S. Senate,,DEM,Loretta L. Sanchez,302
+Contra Costa,Brentwood104,U.S. Senate,,DEM,Kamala D. Harris,294
+Contra Costa,Brentwood104,U.S. Senate,,DEM,Loretta L. Sanchez,191
+Contra Costa,Brentwood105,U.S. Senate,,DEM,Kamala D. Harris,151
+Contra Costa,Brentwood105,U.S. Senate,,DEM,Loretta L. Sanchez,182
+Contra Costa,Brentwood106,U.S. Senate,,DEM,Kamala D. Harris,627
+Contra Costa,Brentwood106,U.S. Senate,,DEM,Loretta L. Sanchez,339
+Contra Costa,Brentwood107,U.S. Senate,,DEM,Kamala D. Harris,482
+Contra Costa,Brentwood107,U.S. Senate,,DEM,Loretta L. Sanchez,393
+Contra Costa,Brentwood108,U.S. Senate,,DEM,Kamala D. Harris,377
+Contra Costa,Brentwood108,U.S. Senate,,DEM,Loretta L. Sanchez,284
+Contra Costa,Brentwood109,U.S. Senate,,DEM,Kamala D. Harris,493
+Contra Costa,Brentwood109,U.S. Senate,,DEM,Loretta L. Sanchez,299
+Contra Costa,Brentwood110,U.S. Senate,,DEM,Kamala D. Harris,449
+Contra Costa,Brentwood110,U.S. Senate,,DEM,Loretta L. Sanchez,266
+Contra Costa,Brentwood111,U.S. Senate,,DEM,Kamala D. Harris,473
+Contra Costa,Brentwood111,U.S. Senate,,DEM,Loretta L. Sanchez,335
+Contra Costa,Brentwood112,U.S. Senate,,DEM,Kamala D. Harris,617
+Contra Costa,Brentwood112,U.S. Senate,,DEM,Loretta L. Sanchez,437
+Contra Costa,Brentwood113,U.S. Senate,,DEM,Kamala D. Harris,600
+Contra Costa,Brentwood113,U.S. Senate,,DEM,Loretta L. Sanchez,370
+Contra Costa,Brentwood114,U.S. Senate,,DEM,Kamala D. Harris,275
+Contra Costa,Brentwood114,U.S. Senate,,DEM,Loretta L. Sanchez,170
+Contra Costa,Brentwood115,U.S. Senate,,DEM,Kamala D. Harris,333
+Contra Costa,Brentwood115,U.S. Senate,,DEM,Loretta L. Sanchez,172
+Contra Costa,Brentwood116,U.S. Senate,,DEM,Kamala D. Harris,689
+Contra Costa,Brentwood116,U.S. Senate,,DEM,Loretta L. Sanchez,363
+Contra Costa,Brentwood117,U.S. Senate,,DEM,Kamala D. Harris,188
+Contra Costa,Brentwood117,U.S. Senate,,DEM,Loretta L. Sanchez,139
+Contra Costa,Brentwood118,U.S. Senate,,DEM,Kamala D. Harris,412
+Contra Costa,Brentwood118,U.S. Senate,,DEM,Loretta L. Sanchez,284
+Contra Costa,Brentwood119,U.S. Senate,,DEM,Kamala D. Harris,447
+Contra Costa,Brentwood119,U.S. Senate,,DEM,Loretta L. Sanchez,339
+Contra Costa,Brentwood120,U.S. Senate,,DEM,Kamala D. Harris,608
+Contra Costa,Brentwood120,U.S. Senate,,DEM,Loretta L. Sanchez,398
+Contra Costa,Brentwood121,U.S. Senate,,DEM,Kamala D. Harris,268
+Contra Costa,Brentwood121,U.S. Senate,,DEM,Loretta L. Sanchez,112
+Contra Costa,Brentwood122,U.S. Senate,,DEM,Kamala D. Harris,324
+Contra Costa,Brentwood122,U.S. Senate,,DEM,Loretta L. Sanchez,206
+Contra Costa,Brentwood123,U.S. Senate,,DEM,Kamala D. Harris,394
+Contra Costa,Brentwood123,U.S. Senate,,DEM,Loretta L. Sanchez,240
+Contra Costa,Brentwood124,U.S. Senate,,DEM,Kamala D. Harris,502
+Contra Costa,Brentwood124,U.S. Senate,,DEM,Loretta L. Sanchez,346
+Contra Costa,Brentwood125,U.S. Senate,,DEM,Kamala D. Harris,85
+Contra Costa,Brentwood125,U.S. Senate,,DEM,Loretta L. Sanchez,63
+Contra Costa,Brentwood126,U.S. Senate,,DEM,Kamala D. Harris,422
+Contra Costa,Brentwood126,U.S. Senate,,DEM,Loretta L. Sanchez,224
+Contra Costa,Brentwood127,U.S. Senate,,DEM,Kamala D. Harris,772
+Contra Costa,Brentwood127,U.S. Senate,,DEM,Loretta L. Sanchez,375
+Contra Costa,Brentwood128,U.S. Senate,,DEM,Kamala D. Harris,622
+Contra Costa,Brentwood128,U.S. Senate,,DEM,Loretta L. Sanchez,206
+Contra Costa,Brentwood801,U.S. Senate,,DEM,Kamala D. Harris,3
+Contra Costa,Brentwood801,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Contra Costa,Brentwood802,U.S. Senate,,DEM,Kamala D. Harris,36
+Contra Costa,Brentwood802,U.S. Senate,,DEM,Loretta L. Sanchez,27
+Contra Costa,BrionesHills101,U.S. Senate,,DEM,Kamala D. Harris,328
+Contra Costa,BrionesHills101,U.S. Senate,,DEM,Loretta L. Sanchez,159
+Contra Costa,BrionesHills102,U.S. Senate,,DEM,Kamala D. Harris,398
+Contra Costa,BrionesHills102,U.S. Senate,,DEM,Loretta L. Sanchez,115
+Contra Costa,BrionesHills103,U.S. Senate,,DEM,Kamala D. Harris,518
+Contra Costa,BrionesHills103,U.S. Senate,,DEM,Loretta L. Sanchez,174
+Contra Costa,BrionesHills801,U.S. Senate,,DEM,Kamala D. Harris,2
+Contra Costa,BrionesHills801,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Contra Costa,BrionesValley101,U.S. Senate,,DEM,Kamala D. Harris,166
+Contra Costa,BrionesValley101,U.S. Senate,,DEM,Loretta L. Sanchez,104
+Contra Costa,BrionesValley801,U.S. Senate,,DEM,Kamala D. Harris,95
+Contra Costa,BrionesValley801,U.S. Senate,,DEM,Loretta L. Sanchez,47
+Contra Costa,Byron101,U.S. Senate,,DEM,Kamala D. Harris,147
+Contra Costa,Byron101,U.S. Senate,,DEM,Loretta L. Sanchez,140
+Contra Costa,Byron801,U.S. Senate,,DEM,Kamala D. Harris,43
+Contra Costa,Byron801,U.S. Senate,,DEM,Loretta L. Sanchez,54
+Contra Costa,Byron802,U.S. Senate,,DEM,Kamala D. Harris,19
+Contra Costa,Byron802,U.S. Senate,,DEM,Loretta L. Sanchez,16
+Contra Costa,Byron803,U.S. Senate,,DEM,Kamala D. Harris,1
+Contra Costa,Byron803,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Contra Costa,Caldecott801,U.S. Senate,,DEM,Kamala D. Harris,9
+Contra Costa,Caldecott801,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Contra Costa,Canyon801,U.S. Senate,,DEM,Kamala D. Harris,123
+Contra Costa,Canyon801,U.S. Senate,,DEM,Loretta L. Sanchez,29
+Contra Costa,CastleRock101,U.S. Senate,,DEM,Kamala D. Harris,217
+Contra Costa,CastleRock101,U.S. Senate,,DEM,Loretta L. Sanchez,111
+Contra Costa,Clayton101,U.S. Senate,,DEM,Kamala D. Harris,562
+Contra Costa,Clayton101,U.S. Senate,,DEM,Loretta L. Sanchez,254
+Contra Costa,Clayton102,U.S. Senate,,DEM,Kamala D. Harris,551
+Contra Costa,Clayton102,U.S. Senate,,DEM,Loretta L. Sanchez,311
+Contra Costa,Clayton103,U.S. Senate,,DEM,Kamala D. Harris,359
+Contra Costa,Clayton103,U.S. Senate,,DEM,Loretta L. Sanchez,168
+Contra Costa,Clayton104,U.S. Senate,,DEM,Kamala D. Harris,437
+Contra Costa,Clayton104,U.S. Senate,,DEM,Loretta L. Sanchez,237
+Contra Costa,Clayton105,U.S. Senate,,DEM,Kamala D. Harris,648
+Contra Costa,Clayton105,U.S. Senate,,DEM,Loretta L. Sanchez,308
+Contra Costa,Clayton106,U.S. Senate,,DEM,Kamala D. Harris,390
+Contra Costa,Clayton106,U.S. Senate,,DEM,Loretta L. Sanchez,206
+Contra Costa,Clayton107,U.S. Senate,,DEM,Kamala D. Harris,655
+Contra Costa,Clayton107,U.S. Senate,,DEM,Loretta L. Sanchez,295
+Contra Costa,Clyde101,U.S. Senate,,DEM,Kamala D. Harris,213
+Contra Costa,Clyde101,U.S. Senate,,DEM,Loretta L. Sanchez,82
+Contra Costa,Concord101,U.S. Senate,,DEM,Kamala D. Harris,255
+Contra Costa,Concord101,U.S. Senate,,DEM,Loretta L. Sanchez,166
+Contra Costa,Concord102,U.S. Senate,,DEM,Kamala D. Harris,388
+Contra Costa,Concord102,U.S. Senate,,DEM,Loretta L. Sanchez,220
+Contra Costa,Concord103,U.S. Senate,,DEM,Kamala D. Harris,462
+Contra Costa,Concord103,U.S. Senate,,DEM,Loretta L. Sanchez,217
+Contra Costa,Concord104,U.S. Senate,,DEM,Kamala D. Harris,401
+Contra Costa,Concord104,U.S. Senate,,DEM,Loretta L. Sanchez,208
+Contra Costa,Concord105,U.S. Senate,,DEM,Kamala D. Harris,422
+Contra Costa,Concord105,U.S. Senate,,DEM,Loretta L. Sanchez,256
+Contra Costa,Concord106,U.S. Senate,,DEM,Kamala D. Harris,442
+Contra Costa,Concord106,U.S. Senate,,DEM,Loretta L. Sanchez,227
+Contra Costa,Concord107,U.S. Senate,,DEM,Kamala D. Harris,517
+Contra Costa,Concord107,U.S. Senate,,DEM,Loretta L. Sanchez,313
+Contra Costa,Concord108,U.S. Senate,,DEM,Kamala D. Harris,418
+Contra Costa,Concord108,U.S. Senate,,DEM,Loretta L. Sanchez,204
+Contra Costa,Concord109,U.S. Senate,,DEM,Kamala D. Harris,476
+Contra Costa,Concord109,U.S. Senate,,DEM,Loretta L. Sanchez,216
+Contra Costa,Concord110,U.S. Senate,,DEM,Kamala D. Harris,408
+Contra Costa,Concord110,U.S. Senate,,DEM,Loretta L. Sanchez,187
+Contra Costa,Concord111,U.S. Senate,,DEM,Kamala D. Harris,451
+Contra Costa,Concord111,U.S. Senate,,DEM,Loretta L. Sanchez,204
+Contra Costa,Concord112,U.S. Senate,,DEM,Kamala D. Harris,455
+Contra Costa,Concord112,U.S. Senate,,DEM,Loretta L. Sanchez,216
+Contra Costa,Concord113,U.S. Senate,,DEM,Kamala D. Harris,476
+Contra Costa,Concord113,U.S. Senate,,DEM,Loretta L. Sanchez,221
+Contra Costa,Concord114,U.S. Senate,,DEM,Kamala D. Harris,400
+Contra Costa,Concord114,U.S. Senate,,DEM,Loretta L. Sanchez,166
+Contra Costa,Concord115,U.S. Senate,,DEM,Kamala D. Harris,678
+Contra Costa,Concord115,U.S. Senate,,DEM,Loretta L. Sanchez,305
+Contra Costa,Concord116,U.S. Senate,,DEM,Kamala D. Harris,538
+Contra Costa,Concord116,U.S. Senate,,DEM,Loretta L. Sanchez,288
+Contra Costa,Concord117,U.S. Senate,,DEM,Kamala D. Harris,428
+Contra Costa,Concord117,U.S. Senate,,DEM,Loretta L. Sanchez,284
+Contra Costa,Concord118,U.S. Senate,,DEM,Kamala D. Harris,599
+Contra Costa,Concord118,U.S. Senate,,DEM,Loretta L. Sanchez,362
+Contra Costa,Concord119,U.S. Senate,,DEM,Kamala D. Harris,452
+Contra Costa,Concord119,U.S. Senate,,DEM,Loretta L. Sanchez,226
+Contra Costa,Concord120,U.S. Senate,,DEM,Kamala D. Harris,489
+Contra Costa,Concord120,U.S. Senate,,DEM,Loretta L. Sanchez,242
+Contra Costa,Concord121,U.S. Senate,,DEM,Kamala D. Harris,459
+Contra Costa,Concord121,U.S. Senate,,DEM,Loretta L. Sanchez,212
+Contra Costa,Concord122,U.S. Senate,,DEM,Kamala D. Harris,391
+Contra Costa,Concord122,U.S. Senate,,DEM,Loretta L. Sanchez,156
+Contra Costa,Concord123,U.S. Senate,,DEM,Kamala D. Harris,519
+Contra Costa,Concord123,U.S. Senate,,DEM,Loretta L. Sanchez,246
+Contra Costa,Concord124,U.S. Senate,,DEM,Kamala D. Harris,523
+Contra Costa,Concord124,U.S. Senate,,DEM,Loretta L. Sanchez,232
+Contra Costa,Concord125,U.S. Senate,,DEM,Kamala D. Harris,447
+Contra Costa,Concord125,U.S. Senate,,DEM,Loretta L. Sanchez,206
+Contra Costa,Concord126,U.S. Senate,,DEM,Kamala D. Harris,609
+Contra Costa,Concord126,U.S. Senate,,DEM,Loretta L. Sanchez,330
+Contra Costa,Concord127,U.S. Senate,,DEM,Kamala D. Harris,295
+Contra Costa,Concord127,U.S. Senate,,DEM,Loretta L. Sanchez,136
+Contra Costa,Concord128,U.S. Senate,,DEM,Kamala D. Harris,580
+Contra Costa,Concord128,U.S. Senate,,DEM,Loretta L. Sanchez,251
+Contra Costa,Concord129,U.S. Senate,,DEM,Kamala D. Harris,402
+Contra Costa,Concord129,U.S. Senate,,DEM,Loretta L. Sanchez,202
+Contra Costa,Concord130,U.S. Senate,,DEM,Kamala D. Harris,268
+Contra Costa,Concord130,U.S. Senate,,DEM,Loretta L. Sanchez,126
+Contra Costa,Concord131,U.S. Senate,,DEM,Kamala D. Harris,382
+Contra Costa,Concord131,U.S. Senate,,DEM,Loretta L. Sanchez,163
+Contra Costa,Concord132,U.S. Senate,,DEM,Kamala D. Harris,372
+Contra Costa,Concord132,U.S. Senate,,DEM,Loretta L. Sanchez,141
+Contra Costa,Concord133,U.S. Senate,,DEM,Kamala D. Harris,449
+Contra Costa,Concord133,U.S. Senate,,DEM,Loretta L. Sanchez,215
+Contra Costa,Concord134,U.S. Senate,,DEM,Kamala D. Harris,457
+Contra Costa,Concord134,U.S. Senate,,DEM,Loretta L. Sanchez,231
+Contra Costa,Concord135,U.S. Senate,,DEM,Kamala D. Harris,422
+Contra Costa,Concord135,U.S. Senate,,DEM,Loretta L. Sanchez,250
+Contra Costa,Concord136,U.S. Senate,,DEM,Kamala D. Harris,701
+Contra Costa,Concord136,U.S. Senate,,DEM,Loretta L. Sanchez,351
+Contra Costa,Concord137,U.S. Senate,,DEM,Kamala D. Harris,363
+Contra Costa,Concord137,U.S. Senate,,DEM,Loretta L. Sanchez,165
+Contra Costa,Concord138,U.S. Senate,,DEM,Kamala D. Harris,490
+Contra Costa,Concord138,U.S. Senate,,DEM,Loretta L. Sanchez,217
+Contra Costa,Concord139,U.S. Senate,,DEM,Kamala D. Harris,406
+Contra Costa,Concord139,U.S. Senate,,DEM,Loretta L. Sanchez,214
+Contra Costa,Concord140,U.S. Senate,,DEM,Kamala D. Harris,371
+Contra Costa,Concord140,U.S. Senate,,DEM,Loretta L. Sanchez,145
+Contra Costa,Concord141,U.S. Senate,,DEM,Kamala D. Harris,359
+Contra Costa,Concord141,U.S. Senate,,DEM,Loretta L. Sanchez,207
+Contra Costa,Concord142,U.S. Senate,,DEM,Kamala D. Harris,372
+Contra Costa,Concord142,U.S. Senate,,DEM,Loretta L. Sanchez,158
+Contra Costa,Concord143,U.S. Senate,,DEM,Kamala D. Harris,646
+Contra Costa,Concord143,U.S. Senate,,DEM,Loretta L. Sanchez,232
+Contra Costa,Concord144,U.S. Senate,,DEM,Kamala D. Harris,612
+Contra Costa,Concord144,U.S. Senate,,DEM,Loretta L. Sanchez,217
+Contra Costa,Concord145,U.S. Senate,,DEM,Kamala D. Harris,372
+Contra Costa,Concord145,U.S. Senate,,DEM,Loretta L. Sanchez,281
+Contra Costa,Concord146,U.S. Senate,,DEM,Kamala D. Harris,336
+Contra Costa,Concord146,U.S. Senate,,DEM,Loretta L. Sanchez,239
+Contra Costa,Concord147,U.S. Senate,,DEM,Kamala D. Harris,460
+Contra Costa,Concord147,U.S. Senate,,DEM,Loretta L. Sanchez,223
+Contra Costa,Concord148,U.S. Senate,,DEM,Kamala D. Harris,602
+Contra Costa,Concord148,U.S. Senate,,DEM,Loretta L. Sanchez,284
+Contra Costa,Concord149,U.S. Senate,,DEM,Kamala D. Harris,458
+Contra Costa,Concord149,U.S. Senate,,DEM,Loretta L. Sanchez,198
+Contra Costa,Concord150,U.S. Senate,,DEM,Kamala D. Harris,510
+Contra Costa,Concord150,U.S. Senate,,DEM,Loretta L. Sanchez,214
+Contra Costa,Concord151,U.S. Senate,,DEM,Kamala D. Harris,226
+Contra Costa,Concord151,U.S. Senate,,DEM,Loretta L. Sanchez,106
+Contra Costa,Concord152,U.S. Senate,,DEM,Kamala D. Harris,446
+Contra Costa,Concord152,U.S. Senate,,DEM,Loretta L. Sanchez,208
+Contra Costa,Concord153,U.S. Senate,,DEM,Kamala D. Harris,487
+Contra Costa,Concord153,U.S. Senate,,DEM,Loretta L. Sanchez,177
+Contra Costa,Concord154,U.S. Senate,,DEM,Kamala D. Harris,324
+Contra Costa,Concord154,U.S. Senate,,DEM,Loretta L. Sanchez,142
+Contra Costa,Concord155,U.S. Senate,,DEM,Kamala D. Harris,356
+Contra Costa,Concord155,U.S. Senate,,DEM,Loretta L. Sanchez,176
+Contra Costa,Concord156,U.S. Senate,,DEM,Kamala D. Harris,407
+Contra Costa,Concord156,U.S. Senate,,DEM,Loretta L. Sanchez,223
+Contra Costa,Concord157,U.S. Senate,,DEM,Kamala D. Harris,400
+Contra Costa,Concord157,U.S. Senate,,DEM,Loretta L. Sanchez,178
+Contra Costa,Concord158,U.S. Senate,,DEM,Kamala D. Harris,458
+Contra Costa,Concord158,U.S. Senate,,DEM,Loretta L. Sanchez,214
+Contra Costa,Concord159,U.S. Senate,,DEM,Kamala D. Harris,545
+Contra Costa,Concord159,U.S. Senate,,DEM,Loretta L. Sanchez,211
+Contra Costa,Concord160,U.S. Senate,,DEM,Kamala D. Harris,373
+Contra Costa,Concord160,U.S. Senate,,DEM,Loretta L. Sanchez,193
+Contra Costa,Concord161,U.S. Senate,,DEM,Kamala D. Harris,456
+Contra Costa,Concord161,U.S. Senate,,DEM,Loretta L. Sanchez,188
+Contra Costa,Concord163,U.S. Senate,,DEM,Kamala D. Harris,635
+Contra Costa,Concord163,U.S. Senate,,DEM,Loretta L. Sanchez,375
+Contra Costa,Concord164,U.S. Senate,,DEM,Kamala D. Harris,465
+Contra Costa,Concord164,U.S. Senate,,DEM,Loretta L. Sanchez,227
+Contra Costa,Concord801,U.S. Senate,,DEM,Kamala D. Harris,12
+Contra Costa,Concord801,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Contra Costa,Concord802,U.S. Senate,,DEM,Kamala D. Harris,2
+Contra Costa,Concord802,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Contra Costa,Concord803,U.S. Senate,,DEM,Kamala D. Harris,0
+Contra Costa,Concord803,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Contra Costa,Crockett101,U.S. Senate,,DEM,Kamala D. Harris,752
+Contra Costa,Crockett101,U.S. Senate,,DEM,Loretta L. Sanchez,238
+Contra Costa,Crockett102,U.S. Senate,,DEM,Kamala D. Harris,369
+Contra Costa,Crockett102,U.S. Senate,,DEM,Loretta L. Sanchez,164
+Contra Costa,Crockett801,U.S. Senate,,DEM,Kamala D. Harris,0
+Contra Costa,Crockett801,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Contra Costa,Danville101,U.S. Senate,,DEM,Kamala D. Harris,328
+Contra Costa,Danville101,U.S. Senate,,DEM,Loretta L. Sanchez,177
+Contra Costa,Danville102,U.S. Senate,,DEM,Kamala D. Harris,257
+Contra Costa,Danville102,U.S. Senate,,DEM,Loretta L. Sanchez,140
+Contra Costa,Danville103,U.S. Senate,,DEM,Kamala D. Harris,482
+Contra Costa,Danville103,U.S. Senate,,DEM,Loretta L. Sanchez,214
+Contra Costa,Danville104,U.S. Senate,,DEM,Kamala D. Harris,649
+Contra Costa,Danville104,U.S. Senate,,DEM,Loretta L. Sanchez,236
+Contra Costa,Danville105,U.S. Senate,,DEM,Kamala D. Harris,619
+Contra Costa,Danville105,U.S. Senate,,DEM,Loretta L. Sanchez,294
+Contra Costa,Danville106,U.S. Senate,,DEM,Kamala D. Harris,529
+Contra Costa,Danville106,U.S. Senate,,DEM,Loretta L. Sanchez,248
+Contra Costa,Danville107,U.S. Senate,,DEM,Kamala D. Harris,710
+Contra Costa,Danville107,U.S. Senate,,DEM,Loretta L. Sanchez,294
+Contra Costa,Danville108,U.S. Senate,,DEM,Kamala D. Harris,607
+Contra Costa,Danville108,U.S. Senate,,DEM,Loretta L. Sanchez,301
+Contra Costa,Danville109,U.S. Senate,,DEM,Kamala D. Harris,388
+Contra Costa,Danville109,U.S. Senate,,DEM,Loretta L. Sanchez,155
+Contra Costa,Danville110,U.S. Senate,,DEM,Kamala D. Harris,241
+Contra Costa,Danville110,U.S. Senate,,DEM,Loretta L. Sanchez,106
+Contra Costa,Danville111,U.S. Senate,,DEM,Kamala D. Harris,329
+Contra Costa,Danville111,U.S. Senate,,DEM,Loretta L. Sanchez,124
+Contra Costa,Danville112,U.S. Senate,,DEM,Kamala D. Harris,528
+Contra Costa,Danville112,U.S. Senate,,DEM,Loretta L. Sanchez,252
+Contra Costa,Danville113,U.S. Senate,,DEM,Kamala D. Harris,418
+Contra Costa,Danville113,U.S. Senate,,DEM,Loretta L. Sanchez,163
+Contra Costa,Danville114,U.S. Senate,,DEM,Kamala D. Harris,542
+Contra Costa,Danville114,U.S. Senate,,DEM,Loretta L. Sanchez,264
+Contra Costa,Danville115,U.S. Senate,,DEM,Kamala D. Harris,420
+Contra Costa,Danville115,U.S. Senate,,DEM,Loretta L. Sanchez,176
+Contra Costa,Danville116,U.S. Senate,,DEM,Kamala D. Harris,303
+Contra Costa,Danville116,U.S. Senate,,DEM,Loretta L. Sanchez,156
+Contra Costa,Danville117,U.S. Senate,,DEM,Kamala D. Harris,498
+Contra Costa,Danville117,U.S. Senate,,DEM,Loretta L. Sanchez,228
+Contra Costa,Danville118,U.S. Senate,,DEM,Kamala D. Harris,502
+Contra Costa,Danville118,U.S. Senate,,DEM,Loretta L. Sanchez,189
+Contra Costa,Danville119,U.S. Senate,,DEM,Kamala D. Harris,741
+Contra Costa,Danville119,U.S. Senate,,DEM,Loretta L. Sanchez,293
+Contra Costa,Danville120,U.S. Senate,,DEM,Kamala D. Harris,635
+Contra Costa,Danville120,U.S. Senate,,DEM,Loretta L. Sanchez,246
+Contra Costa,Danville121,U.S. Senate,,DEM,Kamala D. Harris,312
+Contra Costa,Danville121,U.S. Senate,,DEM,Loretta L. Sanchez,145
+Contra Costa,Danville122,U.S. Senate,,DEM,Kamala D. Harris,407
+Contra Costa,Danville122,U.S. Senate,,DEM,Loretta L. Sanchez,167
+Contra Costa,Danville123,U.S. Senate,,DEM,Kamala D. Harris,431
+Contra Costa,Danville123,U.S. Senate,,DEM,Loretta L. Sanchez,180
+Contra Costa,Danville124,U.S. Senate,,DEM,Kamala D. Harris,337
+Contra Costa,Danville124,U.S. Senate,,DEM,Loretta L. Sanchez,129
+Contra Costa,Danville125,U.S. Senate,,DEM,Kamala D. Harris,234
+Contra Costa,Danville125,U.S. Senate,,DEM,Loretta L. Sanchez,98
+Contra Costa,Danville126,U.S. Senate,,DEM,Kamala D. Harris,709
+Contra Costa,Danville126,U.S. Senate,,DEM,Loretta L. Sanchez,309
+Contra Costa,Danville127,U.S. Senate,,DEM,Kamala D. Harris,431
+Contra Costa,Danville127,U.S. Senate,,DEM,Loretta L. Sanchez,202
+Contra Costa,Danville128,U.S. Senate,,DEM,Kamala D. Harris,320
+Contra Costa,Danville128,U.S. Senate,,DEM,Loretta L. Sanchez,142
+Contra Costa,Danville129,U.S. Senate,,DEM,Kamala D. Harris,537
+Contra Costa,Danville129,U.S. Senate,,DEM,Loretta L. Sanchez,238
+Contra Costa,Danville130,U.S. Senate,,DEM,Kamala D. Harris,407
+Contra Costa,Danville130,U.S. Senate,,DEM,Loretta L. Sanchez,156
+Contra Costa,Diablo101,U.S. Senate,,DEM,Kamala D. Harris,345
+Contra Costa,Diablo101,U.S. Senate,,DEM,Loretta L. Sanchez,195
+Contra Costa,DiscoveryBay101,U.S. Senate,,DEM,Kamala D. Harris,518
+Contra Costa,DiscoveryBay101,U.S. Senate,,DEM,Loretta L. Sanchez,274
+Contra Costa,DiscoveryBay102,U.S. Senate,,DEM,Kamala D. Harris,581
+Contra Costa,DiscoveryBay102,U.S. Senate,,DEM,Loretta L. Sanchez,347
+Contra Costa,DiscoveryBay103,U.S. Senate,,DEM,Kamala D. Harris,270
+Contra Costa,DiscoveryBay103,U.S. Senate,,DEM,Loretta L. Sanchez,176
+Contra Costa,DiscoveryBay104,U.S. Senate,,DEM,Kamala D. Harris,462
+Contra Costa,DiscoveryBay104,U.S. Senate,,DEM,Loretta L. Sanchez,299
+Contra Costa,DiscoveryBay105,U.S. Senate,,DEM,Kamala D. Harris,203
+Contra Costa,DiscoveryBay105,U.S. Senate,,DEM,Loretta L. Sanchez,142
+Contra Costa,DiscoveryBay106,U.S. Senate,,DEM,Kamala D. Harris,590
+Contra Costa,DiscoveryBay106,U.S. Senate,,DEM,Loretta L. Sanchez,398
+Contra Costa,DiscoveryBay107,U.S. Senate,,DEM,Kamala D. Harris,408
+Contra Costa,DiscoveryBay107,U.S. Senate,,DEM,Loretta L. Sanchez,239
+Contra Costa,DiscoveryBay801,U.S. Senate,,DEM,Kamala D. Harris,54
+Contra Costa,DiscoveryBay801,U.S. Senate,,DEM,Loretta L. Sanchez,58
+Contra Costa,EastRichmond101,U.S. Senate,,DEM,Kamala D. Harris,746
+Contra Costa,EastRichmond101,U.S. Senate,,DEM,Loretta L. Sanchez,197
+Contra Costa,EastRichmond102,U.S. Senate,,DEM,Kamala D. Harris,809
+Contra Costa,EastRichmond102,U.S. Senate,,DEM,Loretta L. Sanchez,152
+Contra Costa,EastRichmond103,U.S. Senate,,DEM,Kamala D. Harris,309
+Contra Costa,EastRichmond103,U.S. Senate,,DEM,Loretta L. Sanchez,95
+Contra Costa,EastRichmond801,U.S. Senate,,DEM,Kamala D. Harris,34
+Contra Costa,EastRichmond801,U.S. Senate,,DEM,Loretta L. Sanchez,5
+Contra Costa,ElCerrito101,U.S. Senate,,DEM,Kamala D. Harris,883
+Contra Costa,ElCerrito101,U.S. Senate,,DEM,Loretta L. Sanchez,191
+Contra Costa,ElCerrito102,U.S. Senate,,DEM,Kamala D. Harris,861
+Contra Costa,ElCerrito102,U.S. Senate,,DEM,Loretta L. Sanchez,177
+Contra Costa,ElCerrito103,U.S. Senate,,DEM,Kamala D. Harris,557
+Contra Costa,ElCerrito103,U.S. Senate,,DEM,Loretta L. Sanchez,177
+Contra Costa,ElCerrito104,U.S. Senate,,DEM,Kamala D. Harris,800
+Contra Costa,ElCerrito104,U.S. Senate,,DEM,Loretta L. Sanchez,223
+Contra Costa,ElCerrito105,U.S. Senate,,DEM,Kamala D. Harris,646
+Contra Costa,ElCerrito105,U.S. Senate,,DEM,Loretta L. Sanchez,162
+Contra Costa,ElCerrito106,U.S. Senate,,DEM,Kamala D. Harris,1010
+Contra Costa,ElCerrito106,U.S. Senate,,DEM,Loretta L. Sanchez,245
+Contra Costa,ElCerrito107,U.S. Senate,,DEM,Kamala D. Harris,510
+Contra Costa,ElCerrito107,U.S. Senate,,DEM,Loretta L. Sanchez,134
+Contra Costa,ElCerrito108,U.S. Senate,,DEM,Kamala D. Harris,617
+Contra Costa,ElCerrito108,U.S. Senate,,DEM,Loretta L. Sanchez,132
+Contra Costa,ElCerrito109,U.S. Senate,,DEM,Kamala D. Harris,780
+Contra Costa,ElCerrito109,U.S. Senate,,DEM,Loretta L. Sanchez,192
+Contra Costa,ElCerrito110,U.S. Senate,,DEM,Kamala D. Harris,800
+Contra Costa,ElCerrito110,U.S. Senate,,DEM,Loretta L. Sanchez,158
+Contra Costa,ElCerrito111,U.S. Senate,,DEM,Kamala D. Harris,653
+Contra Costa,ElCerrito111,U.S. Senate,,DEM,Loretta L. Sanchez,130
+Contra Costa,ElCerrito112,U.S. Senate,,DEM,Kamala D. Harris,969
+Contra Costa,ElCerrito112,U.S. Senate,,DEM,Loretta L. Sanchez,266
+Contra Costa,ElCerrito113,U.S. Senate,,DEM,Kamala D. Harris,952
+Contra Costa,ElCerrito113,U.S. Senate,,DEM,Loretta L. Sanchez,178
+Contra Costa,ElSobrante101,U.S. Senate,,DEM,Kamala D. Harris,539
+Contra Costa,ElSobrante101,U.S. Senate,,DEM,Loretta L. Sanchez,235
+Contra Costa,ElSobrante102,U.S. Senate,,DEM,Kamala D. Harris,640
+Contra Costa,ElSobrante102,U.S. Senate,,DEM,Loretta L. Sanchez,214
+Contra Costa,ElSobrante103,U.S. Senate,,DEM,Kamala D. Harris,455
+Contra Costa,ElSobrante103,U.S. Senate,,DEM,Loretta L. Sanchez,209
+Contra Costa,ElSobrante104,U.S. Senate,,DEM,Kamala D. Harris,733
+Contra Costa,ElSobrante104,U.S. Senate,,DEM,Loretta L. Sanchez,305
+Contra Costa,ElSobrante105,U.S. Senate,,DEM,Kamala D. Harris,551
+Contra Costa,ElSobrante105,U.S. Senate,,DEM,Loretta L. Sanchez,279
+Contra Costa,ElSobrante106,U.S. Senate,,DEM,Kamala D. Harris,507
+Contra Costa,ElSobrante106,U.S. Senate,,DEM,Loretta L. Sanchez,226
+Contra Costa,ElSobrante801,U.S. Senate,,DEM,Kamala D. Harris,2
+Contra Costa,ElSobrante801,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Contra Costa,ElSobrante802,U.S. Senate,,DEM,Kamala D. Harris,105
+Contra Costa,ElSobrante802,U.S. Senate,,DEM,Loretta L. Sanchez,35
+Contra Costa,ElSobrante803,U.S. Senate,,DEM,Kamala D. Harris,7
+Contra Costa,ElSobrante803,U.S. Senate,,DEM,Loretta L. Sanchez,7
+Contra Costa,Fairgrounds801,U.S. Senate,,DEM,Kamala D. Harris,0
+Contra Costa,Fairgrounds801,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Contra Costa,Giant101,U.S. Senate,,DEM,Kamala D. Harris,246
+Contra Costa,Giant101,U.S. Senate,,DEM,Loretta L. Sanchez,300
+Contra Costa,Giant102,U.S. Senate,,DEM,Kamala D. Harris,560
+Contra Costa,Giant102,U.S. Senate,,DEM,Loretta L. Sanchez,347
+Contra Costa,Giant103,U.S. Senate,,DEM,Kamala D. Harris,485
+Contra Costa,Giant103,U.S. Senate,,DEM,Loretta L. Sanchez,319
+Contra Costa,Giant104,U.S. Senate,,DEM,Kamala D. Harris,562
+Contra Costa,Giant104,U.S. Senate,,DEM,Loretta L. Sanchez,297
+Contra Costa,Hercules101,U.S. Senate,,DEM,Kamala D. Harris,707
+Contra Costa,Hercules101,U.S. Senate,,DEM,Loretta L. Sanchez,243
+Contra Costa,Hercules102,U.S. Senate,,DEM,Kamala D. Harris,653
+Contra Costa,Hercules102,U.S. Senate,,DEM,Loretta L. Sanchez,248
+Contra Costa,Hercules103,U.S. Senate,,DEM,Kamala D. Harris,362
+Contra Costa,Hercules103,U.S. Senate,,DEM,Loretta L. Sanchez,130
+Contra Costa,Hercules104,U.S. Senate,,DEM,Kamala D. Harris,542
+Contra Costa,Hercules104,U.S. Senate,,DEM,Loretta L. Sanchez,222
+Contra Costa,Hercules105,U.S. Senate,,DEM,Kamala D. Harris,326
+Contra Costa,Hercules105,U.S. Senate,,DEM,Loretta L. Sanchez,129
+Contra Costa,Hercules106,U.S. Senate,,DEM,Kamala D. Harris,472
+Contra Costa,Hercules106,U.S. Senate,,DEM,Loretta L. Sanchez,211
+Contra Costa,Hercules107,U.S. Senate,,DEM,Kamala D. Harris,613
+Contra Costa,Hercules107,U.S. Senate,,DEM,Loretta L. Sanchez,215
+Contra Costa,Hercules108,U.S. Senate,,DEM,Kamala D. Harris,508
+Contra Costa,Hercules108,U.S. Senate,,DEM,Loretta L. Sanchez,194
+Contra Costa,Hercules109,U.S. Senate,,DEM,Kamala D. Harris,648
+Contra Costa,Hercules109,U.S. Senate,,DEM,Loretta L. Sanchez,189
+Contra Costa,Hercules110,U.S. Senate,,DEM,Kamala D. Harris,439
+Contra Costa,Hercules110,U.S. Senate,,DEM,Loretta L. Sanchez,209
+Contra Costa,Hercules111,U.S. Senate,,DEM,Kamala D. Harris,498
+Contra Costa,Hercules111,U.S. Senate,,DEM,Loretta L. Sanchez,198
+Contra Costa,Hercules113,U.S. Senate,,DEM,Kamala D. Harris,793
+Contra Costa,Hercules113,U.S. Senate,,DEM,Loretta L. Sanchez,268
+Contra Costa,Hercules114,U.S. Senate,,DEM,Kamala D. Harris,468
+Contra Costa,Hercules114,U.S. Senate,,DEM,Loretta L. Sanchez,182
+Contra Costa,Kensington101,U.S. Senate,,DEM,Kamala D. Harris,511
+Contra Costa,Kensington101,U.S. Senate,,DEM,Loretta L. Sanchez,114
+Contra Costa,Kensington102,U.S. Senate,,DEM,Kamala D. Harris,616
+Contra Costa,Kensington102,U.S. Senate,,DEM,Loretta L. Sanchez,121
+Contra Costa,Kensington103,U.S. Senate,,DEM,Kamala D. Harris,947
+Contra Costa,Kensington103,U.S. Senate,,DEM,Loretta L. Sanchez,175
+Contra Costa,Kensington104,U.S. Senate,,DEM,Kamala D. Harris,836
+Contra Costa,Kensington104,U.S. Senate,,DEM,Loretta L. Sanchez,127
+Contra Costa,Kensington801,U.S. Senate,,DEM,Kamala D. Harris,0
+Contra Costa,Kensington801,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Contra Costa,Kensington802,U.S. Senate,,DEM,Kamala D. Harris,4
+Contra Costa,Kensington802,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Contra Costa,Knightsen101,U.S. Senate,,DEM,Kamala D. Harris,258
+Contra Costa,Knightsen101,U.S. Senate,,DEM,Loretta L. Sanchez,248
+Contra Costa,Knightsen801,U.S. Senate,,DEM,Kamala D. Harris,19
+Contra Costa,Knightsen801,U.S. Senate,,DEM,Loretta L. Sanchez,17
+Contra Costa,Knightsen802,U.S. Senate,,DEM,Kamala D. Harris,4
+Contra Costa,Knightsen802,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Contra Costa,Knightsen803,U.S. Senate,,DEM,Kamala D. Harris,39
+Contra Costa,Knightsen803,U.S. Senate,,DEM,Loretta L. Sanchez,36
+Contra Costa,Knightsen804,U.S. Senate,,DEM,Kamala D. Harris,31
+Contra Costa,Knightsen804,U.S. Senate,,DEM,Loretta L. Sanchez,29
+Contra Costa,Lafayette101,U.S. Senate,,DEM,Kamala D. Harris,665
+Contra Costa,Lafayette101,U.S. Senate,,DEM,Loretta L. Sanchez,231
+Contra Costa,Lafayette102,U.S. Senate,,DEM,Kamala D. Harris,504
+Contra Costa,Lafayette102,U.S. Senate,,DEM,Loretta L. Sanchez,208
+Contra Costa,Lafayette103,U.S. Senate,,DEM,Kamala D. Harris,503
+Contra Costa,Lafayette103,U.S. Senate,,DEM,Loretta L. Sanchez,169
+Contra Costa,Lafayette104,U.S. Senate,,DEM,Kamala D. Harris,636
+Contra Costa,Lafayette104,U.S. Senate,,DEM,Loretta L. Sanchez,199
+Contra Costa,Lafayette105,U.S. Senate,,DEM,Kamala D. Harris,471
+Contra Costa,Lafayette105,U.S. Senate,,DEM,Loretta L. Sanchez,172
+Contra Costa,Lafayette106,U.S. Senate,,DEM,Kamala D. Harris,484
+Contra Costa,Lafayette106,U.S. Senate,,DEM,Loretta L. Sanchez,149
+Contra Costa,Lafayette107,U.S. Senate,,DEM,Kamala D. Harris,750
+Contra Costa,Lafayette107,U.S. Senate,,DEM,Loretta L. Sanchez,211
+Contra Costa,Lafayette108,U.S. Senate,,DEM,Kamala D. Harris,783
+Contra Costa,Lafayette108,U.S. Senate,,DEM,Loretta L. Sanchez,261
+Contra Costa,Lafayette109,U.S. Senate,,DEM,Kamala D. Harris,817
+Contra Costa,Lafayette109,U.S. Senate,,DEM,Loretta L. Sanchez,232
+Contra Costa,Lafayette110,U.S. Senate,,DEM,Kamala D. Harris,444
+Contra Costa,Lafayette110,U.S. Senate,,DEM,Loretta L. Sanchez,160
+Contra Costa,Lafayette111,U.S. Senate,,DEM,Kamala D. Harris,511
+Contra Costa,Lafayette111,U.S. Senate,,DEM,Loretta L. Sanchez,151
+Contra Costa,Lafayette112,U.S. Senate,,DEM,Kamala D. Harris,240
+Contra Costa,Lafayette112,U.S. Senate,,DEM,Loretta L. Sanchez,78
+Contra Costa,Lafayette113,U.S. Senate,,DEM,Kamala D. Harris,549
+Contra Costa,Lafayette113,U.S. Senate,,DEM,Loretta L. Sanchez,179
+Contra Costa,Lafayette114,U.S. Senate,,DEM,Kamala D. Harris,518
+Contra Costa,Lafayette114,U.S. Senate,,DEM,Loretta L. Sanchez,137
+Contra Costa,Lafayette115,U.S. Senate,,DEM,Kamala D. Harris,433
+Contra Costa,Lafayette115,U.S. Senate,,DEM,Loretta L. Sanchez,132
+Contra Costa,Lafayette116,U.S. Senate,,DEM,Kamala D. Harris,673
+Contra Costa,Lafayette116,U.S. Senate,,DEM,Loretta L. Sanchez,222
+Contra Costa,Lafayette117,U.S. Senate,,DEM,Kamala D. Harris,793
+Contra Costa,Lafayette117,U.S. Senate,,DEM,Loretta L. Sanchez,223
+Contra Costa,LasTrampas801,U.S. Senate,,DEM,Kamala D. Harris,28
+Contra Costa,LasTrampas801,U.S. Senate,,DEM,Loretta L. Sanchez,13
+Contra Costa,MarshCreek801,U.S. Senate,,DEM,Kamala D. Harris,68
+Contra Costa,MarshCreek801,U.S. Senate,,DEM,Loretta L. Sanchez,72
+Contra Costa,MarshCreek802,U.S. Senate,,DEM,Kamala D. Harris,6
+Contra Costa,MarshCreek802,U.S. Senate,,DEM,Loretta L. Sanchez,14
+Contra Costa,MarshCreek803,U.S. Senate,,DEM,Kamala D. Harris,12
+Contra Costa,MarshCreek803,U.S. Senate,,DEM,Loretta L. Sanchez,7
+Contra Costa,Martinez101,U.S. Senate,,DEM,Kamala D. Harris,601
+Contra Costa,Martinez101,U.S. Senate,,DEM,Loretta L. Sanchez,244
+Contra Costa,Martinez102,U.S. Senate,,DEM,Kamala D. Harris,634
+Contra Costa,Martinez102,U.S. Senate,,DEM,Loretta L. Sanchez,230
+Contra Costa,Martinez103,U.S. Senate,,DEM,Kamala D. Harris,291
+Contra Costa,Martinez103,U.S. Senate,,DEM,Loretta L. Sanchez,129
+Contra Costa,Martinez104,U.S. Senate,,DEM,Kamala D. Harris,561
+Contra Costa,Martinez104,U.S. Senate,,DEM,Loretta L. Sanchez,217
+Contra Costa,Martinez105,U.S. Senate,,DEM,Kamala D. Harris,364
+Contra Costa,Martinez105,U.S. Senate,,DEM,Loretta L. Sanchez,147
+Contra Costa,Martinez106,U.S. Senate,,DEM,Kamala D. Harris,394
+Contra Costa,Martinez106,U.S. Senate,,DEM,Loretta L. Sanchez,197
+Contra Costa,Martinez107,U.S. Senate,,DEM,Kamala D. Harris,475
+Contra Costa,Martinez107,U.S. Senate,,DEM,Loretta L. Sanchez,236
+Contra Costa,Martinez108,U.S. Senate,,DEM,Kamala D. Harris,510
+Contra Costa,Martinez108,U.S. Senate,,DEM,Loretta L. Sanchez,233
+Contra Costa,Martinez109,U.S. Senate,,DEM,Kamala D. Harris,597
+Contra Costa,Martinez109,U.S. Senate,,DEM,Loretta L. Sanchez,250
+Contra Costa,Martinez110,U.S. Senate,,DEM,Kamala D. Harris,699
+Contra Costa,Martinez110,U.S. Senate,,DEM,Loretta L. Sanchez,296
+Contra Costa,Martinez111,U.S. Senate,,DEM,Kamala D. Harris,632
+Contra Costa,Martinez111,U.S. Senate,,DEM,Loretta L. Sanchez,310
+Contra Costa,Martinez112,U.S. Senate,,DEM,Kamala D. Harris,459
+Contra Costa,Martinez112,U.S. Senate,,DEM,Loretta L. Sanchez,158
+Contra Costa,Martinez113,U.S. Senate,,DEM,Kamala D. Harris,213
+Contra Costa,Martinez113,U.S. Senate,,DEM,Loretta L. Sanchez,73
+Contra Costa,Martinez114,U.S. Senate,,DEM,Kamala D. Harris,311
+Contra Costa,Martinez114,U.S. Senate,,DEM,Loretta L. Sanchez,133
+Contra Costa,Martinez115,U.S. Senate,,DEM,Kamala D. Harris,645
+Contra Costa,Martinez115,U.S. Senate,,DEM,Loretta L. Sanchez,284
+Contra Costa,Martinez116,U.S. Senate,,DEM,Kamala D. Harris,524
+Contra Costa,Martinez116,U.S. Senate,,DEM,Loretta L. Sanchez,228
+Contra Costa,Martinez117,U.S. Senate,,DEM,Kamala D. Harris,323
+Contra Costa,Martinez117,U.S. Senate,,DEM,Loretta L. Sanchez,127
+Contra Costa,Martinez118,U.S. Senate,,DEM,Kamala D. Harris,380
+Contra Costa,Martinez118,U.S. Senate,,DEM,Loretta L. Sanchez,190
+Contra Costa,Martinez119,U.S. Senate,,DEM,Kamala D. Harris,738
+Contra Costa,Martinez119,U.S. Senate,,DEM,Loretta L. Sanchez,324
+Contra Costa,Martinez120,U.S. Senate,,DEM,Kamala D. Harris,548
+Contra Costa,Martinez120,U.S. Senate,,DEM,Loretta L. Sanchez,217
+Contra Costa,Martinez121,U.S. Senate,,DEM,Kamala D. Harris,275
+Contra Costa,Martinez121,U.S. Senate,,DEM,Loretta L. Sanchez,130
+Contra Costa,Martinez122,U.S. Senate,,DEM,Kamala D. Harris,455
+Contra Costa,Martinez122,U.S. Senate,,DEM,Loretta L. Sanchez,186
+Contra Costa,Martinez123,U.S. Senate,,DEM,Kamala D. Harris,444
+Contra Costa,Martinez123,U.S. Senate,,DEM,Loretta L. Sanchez,206
+Contra Costa,Martinez124,U.S. Senate,,DEM,Kamala D. Harris,161
+Contra Costa,Martinez124,U.S. Senate,,DEM,Loretta L. Sanchez,57
+Contra Costa,Martinez801,U.S. Senate,,DEM,Kamala D. Harris,1
+Contra Costa,Martinez801,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Contra Costa,Martinez802,U.S. Senate,,DEM,Kamala D. Harris,79
+Contra Costa,Martinez802,U.S. Senate,,DEM,Loretta L. Sanchez,54
+Contra Costa,Martinez803,U.S. Senate,,DEM,Kamala D. Harris,22
+Contra Costa,Martinez803,U.S. Senate,,DEM,Loretta L. Sanchez,11
+Contra Costa,Moraga101,U.S. Senate,,DEM,Kamala D. Harris,818
+Contra Costa,Moraga101,U.S. Senate,,DEM,Loretta L. Sanchez,292
+Contra Costa,Moraga102,U.S. Senate,,DEM,Kamala D. Harris,504
+Contra Costa,Moraga102,U.S. Senate,,DEM,Loretta L. Sanchez,202
+Contra Costa,Moraga103,U.S. Senate,,DEM,Kamala D. Harris,728
+Contra Costa,Moraga103,U.S. Senate,,DEM,Loretta L. Sanchez,226
+Contra Costa,Moraga104,U.S. Senate,,DEM,Kamala D. Harris,736
+Contra Costa,Moraga104,U.S. Senate,,DEM,Loretta L. Sanchez,288
+Contra Costa,Moraga105,U.S. Senate,,DEM,Kamala D. Harris,771
+Contra Costa,Moraga105,U.S. Senate,,DEM,Loretta L. Sanchez,237
+Contra Costa,Moraga106,U.S. Senate,,DEM,Kamala D. Harris,781
+Contra Costa,Moraga106,U.S. Senate,,DEM,Loretta L. Sanchez,253
+Contra Costa,Moraga107,U.S. Senate,,DEM,Kamala D. Harris,830
+Contra Costa,Moraga107,U.S. Senate,,DEM,Loretta L. Sanchez,290
+Contra Costa,Moraga108,U.S. Senate,,DEM,Kamala D. Harris,528
+Contra Costa,Moraga108,U.S. Senate,,DEM,Loretta L. Sanchez,208
+Contra Costa,MountDiablo101,U.S. Senate,,DEM,Kamala D. Harris,202
+Contra Costa,MountDiablo101,U.S. Senate,,DEM,Loretta L. Sanchez,89
+Contra Costa,MountDiablo801,U.S. Senate,,DEM,Kamala D. Harris,4
+Contra Costa,MountDiablo801,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Contra Costa,MountDiablo802,U.S. Senate,,DEM,Kamala D. Harris,3
+Contra Costa,MountDiablo802,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Contra Costa,MountainView101,U.S. Senate,,DEM,Kamala D. Harris,293
+Contra Costa,MountainView101,U.S. Senate,,DEM,Loretta L. Sanchez,141
+Contra Costa,MountainView102,U.S. Senate,,DEM,Kamala D. Harris,333
+Contra Costa,MountainView102,U.S. Senate,,DEM,Loretta L. Sanchez,139
+Contra Costa,Nichols801,U.S. Senate,,DEM,Kamala D. Harris,1
+Contra Costa,Nichols801,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Contra Costa,NorrisCanyon101,U.S. Senate,,DEM,Kamala D. Harris,314
+Contra Costa,NorrisCanyon101,U.S. Senate,,DEM,Loretta L. Sanchez,108
+Contra Costa,NorthRichmond101,U.S. Senate,,DEM,Kamala D. Harris,488
+Contra Costa,NorthRichmond101,U.S. Senate,,DEM,Loretta L. Sanchez,254
+Contra Costa,NortonValley801,U.S. Senate,,DEM,Kamala D. Harris,3
+Contra Costa,NortonValley801,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Contra Costa,NortonValley802,U.S. Senate,,DEM,Kamala D. Harris,3
+Contra Costa,NortonValley802,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Contra Costa,Oakley101,U.S. Senate,,DEM,Kamala D. Harris,613
+Contra Costa,Oakley101,U.S. Senate,,DEM,Loretta L. Sanchez,422
+Contra Costa,Oakley102,U.S. Senate,,DEM,Kamala D. Harris,355
+Contra Costa,Oakley102,U.S. Senate,,DEM,Loretta L. Sanchez,311
+Contra Costa,Oakley103,U.S. Senate,,DEM,Kamala D. Harris,430
+Contra Costa,Oakley103,U.S. Senate,,DEM,Loretta L. Sanchez,289
+Contra Costa,Oakley104,U.S. Senate,,DEM,Kamala D. Harris,406
+Contra Costa,Oakley104,U.S. Senate,,DEM,Loretta L. Sanchez,238
+Contra Costa,Oakley105,U.S. Senate,,DEM,Kamala D. Harris,433
+Contra Costa,Oakley105,U.S. Senate,,DEM,Loretta L. Sanchez,251
+Contra Costa,Oakley106,U.S. Senate,,DEM,Kamala D. Harris,440
+Contra Costa,Oakley106,U.S. Senate,,DEM,Loretta L. Sanchez,318
+Contra Costa,Oakley107,U.S. Senate,,DEM,Kamala D. Harris,565
+Contra Costa,Oakley107,U.S. Senate,,DEM,Loretta L. Sanchez,398
+Contra Costa,Oakley108,U.S. Senate,,DEM,Kamala D. Harris,305
+Contra Costa,Oakley108,U.S. Senate,,DEM,Loretta L. Sanchez,248
+Contra Costa,Oakley109,U.S. Senate,,DEM,Kamala D. Harris,324
+Contra Costa,Oakley109,U.S. Senate,,DEM,Loretta L. Sanchez,256
+Contra Costa,Oakley110,U.S. Senate,,DEM,Kamala D. Harris,372
+Contra Costa,Oakley110,U.S. Senate,,DEM,Loretta L. Sanchez,255
+Contra Costa,Oakley111,U.S. Senate,,DEM,Kamala D. Harris,296
+Contra Costa,Oakley111,U.S. Senate,,DEM,Loretta L. Sanchez,223
+Contra Costa,Oakley112,U.S. Senate,,DEM,Kamala D. Harris,293
+Contra Costa,Oakley112,U.S. Senate,,DEM,Loretta L. Sanchez,186
+Contra Costa,Oakley113,U.S. Senate,,DEM,Kamala D. Harris,526
+Contra Costa,Oakley113,U.S. Senate,,DEM,Loretta L. Sanchez,363
+Contra Costa,Oakley114,U.S. Senate,,DEM,Kamala D. Harris,416
+Contra Costa,Oakley114,U.S. Senate,,DEM,Loretta L. Sanchez,310
+Contra Costa,Oakley115,U.S. Senate,,DEM,Kamala D. Harris,395
+Contra Costa,Oakley115,U.S. Senate,,DEM,Loretta L. Sanchez,280
+Contra Costa,Oakley116,U.S. Senate,,DEM,Kamala D. Harris,480
+Contra Costa,Oakley116,U.S. Senate,,DEM,Loretta L. Sanchez,339
+Contra Costa,Oakley117,U.S. Senate,,DEM,Kamala D. Harris,283
+Contra Costa,Oakley117,U.S. Senate,,DEM,Loretta L. Sanchez,266
+Contra Costa,Oakley801,U.S. Senate,,DEM,Kamala D. Harris,3
+Contra Costa,Oakley801,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Contra Costa,Oleum801,U.S. Senate,,DEM,Kamala D. Harris,6
+Contra Costa,Oleum801,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Contra Costa,Oleum802,U.S. Senate,,DEM,Kamala D. Harris,10
+Contra Costa,Oleum802,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Contra Costa,Orinda101,U.S. Senate,,DEM,Kamala D. Harris,946
+Contra Costa,Orinda101,U.S. Senate,,DEM,Loretta L. Sanchez,256
+Contra Costa,Orinda102,U.S. Senate,,DEM,Kamala D. Harris,442
+Contra Costa,Orinda102,U.S. Senate,,DEM,Loretta L. Sanchez,125
+Contra Costa,Orinda103,U.S. Senate,,DEM,Kamala D. Harris,564
+Contra Costa,Orinda103,U.S. Senate,,DEM,Loretta L. Sanchez,185
+Contra Costa,Orinda104,U.S. Senate,,DEM,Kamala D. Harris,357
+Contra Costa,Orinda104,U.S. Senate,,DEM,Loretta L. Sanchez,99
+Contra Costa,Orinda105,U.S. Senate,,DEM,Kamala D. Harris,677
+Contra Costa,Orinda105,U.S. Senate,,DEM,Loretta L. Sanchez,234
+Contra Costa,Orinda106,U.S. Senate,,DEM,Kamala D. Harris,1082
+Contra Costa,Orinda106,U.S. Senate,,DEM,Loretta L. Sanchez,308
+Contra Costa,Orinda107,U.S. Senate,,DEM,Kamala D. Harris,854
+Contra Costa,Orinda107,U.S. Senate,,DEM,Loretta L. Sanchez,243
+Contra Costa,Orinda108,U.S. Senate,,DEM,Kamala D. Harris,771
+Contra Costa,Orinda108,U.S. Senate,,DEM,Loretta L. Sanchez,235
+Contra Costa,Orinda109,U.S. Senate,,DEM,Kamala D. Harris,460
+Contra Costa,Orinda109,U.S. Senate,,DEM,Loretta L. Sanchez,192
+Contra Costa,Orinda110,U.S. Senate,,DEM,Kamala D. Harris,283
+Contra Costa,Orinda110,U.S. Senate,,DEM,Loretta L. Sanchez,75
+Contra Costa,Orinda111,U.S. Senate,,DEM,Kamala D. Harris,846
+Contra Costa,Orinda111,U.S. Senate,,DEM,Loretta L. Sanchez,240
+Contra Costa,Orinda112,U.S. Senate,,DEM,Kamala D. Harris,591
+Contra Costa,Orinda112,U.S. Senate,,DEM,Loretta L. Sanchez,173
+Contra Costa,Orinda801,U.S. Senate,,DEM,Kamala D. Harris,3
+Contra Costa,Orinda801,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Contra Costa,Pacheco101,U.S. Senate,,DEM,Kamala D. Harris,642
+Contra Costa,Pacheco101,U.S. Senate,,DEM,Loretta L. Sanchez,295
+Contra Costa,Pacheco102,U.S. Senate,,DEM,Kamala D. Harris,307
+Contra Costa,Pacheco102,U.S. Senate,,DEM,Loretta L. Sanchez,175
+Contra Costa,Pacheco801,U.S. Senate,,DEM,Kamala D. Harris,1
+Contra Costa,Pacheco801,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Contra Costa,Pacheco802,U.S. Senate,,DEM,Kamala D. Harris,46
+Contra Costa,Pacheco802,U.S. Senate,,DEM,Loretta L. Sanchez,39
+Contra Costa,Pacheco803,U.S. Senate,,DEM,Kamala D. Harris,0
+Contra Costa,Pacheco803,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Contra Costa,Pinole102,U.S. Senate,,DEM,Kamala D. Harris,437
+Contra Costa,Pinole102,U.S. Senate,,DEM,Loretta L. Sanchez,192
+Contra Costa,Pinole103,U.S. Senate,,DEM,Kamala D. Harris,509
+Contra Costa,Pinole103,U.S. Senate,,DEM,Loretta L. Sanchez,199
+Contra Costa,Pinole104,U.S. Senate,,DEM,Kamala D. Harris,341
+Contra Costa,Pinole104,U.S. Senate,,DEM,Loretta L. Sanchez,179
+Contra Costa,Pinole105,U.S. Senate,,DEM,Kamala D. Harris,551
+Contra Costa,Pinole105,U.S. Senate,,DEM,Loretta L. Sanchez,211
+Contra Costa,Pinole106,U.S. Senate,,DEM,Kamala D. Harris,410
+Contra Costa,Pinole106,U.S. Senate,,DEM,Loretta L. Sanchez,185
+Contra Costa,Pinole107,U.S. Senate,,DEM,Kamala D. Harris,353
+Contra Costa,Pinole107,U.S. Senate,,DEM,Loretta L. Sanchez,193
+Contra Costa,Pinole108,U.S. Senate,,DEM,Kamala D. Harris,542
+Contra Costa,Pinole108,U.S. Senate,,DEM,Loretta L. Sanchez,215
+Contra Costa,Pinole109,U.S. Senate,,DEM,Kamala D. Harris,325
+Contra Costa,Pinole109,U.S. Senate,,DEM,Loretta L. Sanchez,161
+Contra Costa,Pinole110,U.S. Senate,,DEM,Kamala D. Harris,535
+Contra Costa,Pinole110,U.S. Senate,,DEM,Loretta L. Sanchez,287
+Contra Costa,Pinole111,U.S. Senate,,DEM,Kamala D. Harris,524
+Contra Costa,Pinole111,U.S. Senate,,DEM,Loretta L. Sanchez,240
+Contra Costa,Pinole112,U.S. Senate,,DEM,Kamala D. Harris,522
+Contra Costa,Pinole112,U.S. Senate,,DEM,Loretta L. Sanchez,245
+Contra Costa,Pinole801,U.S. Senate,,DEM,Kamala D. Harris,2
+Contra Costa,Pinole801,U.S. Senate,,DEM,Loretta L. Sanchez,10
+Contra Costa,Pinole802,U.S. Senate,,DEM,Kamala D. Harris,110
+Contra Costa,Pinole802,U.S. Senate,,DEM,Loretta L. Sanchez,68
+Contra Costa,Pinole803,U.S. Senate,,DEM,Kamala D. Harris,47
+Contra Costa,Pinole803,U.S. Senate,,DEM,Loretta L. Sanchez,11
+Contra Costa,Pittsburg101,U.S. Senate,,DEM,Kamala D. Harris,892
+Contra Costa,Pittsburg101,U.S. Senate,,DEM,Loretta L. Sanchez,374
+Contra Costa,Pittsburg102,U.S. Senate,,DEM,Kamala D. Harris,376
+Contra Costa,Pittsburg102,U.S. Senate,,DEM,Loretta L. Sanchez,191
+Contra Costa,Pittsburg103,U.S. Senate,,DEM,Kamala D. Harris,432
+Contra Costa,Pittsburg103,U.S. Senate,,DEM,Loretta L. Sanchez,170
+Contra Costa,Pittsburg104,U.S. Senate,,DEM,Kamala D. Harris,518
+Contra Costa,Pittsburg104,U.S. Senate,,DEM,Loretta L. Sanchez,235
+Contra Costa,Pittsburg105,U.S. Senate,,DEM,Kamala D. Harris,194
+Contra Costa,Pittsburg105,U.S. Senate,,DEM,Loretta L. Sanchez,119
+Contra Costa,Pittsburg106,U.S. Senate,,DEM,Kamala D. Harris,401
+Contra Costa,Pittsburg106,U.S. Senate,,DEM,Loretta L. Sanchez,227
+Contra Costa,Pittsburg107,U.S. Senate,,DEM,Kamala D. Harris,432
+Contra Costa,Pittsburg107,U.S. Senate,,DEM,Loretta L. Sanchez,273
+Contra Costa,Pittsburg108,U.S. Senate,,DEM,Kamala D. Harris,535
+Contra Costa,Pittsburg108,U.S. Senate,,DEM,Loretta L. Sanchez,212
+Contra Costa,Pittsburg109,U.S. Senate,,DEM,Kamala D. Harris,334
+Contra Costa,Pittsburg109,U.S. Senate,,DEM,Loretta L. Sanchez,253
+Contra Costa,Pittsburg110,U.S. Senate,,DEM,Kamala D. Harris,363
+Contra Costa,Pittsburg110,U.S. Senate,,DEM,Loretta L. Sanchez,241
+Contra Costa,Pittsburg111,U.S. Senate,,DEM,Kamala D. Harris,393
+Contra Costa,Pittsburg111,U.S. Senate,,DEM,Loretta L. Sanchez,211
+Contra Costa,Pittsburg112,U.S. Senate,,DEM,Kamala D. Harris,379
+Contra Costa,Pittsburg112,U.S. Senate,,DEM,Loretta L. Sanchez,182
+Contra Costa,Pittsburg113,U.S. Senate,,DEM,Kamala D. Harris,307
+Contra Costa,Pittsburg113,U.S. Senate,,DEM,Loretta L. Sanchez,227
+Contra Costa,Pittsburg114,U.S. Senate,,DEM,Kamala D. Harris,460
+Contra Costa,Pittsburg114,U.S. Senate,,DEM,Loretta L. Sanchez,241
+Contra Costa,Pittsburg115,U.S. Senate,,DEM,Kamala D. Harris,419
+Contra Costa,Pittsburg115,U.S. Senate,,DEM,Loretta L. Sanchez,285
+Contra Costa,Pittsburg116,U.S. Senate,,DEM,Kamala D. Harris,372
+Contra Costa,Pittsburg116,U.S. Senate,,DEM,Loretta L. Sanchez,187
+Contra Costa,Pittsburg117,U.S. Senate,,DEM,Kamala D. Harris,664
+Contra Costa,Pittsburg117,U.S. Senate,,DEM,Loretta L. Sanchez,305
+Contra Costa,Pittsburg118,U.S. Senate,,DEM,Kamala D. Harris,376
+Contra Costa,Pittsburg118,U.S. Senate,,DEM,Loretta L. Sanchez,210
+Contra Costa,Pittsburg119,U.S. Senate,,DEM,Kamala D. Harris,676
+Contra Costa,Pittsburg119,U.S. Senate,,DEM,Loretta L. Sanchez,330
+Contra Costa,Pittsburg120,U.S. Senate,,DEM,Kamala D. Harris,638
+Contra Costa,Pittsburg120,U.S. Senate,,DEM,Loretta L. Sanchez,318
+Contra Costa,Pittsburg121,U.S. Senate,,DEM,Kamala D. Harris,341
+Contra Costa,Pittsburg121,U.S. Senate,,DEM,Loretta L. Sanchez,144
+Contra Costa,Pittsburg122,U.S. Senate,,DEM,Kamala D. Harris,266
+Contra Costa,Pittsburg122,U.S. Senate,,DEM,Loretta L. Sanchez,225
+Contra Costa,Pittsburg123,U.S. Senate,,DEM,Kamala D. Harris,231
+Contra Costa,Pittsburg123,U.S. Senate,,DEM,Loretta L. Sanchez,130
+Contra Costa,Pittsburg124,U.S. Senate,,DEM,Kamala D. Harris,245
+Contra Costa,Pittsburg124,U.S. Senate,,DEM,Loretta L. Sanchez,125
+Contra Costa,Pittsburg125,U.S. Senate,,DEM,Kamala D. Harris,437
+Contra Costa,Pittsburg125,U.S. Senate,,DEM,Loretta L. Sanchez,229
+Contra Costa,Pittsburg126,U.S. Senate,,DEM,Kamala D. Harris,363
+Contra Costa,Pittsburg126,U.S. Senate,,DEM,Loretta L. Sanchez,228
+Contra Costa,Pittsburg127,U.S. Senate,,DEM,Kamala D. Harris,319
+Contra Costa,Pittsburg127,U.S. Senate,,DEM,Loretta L. Sanchez,96
+Contra Costa,Pittsburg128,U.S. Senate,,DEM,Kamala D. Harris,412
+Contra Costa,Pittsburg128,U.S. Senate,,DEM,Loretta L. Sanchez,264
+Contra Costa,Pittsburg129,U.S. Senate,,DEM,Kamala D. Harris,759
+Contra Costa,Pittsburg129,U.S. Senate,,DEM,Loretta L. Sanchez,300
+Contra Costa,Pittsburg130,U.S. Senate,,DEM,Kamala D. Harris,291
+Contra Costa,Pittsburg130,U.S. Senate,,DEM,Loretta L. Sanchez,252
+Contra Costa,Pittsburg131,U.S. Senate,,DEM,Kamala D. Harris,379
+Contra Costa,Pittsburg131,U.S. Senate,,DEM,Loretta L. Sanchez,195
+Contra Costa,Pittsburg801,U.S. Senate,,DEM,Kamala D. Harris,1
+Contra Costa,Pittsburg801,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Contra Costa,Pittsburg802,U.S. Senate,,DEM,Kamala D. Harris,0
+Contra Costa,Pittsburg802,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Contra Costa,PleasantHill101,U.S. Senate,,DEM,Kamala D. Harris,538
+Contra Costa,PleasantHill101,U.S. Senate,,DEM,Loretta L. Sanchez,192
+Contra Costa,PleasantHill102,U.S. Senate,,DEM,Kamala D. Harris,398
+Contra Costa,PleasantHill102,U.S. Senate,,DEM,Loretta L. Sanchez,183
+Contra Costa,PleasantHill103,U.S. Senate,,DEM,Kamala D. Harris,393
+Contra Costa,PleasantHill103,U.S. Senate,,DEM,Loretta L. Sanchez,184
+Contra Costa,PleasantHill104,U.S. Senate,,DEM,Kamala D. Harris,780
+Contra Costa,PleasantHill104,U.S. Senate,,DEM,Loretta L. Sanchez,281
+Contra Costa,PleasantHill105,U.S. Senate,,DEM,Kamala D. Harris,440
+Contra Costa,PleasantHill105,U.S. Senate,,DEM,Loretta L. Sanchez,192
+Contra Costa,PleasantHill106,U.S. Senate,,DEM,Kamala D. Harris,660
+Contra Costa,PleasantHill106,U.S. Senate,,DEM,Loretta L. Sanchez,265
+Contra Costa,PleasantHill107,U.S. Senate,,DEM,Kamala D. Harris,631
+Contra Costa,PleasantHill107,U.S. Senate,,DEM,Loretta L. Sanchez,230
+Contra Costa,PleasantHill108,U.S. Senate,,DEM,Kamala D. Harris,664
+Contra Costa,PleasantHill108,U.S. Senate,,DEM,Loretta L. Sanchez,263
+Contra Costa,PleasantHill109,U.S. Senate,,DEM,Kamala D. Harris,583
+Contra Costa,PleasantHill109,U.S. Senate,,DEM,Loretta L. Sanchez,206
+Contra Costa,PleasantHill110,U.S. Senate,,DEM,Kamala D. Harris,567
+Contra Costa,PleasantHill110,U.S. Senate,,DEM,Loretta L. Sanchez,205
+Contra Costa,PleasantHill111,U.S. Senate,,DEM,Kamala D. Harris,583
+Contra Costa,PleasantHill111,U.S. Senate,,DEM,Loretta L. Sanchez,225
+Contra Costa,PleasantHill112,U.S. Senate,,DEM,Kamala D. Harris,452
+Contra Costa,PleasantHill112,U.S. Senate,,DEM,Loretta L. Sanchez,141
+Contra Costa,PleasantHill113,U.S. Senate,,DEM,Kamala D. Harris,588
+Contra Costa,PleasantHill113,U.S. Senate,,DEM,Loretta L. Sanchez,169
+Contra Costa,PleasantHill114,U.S. Senate,,DEM,Kamala D. Harris,651
+Contra Costa,PleasantHill114,U.S. Senate,,DEM,Loretta L. Sanchez,238
+Contra Costa,PleasantHill115,U.S. Senate,,DEM,Kamala D. Harris,655
+Contra Costa,PleasantHill115,U.S. Senate,,DEM,Loretta L. Sanchez,260
+Contra Costa,PleasantHill116,U.S. Senate,,DEM,Kamala D. Harris,472
+Contra Costa,PleasantHill116,U.S. Senate,,DEM,Loretta L. Sanchez,190
+Contra Costa,PleasantHill117,U.S. Senate,,DEM,Kamala D. Harris,542
+Contra Costa,PleasantHill117,U.S. Senate,,DEM,Loretta L. Sanchez,203
+Contra Costa,PleasantHill118,U.S. Senate,,DEM,Kamala D. Harris,434
+Contra Costa,PleasantHill118,U.S. Senate,,DEM,Loretta L. Sanchez,196
+Contra Costa,PleasantHill119,U.S. Senate,,DEM,Kamala D. Harris,510
+Contra Costa,PleasantHill119,U.S. Senate,,DEM,Loretta L. Sanchez,182
+Contra Costa,PortCosta801,U.S. Senate,,DEM,Kamala D. Harris,80
+Contra Costa,PortCosta801,U.S. Senate,,DEM,Loretta L. Sanchez,25
+Contra Costa,Richmond101,U.S. Senate,,DEM,Kamala D. Harris,644
+Contra Costa,Richmond101,U.S. Senate,,DEM,Loretta L. Sanchez,183
+Contra Costa,Richmond102,U.S. Senate,,DEM,Kamala D. Harris,393
+Contra Costa,Richmond102,U.S. Senate,,DEM,Loretta L. Sanchez,91
+Contra Costa,Richmond103,U.S. Senate,,DEM,Kamala D. Harris,523
+Contra Costa,Richmond103,U.S. Senate,,DEM,Loretta L. Sanchez,122
+Contra Costa,Richmond104,U.S. Senate,,DEM,Kamala D. Harris,715
+Contra Costa,Richmond104,U.S. Senate,,DEM,Loretta L. Sanchez,171
+Contra Costa,Richmond105,U.S. Senate,,DEM,Kamala D. Harris,861
+Contra Costa,Richmond105,U.S. Senate,,DEM,Loretta L. Sanchez,192
+Contra Costa,Richmond106,U.S. Senate,,DEM,Kamala D. Harris,507
+Contra Costa,Richmond106,U.S. Senate,,DEM,Loretta L. Sanchez,147
+Contra Costa,Richmond107,U.S. Senate,,DEM,Kamala D. Harris,147
+Contra Costa,Richmond107,U.S. Senate,,DEM,Loretta L. Sanchez,45
+Contra Costa,Richmond108,U.S. Senate,,DEM,Kamala D. Harris,611
+Contra Costa,Richmond108,U.S. Senate,,DEM,Loretta L. Sanchez,138
+Contra Costa,Richmond109,U.S. Senate,,DEM,Kamala D. Harris,499
+Contra Costa,Richmond109,U.S. Senate,,DEM,Loretta L. Sanchez,95
+Contra Costa,Richmond110,U.S. Senate,,DEM,Kamala D. Harris,413
+Contra Costa,Richmond110,U.S. Senate,,DEM,Loretta L. Sanchez,110
+Contra Costa,Richmond111,U.S. Senate,,DEM,Kamala D. Harris,466
+Contra Costa,Richmond111,U.S. Senate,,DEM,Loretta L. Sanchez,105
+Contra Costa,Richmond112,U.S. Senate,,DEM,Kamala D. Harris,466
+Contra Costa,Richmond112,U.S. Senate,,DEM,Loretta L. Sanchez,107
+Contra Costa,Richmond113,U.S. Senate,,DEM,Kamala D. Harris,632
+Contra Costa,Richmond113,U.S. Senate,,DEM,Loretta L. Sanchez,181
+Contra Costa,Richmond114,U.S. Senate,,DEM,Kamala D. Harris,518
+Contra Costa,Richmond114,U.S. Senate,,DEM,Loretta L. Sanchez,200
+Contra Costa,Richmond115,U.S. Senate,,DEM,Kamala D. Harris,522
+Contra Costa,Richmond115,U.S. Senate,,DEM,Loretta L. Sanchez,145
+Contra Costa,Richmond116,U.S. Senate,,DEM,Kamala D. Harris,664
+Contra Costa,Richmond116,U.S. Senate,,DEM,Loretta L. Sanchez,209
+Contra Costa,Richmond117,U.S. Senate,,DEM,Kamala D. Harris,386
+Contra Costa,Richmond117,U.S. Senate,,DEM,Loretta L. Sanchez,159
+Contra Costa,Richmond118,U.S. Senate,,DEM,Kamala D. Harris,432
+Contra Costa,Richmond118,U.S. Senate,,DEM,Loretta L. Sanchez,303
+Contra Costa,Richmond119,U.S. Senate,,DEM,Kamala D. Harris,530
+Contra Costa,Richmond119,U.S. Senate,,DEM,Loretta L. Sanchez,279
+Contra Costa,Richmond120,U.S. Senate,,DEM,Kamala D. Harris,299
+Contra Costa,Richmond120,U.S. Senate,,DEM,Loretta L. Sanchez,172
+Contra Costa,Richmond121,U.S. Senate,,DEM,Kamala D. Harris,345
+Contra Costa,Richmond121,U.S. Senate,,DEM,Loretta L. Sanchez,310
+Contra Costa,Richmond122,U.S. Senate,,DEM,Kamala D. Harris,678
+Contra Costa,Richmond122,U.S. Senate,,DEM,Loretta L. Sanchez,249
+Contra Costa,Richmond123,U.S. Senate,,DEM,Kamala D. Harris,706
+Contra Costa,Richmond123,U.S. Senate,,DEM,Loretta L. Sanchez,279
+Contra Costa,Richmond124,U.S. Senate,,DEM,Kamala D. Harris,432
+Contra Costa,Richmond124,U.S. Senate,,DEM,Loretta L. Sanchez,111
+Contra Costa,Richmond125,U.S. Senate,,DEM,Kamala D. Harris,424
+Contra Costa,Richmond125,U.S. Senate,,DEM,Loretta L. Sanchez,227
+Contra Costa,Richmond126,U.S. Senate,,DEM,Kamala D. Harris,734
+Contra Costa,Richmond126,U.S. Senate,,DEM,Loretta L. Sanchez,388
+Contra Costa,Richmond127,U.S. Senate,,DEM,Kamala D. Harris,276
+Contra Costa,Richmond127,U.S. Senate,,DEM,Loretta L. Sanchez,222
+Contra Costa,Richmond128,U.S. Senate,,DEM,Kamala D. Harris,408
+Contra Costa,Richmond128,U.S. Senate,,DEM,Loretta L. Sanchez,280
+Contra Costa,Richmond129,U.S. Senate,,DEM,Kamala D. Harris,462
+Contra Costa,Richmond129,U.S. Senate,,DEM,Loretta L. Sanchez,438
+Contra Costa,Richmond130,U.S. Senate,,DEM,Kamala D. Harris,393
+Contra Costa,Richmond130,U.S. Senate,,DEM,Loretta L. Sanchez,231
+Contra Costa,Richmond131,U.S. Senate,,DEM,Kamala D. Harris,394
+Contra Costa,Richmond131,U.S. Senate,,DEM,Loretta L. Sanchez,149
+Contra Costa,Richmond132,U.S. Senate,,DEM,Kamala D. Harris,468
+Contra Costa,Richmond132,U.S. Senate,,DEM,Loretta L. Sanchez,160
+Contra Costa,Richmond133,U.S. Senate,,DEM,Kamala D. Harris,596
+Contra Costa,Richmond133,U.S. Senate,,DEM,Loretta L. Sanchez,116
+Contra Costa,Richmond134,U.S. Senate,,DEM,Kamala D. Harris,766
+Contra Costa,Richmond134,U.S. Senate,,DEM,Loretta L. Sanchez,234
+Contra Costa,Richmond135,U.S. Senate,,DEM,Kamala D. Harris,860
+Contra Costa,Richmond135,U.S. Senate,,DEM,Loretta L. Sanchez,257
+Contra Costa,Richmond136,U.S. Senate,,DEM,Kamala D. Harris,680
+Contra Costa,Richmond136,U.S. Senate,,DEM,Loretta L. Sanchez,244
+Contra Costa,Richmond137,U.S. Senate,,DEM,Kamala D. Harris,525
+Contra Costa,Richmond137,U.S. Senate,,DEM,Loretta L. Sanchez,142
+Contra Costa,Richmond138,U.S. Senate,,DEM,Kamala D. Harris,269
+Contra Costa,Richmond138,U.S. Senate,,DEM,Loretta L. Sanchez,128
+Contra Costa,Richmond139,U.S. Senate,,DEM,Kamala D. Harris,724
+Contra Costa,Richmond139,U.S. Senate,,DEM,Loretta L. Sanchez,293
+Contra Costa,Richmond140,U.S. Senate,,DEM,Kamala D. Harris,398
+Contra Costa,Richmond140,U.S. Senate,,DEM,Loretta L. Sanchez,136
+Contra Costa,Richmond141,U.S. Senate,,DEM,Kamala D. Harris,834
+Contra Costa,Richmond141,U.S. Senate,,DEM,Loretta L. Sanchez,253
+Contra Costa,Richmond142,U.S. Senate,,DEM,Kamala D. Harris,755
+Contra Costa,Richmond142,U.S. Senate,,DEM,Loretta L. Sanchez,241
+Contra Costa,Richmond143,U.S. Senate,,DEM,Kamala D. Harris,665
+Contra Costa,Richmond143,U.S. Senate,,DEM,Loretta L. Sanchez,307
+Contra Costa,Richmond144,U.S. Senate,,DEM,Kamala D. Harris,655
+Contra Costa,Richmond144,U.S. Senate,,DEM,Loretta L. Sanchez,167
+Contra Costa,Richmond145,U.S. Senate,,DEM,Kamala D. Harris,811
+Contra Costa,Richmond145,U.S. Senate,,DEM,Loretta L. Sanchez,156
+Contra Costa,Richmond146,U.S. Senate,,DEM,Kamala D. Harris,135
+Contra Costa,Richmond146,U.S. Senate,,DEM,Loretta L. Sanchez,88
+Contra Costa,Richmond801,U.S. Senate,,DEM,Kamala D. Harris,20
+Contra Costa,Richmond801,U.S. Senate,,DEM,Loretta L. Sanchez,6
+Contra Costa,Richmond802,U.S. Senate,,DEM,Kamala D. Harris,30
+Contra Costa,Richmond802,U.S. Senate,,DEM,Loretta L. Sanchez,10
+Contra Costa,Richmond803,U.S. Senate,,DEM,Kamala D. Harris,100
+Contra Costa,Richmond803,U.S. Senate,,DEM,Loretta L. Sanchez,57
+Contra Costa,Richmond804,U.S. Senate,,DEM,Kamala D. Harris,112
+Contra Costa,Richmond804,U.S. Senate,,DEM,Loretta L. Sanchez,28
+Contra Costa,Richmond805,U.S. Senate,,DEM,Kamala D. Harris,76
+Contra Costa,Richmond805,U.S. Senate,,DEM,Loretta L. Sanchez,14
+Contra Costa,Richmond806,U.S. Senate,,DEM,Kamala D. Harris,111
+Contra Costa,Richmond806,U.S. Senate,,DEM,Loretta L. Sanchez,45
+Contra Costa,Richmond807,U.S. Senate,,DEM,Kamala D. Harris,0
+Contra Costa,Richmond807,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Contra Costa,Rodeo101,U.S. Senate,,DEM,Kamala D. Harris,427
+Contra Costa,Rodeo101,U.S. Senate,,DEM,Loretta L. Sanchez,188
+Contra Costa,Rodeo102,U.S. Senate,,DEM,Kamala D. Harris,516
+Contra Costa,Rodeo102,U.S. Senate,,DEM,Loretta L. Sanchez,226
+Contra Costa,Rodeo103,U.S. Senate,,DEM,Kamala D. Harris,585
+Contra Costa,Rodeo103,U.S. Senate,,DEM,Loretta L. Sanchez,266
+Contra Costa,Rodeo104,U.S. Senate,,DEM,Kamala D. Harris,574
+Contra Costa,Rodeo104,U.S. Senate,,DEM,Loretta L. Sanchez,238
+Contra Costa,Rollingwood101,U.S. Senate,,DEM,Kamala D. Harris,379
+Contra Costa,Rollingwood101,U.S. Senate,,DEM,Loretta L. Sanchez,439
+Contra Costa,SaintMarys801,U.S. Senate,,DEM,Kamala D. Harris,77
+Contra Costa,SaintMarys801,U.S. Senate,,DEM,Loretta L. Sanchez,22
+Contra Costa,SanPablo101,U.S. Senate,,DEM,Kamala D. Harris,354
+Contra Costa,SanPablo101,U.S. Senate,,DEM,Loretta L. Sanchez,441
+Contra Costa,SanPablo102,U.S. Senate,,DEM,Kamala D. Harris,330
+Contra Costa,SanPablo102,U.S. Senate,,DEM,Loretta L. Sanchez,364
+Contra Costa,SanPablo103,U.S. Senate,,DEM,Kamala D. Harris,284
+Contra Costa,SanPablo103,U.S. Senate,,DEM,Loretta L. Sanchez,228
+Contra Costa,SanPablo104,U.S. Senate,,DEM,Kamala D. Harris,459
+Contra Costa,SanPablo104,U.S. Senate,,DEM,Loretta L. Sanchez,151
+Contra Costa,SanPablo105,U.S. Senate,,DEM,Kamala D. Harris,326
+Contra Costa,SanPablo105,U.S. Senate,,DEM,Loretta L. Sanchez,146
+Contra Costa,SanPablo106,U.S. Senate,,DEM,Kamala D. Harris,654
+Contra Costa,SanPablo106,U.S. Senate,,DEM,Loretta L. Sanchez,234
+Contra Costa,SanPablo107,U.S. Senate,,DEM,Kamala D. Harris,379
+Contra Costa,SanPablo107,U.S. Senate,,DEM,Loretta L. Sanchez,285
+Contra Costa,SanPablo108,U.S. Senate,,DEM,Kamala D. Harris,383
+Contra Costa,SanPablo108,U.S. Senate,,DEM,Loretta L. Sanchez,294
+Contra Costa,SanPablo109,U.S. Senate,,DEM,Kamala D. Harris,228
+Contra Costa,SanPablo109,U.S. Senate,,DEM,Loretta L. Sanchez,220
+Contra Costa,SanPablo110,U.S. Senate,,DEM,Kamala D. Harris,429
+Contra Costa,SanPablo110,U.S. Senate,,DEM,Loretta L. Sanchez,389
+Contra Costa,SanRamon101,U.S. Senate,,DEM,Kamala D. Harris,802
+Contra Costa,SanRamon101,U.S. Senate,,DEM,Loretta L. Sanchez,316
+Contra Costa,SanRamon102,U.S. Senate,,DEM,Kamala D. Harris,567
+Contra Costa,SanRamon102,U.S. Senate,,DEM,Loretta L. Sanchez,238
+Contra Costa,SanRamon103,U.S. Senate,,DEM,Kamala D. Harris,499
+Contra Costa,SanRamon103,U.S. Senate,,DEM,Loretta L. Sanchez,250
+Contra Costa,SanRamon104,U.S. Senate,,DEM,Kamala D. Harris,524
+Contra Costa,SanRamon104,U.S. Senate,,DEM,Loretta L. Sanchez,202
+Contra Costa,SanRamon105,U.S. Senate,,DEM,Kamala D. Harris,413
+Contra Costa,SanRamon105,U.S. Senate,,DEM,Loretta L. Sanchez,154
+Contra Costa,SanRamon106,U.S. Senate,,DEM,Kamala D. Harris,560
+Contra Costa,SanRamon106,U.S. Senate,,DEM,Loretta L. Sanchez,210
+Contra Costa,SanRamon107,U.S. Senate,,DEM,Kamala D. Harris,543
+Contra Costa,SanRamon107,U.S. Senate,,DEM,Loretta L. Sanchez,220
+Contra Costa,SanRamon108,U.S. Senate,,DEM,Kamala D. Harris,598
+Contra Costa,SanRamon108,U.S. Senate,,DEM,Loretta L. Sanchez,196
+Contra Costa,SanRamon109,U.S. Senate,,DEM,Kamala D. Harris,538
+Contra Costa,SanRamon109,U.S. Senate,,DEM,Loretta L. Sanchez,190
+Contra Costa,SanRamon110,U.S. Senate,,DEM,Kamala D. Harris,467
+Contra Costa,SanRamon110,U.S. Senate,,DEM,Loretta L. Sanchez,241
+Contra Costa,SanRamon111,U.S. Senate,,DEM,Kamala D. Harris,717
+Contra Costa,SanRamon111,U.S. Senate,,DEM,Loretta L. Sanchez,278
+Contra Costa,SanRamon112,U.S. Senate,,DEM,Kamala D. Harris,556
+Contra Costa,SanRamon112,U.S. Senate,,DEM,Loretta L. Sanchez,271
+Contra Costa,SanRamon113,U.S. Senate,,DEM,Kamala D. Harris,456
+Contra Costa,SanRamon113,U.S. Senate,,DEM,Loretta L. Sanchez,203
+Contra Costa,SanRamon114,U.S. Senate,,DEM,Kamala D. Harris,741
+Contra Costa,SanRamon114,U.S. Senate,,DEM,Loretta L. Sanchez,370
+Contra Costa,SanRamon115,U.S. Senate,,DEM,Kamala D. Harris,592
+Contra Costa,SanRamon115,U.S. Senate,,DEM,Loretta L. Sanchez,235
+Contra Costa,SanRamon116,U.S. Senate,,DEM,Kamala D. Harris,479
+Contra Costa,SanRamon116,U.S. Senate,,DEM,Loretta L. Sanchez,245
+Contra Costa,SanRamon117,U.S. Senate,,DEM,Kamala D. Harris,735
+Contra Costa,SanRamon117,U.S. Senate,,DEM,Loretta L. Sanchez,257
+Contra Costa,SanRamon118,U.S. Senate,,DEM,Kamala D. Harris,419
+Contra Costa,SanRamon118,U.S. Senate,,DEM,Loretta L. Sanchez,179
+Contra Costa,SanRamon119,U.S. Senate,,DEM,Kamala D. Harris,427
+Contra Costa,SanRamon119,U.S. Senate,,DEM,Loretta L. Sanchez,146
+Contra Costa,SanRamon120,U.S. Senate,,DEM,Kamala D. Harris,510
+Contra Costa,SanRamon120,U.S. Senate,,DEM,Loretta L. Sanchez,244
+Contra Costa,SanRamon121,U.S. Senate,,DEM,Kamala D. Harris,252
+Contra Costa,SanRamon121,U.S. Senate,,DEM,Loretta L. Sanchez,129
+Contra Costa,SanRamon122,U.S. Senate,,DEM,Kamala D. Harris,889
+Contra Costa,SanRamon122,U.S. Senate,,DEM,Loretta L. Sanchez,153
+Contra Costa,SanRamon123,U.S. Senate,,DEM,Kamala D. Harris,812
+Contra Costa,SanRamon123,U.S. Senate,,DEM,Loretta L. Sanchez,190
+Contra Costa,SanRamon124,U.S. Senate,,DEM,Kamala D. Harris,812
+Contra Costa,SanRamon124,U.S. Senate,,DEM,Loretta L. Sanchez,229
+Contra Costa,SanRamon125,U.S. Senate,,DEM,Kamala D. Harris,448
+Contra Costa,SanRamon125,U.S. Senate,,DEM,Loretta L. Sanchez,177
+Contra Costa,SanRamon126,U.S. Senate,,DEM,Kamala D. Harris,469
+Contra Costa,SanRamon126,U.S. Senate,,DEM,Loretta L. Sanchez,188
+Contra Costa,SanRamon127,U.S. Senate,,DEM,Kamala D. Harris,849
+Contra Costa,SanRamon127,U.S. Senate,,DEM,Loretta L. Sanchez,188
+Contra Costa,SanRamon128,U.S. Senate,,DEM,Kamala D. Harris,625
+Contra Costa,SanRamon128,U.S. Senate,,DEM,Loretta L. Sanchez,261
+Contra Costa,SanRamon129,U.S. Senate,,DEM,Kamala D. Harris,306
+Contra Costa,SanRamon129,U.S. Senate,,DEM,Loretta L. Sanchez,130
+Contra Costa,SanRamon130,U.S. Senate,,DEM,Kamala D. Harris,391
+Contra Costa,SanRamon130,U.S. Senate,,DEM,Loretta L. Sanchez,167
+Contra Costa,SanRamon131,U.S. Senate,,DEM,Kamala D. Harris,870
+Contra Costa,SanRamon131,U.S. Senate,,DEM,Loretta L. Sanchez,202
+Contra Costa,SanRamon132,U.S. Senate,,DEM,Kamala D. Harris,462
+Contra Costa,SanRamon132,U.S. Senate,,DEM,Loretta L. Sanchez,131
+Contra Costa,SanRamon133,U.S. Senate,,DEM,Kamala D. Harris,628
+Contra Costa,SanRamon133,U.S. Senate,,DEM,Loretta L. Sanchez,170
+Contra Costa,SanRamon134,U.S. Senate,,DEM,Kamala D. Harris,1074
+Contra Costa,SanRamon134,U.S. Senate,,DEM,Loretta L. Sanchez,290
+Contra Costa,SanRamon801,U.S. Senate,,DEM,Kamala D. Harris,2
+Contra Costa,SanRamon801,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Contra Costa,Saranap101,U.S. Senate,,DEM,Kamala D. Harris,362
+Contra Costa,Saranap101,U.S. Senate,,DEM,Loretta L. Sanchez,89
+Contra Costa,Saranap102,U.S. Senate,,DEM,Kamala D. Harris,668
+Contra Costa,Saranap102,U.S. Senate,,DEM,Loretta L. Sanchez,226
+Contra Costa,Saranap103,U.S. Senate,,DEM,Kamala D. Harris,659
+Contra Costa,Saranap103,U.S. Senate,,DEM,Loretta L. Sanchez,164
+Contra Costa,Saranap105,U.S. Senate,,DEM,Kamala D. Harris,367
+Contra Costa,Saranap105,U.S. Senate,,DEM,Loretta L. Sanchez,115
+Contra Costa,Saranap106,U.S. Senate,,DEM,Kamala D. Harris,447
+Contra Costa,Saranap106,U.S. Senate,,DEM,Loretta L. Sanchez,165
+Contra Costa,Saranap801,U.S. Senate,,DEM,Kamala D. Harris,2
+Contra Costa,Saranap801,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Contra Costa,Saranap802,U.S. Senate,,DEM,Kamala D. Harris,132
+Contra Costa,Saranap802,U.S. Senate,,DEM,Loretta L. Sanchez,33
+Contra Costa,ShellRidge101,U.S. Senate,,DEM,Kamala D. Harris,122
+Contra Costa,ShellRidge101,U.S. Senate,,DEM,Loretta L. Sanchez,41
+Contra Costa,ShellRidge102,U.S. Senate,,DEM,Kamala D. Harris,252
+Contra Costa,ShellRidge102,U.S. Senate,,DEM,Loretta L. Sanchez,97
+Contra Costa,Tassajara101,U.S. Senate,,DEM,Kamala D. Harris,108
+Contra Costa,Tassajara101,U.S. Senate,,DEM,Loretta L. Sanchez,77
+Contra Costa,Tassajara801,U.S. Senate,,DEM,Kamala D. Harris,0
+Contra Costa,Tassajara801,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Contra Costa,Tassajara802,U.S. Senate,,DEM,Kamala D. Harris,65
+Contra Costa,Tassajara802,U.S. Senate,,DEM,Loretta L. Sanchez,44
+Contra Costa,Tassajara803,U.S. Senate,,DEM,Kamala D. Harris,13
+Contra Costa,Tassajara803,U.S. Senate,,DEM,Loretta L. Sanchez,20
+Contra Costa,Tassajara804,U.S. Senate,,DEM,Kamala D. Harris,26
+Contra Costa,Tassajara804,U.S. Senate,,DEM,Loretta L. Sanchez,7
+Contra Costa,Tesoro801,U.S. Senate,,DEM,Kamala D. Harris,0
+Contra Costa,Tesoro801,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Contra Costa,Viera801,U.S. Senate,,DEM,Kamala D. Harris,8
+Contra Costa,Viera801,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Contra Costa,VineHill101,U.S. Senate,,DEM,Kamala D. Harris,493
+Contra Costa,VineHill101,U.S. Senate,,DEM,Loretta L. Sanchez,249
+Contra Costa,VineHill102,U.S. Senate,,DEM,Kamala D. Harris,230
+Contra Costa,VineHill102,U.S. Senate,,DEM,Loretta L. Sanchez,193
+Contra Costa,VineHill801,U.S. Senate,,DEM,Kamala D. Harris,75
+Contra Costa,VineHill801,U.S. Senate,,DEM,Loretta L. Sanchez,30
+Contra Costa,VineHill802,U.S. Senate,,DEM,Kamala D. Harris,54
+Contra Costa,VineHill802,U.S. Senate,,DEM,Loretta L. Sanchez,17
+Contra Costa,Waldon101,U.S. Senate,,DEM,Kamala D. Harris,485
+Contra Costa,Waldon101,U.S. Senate,,DEM,Loretta L. Sanchez,179
+Contra Costa,Waldon102,U.S. Senate,,DEM,Kamala D. Harris,776
+Contra Costa,Waldon102,U.S. Senate,,DEM,Loretta L. Sanchez,317
+Contra Costa,Waldon103,U.S. Senate,,DEM,Kamala D. Harris,476
+Contra Costa,Waldon103,U.S. Senate,,DEM,Loretta L. Sanchez,200
+Contra Costa,Waldon801,U.S. Senate,,DEM,Kamala D. Harris,58
+Contra Costa,Waldon801,U.S. Senate,,DEM,Loretta L. Sanchez,21
+Contra Costa,WalnutCreek101,U.S. Senate,,DEM,Kamala D. Harris,809
+Contra Costa,WalnutCreek101,U.S. Senate,,DEM,Loretta L. Sanchez,250
+Contra Costa,WalnutCreek102,U.S. Senate,,DEM,Kamala D. Harris,647
+Contra Costa,WalnutCreek102,U.S. Senate,,DEM,Loretta L. Sanchez,219
+Contra Costa,WalnutCreek103,U.S. Senate,,DEM,Kamala D. Harris,1009
+Contra Costa,WalnutCreek103,U.S. Senate,,DEM,Loretta L. Sanchez,298
+Contra Costa,WalnutCreek104,U.S. Senate,,DEM,Kamala D. Harris,255
+Contra Costa,WalnutCreek104,U.S. Senate,,DEM,Loretta L. Sanchez,67
+Contra Costa,WalnutCreek105,U.S. Senate,,DEM,Kamala D. Harris,570
+Contra Costa,WalnutCreek105,U.S. Senate,,DEM,Loretta L. Sanchez,207
+Contra Costa,WalnutCreek106,U.S. Senate,,DEM,Kamala D. Harris,838
+Contra Costa,WalnutCreek106,U.S. Senate,,DEM,Loretta L. Sanchez,298
+Contra Costa,WalnutCreek107,U.S. Senate,,DEM,Kamala D. Harris,236
+Contra Costa,WalnutCreek107,U.S. Senate,,DEM,Loretta L. Sanchez,90
+Contra Costa,WalnutCreek108,U.S. Senate,,DEM,Kamala D. Harris,346
+Contra Costa,WalnutCreek108,U.S. Senate,,DEM,Loretta L. Sanchez,127
+Contra Costa,WalnutCreek109,U.S. Senate,,DEM,Kamala D. Harris,237
+Contra Costa,WalnutCreek109,U.S. Senate,,DEM,Loretta L. Sanchez,113
+Contra Costa,WalnutCreek110,U.S. Senate,,DEM,Kamala D. Harris,598
+Contra Costa,WalnutCreek110,U.S. Senate,,DEM,Loretta L. Sanchez,208
+Contra Costa,WalnutCreek111,U.S. Senate,,DEM,Kamala D. Harris,578
+Contra Costa,WalnutCreek111,U.S. Senate,,DEM,Loretta L. Sanchez,246
+Contra Costa,WalnutCreek112,U.S. Senate,,DEM,Kamala D. Harris,471
+Contra Costa,WalnutCreek112,U.S. Senate,,DEM,Loretta L. Sanchez,183
+Contra Costa,WalnutCreek113,U.S. Senate,,DEM,Kamala D. Harris,620
+Contra Costa,WalnutCreek113,U.S. Senate,,DEM,Loretta L. Sanchez,199
+Contra Costa,WalnutCreek114,U.S. Senate,,DEM,Kamala D. Harris,225
+Contra Costa,WalnutCreek114,U.S. Senate,,DEM,Loretta L. Sanchez,71
+Contra Costa,WalnutCreek115,U.S. Senate,,DEM,Kamala D. Harris,374
+Contra Costa,WalnutCreek115,U.S. Senate,,DEM,Loretta L. Sanchez,128
+Contra Costa,WalnutCreek116,U.S. Senate,,DEM,Kamala D. Harris,337
+Contra Costa,WalnutCreek116,U.S. Senate,,DEM,Loretta L. Sanchez,141
+Contra Costa,WalnutCreek117,U.S. Senate,,DEM,Kamala D. Harris,648
+Contra Costa,WalnutCreek117,U.S. Senate,,DEM,Loretta L. Sanchez,274
+Contra Costa,WalnutCreek118,U.S. Senate,,DEM,Kamala D. Harris,285
+Contra Costa,WalnutCreek118,U.S. Senate,,DEM,Loretta L. Sanchez,121
+Contra Costa,WalnutCreek119,U.S. Senate,,DEM,Kamala D. Harris,637
+Contra Costa,WalnutCreek119,U.S. Senate,,DEM,Loretta L. Sanchez,205
+Contra Costa,WalnutCreek120,U.S. Senate,,DEM,Kamala D. Harris,726
+Contra Costa,WalnutCreek120,U.S. Senate,,DEM,Loretta L. Sanchez,224
+Contra Costa,WalnutCreek121,U.S. Senate,,DEM,Kamala D. Harris,731
+Contra Costa,WalnutCreek121,U.S. Senate,,DEM,Loretta L. Sanchez,214
+Contra Costa,WalnutCreek122,U.S. Senate,,DEM,Kamala D. Harris,471
+Contra Costa,WalnutCreek122,U.S. Senate,,DEM,Loretta L. Sanchez,139
+Contra Costa,WalnutCreek123,U.S. Senate,,DEM,Kamala D. Harris,540
+Contra Costa,WalnutCreek123,U.S. Senate,,DEM,Loretta L. Sanchez,258
+Contra Costa,WalnutCreek124,U.S. Senate,,DEM,Kamala D. Harris,425
+Contra Costa,WalnutCreek124,U.S. Senate,,DEM,Loretta L. Sanchez,157
+Contra Costa,WalnutCreek125,U.S. Senate,,DEM,Kamala D. Harris,597
+Contra Costa,WalnutCreek125,U.S. Senate,,DEM,Loretta L. Sanchez,249
+Contra Costa,WalnutCreek126,U.S. Senate,,DEM,Kamala D. Harris,720
+Contra Costa,WalnutCreek126,U.S. Senate,,DEM,Loretta L. Sanchez,260
+Contra Costa,WalnutCreek127,U.S. Senate,,DEM,Kamala D. Harris,614
+Contra Costa,WalnutCreek127,U.S. Senate,,DEM,Loretta L. Sanchez,173
+Contra Costa,WalnutCreek129,U.S. Senate,,DEM,Kamala D. Harris,683
+Contra Costa,WalnutCreek129,U.S. Senate,,DEM,Loretta L. Sanchez,156
+Contra Costa,WalnutCreek130,U.S. Senate,,DEM,Kamala D. Harris,430
+Contra Costa,WalnutCreek130,U.S. Senate,,DEM,Loretta L. Sanchez,152
+Contra Costa,WalnutCreek131,U.S. Senate,,DEM,Kamala D. Harris,518
+Contra Costa,WalnutCreek131,U.S. Senate,,DEM,Loretta L. Sanchez,193
+Contra Costa,WalnutCreek132,U.S. Senate,,DEM,Kamala D. Harris,472
+Contra Costa,WalnutCreek132,U.S. Senate,,DEM,Loretta L. Sanchez,227
+Contra Costa,WalnutCreek133,U.S. Senate,,DEM,Kamala D. Harris,564
+Contra Costa,WalnutCreek133,U.S. Senate,,DEM,Loretta L. Sanchez,222
+Contra Costa,WalnutCreek134,U.S. Senate,,DEM,Kamala D. Harris,522
+Contra Costa,WalnutCreek134,U.S. Senate,,DEM,Loretta L. Sanchez,222
+Contra Costa,WalnutCreek135,U.S. Senate,,DEM,Kamala D. Harris,623
+Contra Costa,WalnutCreek135,U.S. Senate,,DEM,Loretta L. Sanchez,260
+Contra Costa,WalnutCreek136,U.S. Senate,,DEM,Kamala D. Harris,257
+Contra Costa,WalnutCreek136,U.S. Senate,,DEM,Loretta L. Sanchez,84
+Contra Costa,WalnutCreek137,U.S. Senate,,DEM,Kamala D. Harris,744
+Contra Costa,WalnutCreek137,U.S. Senate,,DEM,Loretta L. Sanchez,259
+Contra Costa,WalnutCreek138,U.S. Senate,,DEM,Kamala D. Harris,555
+Contra Costa,WalnutCreek138,U.S. Senate,,DEM,Loretta L. Sanchez,207
+Contra Costa,WalnutCreek139,U.S. Senate,,DEM,Kamala D. Harris,553
+Contra Costa,WalnutCreek139,U.S. Senate,,DEM,Loretta L. Sanchez,213
+Contra Costa,WalnutCreek140,U.S. Senate,,DEM,Kamala D. Harris,557
+Contra Costa,WalnutCreek140,U.S. Senate,,DEM,Loretta L. Sanchez,232
+Contra Costa,WalnutCreek141,U.S. Senate,,DEM,Kamala D. Harris,619
+Contra Costa,WalnutCreek141,U.S. Senate,,DEM,Loretta L. Sanchez,258
+Contra Costa,WalnutCreek142,U.S. Senate,,DEM,Kamala D. Harris,786
+Contra Costa,WalnutCreek142,U.S. Senate,,DEM,Loretta L. Sanchez,288
+Contra Costa,WalnutCreek143,U.S. Senate,,DEM,Kamala D. Harris,517
+Contra Costa,WalnutCreek143,U.S. Senate,,DEM,Loretta L. Sanchez,211
+Contra Costa,WalnutCreek144,U.S. Senate,,DEM,Kamala D. Harris,529
+Contra Costa,WalnutCreek144,U.S. Senate,,DEM,Loretta L. Sanchez,199
+Contra Costa,WalnutCreek801,U.S. Senate,,DEM,Kamala D. Harris,124
+Contra Costa,WalnutCreek801,U.S. Senate,,DEM,Loretta L. Sanchez,44
+Contra Costa,WalnutCreek802,U.S. Senate,,DEM,Kamala D. Harris,2
+Contra Costa,WalnutCreek802,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Contra Costa,WalnutCreek803,U.S. Senate,,DEM,Kamala D. Harris,39
+Contra Costa,WalnutCreek803,U.S. Senate,,DEM,Loretta L. Sanchez,19
+Contra Costa,WalnutCreek804,U.S. Senate,,DEM,Kamala D. Harris,141
+Contra Costa,WalnutCreek804,U.S. Senate,,DEM,Loretta L. Sanchez,43
+Contra Costa,WalnutCreek805,U.S. Senate,,DEM,Kamala D. Harris,0
+Contra Costa,WalnutCreek805,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Contra Costa,WalnutKnolls101,U.S. Senate,,DEM,Kamala D. Harris,603
+Contra Costa,WalnutKnolls101,U.S. Senate,,DEM,Loretta L. Sanchez,207
+Contra Costa,WalnutKnolls102,U.S. Senate,,DEM,Kamala D. Harris,437
+Contra Costa,WalnutKnolls102,U.S. Senate,,DEM,Loretta L. Sanchez,146
+Contra Costa,WalnutKnolls103,U.S. Senate,,DEM,Kamala D. Harris,364
+Contra Costa,WalnutKnolls103,U.S. Senate,,DEM,Loretta L. Sanchez,131
+Contra Costa,WalnutKnolls801,U.S. Senate,,DEM,Kamala D. Harris,79
+Contra Costa,WalnutKnolls801,U.S. Senate,,DEM,Loretta L. Sanchez,44

--- a/2016/20161108__ca__general__del_norte__precinct.csv
+++ b/2016/20161108__ca__general__del_norte__precinct.csv
@@ -719,39 +719,39 @@ Del Norte,8,Proposition 67,,N/A,Yes,157
 Del Norte,8,Proposition 67,,N/A,No,231
 Del Norte,9,Proposition 67,,N/A,Yes,115
 Del Norte,9,Proposition 67,,N/A,No,245
-Del Norte,1,U.S. Senate,,DEM,Kamala Harris,263
-Del Norte,1,U.S. Senate,,DEM,Loretta Sanchez,187
-Del Norte,10,U.S. Senate,,DEM,Kamala Harris,276
-Del Norte,10,U.S. Senate,,DEM,Loretta Sanchez,140
-Del Norte,11,U.S. Senate,,DEM,Kamala Harris,286
-Del Norte,11,U.S. Senate,,DEM,Loretta Sanchez,166
-Del Norte,12,U.S. Senate,,DEM,Kamala Harris,214
-Del Norte,12,U.S. Senate,,DEM,Loretta Sanchez,108
-Del Norte,13,U.S. Senate,,DEM,Kamala Harris,161
-Del Norte,13,U.S. Senate,,DEM,Loretta Sanchez,113
-Del Norte,14,U.S. Senate,,DEM,Kamala Harris,484
-Del Norte,14,U.S. Senate,,DEM,Loretta Sanchez,289
-Del Norte,15,U.S. Senate,,DEM,Kamala Harris,362
-Del Norte,15,U.S. Senate,,DEM,Loretta Sanchez,211
-Del Norte,16,U.S. Senate,,DEM,Kamala Harris,394
-Del Norte,16,U.S. Senate,,DEM,Loretta Sanchez,225
-Del Norte,17,U.S. Senate,,DEM,Kamala Harris,415
-Del Norte,17,U.S. Senate,,DEM,Loretta Sanchez,290
-Del Norte,18,U.S. Senate,,DEM,Kamala Harris,148
-Del Norte,18,U.S. Senate,,DEM,Loretta Sanchez,154
-Del Norte,2,U.S. Senate,,DEM,Kamala Harris,229
-Del Norte,2,U.S. Senate,,DEM,Loretta Sanchez,136
-Del Norte,3,U.S. Senate,,DEM,Kamala Harris,214
-Del Norte,3,U.S. Senate,,DEM,Loretta Sanchez,161
-Del Norte,4,U.S. Senate,,DEM,Kamala Harris,171
-Del Norte,4,U.S. Senate,,DEM,Loretta Sanchez,95
-Del Norte,5,U.S. Senate,,DEM,Kamala Harris,180
-Del Norte,5,U.S. Senate,,DEM,Loretta Sanchez,110
-Del Norte,6,U.S. Senate,,DEM,Kamala Harris,148
-Del Norte,6,U.S. Senate,,DEM,Loretta Sanchez,115
-Del Norte,7,U.S. Senate,,DEM,Kamala Harris,321
-Del Norte,7,U.S. Senate,,DEM,Loretta Sanchez,183
-Del Norte,8,U.S. Senate,,DEM,Kamala Harris,176
-Del Norte,8,U.S. Senate,,DEM,Loretta Sanchez,136
-Del Norte,9,U.S. Senate,,DEM,Kamala Harris,161
-Del Norte,9,U.S. Senate,,DEM,Loretta Sanchez,120
+Del Norte,1,U.S. Senate,,DEM,Kamala D. Harris,263
+Del Norte,1,U.S. Senate,,DEM,Loretta L. Sanchez,187
+Del Norte,10,U.S. Senate,,DEM,Kamala D. Harris,276
+Del Norte,10,U.S. Senate,,DEM,Loretta L. Sanchez,140
+Del Norte,11,U.S. Senate,,DEM,Kamala D. Harris,286
+Del Norte,11,U.S. Senate,,DEM,Loretta L. Sanchez,166
+Del Norte,12,U.S. Senate,,DEM,Kamala D. Harris,214
+Del Norte,12,U.S. Senate,,DEM,Loretta L. Sanchez,108
+Del Norte,13,U.S. Senate,,DEM,Kamala D. Harris,161
+Del Norte,13,U.S. Senate,,DEM,Loretta L. Sanchez,113
+Del Norte,14,U.S. Senate,,DEM,Kamala D. Harris,484
+Del Norte,14,U.S. Senate,,DEM,Loretta L. Sanchez,289
+Del Norte,15,U.S. Senate,,DEM,Kamala D. Harris,362
+Del Norte,15,U.S. Senate,,DEM,Loretta L. Sanchez,211
+Del Norte,16,U.S. Senate,,DEM,Kamala D. Harris,394
+Del Norte,16,U.S. Senate,,DEM,Loretta L. Sanchez,225
+Del Norte,17,U.S. Senate,,DEM,Kamala D. Harris,415
+Del Norte,17,U.S. Senate,,DEM,Loretta L. Sanchez,290
+Del Norte,18,U.S. Senate,,DEM,Kamala D. Harris,148
+Del Norte,18,U.S. Senate,,DEM,Loretta L. Sanchez,154
+Del Norte,2,U.S. Senate,,DEM,Kamala D. Harris,229
+Del Norte,2,U.S. Senate,,DEM,Loretta L. Sanchez,136
+Del Norte,3,U.S. Senate,,DEM,Kamala D. Harris,214
+Del Norte,3,U.S. Senate,,DEM,Loretta L. Sanchez,161
+Del Norte,4,U.S. Senate,,DEM,Kamala D. Harris,171
+Del Norte,4,U.S. Senate,,DEM,Loretta L. Sanchez,95
+Del Norte,5,U.S. Senate,,DEM,Kamala D. Harris,180
+Del Norte,5,U.S. Senate,,DEM,Loretta L. Sanchez,110
+Del Norte,6,U.S. Senate,,DEM,Kamala D. Harris,148
+Del Norte,6,U.S. Senate,,DEM,Loretta L. Sanchez,115
+Del Norte,7,U.S. Senate,,DEM,Kamala D. Harris,321
+Del Norte,7,U.S. Senate,,DEM,Loretta L. Sanchez,183
+Del Norte,8,U.S. Senate,,DEM,Kamala D. Harris,176
+Del Norte,8,U.S. Senate,,DEM,Loretta L. Sanchez,136
+Del Norte,9,U.S. Senate,,DEM,Kamala D. Harris,161
+Del Norte,9,U.S. Senate,,DEM,Loretta L. Sanchez,120

--- a/2016/20161108__ca__general__el_dorado__precinct.csv
+++ b/2016/20161108__ca__general__el_dorado__precinct.csv
@@ -7919,399 +7919,399 @@ El Dorado,96U401.64,Proposition 67,,N/A,Yes,33
 El Dorado,96U401.64,Proposition 67,,N/A,No,51
 El Dorado,96U401.79,Proposition 67,,N/A,Yes,0
 El Dorado,96U401.79,Proposition 67,,N/A,No,0
-El Dorado,100001.55,U.S. Senate,,DEM,Kamala Harris,411
-El Dorado,100001.55,U.S. Senate,,DEM,Loretta Sanchez,237
-El Dorado,100002.55,U.S. Senate,,DEM,Kamala Harris,456
-El Dorado,100002.55,U.S. Senate,,DEM,Loretta Sanchez,246
-El Dorado,100003.68,U.S. Senate,,DEM,Kamala Harris,395
-El Dorado,100003.68,U.S. Senate,,DEM,Loretta Sanchez,151
-El Dorado,100003.7,U.S. Senate,,DEM,Kamala Harris,275
-El Dorado,100003.7,U.S. Senate,,DEM,Loretta Sanchez,137
-El Dorado,100004.68,U.S. Senate,,DEM,Kamala Harris,525
-El Dorado,100004.68,U.S. Senate,,DEM,Loretta Sanchez,261
-El Dorado,100005.68,U.S. Senate,,DEM,Kamala Harris,529
-El Dorado,100005.68,U.S. Senate,,DEM,Loretta Sanchez,376
-El Dorado,100006.68,U.S. Senate,,DEM,Kamala Harris,519
-El Dorado,100006.68,U.S. Senate,,DEM,Loretta Sanchez,284
-El Dorado,100007.67,U.S. Senate,,DEM,Kamala Harris,117
-El Dorado,100007.67,U.S. Senate,,DEM,Loretta Sanchez,54
-El Dorado,100007.68,U.S. Senate,,DEM,Kamala Harris,351
-El Dorado,100007.68,U.S. Senate,,DEM,Loretta Sanchez,179
-El Dorado,100008.53,U.S. Senate,,DEM,Kamala Harris,355
-El Dorado,100008.53,U.S. Senate,,DEM,Loretta Sanchez,237
-El Dorado,100008.67,U.S. Senate,,DEM,Kamala Harris,533
-El Dorado,100008.67,U.S. Senate,,DEM,Loretta Sanchez,302
-El Dorado,100009.67,U.S. Senate,,DEM,Kamala Harris,759
-El Dorado,100009.67,U.S. Senate,,DEM,Loretta Sanchez,355
-El Dorado,100011.55,U.S. Senate,,DEM,Kamala Harris,615
-El Dorado,100011.55,U.S. Senate,,DEM,Loretta Sanchez,342
-El Dorado,100012.55,U.S. Senate,,DEM,Kamala Harris,569
-El Dorado,100012.55,U.S. Senate,,DEM,Loretta Sanchez,309
-El Dorado,100013.55,U.S. Senate,,DEM,Kamala Harris,341
-El Dorado,100013.55,U.S. Senate,,DEM,Loretta Sanchez,230
-El Dorado,100013.68,U.S. Senate,,DEM,Kamala Harris,173
-El Dorado,100013.68,U.S. Senate,,DEM,Loretta Sanchez,108
-El Dorado,100014.68,U.S. Senate,,DEM,Kamala Harris,453
-El Dorado,100014.68,U.S. Senate,,DEM,Loretta Sanchez,263
-El Dorado,100015.55,U.S. Senate,,DEM,Kamala Harris,398
-El Dorado,100015.55,U.S. Senate,,DEM,Loretta Sanchez,245
-El Dorado,100016.68,U.S. Senate,,DEM,Kamala Harris,480
-El Dorado,100016.68,U.S. Senate,,DEM,Loretta Sanchez,241
-El Dorado,100017.53,U.S. Senate,,DEM,Kamala Harris,375
-El Dorado,100017.53,U.S. Senate,,DEM,Loretta Sanchez,265
-El Dorado,100022.55,U.S. Senate,,DEM,Kamala Harris,596
-El Dorado,100022.55,U.S. Senate,,DEM,Loretta Sanchez,341
-El Dorado,100023.53,U.S. Senate,,DEM,Kamala Harris,444
-El Dorado,100023.53,U.S. Senate,,DEM,Loretta Sanchez,269
-El Dorado,200003.58,U.S. Senate,,DEM,Kamala Harris,594
-El Dorado,200003.58,U.S. Senate,,DEM,Loretta Sanchez,316
-El Dorado,200004.58,U.S. Senate,,DEM,Kamala Harris,657
-El Dorado,200004.58,U.S. Senate,,DEM,Loretta Sanchez,356
-El Dorado,200005.2,U.S. Senate,,DEM,Kamala Harris,366
-El Dorado,200005.2,U.S. Senate,,DEM,Loretta Sanchez,223
-El Dorado,200006.64,U.S. Senate,,DEM,Kamala Harris,102
-El Dorado,200006.64,U.S. Senate,,DEM,Loretta Sanchez,91
-El Dorado,200006.77,U.S. Senate,,DEM,Kamala Harris,305
-El Dorado,200006.77,U.S. Senate,,DEM,Loretta Sanchez,223
-El Dorado,200008.71,U.S. Senate,,DEM,Kamala Harris,433
-El Dorado,200008.71,U.S. Senate,,DEM,Loretta Sanchez,194
-El Dorado,200009.74,U.S. Senate,,DEM,Kamala Harris,461
-El Dorado,200009.74,U.S. Senate,,DEM,Loretta Sanchez,240
-El Dorado,200010.74,U.S. Senate,,DEM,Kamala Harris,549
-El Dorado,200010.74,U.S. Senate,,DEM,Loretta Sanchez,232
-El Dorado,200012.71,U.S. Senate,,DEM,Kamala Harris,469
-El Dorado,200012.71,U.S. Senate,,DEM,Loretta Sanchez,234
-El Dorado,200013.58,U.S. Senate,,DEM,Kamala Harris,212
-El Dorado,200013.58,U.S. Senate,,DEM,Loretta Sanchez,107
-El Dorado,200013.71,U.S. Senate,,DEM,Kamala Harris,440
-El Dorado,200013.71,U.S. Senate,,DEM,Loretta Sanchez,270
-El Dorado,200014.58,U.S. Senate,,DEM,Kamala Harris,231
-El Dorado,200014.58,U.S. Senate,,DEM,Loretta Sanchez,110
-El Dorado,200014.71,U.S. Senate,,DEM,Kamala Harris,398
-El Dorado,200014.71,U.S. Senate,,DEM,Loretta Sanchez,210
-El Dorado,200015.2,U.S. Senate,,DEM,Kamala Harris,377
-El Dorado,200015.2,U.S. Senate,,DEM,Loretta Sanchez,197
-El Dorado,200016.71,U.S. Senate,,DEM,Kamala Harris,112
-El Dorado,200016.71,U.S. Senate,,DEM,Loretta Sanchez,77
-El Dorado,200016.72,U.S. Senate,,DEM,Kamala Harris,191
-El Dorado,200016.72,U.S. Senate,,DEM,Loretta Sanchez,136
-El Dorado,200017.2,U.S. Senate,,DEM,Kamala Harris,558
-El Dorado,200017.2,U.S. Senate,,DEM,Loretta Sanchez,320
-El Dorado,200018.2,U.S. Senate,,DEM,Kamala Harris,542
-El Dorado,200018.2,U.S. Senate,,DEM,Loretta Sanchez,356
-El Dorado,200019.2,U.S. Senate,,DEM,Kamala Harris,357
-El Dorado,200019.2,U.S. Senate,,DEM,Loretta Sanchez,221
-El Dorado,200020.2,U.S. Senate,,DEM,Kamala Harris,429
-El Dorado,200020.2,U.S. Senate,,DEM,Loretta Sanchez,280
-El Dorado,200021.1,U.S. Senate,,DEM,Kamala Harris,160
-El Dorado,200021.1,U.S. Senate,,DEM,Loretta Sanchez,125
-El Dorado,200021.2,U.S. Senate,,DEM,Kamala Harris,425
-El Dorado,200021.2,U.S. Senate,,DEM,Loretta Sanchez,295
-El Dorado,200024.2,U.S. Senate,,DEM,Kamala Harris,214
-El Dorado,200024.2,U.S. Senate,,DEM,Loretta Sanchez,139
-El Dorado,300001.09,U.S. Senate,,DEM,Kamala Harris,86
-El Dorado,300001.09,U.S. Senate,,DEM,Loretta Sanchez,80
-El Dorado,300001.22,U.S. Senate,,DEM,Kamala Harris,317
-El Dorado,300001.22,U.S. Senate,,DEM,Loretta Sanchez,166
-El Dorado,300002.22,U.S. Senate,,DEM,Kamala Harris,390
-El Dorado,300002.22,U.S. Senate,,DEM,Loretta Sanchez,206
-El Dorado,300003.22,U.S. Senate,,DEM,Kamala Harris,456
-El Dorado,300003.22,U.S. Senate,,DEM,Loretta Sanchez,182
-El Dorado,300004.22,U.S. Senate,,DEM,Kamala Harris,550
-El Dorado,300004.22,U.S. Senate,,DEM,Loretta Sanchez,295
-El Dorado,300005.22,U.S. Senate,,DEM,Kamala Harris,594
-El Dorado,300005.22,U.S. Senate,,DEM,Loretta Sanchez,331
-El Dorado,300008.2,U.S. Senate,,DEM,Kamala Harris,561
-El Dorado,300008.2,U.S. Senate,,DEM,Loretta Sanchez,330
-El Dorado,300009.1,U.S. Senate,,DEM,Kamala Harris,332
-El Dorado,300009.1,U.S. Senate,,DEM,Loretta Sanchez,196
-El Dorado,300010.1,U.S. Senate,,DEM,Kamala Harris,556
-El Dorado,300010.1,U.S. Senate,,DEM,Loretta Sanchez,293
-El Dorado,300011.1,U.S. Senate,,DEM,Kamala Harris,600
-El Dorado,300011.1,U.S. Senate,,DEM,Loretta Sanchez,325
-El Dorado,300013.2,U.S. Senate,,DEM,Kamala Harris,567
-El Dorado,300013.2,U.S. Senate,,DEM,Loretta Sanchez,343
-El Dorado,300015.12,U.S. Senate,,DEM,Kamala Harris,47
-El Dorado,300015.12,U.S. Senate,,DEM,Loretta Sanchez,27
-El Dorado,300015.26,U.S. Senate,,DEM,Kamala Harris,224
-El Dorado,300015.26,U.S. Senate,,DEM,Loretta Sanchez,110
-El Dorado,300017.26,U.S. Senate,,DEM,Kamala Harris,526
-El Dorado,300017.26,U.S. Senate,,DEM,Loretta Sanchez,262
-El Dorado,300018.1,U.S. Senate,,DEM,Kamala Harris,462
-El Dorado,300018.1,U.S. Senate,,DEM,Loretta Sanchez,345
-El Dorado,300019.2,U.S. Senate,,DEM,Kamala Harris,262
-El Dorado,300019.2,U.S. Senate,,DEM,Loretta Sanchez,175
-El Dorado,300020.1,U.S. Senate,,DEM,Kamala Harris,489
-El Dorado,300020.1,U.S. Senate,,DEM,Loretta Sanchez,296
-El Dorado,300021.2,U.S. Senate,,DEM,Kamala Harris,535
-El Dorado,300021.2,U.S. Senate,,DEM,Loretta Sanchez,284
-El Dorado,300022.2,U.S. Senate,,DEM,Kamala Harris,331
-El Dorado,300022.2,U.S. Senate,,DEM,Loretta Sanchez,200
-El Dorado,300023.26,U.S. Senate,,DEM,Kamala Harris,659
-El Dorado,300023.26,U.S. Senate,,DEM,Loretta Sanchez,295
-El Dorado,400001.58,U.S. Senate,,DEM,Kamala Harris,435
-El Dorado,400001.58,U.S. Senate,,DEM,Loretta Sanchez,217
-El Dorado,400001.71,U.S. Senate,,DEM,Kamala Harris,387
-El Dorado,400001.71,U.S. Senate,,DEM,Loretta Sanchez,218
-El Dorado,400002.13,U.S. Senate,,DEM,Kamala Harris,456
-El Dorado,400002.13,U.S. Senate,,DEM,Loretta Sanchez,292
-El Dorado,400002.19,U.S. Senate,,DEM,Kamala Harris,108
-El Dorado,400002.19,U.S. Senate,,DEM,Loretta Sanchez,74
-El Dorado,400003.01,U.S. Senate,,DEM,Kamala Harris,168
-El Dorado,400003.01,U.S. Senate,,DEM,Loretta Sanchez,104
-El Dorado,400003.45,U.S. Senate,,DEM,Kamala Harris,557
-El Dorado,400003.45,U.S. Senate,,DEM,Loretta Sanchez,341
-El Dorado,400004.49,U.S. Senate,,DEM,Kamala Harris,187
-El Dorado,400004.49,U.S. Senate,,DEM,Loretta Sanchez,109
-El Dorado,400004.58,U.S. Senate,,DEM,Kamala Harris,420
-El Dorado,400004.58,U.S. Senate,,DEM,Loretta Sanchez,295
-El Dorado,400005.45,U.S. Senate,,DEM,Kamala Harris,241
-El Dorado,400005.45,U.S. Senate,,DEM,Loretta Sanchez,153
-El Dorado,400006.45,U.S. Senate,,DEM,Kamala Harris,714
-El Dorado,400006.45,U.S. Senate,,DEM,Loretta Sanchez,339
-El Dorado,400007.07,U.S. Senate,,DEM,Kamala Harris,147
-El Dorado,400007.07,U.S. Senate,,DEM,Loretta Sanchez,106
-El Dorado,400007.28,U.S. Senate,,DEM,Kamala Harris,496
-El Dorado,400007.28,U.S. Senate,,DEM,Loretta Sanchez,360
-El Dorado,400010.28,U.S. Senate,,DEM,Kamala Harris,620
-El Dorado,400010.28,U.S. Senate,,DEM,Loretta Sanchez,331
-El Dorado,400012.26,U.S. Senate,,DEM,Kamala Harris,407
-El Dorado,400012.26,U.S. Senate,,DEM,Loretta Sanchez,208
-El Dorado,400013.26,U.S. Senate,,DEM,Kamala Harris,291
-El Dorado,400013.26,U.S. Senate,,DEM,Loretta Sanchez,165
-El Dorado,400014.24,U.S. Senate,,DEM,Kamala Harris,130
-El Dorado,400014.24,U.S. Senate,,DEM,Loretta Sanchez,72
-El Dorado,400014.26,U.S. Senate,,DEM,Kamala Harris,471
-El Dorado,400014.26,U.S. Senate,,DEM,Loretta Sanchez,280
-El Dorado,400017.2,U.S. Senate,,DEM,Kamala Harris,493
-El Dorado,400017.2,U.S. Senate,,DEM,Loretta Sanchez,361
-El Dorado,400018.13,U.S. Senate,,DEM,Kamala Harris,193
-El Dorado,400018.13,U.S. Senate,,DEM,Loretta Sanchez,139
-El Dorado,400020.26,U.S. Senate,,DEM,Kamala Harris,304
-El Dorado,400020.26,U.S. Senate,,DEM,Loretta Sanchez,168
-El Dorado,400021.1,U.S. Senate,,DEM,Kamala Harris,231
-El Dorado,400021.1,U.S. Senate,,DEM,Loretta Sanchez,164
-El Dorado,400021.11,U.S. Senate,,DEM,Kamala Harris,245
-El Dorado,400021.11,U.S. Senate,,DEM,Loretta Sanchez,178
-El Dorado,500001.06,U.S. Senate,,DEM,Kamala Harris,531
-El Dorado,500001.06,U.S. Senate,,DEM,Loretta Sanchez,253
-El Dorado,500001.36,U.S. Senate,,DEM,Kamala Harris,236
-El Dorado,500001.36,U.S. Senate,,DEM,Loretta Sanchez,109
-El Dorado,500002.42,U.S. Senate,,DEM,Kamala Harris,389
-El Dorado,500002.42,U.S. Senate,,DEM,Loretta Sanchez,259
-El Dorado,500003.06,U.S. Senate,,DEM,Kamala Harris,180
-El Dorado,500003.06,U.S. Senate,,DEM,Loretta Sanchez,91
-El Dorado,500003.36,U.S. Senate,,DEM,Kamala Harris,599
-El Dorado,500003.36,U.S. Senate,,DEM,Loretta Sanchez,246
-El Dorado,500004.39,U.S. Senate,,DEM,Kamala Harris,45
-El Dorado,500004.39,U.S. Senate,,DEM,Loretta Sanchez,39
-El Dorado,500004.42,U.S. Senate,,DEM,Kamala Harris,306
-El Dorado,500004.42,U.S. Senate,,DEM,Loretta Sanchez,200
-El Dorado,500005.04,U.S. Senate,,DEM,Kamala Harris,69
-El Dorado,500005.04,U.S. Senate,,DEM,Loretta Sanchez,52
-El Dorado,500005.42,U.S. Senate,,DEM,Kamala Harris,310
-El Dorado,500005.42,U.S. Senate,,DEM,Loretta Sanchez,181
-El Dorado,500006.04,U.S. Senate,,DEM,Kamala Harris,449
-El Dorado,500006.04,U.S. Senate,,DEM,Loretta Sanchez,357
-El Dorado,500007.39,U.S. Senate,,DEM,Kamala Harris,337
-El Dorado,500007.39,U.S. Senate,,DEM,Loretta Sanchez,170
-El Dorado,500008.39,U.S. Senate,,DEM,Kamala Harris,380
-El Dorado,500008.39,U.S. Senate,,DEM,Loretta Sanchez,216
-El Dorado,500009.39,U.S. Senate,,DEM,Kamala Harris,506
-El Dorado,500009.39,U.S. Senate,,DEM,Loretta Sanchez,316
-El Dorado,500010.42,U.S. Senate,,DEM,Kamala Harris,284
-El Dorado,500010.42,U.S. Senate,,DEM,Loretta Sanchez,264
-El Dorado,500011.34,U.S. Senate,,DEM,Kamala Harris,227
-El Dorado,500011.34,U.S. Senate,,DEM,Loretta Sanchez,174
-El Dorado,500012.44,U.S. Senate,,DEM,Kamala Harris,400
-El Dorado,500012.44,U.S. Senate,,DEM,Loretta Sanchez,172
-El Dorado,500015.44,U.S. Senate,,DEM,Kamala Harris,460
-El Dorado,500015.44,U.S. Senate,,DEM,Loretta Sanchez,214
-El Dorado,500020.2,U.S. Senate,,DEM,Kamala Harris,625
-El Dorado,500020.2,U.S. Senate,,DEM,Loretta Sanchez,360
-El Dorado,500021.2,U.S. Senate,,DEM,Kamala Harris,609
-El Dorado,500021.2,U.S. Senate,,DEM,Loretta Sanchez,346
-El Dorado,95U201.08,U.S. Senate,,DEM,Kamala Harris,6
-El Dorado,95U201.08,U.S. Senate,,DEM,Loretta Sanchez,0
-El Dorado,95U201.20,U.S. Senate,,DEM,Kamala Harris,211
-El Dorado,95U201.20,U.S. Senate,,DEM,Loretta Sanchez,129
-El Dorado,95U201.23,U.S. Senate,,DEM,Kamala Harris,82
-El Dorado,95U201.23,U.S. Senate,,DEM,Loretta Sanchez,41
-El Dorado,95U201.25,U.S. Senate,,DEM,Kamala Harris,0
-El Dorado,95U201.25,U.S. Senate,,DEM,Loretta Sanchez,0
-El Dorado,95U202.20,U.S. Senate,,DEM,Kamala Harris,350
-El Dorado,95U202.20,U.S. Senate,,DEM,Loretta Sanchez,197
-El Dorado,95U204.10,U.S. Senate,,DEM,Kamala Harris,351
-El Dorado,95U204.10,U.S. Senate,,DEM,Loretta Sanchez,261
-El Dorado,95U301.11,U.S. Senate,,DEM,Kamala Harris,6
-El Dorado,95U301.11,U.S. Senate,,DEM,Loretta Sanchez,2
-El Dorado,95U301.12,U.S. Senate,,DEM,Kamala Harris,57
-El Dorado,95U301.12,U.S. Senate,,DEM,Loretta Sanchez,35
-El Dorado,95U301.20,U.S. Senate,,DEM,Kamala Harris,15
-El Dorado,95U301.20,U.S. Senate,,DEM,Loretta Sanchez,25
-El Dorado,95U301.21,U.S. Senate,,DEM,Kamala Harris,0
-El Dorado,95U301.21,U.S. Senate,,DEM,Loretta Sanchez,0
-El Dorado,95U301.26,U.S. Senate,,DEM,Kamala Harris,85
-El Dorado,95U301.26,U.S. Senate,,DEM,Loretta Sanchez,48
-El Dorado,95U302.10,U.S. Senate,,DEM,Kamala Harris,0
-El Dorado,95U302.10,U.S. Senate,,DEM,Loretta Sanchez,0
-El Dorado,95U302.20,U.S. Senate,,DEM,Kamala Harris,56
-El Dorado,95U302.20,U.S. Senate,,DEM,Loretta Sanchez,51
-El Dorado,95U303.20,U.S. Senate,,DEM,Kamala Harris,118
-El Dorado,95U303.20,U.S. Senate,,DEM,Loretta Sanchez,85
-El Dorado,95U304.08,U.S. Senate,,DEM,Kamala Harris,0
-El Dorado,95U304.08,U.S. Senate,,DEM,Loretta Sanchez,0
-El Dorado,95U304.23,U.S. Senate,,DEM,Kamala Harris,0
-El Dorado,95U304.23,U.S. Senate,,DEM,Loretta Sanchez,3
-El Dorado,95U401.13,U.S. Senate,,DEM,Kamala Harris,5
-El Dorado,95U401.13,U.S. Senate,,DEM,Loretta Sanchez,11
-El Dorado,95U401.15,U.S. Senate,,DEM,Kamala Harris,1
-El Dorado,95U401.15,U.S. Senate,,DEM,Loretta Sanchez,0
-El Dorado,95U401.18,U.S. Senate,,DEM,Kamala Harris,0
-El Dorado,95U401.18,U.S. Senate,,DEM,Loretta Sanchez,0
-El Dorado,95U401.19,U.S. Senate,,DEM,Kamala Harris,5
-El Dorado,95U401.19,U.S. Senate,,DEM,Loretta Sanchez,2
-El Dorado,95U402.08,U.S. Senate,,DEM,Kamala Harris,0
-El Dorado,95U402.08,U.S. Senate,,DEM,Loretta Sanchez,0
-El Dorado,95U402.10,U.S. Senate,,DEM,Kamala Harris,171
-El Dorado,95U402.10,U.S. Senate,,DEM,Loretta Sanchez,112
-El Dorado,95U402.13,U.S. Senate,,DEM,Kamala Harris,31
-El Dorado,95U402.13,U.S. Senate,,DEM,Loretta Sanchez,13
-El Dorado,95U402.14,U.S. Senate,,DEM,Kamala Harris,2
-El Dorado,95U402.14,U.S. Senate,,DEM,Loretta Sanchez,2
-El Dorado,95U402.16,U.S. Senate,,DEM,Kamala Harris,171
-El Dorado,95U402.16,U.S. Senate,,DEM,Loretta Sanchez,117
-El Dorado,95U402.17,U.S. Senate,,DEM,Kamala Harris,20
-El Dorado,95U402.17,U.S. Senate,,DEM,Loretta Sanchez,11
-El Dorado,95U402.19,U.S. Senate,,DEM,Kamala Harris,45
-El Dorado,95U402.19,U.S. Senate,,DEM,Loretta Sanchez,24
-El Dorado,95U402.20,U.S. Senate,,DEM,Kamala Harris,117
-El Dorado,95U402.20,U.S. Senate,,DEM,Loretta Sanchez,80
-El Dorado,95U402.23,U.S. Senate,,DEM,Kamala Harris,55
-El Dorado,95U402.23,U.S. Senate,,DEM,Loretta Sanchez,40
-El Dorado,95U403.01,U.S. Senate,,DEM,Kamala Harris,1
-El Dorado,95U403.01,U.S. Senate,,DEM,Loretta Sanchez,0
-El Dorado,95U403.07,U.S. Senate,,DEM,Kamala Harris,108
-El Dorado,95U403.07,U.S. Senate,,DEM,Loretta Sanchez,61
-El Dorado,95U403.20,U.S. Senate,,DEM,Kamala Harris,269
-El Dorado,95U403.20,U.S. Senate,,DEM,Loretta Sanchez,141
-El Dorado,95U403.26,U.S. Senate,,DEM,Kamala Harris,118
-El Dorado,95U403.26,U.S. Senate,,DEM,Loretta Sanchez,72
-El Dorado,95U403.27,U.S. Senate,,DEM,Kamala Harris,12
-El Dorado,95U403.27,U.S. Senate,,DEM,Loretta Sanchez,1
-El Dorado,95U403.28,U.S. Senate,,DEM,Kamala Harris,365
-El Dorado,95U403.28,U.S. Senate,,DEM,Loretta Sanchez,201
-El Dorado,95U403.30,U.S. Senate,,DEM,Kamala Harris,0
-El Dorado,95U403.30,U.S. Senate,,DEM,Loretta Sanchez,0
-El Dorado,95U404.07,U.S. Senate,,DEM,Kamala Harris,0
-El Dorado,95U404.07,U.S. Senate,,DEM,Loretta Sanchez,0
-El Dorado,95U404.20,U.S. Senate,,DEM,Kamala Harris,1
-El Dorado,95U404.20,U.S. Senate,,DEM,Loretta Sanchez,1
-El Dorado,95U404.27,U.S. Senate,,DEM,Kamala Harris,0
-El Dorado,95U404.27,U.S. Senate,,DEM,Loretta Sanchez,0
-El Dorado,95U404.29,U.S. Senate,,DEM,Kamala Harris,0
-El Dorado,95U404.29,U.S. Senate,,DEM,Loretta Sanchez,0
-El Dorado,95U404.31,U.S. Senate,,DEM,Kamala Harris,2
-El Dorado,95U404.31,U.S. Senate,,DEM,Loretta Sanchez,2
-El Dorado,95U501.20,U.S. Senate,,DEM,Kamala Harris,122
-El Dorado,95U501.20,U.S. Senate,,DEM,Loretta Sanchez,61
-El Dorado,95U502.02,U.S. Senate,,DEM,Kamala Harris,0
-El Dorado,95U502.02,U.S. Senate,,DEM,Loretta Sanchez,0
-El Dorado,95U502.03,U.S. Senate,,DEM,Kamala Harris,0
-El Dorado,95U502.03,U.S. Senate,,DEM,Loretta Sanchez,0
-El Dorado,95U502.04,U.S. Senate,,DEM,Kamala Harris,49
-El Dorado,95U502.04,U.S. Senate,,DEM,Loretta Sanchez,26
-El Dorado,95U502.33,U.S. Senate,,DEM,Kamala Harris,0
-El Dorado,95U502.33,U.S. Senate,,DEM,Loretta Sanchez,0
-El Dorado,95U502.34,U.S. Senate,,DEM,Kamala Harris,87
-El Dorado,95U502.34,U.S. Senate,,DEM,Loretta Sanchez,64
-El Dorado,95U502.38,U.S. Senate,,DEM,Kamala Harris,0
-El Dorado,95U502.38,U.S. Senate,,DEM,Loretta Sanchez,0
-El Dorado,95U502.40,U.S. Senate,,DEM,Kamala Harris,8
-El Dorado,95U502.40,U.S. Senate,,DEM,Loretta Sanchez,2
-El Dorado,95U502.41,U.S. Senate,,DEM,Kamala Harris,0
-El Dorado,95U502.41,U.S. Senate,,DEM,Loretta Sanchez,0
-El Dorado,95U502.42,U.S. Senate,,DEM,Kamala Harris,35
-El Dorado,95U502.42,U.S. Senate,,DEM,Loretta Sanchez,11
-El Dorado,95U503.05,U.S. Senate,,DEM,Kamala Harris,0
-El Dorado,95U503.05,U.S. Senate,,DEM,Loretta Sanchez,1
-El Dorado,95U503.32,U.S. Senate,,DEM,Kamala Harris,0
-El Dorado,95U503.32,U.S. Senate,,DEM,Loretta Sanchez,0
-El Dorado,95U503.35,U.S. Senate,,DEM,Kamala Harris,1
-El Dorado,95U503.35,U.S. Senate,,DEM,Loretta Sanchez,0
-El Dorado,95U503.37,U.S. Senate,,DEM,Kamala Harris,0
-El Dorado,95U503.37,U.S. Senate,,DEM,Loretta Sanchez,0
-El Dorado,95U503.43,U.S. Senate,,DEM,Kamala Harris,5
-El Dorado,95U503.43,U.S. Senate,,DEM,Loretta Sanchez,5
-El Dorado,95U503.44,U.S. Senate,,DEM,Kamala Harris,4
-El Dorado,95U503.44,U.S. Senate,,DEM,Loretta Sanchez,4
-El Dorado,95U503.47,U.S. Senate,,DEM,Kamala Harris,0
-El Dorado,95U503.47,U.S. Senate,,DEM,Loretta Sanchez,0
-El Dorado,95U598.07,U.S. Senate,,DEM,Kamala Harris,0
-El Dorado,95U598.07,U.S. Senate,,DEM,Loretta Sanchez,0
-El Dorado,95U598.29,U.S. Senate,,DEM,Kamala Harris,262
-El Dorado,95U598.29,U.S. Senate,,DEM,Loretta Sanchez,94
-El Dorado,95U599.01,U.S. Senate,,DEM,Kamala Harris,0
-El Dorado,95U599.01,U.S. Senate,,DEM,Loretta Sanchez,0
-El Dorado,95U599.46,U.S. Senate,,DEM,Kamala Harris,30
-El Dorado,95U599.46,U.S. Senate,,DEM,Loretta Sanchez,9
-El Dorado,96U101.50,U.S. Senate,,DEM,Kamala Harris,101
-El Dorado,96U101.50,U.S. Senate,,DEM,Loretta Sanchez,79
-El Dorado,96U101.51,U.S. Senate,,DEM,Kamala Harris,0
-El Dorado,96U101.51,U.S. Senate,,DEM,Loretta Sanchez,0
-El Dorado,96U101.52,U.S. Senate,,DEM,Kamala Harris,78
-El Dorado,96U101.52,U.S. Senate,,DEM,Loretta Sanchez,48
-El Dorado,96U101.53,U.S. Senate,,DEM,Kamala Harris,31
-El Dorado,96U101.53,U.S. Senate,,DEM,Loretta Sanchez,23
-El Dorado,96U101.54,U.S. Senate,,DEM,Kamala Harris,140
-El Dorado,96U101.54,U.S. Senate,,DEM,Loretta Sanchez,84
-El Dorado,96U101.56,U.S. Senate,,DEM,Kamala Harris,15
-El Dorado,96U101.56,U.S. Senate,,DEM,Loretta Sanchez,10
-El Dorado,96U101.57,U.S. Senate,,DEM,Kamala Harris,0
-El Dorado,96U101.57,U.S. Senate,,DEM,Loretta Sanchez,1
-El Dorado,96U101.65,U.S. Senate,,DEM,Kamala Harris,0
-El Dorado,96U101.65,U.S. Senate,,DEM,Loretta Sanchez,0
-El Dorado,96U101.66,U.S. Senate,,DEM,Kamala Harris,0
-El Dorado,96U101.66,U.S. Senate,,DEM,Loretta Sanchez,0
-El Dorado,96U101.67,U.S. Senate,,DEM,Kamala Harris,90
-El Dorado,96U101.67,U.S. Senate,,DEM,Loretta Sanchez,49
-El Dorado,96U101.68,U.S. Senate,,DEM,Kamala Harris,0
-El Dorado,96U101.68,U.S. Senate,,DEM,Loretta Sanchez,0
-El Dorado,96U101.69,U.S. Senate,,DEM,Kamala Harris,0
-El Dorado,96U101.69,U.S. Senate,,DEM,Loretta Sanchez,0
-El Dorado,96U101.70,U.S. Senate,,DEM,Kamala Harris,0
-El Dorado,96U101.70,U.S. Senate,,DEM,Loretta Sanchez,0
-El Dorado,96U201.49,U.S. Senate,,DEM,Kamala Harris,0
-El Dorado,96U201.49,U.S. Senate,,DEM,Loretta Sanchez,0
-El Dorado,96U201.74,U.S. Senate,,DEM,Kamala Harris,0
-El Dorado,96U201.74,U.S. Senate,,DEM,Loretta Sanchez,1
-El Dorado,96U202.64,U.S. Senate,,DEM,Kamala Harris,2
-El Dorado,96U202.64,U.S. Senate,,DEM,Loretta Sanchez,2
-El Dorado,96U202.73,U.S. Senate,,DEM,Kamala Harris,0
-El Dorado,96U202.73,U.S. Senate,,DEM,Loretta Sanchez,0
-El Dorado,96U202.75,U.S. Senate,,DEM,Kamala Harris,33
-El Dorado,96U202.75,U.S. Senate,,DEM,Loretta Sanchez,20
-El Dorado,96U202.76,U.S. Senate,,DEM,Kamala Harris,48
-El Dorado,96U202.76,U.S. Senate,,DEM,Loretta Sanchez,41
-El Dorado,96U202.77,U.S. Senate,,DEM,Kamala Harris,0
-El Dorado,96U202.77,U.S. Senate,,DEM,Loretta Sanchez,0
-El Dorado,96U202.78,U.S. Senate,,DEM,Kamala Harris,0
-El Dorado,96U202.78,U.S. Senate,,DEM,Loretta Sanchez,1
-El Dorado,96U401.48,U.S. Senate,,DEM,Kamala Harris,34
-El Dorado,96U401.48,U.S. Senate,,DEM,Loretta Sanchez,25
-El Dorado,96U401.49,U.S. Senate,,DEM,Kamala Harris,2
-El Dorado,96U401.49,U.S. Senate,,DEM,Loretta Sanchez,1
-El Dorado,96U401.59,U.S. Senate,,DEM,Kamala Harris,7
-El Dorado,96U401.59,U.S. Senate,,DEM,Loretta Sanchez,4
-El Dorado,96U401.60,U.S. Senate,,DEM,Kamala Harris,26
-El Dorado,96U401.60,U.S. Senate,,DEM,Loretta Sanchez,10
-El Dorado,96U401.61,U.S. Senate,,DEM,Kamala Harris,82
-El Dorado,96U401.61,U.S. Senate,,DEM,Loretta Sanchez,76
-El Dorado,96U401.62,U.S. Senate,,DEM,Kamala Harris,64
-El Dorado,96U401.62,U.S. Senate,,DEM,Loretta Sanchez,44
-El Dorado,96U401.63,U.S. Senate,,DEM,Kamala Harris,1
-El Dorado,96U401.63,U.S. Senate,,DEM,Loretta Sanchez,0
-El Dorado,96U401.64,U.S. Senate,,DEM,Kamala Harris,40
-El Dorado,96U401.64,U.S. Senate,,DEM,Loretta Sanchez,26
-El Dorado,96U401.79,U.S. Senate,,DEM,Kamala Harris,0
-El Dorado,96U401.79,U.S. Senate,,DEM,Loretta Sanchez,0
+El Dorado,100001.55,U.S. Senate,,DEM,Kamala D. Harris,411
+El Dorado,100001.55,U.S. Senate,,DEM,Loretta L. Sanchez,237
+El Dorado,100002.55,U.S. Senate,,DEM,Kamala D. Harris,456
+El Dorado,100002.55,U.S. Senate,,DEM,Loretta L. Sanchez,246
+El Dorado,100003.68,U.S. Senate,,DEM,Kamala D. Harris,395
+El Dorado,100003.68,U.S. Senate,,DEM,Loretta L. Sanchez,151
+El Dorado,100003.7,U.S. Senate,,DEM,Kamala D. Harris,275
+El Dorado,100003.7,U.S. Senate,,DEM,Loretta L. Sanchez,137
+El Dorado,100004.68,U.S. Senate,,DEM,Kamala D. Harris,525
+El Dorado,100004.68,U.S. Senate,,DEM,Loretta L. Sanchez,261
+El Dorado,100005.68,U.S. Senate,,DEM,Kamala D. Harris,529
+El Dorado,100005.68,U.S. Senate,,DEM,Loretta L. Sanchez,376
+El Dorado,100006.68,U.S. Senate,,DEM,Kamala D. Harris,519
+El Dorado,100006.68,U.S. Senate,,DEM,Loretta L. Sanchez,284
+El Dorado,100007.67,U.S. Senate,,DEM,Kamala D. Harris,117
+El Dorado,100007.67,U.S. Senate,,DEM,Loretta L. Sanchez,54
+El Dorado,100007.68,U.S. Senate,,DEM,Kamala D. Harris,351
+El Dorado,100007.68,U.S. Senate,,DEM,Loretta L. Sanchez,179
+El Dorado,100008.53,U.S. Senate,,DEM,Kamala D. Harris,355
+El Dorado,100008.53,U.S. Senate,,DEM,Loretta L. Sanchez,237
+El Dorado,100008.67,U.S. Senate,,DEM,Kamala D. Harris,533
+El Dorado,100008.67,U.S. Senate,,DEM,Loretta L. Sanchez,302
+El Dorado,100009.67,U.S. Senate,,DEM,Kamala D. Harris,759
+El Dorado,100009.67,U.S. Senate,,DEM,Loretta L. Sanchez,355
+El Dorado,100011.55,U.S. Senate,,DEM,Kamala D. Harris,615
+El Dorado,100011.55,U.S. Senate,,DEM,Loretta L. Sanchez,342
+El Dorado,100012.55,U.S. Senate,,DEM,Kamala D. Harris,569
+El Dorado,100012.55,U.S. Senate,,DEM,Loretta L. Sanchez,309
+El Dorado,100013.55,U.S. Senate,,DEM,Kamala D. Harris,341
+El Dorado,100013.55,U.S. Senate,,DEM,Loretta L. Sanchez,230
+El Dorado,100013.68,U.S. Senate,,DEM,Kamala D. Harris,173
+El Dorado,100013.68,U.S. Senate,,DEM,Loretta L. Sanchez,108
+El Dorado,100014.68,U.S. Senate,,DEM,Kamala D. Harris,453
+El Dorado,100014.68,U.S. Senate,,DEM,Loretta L. Sanchez,263
+El Dorado,100015.55,U.S. Senate,,DEM,Kamala D. Harris,398
+El Dorado,100015.55,U.S. Senate,,DEM,Loretta L. Sanchez,245
+El Dorado,100016.68,U.S. Senate,,DEM,Kamala D. Harris,480
+El Dorado,100016.68,U.S. Senate,,DEM,Loretta L. Sanchez,241
+El Dorado,100017.53,U.S. Senate,,DEM,Kamala D. Harris,375
+El Dorado,100017.53,U.S. Senate,,DEM,Loretta L. Sanchez,265
+El Dorado,100022.55,U.S. Senate,,DEM,Kamala D. Harris,596
+El Dorado,100022.55,U.S. Senate,,DEM,Loretta L. Sanchez,341
+El Dorado,100023.53,U.S. Senate,,DEM,Kamala D. Harris,444
+El Dorado,100023.53,U.S. Senate,,DEM,Loretta L. Sanchez,269
+El Dorado,200003.58,U.S. Senate,,DEM,Kamala D. Harris,594
+El Dorado,200003.58,U.S. Senate,,DEM,Loretta L. Sanchez,316
+El Dorado,200004.58,U.S. Senate,,DEM,Kamala D. Harris,657
+El Dorado,200004.58,U.S. Senate,,DEM,Loretta L. Sanchez,356
+El Dorado,200005.2,U.S. Senate,,DEM,Kamala D. Harris,366
+El Dorado,200005.2,U.S. Senate,,DEM,Loretta L. Sanchez,223
+El Dorado,200006.64,U.S. Senate,,DEM,Kamala D. Harris,102
+El Dorado,200006.64,U.S. Senate,,DEM,Loretta L. Sanchez,91
+El Dorado,200006.77,U.S. Senate,,DEM,Kamala D. Harris,305
+El Dorado,200006.77,U.S. Senate,,DEM,Loretta L. Sanchez,223
+El Dorado,200008.71,U.S. Senate,,DEM,Kamala D. Harris,433
+El Dorado,200008.71,U.S. Senate,,DEM,Loretta L. Sanchez,194
+El Dorado,200009.74,U.S. Senate,,DEM,Kamala D. Harris,461
+El Dorado,200009.74,U.S. Senate,,DEM,Loretta L. Sanchez,240
+El Dorado,200010.74,U.S. Senate,,DEM,Kamala D. Harris,549
+El Dorado,200010.74,U.S. Senate,,DEM,Loretta L. Sanchez,232
+El Dorado,200012.71,U.S. Senate,,DEM,Kamala D. Harris,469
+El Dorado,200012.71,U.S. Senate,,DEM,Loretta L. Sanchez,234
+El Dorado,200013.58,U.S. Senate,,DEM,Kamala D. Harris,212
+El Dorado,200013.58,U.S. Senate,,DEM,Loretta L. Sanchez,107
+El Dorado,200013.71,U.S. Senate,,DEM,Kamala D. Harris,440
+El Dorado,200013.71,U.S. Senate,,DEM,Loretta L. Sanchez,270
+El Dorado,200014.58,U.S. Senate,,DEM,Kamala D. Harris,231
+El Dorado,200014.58,U.S. Senate,,DEM,Loretta L. Sanchez,110
+El Dorado,200014.71,U.S. Senate,,DEM,Kamala D. Harris,398
+El Dorado,200014.71,U.S. Senate,,DEM,Loretta L. Sanchez,210
+El Dorado,200015.2,U.S. Senate,,DEM,Kamala D. Harris,377
+El Dorado,200015.2,U.S. Senate,,DEM,Loretta L. Sanchez,197
+El Dorado,200016.71,U.S. Senate,,DEM,Kamala D. Harris,112
+El Dorado,200016.71,U.S. Senate,,DEM,Loretta L. Sanchez,77
+El Dorado,200016.72,U.S. Senate,,DEM,Kamala D. Harris,191
+El Dorado,200016.72,U.S. Senate,,DEM,Loretta L. Sanchez,136
+El Dorado,200017.2,U.S. Senate,,DEM,Kamala D. Harris,558
+El Dorado,200017.2,U.S. Senate,,DEM,Loretta L. Sanchez,320
+El Dorado,200018.2,U.S. Senate,,DEM,Kamala D. Harris,542
+El Dorado,200018.2,U.S. Senate,,DEM,Loretta L. Sanchez,356
+El Dorado,200019.2,U.S. Senate,,DEM,Kamala D. Harris,357
+El Dorado,200019.2,U.S. Senate,,DEM,Loretta L. Sanchez,221
+El Dorado,200020.2,U.S. Senate,,DEM,Kamala D. Harris,429
+El Dorado,200020.2,U.S. Senate,,DEM,Loretta L. Sanchez,280
+El Dorado,200021.1,U.S. Senate,,DEM,Kamala D. Harris,160
+El Dorado,200021.1,U.S. Senate,,DEM,Loretta L. Sanchez,125
+El Dorado,200021.2,U.S. Senate,,DEM,Kamala D. Harris,425
+El Dorado,200021.2,U.S. Senate,,DEM,Loretta L. Sanchez,295
+El Dorado,200024.2,U.S. Senate,,DEM,Kamala D. Harris,214
+El Dorado,200024.2,U.S. Senate,,DEM,Loretta L. Sanchez,139
+El Dorado,300001.09,U.S. Senate,,DEM,Kamala D. Harris,86
+El Dorado,300001.09,U.S. Senate,,DEM,Loretta L. Sanchez,80
+El Dorado,300001.22,U.S. Senate,,DEM,Kamala D. Harris,317
+El Dorado,300001.22,U.S. Senate,,DEM,Loretta L. Sanchez,166
+El Dorado,300002.22,U.S. Senate,,DEM,Kamala D. Harris,390
+El Dorado,300002.22,U.S. Senate,,DEM,Loretta L. Sanchez,206
+El Dorado,300003.22,U.S. Senate,,DEM,Kamala D. Harris,456
+El Dorado,300003.22,U.S. Senate,,DEM,Loretta L. Sanchez,182
+El Dorado,300004.22,U.S. Senate,,DEM,Kamala D. Harris,550
+El Dorado,300004.22,U.S. Senate,,DEM,Loretta L. Sanchez,295
+El Dorado,300005.22,U.S. Senate,,DEM,Kamala D. Harris,594
+El Dorado,300005.22,U.S. Senate,,DEM,Loretta L. Sanchez,331
+El Dorado,300008.2,U.S. Senate,,DEM,Kamala D. Harris,561
+El Dorado,300008.2,U.S. Senate,,DEM,Loretta L. Sanchez,330
+El Dorado,300009.1,U.S. Senate,,DEM,Kamala D. Harris,332
+El Dorado,300009.1,U.S. Senate,,DEM,Loretta L. Sanchez,196
+El Dorado,300010.1,U.S. Senate,,DEM,Kamala D. Harris,556
+El Dorado,300010.1,U.S. Senate,,DEM,Loretta L. Sanchez,293
+El Dorado,300011.1,U.S. Senate,,DEM,Kamala D. Harris,600
+El Dorado,300011.1,U.S. Senate,,DEM,Loretta L. Sanchez,325
+El Dorado,300013.2,U.S. Senate,,DEM,Kamala D. Harris,567
+El Dorado,300013.2,U.S. Senate,,DEM,Loretta L. Sanchez,343
+El Dorado,300015.12,U.S. Senate,,DEM,Kamala D. Harris,47
+El Dorado,300015.12,U.S. Senate,,DEM,Loretta L. Sanchez,27
+El Dorado,300015.26,U.S. Senate,,DEM,Kamala D. Harris,224
+El Dorado,300015.26,U.S. Senate,,DEM,Loretta L. Sanchez,110
+El Dorado,300017.26,U.S. Senate,,DEM,Kamala D. Harris,526
+El Dorado,300017.26,U.S. Senate,,DEM,Loretta L. Sanchez,262
+El Dorado,300018.1,U.S. Senate,,DEM,Kamala D. Harris,462
+El Dorado,300018.1,U.S. Senate,,DEM,Loretta L. Sanchez,345
+El Dorado,300019.2,U.S. Senate,,DEM,Kamala D. Harris,262
+El Dorado,300019.2,U.S. Senate,,DEM,Loretta L. Sanchez,175
+El Dorado,300020.1,U.S. Senate,,DEM,Kamala D. Harris,489
+El Dorado,300020.1,U.S. Senate,,DEM,Loretta L. Sanchez,296
+El Dorado,300021.2,U.S. Senate,,DEM,Kamala D. Harris,535
+El Dorado,300021.2,U.S. Senate,,DEM,Loretta L. Sanchez,284
+El Dorado,300022.2,U.S. Senate,,DEM,Kamala D. Harris,331
+El Dorado,300022.2,U.S. Senate,,DEM,Loretta L. Sanchez,200
+El Dorado,300023.26,U.S. Senate,,DEM,Kamala D. Harris,659
+El Dorado,300023.26,U.S. Senate,,DEM,Loretta L. Sanchez,295
+El Dorado,400001.58,U.S. Senate,,DEM,Kamala D. Harris,435
+El Dorado,400001.58,U.S. Senate,,DEM,Loretta L. Sanchez,217
+El Dorado,400001.71,U.S. Senate,,DEM,Kamala D. Harris,387
+El Dorado,400001.71,U.S. Senate,,DEM,Loretta L. Sanchez,218
+El Dorado,400002.13,U.S. Senate,,DEM,Kamala D. Harris,456
+El Dorado,400002.13,U.S. Senate,,DEM,Loretta L. Sanchez,292
+El Dorado,400002.19,U.S. Senate,,DEM,Kamala D. Harris,108
+El Dorado,400002.19,U.S. Senate,,DEM,Loretta L. Sanchez,74
+El Dorado,400003.01,U.S. Senate,,DEM,Kamala D. Harris,168
+El Dorado,400003.01,U.S. Senate,,DEM,Loretta L. Sanchez,104
+El Dorado,400003.45,U.S. Senate,,DEM,Kamala D. Harris,557
+El Dorado,400003.45,U.S. Senate,,DEM,Loretta L. Sanchez,341
+El Dorado,400004.49,U.S. Senate,,DEM,Kamala D. Harris,187
+El Dorado,400004.49,U.S. Senate,,DEM,Loretta L. Sanchez,109
+El Dorado,400004.58,U.S. Senate,,DEM,Kamala D. Harris,420
+El Dorado,400004.58,U.S. Senate,,DEM,Loretta L. Sanchez,295
+El Dorado,400005.45,U.S. Senate,,DEM,Kamala D. Harris,241
+El Dorado,400005.45,U.S. Senate,,DEM,Loretta L. Sanchez,153
+El Dorado,400006.45,U.S. Senate,,DEM,Kamala D. Harris,714
+El Dorado,400006.45,U.S. Senate,,DEM,Loretta L. Sanchez,339
+El Dorado,400007.07,U.S. Senate,,DEM,Kamala D. Harris,147
+El Dorado,400007.07,U.S. Senate,,DEM,Loretta L. Sanchez,106
+El Dorado,400007.28,U.S. Senate,,DEM,Kamala D. Harris,496
+El Dorado,400007.28,U.S. Senate,,DEM,Loretta L. Sanchez,360
+El Dorado,400010.28,U.S. Senate,,DEM,Kamala D. Harris,620
+El Dorado,400010.28,U.S. Senate,,DEM,Loretta L. Sanchez,331
+El Dorado,400012.26,U.S. Senate,,DEM,Kamala D. Harris,407
+El Dorado,400012.26,U.S. Senate,,DEM,Loretta L. Sanchez,208
+El Dorado,400013.26,U.S. Senate,,DEM,Kamala D. Harris,291
+El Dorado,400013.26,U.S. Senate,,DEM,Loretta L. Sanchez,165
+El Dorado,400014.24,U.S. Senate,,DEM,Kamala D. Harris,130
+El Dorado,400014.24,U.S. Senate,,DEM,Loretta L. Sanchez,72
+El Dorado,400014.26,U.S. Senate,,DEM,Kamala D. Harris,471
+El Dorado,400014.26,U.S. Senate,,DEM,Loretta L. Sanchez,280
+El Dorado,400017.2,U.S. Senate,,DEM,Kamala D. Harris,493
+El Dorado,400017.2,U.S. Senate,,DEM,Loretta L. Sanchez,361
+El Dorado,400018.13,U.S. Senate,,DEM,Kamala D. Harris,193
+El Dorado,400018.13,U.S. Senate,,DEM,Loretta L. Sanchez,139
+El Dorado,400020.26,U.S. Senate,,DEM,Kamala D. Harris,304
+El Dorado,400020.26,U.S. Senate,,DEM,Loretta L. Sanchez,168
+El Dorado,400021.1,U.S. Senate,,DEM,Kamala D. Harris,231
+El Dorado,400021.1,U.S. Senate,,DEM,Loretta L. Sanchez,164
+El Dorado,400021.11,U.S. Senate,,DEM,Kamala D. Harris,245
+El Dorado,400021.11,U.S. Senate,,DEM,Loretta L. Sanchez,178
+El Dorado,500001.06,U.S. Senate,,DEM,Kamala D. Harris,531
+El Dorado,500001.06,U.S. Senate,,DEM,Loretta L. Sanchez,253
+El Dorado,500001.36,U.S. Senate,,DEM,Kamala D. Harris,236
+El Dorado,500001.36,U.S. Senate,,DEM,Loretta L. Sanchez,109
+El Dorado,500002.42,U.S. Senate,,DEM,Kamala D. Harris,389
+El Dorado,500002.42,U.S. Senate,,DEM,Loretta L. Sanchez,259
+El Dorado,500003.06,U.S. Senate,,DEM,Kamala D. Harris,180
+El Dorado,500003.06,U.S. Senate,,DEM,Loretta L. Sanchez,91
+El Dorado,500003.36,U.S. Senate,,DEM,Kamala D. Harris,599
+El Dorado,500003.36,U.S. Senate,,DEM,Loretta L. Sanchez,246
+El Dorado,500004.39,U.S. Senate,,DEM,Kamala D. Harris,45
+El Dorado,500004.39,U.S. Senate,,DEM,Loretta L. Sanchez,39
+El Dorado,500004.42,U.S. Senate,,DEM,Kamala D. Harris,306
+El Dorado,500004.42,U.S. Senate,,DEM,Loretta L. Sanchez,200
+El Dorado,500005.04,U.S. Senate,,DEM,Kamala D. Harris,69
+El Dorado,500005.04,U.S. Senate,,DEM,Loretta L. Sanchez,52
+El Dorado,500005.42,U.S. Senate,,DEM,Kamala D. Harris,310
+El Dorado,500005.42,U.S. Senate,,DEM,Loretta L. Sanchez,181
+El Dorado,500006.04,U.S. Senate,,DEM,Kamala D. Harris,449
+El Dorado,500006.04,U.S. Senate,,DEM,Loretta L. Sanchez,357
+El Dorado,500007.39,U.S. Senate,,DEM,Kamala D. Harris,337
+El Dorado,500007.39,U.S. Senate,,DEM,Loretta L. Sanchez,170
+El Dorado,500008.39,U.S. Senate,,DEM,Kamala D. Harris,380
+El Dorado,500008.39,U.S. Senate,,DEM,Loretta L. Sanchez,216
+El Dorado,500009.39,U.S. Senate,,DEM,Kamala D. Harris,506
+El Dorado,500009.39,U.S. Senate,,DEM,Loretta L. Sanchez,316
+El Dorado,500010.42,U.S. Senate,,DEM,Kamala D. Harris,284
+El Dorado,500010.42,U.S. Senate,,DEM,Loretta L. Sanchez,264
+El Dorado,500011.34,U.S. Senate,,DEM,Kamala D. Harris,227
+El Dorado,500011.34,U.S. Senate,,DEM,Loretta L. Sanchez,174
+El Dorado,500012.44,U.S. Senate,,DEM,Kamala D. Harris,400
+El Dorado,500012.44,U.S. Senate,,DEM,Loretta L. Sanchez,172
+El Dorado,500015.44,U.S. Senate,,DEM,Kamala D. Harris,460
+El Dorado,500015.44,U.S. Senate,,DEM,Loretta L. Sanchez,214
+El Dorado,500020.2,U.S. Senate,,DEM,Kamala D. Harris,625
+El Dorado,500020.2,U.S. Senate,,DEM,Loretta L. Sanchez,360
+El Dorado,500021.2,U.S. Senate,,DEM,Kamala D. Harris,609
+El Dorado,500021.2,U.S. Senate,,DEM,Loretta L. Sanchez,346
+El Dorado,95U201.08,U.S. Senate,,DEM,Kamala D. Harris,6
+El Dorado,95U201.08,U.S. Senate,,DEM,Loretta L. Sanchez,0
+El Dorado,95U201.20,U.S. Senate,,DEM,Kamala D. Harris,211
+El Dorado,95U201.20,U.S. Senate,,DEM,Loretta L. Sanchez,129
+El Dorado,95U201.23,U.S. Senate,,DEM,Kamala D. Harris,82
+El Dorado,95U201.23,U.S. Senate,,DEM,Loretta L. Sanchez,41
+El Dorado,95U201.25,U.S. Senate,,DEM,Kamala D. Harris,0
+El Dorado,95U201.25,U.S. Senate,,DEM,Loretta L. Sanchez,0
+El Dorado,95U202.20,U.S. Senate,,DEM,Kamala D. Harris,350
+El Dorado,95U202.20,U.S. Senate,,DEM,Loretta L. Sanchez,197
+El Dorado,95U204.10,U.S. Senate,,DEM,Kamala D. Harris,351
+El Dorado,95U204.10,U.S. Senate,,DEM,Loretta L. Sanchez,261
+El Dorado,95U301.11,U.S. Senate,,DEM,Kamala D. Harris,6
+El Dorado,95U301.11,U.S. Senate,,DEM,Loretta L. Sanchez,2
+El Dorado,95U301.12,U.S. Senate,,DEM,Kamala D. Harris,57
+El Dorado,95U301.12,U.S. Senate,,DEM,Loretta L. Sanchez,35
+El Dorado,95U301.20,U.S. Senate,,DEM,Kamala D. Harris,15
+El Dorado,95U301.20,U.S. Senate,,DEM,Loretta L. Sanchez,25
+El Dorado,95U301.21,U.S. Senate,,DEM,Kamala D. Harris,0
+El Dorado,95U301.21,U.S. Senate,,DEM,Loretta L. Sanchez,0
+El Dorado,95U301.26,U.S. Senate,,DEM,Kamala D. Harris,85
+El Dorado,95U301.26,U.S. Senate,,DEM,Loretta L. Sanchez,48
+El Dorado,95U302.10,U.S. Senate,,DEM,Kamala D. Harris,0
+El Dorado,95U302.10,U.S. Senate,,DEM,Loretta L. Sanchez,0
+El Dorado,95U302.20,U.S. Senate,,DEM,Kamala D. Harris,56
+El Dorado,95U302.20,U.S. Senate,,DEM,Loretta L. Sanchez,51
+El Dorado,95U303.20,U.S. Senate,,DEM,Kamala D. Harris,118
+El Dorado,95U303.20,U.S. Senate,,DEM,Loretta L. Sanchez,85
+El Dorado,95U304.08,U.S. Senate,,DEM,Kamala D. Harris,0
+El Dorado,95U304.08,U.S. Senate,,DEM,Loretta L. Sanchez,0
+El Dorado,95U304.23,U.S. Senate,,DEM,Kamala D. Harris,0
+El Dorado,95U304.23,U.S. Senate,,DEM,Loretta L. Sanchez,3
+El Dorado,95U401.13,U.S. Senate,,DEM,Kamala D. Harris,5
+El Dorado,95U401.13,U.S. Senate,,DEM,Loretta L. Sanchez,11
+El Dorado,95U401.15,U.S. Senate,,DEM,Kamala D. Harris,1
+El Dorado,95U401.15,U.S. Senate,,DEM,Loretta L. Sanchez,0
+El Dorado,95U401.18,U.S. Senate,,DEM,Kamala D. Harris,0
+El Dorado,95U401.18,U.S. Senate,,DEM,Loretta L. Sanchez,0
+El Dorado,95U401.19,U.S. Senate,,DEM,Kamala D. Harris,5
+El Dorado,95U401.19,U.S. Senate,,DEM,Loretta L. Sanchez,2
+El Dorado,95U402.08,U.S. Senate,,DEM,Kamala D. Harris,0
+El Dorado,95U402.08,U.S. Senate,,DEM,Loretta L. Sanchez,0
+El Dorado,95U402.10,U.S. Senate,,DEM,Kamala D. Harris,171
+El Dorado,95U402.10,U.S. Senate,,DEM,Loretta L. Sanchez,112
+El Dorado,95U402.13,U.S. Senate,,DEM,Kamala D. Harris,31
+El Dorado,95U402.13,U.S. Senate,,DEM,Loretta L. Sanchez,13
+El Dorado,95U402.14,U.S. Senate,,DEM,Kamala D. Harris,2
+El Dorado,95U402.14,U.S. Senate,,DEM,Loretta L. Sanchez,2
+El Dorado,95U402.16,U.S. Senate,,DEM,Kamala D. Harris,171
+El Dorado,95U402.16,U.S. Senate,,DEM,Loretta L. Sanchez,117
+El Dorado,95U402.17,U.S. Senate,,DEM,Kamala D. Harris,20
+El Dorado,95U402.17,U.S. Senate,,DEM,Loretta L. Sanchez,11
+El Dorado,95U402.19,U.S. Senate,,DEM,Kamala D. Harris,45
+El Dorado,95U402.19,U.S. Senate,,DEM,Loretta L. Sanchez,24
+El Dorado,95U402.20,U.S. Senate,,DEM,Kamala D. Harris,117
+El Dorado,95U402.20,U.S. Senate,,DEM,Loretta L. Sanchez,80
+El Dorado,95U402.23,U.S. Senate,,DEM,Kamala D. Harris,55
+El Dorado,95U402.23,U.S. Senate,,DEM,Loretta L. Sanchez,40
+El Dorado,95U403.01,U.S. Senate,,DEM,Kamala D. Harris,1
+El Dorado,95U403.01,U.S. Senate,,DEM,Loretta L. Sanchez,0
+El Dorado,95U403.07,U.S. Senate,,DEM,Kamala D. Harris,108
+El Dorado,95U403.07,U.S. Senate,,DEM,Loretta L. Sanchez,61
+El Dorado,95U403.20,U.S. Senate,,DEM,Kamala D. Harris,269
+El Dorado,95U403.20,U.S. Senate,,DEM,Loretta L. Sanchez,141
+El Dorado,95U403.26,U.S. Senate,,DEM,Kamala D. Harris,118
+El Dorado,95U403.26,U.S. Senate,,DEM,Loretta L. Sanchez,72
+El Dorado,95U403.27,U.S. Senate,,DEM,Kamala D. Harris,12
+El Dorado,95U403.27,U.S. Senate,,DEM,Loretta L. Sanchez,1
+El Dorado,95U403.28,U.S. Senate,,DEM,Kamala D. Harris,365
+El Dorado,95U403.28,U.S. Senate,,DEM,Loretta L. Sanchez,201
+El Dorado,95U403.30,U.S. Senate,,DEM,Kamala D. Harris,0
+El Dorado,95U403.30,U.S. Senate,,DEM,Loretta L. Sanchez,0
+El Dorado,95U404.07,U.S. Senate,,DEM,Kamala D. Harris,0
+El Dorado,95U404.07,U.S. Senate,,DEM,Loretta L. Sanchez,0
+El Dorado,95U404.20,U.S. Senate,,DEM,Kamala D. Harris,1
+El Dorado,95U404.20,U.S. Senate,,DEM,Loretta L. Sanchez,1
+El Dorado,95U404.27,U.S. Senate,,DEM,Kamala D. Harris,0
+El Dorado,95U404.27,U.S. Senate,,DEM,Loretta L. Sanchez,0
+El Dorado,95U404.29,U.S. Senate,,DEM,Kamala D. Harris,0
+El Dorado,95U404.29,U.S. Senate,,DEM,Loretta L. Sanchez,0
+El Dorado,95U404.31,U.S. Senate,,DEM,Kamala D. Harris,2
+El Dorado,95U404.31,U.S. Senate,,DEM,Loretta L. Sanchez,2
+El Dorado,95U501.20,U.S. Senate,,DEM,Kamala D. Harris,122
+El Dorado,95U501.20,U.S. Senate,,DEM,Loretta L. Sanchez,61
+El Dorado,95U502.02,U.S. Senate,,DEM,Kamala D. Harris,0
+El Dorado,95U502.02,U.S. Senate,,DEM,Loretta L. Sanchez,0
+El Dorado,95U502.03,U.S. Senate,,DEM,Kamala D. Harris,0
+El Dorado,95U502.03,U.S. Senate,,DEM,Loretta L. Sanchez,0
+El Dorado,95U502.04,U.S. Senate,,DEM,Kamala D. Harris,49
+El Dorado,95U502.04,U.S. Senate,,DEM,Loretta L. Sanchez,26
+El Dorado,95U502.33,U.S. Senate,,DEM,Kamala D. Harris,0
+El Dorado,95U502.33,U.S. Senate,,DEM,Loretta L. Sanchez,0
+El Dorado,95U502.34,U.S. Senate,,DEM,Kamala D. Harris,87
+El Dorado,95U502.34,U.S. Senate,,DEM,Loretta L. Sanchez,64
+El Dorado,95U502.38,U.S. Senate,,DEM,Kamala D. Harris,0
+El Dorado,95U502.38,U.S. Senate,,DEM,Loretta L. Sanchez,0
+El Dorado,95U502.40,U.S. Senate,,DEM,Kamala D. Harris,8
+El Dorado,95U502.40,U.S. Senate,,DEM,Loretta L. Sanchez,2
+El Dorado,95U502.41,U.S. Senate,,DEM,Kamala D. Harris,0
+El Dorado,95U502.41,U.S. Senate,,DEM,Loretta L. Sanchez,0
+El Dorado,95U502.42,U.S. Senate,,DEM,Kamala D. Harris,35
+El Dorado,95U502.42,U.S. Senate,,DEM,Loretta L. Sanchez,11
+El Dorado,95U503.05,U.S. Senate,,DEM,Kamala D. Harris,0
+El Dorado,95U503.05,U.S. Senate,,DEM,Loretta L. Sanchez,1
+El Dorado,95U503.32,U.S. Senate,,DEM,Kamala D. Harris,0
+El Dorado,95U503.32,U.S. Senate,,DEM,Loretta L. Sanchez,0
+El Dorado,95U503.35,U.S. Senate,,DEM,Kamala D. Harris,1
+El Dorado,95U503.35,U.S. Senate,,DEM,Loretta L. Sanchez,0
+El Dorado,95U503.37,U.S. Senate,,DEM,Kamala D. Harris,0
+El Dorado,95U503.37,U.S. Senate,,DEM,Loretta L. Sanchez,0
+El Dorado,95U503.43,U.S. Senate,,DEM,Kamala D. Harris,5
+El Dorado,95U503.43,U.S. Senate,,DEM,Loretta L. Sanchez,5
+El Dorado,95U503.44,U.S. Senate,,DEM,Kamala D. Harris,4
+El Dorado,95U503.44,U.S. Senate,,DEM,Loretta L. Sanchez,4
+El Dorado,95U503.47,U.S. Senate,,DEM,Kamala D. Harris,0
+El Dorado,95U503.47,U.S. Senate,,DEM,Loretta L. Sanchez,0
+El Dorado,95U598.07,U.S. Senate,,DEM,Kamala D. Harris,0
+El Dorado,95U598.07,U.S. Senate,,DEM,Loretta L. Sanchez,0
+El Dorado,95U598.29,U.S. Senate,,DEM,Kamala D. Harris,262
+El Dorado,95U598.29,U.S. Senate,,DEM,Loretta L. Sanchez,94
+El Dorado,95U599.01,U.S. Senate,,DEM,Kamala D. Harris,0
+El Dorado,95U599.01,U.S. Senate,,DEM,Loretta L. Sanchez,0
+El Dorado,95U599.46,U.S. Senate,,DEM,Kamala D. Harris,30
+El Dorado,95U599.46,U.S. Senate,,DEM,Loretta L. Sanchez,9
+El Dorado,96U101.50,U.S. Senate,,DEM,Kamala D. Harris,101
+El Dorado,96U101.50,U.S. Senate,,DEM,Loretta L. Sanchez,79
+El Dorado,96U101.51,U.S. Senate,,DEM,Kamala D. Harris,0
+El Dorado,96U101.51,U.S. Senate,,DEM,Loretta L. Sanchez,0
+El Dorado,96U101.52,U.S. Senate,,DEM,Kamala D. Harris,78
+El Dorado,96U101.52,U.S. Senate,,DEM,Loretta L. Sanchez,48
+El Dorado,96U101.53,U.S. Senate,,DEM,Kamala D. Harris,31
+El Dorado,96U101.53,U.S. Senate,,DEM,Loretta L. Sanchez,23
+El Dorado,96U101.54,U.S. Senate,,DEM,Kamala D. Harris,140
+El Dorado,96U101.54,U.S. Senate,,DEM,Loretta L. Sanchez,84
+El Dorado,96U101.56,U.S. Senate,,DEM,Kamala D. Harris,15
+El Dorado,96U101.56,U.S. Senate,,DEM,Loretta L. Sanchez,10
+El Dorado,96U101.57,U.S. Senate,,DEM,Kamala D. Harris,0
+El Dorado,96U101.57,U.S. Senate,,DEM,Loretta L. Sanchez,1
+El Dorado,96U101.65,U.S. Senate,,DEM,Kamala D. Harris,0
+El Dorado,96U101.65,U.S. Senate,,DEM,Loretta L. Sanchez,0
+El Dorado,96U101.66,U.S. Senate,,DEM,Kamala D. Harris,0
+El Dorado,96U101.66,U.S. Senate,,DEM,Loretta L. Sanchez,0
+El Dorado,96U101.67,U.S. Senate,,DEM,Kamala D. Harris,90
+El Dorado,96U101.67,U.S. Senate,,DEM,Loretta L. Sanchez,49
+El Dorado,96U101.68,U.S. Senate,,DEM,Kamala D. Harris,0
+El Dorado,96U101.68,U.S. Senate,,DEM,Loretta L. Sanchez,0
+El Dorado,96U101.69,U.S. Senate,,DEM,Kamala D. Harris,0
+El Dorado,96U101.69,U.S. Senate,,DEM,Loretta L. Sanchez,0
+El Dorado,96U101.70,U.S. Senate,,DEM,Kamala D. Harris,0
+El Dorado,96U101.70,U.S. Senate,,DEM,Loretta L. Sanchez,0
+El Dorado,96U201.49,U.S. Senate,,DEM,Kamala D. Harris,0
+El Dorado,96U201.49,U.S. Senate,,DEM,Loretta L. Sanchez,0
+El Dorado,96U201.74,U.S. Senate,,DEM,Kamala D. Harris,0
+El Dorado,96U201.74,U.S. Senate,,DEM,Loretta L. Sanchez,1
+El Dorado,96U202.64,U.S. Senate,,DEM,Kamala D. Harris,2
+El Dorado,96U202.64,U.S. Senate,,DEM,Loretta L. Sanchez,2
+El Dorado,96U202.73,U.S. Senate,,DEM,Kamala D. Harris,0
+El Dorado,96U202.73,U.S. Senate,,DEM,Loretta L. Sanchez,0
+El Dorado,96U202.75,U.S. Senate,,DEM,Kamala D. Harris,33
+El Dorado,96U202.75,U.S. Senate,,DEM,Loretta L. Sanchez,20
+El Dorado,96U202.76,U.S. Senate,,DEM,Kamala D. Harris,48
+El Dorado,96U202.76,U.S. Senate,,DEM,Loretta L. Sanchez,41
+El Dorado,96U202.77,U.S. Senate,,DEM,Kamala D. Harris,0
+El Dorado,96U202.77,U.S. Senate,,DEM,Loretta L. Sanchez,0
+El Dorado,96U202.78,U.S. Senate,,DEM,Kamala D. Harris,0
+El Dorado,96U202.78,U.S. Senate,,DEM,Loretta L. Sanchez,1
+El Dorado,96U401.48,U.S. Senate,,DEM,Kamala D. Harris,34
+El Dorado,96U401.48,U.S. Senate,,DEM,Loretta L. Sanchez,25
+El Dorado,96U401.49,U.S. Senate,,DEM,Kamala D. Harris,2
+El Dorado,96U401.49,U.S. Senate,,DEM,Loretta L. Sanchez,1
+El Dorado,96U401.59,U.S. Senate,,DEM,Kamala D. Harris,7
+El Dorado,96U401.59,U.S. Senate,,DEM,Loretta L. Sanchez,4
+El Dorado,96U401.60,U.S. Senate,,DEM,Kamala D. Harris,26
+El Dorado,96U401.60,U.S. Senate,,DEM,Loretta L. Sanchez,10
+El Dorado,96U401.61,U.S. Senate,,DEM,Kamala D. Harris,82
+El Dorado,96U401.61,U.S. Senate,,DEM,Loretta L. Sanchez,76
+El Dorado,96U401.62,U.S. Senate,,DEM,Kamala D. Harris,64
+El Dorado,96U401.62,U.S. Senate,,DEM,Loretta L. Sanchez,44
+El Dorado,96U401.63,U.S. Senate,,DEM,Kamala D. Harris,1
+El Dorado,96U401.63,U.S. Senate,,DEM,Loretta L. Sanchez,0
+El Dorado,96U401.64,U.S. Senate,,DEM,Kamala D. Harris,40
+El Dorado,96U401.64,U.S. Senate,,DEM,Loretta L. Sanchez,26
+El Dorado,96U401.79,U.S. Senate,,DEM,Kamala D. Harris,0
+El Dorado,96U401.79,U.S. Senate,,DEM,Loretta L. Sanchez,0

--- a/2016/20161108__ca__general__fresno__precinct.csv
+++ b/2016/20161108__ca__general__fresno__precinct.csv
@@ -23679,1187 +23679,1187 @@ Fresno,98,Proposition 67,,N/A,Yes,183
 Fresno,98,Proposition 67,,N/A,No,247
 Fresno,99,Proposition 67,,N/A,Yes,195
 Fresno,99,Proposition 67,,N/A,No,274
-Fresno,1,U.S. Senate,,DEM,Kamala Harris,309
-Fresno,1,U.S. Senate,,DEM,Loretta Sanchez,173
-Fresno,10,U.S. Senate,,DEM,Kamala Harris,238
-Fresno,10,U.S. Senate,,DEM,Loretta Sanchez,285
-Fresno,100,U.S. Senate,,DEM,Kamala Harris,227
-Fresno,100,U.S. Senate,,DEM,Loretta Sanchez,398
-Fresno,1001,U.S. Senate,,DEM,Kamala Harris,5
-Fresno,1001,U.S. Senate,,DEM,Loretta Sanchez,15
-Fresno,1002,U.S. Senate,,DEM,Kamala Harris,0
-Fresno,1002,U.S. Senate,,DEM,Loretta Sanchez,0
-Fresno,1003,U.S. Senate,,DEM,Kamala Harris,39
-Fresno,1003,U.S. Senate,,DEM,Loretta Sanchez,33
-Fresno,1004,U.S. Senate,,DEM,Kamala Harris,1
-Fresno,1004,U.S. Senate,,DEM,Loretta Sanchez,1
-Fresno,1005,U.S. Senate,,DEM,Kamala Harris,0
-Fresno,1005,U.S. Senate,,DEM,Loretta Sanchez,0
-Fresno,1006,U.S. Senate,,DEM,Kamala Harris,2
-Fresno,1006,U.S. Senate,,DEM,Loretta Sanchez,5
-Fresno,1007,U.S. Senate,,DEM,Kamala Harris,0
-Fresno,1007,U.S. Senate,,DEM,Loretta Sanchez,3
-Fresno,1008,U.S. Senate,,DEM,Kamala Harris,0
-Fresno,1008,U.S. Senate,,DEM,Loretta Sanchez,0
-Fresno,1009,U.S. Senate,,DEM,Kamala Harris,90
-Fresno,1009,U.S. Senate,,DEM,Loretta Sanchez,46
-Fresno,101,U.S. Senate,,DEM,Kamala Harris,365
-Fresno,101,U.S. Senate,,DEM,Loretta Sanchez,356
-Fresno,1010,U.S. Senate,,DEM,Kamala Harris,12
-Fresno,1010,U.S. Senate,,DEM,Loretta Sanchez,31
-Fresno,1011,U.S. Senate,,DEM,Kamala Harris,4
-Fresno,1011,U.S. Senate,,DEM,Loretta Sanchez,2
-Fresno,1012,U.S. Senate,,DEM,Kamala Harris,7
-Fresno,1012,U.S. Senate,,DEM,Loretta Sanchez,5
-Fresno,1013,U.S. Senate,,DEM,Kamala Harris,7
-Fresno,1013,U.S. Senate,,DEM,Loretta Sanchez,11
-Fresno,1014,U.S. Senate,,DEM,Kamala Harris,0
-Fresno,1014,U.S. Senate,,DEM,Loretta Sanchez,0
-Fresno,1015,U.S. Senate,,DEM,Kamala Harris,31
-Fresno,1015,U.S. Senate,,DEM,Loretta Sanchez,26
-Fresno,1016,U.S. Senate,,DEM,Kamala Harris,32
-Fresno,1016,U.S. Senate,,DEM,Loretta Sanchez,40
-Fresno,1017,U.S. Senate,,DEM,Kamala Harris,0
-Fresno,1017,U.S. Senate,,DEM,Loretta Sanchez,2
-Fresno,1018,U.S. Senate,,DEM,Kamala Harris,38
-Fresno,1018,U.S. Senate,,DEM,Loretta Sanchez,57
-Fresno,1019,U.S. Senate,,DEM,Kamala Harris,0
-Fresno,1019,U.S. Senate,,DEM,Loretta Sanchez,0
-Fresno,102,U.S. Senate,,DEM,Kamala Harris,187
-Fresno,102,U.S. Senate,,DEM,Loretta Sanchez,182
-Fresno,1020,U.S. Senate,,DEM,Kamala Harris,49
-Fresno,1020,U.S. Senate,,DEM,Loretta Sanchez,24
-Fresno,1021,U.S. Senate,,DEM,Kamala Harris,2
-Fresno,1021,U.S. Senate,,DEM,Loretta Sanchez,3
-Fresno,1022,U.S. Senate,,DEM,Kamala Harris,0
-Fresno,1022,U.S. Senate,,DEM,Loretta Sanchez,1
-Fresno,1023,U.S. Senate,,DEM,Kamala Harris,26
-Fresno,1023,U.S. Senate,,DEM,Loretta Sanchez,34
-Fresno,1024,U.S. Senate,,DEM,Kamala Harris,1
-Fresno,1024,U.S. Senate,,DEM,Loretta Sanchez,1
-Fresno,1025,U.S. Senate,,DEM,Kamala Harris,2
-Fresno,1025,U.S. Senate,,DEM,Loretta Sanchez,0
-Fresno,1026,U.S. Senate,,DEM,Kamala Harris,0
-Fresno,1026,U.S. Senate,,DEM,Loretta Sanchez,0
-Fresno,1027,U.S. Senate,,DEM,Kamala Harris,0
-Fresno,1027,U.S. Senate,,DEM,Loretta Sanchez,0
-Fresno,1028,U.S. Senate,,DEM,Kamala Harris,1
-Fresno,1028,U.S. Senate,,DEM,Loretta Sanchez,0
-Fresno,1029,U.S. Senate,,DEM,Kamala Harris,0
-Fresno,1029,U.S. Senate,,DEM,Loretta Sanchez,0
-Fresno,103,U.S. Senate,,DEM,Kamala Harris,260
-Fresno,103,U.S. Senate,,DEM,Loretta Sanchez,259
-Fresno,1030,U.S. Senate,,DEM,Kamala Harris,0
-Fresno,1030,U.S. Senate,,DEM,Loretta Sanchez,1
-Fresno,1031,U.S. Senate,,DEM,Kamala Harris,3
-Fresno,1031,U.S. Senate,,DEM,Loretta Sanchez,0
-Fresno,1032,U.S. Senate,,DEM,Kamala Harris,13
-Fresno,1032,U.S. Senate,,DEM,Loretta Sanchez,18
-Fresno,1033,U.S. Senate,,DEM,Kamala Harris,4
-Fresno,1033,U.S. Senate,,DEM,Loretta Sanchez,3
-Fresno,1034,U.S. Senate,,DEM,Kamala Harris,73
-Fresno,1034,U.S. Senate,,DEM,Loretta Sanchez,67
-Fresno,1035,U.S. Senate,,DEM,Kamala Harris,3
-Fresno,1035,U.S. Senate,,DEM,Loretta Sanchez,6
-Fresno,1036,U.S. Senate,,DEM,Kamala Harris,30
-Fresno,1036,U.S. Senate,,DEM,Loretta Sanchez,12
-Fresno,1037,U.S. Senate,,DEM,Kamala Harris,0
-Fresno,1037,U.S. Senate,,DEM,Loretta Sanchez,0
-Fresno,1038,U.S. Senate,,DEM,Kamala Harris,0
-Fresno,1038,U.S. Senate,,DEM,Loretta Sanchez,0
-Fresno,1039,U.S. Senate,,DEM,Kamala Harris,0
-Fresno,1039,U.S. Senate,,DEM,Loretta Sanchez,0
-Fresno,104,U.S. Senate,,DEM,Kamala Harris,449
-Fresno,104,U.S. Senate,,DEM,Loretta Sanchez,444
-Fresno,1040,U.S. Senate,,DEM,Kamala Harris,0
-Fresno,1040,U.S. Senate,,DEM,Loretta Sanchez,0
-Fresno,1041,U.S. Senate,,DEM,Kamala Harris,0
-Fresno,1041,U.S. Senate,,DEM,Loretta Sanchez,0
-Fresno,1042,U.S. Senate,,DEM,Kamala Harris,1
-Fresno,1042,U.S. Senate,,DEM,Loretta Sanchez,0
-Fresno,1043,U.S. Senate,,DEM,Kamala Harris,9
-Fresno,1043,U.S. Senate,,DEM,Loretta Sanchez,6
-Fresno,1044,U.S. Senate,,DEM,Kamala Harris,24
-Fresno,1044,U.S. Senate,,DEM,Loretta Sanchez,29
-Fresno,1045,U.S. Senate,,DEM,Kamala Harris,0
-Fresno,1045,U.S. Senate,,DEM,Loretta Sanchez,0
-Fresno,1046,U.S. Senate,,DEM,Kamala Harris,18
-Fresno,1046,U.S. Senate,,DEM,Loretta Sanchez,20
-Fresno,1047,U.S. Senate,,DEM,Kamala Harris,0
-Fresno,1047,U.S. Senate,,DEM,Loretta Sanchez,0
-Fresno,1048,U.S. Senate,,DEM,Kamala Harris,0
-Fresno,1048,U.S. Senate,,DEM,Loretta Sanchez,0
-Fresno,1049,U.S. Senate,,DEM,Kamala Harris,2
-Fresno,1049,U.S. Senate,,DEM,Loretta Sanchez,2
-Fresno,105,U.S. Senate,,DEM,Kamala Harris,329
-Fresno,105,U.S. Senate,,DEM,Loretta Sanchez,275
-Fresno,1050,U.S. Senate,,DEM,Kamala Harris,53
-Fresno,1050,U.S. Senate,,DEM,Loretta Sanchez,45
-Fresno,1051,U.S. Senate,,DEM,Kamala Harris,39
-Fresno,1051,U.S. Senate,,DEM,Loretta Sanchez,42
-Fresno,1052,U.S. Senate,,DEM,Kamala Harris,19
-Fresno,1052,U.S. Senate,,DEM,Loretta Sanchez,23
-Fresno,1053,U.S. Senate,,DEM,Kamala Harris,21
-Fresno,1053,U.S. Senate,,DEM,Loretta Sanchez,34
-Fresno,1054,U.S. Senate,,DEM,Kamala Harris,3
-Fresno,1054,U.S. Senate,,DEM,Loretta Sanchez,1
-Fresno,1055,U.S. Senate,,DEM,Kamala Harris,9
-Fresno,1055,U.S. Senate,,DEM,Loretta Sanchez,0
-Fresno,1056,U.S. Senate,,DEM,Kamala Harris,17
-Fresno,1056,U.S. Senate,,DEM,Loretta Sanchez,24
-Fresno,1057,U.S. Senate,,DEM,Kamala Harris,3
-Fresno,1057,U.S. Senate,,DEM,Loretta Sanchez,4
-Fresno,1058,U.S. Senate,,DEM,Kamala Harris,0
-Fresno,1058,U.S. Senate,,DEM,Loretta Sanchez,0
-Fresno,1059,U.S. Senate,,DEM,Kamala Harris,14
-Fresno,1059,U.S. Senate,,DEM,Loretta Sanchez,34
-Fresno,106,U.S. Senate,,DEM,Kamala Harris,136
-Fresno,106,U.S. Senate,,DEM,Loretta Sanchez,114
-Fresno,1060,U.S. Senate,,DEM,Kamala Harris,24
-Fresno,1060,U.S. Senate,,DEM,Loretta Sanchez,25
-Fresno,1061,U.S. Senate,,DEM,Kamala Harris,9
-Fresno,1061,U.S. Senate,,DEM,Loretta Sanchez,17
-Fresno,1062,U.S. Senate,,DEM,Kamala Harris,14
-Fresno,1062,U.S. Senate,,DEM,Loretta Sanchez,16
-Fresno,1063,U.S. Senate,,DEM,Kamala Harris,0
-Fresno,1063,U.S. Senate,,DEM,Loretta Sanchez,0
-Fresno,1064,U.S. Senate,,DEM,Kamala Harris,1
-Fresno,1064,U.S. Senate,,DEM,Loretta Sanchez,3
-Fresno,1065,U.S. Senate,,DEM,Kamala Harris,2
-Fresno,1065,U.S. Senate,,DEM,Loretta Sanchez,4
-Fresno,1066,U.S. Senate,,DEM,Kamala Harris,34
-Fresno,1066,U.S. Senate,,DEM,Loretta Sanchez,40
-Fresno,1067,U.S. Senate,,DEM,Kamala Harris,6
-Fresno,1067,U.S. Senate,,DEM,Loretta Sanchez,5
-Fresno,1068,U.S. Senate,,DEM,Kamala Harris,0
-Fresno,1068,U.S. Senate,,DEM,Loretta Sanchez,2
-Fresno,1069,U.S. Senate,,DEM,Kamala Harris,5
-Fresno,1069,U.S. Senate,,DEM,Loretta Sanchez,7
-Fresno,107,U.S. Senate,,DEM,Kamala Harris,272
-Fresno,107,U.S. Senate,,DEM,Loretta Sanchez,303
-Fresno,1070,U.S. Senate,,DEM,Kamala Harris,34
-Fresno,1070,U.S. Senate,,DEM,Loretta Sanchez,37
-Fresno,1071,U.S. Senate,,DEM,Kamala Harris,56
-Fresno,1071,U.S. Senate,,DEM,Loretta Sanchez,49
-Fresno,1072,U.S. Senate,,DEM,Kamala Harris,25
-Fresno,1072,U.S. Senate,,DEM,Loretta Sanchez,33
-Fresno,1073,U.S. Senate,,DEM,Kamala Harris,0
-Fresno,1073,U.S. Senate,,DEM,Loretta Sanchez,0
-Fresno,1074,U.S. Senate,,DEM,Kamala Harris,41
-Fresno,1074,U.S. Senate,,DEM,Loretta Sanchez,36
-Fresno,1075,U.S. Senate,,DEM,Kamala Harris,0
-Fresno,1075,U.S. Senate,,DEM,Loretta Sanchez,1
-Fresno,1076,U.S. Senate,,DEM,Kamala Harris,0
-Fresno,1076,U.S. Senate,,DEM,Loretta Sanchez,1
-Fresno,1077,U.S. Senate,,DEM,Kamala Harris,5
-Fresno,1077,U.S. Senate,,DEM,Loretta Sanchez,0
-Fresno,1078,U.S. Senate,,DEM,Kamala Harris,0
-Fresno,1078,U.S. Senate,,DEM,Loretta Sanchez,0
-Fresno,1079,U.S. Senate,,DEM,Kamala Harris,0
-Fresno,1079,U.S. Senate,,DEM,Loretta Sanchez,0
-Fresno,108,U.S. Senate,,DEM,Kamala Harris,434
-Fresno,108,U.S. Senate,,DEM,Loretta Sanchez,275
-Fresno,1080,U.S. Senate,,DEM,Kamala Harris,0
-Fresno,1080,U.S. Senate,,DEM,Loretta Sanchez,0
-Fresno,1081,U.S. Senate,,DEM,Kamala Harris,1
-Fresno,1081,U.S. Senate,,DEM,Loretta Sanchez,4
-Fresno,1082,U.S. Senate,,DEM,Kamala Harris,25
-Fresno,1082,U.S. Senate,,DEM,Loretta Sanchez,17
-Fresno,1083,U.S. Senate,,DEM,Kamala Harris,4
-Fresno,1083,U.S. Senate,,DEM,Loretta Sanchez,9
-Fresno,1084,U.S. Senate,,DEM,Kamala Harris,5
-Fresno,1084,U.S. Senate,,DEM,Loretta Sanchez,11
-Fresno,1085,U.S. Senate,,DEM,Kamala Harris,0
-Fresno,1085,U.S. Senate,,DEM,Loretta Sanchez,0
-Fresno,1086,U.S. Senate,,DEM,Kamala Harris,69
-Fresno,1086,U.S. Senate,,DEM,Loretta Sanchez,82
-Fresno,1087,U.S. Senate,,DEM,Kamala Harris,8
-Fresno,1087,U.S. Senate,,DEM,Loretta Sanchez,10
-Fresno,1088,U.S. Senate,,DEM,Kamala Harris,1
-Fresno,1088,U.S. Senate,,DEM,Loretta Sanchez,1
-Fresno,1089,U.S. Senate,,DEM,Kamala Harris,59
-Fresno,1089,U.S. Senate,,DEM,Loretta Sanchez,45
-Fresno,109,U.S. Senate,,DEM,Kamala Harris,467
-Fresno,109,U.S. Senate,,DEM,Loretta Sanchez,410
-Fresno,1090,U.S. Senate,,DEM,Kamala Harris,67
-Fresno,1090,U.S. Senate,,DEM,Loretta Sanchez,67
-Fresno,1091,U.S. Senate,,DEM,Kamala Harris,36
-Fresno,1091,U.S. Senate,,DEM,Loretta Sanchez,34
-Fresno,1092,U.S. Senate,,DEM,Kamala Harris,25
-Fresno,1092,U.S. Senate,,DEM,Loretta Sanchez,28
-Fresno,1093,U.S. Senate,,DEM,Kamala Harris,44
-Fresno,1093,U.S. Senate,,DEM,Loretta Sanchez,38
-Fresno,1094,U.S. Senate,,DEM,Kamala Harris,0
-Fresno,1094,U.S. Senate,,DEM,Loretta Sanchez,0
-Fresno,1095,U.S. Senate,,DEM,Kamala Harris,2
-Fresno,1095,U.S. Senate,,DEM,Loretta Sanchez,0
-Fresno,1096,U.S. Senate,,DEM,Kamala Harris,0
-Fresno,1096,U.S. Senate,,DEM,Loretta Sanchez,0
-Fresno,1097,U.S. Senate,,DEM,Kamala Harris,37
-Fresno,1097,U.S. Senate,,DEM,Loretta Sanchez,58
-Fresno,1098,U.S. Senate,,DEM,Kamala Harris,32
-Fresno,1098,U.S. Senate,,DEM,Loretta Sanchez,32
-Fresno,1099,U.S. Senate,,DEM,Kamala Harris,17
-Fresno,1099,U.S. Senate,,DEM,Loretta Sanchez,11
-Fresno,11,U.S. Senate,,DEM,Kamala Harris,384
-Fresno,11,U.S. Senate,,DEM,Loretta Sanchez,259
-Fresno,110,U.S. Senate,,DEM,Kamala Harris,465
-Fresno,110,U.S. Senate,,DEM,Loretta Sanchez,300
-Fresno,1100,U.S. Senate,,DEM,Kamala Harris,24
-Fresno,1100,U.S. Senate,,DEM,Loretta Sanchez,21
-Fresno,1101,U.S. Senate,,DEM,Kamala Harris,51
-Fresno,1101,U.S. Senate,,DEM,Loretta Sanchez,57
-Fresno,1102,U.S. Senate,,DEM,Kamala Harris,20
-Fresno,1102,U.S. Senate,,DEM,Loretta Sanchez,25
-Fresno,1103,U.S. Senate,,DEM,Kamala Harris,9
-Fresno,1103,U.S. Senate,,DEM,Loretta Sanchez,27
-Fresno,1104,U.S. Senate,,DEM,Kamala Harris,27
-Fresno,1104,U.S. Senate,,DEM,Loretta Sanchez,49
-Fresno,1105,U.S. Senate,,DEM,Kamala Harris,0
-Fresno,1105,U.S. Senate,,DEM,Loretta Sanchez,0
-Fresno,1106,U.S. Senate,,DEM,Kamala Harris,5
-Fresno,1106,U.S. Senate,,DEM,Loretta Sanchez,7
-Fresno,1107,U.S. Senate,,DEM,Kamala Harris,59
-Fresno,1107,U.S. Senate,,DEM,Loretta Sanchez,43
-Fresno,1108,U.S. Senate,,DEM,Kamala Harris,30
-Fresno,1108,U.S. Senate,,DEM,Loretta Sanchez,41
-Fresno,1109,U.S. Senate,,DEM,Kamala Harris,1
-Fresno,1109,U.S. Senate,,DEM,Loretta Sanchez,2
-Fresno,111,U.S. Senate,,DEM,Kamala Harris,598
-Fresno,111,U.S. Senate,,DEM,Loretta Sanchez,421
-Fresno,1110,U.S. Senate,,DEM,Kamala Harris,0
-Fresno,1110,U.S. Senate,,DEM,Loretta Sanchez,0
-Fresno,1111,U.S. Senate,,DEM,Kamala Harris,23
-Fresno,1111,U.S. Senate,,DEM,Loretta Sanchez,35
-Fresno,1112,U.S. Senate,,DEM,Kamala Harris,21
-Fresno,1112,U.S. Senate,,DEM,Loretta Sanchez,25
-Fresno,1113,U.S. Senate,,DEM,Kamala Harris,0
-Fresno,1113,U.S. Senate,,DEM,Loretta Sanchez,1
-Fresno,1114,U.S. Senate,,DEM,Kamala Harris,45
-Fresno,1114,U.S. Senate,,DEM,Loretta Sanchez,34
-Fresno,1115,U.S. Senate,,DEM,Kamala Harris,34
-Fresno,1115,U.S. Senate,,DEM,Loretta Sanchez,48
-Fresno,1116,U.S. Senate,,DEM,Kamala Harris,54
-Fresno,1116,U.S. Senate,,DEM,Loretta Sanchez,59
-Fresno,1117,U.S. Senate,,DEM,Kamala Harris,1
-Fresno,1117,U.S. Senate,,DEM,Loretta Sanchez,15
-Fresno,1118,U.S. Senate,,DEM,Kamala Harris,45
-Fresno,1118,U.S. Senate,,DEM,Loretta Sanchez,44
-Fresno,1119,U.S. Senate,,DEM,Kamala Harris,2
-Fresno,1119,U.S. Senate,,DEM,Loretta Sanchez,9
-Fresno,112,U.S. Senate,,DEM,Kamala Harris,640
-Fresno,112,U.S. Senate,,DEM,Loretta Sanchez,482
-Fresno,1120,U.S. Senate,,DEM,Kamala Harris,17
-Fresno,1120,U.S. Senate,,DEM,Loretta Sanchez,32
-Fresno,1121,U.S. Senate,,DEM,Kamala Harris,0
-Fresno,1121,U.S. Senate,,DEM,Loretta Sanchez,0
-Fresno,1122,U.S. Senate,,DEM,Kamala Harris,12
-Fresno,1122,U.S. Senate,,DEM,Loretta Sanchez,15
-Fresno,1123,U.S. Senate,,DEM,Kamala Harris,22
-Fresno,1123,U.S. Senate,,DEM,Loretta Sanchez,22
-Fresno,1124,U.S. Senate,,DEM,Kamala Harris,21
-Fresno,1124,U.S. Senate,,DEM,Loretta Sanchez,15
-Fresno,1125,U.S. Senate,,DEM,Kamala Harris,15
-Fresno,1125,U.S. Senate,,DEM,Loretta Sanchez,14
-Fresno,1126,U.S. Senate,,DEM,Kamala Harris,23
-Fresno,1126,U.S. Senate,,DEM,Loretta Sanchez,36
-Fresno,1127,U.S. Senate,,DEM,Kamala Harris,56
-Fresno,1127,U.S. Senate,,DEM,Loretta Sanchez,59
-Fresno,1128,U.S. Senate,,DEM,Kamala Harris,0
-Fresno,1128,U.S. Senate,,DEM,Loretta Sanchez,3
-Fresno,1129,U.S. Senate,,DEM,Kamala Harris,0
-Fresno,1129,U.S. Senate,,DEM,Loretta Sanchez,0
-Fresno,113,U.S. Senate,,DEM,Kamala Harris,493
-Fresno,113,U.S. Senate,,DEM,Loretta Sanchez,366
-Fresno,1130,U.S. Senate,,DEM,Kamala Harris,4
-Fresno,1130,U.S. Senate,,DEM,Loretta Sanchez,13
-Fresno,1131,U.S. Senate,,DEM,Kamala Harris,13
-Fresno,1131,U.S. Senate,,DEM,Loretta Sanchez,51
-Fresno,1132,U.S. Senate,,DEM,Kamala Harris,22
-Fresno,1132,U.S. Senate,,DEM,Loretta Sanchez,34
-Fresno,1133,U.S. Senate,,DEM,Kamala Harris,55
-Fresno,1133,U.S. Senate,,DEM,Loretta Sanchez,60
-Fresno,1134,U.S. Senate,,DEM,Kamala Harris,1
-Fresno,1134,U.S. Senate,,DEM,Loretta Sanchez,0
-Fresno,1135,U.S. Senate,,DEM,Kamala Harris,16
-Fresno,1135,U.S. Senate,,DEM,Loretta Sanchez,30
-Fresno,1136,U.S. Senate,,DEM,Kamala Harris,26
-Fresno,1136,U.S. Senate,,DEM,Loretta Sanchez,31
-Fresno,1137,U.S. Senate,,DEM,Kamala Harris,55
-Fresno,1137,U.S. Senate,,DEM,Loretta Sanchez,76
-Fresno,1138,U.S. Senate,,DEM,Kamala Harris,20
-Fresno,1138,U.S. Senate,,DEM,Loretta Sanchez,21
-Fresno,1139,U.S. Senate,,DEM,Kamala Harris,26
-Fresno,1139,U.S. Senate,,DEM,Loretta Sanchez,19
-Fresno,114,U.S. Senate,,DEM,Kamala Harris,341
-Fresno,114,U.S. Senate,,DEM,Loretta Sanchez,272
-Fresno,1140,U.S. Senate,,DEM,Kamala Harris,25
-Fresno,1140,U.S. Senate,,DEM,Loretta Sanchez,50
-Fresno,1141,U.S. Senate,,DEM,Kamala Harris,56
-Fresno,1141,U.S. Senate,,DEM,Loretta Sanchez,70
-Fresno,1142,U.S. Senate,,DEM,Kamala Harris,4
-Fresno,1142,U.S. Senate,,DEM,Loretta Sanchez,7
-Fresno,1143,U.S. Senate,,DEM,Kamala Harris,5
-Fresno,1143,U.S. Senate,,DEM,Loretta Sanchez,2
-Fresno,1144,U.S. Senate,,DEM,Kamala Harris,6
-Fresno,1144,U.S. Senate,,DEM,Loretta Sanchez,1
-Fresno,1145,U.S. Senate,,DEM,Kamala Harris,4
-Fresno,1145,U.S. Senate,,DEM,Loretta Sanchez,10
-Fresno,1146,U.S. Senate,,DEM,Kamala Harris,39
-Fresno,1146,U.S. Senate,,DEM,Loretta Sanchez,78
-Fresno,1147,U.S. Senate,,DEM,Kamala Harris,2
-Fresno,1147,U.S. Senate,,DEM,Loretta Sanchez,2
-Fresno,1148,U.S. Senate,,DEM,Kamala Harris,2
-Fresno,1148,U.S. Senate,,DEM,Loretta Sanchez,11
-Fresno,1149,U.S. Senate,,DEM,Kamala Harris,62
-Fresno,1149,U.S. Senate,,DEM,Loretta Sanchez,64
-Fresno,115,U.S. Senate,,DEM,Kamala Harris,342
-Fresno,115,U.S. Senate,,DEM,Loretta Sanchez,274
-Fresno,1150,U.S. Senate,,DEM,Kamala Harris,16
-Fresno,1150,U.S. Senate,,DEM,Loretta Sanchez,27
-Fresno,1151,U.S. Senate,,DEM,Kamala Harris,0
-Fresno,1151,U.S. Senate,,DEM,Loretta Sanchez,0
-Fresno,1152,U.S. Senate,,DEM,Kamala Harris,36
-Fresno,1152,U.S. Senate,,DEM,Loretta Sanchez,30
-Fresno,1153,U.S. Senate,,DEM,Kamala Harris,76
-Fresno,1153,U.S. Senate,,DEM,Loretta Sanchez,165
-Fresno,1154,U.S. Senate,,DEM,Kamala Harris,36
-Fresno,1154,U.S. Senate,,DEM,Loretta Sanchez,56
-Fresno,1155,U.S. Senate,,DEM,Kamala Harris,0
-Fresno,1155,U.S. Senate,,DEM,Loretta Sanchez,0
-Fresno,1156,U.S. Senate,,DEM,Kamala Harris,0
-Fresno,1156,U.S. Senate,,DEM,Loretta Sanchez,1
-Fresno,1157,U.S. Senate,,DEM,Kamala Harris,27
-Fresno,1157,U.S. Senate,,DEM,Loretta Sanchez,67
-Fresno,1158,U.S. Senate,,DEM,Kamala Harris,19
-Fresno,1158,U.S. Senate,,DEM,Loretta Sanchez,59
-Fresno,1159,U.S. Senate,,DEM,Kamala Harris,0
-Fresno,1159,U.S. Senate,,DEM,Loretta Sanchez,0
-Fresno,116,U.S. Senate,,DEM,Kamala Harris,334
-Fresno,116,U.S. Senate,,DEM,Loretta Sanchez,270
-Fresno,1160,U.S. Senate,,DEM,Kamala Harris,26
-Fresno,1160,U.S. Senate,,DEM,Loretta Sanchez,54
-Fresno,1161,U.S. Senate,,DEM,Kamala Harris,45
-Fresno,1161,U.S. Senate,,DEM,Loretta Sanchez,53
-Fresno,1162,U.S. Senate,,DEM,Kamala Harris,15
-Fresno,1162,U.S. Senate,,DEM,Loretta Sanchez,21
-Fresno,1163,U.S. Senate,,DEM,Kamala Harris,19
-Fresno,1163,U.S. Senate,,DEM,Loretta Sanchez,19
-Fresno,1164,U.S. Senate,,DEM,Kamala Harris,8
-Fresno,1164,U.S. Senate,,DEM,Loretta Sanchez,12
-Fresno,1165,U.S. Senate,,DEM,Kamala Harris,9
-Fresno,1165,U.S. Senate,,DEM,Loretta Sanchez,6
-Fresno,1166,U.S. Senate,,DEM,Kamala Harris,18
-Fresno,1166,U.S. Senate,,DEM,Loretta Sanchez,19
-Fresno,1167,U.S. Senate,,DEM,Kamala Harris,5
-Fresno,1167,U.S. Senate,,DEM,Loretta Sanchez,11
-Fresno,1168,U.S. Senate,,DEM,Kamala Harris,31
-Fresno,1168,U.S. Senate,,DEM,Loretta Sanchez,32
-Fresno,1169,U.S. Senate,,DEM,Kamala Harris,0
-Fresno,1169,U.S. Senate,,DEM,Loretta Sanchez,0
-Fresno,117,U.S. Senate,,DEM,Kamala Harris,569
-Fresno,117,U.S. Senate,,DEM,Loretta Sanchez,456
-Fresno,1170,U.S. Senate,,DEM,Kamala Harris,14
-Fresno,1170,U.S. Senate,,DEM,Loretta Sanchez,8
-Fresno,1171,U.S. Senate,,DEM,Kamala Harris,12
-Fresno,1171,U.S. Senate,,DEM,Loretta Sanchez,27
-Fresno,1172,U.S. Senate,,DEM,Kamala Harris,17
-Fresno,1172,U.S. Senate,,DEM,Loretta Sanchez,23
-Fresno,1173,U.S. Senate,,DEM,Kamala Harris,25
-Fresno,1173,U.S. Senate,,DEM,Loretta Sanchez,25
-Fresno,1174,U.S. Senate,,DEM,Kamala Harris,6
-Fresno,1174,U.S. Senate,,DEM,Loretta Sanchez,4
-Fresno,1175,U.S. Senate,,DEM,Kamala Harris,44
-Fresno,1175,U.S. Senate,,DEM,Loretta Sanchez,62
-Fresno,1176,U.S. Senate,,DEM,Kamala Harris,8
-Fresno,1176,U.S. Senate,,DEM,Loretta Sanchez,13
-Fresno,1177,U.S. Senate,,DEM,Kamala Harris,9
-Fresno,1177,U.S. Senate,,DEM,Loretta Sanchez,12
-Fresno,1178,U.S. Senate,,DEM,Kamala Harris,0
-Fresno,1178,U.S. Senate,,DEM,Loretta Sanchez,0
-Fresno,1179,U.S. Senate,,DEM,Kamala Harris,5
-Fresno,1179,U.S. Senate,,DEM,Loretta Sanchez,3
-Fresno,118,U.S. Senate,,DEM,Kamala Harris,556
-Fresno,118,U.S. Senate,,DEM,Loretta Sanchez,435
-Fresno,1180,U.S. Senate,,DEM,Kamala Harris,13
-Fresno,1180,U.S. Senate,,DEM,Loretta Sanchez,14
-Fresno,1181,U.S. Senate,,DEM,Kamala Harris,65
-Fresno,1181,U.S. Senate,,DEM,Loretta Sanchez,70
-Fresno,119,U.S. Senate,,DEM,Kamala Harris,389
-Fresno,119,U.S. Senate,,DEM,Loretta Sanchez,321
-Fresno,12,U.S. Senate,,DEM,Kamala Harris,341
-Fresno,12,U.S. Senate,,DEM,Loretta Sanchez,225
-Fresno,120,U.S. Senate,,DEM,Kamala Harris,591
-Fresno,120,U.S. Senate,,DEM,Loretta Sanchez,522
-Fresno,121,U.S. Senate,,DEM,Kamala Harris,374
-Fresno,121,U.S. Senate,,DEM,Loretta Sanchez,407
-Fresno,122,U.S. Senate,,DEM,Kamala Harris,320
-Fresno,122,U.S. Senate,,DEM,Loretta Sanchez,263
-Fresno,123,U.S. Senate,,DEM,Kamala Harris,362
-Fresno,123,U.S. Senate,,DEM,Loretta Sanchez,327
-Fresno,124,U.S. Senate,,DEM,Kamala Harris,320
-Fresno,124,U.S. Senate,,DEM,Loretta Sanchez,246
-Fresno,125,U.S. Senate,,DEM,Kamala Harris,367
-Fresno,125,U.S. Senate,,DEM,Loretta Sanchez,316
-Fresno,126,U.S. Senate,,DEM,Kamala Harris,397
-Fresno,126,U.S. Senate,,DEM,Loretta Sanchez,310
-Fresno,127,U.S. Senate,,DEM,Kamala Harris,359
-Fresno,127,U.S. Senate,,DEM,Loretta Sanchez,281
-Fresno,128,U.S. Senate,,DEM,Kamala Harris,268
-Fresno,128,U.S. Senate,,DEM,Loretta Sanchez,237
-Fresno,129,U.S. Senate,,DEM,Kamala Harris,330
-Fresno,129,U.S. Senate,,DEM,Loretta Sanchez,235
-Fresno,13,U.S. Senate,,DEM,Kamala Harris,607
-Fresno,13,U.S. Senate,,DEM,Loretta Sanchez,357
-Fresno,130,U.S. Senate,,DEM,Kamala Harris,363
-Fresno,130,U.S. Senate,,DEM,Loretta Sanchez,294
-Fresno,131,U.S. Senate,,DEM,Kamala Harris,291
-Fresno,131,U.S. Senate,,DEM,Loretta Sanchez,255
-Fresno,132,U.S. Senate,,DEM,Kamala Harris,478
-Fresno,132,U.S. Senate,,DEM,Loretta Sanchez,410
-Fresno,133,U.S. Senate,,DEM,Kamala Harris,300
-Fresno,133,U.S. Senate,,DEM,Loretta Sanchez,268
-Fresno,134,U.S. Senate,,DEM,Kamala Harris,370
-Fresno,134,U.S. Senate,,DEM,Loretta Sanchez,327
-Fresno,135,U.S. Senate,,DEM,Kamala Harris,262
-Fresno,135,U.S. Senate,,DEM,Loretta Sanchez,264
-Fresno,136,U.S. Senate,,DEM,Kamala Harris,265
-Fresno,136,U.S. Senate,,DEM,Loretta Sanchez,233
-Fresno,137,U.S. Senate,,DEM,Kamala Harris,215
-Fresno,137,U.S. Senate,,DEM,Loretta Sanchez,237
-Fresno,138,U.S. Senate,,DEM,Kamala Harris,264
-Fresno,138,U.S. Senate,,DEM,Loretta Sanchez,211
-Fresno,139,U.S. Senate,,DEM,Kamala Harris,258
-Fresno,139,U.S. Senate,,DEM,Loretta Sanchez,322
-Fresno,14,U.S. Senate,,DEM,Kamala Harris,268
-Fresno,14,U.S. Senate,,DEM,Loretta Sanchez,160
-Fresno,140,U.S. Senate,,DEM,Kamala Harris,331
-Fresno,140,U.S. Senate,,DEM,Loretta Sanchez,262
-Fresno,141,U.S. Senate,,DEM,Kamala Harris,482
-Fresno,141,U.S. Senate,,DEM,Loretta Sanchez,346
-Fresno,142,U.S. Senate,,DEM,Kamala Harris,300
-Fresno,142,U.S. Senate,,DEM,Loretta Sanchez,237
-Fresno,143,U.S. Senate,,DEM,Kamala Harris,240
-Fresno,143,U.S. Senate,,DEM,Loretta Sanchez,242
-Fresno,144,U.S. Senate,,DEM,Kamala Harris,146
-Fresno,144,U.S. Senate,,DEM,Loretta Sanchez,169
-Fresno,145,U.S. Senate,,DEM,Kamala Harris,81
-Fresno,145,U.S. Senate,,DEM,Loretta Sanchez,59
-Fresno,146,U.S. Senate,,DEM,Kamala Harris,365
-Fresno,146,U.S. Senate,,DEM,Loretta Sanchez,373
-Fresno,147,U.S. Senate,,DEM,Kamala Harris,134
-Fresno,147,U.S. Senate,,DEM,Loretta Sanchez,129
-Fresno,148,U.S. Senate,,DEM,Kamala Harris,318
-Fresno,148,U.S. Senate,,DEM,Loretta Sanchez,312
-Fresno,149,U.S. Senate,,DEM,Kamala Harris,348
-Fresno,149,U.S. Senate,,DEM,Loretta Sanchez,385
-Fresno,15,U.S. Senate,,DEM,Kamala Harris,241
-Fresno,15,U.S. Senate,,DEM,Loretta Sanchez,257
-Fresno,150,U.S. Senate,,DEM,Kamala Harris,453
-Fresno,150,U.S. Senate,,DEM,Loretta Sanchez,401
-Fresno,151,U.S. Senate,,DEM,Kamala Harris,451
-Fresno,151,U.S. Senate,,DEM,Loretta Sanchez,342
-Fresno,152,U.S. Senate,,DEM,Kamala Harris,302
-Fresno,152,U.S. Senate,,DEM,Loretta Sanchez,245
-Fresno,153,U.S. Senate,,DEM,Kamala Harris,579
-Fresno,153,U.S. Senate,,DEM,Loretta Sanchez,398
-Fresno,154,U.S. Senate,,DEM,Kamala Harris,303
-Fresno,154,U.S. Senate,,DEM,Loretta Sanchez,251
-Fresno,155,U.S. Senate,,DEM,Kamala Harris,314
-Fresno,155,U.S. Senate,,DEM,Loretta Sanchez,241
-Fresno,156,U.S. Senate,,DEM,Kamala Harris,595
-Fresno,156,U.S. Senate,,DEM,Loretta Sanchez,443
-Fresno,157,U.S. Senate,,DEM,Kamala Harris,586
-Fresno,157,U.S. Senate,,DEM,Loretta Sanchez,406
-Fresno,158,U.S. Senate,,DEM,Kamala Harris,343
-Fresno,158,U.S. Senate,,DEM,Loretta Sanchez,279
-Fresno,159,U.S. Senate,,DEM,Kamala Harris,601
-Fresno,159,U.S. Senate,,DEM,Loretta Sanchez,418
-Fresno,16,U.S. Senate,,DEM,Kamala Harris,230
-Fresno,16,U.S. Senate,,DEM,Loretta Sanchez,269
-Fresno,160,U.S. Senate,,DEM,Kamala Harris,343
-Fresno,160,U.S. Senate,,DEM,Loretta Sanchez,282
-Fresno,161,U.S. Senate,,DEM,Kamala Harris,362
-Fresno,161,U.S. Senate,,DEM,Loretta Sanchez,304
-Fresno,162,U.S. Senate,,DEM,Kamala Harris,275
-Fresno,162,U.S. Senate,,DEM,Loretta Sanchez,190
-Fresno,163,U.S. Senate,,DEM,Kamala Harris,354
-Fresno,163,U.S. Senate,,DEM,Loretta Sanchez,271
-Fresno,164,U.S. Senate,,DEM,Kamala Harris,438
-Fresno,164,U.S. Senate,,DEM,Loretta Sanchez,304
-Fresno,165,U.S. Senate,,DEM,Kamala Harris,305
-Fresno,165,U.S. Senate,,DEM,Loretta Sanchez,262
-Fresno,166,U.S. Senate,,DEM,Kamala Harris,340
-Fresno,166,U.S. Senate,,DEM,Loretta Sanchez,318
-Fresno,167,U.S. Senate,,DEM,Kamala Harris,600
-Fresno,167,U.S. Senate,,DEM,Loretta Sanchez,509
-Fresno,168,U.S. Senate,,DEM,Kamala Harris,451
-Fresno,168,U.S. Senate,,DEM,Loretta Sanchez,296
-Fresno,169,U.S. Senate,,DEM,Kamala Harris,504
-Fresno,169,U.S. Senate,,DEM,Loretta Sanchez,404
-Fresno,17,U.S. Senate,,DEM,Kamala Harris,318
-Fresno,17,U.S. Senate,,DEM,Loretta Sanchez,355
-Fresno,170,U.S. Senate,,DEM,Kamala Harris,457
-Fresno,170,U.S. Senate,,DEM,Loretta Sanchez,421
-Fresno,171,U.S. Senate,,DEM,Kamala Harris,465
-Fresno,171,U.S. Senate,,DEM,Loretta Sanchez,429
-Fresno,172,U.S. Senate,,DEM,Kamala Harris,227
-Fresno,172,U.S. Senate,,DEM,Loretta Sanchez,157
-Fresno,173,U.S. Senate,,DEM,Kamala Harris,486
-Fresno,173,U.S. Senate,,DEM,Loretta Sanchez,360
-Fresno,174,U.S. Senate,,DEM,Kamala Harris,263
-Fresno,174,U.S. Senate,,DEM,Loretta Sanchez,204
-Fresno,175,U.S. Senate,,DEM,Kamala Harris,402
-Fresno,175,U.S. Senate,,DEM,Loretta Sanchez,324
-Fresno,176,U.S. Senate,,DEM,Kamala Harris,635
-Fresno,176,U.S. Senate,,DEM,Loretta Sanchez,509
-Fresno,177,U.S. Senate,,DEM,Kamala Harris,330
-Fresno,177,U.S. Senate,,DEM,Loretta Sanchez,369
-Fresno,178,U.S. Senate,,DEM,Kamala Harris,239
-Fresno,178,U.S. Senate,,DEM,Loretta Sanchez,259
-Fresno,179,U.S. Senate,,DEM,Kamala Harris,167
-Fresno,179,U.S. Senate,,DEM,Loretta Sanchez,252
-Fresno,18,U.S. Senate,,DEM,Kamala Harris,197
-Fresno,18,U.S. Senate,,DEM,Loretta Sanchez,250
-Fresno,180,U.S. Senate,,DEM,Kamala Harris,233
-Fresno,180,U.S. Senate,,DEM,Loretta Sanchez,179
-Fresno,181,U.S. Senate,,DEM,Kamala Harris,201
-Fresno,181,U.S. Senate,,DEM,Loretta Sanchez,181
-Fresno,182,U.S. Senate,,DEM,Kamala Harris,256
-Fresno,182,U.S. Senate,,DEM,Loretta Sanchez,237
-Fresno,183,U.S. Senate,,DEM,Kamala Harris,343
-Fresno,183,U.S. Senate,,DEM,Loretta Sanchez,388
-Fresno,184,U.S. Senate,,DEM,Kamala Harris,670
-Fresno,184,U.S. Senate,,DEM,Loretta Sanchez,608
-Fresno,185,U.S. Senate,,DEM,Kamala Harris,450
-Fresno,185,U.S. Senate,,DEM,Loretta Sanchez,392
-Fresno,186,U.S. Senate,,DEM,Kamala Harris,585
-Fresno,186,U.S. Senate,,DEM,Loretta Sanchez,519
-Fresno,187,U.S. Senate,,DEM,Kamala Harris,392
-Fresno,187,U.S. Senate,,DEM,Loretta Sanchez,324
-Fresno,188,U.S. Senate,,DEM,Kamala Harris,266
-Fresno,188,U.S. Senate,,DEM,Loretta Sanchez,244
-Fresno,189,U.S. Senate,,DEM,Kamala Harris,362
-Fresno,189,U.S. Senate,,DEM,Loretta Sanchez,287
-Fresno,19,U.S. Senate,,DEM,Kamala Harris,279
-Fresno,19,U.S. Senate,,DEM,Loretta Sanchez,358
-Fresno,190,U.S. Senate,,DEM,Kamala Harris,306
-Fresno,190,U.S. Senate,,DEM,Loretta Sanchez,246
-Fresno,191,U.S. Senate,,DEM,Kamala Harris,173
-Fresno,191,U.S. Senate,,DEM,Loretta Sanchez,251
-Fresno,192,U.S. Senate,,DEM,Kamala Harris,469
-Fresno,192,U.S. Senate,,DEM,Loretta Sanchez,423
-Fresno,193,U.S. Senate,,DEM,Kamala Harris,479
-Fresno,193,U.S. Senate,,DEM,Loretta Sanchez,469
-Fresno,194,U.S. Senate,,DEM,Kamala Harris,351
-Fresno,194,U.S. Senate,,DEM,Loretta Sanchez,279
-Fresno,195,U.S. Senate,,DEM,Kamala Harris,265
-Fresno,195,U.S. Senate,,DEM,Loretta Sanchez,231
-Fresno,196,U.S. Senate,,DEM,Kamala Harris,429
-Fresno,196,U.S. Senate,,DEM,Loretta Sanchez,340
-Fresno,197,U.S. Senate,,DEM,Kamala Harris,281
-Fresno,197,U.S. Senate,,DEM,Loretta Sanchez,284
-Fresno,198,U.S. Senate,,DEM,Kamala Harris,280
-Fresno,198,U.S. Senate,,DEM,Loretta Sanchez,281
-Fresno,199,U.S. Senate,,DEM,Kamala Harris,532
-Fresno,199,U.S. Senate,,DEM,Loretta Sanchez,391
-Fresno,2,U.S. Senate,,DEM,Kamala Harris,349
-Fresno,2,U.S. Senate,,DEM,Loretta Sanchez,241
-Fresno,20,U.S. Senate,,DEM,Kamala Harris,228
-Fresno,20,U.S. Senate,,DEM,Loretta Sanchez,222
-Fresno,200,U.S. Senate,,DEM,Kamala Harris,397
-Fresno,200,U.S. Senate,,DEM,Loretta Sanchez,276
-Fresno,201,U.S. Senate,,DEM,Kamala Harris,268
-Fresno,201,U.S. Senate,,DEM,Loretta Sanchez,221
-Fresno,202,U.S. Senate,,DEM,Kamala Harris,215
-Fresno,202,U.S. Senate,,DEM,Loretta Sanchez,136
-Fresno,203,U.S. Senate,,DEM,Kamala Harris,303
-Fresno,203,U.S. Senate,,DEM,Loretta Sanchez,284
-Fresno,204,U.S. Senate,,DEM,Kamala Harris,399
-Fresno,204,U.S. Senate,,DEM,Loretta Sanchez,339
-Fresno,205,U.S. Senate,,DEM,Kamala Harris,281
-Fresno,205,U.S. Senate,,DEM,Loretta Sanchez,228
-Fresno,206,U.S. Senate,,DEM,Kamala Harris,189
-Fresno,206,U.S. Senate,,DEM,Loretta Sanchez,176
-Fresno,207,U.S. Senate,,DEM,Kamala Harris,255
-Fresno,207,U.S. Senate,,DEM,Loretta Sanchez,305
-Fresno,208,U.S. Senate,,DEM,Kamala Harris,215
-Fresno,208,U.S. Senate,,DEM,Loretta Sanchez,251
-Fresno,209,U.S. Senate,,DEM,Kamala Harris,160
-Fresno,209,U.S. Senate,,DEM,Loretta Sanchez,185
-Fresno,21,U.S. Senate,,DEM,Kamala Harris,200
-Fresno,21,U.S. Senate,,DEM,Loretta Sanchez,212
-Fresno,210,U.S. Senate,,DEM,Kamala Harris,251
-Fresno,210,U.S. Senate,,DEM,Loretta Sanchez,287
-Fresno,211,U.S. Senate,,DEM,Kamala Harris,116
-Fresno,211,U.S. Senate,,DEM,Loretta Sanchez,93
-Fresno,212,U.S. Senate,,DEM,Kamala Harris,329
-Fresno,212,U.S. Senate,,DEM,Loretta Sanchez,297
-Fresno,213,U.S. Senate,,DEM,Kamala Harris,152
-Fresno,213,U.S. Senate,,DEM,Loretta Sanchez,182
-Fresno,214,U.S. Senate,,DEM,Kamala Harris,475
-Fresno,214,U.S. Senate,,DEM,Loretta Sanchez,485
-Fresno,215,U.S. Senate,,DEM,Kamala Harris,128
-Fresno,215,U.S. Senate,,DEM,Loretta Sanchez,150
-Fresno,216,U.S. Senate,,DEM,Kamala Harris,145
-Fresno,216,U.S. Senate,,DEM,Loretta Sanchez,136
-Fresno,217,U.S. Senate,,DEM,Kamala Harris,585
-Fresno,217,U.S. Senate,,DEM,Loretta Sanchez,437
-Fresno,218,U.S. Senate,,DEM,Kamala Harris,311
-Fresno,218,U.S. Senate,,DEM,Loretta Sanchez,235
-Fresno,219,U.S. Senate,,DEM,Kamala Harris,379
-Fresno,219,U.S. Senate,,DEM,Loretta Sanchez,324
-Fresno,22,U.S. Senate,,DEM,Kamala Harris,123
-Fresno,22,U.S. Senate,,DEM,Loretta Sanchez,191
-Fresno,220,U.S. Senate,,DEM,Kamala Harris,231
-Fresno,220,U.S. Senate,,DEM,Loretta Sanchez,219
-Fresno,221,U.S. Senate,,DEM,Kamala Harris,289
-Fresno,221,U.S. Senate,,DEM,Loretta Sanchez,237
-Fresno,222,U.S. Senate,,DEM,Kamala Harris,91
-Fresno,222,U.S. Senate,,DEM,Loretta Sanchez,141
-Fresno,223,U.S. Senate,,DEM,Kamala Harris,221
-Fresno,223,U.S. Senate,,DEM,Loretta Sanchez,322
-Fresno,224,U.S. Senate,,DEM,Kamala Harris,255
-Fresno,224,U.S. Senate,,DEM,Loretta Sanchez,273
-Fresno,225,U.S. Senate,,DEM,Kamala Harris,500
-Fresno,225,U.S. Senate,,DEM,Loretta Sanchez,368
-Fresno,226,U.S. Senate,,DEM,Kamala Harris,240
-Fresno,226,U.S. Senate,,DEM,Loretta Sanchez,221
-Fresno,227,U.S. Senate,,DEM,Kamala Harris,267
-Fresno,227,U.S. Senate,,DEM,Loretta Sanchez,254
-Fresno,228,U.S. Senate,,DEM,Kamala Harris,383
-Fresno,228,U.S. Senate,,DEM,Loretta Sanchez,324
-Fresno,229,U.S. Senate,,DEM,Kamala Harris,454
-Fresno,229,U.S. Senate,,DEM,Loretta Sanchez,394
-Fresno,23,U.S. Senate,,DEM,Kamala Harris,315
-Fresno,23,U.S. Senate,,DEM,Loretta Sanchez,289
-Fresno,230,U.S. Senate,,DEM,Kamala Harris,366
-Fresno,230,U.S. Senate,,DEM,Loretta Sanchez,276
-Fresno,231,U.S. Senate,,DEM,Kamala Harris,73
-Fresno,231,U.S. Senate,,DEM,Loretta Sanchez,136
-Fresno,232,U.S. Senate,,DEM,Kamala Harris,203
-Fresno,232,U.S. Senate,,DEM,Loretta Sanchez,201
-Fresno,233,U.S. Senate,,DEM,Kamala Harris,158
-Fresno,233,U.S. Senate,,DEM,Loretta Sanchez,167
-Fresno,234,U.S. Senate,,DEM,Kamala Harris,113
-Fresno,234,U.S. Senate,,DEM,Loretta Sanchez,100
-Fresno,235,U.S. Senate,,DEM,Kamala Harris,332
-Fresno,235,U.S. Senate,,DEM,Loretta Sanchez,291
-Fresno,236,U.S. Senate,,DEM,Kamala Harris,360
-Fresno,236,U.S. Senate,,DEM,Loretta Sanchez,360
-Fresno,237,U.S. Senate,,DEM,Kamala Harris,232
-Fresno,237,U.S. Senate,,DEM,Loretta Sanchez,236
-Fresno,238,U.S. Senate,,DEM,Kamala Harris,232
-Fresno,238,U.S. Senate,,DEM,Loretta Sanchez,249
-Fresno,239,U.S. Senate,,DEM,Kamala Harris,137
-Fresno,239,U.S. Senate,,DEM,Loretta Sanchez,125
-Fresno,24,U.S. Senate,,DEM,Kamala Harris,453
-Fresno,24,U.S. Senate,,DEM,Loretta Sanchez,432
-Fresno,240,U.S. Senate,,DEM,Kamala Harris,198
-Fresno,240,U.S. Senate,,DEM,Loretta Sanchez,218
-Fresno,241,U.S. Senate,,DEM,Kamala Harris,287
-Fresno,241,U.S. Senate,,DEM,Loretta Sanchez,435
-Fresno,242,U.S. Senate,,DEM,Kamala Harris,241
-Fresno,242,U.S. Senate,,DEM,Loretta Sanchez,356
-Fresno,243,U.S. Senate,,DEM,Kamala Harris,78
-Fresno,243,U.S. Senate,,DEM,Loretta Sanchez,93
-Fresno,244,U.S. Senate,,DEM,Kamala Harris,82
-Fresno,244,U.S. Senate,,DEM,Loretta Sanchez,160
-Fresno,245,U.S. Senate,,DEM,Kamala Harris,172
-Fresno,245,U.S. Senate,,DEM,Loretta Sanchez,130
-Fresno,246,U.S. Senate,,DEM,Kamala Harris,115
-Fresno,246,U.S. Senate,,DEM,Loretta Sanchez,124
-Fresno,247,U.S. Senate,,DEM,Kamala Harris,91
-Fresno,247,U.S. Senate,,DEM,Loretta Sanchez,138
-Fresno,248,U.S. Senate,,DEM,Kamala Harris,451
-Fresno,248,U.S. Senate,,DEM,Loretta Sanchez,320
-Fresno,249,U.S. Senate,,DEM,Kamala Harris,514
-Fresno,249,U.S. Senate,,DEM,Loretta Sanchez,345
-Fresno,25,U.S. Senate,,DEM,Kamala Harris,295
-Fresno,25,U.S. Senate,,DEM,Loretta Sanchez,266
-Fresno,250,U.S. Senate,,DEM,Kamala Harris,143
-Fresno,250,U.S. Senate,,DEM,Loretta Sanchez,231
-Fresno,251,U.S. Senate,,DEM,Kamala Harris,628
-Fresno,251,U.S. Senate,,DEM,Loretta Sanchez,394
-Fresno,252,U.S. Senate,,DEM,Kamala Harris,578
-Fresno,252,U.S. Senate,,DEM,Loretta Sanchez,436
-Fresno,253,U.S. Senate,,DEM,Kamala Harris,280
-Fresno,253,U.S. Senate,,DEM,Loretta Sanchez,244
-Fresno,254,U.S. Senate,,DEM,Kamala Harris,307
-Fresno,254,U.S. Senate,,DEM,Loretta Sanchez,295
-Fresno,255,U.S. Senate,,DEM,Kamala Harris,487
-Fresno,255,U.S. Senate,,DEM,Loretta Sanchez,401
-Fresno,256,U.S. Senate,,DEM,Kamala Harris,448
-Fresno,256,U.S. Senate,,DEM,Loretta Sanchez,365
-Fresno,257,U.S. Senate,,DEM,Kamala Harris,543
-Fresno,257,U.S. Senate,,DEM,Loretta Sanchez,384
-Fresno,258,U.S. Senate,,DEM,Kamala Harris,181
-Fresno,258,U.S. Senate,,DEM,Loretta Sanchez,178
-Fresno,259,U.S. Senate,,DEM,Kamala Harris,418
-Fresno,259,U.S. Senate,,DEM,Loretta Sanchez,414
-Fresno,26,U.S. Senate,,DEM,Kamala Harris,184
-Fresno,26,U.S. Senate,,DEM,Loretta Sanchez,194
-Fresno,260,U.S. Senate,,DEM,Kamala Harris,165
-Fresno,260,U.S. Senate,,DEM,Loretta Sanchez,203
-Fresno,261,U.S. Senate,,DEM,Kamala Harris,371
-Fresno,261,U.S. Senate,,DEM,Loretta Sanchez,357
-Fresno,262,U.S. Senate,,DEM,Kamala Harris,138
-Fresno,262,U.S. Senate,,DEM,Loretta Sanchez,132
-Fresno,263,U.S. Senate,,DEM,Kamala Harris,750
-Fresno,263,U.S. Senate,,DEM,Loretta Sanchez,564
-Fresno,264,U.S. Senate,,DEM,Kamala Harris,545
-Fresno,264,U.S. Senate,,DEM,Loretta Sanchez,487
-Fresno,265,U.S. Senate,,DEM,Kamala Harris,474
-Fresno,265,U.S. Senate,,DEM,Loretta Sanchez,423
-Fresno,266,U.S. Senate,,DEM,Kamala Harris,518
-Fresno,266,U.S. Senate,,DEM,Loretta Sanchez,476
-Fresno,267,U.S. Senate,,DEM,Kamala Harris,508
-Fresno,267,U.S. Senate,,DEM,Loretta Sanchez,389
-Fresno,268,U.S. Senate,,DEM,Kamala Harris,372
-Fresno,268,U.S. Senate,,DEM,Loretta Sanchez,370
-Fresno,269,U.S. Senate,,DEM,Kamala Harris,330
-Fresno,269,U.S. Senate,,DEM,Loretta Sanchez,265
-Fresno,27,U.S. Senate,,DEM,Kamala Harris,138
-Fresno,27,U.S. Senate,,DEM,Loretta Sanchez,188
-Fresno,270,U.S. Senate,,DEM,Kamala Harris,300
-Fresno,270,U.S. Senate,,DEM,Loretta Sanchez,219
-Fresno,271,U.S. Senate,,DEM,Kamala Harris,329
-Fresno,271,U.S. Senate,,DEM,Loretta Sanchez,300
-Fresno,272,U.S. Senate,,DEM,Kamala Harris,399
-Fresno,272,U.S. Senate,,DEM,Loretta Sanchez,337
-Fresno,273,U.S. Senate,,DEM,Kamala Harris,363
-Fresno,273,U.S. Senate,,DEM,Loretta Sanchez,304
-Fresno,274,U.S. Senate,,DEM,Kamala Harris,446
-Fresno,274,U.S. Senate,,DEM,Loretta Sanchez,377
-Fresno,275,U.S. Senate,,DEM,Kamala Harris,327
-Fresno,275,U.S. Senate,,DEM,Loretta Sanchez,289
-Fresno,276,U.S. Senate,,DEM,Kamala Harris,275
-Fresno,276,U.S. Senate,,DEM,Loretta Sanchez,216
-Fresno,277,U.S. Senate,,DEM,Kamala Harris,662
-Fresno,277,U.S. Senate,,DEM,Loretta Sanchez,525
-Fresno,278,U.S. Senate,,DEM,Kamala Harris,462
-Fresno,278,U.S. Senate,,DEM,Loretta Sanchez,370
-Fresno,279,U.S. Senate,,DEM,Kamala Harris,513
-Fresno,279,U.S. Senate,,DEM,Loretta Sanchez,450
-Fresno,28,U.S. Senate,,DEM,Kamala Harris,302
-Fresno,28,U.S. Senate,,DEM,Loretta Sanchez,353
-Fresno,280,U.S. Senate,,DEM,Kamala Harris,440
-Fresno,280,U.S. Senate,,DEM,Loretta Sanchez,386
-Fresno,281,U.S. Senate,,DEM,Kamala Harris,498
-Fresno,281,U.S. Senate,,DEM,Loretta Sanchez,457
-Fresno,282,U.S. Senate,,DEM,Kamala Harris,520
-Fresno,282,U.S. Senate,,DEM,Loretta Sanchez,491
-Fresno,283,U.S. Senate,,DEM,Kamala Harris,498
-Fresno,283,U.S. Senate,,DEM,Loretta Sanchez,443
-Fresno,284,U.S. Senate,,DEM,Kamala Harris,538
-Fresno,284,U.S. Senate,,DEM,Loretta Sanchez,469
-Fresno,285,U.S. Senate,,DEM,Kamala Harris,190
-Fresno,285,U.S. Senate,,DEM,Loretta Sanchez,193
-Fresno,286,U.S. Senate,,DEM,Kamala Harris,315
-Fresno,286,U.S. Senate,,DEM,Loretta Sanchez,252
-Fresno,287,U.S. Senate,,DEM,Kamala Harris,245
-Fresno,287,U.S. Senate,,DEM,Loretta Sanchez,190
-Fresno,288,U.S. Senate,,DEM,Kamala Harris,300
-Fresno,288,U.S. Senate,,DEM,Loretta Sanchez,174
-Fresno,289,U.S. Senate,,DEM,Kamala Harris,197
-Fresno,289,U.S. Senate,,DEM,Loretta Sanchez,175
-Fresno,29,U.S. Senate,,DEM,Kamala Harris,447
-Fresno,29,U.S. Senate,,DEM,Loretta Sanchez,261
-Fresno,290,U.S. Senate,,DEM,Kamala Harris,213
-Fresno,290,U.S. Senate,,DEM,Loretta Sanchez,160
-Fresno,291,U.S. Senate,,DEM,Kamala Harris,204
-Fresno,291,U.S. Senate,,DEM,Loretta Sanchez,147
-Fresno,292,U.S. Senate,,DEM,Kamala Harris,175
-Fresno,292,U.S. Senate,,DEM,Loretta Sanchez,190
-Fresno,293,U.S. Senate,,DEM,Kamala Harris,246
-Fresno,293,U.S. Senate,,DEM,Loretta Sanchez,216
-Fresno,294,U.S. Senate,,DEM,Kamala Harris,276
-Fresno,294,U.S. Senate,,DEM,Loretta Sanchez,315
-Fresno,295,U.S. Senate,,DEM,Kamala Harris,349
-Fresno,295,U.S. Senate,,DEM,Loretta Sanchez,344
-Fresno,296,U.S. Senate,,DEM,Kamala Harris,258
-Fresno,296,U.S. Senate,,DEM,Loretta Sanchez,223
-Fresno,297,U.S. Senate,,DEM,Kamala Harris,223
-Fresno,297,U.S. Senate,,DEM,Loretta Sanchez,210
-Fresno,298,U.S. Senate,,DEM,Kamala Harris,223
-Fresno,298,U.S. Senate,,DEM,Loretta Sanchez,240
-Fresno,299,U.S. Senate,,DEM,Kamala Harris,155
-Fresno,299,U.S. Senate,,DEM,Loretta Sanchez,199
-Fresno,3,U.S. Senate,,DEM,Kamala Harris,97
-Fresno,3,U.S. Senate,,DEM,Loretta Sanchez,110
-Fresno,30,U.S. Senate,,DEM,Kamala Harris,125
-Fresno,30,U.S. Senate,,DEM,Loretta Sanchez,186
-Fresno,300,U.S. Senate,,DEM,Kamala Harris,183
-Fresno,300,U.S. Senate,,DEM,Loretta Sanchez,203
-Fresno,301,U.S. Senate,,DEM,Kamala Harris,432
-Fresno,301,U.S. Senate,,DEM,Loretta Sanchez,354
-Fresno,302,U.S. Senate,,DEM,Kamala Harris,353
-Fresno,302,U.S. Senate,,DEM,Loretta Sanchez,449
-Fresno,303,U.S. Senate,,DEM,Kamala Harris,248
-Fresno,303,U.S. Senate,,DEM,Loretta Sanchez,228
-Fresno,304,U.S. Senate,,DEM,Kamala Harris,334
-Fresno,304,U.S. Senate,,DEM,Loretta Sanchez,317
-Fresno,305,U.S. Senate,,DEM,Kamala Harris,163
-Fresno,305,U.S. Senate,,DEM,Loretta Sanchez,146
-Fresno,306,U.S. Senate,,DEM,Kamala Harris,335
-Fresno,306,U.S. Senate,,DEM,Loretta Sanchez,370
-Fresno,307,U.S. Senate,,DEM,Kamala Harris,153
-Fresno,307,U.S. Senate,,DEM,Loretta Sanchez,198
-Fresno,308,U.S. Senate,,DEM,Kamala Harris,131
-Fresno,308,U.S. Senate,,DEM,Loretta Sanchez,90
-Fresno,309,U.S. Senate,,DEM,Kamala Harris,208
-Fresno,309,U.S. Senate,,DEM,Loretta Sanchez,192
-Fresno,31,U.S. Senate,,DEM,Kamala Harris,149
-Fresno,31,U.S. Senate,,DEM,Loretta Sanchez,177
-Fresno,310,U.S. Senate,,DEM,Kamala Harris,219
-Fresno,310,U.S. Senate,,DEM,Loretta Sanchez,196
-Fresno,311,U.S. Senate,,DEM,Kamala Harris,332
-Fresno,311,U.S. Senate,,DEM,Loretta Sanchez,304
-Fresno,312,U.S. Senate,,DEM,Kamala Harris,298
-Fresno,312,U.S. Senate,,DEM,Loretta Sanchez,286
-Fresno,313,U.S. Senate,,DEM,Kamala Harris,306
-Fresno,313,U.S. Senate,,DEM,Loretta Sanchez,263
-Fresno,314,U.S. Senate,,DEM,Kamala Harris,233
-Fresno,314,U.S. Senate,,DEM,Loretta Sanchez,244
-Fresno,315,U.S. Senate,,DEM,Kamala Harris,482
-Fresno,315,U.S. Senate,,DEM,Loretta Sanchez,437
-Fresno,316,U.S. Senate,,DEM,Kamala Harris,135
-Fresno,316,U.S. Senate,,DEM,Loretta Sanchez,236
-Fresno,317,U.S. Senate,,DEM,Kamala Harris,299
-Fresno,317,U.S. Senate,,DEM,Loretta Sanchez,353
-Fresno,318,U.S. Senate,,DEM,Kamala Harris,281
-Fresno,318,U.S. Senate,,DEM,Loretta Sanchez,398
-Fresno,319,U.S. Senate,,DEM,Kamala Harris,159
-Fresno,319,U.S. Senate,,DEM,Loretta Sanchez,155
-Fresno,32,U.S. Senate,,DEM,Kamala Harris,226
-Fresno,32,U.S. Senate,,DEM,Loretta Sanchez,321
-Fresno,320,U.S. Senate,,DEM,Kamala Harris,272
-Fresno,320,U.S. Senate,,DEM,Loretta Sanchez,337
-Fresno,321,U.S. Senate,,DEM,Kamala Harris,64
-Fresno,321,U.S. Senate,,DEM,Loretta Sanchez,166
-Fresno,322,U.S. Senate,,DEM,Kamala Harris,113
-Fresno,322,U.S. Senate,,DEM,Loretta Sanchez,97
-Fresno,323,U.S. Senate,,DEM,Kamala Harris,96
-Fresno,323,U.S. Senate,,DEM,Loretta Sanchez,94
-Fresno,324,U.S. Senate,,DEM,Kamala Harris,147
-Fresno,324,U.S. Senate,,DEM,Loretta Sanchez,332
-Fresno,325,U.S. Senate,,DEM,Kamala Harris,160
-Fresno,325,U.S. Senate,,DEM,Loretta Sanchez,221
-Fresno,326,U.S. Senate,,DEM,Kamala Harris,231
-Fresno,326,U.S. Senate,,DEM,Loretta Sanchez,278
-Fresno,327,U.S. Senate,,DEM,Kamala Harris,182
-Fresno,327,U.S. Senate,,DEM,Loretta Sanchez,259
-Fresno,328,U.S. Senate,,DEM,Kamala Harris,208
-Fresno,328,U.S. Senate,,DEM,Loretta Sanchez,287
-Fresno,329,U.S. Senate,,DEM,Kamala Harris,161
-Fresno,329,U.S. Senate,,DEM,Loretta Sanchez,227
-Fresno,33,U.S. Senate,,DEM,Kamala Harris,162
-Fresno,33,U.S. Senate,,DEM,Loretta Sanchez,225
-Fresno,330,U.S. Senate,,DEM,Kamala Harris,208
-Fresno,330,U.S. Senate,,DEM,Loretta Sanchez,241
-Fresno,331,U.S. Senate,,DEM,Kamala Harris,273
-Fresno,331,U.S. Senate,,DEM,Loretta Sanchez,284
-Fresno,332,U.S. Senate,,DEM,Kamala Harris,413
-Fresno,332,U.S. Senate,,DEM,Loretta Sanchez,373
-Fresno,333,U.S. Senate,,DEM,Kamala Harris,158
-Fresno,333,U.S. Senate,,DEM,Loretta Sanchez,216
-Fresno,334,U.S. Senate,,DEM,Kamala Harris,186
-Fresno,334,U.S. Senate,,DEM,Loretta Sanchez,274
-Fresno,335,U.S. Senate,,DEM,Kamala Harris,77
-Fresno,335,U.S. Senate,,DEM,Loretta Sanchez,112
-Fresno,336,U.S. Senate,,DEM,Kamala Harris,162
-Fresno,336,U.S. Senate,,DEM,Loretta Sanchez,184
-Fresno,337,U.S. Senate,,DEM,Kamala Harris,154
-Fresno,337,U.S. Senate,,DEM,Loretta Sanchez,180
-Fresno,338,U.S. Senate,,DEM,Kamala Harris,427
-Fresno,338,U.S. Senate,,DEM,Loretta Sanchez,417
-Fresno,339,U.S. Senate,,DEM,Kamala Harris,420
-Fresno,339,U.S. Senate,,DEM,Loretta Sanchez,355
-Fresno,34,U.S. Senate,,DEM,Kamala Harris,143
-Fresno,34,U.S. Senate,,DEM,Loretta Sanchez,210
-Fresno,340,U.S. Senate,,DEM,Kamala Harris,208
-Fresno,340,U.S. Senate,,DEM,Loretta Sanchez,266
-Fresno,341,U.S. Senate,,DEM,Kamala Harris,297
-Fresno,341,U.S. Senate,,DEM,Loretta Sanchez,269
-Fresno,342,U.S. Senate,,DEM,Kamala Harris,200
-Fresno,342,U.S. Senate,,DEM,Loretta Sanchez,203
-Fresno,343,U.S. Senate,,DEM,Kamala Harris,224
-Fresno,343,U.S. Senate,,DEM,Loretta Sanchez,230
-Fresno,344,U.S. Senate,,DEM,Kamala Harris,82
-Fresno,344,U.S. Senate,,DEM,Loretta Sanchez,97
-Fresno,345,U.S. Senate,,DEM,Kamala Harris,56
-Fresno,345,U.S. Senate,,DEM,Loretta Sanchez,84
-Fresno,346,U.S. Senate,,DEM,Kamala Harris,215
-Fresno,346,U.S. Senate,,DEM,Loretta Sanchez,468
-Fresno,347,U.S. Senate,,DEM,Kamala Harris,174
-Fresno,347,U.S. Senate,,DEM,Loretta Sanchez,332
-Fresno,348,U.S. Senate,,DEM,Kamala Harris,256
-Fresno,348,U.S. Senate,,DEM,Loretta Sanchez,539
-Fresno,349,U.S. Senate,,DEM,Kamala Harris,266
-Fresno,349,U.S. Senate,,DEM,Loretta Sanchez,391
-Fresno,35,U.S. Senate,,DEM,Kamala Harris,131
-Fresno,35,U.S. Senate,,DEM,Loretta Sanchez,194
-Fresno,350,U.S. Senate,,DEM,Kamala Harris,218
-Fresno,350,U.S. Senate,,DEM,Loretta Sanchez,254
-Fresno,351,U.S. Senate,,DEM,Kamala Harris,354
-Fresno,351,U.S. Senate,,DEM,Loretta Sanchez,431
-Fresno,352,U.S. Senate,,DEM,Kamala Harris,394
-Fresno,352,U.S. Senate,,DEM,Loretta Sanchez,462
-Fresno,353,U.S. Senate,,DEM,Kamala Harris,202
-Fresno,353,U.S. Senate,,DEM,Loretta Sanchez,252
-Fresno,354,U.S. Senate,,DEM,Kamala Harris,385
-Fresno,354,U.S. Senate,,DEM,Loretta Sanchez,412
-Fresno,355,U.S. Senate,,DEM,Kamala Harris,62
-Fresno,355,U.S. Senate,,DEM,Loretta Sanchez,78
-Fresno,356,U.S. Senate,,DEM,Kamala Harris,187
-Fresno,356,U.S. Senate,,DEM,Loretta Sanchez,324
-Fresno,357,U.S. Senate,,DEM,Kamala Harris,235
-Fresno,357,U.S. Senate,,DEM,Loretta Sanchez,190
-Fresno,358,U.S. Senate,,DEM,Kamala Harris,298
-Fresno,358,U.S. Senate,,DEM,Loretta Sanchez,216
-Fresno,359,U.S. Senate,,DEM,Kamala Harris,89
-Fresno,359,U.S. Senate,,DEM,Loretta Sanchez,69
-Fresno,36,U.S. Senate,,DEM,Kamala Harris,63
-Fresno,36,U.S. Senate,,DEM,Loretta Sanchez,143
-Fresno,360,U.S. Senate,,DEM,Kamala Harris,181
-Fresno,360,U.S. Senate,,DEM,Loretta Sanchez,412
-Fresno,361,U.S. Senate,,DEM,Kamala Harris,174
-Fresno,361,U.S. Senate,,DEM,Loretta Sanchez,420
-Fresno,362,U.S. Senate,,DEM,Kamala Harris,146
-Fresno,362,U.S. Senate,,DEM,Loretta Sanchez,314
-Fresno,363,U.S. Senate,,DEM,Kamala Harris,185
-Fresno,363,U.S. Senate,,DEM,Loretta Sanchez,375
-Fresno,364,U.S. Senate,,DEM,Kamala Harris,184
-Fresno,364,U.S. Senate,,DEM,Loretta Sanchez,207
-Fresno,365,U.S. Senate,,DEM,Kamala Harris,202
-Fresno,365,U.S. Senate,,DEM,Loretta Sanchez,256
-Fresno,366,U.S. Senate,,DEM,Kamala Harris,249
-Fresno,366,U.S. Senate,,DEM,Loretta Sanchez,217
-Fresno,367,U.S. Senate,,DEM,Kamala Harris,242
-Fresno,367,U.S. Senate,,DEM,Loretta Sanchez,321
-Fresno,368,U.S. Senate,,DEM,Kamala Harris,242
-Fresno,368,U.S. Senate,,DEM,Loretta Sanchez,294
-Fresno,369,U.S. Senate,,DEM,Kamala Harris,371
-Fresno,369,U.S. Senate,,DEM,Loretta Sanchez,307
-Fresno,37,U.S. Senate,,DEM,Kamala Harris,157
-Fresno,37,U.S. Senate,,DEM,Loretta Sanchez,301
-Fresno,370,U.S. Senate,,DEM,Kamala Harris,188
-Fresno,370,U.S. Senate,,DEM,Loretta Sanchez,203
-Fresno,371,U.S. Senate,,DEM,Kamala Harris,296
-Fresno,371,U.S. Senate,,DEM,Loretta Sanchez,316
-Fresno,372,U.S. Senate,,DEM,Kamala Harris,144
-Fresno,372,U.S. Senate,,DEM,Loretta Sanchez,200
-Fresno,373,U.S. Senate,,DEM,Kamala Harris,200
-Fresno,373,U.S. Senate,,DEM,Loretta Sanchez,224
-Fresno,374,U.S. Senate,,DEM,Kamala Harris,197
-Fresno,374,U.S. Senate,,DEM,Loretta Sanchez,365
-Fresno,375,U.S. Senate,,DEM,Kamala Harris,173
-Fresno,375,U.S. Senate,,DEM,Loretta Sanchez,415
-Fresno,376,U.S. Senate,,DEM,Kamala Harris,196
-Fresno,376,U.S. Senate,,DEM,Loretta Sanchez,470
-Fresno,377,U.S. Senate,,DEM,Kamala Harris,164
-Fresno,377,U.S. Senate,,DEM,Loretta Sanchez,510
-Fresno,378,U.S. Senate,,DEM,Kamala Harris,159
-Fresno,378,U.S. Senate,,DEM,Loretta Sanchez,232
-Fresno,379,U.S. Senate,,DEM,Kamala Harris,156
-Fresno,379,U.S. Senate,,DEM,Loretta Sanchez,179
-Fresno,38,U.S. Senate,,DEM,Kamala Harris,238
-Fresno,38,U.S. Senate,,DEM,Loretta Sanchez,202
-Fresno,380,U.S. Senate,,DEM,Kamala Harris,119
-Fresno,380,U.S. Senate,,DEM,Loretta Sanchez,159
-Fresno,381,U.S. Senate,,DEM,Kamala Harris,172
-Fresno,381,U.S. Senate,,DEM,Loretta Sanchez,159
-Fresno,382,U.S. Senate,,DEM,Kamala Harris,103
-Fresno,382,U.S. Senate,,DEM,Loretta Sanchez,93
-Fresno,383,U.S. Senate,,DEM,Kamala Harris,31
-Fresno,383,U.S. Senate,,DEM,Loretta Sanchez,45
-Fresno,384,U.S. Senate,,DEM,Kamala Harris,78
-Fresno,384,U.S. Senate,,DEM,Loretta Sanchez,69
-Fresno,385,U.S. Senate,,DEM,Kamala Harris,196
-Fresno,385,U.S. Senate,,DEM,Loretta Sanchez,243
-Fresno,386,U.S. Senate,,DEM,Kamala Harris,263
-Fresno,386,U.S. Senate,,DEM,Loretta Sanchez,344
-Fresno,387,U.S. Senate,,DEM,Kamala Harris,221
-Fresno,387,U.S. Senate,,DEM,Loretta Sanchez,244
-Fresno,388,U.S. Senate,,DEM,Kamala Harris,277
-Fresno,388,U.S. Senate,,DEM,Loretta Sanchez,300
-Fresno,389,U.S. Senate,,DEM,Kamala Harris,252
-Fresno,389,U.S. Senate,,DEM,Loretta Sanchez,322
-Fresno,39,U.S. Senate,,DEM,Kamala Harris,140
-Fresno,39,U.S. Senate,,DEM,Loretta Sanchez,353
-Fresno,390,U.S. Senate,,DEM,Kamala Harris,328
-Fresno,390,U.S. Senate,,DEM,Loretta Sanchez,394
-Fresno,391,U.S. Senate,,DEM,Kamala Harris,270
-Fresno,391,U.S. Senate,,DEM,Loretta Sanchez,414
-Fresno,392,U.S. Senate,,DEM,Kamala Harris,140
-Fresno,392,U.S. Senate,,DEM,Loretta Sanchez,247
-Fresno,393,U.S. Senate,,DEM,Kamala Harris,144
-Fresno,393,U.S. Senate,,DEM,Loretta Sanchez,402
-Fresno,394,U.S. Senate,,DEM,Kamala Harris,143
-Fresno,394,U.S. Senate,,DEM,Loretta Sanchez,167
-Fresno,395,U.S. Senate,,DEM,Kamala Harris,210
-Fresno,395,U.S. Senate,,DEM,Loretta Sanchez,214
-Fresno,396,U.S. Senate,,DEM,Kamala Harris,277
-Fresno,396,U.S. Senate,,DEM,Loretta Sanchez,318
-Fresno,397,U.S. Senate,,DEM,Kamala Harris,213
-Fresno,397,U.S. Senate,,DEM,Loretta Sanchez,226
-Fresno,398,U.S. Senate,,DEM,Kamala Harris,489
-Fresno,398,U.S. Senate,,DEM,Loretta Sanchez,397
-Fresno,399,U.S. Senate,,DEM,Kamala Harris,138
-Fresno,399,U.S. Senate,,DEM,Loretta Sanchez,462
-Fresno,4,U.S. Senate,,DEM,Kamala Harris,241
-Fresno,4,U.S. Senate,,DEM,Loretta Sanchez,166
-Fresno,40,U.S. Senate,,DEM,Kamala Harris,238
-Fresno,40,U.S. Senate,,DEM,Loretta Sanchez,463
-Fresno,400,U.S. Senate,,DEM,Kamala Harris,136
-Fresno,400,U.S. Senate,,DEM,Loretta Sanchez,366
-Fresno,401,U.S. Senate,,DEM,Kamala Harris,212
-Fresno,401,U.S. Senate,,DEM,Loretta Sanchez,512
-Fresno,402,U.S. Senate,,DEM,Kamala Harris,229
-Fresno,402,U.S. Senate,,DEM,Loretta Sanchez,446
-Fresno,403,U.S. Senate,,DEM,Kamala Harris,167
-Fresno,403,U.S. Senate,,DEM,Loretta Sanchez,468
-Fresno,404,U.S. Senate,,DEM,Kamala Harris,98
-Fresno,404,U.S. Senate,,DEM,Loretta Sanchez,99
-Fresno,405,U.S. Senate,,DEM,Kamala Harris,208
-Fresno,405,U.S. Senate,,DEM,Loretta Sanchez,233
-Fresno,406,U.S. Senate,,DEM,Kamala Harris,148
-Fresno,406,U.S. Senate,,DEM,Loretta Sanchez,213
-Fresno,407,U.S. Senate,,DEM,Kamala Harris,107
-Fresno,407,U.S. Senate,,DEM,Loretta Sanchez,116
-Fresno,408,U.S. Senate,,DEM,Kamala Harris,109
-Fresno,408,U.S. Senate,,DEM,Loretta Sanchez,166
-Fresno,409,U.S. Senate,,DEM,Kamala Harris,123
-Fresno,409,U.S. Senate,,DEM,Loretta Sanchez,148
-Fresno,41,U.S. Senate,,DEM,Kamala Harris,227
-Fresno,41,U.S. Senate,,DEM,Loretta Sanchez,468
-Fresno,410,U.S. Senate,,DEM,Kamala Harris,107
-Fresno,410,U.S. Senate,,DEM,Loretta Sanchez,152
-Fresno,411,U.S. Senate,,DEM,Kamala Harris,83
-Fresno,411,U.S. Senate,,DEM,Loretta Sanchez,68
-Fresno,42,U.S. Senate,,DEM,Kamala Harris,183
-Fresno,42,U.S. Senate,,DEM,Loretta Sanchez,171
-Fresno,43,U.S. Senate,,DEM,Kamala Harris,154
-Fresno,43,U.S. Senate,,DEM,Loretta Sanchez,187
-Fresno,44,U.S. Senate,,DEM,Kamala Harris,49
-Fresno,44,U.S. Senate,,DEM,Loretta Sanchez,81
-Fresno,45,U.S. Senate,,DEM,Kamala Harris,128
-Fresno,45,U.S. Senate,,DEM,Loretta Sanchez,160
-Fresno,46,U.S. Senate,,DEM,Kamala Harris,161
-Fresno,46,U.S. Senate,,DEM,Loretta Sanchez,366
-Fresno,47,U.S. Senate,,DEM,Kamala Harris,162
-Fresno,47,U.S. Senate,,DEM,Loretta Sanchez,251
-Fresno,48,U.S. Senate,,DEM,Kamala Harris,243
-Fresno,48,U.S. Senate,,DEM,Loretta Sanchez,311
-Fresno,49,U.S. Senate,,DEM,Kamala Harris,268
-Fresno,49,U.S. Senate,,DEM,Loretta Sanchez,321
-Fresno,5,U.S. Senate,,DEM,Kamala Harris,287
-Fresno,5,U.S. Senate,,DEM,Loretta Sanchez,236
-Fresno,50,U.S. Senate,,DEM,Kamala Harris,78
-Fresno,50,U.S. Senate,,DEM,Loretta Sanchez,85
-Fresno,51,U.S. Senate,,DEM,Kamala Harris,198
-Fresno,51,U.S. Senate,,DEM,Loretta Sanchez,232
-Fresno,52,U.S. Senate,,DEM,Kamala Harris,323
-Fresno,52,U.S. Senate,,DEM,Loretta Sanchez,456
-Fresno,53,U.S. Senate,,DEM,Kamala Harris,79
-Fresno,53,U.S. Senate,,DEM,Loretta Sanchez,83
-Fresno,54,U.S. Senate,,DEM,Kamala Harris,92
-Fresno,54,U.S. Senate,,DEM,Loretta Sanchez,97
-Fresno,55,U.S. Senate,,DEM,Kamala Harris,287
-Fresno,55,U.S. Senate,,DEM,Loretta Sanchez,322
-Fresno,56,U.S. Senate,,DEM,Kamala Harris,162
-Fresno,56,U.S. Senate,,DEM,Loretta Sanchez,432
-Fresno,57,U.S. Senate,,DEM,Kamala Harris,97
-Fresno,57,U.S. Senate,,DEM,Loretta Sanchez,213
-Fresno,58,U.S. Senate,,DEM,Kamala Harris,261
-Fresno,58,U.S. Senate,,DEM,Loretta Sanchez,440
-Fresno,59,U.S. Senate,,DEM,Kamala Harris,69
-Fresno,59,U.S. Senate,,DEM,Loretta Sanchez,90
-Fresno,6,U.S. Senate,,DEM,Kamala Harris,425
-Fresno,6,U.S. Senate,,DEM,Loretta Sanchez,260
-Fresno,60,U.S. Senate,,DEM,Kamala Harris,350
-Fresno,60,U.S. Senate,,DEM,Loretta Sanchez,348
-Fresno,61,U.S. Senate,,DEM,Kamala Harris,211
-Fresno,61,U.S. Senate,,DEM,Loretta Sanchez,207
-Fresno,62,U.S. Senate,,DEM,Kamala Harris,226
-Fresno,62,U.S. Senate,,DEM,Loretta Sanchez,246
-Fresno,63,U.S. Senate,,DEM,Kamala Harris,439
-Fresno,63,U.S. Senate,,DEM,Loretta Sanchez,374
-Fresno,64,U.S. Senate,,DEM,Kamala Harris,140
-Fresno,64,U.S. Senate,,DEM,Loretta Sanchez,100
-Fresno,65,U.S. Senate,,DEM,Kamala Harris,440
-Fresno,65,U.S. Senate,,DEM,Loretta Sanchez,384
-Fresno,66,U.S. Senate,,DEM,Kamala Harris,745
-Fresno,66,U.S. Senate,,DEM,Loretta Sanchez,548
-Fresno,67,U.S. Senate,,DEM,Kamala Harris,93
-Fresno,67,U.S. Senate,,DEM,Loretta Sanchez,89
-Fresno,68,U.S. Senate,,DEM,Kamala Harris,97
-Fresno,68,U.S. Senate,,DEM,Loretta Sanchez,72
-Fresno,69,U.S. Senate,,DEM,Kamala Harris,269
-Fresno,69,U.S. Senate,,DEM,Loretta Sanchez,210
-Fresno,7,U.S. Senate,,DEM,Kamala Harris,145
-Fresno,7,U.S. Senate,,DEM,Loretta Sanchez,198
-Fresno,70,U.S. Senate,,DEM,Kamala Harris,139
-Fresno,70,U.S. Senate,,DEM,Loretta Sanchez,111
-Fresno,71,U.S. Senate,,DEM,Kamala Harris,197
-Fresno,71,U.S. Senate,,DEM,Loretta Sanchez,185
-Fresno,72,U.S. Senate,,DEM,Kamala Harris,186
-Fresno,72,U.S. Senate,,DEM,Loretta Sanchez,183
-Fresno,73,U.S. Senate,,DEM,Kamala Harris,246
-Fresno,73,U.S. Senate,,DEM,Loretta Sanchez,225
-Fresno,74,U.S. Senate,,DEM,Kamala Harris,237
-Fresno,74,U.S. Senate,,DEM,Loretta Sanchez,257
-Fresno,75,U.S. Senate,,DEM,Kamala Harris,248
-Fresno,75,U.S. Senate,,DEM,Loretta Sanchez,198
-Fresno,76,U.S. Senate,,DEM,Kamala Harris,262
-Fresno,76,U.S. Senate,,DEM,Loretta Sanchez,322
-Fresno,77,U.S. Senate,,DEM,Kamala Harris,114
-Fresno,77,U.S. Senate,,DEM,Loretta Sanchez,138
-Fresno,78,U.S. Senate,,DEM,Kamala Harris,242
-Fresno,78,U.S. Senate,,DEM,Loretta Sanchez,256
-Fresno,79,U.S. Senate,,DEM,Kamala Harris,235
-Fresno,79,U.S. Senate,,DEM,Loretta Sanchez,245
-Fresno,8,U.S. Senate,,DEM,Kamala Harris,346
-Fresno,8,U.S. Senate,,DEM,Loretta Sanchez,343
-Fresno,80,U.S. Senate,,DEM,Kamala Harris,202
-Fresno,80,U.S. Senate,,DEM,Loretta Sanchez,211
-Fresno,81,U.S. Senate,,DEM,Kamala Harris,249
-Fresno,81,U.S. Senate,,DEM,Loretta Sanchez,246
-Fresno,82,U.S. Senate,,DEM,Kamala Harris,299
-Fresno,82,U.S. Senate,,DEM,Loretta Sanchez,320
-Fresno,83,U.S. Senate,,DEM,Kamala Harris,244
-Fresno,83,U.S. Senate,,DEM,Loretta Sanchez,221
-Fresno,84,U.S. Senate,,DEM,Kamala Harris,347
-Fresno,84,U.S. Senate,,DEM,Loretta Sanchez,324
-Fresno,85,U.S. Senate,,DEM,Kamala Harris,124
-Fresno,85,U.S. Senate,,DEM,Loretta Sanchez,98
-Fresno,86,U.S. Senate,,DEM,Kamala Harris,265
-Fresno,86,U.S. Senate,,DEM,Loretta Sanchez,230
-Fresno,87,U.S. Senate,,DEM,Kamala Harris,276
-Fresno,87,U.S. Senate,,DEM,Loretta Sanchez,234
-Fresno,88,U.S. Senate,,DEM,Kamala Harris,218
-Fresno,88,U.S. Senate,,DEM,Loretta Sanchez,235
-Fresno,89,U.S. Senate,,DEM,Kamala Harris,403
-Fresno,89,U.S. Senate,,DEM,Loretta Sanchez,377
-Fresno,9,U.S. Senate,,DEM,Kamala Harris,153
-Fresno,9,U.S. Senate,,DEM,Loretta Sanchez,149
-Fresno,90,U.S. Senate,,DEM,Kamala Harris,272
-Fresno,90,U.S. Senate,,DEM,Loretta Sanchez,243
-Fresno,91,U.S. Senate,,DEM,Kamala Harris,364
-Fresno,91,U.S. Senate,,DEM,Loretta Sanchez,265
-Fresno,92,U.S. Senate,,DEM,Kamala Harris,225
-Fresno,92,U.S. Senate,,DEM,Loretta Sanchez,250
-Fresno,93,U.S. Senate,,DEM,Kamala Harris,259
-Fresno,93,U.S. Senate,,DEM,Loretta Sanchez,232
-Fresno,94,U.S. Senate,,DEM,Kamala Harris,272
-Fresno,94,U.S. Senate,,DEM,Loretta Sanchez,198
-Fresno,95,U.S. Senate,,DEM,Kamala Harris,285
-Fresno,95,U.S. Senate,,DEM,Loretta Sanchez,349
-Fresno,96,U.S. Senate,,DEM,Kamala Harris,94
-Fresno,96,U.S. Senate,,DEM,Loretta Sanchez,115
-Fresno,97,U.S. Senate,,DEM,Kamala Harris,197
-Fresno,97,U.S. Senate,,DEM,Loretta Sanchez,272
-Fresno,98,U.S. Senate,,DEM,Kamala Harris,164
-Fresno,98,U.S. Senate,,DEM,Loretta Sanchez,261
-Fresno,99,U.S. Senate,,DEM,Kamala Harris,164
-Fresno,99,U.S. Senate,,DEM,Loretta Sanchez,308
+Fresno,1,U.S. Senate,,DEM,Kamala D. Harris,309
+Fresno,1,U.S. Senate,,DEM,Loretta L. Sanchez,173
+Fresno,10,U.S. Senate,,DEM,Kamala D. Harris,238
+Fresno,10,U.S. Senate,,DEM,Loretta L. Sanchez,285
+Fresno,100,U.S. Senate,,DEM,Kamala D. Harris,227
+Fresno,100,U.S. Senate,,DEM,Loretta L. Sanchez,398
+Fresno,1001,U.S. Senate,,DEM,Kamala D. Harris,5
+Fresno,1001,U.S. Senate,,DEM,Loretta L. Sanchez,15
+Fresno,1002,U.S. Senate,,DEM,Kamala D. Harris,0
+Fresno,1002,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Fresno,1003,U.S. Senate,,DEM,Kamala D. Harris,39
+Fresno,1003,U.S. Senate,,DEM,Loretta L. Sanchez,33
+Fresno,1004,U.S. Senate,,DEM,Kamala D. Harris,1
+Fresno,1004,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Fresno,1005,U.S. Senate,,DEM,Kamala D. Harris,0
+Fresno,1005,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Fresno,1006,U.S. Senate,,DEM,Kamala D. Harris,2
+Fresno,1006,U.S. Senate,,DEM,Loretta L. Sanchez,5
+Fresno,1007,U.S. Senate,,DEM,Kamala D. Harris,0
+Fresno,1007,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Fresno,1008,U.S. Senate,,DEM,Kamala D. Harris,0
+Fresno,1008,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Fresno,1009,U.S. Senate,,DEM,Kamala D. Harris,90
+Fresno,1009,U.S. Senate,,DEM,Loretta L. Sanchez,46
+Fresno,101,U.S. Senate,,DEM,Kamala D. Harris,365
+Fresno,101,U.S. Senate,,DEM,Loretta L. Sanchez,356
+Fresno,1010,U.S. Senate,,DEM,Kamala D. Harris,12
+Fresno,1010,U.S. Senate,,DEM,Loretta L. Sanchez,31
+Fresno,1011,U.S. Senate,,DEM,Kamala D. Harris,4
+Fresno,1011,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Fresno,1012,U.S. Senate,,DEM,Kamala D. Harris,7
+Fresno,1012,U.S. Senate,,DEM,Loretta L. Sanchez,5
+Fresno,1013,U.S. Senate,,DEM,Kamala D. Harris,7
+Fresno,1013,U.S. Senate,,DEM,Loretta L. Sanchez,11
+Fresno,1014,U.S. Senate,,DEM,Kamala D. Harris,0
+Fresno,1014,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Fresno,1015,U.S. Senate,,DEM,Kamala D. Harris,31
+Fresno,1015,U.S. Senate,,DEM,Loretta L. Sanchez,26
+Fresno,1016,U.S. Senate,,DEM,Kamala D. Harris,32
+Fresno,1016,U.S. Senate,,DEM,Loretta L. Sanchez,40
+Fresno,1017,U.S. Senate,,DEM,Kamala D. Harris,0
+Fresno,1017,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Fresno,1018,U.S. Senate,,DEM,Kamala D. Harris,38
+Fresno,1018,U.S. Senate,,DEM,Loretta L. Sanchez,57
+Fresno,1019,U.S. Senate,,DEM,Kamala D. Harris,0
+Fresno,1019,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Fresno,102,U.S. Senate,,DEM,Kamala D. Harris,187
+Fresno,102,U.S. Senate,,DEM,Loretta L. Sanchez,182
+Fresno,1020,U.S. Senate,,DEM,Kamala D. Harris,49
+Fresno,1020,U.S. Senate,,DEM,Loretta L. Sanchez,24
+Fresno,1021,U.S. Senate,,DEM,Kamala D. Harris,2
+Fresno,1021,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Fresno,1022,U.S. Senate,,DEM,Kamala D. Harris,0
+Fresno,1022,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Fresno,1023,U.S. Senate,,DEM,Kamala D. Harris,26
+Fresno,1023,U.S. Senate,,DEM,Loretta L. Sanchez,34
+Fresno,1024,U.S. Senate,,DEM,Kamala D. Harris,1
+Fresno,1024,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Fresno,1025,U.S. Senate,,DEM,Kamala D. Harris,2
+Fresno,1025,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Fresno,1026,U.S. Senate,,DEM,Kamala D. Harris,0
+Fresno,1026,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Fresno,1027,U.S. Senate,,DEM,Kamala D. Harris,0
+Fresno,1027,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Fresno,1028,U.S. Senate,,DEM,Kamala D. Harris,1
+Fresno,1028,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Fresno,1029,U.S. Senate,,DEM,Kamala D. Harris,0
+Fresno,1029,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Fresno,103,U.S. Senate,,DEM,Kamala D. Harris,260
+Fresno,103,U.S. Senate,,DEM,Loretta L. Sanchez,259
+Fresno,1030,U.S. Senate,,DEM,Kamala D. Harris,0
+Fresno,1030,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Fresno,1031,U.S. Senate,,DEM,Kamala D. Harris,3
+Fresno,1031,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Fresno,1032,U.S. Senate,,DEM,Kamala D. Harris,13
+Fresno,1032,U.S. Senate,,DEM,Loretta L. Sanchez,18
+Fresno,1033,U.S. Senate,,DEM,Kamala D. Harris,4
+Fresno,1033,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Fresno,1034,U.S. Senate,,DEM,Kamala D. Harris,73
+Fresno,1034,U.S. Senate,,DEM,Loretta L. Sanchez,67
+Fresno,1035,U.S. Senate,,DEM,Kamala D. Harris,3
+Fresno,1035,U.S. Senate,,DEM,Loretta L. Sanchez,6
+Fresno,1036,U.S. Senate,,DEM,Kamala D. Harris,30
+Fresno,1036,U.S. Senate,,DEM,Loretta L. Sanchez,12
+Fresno,1037,U.S. Senate,,DEM,Kamala D. Harris,0
+Fresno,1037,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Fresno,1038,U.S. Senate,,DEM,Kamala D. Harris,0
+Fresno,1038,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Fresno,1039,U.S. Senate,,DEM,Kamala D. Harris,0
+Fresno,1039,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Fresno,104,U.S. Senate,,DEM,Kamala D. Harris,449
+Fresno,104,U.S. Senate,,DEM,Loretta L. Sanchez,444
+Fresno,1040,U.S. Senate,,DEM,Kamala D. Harris,0
+Fresno,1040,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Fresno,1041,U.S. Senate,,DEM,Kamala D. Harris,0
+Fresno,1041,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Fresno,1042,U.S. Senate,,DEM,Kamala D. Harris,1
+Fresno,1042,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Fresno,1043,U.S. Senate,,DEM,Kamala D. Harris,9
+Fresno,1043,U.S. Senate,,DEM,Loretta L. Sanchez,6
+Fresno,1044,U.S. Senate,,DEM,Kamala D. Harris,24
+Fresno,1044,U.S. Senate,,DEM,Loretta L. Sanchez,29
+Fresno,1045,U.S. Senate,,DEM,Kamala D. Harris,0
+Fresno,1045,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Fresno,1046,U.S. Senate,,DEM,Kamala D. Harris,18
+Fresno,1046,U.S. Senate,,DEM,Loretta L. Sanchez,20
+Fresno,1047,U.S. Senate,,DEM,Kamala D. Harris,0
+Fresno,1047,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Fresno,1048,U.S. Senate,,DEM,Kamala D. Harris,0
+Fresno,1048,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Fresno,1049,U.S. Senate,,DEM,Kamala D. Harris,2
+Fresno,1049,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Fresno,105,U.S. Senate,,DEM,Kamala D. Harris,329
+Fresno,105,U.S. Senate,,DEM,Loretta L. Sanchez,275
+Fresno,1050,U.S. Senate,,DEM,Kamala D. Harris,53
+Fresno,1050,U.S. Senate,,DEM,Loretta L. Sanchez,45
+Fresno,1051,U.S. Senate,,DEM,Kamala D. Harris,39
+Fresno,1051,U.S. Senate,,DEM,Loretta L. Sanchez,42
+Fresno,1052,U.S. Senate,,DEM,Kamala D. Harris,19
+Fresno,1052,U.S. Senate,,DEM,Loretta L. Sanchez,23
+Fresno,1053,U.S. Senate,,DEM,Kamala D. Harris,21
+Fresno,1053,U.S. Senate,,DEM,Loretta L. Sanchez,34
+Fresno,1054,U.S. Senate,,DEM,Kamala D. Harris,3
+Fresno,1054,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Fresno,1055,U.S. Senate,,DEM,Kamala D. Harris,9
+Fresno,1055,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Fresno,1056,U.S. Senate,,DEM,Kamala D. Harris,17
+Fresno,1056,U.S. Senate,,DEM,Loretta L. Sanchez,24
+Fresno,1057,U.S. Senate,,DEM,Kamala D. Harris,3
+Fresno,1057,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Fresno,1058,U.S. Senate,,DEM,Kamala D. Harris,0
+Fresno,1058,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Fresno,1059,U.S. Senate,,DEM,Kamala D. Harris,14
+Fresno,1059,U.S. Senate,,DEM,Loretta L. Sanchez,34
+Fresno,106,U.S. Senate,,DEM,Kamala D. Harris,136
+Fresno,106,U.S. Senate,,DEM,Loretta L. Sanchez,114
+Fresno,1060,U.S. Senate,,DEM,Kamala D. Harris,24
+Fresno,1060,U.S. Senate,,DEM,Loretta L. Sanchez,25
+Fresno,1061,U.S. Senate,,DEM,Kamala D. Harris,9
+Fresno,1061,U.S. Senate,,DEM,Loretta L. Sanchez,17
+Fresno,1062,U.S. Senate,,DEM,Kamala D. Harris,14
+Fresno,1062,U.S. Senate,,DEM,Loretta L. Sanchez,16
+Fresno,1063,U.S. Senate,,DEM,Kamala D. Harris,0
+Fresno,1063,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Fresno,1064,U.S. Senate,,DEM,Kamala D. Harris,1
+Fresno,1064,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Fresno,1065,U.S. Senate,,DEM,Kamala D. Harris,2
+Fresno,1065,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Fresno,1066,U.S. Senate,,DEM,Kamala D. Harris,34
+Fresno,1066,U.S. Senate,,DEM,Loretta L. Sanchez,40
+Fresno,1067,U.S. Senate,,DEM,Kamala D. Harris,6
+Fresno,1067,U.S. Senate,,DEM,Loretta L. Sanchez,5
+Fresno,1068,U.S. Senate,,DEM,Kamala D. Harris,0
+Fresno,1068,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Fresno,1069,U.S. Senate,,DEM,Kamala D. Harris,5
+Fresno,1069,U.S. Senate,,DEM,Loretta L. Sanchez,7
+Fresno,107,U.S. Senate,,DEM,Kamala D. Harris,272
+Fresno,107,U.S. Senate,,DEM,Loretta L. Sanchez,303
+Fresno,1070,U.S. Senate,,DEM,Kamala D. Harris,34
+Fresno,1070,U.S. Senate,,DEM,Loretta L. Sanchez,37
+Fresno,1071,U.S. Senate,,DEM,Kamala D. Harris,56
+Fresno,1071,U.S. Senate,,DEM,Loretta L. Sanchez,49
+Fresno,1072,U.S. Senate,,DEM,Kamala D. Harris,25
+Fresno,1072,U.S. Senate,,DEM,Loretta L. Sanchez,33
+Fresno,1073,U.S. Senate,,DEM,Kamala D. Harris,0
+Fresno,1073,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Fresno,1074,U.S. Senate,,DEM,Kamala D. Harris,41
+Fresno,1074,U.S. Senate,,DEM,Loretta L. Sanchez,36
+Fresno,1075,U.S. Senate,,DEM,Kamala D. Harris,0
+Fresno,1075,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Fresno,1076,U.S. Senate,,DEM,Kamala D. Harris,0
+Fresno,1076,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Fresno,1077,U.S. Senate,,DEM,Kamala D. Harris,5
+Fresno,1077,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Fresno,1078,U.S. Senate,,DEM,Kamala D. Harris,0
+Fresno,1078,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Fresno,1079,U.S. Senate,,DEM,Kamala D. Harris,0
+Fresno,1079,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Fresno,108,U.S. Senate,,DEM,Kamala D. Harris,434
+Fresno,108,U.S. Senate,,DEM,Loretta L. Sanchez,275
+Fresno,1080,U.S. Senate,,DEM,Kamala D. Harris,0
+Fresno,1080,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Fresno,1081,U.S. Senate,,DEM,Kamala D. Harris,1
+Fresno,1081,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Fresno,1082,U.S. Senate,,DEM,Kamala D. Harris,25
+Fresno,1082,U.S. Senate,,DEM,Loretta L. Sanchez,17
+Fresno,1083,U.S. Senate,,DEM,Kamala D. Harris,4
+Fresno,1083,U.S. Senate,,DEM,Loretta L. Sanchez,9
+Fresno,1084,U.S. Senate,,DEM,Kamala D. Harris,5
+Fresno,1084,U.S. Senate,,DEM,Loretta L. Sanchez,11
+Fresno,1085,U.S. Senate,,DEM,Kamala D. Harris,0
+Fresno,1085,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Fresno,1086,U.S. Senate,,DEM,Kamala D. Harris,69
+Fresno,1086,U.S. Senate,,DEM,Loretta L. Sanchez,82
+Fresno,1087,U.S. Senate,,DEM,Kamala D. Harris,8
+Fresno,1087,U.S. Senate,,DEM,Loretta L. Sanchez,10
+Fresno,1088,U.S. Senate,,DEM,Kamala D. Harris,1
+Fresno,1088,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Fresno,1089,U.S. Senate,,DEM,Kamala D. Harris,59
+Fresno,1089,U.S. Senate,,DEM,Loretta L. Sanchez,45
+Fresno,109,U.S. Senate,,DEM,Kamala D. Harris,467
+Fresno,109,U.S. Senate,,DEM,Loretta L. Sanchez,410
+Fresno,1090,U.S. Senate,,DEM,Kamala D. Harris,67
+Fresno,1090,U.S. Senate,,DEM,Loretta L. Sanchez,67
+Fresno,1091,U.S. Senate,,DEM,Kamala D. Harris,36
+Fresno,1091,U.S. Senate,,DEM,Loretta L. Sanchez,34
+Fresno,1092,U.S. Senate,,DEM,Kamala D. Harris,25
+Fresno,1092,U.S. Senate,,DEM,Loretta L. Sanchez,28
+Fresno,1093,U.S. Senate,,DEM,Kamala D. Harris,44
+Fresno,1093,U.S. Senate,,DEM,Loretta L. Sanchez,38
+Fresno,1094,U.S. Senate,,DEM,Kamala D. Harris,0
+Fresno,1094,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Fresno,1095,U.S. Senate,,DEM,Kamala D. Harris,2
+Fresno,1095,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Fresno,1096,U.S. Senate,,DEM,Kamala D. Harris,0
+Fresno,1096,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Fresno,1097,U.S. Senate,,DEM,Kamala D. Harris,37
+Fresno,1097,U.S. Senate,,DEM,Loretta L. Sanchez,58
+Fresno,1098,U.S. Senate,,DEM,Kamala D. Harris,32
+Fresno,1098,U.S. Senate,,DEM,Loretta L. Sanchez,32
+Fresno,1099,U.S. Senate,,DEM,Kamala D. Harris,17
+Fresno,1099,U.S. Senate,,DEM,Loretta L. Sanchez,11
+Fresno,11,U.S. Senate,,DEM,Kamala D. Harris,384
+Fresno,11,U.S. Senate,,DEM,Loretta L. Sanchez,259
+Fresno,110,U.S. Senate,,DEM,Kamala D. Harris,465
+Fresno,110,U.S. Senate,,DEM,Loretta L. Sanchez,300
+Fresno,1100,U.S. Senate,,DEM,Kamala D. Harris,24
+Fresno,1100,U.S. Senate,,DEM,Loretta L. Sanchez,21
+Fresno,1101,U.S. Senate,,DEM,Kamala D. Harris,51
+Fresno,1101,U.S. Senate,,DEM,Loretta L. Sanchez,57
+Fresno,1102,U.S. Senate,,DEM,Kamala D. Harris,20
+Fresno,1102,U.S. Senate,,DEM,Loretta L. Sanchez,25
+Fresno,1103,U.S. Senate,,DEM,Kamala D. Harris,9
+Fresno,1103,U.S. Senate,,DEM,Loretta L. Sanchez,27
+Fresno,1104,U.S. Senate,,DEM,Kamala D. Harris,27
+Fresno,1104,U.S. Senate,,DEM,Loretta L. Sanchez,49
+Fresno,1105,U.S. Senate,,DEM,Kamala D. Harris,0
+Fresno,1105,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Fresno,1106,U.S. Senate,,DEM,Kamala D. Harris,5
+Fresno,1106,U.S. Senate,,DEM,Loretta L. Sanchez,7
+Fresno,1107,U.S. Senate,,DEM,Kamala D. Harris,59
+Fresno,1107,U.S. Senate,,DEM,Loretta L. Sanchez,43
+Fresno,1108,U.S. Senate,,DEM,Kamala D. Harris,30
+Fresno,1108,U.S. Senate,,DEM,Loretta L. Sanchez,41
+Fresno,1109,U.S. Senate,,DEM,Kamala D. Harris,1
+Fresno,1109,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Fresno,111,U.S. Senate,,DEM,Kamala D. Harris,598
+Fresno,111,U.S. Senate,,DEM,Loretta L. Sanchez,421
+Fresno,1110,U.S. Senate,,DEM,Kamala D. Harris,0
+Fresno,1110,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Fresno,1111,U.S. Senate,,DEM,Kamala D. Harris,23
+Fresno,1111,U.S. Senate,,DEM,Loretta L. Sanchez,35
+Fresno,1112,U.S. Senate,,DEM,Kamala D. Harris,21
+Fresno,1112,U.S. Senate,,DEM,Loretta L. Sanchez,25
+Fresno,1113,U.S. Senate,,DEM,Kamala D. Harris,0
+Fresno,1113,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Fresno,1114,U.S. Senate,,DEM,Kamala D. Harris,45
+Fresno,1114,U.S. Senate,,DEM,Loretta L. Sanchez,34
+Fresno,1115,U.S. Senate,,DEM,Kamala D. Harris,34
+Fresno,1115,U.S. Senate,,DEM,Loretta L. Sanchez,48
+Fresno,1116,U.S. Senate,,DEM,Kamala D. Harris,54
+Fresno,1116,U.S. Senate,,DEM,Loretta L. Sanchez,59
+Fresno,1117,U.S. Senate,,DEM,Kamala D. Harris,1
+Fresno,1117,U.S. Senate,,DEM,Loretta L. Sanchez,15
+Fresno,1118,U.S. Senate,,DEM,Kamala D. Harris,45
+Fresno,1118,U.S. Senate,,DEM,Loretta L. Sanchez,44
+Fresno,1119,U.S. Senate,,DEM,Kamala D. Harris,2
+Fresno,1119,U.S. Senate,,DEM,Loretta L. Sanchez,9
+Fresno,112,U.S. Senate,,DEM,Kamala D. Harris,640
+Fresno,112,U.S. Senate,,DEM,Loretta L. Sanchez,482
+Fresno,1120,U.S. Senate,,DEM,Kamala D. Harris,17
+Fresno,1120,U.S. Senate,,DEM,Loretta L. Sanchez,32
+Fresno,1121,U.S. Senate,,DEM,Kamala D. Harris,0
+Fresno,1121,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Fresno,1122,U.S. Senate,,DEM,Kamala D. Harris,12
+Fresno,1122,U.S. Senate,,DEM,Loretta L. Sanchez,15
+Fresno,1123,U.S. Senate,,DEM,Kamala D. Harris,22
+Fresno,1123,U.S. Senate,,DEM,Loretta L. Sanchez,22
+Fresno,1124,U.S. Senate,,DEM,Kamala D. Harris,21
+Fresno,1124,U.S. Senate,,DEM,Loretta L. Sanchez,15
+Fresno,1125,U.S. Senate,,DEM,Kamala D. Harris,15
+Fresno,1125,U.S. Senate,,DEM,Loretta L. Sanchez,14
+Fresno,1126,U.S. Senate,,DEM,Kamala D. Harris,23
+Fresno,1126,U.S. Senate,,DEM,Loretta L. Sanchez,36
+Fresno,1127,U.S. Senate,,DEM,Kamala D. Harris,56
+Fresno,1127,U.S. Senate,,DEM,Loretta L. Sanchez,59
+Fresno,1128,U.S. Senate,,DEM,Kamala D. Harris,0
+Fresno,1128,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Fresno,1129,U.S. Senate,,DEM,Kamala D. Harris,0
+Fresno,1129,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Fresno,113,U.S. Senate,,DEM,Kamala D. Harris,493
+Fresno,113,U.S. Senate,,DEM,Loretta L. Sanchez,366
+Fresno,1130,U.S. Senate,,DEM,Kamala D. Harris,4
+Fresno,1130,U.S. Senate,,DEM,Loretta L. Sanchez,13
+Fresno,1131,U.S. Senate,,DEM,Kamala D. Harris,13
+Fresno,1131,U.S. Senate,,DEM,Loretta L. Sanchez,51
+Fresno,1132,U.S. Senate,,DEM,Kamala D. Harris,22
+Fresno,1132,U.S. Senate,,DEM,Loretta L. Sanchez,34
+Fresno,1133,U.S. Senate,,DEM,Kamala D. Harris,55
+Fresno,1133,U.S. Senate,,DEM,Loretta L. Sanchez,60
+Fresno,1134,U.S. Senate,,DEM,Kamala D. Harris,1
+Fresno,1134,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Fresno,1135,U.S. Senate,,DEM,Kamala D. Harris,16
+Fresno,1135,U.S. Senate,,DEM,Loretta L. Sanchez,30
+Fresno,1136,U.S. Senate,,DEM,Kamala D. Harris,26
+Fresno,1136,U.S. Senate,,DEM,Loretta L. Sanchez,31
+Fresno,1137,U.S. Senate,,DEM,Kamala D. Harris,55
+Fresno,1137,U.S. Senate,,DEM,Loretta L. Sanchez,76
+Fresno,1138,U.S. Senate,,DEM,Kamala D. Harris,20
+Fresno,1138,U.S. Senate,,DEM,Loretta L. Sanchez,21
+Fresno,1139,U.S. Senate,,DEM,Kamala D. Harris,26
+Fresno,1139,U.S. Senate,,DEM,Loretta L. Sanchez,19
+Fresno,114,U.S. Senate,,DEM,Kamala D. Harris,341
+Fresno,114,U.S. Senate,,DEM,Loretta L. Sanchez,272
+Fresno,1140,U.S. Senate,,DEM,Kamala D. Harris,25
+Fresno,1140,U.S. Senate,,DEM,Loretta L. Sanchez,50
+Fresno,1141,U.S. Senate,,DEM,Kamala D. Harris,56
+Fresno,1141,U.S. Senate,,DEM,Loretta L. Sanchez,70
+Fresno,1142,U.S. Senate,,DEM,Kamala D. Harris,4
+Fresno,1142,U.S. Senate,,DEM,Loretta L. Sanchez,7
+Fresno,1143,U.S. Senate,,DEM,Kamala D. Harris,5
+Fresno,1143,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Fresno,1144,U.S. Senate,,DEM,Kamala D. Harris,6
+Fresno,1144,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Fresno,1145,U.S. Senate,,DEM,Kamala D. Harris,4
+Fresno,1145,U.S. Senate,,DEM,Loretta L. Sanchez,10
+Fresno,1146,U.S. Senate,,DEM,Kamala D. Harris,39
+Fresno,1146,U.S. Senate,,DEM,Loretta L. Sanchez,78
+Fresno,1147,U.S. Senate,,DEM,Kamala D. Harris,2
+Fresno,1147,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Fresno,1148,U.S. Senate,,DEM,Kamala D. Harris,2
+Fresno,1148,U.S. Senate,,DEM,Loretta L. Sanchez,11
+Fresno,1149,U.S. Senate,,DEM,Kamala D. Harris,62
+Fresno,1149,U.S. Senate,,DEM,Loretta L. Sanchez,64
+Fresno,115,U.S. Senate,,DEM,Kamala D. Harris,342
+Fresno,115,U.S. Senate,,DEM,Loretta L. Sanchez,274
+Fresno,1150,U.S. Senate,,DEM,Kamala D. Harris,16
+Fresno,1150,U.S. Senate,,DEM,Loretta L. Sanchez,27
+Fresno,1151,U.S. Senate,,DEM,Kamala D. Harris,0
+Fresno,1151,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Fresno,1152,U.S. Senate,,DEM,Kamala D. Harris,36
+Fresno,1152,U.S. Senate,,DEM,Loretta L. Sanchez,30
+Fresno,1153,U.S. Senate,,DEM,Kamala D. Harris,76
+Fresno,1153,U.S. Senate,,DEM,Loretta L. Sanchez,165
+Fresno,1154,U.S. Senate,,DEM,Kamala D. Harris,36
+Fresno,1154,U.S. Senate,,DEM,Loretta L. Sanchez,56
+Fresno,1155,U.S. Senate,,DEM,Kamala D. Harris,0
+Fresno,1155,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Fresno,1156,U.S. Senate,,DEM,Kamala D. Harris,0
+Fresno,1156,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Fresno,1157,U.S. Senate,,DEM,Kamala D. Harris,27
+Fresno,1157,U.S. Senate,,DEM,Loretta L. Sanchez,67
+Fresno,1158,U.S. Senate,,DEM,Kamala D. Harris,19
+Fresno,1158,U.S. Senate,,DEM,Loretta L. Sanchez,59
+Fresno,1159,U.S. Senate,,DEM,Kamala D. Harris,0
+Fresno,1159,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Fresno,116,U.S. Senate,,DEM,Kamala D. Harris,334
+Fresno,116,U.S. Senate,,DEM,Loretta L. Sanchez,270
+Fresno,1160,U.S. Senate,,DEM,Kamala D. Harris,26
+Fresno,1160,U.S. Senate,,DEM,Loretta L. Sanchez,54
+Fresno,1161,U.S. Senate,,DEM,Kamala D. Harris,45
+Fresno,1161,U.S. Senate,,DEM,Loretta L. Sanchez,53
+Fresno,1162,U.S. Senate,,DEM,Kamala D. Harris,15
+Fresno,1162,U.S. Senate,,DEM,Loretta L. Sanchez,21
+Fresno,1163,U.S. Senate,,DEM,Kamala D. Harris,19
+Fresno,1163,U.S. Senate,,DEM,Loretta L. Sanchez,19
+Fresno,1164,U.S. Senate,,DEM,Kamala D. Harris,8
+Fresno,1164,U.S. Senate,,DEM,Loretta L. Sanchez,12
+Fresno,1165,U.S. Senate,,DEM,Kamala D. Harris,9
+Fresno,1165,U.S. Senate,,DEM,Loretta L. Sanchez,6
+Fresno,1166,U.S. Senate,,DEM,Kamala D. Harris,18
+Fresno,1166,U.S. Senate,,DEM,Loretta L. Sanchez,19
+Fresno,1167,U.S. Senate,,DEM,Kamala D. Harris,5
+Fresno,1167,U.S. Senate,,DEM,Loretta L. Sanchez,11
+Fresno,1168,U.S. Senate,,DEM,Kamala D. Harris,31
+Fresno,1168,U.S. Senate,,DEM,Loretta L. Sanchez,32
+Fresno,1169,U.S. Senate,,DEM,Kamala D. Harris,0
+Fresno,1169,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Fresno,117,U.S. Senate,,DEM,Kamala D. Harris,569
+Fresno,117,U.S. Senate,,DEM,Loretta L. Sanchez,456
+Fresno,1170,U.S. Senate,,DEM,Kamala D. Harris,14
+Fresno,1170,U.S. Senate,,DEM,Loretta L. Sanchez,8
+Fresno,1171,U.S. Senate,,DEM,Kamala D. Harris,12
+Fresno,1171,U.S. Senate,,DEM,Loretta L. Sanchez,27
+Fresno,1172,U.S. Senate,,DEM,Kamala D. Harris,17
+Fresno,1172,U.S. Senate,,DEM,Loretta L. Sanchez,23
+Fresno,1173,U.S. Senate,,DEM,Kamala D. Harris,25
+Fresno,1173,U.S. Senate,,DEM,Loretta L. Sanchez,25
+Fresno,1174,U.S. Senate,,DEM,Kamala D. Harris,6
+Fresno,1174,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Fresno,1175,U.S. Senate,,DEM,Kamala D. Harris,44
+Fresno,1175,U.S. Senate,,DEM,Loretta L. Sanchez,62
+Fresno,1176,U.S. Senate,,DEM,Kamala D. Harris,8
+Fresno,1176,U.S. Senate,,DEM,Loretta L. Sanchez,13
+Fresno,1177,U.S. Senate,,DEM,Kamala D. Harris,9
+Fresno,1177,U.S. Senate,,DEM,Loretta L. Sanchez,12
+Fresno,1178,U.S. Senate,,DEM,Kamala D. Harris,0
+Fresno,1178,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Fresno,1179,U.S. Senate,,DEM,Kamala D. Harris,5
+Fresno,1179,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Fresno,118,U.S. Senate,,DEM,Kamala D. Harris,556
+Fresno,118,U.S. Senate,,DEM,Loretta L. Sanchez,435
+Fresno,1180,U.S. Senate,,DEM,Kamala D. Harris,13
+Fresno,1180,U.S. Senate,,DEM,Loretta L. Sanchez,14
+Fresno,1181,U.S. Senate,,DEM,Kamala D. Harris,65
+Fresno,1181,U.S. Senate,,DEM,Loretta L. Sanchez,70
+Fresno,119,U.S. Senate,,DEM,Kamala D. Harris,389
+Fresno,119,U.S. Senate,,DEM,Loretta L. Sanchez,321
+Fresno,12,U.S. Senate,,DEM,Kamala D. Harris,341
+Fresno,12,U.S. Senate,,DEM,Loretta L. Sanchez,225
+Fresno,120,U.S. Senate,,DEM,Kamala D. Harris,591
+Fresno,120,U.S. Senate,,DEM,Loretta L. Sanchez,522
+Fresno,121,U.S. Senate,,DEM,Kamala D. Harris,374
+Fresno,121,U.S. Senate,,DEM,Loretta L. Sanchez,407
+Fresno,122,U.S. Senate,,DEM,Kamala D. Harris,320
+Fresno,122,U.S. Senate,,DEM,Loretta L. Sanchez,263
+Fresno,123,U.S. Senate,,DEM,Kamala D. Harris,362
+Fresno,123,U.S. Senate,,DEM,Loretta L. Sanchez,327
+Fresno,124,U.S. Senate,,DEM,Kamala D. Harris,320
+Fresno,124,U.S. Senate,,DEM,Loretta L. Sanchez,246
+Fresno,125,U.S. Senate,,DEM,Kamala D. Harris,367
+Fresno,125,U.S. Senate,,DEM,Loretta L. Sanchez,316
+Fresno,126,U.S. Senate,,DEM,Kamala D. Harris,397
+Fresno,126,U.S. Senate,,DEM,Loretta L. Sanchez,310
+Fresno,127,U.S. Senate,,DEM,Kamala D. Harris,359
+Fresno,127,U.S. Senate,,DEM,Loretta L. Sanchez,281
+Fresno,128,U.S. Senate,,DEM,Kamala D. Harris,268
+Fresno,128,U.S. Senate,,DEM,Loretta L. Sanchez,237
+Fresno,129,U.S. Senate,,DEM,Kamala D. Harris,330
+Fresno,129,U.S. Senate,,DEM,Loretta L. Sanchez,235
+Fresno,13,U.S. Senate,,DEM,Kamala D. Harris,607
+Fresno,13,U.S. Senate,,DEM,Loretta L. Sanchez,357
+Fresno,130,U.S. Senate,,DEM,Kamala D. Harris,363
+Fresno,130,U.S. Senate,,DEM,Loretta L. Sanchez,294
+Fresno,131,U.S. Senate,,DEM,Kamala D. Harris,291
+Fresno,131,U.S. Senate,,DEM,Loretta L. Sanchez,255
+Fresno,132,U.S. Senate,,DEM,Kamala D. Harris,478
+Fresno,132,U.S. Senate,,DEM,Loretta L. Sanchez,410
+Fresno,133,U.S. Senate,,DEM,Kamala D. Harris,300
+Fresno,133,U.S. Senate,,DEM,Loretta L. Sanchez,268
+Fresno,134,U.S. Senate,,DEM,Kamala D. Harris,370
+Fresno,134,U.S. Senate,,DEM,Loretta L. Sanchez,327
+Fresno,135,U.S. Senate,,DEM,Kamala D. Harris,262
+Fresno,135,U.S. Senate,,DEM,Loretta L. Sanchez,264
+Fresno,136,U.S. Senate,,DEM,Kamala D. Harris,265
+Fresno,136,U.S. Senate,,DEM,Loretta L. Sanchez,233
+Fresno,137,U.S. Senate,,DEM,Kamala D. Harris,215
+Fresno,137,U.S. Senate,,DEM,Loretta L. Sanchez,237
+Fresno,138,U.S. Senate,,DEM,Kamala D. Harris,264
+Fresno,138,U.S. Senate,,DEM,Loretta L. Sanchez,211
+Fresno,139,U.S. Senate,,DEM,Kamala D. Harris,258
+Fresno,139,U.S. Senate,,DEM,Loretta L. Sanchez,322
+Fresno,14,U.S. Senate,,DEM,Kamala D. Harris,268
+Fresno,14,U.S. Senate,,DEM,Loretta L. Sanchez,160
+Fresno,140,U.S. Senate,,DEM,Kamala D. Harris,331
+Fresno,140,U.S. Senate,,DEM,Loretta L. Sanchez,262
+Fresno,141,U.S. Senate,,DEM,Kamala D. Harris,482
+Fresno,141,U.S. Senate,,DEM,Loretta L. Sanchez,346
+Fresno,142,U.S. Senate,,DEM,Kamala D. Harris,300
+Fresno,142,U.S. Senate,,DEM,Loretta L. Sanchez,237
+Fresno,143,U.S. Senate,,DEM,Kamala D. Harris,240
+Fresno,143,U.S. Senate,,DEM,Loretta L. Sanchez,242
+Fresno,144,U.S. Senate,,DEM,Kamala D. Harris,146
+Fresno,144,U.S. Senate,,DEM,Loretta L. Sanchez,169
+Fresno,145,U.S. Senate,,DEM,Kamala D. Harris,81
+Fresno,145,U.S. Senate,,DEM,Loretta L. Sanchez,59
+Fresno,146,U.S. Senate,,DEM,Kamala D. Harris,365
+Fresno,146,U.S. Senate,,DEM,Loretta L. Sanchez,373
+Fresno,147,U.S. Senate,,DEM,Kamala D. Harris,134
+Fresno,147,U.S. Senate,,DEM,Loretta L. Sanchez,129
+Fresno,148,U.S. Senate,,DEM,Kamala D. Harris,318
+Fresno,148,U.S. Senate,,DEM,Loretta L. Sanchez,312
+Fresno,149,U.S. Senate,,DEM,Kamala D. Harris,348
+Fresno,149,U.S. Senate,,DEM,Loretta L. Sanchez,385
+Fresno,15,U.S. Senate,,DEM,Kamala D. Harris,241
+Fresno,15,U.S. Senate,,DEM,Loretta L. Sanchez,257
+Fresno,150,U.S. Senate,,DEM,Kamala D. Harris,453
+Fresno,150,U.S. Senate,,DEM,Loretta L. Sanchez,401
+Fresno,151,U.S. Senate,,DEM,Kamala D. Harris,451
+Fresno,151,U.S. Senate,,DEM,Loretta L. Sanchez,342
+Fresno,152,U.S. Senate,,DEM,Kamala D. Harris,302
+Fresno,152,U.S. Senate,,DEM,Loretta L. Sanchez,245
+Fresno,153,U.S. Senate,,DEM,Kamala D. Harris,579
+Fresno,153,U.S. Senate,,DEM,Loretta L. Sanchez,398
+Fresno,154,U.S. Senate,,DEM,Kamala D. Harris,303
+Fresno,154,U.S. Senate,,DEM,Loretta L. Sanchez,251
+Fresno,155,U.S. Senate,,DEM,Kamala D. Harris,314
+Fresno,155,U.S. Senate,,DEM,Loretta L. Sanchez,241
+Fresno,156,U.S. Senate,,DEM,Kamala D. Harris,595
+Fresno,156,U.S. Senate,,DEM,Loretta L. Sanchez,443
+Fresno,157,U.S. Senate,,DEM,Kamala D. Harris,586
+Fresno,157,U.S. Senate,,DEM,Loretta L. Sanchez,406
+Fresno,158,U.S. Senate,,DEM,Kamala D. Harris,343
+Fresno,158,U.S. Senate,,DEM,Loretta L. Sanchez,279
+Fresno,159,U.S. Senate,,DEM,Kamala D. Harris,601
+Fresno,159,U.S. Senate,,DEM,Loretta L. Sanchez,418
+Fresno,16,U.S. Senate,,DEM,Kamala D. Harris,230
+Fresno,16,U.S. Senate,,DEM,Loretta L. Sanchez,269
+Fresno,160,U.S. Senate,,DEM,Kamala D. Harris,343
+Fresno,160,U.S. Senate,,DEM,Loretta L. Sanchez,282
+Fresno,161,U.S. Senate,,DEM,Kamala D. Harris,362
+Fresno,161,U.S. Senate,,DEM,Loretta L. Sanchez,304
+Fresno,162,U.S. Senate,,DEM,Kamala D. Harris,275
+Fresno,162,U.S. Senate,,DEM,Loretta L. Sanchez,190
+Fresno,163,U.S. Senate,,DEM,Kamala D. Harris,354
+Fresno,163,U.S. Senate,,DEM,Loretta L. Sanchez,271
+Fresno,164,U.S. Senate,,DEM,Kamala D. Harris,438
+Fresno,164,U.S. Senate,,DEM,Loretta L. Sanchez,304
+Fresno,165,U.S. Senate,,DEM,Kamala D. Harris,305
+Fresno,165,U.S. Senate,,DEM,Loretta L. Sanchez,262
+Fresno,166,U.S. Senate,,DEM,Kamala D. Harris,340
+Fresno,166,U.S. Senate,,DEM,Loretta L. Sanchez,318
+Fresno,167,U.S. Senate,,DEM,Kamala D. Harris,600
+Fresno,167,U.S. Senate,,DEM,Loretta L. Sanchez,509
+Fresno,168,U.S. Senate,,DEM,Kamala D. Harris,451
+Fresno,168,U.S. Senate,,DEM,Loretta L. Sanchez,296
+Fresno,169,U.S. Senate,,DEM,Kamala D. Harris,504
+Fresno,169,U.S. Senate,,DEM,Loretta L. Sanchez,404
+Fresno,17,U.S. Senate,,DEM,Kamala D. Harris,318
+Fresno,17,U.S. Senate,,DEM,Loretta L. Sanchez,355
+Fresno,170,U.S. Senate,,DEM,Kamala D. Harris,457
+Fresno,170,U.S. Senate,,DEM,Loretta L. Sanchez,421
+Fresno,171,U.S. Senate,,DEM,Kamala D. Harris,465
+Fresno,171,U.S. Senate,,DEM,Loretta L. Sanchez,429
+Fresno,172,U.S. Senate,,DEM,Kamala D. Harris,227
+Fresno,172,U.S. Senate,,DEM,Loretta L. Sanchez,157
+Fresno,173,U.S. Senate,,DEM,Kamala D. Harris,486
+Fresno,173,U.S. Senate,,DEM,Loretta L. Sanchez,360
+Fresno,174,U.S. Senate,,DEM,Kamala D. Harris,263
+Fresno,174,U.S. Senate,,DEM,Loretta L. Sanchez,204
+Fresno,175,U.S. Senate,,DEM,Kamala D. Harris,402
+Fresno,175,U.S. Senate,,DEM,Loretta L. Sanchez,324
+Fresno,176,U.S. Senate,,DEM,Kamala D. Harris,635
+Fresno,176,U.S. Senate,,DEM,Loretta L. Sanchez,509
+Fresno,177,U.S. Senate,,DEM,Kamala D. Harris,330
+Fresno,177,U.S. Senate,,DEM,Loretta L. Sanchez,369
+Fresno,178,U.S. Senate,,DEM,Kamala D. Harris,239
+Fresno,178,U.S. Senate,,DEM,Loretta L. Sanchez,259
+Fresno,179,U.S. Senate,,DEM,Kamala D. Harris,167
+Fresno,179,U.S. Senate,,DEM,Loretta L. Sanchez,252
+Fresno,18,U.S. Senate,,DEM,Kamala D. Harris,197
+Fresno,18,U.S. Senate,,DEM,Loretta L. Sanchez,250
+Fresno,180,U.S. Senate,,DEM,Kamala D. Harris,233
+Fresno,180,U.S. Senate,,DEM,Loretta L. Sanchez,179
+Fresno,181,U.S. Senate,,DEM,Kamala D. Harris,201
+Fresno,181,U.S. Senate,,DEM,Loretta L. Sanchez,181
+Fresno,182,U.S. Senate,,DEM,Kamala D. Harris,256
+Fresno,182,U.S. Senate,,DEM,Loretta L. Sanchez,237
+Fresno,183,U.S. Senate,,DEM,Kamala D. Harris,343
+Fresno,183,U.S. Senate,,DEM,Loretta L. Sanchez,388
+Fresno,184,U.S. Senate,,DEM,Kamala D. Harris,670
+Fresno,184,U.S. Senate,,DEM,Loretta L. Sanchez,608
+Fresno,185,U.S. Senate,,DEM,Kamala D. Harris,450
+Fresno,185,U.S. Senate,,DEM,Loretta L. Sanchez,392
+Fresno,186,U.S. Senate,,DEM,Kamala D. Harris,585
+Fresno,186,U.S. Senate,,DEM,Loretta L. Sanchez,519
+Fresno,187,U.S. Senate,,DEM,Kamala D. Harris,392
+Fresno,187,U.S. Senate,,DEM,Loretta L. Sanchez,324
+Fresno,188,U.S. Senate,,DEM,Kamala D. Harris,266
+Fresno,188,U.S. Senate,,DEM,Loretta L. Sanchez,244
+Fresno,189,U.S. Senate,,DEM,Kamala D. Harris,362
+Fresno,189,U.S. Senate,,DEM,Loretta L. Sanchez,287
+Fresno,19,U.S. Senate,,DEM,Kamala D. Harris,279
+Fresno,19,U.S. Senate,,DEM,Loretta L. Sanchez,358
+Fresno,190,U.S. Senate,,DEM,Kamala D. Harris,306
+Fresno,190,U.S. Senate,,DEM,Loretta L. Sanchez,246
+Fresno,191,U.S. Senate,,DEM,Kamala D. Harris,173
+Fresno,191,U.S. Senate,,DEM,Loretta L. Sanchez,251
+Fresno,192,U.S. Senate,,DEM,Kamala D. Harris,469
+Fresno,192,U.S. Senate,,DEM,Loretta L. Sanchez,423
+Fresno,193,U.S. Senate,,DEM,Kamala D. Harris,479
+Fresno,193,U.S. Senate,,DEM,Loretta L. Sanchez,469
+Fresno,194,U.S. Senate,,DEM,Kamala D. Harris,351
+Fresno,194,U.S. Senate,,DEM,Loretta L. Sanchez,279
+Fresno,195,U.S. Senate,,DEM,Kamala D. Harris,265
+Fresno,195,U.S. Senate,,DEM,Loretta L. Sanchez,231
+Fresno,196,U.S. Senate,,DEM,Kamala D. Harris,429
+Fresno,196,U.S. Senate,,DEM,Loretta L. Sanchez,340
+Fresno,197,U.S. Senate,,DEM,Kamala D. Harris,281
+Fresno,197,U.S. Senate,,DEM,Loretta L. Sanchez,284
+Fresno,198,U.S. Senate,,DEM,Kamala D. Harris,280
+Fresno,198,U.S. Senate,,DEM,Loretta L. Sanchez,281
+Fresno,199,U.S. Senate,,DEM,Kamala D. Harris,532
+Fresno,199,U.S. Senate,,DEM,Loretta L. Sanchez,391
+Fresno,2,U.S. Senate,,DEM,Kamala D. Harris,349
+Fresno,2,U.S. Senate,,DEM,Loretta L. Sanchez,241
+Fresno,20,U.S. Senate,,DEM,Kamala D. Harris,228
+Fresno,20,U.S. Senate,,DEM,Loretta L. Sanchez,222
+Fresno,200,U.S. Senate,,DEM,Kamala D. Harris,397
+Fresno,200,U.S. Senate,,DEM,Loretta L. Sanchez,276
+Fresno,201,U.S. Senate,,DEM,Kamala D. Harris,268
+Fresno,201,U.S. Senate,,DEM,Loretta L. Sanchez,221
+Fresno,202,U.S. Senate,,DEM,Kamala D. Harris,215
+Fresno,202,U.S. Senate,,DEM,Loretta L. Sanchez,136
+Fresno,203,U.S. Senate,,DEM,Kamala D. Harris,303
+Fresno,203,U.S. Senate,,DEM,Loretta L. Sanchez,284
+Fresno,204,U.S. Senate,,DEM,Kamala D. Harris,399
+Fresno,204,U.S. Senate,,DEM,Loretta L. Sanchez,339
+Fresno,205,U.S. Senate,,DEM,Kamala D. Harris,281
+Fresno,205,U.S. Senate,,DEM,Loretta L. Sanchez,228
+Fresno,206,U.S. Senate,,DEM,Kamala D. Harris,189
+Fresno,206,U.S. Senate,,DEM,Loretta L. Sanchez,176
+Fresno,207,U.S. Senate,,DEM,Kamala D. Harris,255
+Fresno,207,U.S. Senate,,DEM,Loretta L. Sanchez,305
+Fresno,208,U.S. Senate,,DEM,Kamala D. Harris,215
+Fresno,208,U.S. Senate,,DEM,Loretta L. Sanchez,251
+Fresno,209,U.S. Senate,,DEM,Kamala D. Harris,160
+Fresno,209,U.S. Senate,,DEM,Loretta L. Sanchez,185
+Fresno,21,U.S. Senate,,DEM,Kamala D. Harris,200
+Fresno,21,U.S. Senate,,DEM,Loretta L. Sanchez,212
+Fresno,210,U.S. Senate,,DEM,Kamala D. Harris,251
+Fresno,210,U.S. Senate,,DEM,Loretta L. Sanchez,287
+Fresno,211,U.S. Senate,,DEM,Kamala D. Harris,116
+Fresno,211,U.S. Senate,,DEM,Loretta L. Sanchez,93
+Fresno,212,U.S. Senate,,DEM,Kamala D. Harris,329
+Fresno,212,U.S. Senate,,DEM,Loretta L. Sanchez,297
+Fresno,213,U.S. Senate,,DEM,Kamala D. Harris,152
+Fresno,213,U.S. Senate,,DEM,Loretta L. Sanchez,182
+Fresno,214,U.S. Senate,,DEM,Kamala D. Harris,475
+Fresno,214,U.S. Senate,,DEM,Loretta L. Sanchez,485
+Fresno,215,U.S. Senate,,DEM,Kamala D. Harris,128
+Fresno,215,U.S. Senate,,DEM,Loretta L. Sanchez,150
+Fresno,216,U.S. Senate,,DEM,Kamala D. Harris,145
+Fresno,216,U.S. Senate,,DEM,Loretta L. Sanchez,136
+Fresno,217,U.S. Senate,,DEM,Kamala D. Harris,585
+Fresno,217,U.S. Senate,,DEM,Loretta L. Sanchez,437
+Fresno,218,U.S. Senate,,DEM,Kamala D. Harris,311
+Fresno,218,U.S. Senate,,DEM,Loretta L. Sanchez,235
+Fresno,219,U.S. Senate,,DEM,Kamala D. Harris,379
+Fresno,219,U.S. Senate,,DEM,Loretta L. Sanchez,324
+Fresno,22,U.S. Senate,,DEM,Kamala D. Harris,123
+Fresno,22,U.S. Senate,,DEM,Loretta L. Sanchez,191
+Fresno,220,U.S. Senate,,DEM,Kamala D. Harris,231
+Fresno,220,U.S. Senate,,DEM,Loretta L. Sanchez,219
+Fresno,221,U.S. Senate,,DEM,Kamala D. Harris,289
+Fresno,221,U.S. Senate,,DEM,Loretta L. Sanchez,237
+Fresno,222,U.S. Senate,,DEM,Kamala D. Harris,91
+Fresno,222,U.S. Senate,,DEM,Loretta L. Sanchez,141
+Fresno,223,U.S. Senate,,DEM,Kamala D. Harris,221
+Fresno,223,U.S. Senate,,DEM,Loretta L. Sanchez,322
+Fresno,224,U.S. Senate,,DEM,Kamala D. Harris,255
+Fresno,224,U.S. Senate,,DEM,Loretta L. Sanchez,273
+Fresno,225,U.S. Senate,,DEM,Kamala D. Harris,500
+Fresno,225,U.S. Senate,,DEM,Loretta L. Sanchez,368
+Fresno,226,U.S. Senate,,DEM,Kamala D. Harris,240
+Fresno,226,U.S. Senate,,DEM,Loretta L. Sanchez,221
+Fresno,227,U.S. Senate,,DEM,Kamala D. Harris,267
+Fresno,227,U.S. Senate,,DEM,Loretta L. Sanchez,254
+Fresno,228,U.S. Senate,,DEM,Kamala D. Harris,383
+Fresno,228,U.S. Senate,,DEM,Loretta L. Sanchez,324
+Fresno,229,U.S. Senate,,DEM,Kamala D. Harris,454
+Fresno,229,U.S. Senate,,DEM,Loretta L. Sanchez,394
+Fresno,23,U.S. Senate,,DEM,Kamala D. Harris,315
+Fresno,23,U.S. Senate,,DEM,Loretta L. Sanchez,289
+Fresno,230,U.S. Senate,,DEM,Kamala D. Harris,366
+Fresno,230,U.S. Senate,,DEM,Loretta L. Sanchez,276
+Fresno,231,U.S. Senate,,DEM,Kamala D. Harris,73
+Fresno,231,U.S. Senate,,DEM,Loretta L. Sanchez,136
+Fresno,232,U.S. Senate,,DEM,Kamala D. Harris,203
+Fresno,232,U.S. Senate,,DEM,Loretta L. Sanchez,201
+Fresno,233,U.S. Senate,,DEM,Kamala D. Harris,158
+Fresno,233,U.S. Senate,,DEM,Loretta L. Sanchez,167
+Fresno,234,U.S. Senate,,DEM,Kamala D. Harris,113
+Fresno,234,U.S. Senate,,DEM,Loretta L. Sanchez,100
+Fresno,235,U.S. Senate,,DEM,Kamala D. Harris,332
+Fresno,235,U.S. Senate,,DEM,Loretta L. Sanchez,291
+Fresno,236,U.S. Senate,,DEM,Kamala D. Harris,360
+Fresno,236,U.S. Senate,,DEM,Loretta L. Sanchez,360
+Fresno,237,U.S. Senate,,DEM,Kamala D. Harris,232
+Fresno,237,U.S. Senate,,DEM,Loretta L. Sanchez,236
+Fresno,238,U.S. Senate,,DEM,Kamala D. Harris,232
+Fresno,238,U.S. Senate,,DEM,Loretta L. Sanchez,249
+Fresno,239,U.S. Senate,,DEM,Kamala D. Harris,137
+Fresno,239,U.S. Senate,,DEM,Loretta L. Sanchez,125
+Fresno,24,U.S. Senate,,DEM,Kamala D. Harris,453
+Fresno,24,U.S. Senate,,DEM,Loretta L. Sanchez,432
+Fresno,240,U.S. Senate,,DEM,Kamala D. Harris,198
+Fresno,240,U.S. Senate,,DEM,Loretta L. Sanchez,218
+Fresno,241,U.S. Senate,,DEM,Kamala D. Harris,287
+Fresno,241,U.S. Senate,,DEM,Loretta L. Sanchez,435
+Fresno,242,U.S. Senate,,DEM,Kamala D. Harris,241
+Fresno,242,U.S. Senate,,DEM,Loretta L. Sanchez,356
+Fresno,243,U.S. Senate,,DEM,Kamala D. Harris,78
+Fresno,243,U.S. Senate,,DEM,Loretta L. Sanchez,93
+Fresno,244,U.S. Senate,,DEM,Kamala D. Harris,82
+Fresno,244,U.S. Senate,,DEM,Loretta L. Sanchez,160
+Fresno,245,U.S. Senate,,DEM,Kamala D. Harris,172
+Fresno,245,U.S. Senate,,DEM,Loretta L. Sanchez,130
+Fresno,246,U.S. Senate,,DEM,Kamala D. Harris,115
+Fresno,246,U.S. Senate,,DEM,Loretta L. Sanchez,124
+Fresno,247,U.S. Senate,,DEM,Kamala D. Harris,91
+Fresno,247,U.S. Senate,,DEM,Loretta L. Sanchez,138
+Fresno,248,U.S. Senate,,DEM,Kamala D. Harris,451
+Fresno,248,U.S. Senate,,DEM,Loretta L. Sanchez,320
+Fresno,249,U.S. Senate,,DEM,Kamala D. Harris,514
+Fresno,249,U.S. Senate,,DEM,Loretta L. Sanchez,345
+Fresno,25,U.S. Senate,,DEM,Kamala D. Harris,295
+Fresno,25,U.S. Senate,,DEM,Loretta L. Sanchez,266
+Fresno,250,U.S. Senate,,DEM,Kamala D. Harris,143
+Fresno,250,U.S. Senate,,DEM,Loretta L. Sanchez,231
+Fresno,251,U.S. Senate,,DEM,Kamala D. Harris,628
+Fresno,251,U.S. Senate,,DEM,Loretta L. Sanchez,394
+Fresno,252,U.S. Senate,,DEM,Kamala D. Harris,578
+Fresno,252,U.S. Senate,,DEM,Loretta L. Sanchez,436
+Fresno,253,U.S. Senate,,DEM,Kamala D. Harris,280
+Fresno,253,U.S. Senate,,DEM,Loretta L. Sanchez,244
+Fresno,254,U.S. Senate,,DEM,Kamala D. Harris,307
+Fresno,254,U.S. Senate,,DEM,Loretta L. Sanchez,295
+Fresno,255,U.S. Senate,,DEM,Kamala D. Harris,487
+Fresno,255,U.S. Senate,,DEM,Loretta L. Sanchez,401
+Fresno,256,U.S. Senate,,DEM,Kamala D. Harris,448
+Fresno,256,U.S. Senate,,DEM,Loretta L. Sanchez,365
+Fresno,257,U.S. Senate,,DEM,Kamala D. Harris,543
+Fresno,257,U.S. Senate,,DEM,Loretta L. Sanchez,384
+Fresno,258,U.S. Senate,,DEM,Kamala D. Harris,181
+Fresno,258,U.S. Senate,,DEM,Loretta L. Sanchez,178
+Fresno,259,U.S. Senate,,DEM,Kamala D. Harris,418
+Fresno,259,U.S. Senate,,DEM,Loretta L. Sanchez,414
+Fresno,26,U.S. Senate,,DEM,Kamala D. Harris,184
+Fresno,26,U.S. Senate,,DEM,Loretta L. Sanchez,194
+Fresno,260,U.S. Senate,,DEM,Kamala D. Harris,165
+Fresno,260,U.S. Senate,,DEM,Loretta L. Sanchez,203
+Fresno,261,U.S. Senate,,DEM,Kamala D. Harris,371
+Fresno,261,U.S. Senate,,DEM,Loretta L. Sanchez,357
+Fresno,262,U.S. Senate,,DEM,Kamala D. Harris,138
+Fresno,262,U.S. Senate,,DEM,Loretta L. Sanchez,132
+Fresno,263,U.S. Senate,,DEM,Kamala D. Harris,750
+Fresno,263,U.S. Senate,,DEM,Loretta L. Sanchez,564
+Fresno,264,U.S. Senate,,DEM,Kamala D. Harris,545
+Fresno,264,U.S. Senate,,DEM,Loretta L. Sanchez,487
+Fresno,265,U.S. Senate,,DEM,Kamala D. Harris,474
+Fresno,265,U.S. Senate,,DEM,Loretta L. Sanchez,423
+Fresno,266,U.S. Senate,,DEM,Kamala D. Harris,518
+Fresno,266,U.S. Senate,,DEM,Loretta L. Sanchez,476
+Fresno,267,U.S. Senate,,DEM,Kamala D. Harris,508
+Fresno,267,U.S. Senate,,DEM,Loretta L. Sanchez,389
+Fresno,268,U.S. Senate,,DEM,Kamala D. Harris,372
+Fresno,268,U.S. Senate,,DEM,Loretta L. Sanchez,370
+Fresno,269,U.S. Senate,,DEM,Kamala D. Harris,330
+Fresno,269,U.S. Senate,,DEM,Loretta L. Sanchez,265
+Fresno,27,U.S. Senate,,DEM,Kamala D. Harris,138
+Fresno,27,U.S. Senate,,DEM,Loretta L. Sanchez,188
+Fresno,270,U.S. Senate,,DEM,Kamala D. Harris,300
+Fresno,270,U.S. Senate,,DEM,Loretta L. Sanchez,219
+Fresno,271,U.S. Senate,,DEM,Kamala D. Harris,329
+Fresno,271,U.S. Senate,,DEM,Loretta L. Sanchez,300
+Fresno,272,U.S. Senate,,DEM,Kamala D. Harris,399
+Fresno,272,U.S. Senate,,DEM,Loretta L. Sanchez,337
+Fresno,273,U.S. Senate,,DEM,Kamala D. Harris,363
+Fresno,273,U.S. Senate,,DEM,Loretta L. Sanchez,304
+Fresno,274,U.S. Senate,,DEM,Kamala D. Harris,446
+Fresno,274,U.S. Senate,,DEM,Loretta L. Sanchez,377
+Fresno,275,U.S. Senate,,DEM,Kamala D. Harris,327
+Fresno,275,U.S. Senate,,DEM,Loretta L. Sanchez,289
+Fresno,276,U.S. Senate,,DEM,Kamala D. Harris,275
+Fresno,276,U.S. Senate,,DEM,Loretta L. Sanchez,216
+Fresno,277,U.S. Senate,,DEM,Kamala D. Harris,662
+Fresno,277,U.S. Senate,,DEM,Loretta L. Sanchez,525
+Fresno,278,U.S. Senate,,DEM,Kamala D. Harris,462
+Fresno,278,U.S. Senate,,DEM,Loretta L. Sanchez,370
+Fresno,279,U.S. Senate,,DEM,Kamala D. Harris,513
+Fresno,279,U.S. Senate,,DEM,Loretta L. Sanchez,450
+Fresno,28,U.S. Senate,,DEM,Kamala D. Harris,302
+Fresno,28,U.S. Senate,,DEM,Loretta L. Sanchez,353
+Fresno,280,U.S. Senate,,DEM,Kamala D. Harris,440
+Fresno,280,U.S. Senate,,DEM,Loretta L. Sanchez,386
+Fresno,281,U.S. Senate,,DEM,Kamala D. Harris,498
+Fresno,281,U.S. Senate,,DEM,Loretta L. Sanchez,457
+Fresno,282,U.S. Senate,,DEM,Kamala D. Harris,520
+Fresno,282,U.S. Senate,,DEM,Loretta L. Sanchez,491
+Fresno,283,U.S. Senate,,DEM,Kamala D. Harris,498
+Fresno,283,U.S. Senate,,DEM,Loretta L. Sanchez,443
+Fresno,284,U.S. Senate,,DEM,Kamala D. Harris,538
+Fresno,284,U.S. Senate,,DEM,Loretta L. Sanchez,469
+Fresno,285,U.S. Senate,,DEM,Kamala D. Harris,190
+Fresno,285,U.S. Senate,,DEM,Loretta L. Sanchez,193
+Fresno,286,U.S. Senate,,DEM,Kamala D. Harris,315
+Fresno,286,U.S. Senate,,DEM,Loretta L. Sanchez,252
+Fresno,287,U.S. Senate,,DEM,Kamala D. Harris,245
+Fresno,287,U.S. Senate,,DEM,Loretta L. Sanchez,190
+Fresno,288,U.S. Senate,,DEM,Kamala D. Harris,300
+Fresno,288,U.S. Senate,,DEM,Loretta L. Sanchez,174
+Fresno,289,U.S. Senate,,DEM,Kamala D. Harris,197
+Fresno,289,U.S. Senate,,DEM,Loretta L. Sanchez,175
+Fresno,29,U.S. Senate,,DEM,Kamala D. Harris,447
+Fresno,29,U.S. Senate,,DEM,Loretta L. Sanchez,261
+Fresno,290,U.S. Senate,,DEM,Kamala D. Harris,213
+Fresno,290,U.S. Senate,,DEM,Loretta L. Sanchez,160
+Fresno,291,U.S. Senate,,DEM,Kamala D. Harris,204
+Fresno,291,U.S. Senate,,DEM,Loretta L. Sanchez,147
+Fresno,292,U.S. Senate,,DEM,Kamala D. Harris,175
+Fresno,292,U.S. Senate,,DEM,Loretta L. Sanchez,190
+Fresno,293,U.S. Senate,,DEM,Kamala D. Harris,246
+Fresno,293,U.S. Senate,,DEM,Loretta L. Sanchez,216
+Fresno,294,U.S. Senate,,DEM,Kamala D. Harris,276
+Fresno,294,U.S. Senate,,DEM,Loretta L. Sanchez,315
+Fresno,295,U.S. Senate,,DEM,Kamala D. Harris,349
+Fresno,295,U.S. Senate,,DEM,Loretta L. Sanchez,344
+Fresno,296,U.S. Senate,,DEM,Kamala D. Harris,258
+Fresno,296,U.S. Senate,,DEM,Loretta L. Sanchez,223
+Fresno,297,U.S. Senate,,DEM,Kamala D. Harris,223
+Fresno,297,U.S. Senate,,DEM,Loretta L. Sanchez,210
+Fresno,298,U.S. Senate,,DEM,Kamala D. Harris,223
+Fresno,298,U.S. Senate,,DEM,Loretta L. Sanchez,240
+Fresno,299,U.S. Senate,,DEM,Kamala D. Harris,155
+Fresno,299,U.S. Senate,,DEM,Loretta L. Sanchez,199
+Fresno,3,U.S. Senate,,DEM,Kamala D. Harris,97
+Fresno,3,U.S. Senate,,DEM,Loretta L. Sanchez,110
+Fresno,30,U.S. Senate,,DEM,Kamala D. Harris,125
+Fresno,30,U.S. Senate,,DEM,Loretta L. Sanchez,186
+Fresno,300,U.S. Senate,,DEM,Kamala D. Harris,183
+Fresno,300,U.S. Senate,,DEM,Loretta L. Sanchez,203
+Fresno,301,U.S. Senate,,DEM,Kamala D. Harris,432
+Fresno,301,U.S. Senate,,DEM,Loretta L. Sanchez,354
+Fresno,302,U.S. Senate,,DEM,Kamala D. Harris,353
+Fresno,302,U.S. Senate,,DEM,Loretta L. Sanchez,449
+Fresno,303,U.S. Senate,,DEM,Kamala D. Harris,248
+Fresno,303,U.S. Senate,,DEM,Loretta L. Sanchez,228
+Fresno,304,U.S. Senate,,DEM,Kamala D. Harris,334
+Fresno,304,U.S. Senate,,DEM,Loretta L. Sanchez,317
+Fresno,305,U.S. Senate,,DEM,Kamala D. Harris,163
+Fresno,305,U.S. Senate,,DEM,Loretta L. Sanchez,146
+Fresno,306,U.S. Senate,,DEM,Kamala D. Harris,335
+Fresno,306,U.S. Senate,,DEM,Loretta L. Sanchez,370
+Fresno,307,U.S. Senate,,DEM,Kamala D. Harris,153
+Fresno,307,U.S. Senate,,DEM,Loretta L. Sanchez,198
+Fresno,308,U.S. Senate,,DEM,Kamala D. Harris,131
+Fresno,308,U.S. Senate,,DEM,Loretta L. Sanchez,90
+Fresno,309,U.S. Senate,,DEM,Kamala D. Harris,208
+Fresno,309,U.S. Senate,,DEM,Loretta L. Sanchez,192
+Fresno,31,U.S. Senate,,DEM,Kamala D. Harris,149
+Fresno,31,U.S. Senate,,DEM,Loretta L. Sanchez,177
+Fresno,310,U.S. Senate,,DEM,Kamala D. Harris,219
+Fresno,310,U.S. Senate,,DEM,Loretta L. Sanchez,196
+Fresno,311,U.S. Senate,,DEM,Kamala D. Harris,332
+Fresno,311,U.S. Senate,,DEM,Loretta L. Sanchez,304
+Fresno,312,U.S. Senate,,DEM,Kamala D. Harris,298
+Fresno,312,U.S. Senate,,DEM,Loretta L. Sanchez,286
+Fresno,313,U.S. Senate,,DEM,Kamala D. Harris,306
+Fresno,313,U.S. Senate,,DEM,Loretta L. Sanchez,263
+Fresno,314,U.S. Senate,,DEM,Kamala D. Harris,233
+Fresno,314,U.S. Senate,,DEM,Loretta L. Sanchez,244
+Fresno,315,U.S. Senate,,DEM,Kamala D. Harris,482
+Fresno,315,U.S. Senate,,DEM,Loretta L. Sanchez,437
+Fresno,316,U.S. Senate,,DEM,Kamala D. Harris,135
+Fresno,316,U.S. Senate,,DEM,Loretta L. Sanchez,236
+Fresno,317,U.S. Senate,,DEM,Kamala D. Harris,299
+Fresno,317,U.S. Senate,,DEM,Loretta L. Sanchez,353
+Fresno,318,U.S. Senate,,DEM,Kamala D. Harris,281
+Fresno,318,U.S. Senate,,DEM,Loretta L. Sanchez,398
+Fresno,319,U.S. Senate,,DEM,Kamala D. Harris,159
+Fresno,319,U.S. Senate,,DEM,Loretta L. Sanchez,155
+Fresno,32,U.S. Senate,,DEM,Kamala D. Harris,226
+Fresno,32,U.S. Senate,,DEM,Loretta L. Sanchez,321
+Fresno,320,U.S. Senate,,DEM,Kamala D. Harris,272
+Fresno,320,U.S. Senate,,DEM,Loretta L. Sanchez,337
+Fresno,321,U.S. Senate,,DEM,Kamala D. Harris,64
+Fresno,321,U.S. Senate,,DEM,Loretta L. Sanchez,166
+Fresno,322,U.S. Senate,,DEM,Kamala D. Harris,113
+Fresno,322,U.S. Senate,,DEM,Loretta L. Sanchez,97
+Fresno,323,U.S. Senate,,DEM,Kamala D. Harris,96
+Fresno,323,U.S. Senate,,DEM,Loretta L. Sanchez,94
+Fresno,324,U.S. Senate,,DEM,Kamala D. Harris,147
+Fresno,324,U.S. Senate,,DEM,Loretta L. Sanchez,332
+Fresno,325,U.S. Senate,,DEM,Kamala D. Harris,160
+Fresno,325,U.S. Senate,,DEM,Loretta L. Sanchez,221
+Fresno,326,U.S. Senate,,DEM,Kamala D. Harris,231
+Fresno,326,U.S. Senate,,DEM,Loretta L. Sanchez,278
+Fresno,327,U.S. Senate,,DEM,Kamala D. Harris,182
+Fresno,327,U.S. Senate,,DEM,Loretta L. Sanchez,259
+Fresno,328,U.S. Senate,,DEM,Kamala D. Harris,208
+Fresno,328,U.S. Senate,,DEM,Loretta L. Sanchez,287
+Fresno,329,U.S. Senate,,DEM,Kamala D. Harris,161
+Fresno,329,U.S. Senate,,DEM,Loretta L. Sanchez,227
+Fresno,33,U.S. Senate,,DEM,Kamala D. Harris,162
+Fresno,33,U.S. Senate,,DEM,Loretta L. Sanchez,225
+Fresno,330,U.S. Senate,,DEM,Kamala D. Harris,208
+Fresno,330,U.S. Senate,,DEM,Loretta L. Sanchez,241
+Fresno,331,U.S. Senate,,DEM,Kamala D. Harris,273
+Fresno,331,U.S. Senate,,DEM,Loretta L. Sanchez,284
+Fresno,332,U.S. Senate,,DEM,Kamala D. Harris,413
+Fresno,332,U.S. Senate,,DEM,Loretta L. Sanchez,373
+Fresno,333,U.S. Senate,,DEM,Kamala D. Harris,158
+Fresno,333,U.S. Senate,,DEM,Loretta L. Sanchez,216
+Fresno,334,U.S. Senate,,DEM,Kamala D. Harris,186
+Fresno,334,U.S. Senate,,DEM,Loretta L. Sanchez,274
+Fresno,335,U.S. Senate,,DEM,Kamala D. Harris,77
+Fresno,335,U.S. Senate,,DEM,Loretta L. Sanchez,112
+Fresno,336,U.S. Senate,,DEM,Kamala D. Harris,162
+Fresno,336,U.S. Senate,,DEM,Loretta L. Sanchez,184
+Fresno,337,U.S. Senate,,DEM,Kamala D. Harris,154
+Fresno,337,U.S. Senate,,DEM,Loretta L. Sanchez,180
+Fresno,338,U.S. Senate,,DEM,Kamala D. Harris,427
+Fresno,338,U.S. Senate,,DEM,Loretta L. Sanchez,417
+Fresno,339,U.S. Senate,,DEM,Kamala D. Harris,420
+Fresno,339,U.S. Senate,,DEM,Loretta L. Sanchez,355
+Fresno,34,U.S. Senate,,DEM,Kamala D. Harris,143
+Fresno,34,U.S. Senate,,DEM,Loretta L. Sanchez,210
+Fresno,340,U.S. Senate,,DEM,Kamala D. Harris,208
+Fresno,340,U.S. Senate,,DEM,Loretta L. Sanchez,266
+Fresno,341,U.S. Senate,,DEM,Kamala D. Harris,297
+Fresno,341,U.S. Senate,,DEM,Loretta L. Sanchez,269
+Fresno,342,U.S. Senate,,DEM,Kamala D. Harris,200
+Fresno,342,U.S. Senate,,DEM,Loretta L. Sanchez,203
+Fresno,343,U.S. Senate,,DEM,Kamala D. Harris,224
+Fresno,343,U.S. Senate,,DEM,Loretta L. Sanchez,230
+Fresno,344,U.S. Senate,,DEM,Kamala D. Harris,82
+Fresno,344,U.S. Senate,,DEM,Loretta L. Sanchez,97
+Fresno,345,U.S. Senate,,DEM,Kamala D. Harris,56
+Fresno,345,U.S. Senate,,DEM,Loretta L. Sanchez,84
+Fresno,346,U.S. Senate,,DEM,Kamala D. Harris,215
+Fresno,346,U.S. Senate,,DEM,Loretta L. Sanchez,468
+Fresno,347,U.S. Senate,,DEM,Kamala D. Harris,174
+Fresno,347,U.S. Senate,,DEM,Loretta L. Sanchez,332
+Fresno,348,U.S. Senate,,DEM,Kamala D. Harris,256
+Fresno,348,U.S. Senate,,DEM,Loretta L. Sanchez,539
+Fresno,349,U.S. Senate,,DEM,Kamala D. Harris,266
+Fresno,349,U.S. Senate,,DEM,Loretta L. Sanchez,391
+Fresno,35,U.S. Senate,,DEM,Kamala D. Harris,131
+Fresno,35,U.S. Senate,,DEM,Loretta L. Sanchez,194
+Fresno,350,U.S. Senate,,DEM,Kamala D. Harris,218
+Fresno,350,U.S. Senate,,DEM,Loretta L. Sanchez,254
+Fresno,351,U.S. Senate,,DEM,Kamala D. Harris,354
+Fresno,351,U.S. Senate,,DEM,Loretta L. Sanchez,431
+Fresno,352,U.S. Senate,,DEM,Kamala D. Harris,394
+Fresno,352,U.S. Senate,,DEM,Loretta L. Sanchez,462
+Fresno,353,U.S. Senate,,DEM,Kamala D. Harris,202
+Fresno,353,U.S. Senate,,DEM,Loretta L. Sanchez,252
+Fresno,354,U.S. Senate,,DEM,Kamala D. Harris,385
+Fresno,354,U.S. Senate,,DEM,Loretta L. Sanchez,412
+Fresno,355,U.S. Senate,,DEM,Kamala D. Harris,62
+Fresno,355,U.S. Senate,,DEM,Loretta L. Sanchez,78
+Fresno,356,U.S. Senate,,DEM,Kamala D. Harris,187
+Fresno,356,U.S. Senate,,DEM,Loretta L. Sanchez,324
+Fresno,357,U.S. Senate,,DEM,Kamala D. Harris,235
+Fresno,357,U.S. Senate,,DEM,Loretta L. Sanchez,190
+Fresno,358,U.S. Senate,,DEM,Kamala D. Harris,298
+Fresno,358,U.S. Senate,,DEM,Loretta L. Sanchez,216
+Fresno,359,U.S. Senate,,DEM,Kamala D. Harris,89
+Fresno,359,U.S. Senate,,DEM,Loretta L. Sanchez,69
+Fresno,36,U.S. Senate,,DEM,Kamala D. Harris,63
+Fresno,36,U.S. Senate,,DEM,Loretta L. Sanchez,143
+Fresno,360,U.S. Senate,,DEM,Kamala D. Harris,181
+Fresno,360,U.S. Senate,,DEM,Loretta L. Sanchez,412
+Fresno,361,U.S. Senate,,DEM,Kamala D. Harris,174
+Fresno,361,U.S. Senate,,DEM,Loretta L. Sanchez,420
+Fresno,362,U.S. Senate,,DEM,Kamala D. Harris,146
+Fresno,362,U.S. Senate,,DEM,Loretta L. Sanchez,314
+Fresno,363,U.S. Senate,,DEM,Kamala D. Harris,185
+Fresno,363,U.S. Senate,,DEM,Loretta L. Sanchez,375
+Fresno,364,U.S. Senate,,DEM,Kamala D. Harris,184
+Fresno,364,U.S. Senate,,DEM,Loretta L. Sanchez,207
+Fresno,365,U.S. Senate,,DEM,Kamala D. Harris,202
+Fresno,365,U.S. Senate,,DEM,Loretta L. Sanchez,256
+Fresno,366,U.S. Senate,,DEM,Kamala D. Harris,249
+Fresno,366,U.S. Senate,,DEM,Loretta L. Sanchez,217
+Fresno,367,U.S. Senate,,DEM,Kamala D. Harris,242
+Fresno,367,U.S. Senate,,DEM,Loretta L. Sanchez,321
+Fresno,368,U.S. Senate,,DEM,Kamala D. Harris,242
+Fresno,368,U.S. Senate,,DEM,Loretta L. Sanchez,294
+Fresno,369,U.S. Senate,,DEM,Kamala D. Harris,371
+Fresno,369,U.S. Senate,,DEM,Loretta L. Sanchez,307
+Fresno,37,U.S. Senate,,DEM,Kamala D. Harris,157
+Fresno,37,U.S. Senate,,DEM,Loretta L. Sanchez,301
+Fresno,370,U.S. Senate,,DEM,Kamala D. Harris,188
+Fresno,370,U.S. Senate,,DEM,Loretta L. Sanchez,203
+Fresno,371,U.S. Senate,,DEM,Kamala D. Harris,296
+Fresno,371,U.S. Senate,,DEM,Loretta L. Sanchez,316
+Fresno,372,U.S. Senate,,DEM,Kamala D. Harris,144
+Fresno,372,U.S. Senate,,DEM,Loretta L. Sanchez,200
+Fresno,373,U.S. Senate,,DEM,Kamala D. Harris,200
+Fresno,373,U.S. Senate,,DEM,Loretta L. Sanchez,224
+Fresno,374,U.S. Senate,,DEM,Kamala D. Harris,197
+Fresno,374,U.S. Senate,,DEM,Loretta L. Sanchez,365
+Fresno,375,U.S. Senate,,DEM,Kamala D. Harris,173
+Fresno,375,U.S. Senate,,DEM,Loretta L. Sanchez,415
+Fresno,376,U.S. Senate,,DEM,Kamala D. Harris,196
+Fresno,376,U.S. Senate,,DEM,Loretta L. Sanchez,470
+Fresno,377,U.S. Senate,,DEM,Kamala D. Harris,164
+Fresno,377,U.S. Senate,,DEM,Loretta L. Sanchez,510
+Fresno,378,U.S. Senate,,DEM,Kamala D. Harris,159
+Fresno,378,U.S. Senate,,DEM,Loretta L. Sanchez,232
+Fresno,379,U.S. Senate,,DEM,Kamala D. Harris,156
+Fresno,379,U.S. Senate,,DEM,Loretta L. Sanchez,179
+Fresno,38,U.S. Senate,,DEM,Kamala D. Harris,238
+Fresno,38,U.S. Senate,,DEM,Loretta L. Sanchez,202
+Fresno,380,U.S. Senate,,DEM,Kamala D. Harris,119
+Fresno,380,U.S. Senate,,DEM,Loretta L. Sanchez,159
+Fresno,381,U.S. Senate,,DEM,Kamala D. Harris,172
+Fresno,381,U.S. Senate,,DEM,Loretta L. Sanchez,159
+Fresno,382,U.S. Senate,,DEM,Kamala D. Harris,103
+Fresno,382,U.S. Senate,,DEM,Loretta L. Sanchez,93
+Fresno,383,U.S. Senate,,DEM,Kamala D. Harris,31
+Fresno,383,U.S. Senate,,DEM,Loretta L. Sanchez,45
+Fresno,384,U.S. Senate,,DEM,Kamala D. Harris,78
+Fresno,384,U.S. Senate,,DEM,Loretta L. Sanchez,69
+Fresno,385,U.S. Senate,,DEM,Kamala D. Harris,196
+Fresno,385,U.S. Senate,,DEM,Loretta L. Sanchez,243
+Fresno,386,U.S. Senate,,DEM,Kamala D. Harris,263
+Fresno,386,U.S. Senate,,DEM,Loretta L. Sanchez,344
+Fresno,387,U.S. Senate,,DEM,Kamala D. Harris,221
+Fresno,387,U.S. Senate,,DEM,Loretta L. Sanchez,244
+Fresno,388,U.S. Senate,,DEM,Kamala D. Harris,277
+Fresno,388,U.S. Senate,,DEM,Loretta L. Sanchez,300
+Fresno,389,U.S. Senate,,DEM,Kamala D. Harris,252
+Fresno,389,U.S. Senate,,DEM,Loretta L. Sanchez,322
+Fresno,39,U.S. Senate,,DEM,Kamala D. Harris,140
+Fresno,39,U.S. Senate,,DEM,Loretta L. Sanchez,353
+Fresno,390,U.S. Senate,,DEM,Kamala D. Harris,328
+Fresno,390,U.S. Senate,,DEM,Loretta L. Sanchez,394
+Fresno,391,U.S. Senate,,DEM,Kamala D. Harris,270
+Fresno,391,U.S. Senate,,DEM,Loretta L. Sanchez,414
+Fresno,392,U.S. Senate,,DEM,Kamala D. Harris,140
+Fresno,392,U.S. Senate,,DEM,Loretta L. Sanchez,247
+Fresno,393,U.S. Senate,,DEM,Kamala D. Harris,144
+Fresno,393,U.S. Senate,,DEM,Loretta L. Sanchez,402
+Fresno,394,U.S. Senate,,DEM,Kamala D. Harris,143
+Fresno,394,U.S. Senate,,DEM,Loretta L. Sanchez,167
+Fresno,395,U.S. Senate,,DEM,Kamala D. Harris,210
+Fresno,395,U.S. Senate,,DEM,Loretta L. Sanchez,214
+Fresno,396,U.S. Senate,,DEM,Kamala D. Harris,277
+Fresno,396,U.S. Senate,,DEM,Loretta L. Sanchez,318
+Fresno,397,U.S. Senate,,DEM,Kamala D. Harris,213
+Fresno,397,U.S. Senate,,DEM,Loretta L. Sanchez,226
+Fresno,398,U.S. Senate,,DEM,Kamala D. Harris,489
+Fresno,398,U.S. Senate,,DEM,Loretta L. Sanchez,397
+Fresno,399,U.S. Senate,,DEM,Kamala D. Harris,138
+Fresno,399,U.S. Senate,,DEM,Loretta L. Sanchez,462
+Fresno,4,U.S. Senate,,DEM,Kamala D. Harris,241
+Fresno,4,U.S. Senate,,DEM,Loretta L. Sanchez,166
+Fresno,40,U.S. Senate,,DEM,Kamala D. Harris,238
+Fresno,40,U.S. Senate,,DEM,Loretta L. Sanchez,463
+Fresno,400,U.S. Senate,,DEM,Kamala D. Harris,136
+Fresno,400,U.S. Senate,,DEM,Loretta L. Sanchez,366
+Fresno,401,U.S. Senate,,DEM,Kamala D. Harris,212
+Fresno,401,U.S. Senate,,DEM,Loretta L. Sanchez,512
+Fresno,402,U.S. Senate,,DEM,Kamala D. Harris,229
+Fresno,402,U.S. Senate,,DEM,Loretta L. Sanchez,446
+Fresno,403,U.S. Senate,,DEM,Kamala D. Harris,167
+Fresno,403,U.S. Senate,,DEM,Loretta L. Sanchez,468
+Fresno,404,U.S. Senate,,DEM,Kamala D. Harris,98
+Fresno,404,U.S. Senate,,DEM,Loretta L. Sanchez,99
+Fresno,405,U.S. Senate,,DEM,Kamala D. Harris,208
+Fresno,405,U.S. Senate,,DEM,Loretta L. Sanchez,233
+Fresno,406,U.S. Senate,,DEM,Kamala D. Harris,148
+Fresno,406,U.S. Senate,,DEM,Loretta L. Sanchez,213
+Fresno,407,U.S. Senate,,DEM,Kamala D. Harris,107
+Fresno,407,U.S. Senate,,DEM,Loretta L. Sanchez,116
+Fresno,408,U.S. Senate,,DEM,Kamala D. Harris,109
+Fresno,408,U.S. Senate,,DEM,Loretta L. Sanchez,166
+Fresno,409,U.S. Senate,,DEM,Kamala D. Harris,123
+Fresno,409,U.S. Senate,,DEM,Loretta L. Sanchez,148
+Fresno,41,U.S. Senate,,DEM,Kamala D. Harris,227
+Fresno,41,U.S. Senate,,DEM,Loretta L. Sanchez,468
+Fresno,410,U.S. Senate,,DEM,Kamala D. Harris,107
+Fresno,410,U.S. Senate,,DEM,Loretta L. Sanchez,152
+Fresno,411,U.S. Senate,,DEM,Kamala D. Harris,83
+Fresno,411,U.S. Senate,,DEM,Loretta L. Sanchez,68
+Fresno,42,U.S. Senate,,DEM,Kamala D. Harris,183
+Fresno,42,U.S. Senate,,DEM,Loretta L. Sanchez,171
+Fresno,43,U.S. Senate,,DEM,Kamala D. Harris,154
+Fresno,43,U.S. Senate,,DEM,Loretta L. Sanchez,187
+Fresno,44,U.S. Senate,,DEM,Kamala D. Harris,49
+Fresno,44,U.S. Senate,,DEM,Loretta L. Sanchez,81
+Fresno,45,U.S. Senate,,DEM,Kamala D. Harris,128
+Fresno,45,U.S. Senate,,DEM,Loretta L. Sanchez,160
+Fresno,46,U.S. Senate,,DEM,Kamala D. Harris,161
+Fresno,46,U.S. Senate,,DEM,Loretta L. Sanchez,366
+Fresno,47,U.S. Senate,,DEM,Kamala D. Harris,162
+Fresno,47,U.S. Senate,,DEM,Loretta L. Sanchez,251
+Fresno,48,U.S. Senate,,DEM,Kamala D. Harris,243
+Fresno,48,U.S. Senate,,DEM,Loretta L. Sanchez,311
+Fresno,49,U.S. Senate,,DEM,Kamala D. Harris,268
+Fresno,49,U.S. Senate,,DEM,Loretta L. Sanchez,321
+Fresno,5,U.S. Senate,,DEM,Kamala D. Harris,287
+Fresno,5,U.S. Senate,,DEM,Loretta L. Sanchez,236
+Fresno,50,U.S. Senate,,DEM,Kamala D. Harris,78
+Fresno,50,U.S. Senate,,DEM,Loretta L. Sanchez,85
+Fresno,51,U.S. Senate,,DEM,Kamala D. Harris,198
+Fresno,51,U.S. Senate,,DEM,Loretta L. Sanchez,232
+Fresno,52,U.S. Senate,,DEM,Kamala D. Harris,323
+Fresno,52,U.S. Senate,,DEM,Loretta L. Sanchez,456
+Fresno,53,U.S. Senate,,DEM,Kamala D. Harris,79
+Fresno,53,U.S. Senate,,DEM,Loretta L. Sanchez,83
+Fresno,54,U.S. Senate,,DEM,Kamala D. Harris,92
+Fresno,54,U.S. Senate,,DEM,Loretta L. Sanchez,97
+Fresno,55,U.S. Senate,,DEM,Kamala D. Harris,287
+Fresno,55,U.S. Senate,,DEM,Loretta L. Sanchez,322
+Fresno,56,U.S. Senate,,DEM,Kamala D. Harris,162
+Fresno,56,U.S. Senate,,DEM,Loretta L. Sanchez,432
+Fresno,57,U.S. Senate,,DEM,Kamala D. Harris,97
+Fresno,57,U.S. Senate,,DEM,Loretta L. Sanchez,213
+Fresno,58,U.S. Senate,,DEM,Kamala D. Harris,261
+Fresno,58,U.S. Senate,,DEM,Loretta L. Sanchez,440
+Fresno,59,U.S. Senate,,DEM,Kamala D. Harris,69
+Fresno,59,U.S. Senate,,DEM,Loretta L. Sanchez,90
+Fresno,6,U.S. Senate,,DEM,Kamala D. Harris,425
+Fresno,6,U.S. Senate,,DEM,Loretta L. Sanchez,260
+Fresno,60,U.S. Senate,,DEM,Kamala D. Harris,350
+Fresno,60,U.S. Senate,,DEM,Loretta L. Sanchez,348
+Fresno,61,U.S. Senate,,DEM,Kamala D. Harris,211
+Fresno,61,U.S. Senate,,DEM,Loretta L. Sanchez,207
+Fresno,62,U.S. Senate,,DEM,Kamala D. Harris,226
+Fresno,62,U.S. Senate,,DEM,Loretta L. Sanchez,246
+Fresno,63,U.S. Senate,,DEM,Kamala D. Harris,439
+Fresno,63,U.S. Senate,,DEM,Loretta L. Sanchez,374
+Fresno,64,U.S. Senate,,DEM,Kamala D. Harris,140
+Fresno,64,U.S. Senate,,DEM,Loretta L. Sanchez,100
+Fresno,65,U.S. Senate,,DEM,Kamala D. Harris,440
+Fresno,65,U.S. Senate,,DEM,Loretta L. Sanchez,384
+Fresno,66,U.S. Senate,,DEM,Kamala D. Harris,745
+Fresno,66,U.S. Senate,,DEM,Loretta L. Sanchez,548
+Fresno,67,U.S. Senate,,DEM,Kamala D. Harris,93
+Fresno,67,U.S. Senate,,DEM,Loretta L. Sanchez,89
+Fresno,68,U.S. Senate,,DEM,Kamala D. Harris,97
+Fresno,68,U.S. Senate,,DEM,Loretta L. Sanchez,72
+Fresno,69,U.S. Senate,,DEM,Kamala D. Harris,269
+Fresno,69,U.S. Senate,,DEM,Loretta L. Sanchez,210
+Fresno,7,U.S. Senate,,DEM,Kamala D. Harris,145
+Fresno,7,U.S. Senate,,DEM,Loretta L. Sanchez,198
+Fresno,70,U.S. Senate,,DEM,Kamala D. Harris,139
+Fresno,70,U.S. Senate,,DEM,Loretta L. Sanchez,111
+Fresno,71,U.S. Senate,,DEM,Kamala D. Harris,197
+Fresno,71,U.S. Senate,,DEM,Loretta L. Sanchez,185
+Fresno,72,U.S. Senate,,DEM,Kamala D. Harris,186
+Fresno,72,U.S. Senate,,DEM,Loretta L. Sanchez,183
+Fresno,73,U.S. Senate,,DEM,Kamala D. Harris,246
+Fresno,73,U.S. Senate,,DEM,Loretta L. Sanchez,225
+Fresno,74,U.S. Senate,,DEM,Kamala D. Harris,237
+Fresno,74,U.S. Senate,,DEM,Loretta L. Sanchez,257
+Fresno,75,U.S. Senate,,DEM,Kamala D. Harris,248
+Fresno,75,U.S. Senate,,DEM,Loretta L. Sanchez,198
+Fresno,76,U.S. Senate,,DEM,Kamala D. Harris,262
+Fresno,76,U.S. Senate,,DEM,Loretta L. Sanchez,322
+Fresno,77,U.S. Senate,,DEM,Kamala D. Harris,114
+Fresno,77,U.S. Senate,,DEM,Loretta L. Sanchez,138
+Fresno,78,U.S. Senate,,DEM,Kamala D. Harris,242
+Fresno,78,U.S. Senate,,DEM,Loretta L. Sanchez,256
+Fresno,79,U.S. Senate,,DEM,Kamala D. Harris,235
+Fresno,79,U.S. Senate,,DEM,Loretta L. Sanchez,245
+Fresno,8,U.S. Senate,,DEM,Kamala D. Harris,346
+Fresno,8,U.S. Senate,,DEM,Loretta L. Sanchez,343
+Fresno,80,U.S. Senate,,DEM,Kamala D. Harris,202
+Fresno,80,U.S. Senate,,DEM,Loretta L. Sanchez,211
+Fresno,81,U.S. Senate,,DEM,Kamala D. Harris,249
+Fresno,81,U.S. Senate,,DEM,Loretta L. Sanchez,246
+Fresno,82,U.S. Senate,,DEM,Kamala D. Harris,299
+Fresno,82,U.S. Senate,,DEM,Loretta L. Sanchez,320
+Fresno,83,U.S. Senate,,DEM,Kamala D. Harris,244
+Fresno,83,U.S. Senate,,DEM,Loretta L. Sanchez,221
+Fresno,84,U.S. Senate,,DEM,Kamala D. Harris,347
+Fresno,84,U.S. Senate,,DEM,Loretta L. Sanchez,324
+Fresno,85,U.S. Senate,,DEM,Kamala D. Harris,124
+Fresno,85,U.S. Senate,,DEM,Loretta L. Sanchez,98
+Fresno,86,U.S. Senate,,DEM,Kamala D. Harris,265
+Fresno,86,U.S. Senate,,DEM,Loretta L. Sanchez,230
+Fresno,87,U.S. Senate,,DEM,Kamala D. Harris,276
+Fresno,87,U.S. Senate,,DEM,Loretta L. Sanchez,234
+Fresno,88,U.S. Senate,,DEM,Kamala D. Harris,218
+Fresno,88,U.S. Senate,,DEM,Loretta L. Sanchez,235
+Fresno,89,U.S. Senate,,DEM,Kamala D. Harris,403
+Fresno,89,U.S. Senate,,DEM,Loretta L. Sanchez,377
+Fresno,9,U.S. Senate,,DEM,Kamala D. Harris,153
+Fresno,9,U.S. Senate,,DEM,Loretta L. Sanchez,149
+Fresno,90,U.S. Senate,,DEM,Kamala D. Harris,272
+Fresno,90,U.S. Senate,,DEM,Loretta L. Sanchez,243
+Fresno,91,U.S. Senate,,DEM,Kamala D. Harris,364
+Fresno,91,U.S. Senate,,DEM,Loretta L. Sanchez,265
+Fresno,92,U.S. Senate,,DEM,Kamala D. Harris,225
+Fresno,92,U.S. Senate,,DEM,Loretta L. Sanchez,250
+Fresno,93,U.S. Senate,,DEM,Kamala D. Harris,259
+Fresno,93,U.S. Senate,,DEM,Loretta L. Sanchez,232
+Fresno,94,U.S. Senate,,DEM,Kamala D. Harris,272
+Fresno,94,U.S. Senate,,DEM,Loretta L. Sanchez,198
+Fresno,95,U.S. Senate,,DEM,Kamala D. Harris,285
+Fresno,95,U.S. Senate,,DEM,Loretta L. Sanchez,349
+Fresno,96,U.S. Senate,,DEM,Kamala D. Harris,94
+Fresno,96,U.S. Senate,,DEM,Loretta L. Sanchez,115
+Fresno,97,U.S. Senate,,DEM,Kamala D. Harris,197
+Fresno,97,U.S. Senate,,DEM,Loretta L. Sanchez,272
+Fresno,98,U.S. Senate,,DEM,Kamala D. Harris,164
+Fresno,98,U.S. Senate,,DEM,Loretta L. Sanchez,261
+Fresno,99,U.S. Senate,,DEM,Kamala D. Harris,164
+Fresno,99,U.S. Senate,,DEM,Loretta L. Sanchez,308

--- a/2016/20161108__ca__general__glenn__precinct.csv
+++ b/2016/20161108__ca__general__glenn__precinct.csv
@@ -1359,71 +1359,71 @@ Glenn,8,Proposition 67,,N/A,Yes,212
 Glenn,8,Proposition 67,,N/A,No,364
 Glenn,9,Proposition 67,,N/A,Yes,175
 Glenn,9,Proposition 67,,N/A,No,342
-Glenn,1,U.S. Senate,,DEM,Kamala Harris,253
-Glenn,1,U.S. Senate,,DEM,Loretta Sanchez,272
-Glenn,10,U.S. Senate,,DEM,Kamala Harris,160
-Glenn,10,U.S. Senate,,DEM,Loretta Sanchez,312
-Glenn,10031,U.S. Senate,,DEM,Kamala Harris,27
-Glenn,10031,U.S. Senate,,DEM,Loretta Sanchez,55
-Glenn,10050,U.S. Senate,,DEM,Kamala Harris,20
-Glenn,10050,U.S. Senate,,DEM,Loretta Sanchez,23
-Glenn,10060,U.S. Senate,,DEM,Kamala Harris,38
-Glenn,10060,U.S. Senate,,DEM,Loretta Sanchez,42
-Glenn,12150,U.S. Senate,,DEM,Kamala Harris,88
-Glenn,12150,U.S. Senate,,DEM,Loretta Sanchez,129
-Glenn,2,U.S. Senate,,DEM,Kamala Harris,288
-Glenn,2,U.S. Senate,,DEM,Loretta Sanchez,292
-Glenn,3,U.S. Senate,,DEM,Kamala Harris,222
-Glenn,3,U.S. Senate,,DEM,Loretta Sanchez,257
-Glenn,30011,U.S. Senate,,DEM,Kamala Harris,55
-Glenn,30011,U.S. Senate,,DEM,Loretta Sanchez,40
-Glenn,30014,U.S. Senate,,DEM,Kamala Harris,26
-Glenn,30014,U.S. Senate,,DEM,Loretta Sanchez,21
-Glenn,30020,U.S. Senate,,DEM,Kamala Harris,81
-Glenn,30020,U.S. Senate,,DEM,Loretta Sanchez,89
-Glenn,30042,U.S. Senate,,DEM,Kamala Harris,91
-Glenn,30042,U.S. Senate,,DEM,Loretta Sanchez,67
-Glenn,30070,U.S. Senate,,DEM,Kamala Harris,57
-Glenn,30070,U.S. Senate,,DEM,Loretta Sanchez,71
-Glenn,30072,U.S. Senate,,DEM,Kamala Harris,24
-Glenn,30072,U.S. Senate,,DEM,Loretta Sanchez,29
-Glenn,30081,U.S. Senate,,DEM,Kamala Harris,56
-Glenn,30081,U.S. Senate,,DEM,Loretta Sanchez,87
-Glenn,30082,U.S. Senate,,DEM,Kamala Harris,26
-Glenn,30082,U.S. Senate,,DEM,Loretta Sanchez,29
-Glenn,30120,U.S. Senate,,DEM,Kamala Harris,75
-Glenn,30120,U.S. Senate,,DEM,Loretta Sanchez,49
-Glenn,31070,U.S. Senate,,DEM,Kamala Harris,80
-Glenn,31070,U.S. Senate,,DEM,Loretta Sanchez,60
-Glenn,4,U.S. Senate,,DEM,Kamala Harris,220
-Glenn,4,U.S. Senate,,DEM,Loretta Sanchez,284
-Glenn,5,U.S. Senate,,DEM,Kamala Harris,244
-Glenn,5,U.S. Senate,,DEM,Loretta Sanchez,276
-Glenn,50010,U.S. Senate,,DEM,Kamala Harris,15
-Glenn,50010,U.S. Senate,,DEM,Loretta Sanchez,34
-Glenn,50022,U.S. Senate,,DEM,Kamala Harris,64
-Glenn,50022,U.S. Senate,,DEM,Loretta Sanchez,39
-Glenn,50030,U.S. Senate,,DEM,Kamala Harris,41
-Glenn,50030,U.S. Senate,,DEM,Loretta Sanchez,55
-Glenn,50052,U.S. Senate,,DEM,Kamala Harris,52
-Glenn,50052,U.S. Senate,,DEM,Loretta Sanchez,42
-Glenn,50061,U.S. Senate,,DEM,Kamala Harris,92
-Glenn,50061,U.S. Senate,,DEM,Loretta Sanchez,94
-Glenn,50081,U.S. Senate,,DEM,Kamala Harris,9
-Glenn,50081,U.S. Senate,,DEM,Loretta Sanchez,7
-Glenn,50082,U.S. Senate,,DEM,Kamala Harris,60
-Glenn,50082,U.S. Senate,,DEM,Loretta Sanchez,45
-Glenn,50083,U.S. Senate,,DEM,Kamala Harris,37
-Glenn,50083,U.S. Senate,,DEM,Loretta Sanchez,35
-Glenn,50084,U.S. Senate,,DEM,Kamala Harris,54
-Glenn,50084,U.S. Senate,,DEM,Loretta Sanchez,55
-Glenn,50085,U.S. Senate,,DEM,Kamala Harris,7
-Glenn,50085,U.S. Senate,,DEM,Loretta Sanchez,8
-Glenn,6,U.S. Senate,,DEM,Kamala Harris,193
-Glenn,6,U.S. Senate,,DEM,Loretta Sanchez,207
-Glenn,7,U.S. Senate,,DEM,Kamala Harris,222
-Glenn,7,U.S. Senate,,DEM,Loretta Sanchez,227
-Glenn,8,U.S. Senate,,DEM,Kamala Harris,226
-Glenn,8,U.S. Senate,,DEM,Loretta Sanchez,243
-Glenn,9,U.S. Senate,,DEM,Kamala Harris,220
-Glenn,9,U.S. Senate,,DEM,Loretta Sanchez,218
+Glenn,1,U.S. Senate,,DEM,Kamala D. Harris,253
+Glenn,1,U.S. Senate,,DEM,Loretta L. Sanchez,272
+Glenn,10,U.S. Senate,,DEM,Kamala D. Harris,160
+Glenn,10,U.S. Senate,,DEM,Loretta L. Sanchez,312
+Glenn,10031,U.S. Senate,,DEM,Kamala D. Harris,27
+Glenn,10031,U.S. Senate,,DEM,Loretta L. Sanchez,55
+Glenn,10050,U.S. Senate,,DEM,Kamala D. Harris,20
+Glenn,10050,U.S. Senate,,DEM,Loretta L. Sanchez,23
+Glenn,10060,U.S. Senate,,DEM,Kamala D. Harris,38
+Glenn,10060,U.S. Senate,,DEM,Loretta L. Sanchez,42
+Glenn,12150,U.S. Senate,,DEM,Kamala D. Harris,88
+Glenn,12150,U.S. Senate,,DEM,Loretta L. Sanchez,129
+Glenn,2,U.S. Senate,,DEM,Kamala D. Harris,288
+Glenn,2,U.S. Senate,,DEM,Loretta L. Sanchez,292
+Glenn,3,U.S. Senate,,DEM,Kamala D. Harris,222
+Glenn,3,U.S. Senate,,DEM,Loretta L. Sanchez,257
+Glenn,30011,U.S. Senate,,DEM,Kamala D. Harris,55
+Glenn,30011,U.S. Senate,,DEM,Loretta L. Sanchez,40
+Glenn,30014,U.S. Senate,,DEM,Kamala D. Harris,26
+Glenn,30014,U.S. Senate,,DEM,Loretta L. Sanchez,21
+Glenn,30020,U.S. Senate,,DEM,Kamala D. Harris,81
+Glenn,30020,U.S. Senate,,DEM,Loretta L. Sanchez,89
+Glenn,30042,U.S. Senate,,DEM,Kamala D. Harris,91
+Glenn,30042,U.S. Senate,,DEM,Loretta L. Sanchez,67
+Glenn,30070,U.S. Senate,,DEM,Kamala D. Harris,57
+Glenn,30070,U.S. Senate,,DEM,Loretta L. Sanchez,71
+Glenn,30072,U.S. Senate,,DEM,Kamala D. Harris,24
+Glenn,30072,U.S. Senate,,DEM,Loretta L. Sanchez,29
+Glenn,30081,U.S. Senate,,DEM,Kamala D. Harris,56
+Glenn,30081,U.S. Senate,,DEM,Loretta L. Sanchez,87
+Glenn,30082,U.S. Senate,,DEM,Kamala D. Harris,26
+Glenn,30082,U.S. Senate,,DEM,Loretta L. Sanchez,29
+Glenn,30120,U.S. Senate,,DEM,Kamala D. Harris,75
+Glenn,30120,U.S. Senate,,DEM,Loretta L. Sanchez,49
+Glenn,31070,U.S. Senate,,DEM,Kamala D. Harris,80
+Glenn,31070,U.S. Senate,,DEM,Loretta L. Sanchez,60
+Glenn,4,U.S. Senate,,DEM,Kamala D. Harris,220
+Glenn,4,U.S. Senate,,DEM,Loretta L. Sanchez,284
+Glenn,5,U.S. Senate,,DEM,Kamala D. Harris,244
+Glenn,5,U.S. Senate,,DEM,Loretta L. Sanchez,276
+Glenn,50010,U.S. Senate,,DEM,Kamala D. Harris,15
+Glenn,50010,U.S. Senate,,DEM,Loretta L. Sanchez,34
+Glenn,50022,U.S. Senate,,DEM,Kamala D. Harris,64
+Glenn,50022,U.S. Senate,,DEM,Loretta L. Sanchez,39
+Glenn,50030,U.S. Senate,,DEM,Kamala D. Harris,41
+Glenn,50030,U.S. Senate,,DEM,Loretta L. Sanchez,55
+Glenn,50052,U.S. Senate,,DEM,Kamala D. Harris,52
+Glenn,50052,U.S. Senate,,DEM,Loretta L. Sanchez,42
+Glenn,50061,U.S. Senate,,DEM,Kamala D. Harris,92
+Glenn,50061,U.S. Senate,,DEM,Loretta L. Sanchez,94
+Glenn,50081,U.S. Senate,,DEM,Kamala D. Harris,9
+Glenn,50081,U.S. Senate,,DEM,Loretta L. Sanchez,7
+Glenn,50082,U.S. Senate,,DEM,Kamala D. Harris,60
+Glenn,50082,U.S. Senate,,DEM,Loretta L. Sanchez,45
+Glenn,50083,U.S. Senate,,DEM,Kamala D. Harris,37
+Glenn,50083,U.S. Senate,,DEM,Loretta L. Sanchez,35
+Glenn,50084,U.S. Senate,,DEM,Kamala D. Harris,54
+Glenn,50084,U.S. Senate,,DEM,Loretta L. Sanchez,55
+Glenn,50085,U.S. Senate,,DEM,Kamala D. Harris,7
+Glenn,50085,U.S. Senate,,DEM,Loretta L. Sanchez,8
+Glenn,6,U.S. Senate,,DEM,Kamala D. Harris,193
+Glenn,6,U.S. Senate,,DEM,Loretta L. Sanchez,207
+Glenn,7,U.S. Senate,,DEM,Kamala D. Harris,222
+Glenn,7,U.S. Senate,,DEM,Loretta L. Sanchez,227
+Glenn,8,U.S. Senate,,DEM,Kamala D. Harris,226
+Glenn,8,U.S. Senate,,DEM,Loretta L. Sanchez,243
+Glenn,9,U.S. Senate,,DEM,Kamala D. Harris,220
+Glenn,9,U.S. Senate,,DEM,Loretta L. Sanchez,218

--- a/2016/20161108__ca__general__humboldt__precinct.csv
+++ b/2016/20161108__ca__general__humboldt__precinct.csv
@@ -5079,257 +5079,257 @@ Humboldt,5TU-1,Proposition 67,,N/A,Yes,478
 Humboldt,5TU-1,Proposition 67,,N/A,No,195
 Humboldt,5TU-4,Proposition 67,,N/A,Yes,455
 Humboldt,5TU-4,Proposition 67,,N/A,No,130
-Humboldt,1CS-1,U.S. Senate,,DEM,Kamala Harris,323
-Humboldt,1CS-1,U.S. Senate,,DEM,Loretta Sanchez,161
-Humboldt,1CS-2,U.S. Senate,,DEM,Kamala Harris,349
-Humboldt,1CS-2,U.S. Senate,,DEM,Loretta Sanchez,170
-Humboldt,1CS-3,U.S. Senate,,DEM,Kamala Harris,330
-Humboldt,1CS-3,U.S. Senate,,DEM,Loretta Sanchez,170
-Humboldt,1CS-4,U.S. Senate,,DEM,Kamala Harris,361
-Humboldt,1CS-4,U.S. Senate,,DEM,Loretta Sanchez,186
-Humboldt,1.00E-36,U.S. Senate,,DEM,Kamala Harris,418
-Humboldt,1.00E-36,U.S. Senate,,DEM,Loretta Sanchez,178
-Humboldt,1.00E-43,U.S. Senate,,DEM,Kamala Harris,387
-Humboldt,1.00E-43,U.S. Senate,,DEM,Loretta Sanchez,149
-Humboldt,1.00E-45,U.S. Senate,,DEM,Kamala Harris,369
-Humboldt,1.00E-45,U.S. Senate,,DEM,Loretta Sanchez,156
-Humboldt,1.00E-55,U.S. Senate,,DEM,Kamala Harris,272
-Humboldt,1.00E-55,U.S. Senate,,DEM,Loretta Sanchez,135
-Humboldt,1.00E-59,U.S. Senate,,DEM,Kamala Harris,0
-Humboldt,1.00E-59,U.S. Senate,,DEM,Loretta Sanchez,1
-Humboldt,1ES-1,U.S. Senate,,DEM,Kamala Harris,486
-Humboldt,1ES-1,U.S. Senate,,DEM,Loretta Sanchez,242
-Humboldt,1F--1,U.S. Senate,,DEM,Kamala Harris,424
-Humboldt,1F--1,U.S. Senate,,DEM,Loretta Sanchez,222
-Humboldt,1F--7,U.S. Senate,,DEM,Kamala Harris,9
-Humboldt,1F--7,U.S. Senate,,DEM,Loretta Sanchez,4
-Humboldt,1FS,U.S. Senate,,DEM,Kamala Harris,282
-Humboldt,1FS,U.S. Senate,,DEM,Loretta Sanchez,188
-Humboldt,1FS-1,U.S. Senate,,DEM,Kamala Harris,60
-Humboldt,1FS-1,U.S. Senate,,DEM,Loretta Sanchez,37
-Humboldt,1FS-4,U.S. Senate,,DEM,Kamala Harris,74
-Humboldt,1FS-4,U.S. Senate,,DEM,Loretta Sanchez,55
-Humboldt,1FS-9,U.S. Senate,,DEM,Kamala Harris,63
-Humboldt,1FS-9,U.S. Senate,,DEM,Loretta Sanchez,37
-Humboldt,1LU,U.S. Senate,,DEM,Kamala Harris,299
-Humboldt,1LU,U.S. Senate,,DEM,Loretta Sanchez,167
-Humboldt,1MU,U.S. Senate,,DEM,Kamala Harris,87
-Humboldt,1MU,U.S. Senate,,DEM,Loretta Sanchez,40
-Humboldt,1MUF,U.S. Senate,,DEM,Kamala Harris,85
-Humboldt,1MUF,U.S. Senate,,DEM,Loretta Sanchez,37
-Humboldt,1RV-2,U.S. Senate,,DEM,Kamala Harris,54
-Humboldt,1RV-2,U.S. Senate,,DEM,Loretta Sanchez,23
-Humboldt,1SB-1,U.S. Senate,,DEM,Kamala Harris,496
-Humboldt,1SB-1,U.S. Senate,,DEM,Loretta Sanchez,317
-Humboldt,1SB-4,U.S. Senate,,DEM,Kamala Harris,460
-Humboldt,1SB-4,U.S. Senate,,DEM,Loretta Sanchez,269
-Humboldt,1SB10,U.S. Senate,,DEM,Kamala Harris,438
-Humboldt,1SB10,U.S. Senate,,DEM,Loretta Sanchez,220
-Humboldt,1SB12,U.S. Senate,,DEM,Kamala Harris,76
-Humboldt,1SB12,U.S. Senate,,DEM,Loretta Sanchez,49
-Humboldt,1SU,U.S. Senate,,DEM,Kamala Harris,174
-Humboldt,1SU,U.S. Senate,,DEM,Loretta Sanchez,109
-Humboldt,2BV-1,U.S. Senate,,DEM,Kamala Harris,111
-Humboldt,2BV-1,U.S. Senate,,DEM,Loretta Sanchez,73
-Humboldt,2CU,U.S. Senate,,DEM,Kamala Harris,179
-Humboldt,2CU,U.S. Senate,,DEM,Loretta Sanchez,100
-Humboldt,2F--2,U.S. Senate,,DEM,Kamala Harris,371
-Humboldt,2F--2,U.S. Senate,,DEM,Loretta Sanchez,229
-Humboldt,2F--3,U.S. Senate,,DEM,Kamala Harris,272
-Humboldt,2F--3,U.S. Senate,,DEM,Loretta Sanchez,148
-Humboldt,2F--4,U.S. Senate,,DEM,Kamala Harris,353
-Humboldt,2F--4,U.S. Senate,,DEM,Loretta Sanchez,206
-Humboldt,2F-R1,U.S. Senate,,DEM,Kamala Harris,404
-Humboldt,2F-R1,U.S. Senate,,DEM,Loretta Sanchez,266
-Humboldt,2F-R2,U.S. Senate,,DEM,Kamala Harris,295
-Humboldt,2F-R2,U.S. Senate,,DEM,Loretta Sanchez,204
-Humboldt,2F-R3,U.S. Senate,,DEM,Kamala Harris,272
-Humboldt,2F-R3,U.S. Senate,,DEM,Loretta Sanchez,196
-Humboldt,2F-R4,U.S. Senate,,DEM,Kamala Harris,279
-Humboldt,2F-R4,U.S. Senate,,DEM,Loretta Sanchez,171
-Humboldt,2HV-1,U.S. Senate,,DEM,Kamala Harris,303
-Humboldt,2HV-1,U.S. Senate,,DEM,Loretta Sanchez,175
-Humboldt,2MR,U.S. Senate,,DEM,Kamala Harris,10
-Humboldt,2MR,U.S. Senate,,DEM,Loretta Sanchez,9
-Humboldt,2R--1,U.S. Senate,,DEM,Kamala Harris,235
-Humboldt,2R--1,U.S. Senate,,DEM,Loretta Sanchez,175
-Humboldt,2R--2,U.S. Senate,,DEM,Kamala Harris,254
-Humboldt,2R--2,U.S. Senate,,DEM,Loretta Sanchez,195
-Humboldt,2RV-1,U.S. Senate,,DEM,Kamala Harris,109
-Humboldt,2RV-1,U.S. Senate,,DEM,Loretta Sanchez,62
-Humboldt,2SH-1,U.S. Senate,,DEM,Kamala Harris,110
-Humboldt,2SH-1,U.S. Senate,,DEM,Loretta Sanchez,28
-Humboldt,2SH-2,U.S. Senate,,DEM,Kamala Harris,44
-Humboldt,2SH-2,U.S. Senate,,DEM,Loretta Sanchez,24
-Humboldt,2SH-3,U.S. Senate,,DEM,Kamala Harris,51
-Humboldt,2SH-3,U.S. Senate,,DEM,Loretta Sanchez,33
-Humboldt,2SH-4,U.S. Senate,,DEM,Kamala Harris,341
-Humboldt,2SH-4,U.S. Senate,,DEM,Loretta Sanchez,118
-Humboldt,2SH-5,U.S. Senate,,DEM,Kamala Harris,439
-Humboldt,2SH-5,U.S. Senate,,DEM,Loretta Sanchez,202
-Humboldt,2SH-7,U.S. Senate,,DEM,Kamala Harris,27
-Humboldt,2SH-7,U.S. Senate,,DEM,Loretta Sanchez,14
-Humboldt,2SH-8,U.S. Senate,,DEM,Kamala Harris,63
-Humboldt,2SH-8,U.S. Senate,,DEM,Loretta Sanchez,40
-Humboldt,2SHF1,U.S. Senate,,DEM,Kamala Harris,80
-Humboldt,2SHF1,U.S. Senate,,DEM,Loretta Sanchez,38
-Humboldt,2SHR1,U.S. Senate,,DEM,Kamala Harris,90
-Humboldt,2SHR1,U.S. Senate,,DEM,Loretta Sanchez,41
-Humboldt,2SHR2,U.S. Senate,,DEM,Kamala Harris,55
-Humboldt,2SHR2,U.S. Senate,,DEM,Loretta Sanchez,53
-Humboldt,2SHS4,U.S. Senate,,DEM,Kamala Harris,265
-Humboldt,2SHS4,U.S. Senate,,DEM,Loretta Sanchez,134
-Humboldt,2SHS7,U.S. Senate,,DEM,Kamala Harris,459
-Humboldt,2SHS7,U.S. Senate,,DEM,Loretta Sanchez,229
-Humboldt,2SHVF,U.S. Senate,,DEM,Kamala Harris,65
-Humboldt,2SHVF,U.S. Senate,,DEM,Loretta Sanchez,23
-Humboldt,3A--1,U.S. Senate,,DEM,Kamala Harris,231
-Humboldt,3A--1,U.S. Senate,,DEM,Loretta Sanchez,114
-Humboldt,3A--2,U.S. Senate,,DEM,Kamala Harris,398
-Humboldt,3A--2,U.S. Senate,,DEM,Loretta Sanchez,148
-Humboldt,3A--3,U.S. Senate,,DEM,Kamala Harris,458
-Humboldt,3A--3,U.S. Senate,,DEM,Loretta Sanchez,168
-Humboldt,3A--4,U.S. Senate,,DEM,Kamala Harris,355
-Humboldt,3A--4,U.S. Senate,,DEM,Loretta Sanchez,152
-Humboldt,3A--7,U.S. Senate,,DEM,Kamala Harris,352
-Humboldt,3A--7,U.S. Senate,,DEM,Loretta Sanchez,144
-Humboldt,3A--9,U.S. Senate,,DEM,Kamala Harris,461
-Humboldt,3A--9,U.S. Senate,,DEM,Loretta Sanchez,184
-Humboldt,3A-10,U.S. Senate,,DEM,Kamala Harris,445
-Humboldt,3A-10,U.S. Senate,,DEM,Loretta Sanchez,256
-Humboldt,3A-11,U.S. Senate,,DEM,Kamala Harris,491
-Humboldt,3A-11,U.S. Senate,,DEM,Loretta Sanchez,231
-Humboldt,3A-12,U.S. Senate,,DEM,Kamala Harris,226
-Humboldt,3A-12,U.S. Senate,,DEM,Loretta Sanchez,182
-Humboldt,3A-13,U.S. Senate,,DEM,Kamala Harris,522
-Humboldt,3A-13,U.S. Senate,,DEM,Loretta Sanchez,241
-Humboldt,3A-J1,U.S. Senate,,DEM,Kamala Harris,409
-Humboldt,3A-J1,U.S. Senate,,DEM,Loretta Sanchez,107
-Humboldt,3A-P2,U.S. Senate,,DEM,Kamala Harris,463
-Humboldt,3A-P2,U.S. Senate,,DEM,Loretta Sanchez,205
-Humboldt,3A-P4,U.S. Senate,,DEM,Kamala Harris,460
-Humboldt,3A-P4,U.S. Senate,,DEM,Loretta Sanchez,234
-Humboldt,3AS-1,U.S. Senate,,DEM,Kamala Harris,82
-Humboldt,3AS-1,U.S. Senate,,DEM,Loretta Sanchez,27
-Humboldt,3AS-9,U.S. Senate,,DEM,Kamala Harris,55
-Humboldt,3AS-9,U.S. Senate,,DEM,Loretta Sanchez,27
-Humboldt,3B--1,U.S. Senate,,DEM,Kamala Harris,381
-Humboldt,3B--1,U.S. Senate,,DEM,Loretta Sanchez,164
-Humboldt,3BLF,U.S. Senate,,DEM,Kamala Harris,0
-Humboldt,3BLF,U.S. Senate,,DEM,Loretta Sanchez,0
-Humboldt,3E-2J,U.S. Senate,,DEM,Kamala Harris,0
-Humboldt,3E-2J,U.S. Senate,,DEM,Loretta Sanchez,0
-Humboldt,3ES-6,U.S. Senate,,DEM,Kamala Harris,212
-Humboldt,3ES-6,U.S. Senate,,DEM,Loretta Sanchez,106
-Humboldt,3FW,U.S. Senate,,DEM,Kamala Harris,455
-Humboldt,3FW,U.S. Senate,,DEM,Loretta Sanchez,191
-Humboldt,3FWS,U.S. Senate,,DEM,Kamala Harris,452
-Humboldt,3FWS,U.S. Senate,,DEM,Loretta Sanchez,167
-Humboldt,3JCFR,U.S. Senate,,DEM,Kamala Harris,315
-Humboldt,3JCFR,U.S. Senate,,DEM,Loretta Sanchez,111
-Humboldt,3JCWR,U.S. Senate,,DEM,Kamala Harris,395
-Humboldt,3JCWR,U.S. Senate,,DEM,Loretta Sanchez,145
-Humboldt,3KL,U.S. Senate,,DEM,Kamala Harris,25
-Humboldt,3KL,U.S. Senate,,DEM,Loretta Sanchez,13
-Humboldt,3KL-1,U.S. Senate,,DEM,Kamala Harris,89
-Humboldt,3KL-1,U.S. Senate,,DEM,Loretta Sanchez,43
-Humboldt,3MA-1,U.S. Senate,,DEM,Kamala Harris,236
-Humboldt,3MA-1,U.S. Senate,,DEM,Loretta Sanchez,94
-Humboldt,3PA-1,U.S. Senate,,DEM,Kamala Harris,393
-Humboldt,3PA-1,U.S. Senate,,DEM,Loretta Sanchez,156
-Humboldt,3PESF,U.S. Senate,,DEM,Kamala Harris,5
-Humboldt,3PESF,U.S. Senate,,DEM,Loretta Sanchez,4
-Humboldt,4.00E-11,U.S. Senate,,DEM,Kamala Harris,309
-Humboldt,4.00E-11,U.S. Senate,,DEM,Loretta Sanchez,168
-Humboldt,4.00E-12,U.S. Senate,,DEM,Kamala Harris,244
-Humboldt,4.00E-12,U.S. Senate,,DEM,Loretta Sanchez,167
-Humboldt,4.00E-13,U.S. Senate,,DEM,Kamala Harris,237
-Humboldt,4.00E-13,U.S. Senate,,DEM,Loretta Sanchez,134
-Humboldt,4.00E-14,U.S. Senate,,DEM,Kamala Harris,388
-Humboldt,4.00E-14,U.S. Senate,,DEM,Loretta Sanchez,169
-Humboldt,4.00E-21,U.S. Senate,,DEM,Kamala Harris,271
-Humboldt,4.00E-21,U.S. Senate,,DEM,Loretta Sanchez,144
-Humboldt,4.00E-22,U.S. Senate,,DEM,Kamala Harris,292
-Humboldt,4.00E-22,U.S. Senate,,DEM,Loretta Sanchez,150
-Humboldt,4.00E-23,U.S. Senate,,DEM,Kamala Harris,266
-Humboldt,4.00E-23,U.S. Senate,,DEM,Loretta Sanchez,125
-Humboldt,4.00E-24,U.S. Senate,,DEM,Kamala Harris,280
-Humboldt,4.00E-24,U.S. Senate,,DEM,Loretta Sanchez,127
-Humboldt,4.00E-25,U.S. Senate,,DEM,Kamala Harris,370
-Humboldt,4.00E-25,U.S. Senate,,DEM,Loretta Sanchez,163
-Humboldt,4E-2J,U.S. Senate,,DEM,Kamala Harris,0
-Humboldt,4E-2J,U.S. Senate,,DEM,Loretta Sanchez,0
-Humboldt,4.00E-31,U.S. Senate,,DEM,Kamala Harris,237
-Humboldt,4.00E-31,U.S. Senate,,DEM,Loretta Sanchez,128
-Humboldt,4.00E-32,U.S. Senate,,DEM,Kamala Harris,256
-Humboldt,4.00E-32,U.S. Senate,,DEM,Loretta Sanchez,122
-Humboldt,4.00E-33,U.S. Senate,,DEM,Kamala Harris,282
-Humboldt,4.00E-33,U.S. Senate,,DEM,Loretta Sanchez,142
-Humboldt,4.00E-34,U.S. Senate,,DEM,Kamala Harris,340
-Humboldt,4.00E-34,U.S. Senate,,DEM,Loretta Sanchez,161
-Humboldt,4.00E-51,U.S. Senate,,DEM,Kamala Harris,274
-Humboldt,4.00E-51,U.S. Senate,,DEM,Loretta Sanchez,117
-Humboldt,4.00E-52,U.S. Senate,,DEM,Kamala Harris,191
-Humboldt,4.00E-52,U.S. Senate,,DEM,Loretta Sanchez,95
-Humboldt,4.00E-54,U.S. Senate,,DEM,Kamala Harris,405
-Humboldt,4.00E-54,U.S. Senate,,DEM,Loretta Sanchez,242
-Humboldt,4ES-4,U.S. Senate,,DEM,Kamala Harris,299
-Humboldt,4ES-4,U.S. Senate,,DEM,Loretta Sanchez,182
-Humboldt,4ES-5,U.S. Senate,,DEM,Kamala Harris,392
-Humboldt,4ES-5,U.S. Senate,,DEM,Loretta Sanchez,185
-Humboldt,4ES-6,U.S. Senate,,DEM,Kamala Harris,323
-Humboldt,4ES-6,U.S. Senate,,DEM,Loretta Sanchez,183
-Humboldt,4PEF,U.S. Senate,,DEM,Kamala Harris,81
-Humboldt,4PEF,U.S. Senate,,DEM,Loretta Sanchez,39
-Humboldt,5AS-4,U.S. Senate,,DEM,Kamala Harris,62
-Humboldt,5AS-4,U.S. Senate,,DEM,Loretta Sanchez,37
-Humboldt,5BL,U.S. Senate,,DEM,Kamala Harris,323
-Humboldt,5BL,U.S. Senate,,DEM,Loretta Sanchez,172
-Humboldt,5FB,U.S. Senate,,DEM,Kamala Harris,313
-Humboldt,5FB,U.S. Senate,,DEM,Loretta Sanchez,125
-Humboldt,5GP,U.S. Senate,,DEM,Kamala Harris,54
-Humboldt,5GP,U.S. Senate,,DEM,Loretta Sanchez,21
-Humboldt,5KT-1,U.S. Senate,,DEM,Kamala Harris,42
-Humboldt,5KT-1,U.S. Senate,,DEM,Loretta Sanchez,20
-Humboldt,5KT-3,U.S. Senate,,DEM,Kamala Harris,70
-Humboldt,5KT-3,U.S. Senate,,DEM,Loretta Sanchez,30
-Humboldt,5KT-4,U.S. Senate,,DEM,Kamala Harris,231
-Humboldt,5KT-4,U.S. Senate,,DEM,Loretta Sanchez,181
-Humboldt,5KT-6,U.S. Senate,,DEM,Kamala Harris,347
-Humboldt,5KT-6,U.S. Senate,,DEM,Loretta Sanchez,239
-Humboldt,5KTS3,U.S. Senate,,DEM,Kamala Harris,64
-Humboldt,5KTS3,U.S. Senate,,DEM,Loretta Sanchez,27
-Humboldt,5MC,U.S. Senate,,DEM,Kamala Harris,18
-Humboldt,5MC,U.S. Senate,,DEM,Loretta Sanchez,3
-Humboldt,5MK-1,U.S. Senate,,DEM,Kamala Harris,490
-Humboldt,5MK-1,U.S. Senate,,DEM,Loretta Sanchez,217
-Humboldt,5MK-2,U.S. Senate,,DEM,Kamala Harris,407
-Humboldt,5MK-2,U.S. Senate,,DEM,Loretta Sanchez,179
-Humboldt,5MK-3,U.S. Senate,,DEM,Kamala Harris,327
-Humboldt,5MK-3,U.S. Senate,,DEM,Loretta Sanchez,129
-Humboldt,5MK-4,U.S. Senate,,DEM,Kamala Harris,446
-Humboldt,5MK-4,U.S. Senate,,DEM,Loretta Sanchez,232
-Humboldt,5MK-4A,U.S. Senate,,DEM,Kamala Harris,286
-Humboldt,5MK-4A,U.S. Senate,,DEM,Loretta Sanchez,145
-Humboldt,5MK-5,U.S. Senate,,DEM,Kamala Harris,448
-Humboldt,5MK-5,U.S. Senate,,DEM,Loretta Sanchez,174
-Humboldt,5MK-5A,U.S. Senate,,DEM,Kamala Harris,375
-Humboldt,5MK-5A,U.S. Senate,,DEM,Loretta Sanchez,186
-Humboldt,5MK-6,U.S. Senate,,DEM,Kamala Harris,368
-Humboldt,5MK-6,U.S. Senate,,DEM,Loretta Sanchez,197
-Humboldt,5MK-6A,U.S. Senate,,DEM,Kamala Harris,271
-Humboldt,5MK-6A,U.S. Senate,,DEM,Loretta Sanchez,133
-Humboldt,5MK-7,U.S. Senate,,DEM,Kamala Harris,322
-Humboldt,5MK-7,U.S. Senate,,DEM,Loretta Sanchez,148
-Humboldt,5MK-8,U.S. Senate,,DEM,Kamala Harris,394
-Humboldt,5MK-8,U.S. Senate,,DEM,Loretta Sanchez,189
-Humboldt,5OR,U.S. Senate,,DEM,Kamala Harris,61
-Humboldt,5OR,U.S. Senate,,DEM,Loretta Sanchez,32
-Humboldt,5PA-3,U.S. Senate,,DEM,Kamala Harris,62
-Humboldt,5PA-3,U.S. Senate,,DEM,Loretta Sanchez,18
-Humboldt,5T--1,U.S. Senate,,DEM,Kamala Harris,130
-Humboldt,5T--1,U.S. Senate,,DEM,Loretta Sanchez,61
-Humboldt,5TU-1,U.S. Senate,,DEM,Kamala Harris,427
-Humboldt,5TU-1,U.S. Senate,,DEM,Loretta Sanchez,176
-Humboldt,5TU-4,U.S. Senate,,DEM,Kamala Harris,376
-Humboldt,5TU-4,U.S. Senate,,DEM,Loretta Sanchez,141
+Humboldt,1CS-1,U.S. Senate,,DEM,Kamala D. Harris,323
+Humboldt,1CS-1,U.S. Senate,,DEM,Loretta L. Sanchez,161
+Humboldt,1CS-2,U.S. Senate,,DEM,Kamala D. Harris,349
+Humboldt,1CS-2,U.S. Senate,,DEM,Loretta L. Sanchez,170
+Humboldt,1CS-3,U.S. Senate,,DEM,Kamala D. Harris,330
+Humboldt,1CS-3,U.S. Senate,,DEM,Loretta L. Sanchez,170
+Humboldt,1CS-4,U.S. Senate,,DEM,Kamala D. Harris,361
+Humboldt,1CS-4,U.S. Senate,,DEM,Loretta L. Sanchez,186
+Humboldt,1.00E-36,U.S. Senate,,DEM,Kamala D. Harris,418
+Humboldt,1.00E-36,U.S. Senate,,DEM,Loretta L. Sanchez,178
+Humboldt,1.00E-43,U.S. Senate,,DEM,Kamala D. Harris,387
+Humboldt,1.00E-43,U.S. Senate,,DEM,Loretta L. Sanchez,149
+Humboldt,1.00E-45,U.S. Senate,,DEM,Kamala D. Harris,369
+Humboldt,1.00E-45,U.S. Senate,,DEM,Loretta L. Sanchez,156
+Humboldt,1.00E-55,U.S. Senate,,DEM,Kamala D. Harris,272
+Humboldt,1.00E-55,U.S. Senate,,DEM,Loretta L. Sanchez,135
+Humboldt,1.00E-59,U.S. Senate,,DEM,Kamala D. Harris,0
+Humboldt,1.00E-59,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Humboldt,1ES-1,U.S. Senate,,DEM,Kamala D. Harris,486
+Humboldt,1ES-1,U.S. Senate,,DEM,Loretta L. Sanchez,242
+Humboldt,1F--1,U.S. Senate,,DEM,Kamala D. Harris,424
+Humboldt,1F--1,U.S. Senate,,DEM,Loretta L. Sanchez,222
+Humboldt,1F--7,U.S. Senate,,DEM,Kamala D. Harris,9
+Humboldt,1F--7,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Humboldt,1FS,U.S. Senate,,DEM,Kamala D. Harris,282
+Humboldt,1FS,U.S. Senate,,DEM,Loretta L. Sanchez,188
+Humboldt,1FS-1,U.S. Senate,,DEM,Kamala D. Harris,60
+Humboldt,1FS-1,U.S. Senate,,DEM,Loretta L. Sanchez,37
+Humboldt,1FS-4,U.S. Senate,,DEM,Kamala D. Harris,74
+Humboldt,1FS-4,U.S. Senate,,DEM,Loretta L. Sanchez,55
+Humboldt,1FS-9,U.S. Senate,,DEM,Kamala D. Harris,63
+Humboldt,1FS-9,U.S. Senate,,DEM,Loretta L. Sanchez,37
+Humboldt,1LU,U.S. Senate,,DEM,Kamala D. Harris,299
+Humboldt,1LU,U.S. Senate,,DEM,Loretta L. Sanchez,167
+Humboldt,1MU,U.S. Senate,,DEM,Kamala D. Harris,87
+Humboldt,1MU,U.S. Senate,,DEM,Loretta L. Sanchez,40
+Humboldt,1MUF,U.S. Senate,,DEM,Kamala D. Harris,85
+Humboldt,1MUF,U.S. Senate,,DEM,Loretta L. Sanchez,37
+Humboldt,1RV-2,U.S. Senate,,DEM,Kamala D. Harris,54
+Humboldt,1RV-2,U.S. Senate,,DEM,Loretta L. Sanchez,23
+Humboldt,1SB-1,U.S. Senate,,DEM,Kamala D. Harris,496
+Humboldt,1SB-1,U.S. Senate,,DEM,Loretta L. Sanchez,317
+Humboldt,1SB-4,U.S. Senate,,DEM,Kamala D. Harris,460
+Humboldt,1SB-4,U.S. Senate,,DEM,Loretta L. Sanchez,269
+Humboldt,1SB10,U.S. Senate,,DEM,Kamala D. Harris,438
+Humboldt,1SB10,U.S. Senate,,DEM,Loretta L. Sanchez,220
+Humboldt,1SB12,U.S. Senate,,DEM,Kamala D. Harris,76
+Humboldt,1SB12,U.S. Senate,,DEM,Loretta L. Sanchez,49
+Humboldt,1SU,U.S. Senate,,DEM,Kamala D. Harris,174
+Humboldt,1SU,U.S. Senate,,DEM,Loretta L. Sanchez,109
+Humboldt,2BV-1,U.S. Senate,,DEM,Kamala D. Harris,111
+Humboldt,2BV-1,U.S. Senate,,DEM,Loretta L. Sanchez,73
+Humboldt,2CU,U.S. Senate,,DEM,Kamala D. Harris,179
+Humboldt,2CU,U.S. Senate,,DEM,Loretta L. Sanchez,100
+Humboldt,2F--2,U.S. Senate,,DEM,Kamala D. Harris,371
+Humboldt,2F--2,U.S. Senate,,DEM,Loretta L. Sanchez,229
+Humboldt,2F--3,U.S. Senate,,DEM,Kamala D. Harris,272
+Humboldt,2F--3,U.S. Senate,,DEM,Loretta L. Sanchez,148
+Humboldt,2F--4,U.S. Senate,,DEM,Kamala D. Harris,353
+Humboldt,2F--4,U.S. Senate,,DEM,Loretta L. Sanchez,206
+Humboldt,2F-R1,U.S. Senate,,DEM,Kamala D. Harris,404
+Humboldt,2F-R1,U.S. Senate,,DEM,Loretta L. Sanchez,266
+Humboldt,2F-R2,U.S. Senate,,DEM,Kamala D. Harris,295
+Humboldt,2F-R2,U.S. Senate,,DEM,Loretta L. Sanchez,204
+Humboldt,2F-R3,U.S. Senate,,DEM,Kamala D. Harris,272
+Humboldt,2F-R3,U.S. Senate,,DEM,Loretta L. Sanchez,196
+Humboldt,2F-R4,U.S. Senate,,DEM,Kamala D. Harris,279
+Humboldt,2F-R4,U.S. Senate,,DEM,Loretta L. Sanchez,171
+Humboldt,2HV-1,U.S. Senate,,DEM,Kamala D. Harris,303
+Humboldt,2HV-1,U.S. Senate,,DEM,Loretta L. Sanchez,175
+Humboldt,2MR,U.S. Senate,,DEM,Kamala D. Harris,10
+Humboldt,2MR,U.S. Senate,,DEM,Loretta L. Sanchez,9
+Humboldt,2R--1,U.S. Senate,,DEM,Kamala D. Harris,235
+Humboldt,2R--1,U.S. Senate,,DEM,Loretta L. Sanchez,175
+Humboldt,2R--2,U.S. Senate,,DEM,Kamala D. Harris,254
+Humboldt,2R--2,U.S. Senate,,DEM,Loretta L. Sanchez,195
+Humboldt,2RV-1,U.S. Senate,,DEM,Kamala D. Harris,109
+Humboldt,2RV-1,U.S. Senate,,DEM,Loretta L. Sanchez,62
+Humboldt,2SH-1,U.S. Senate,,DEM,Kamala D. Harris,110
+Humboldt,2SH-1,U.S. Senate,,DEM,Loretta L. Sanchez,28
+Humboldt,2SH-2,U.S. Senate,,DEM,Kamala D. Harris,44
+Humboldt,2SH-2,U.S. Senate,,DEM,Loretta L. Sanchez,24
+Humboldt,2SH-3,U.S. Senate,,DEM,Kamala D. Harris,51
+Humboldt,2SH-3,U.S. Senate,,DEM,Loretta L. Sanchez,33
+Humboldt,2SH-4,U.S. Senate,,DEM,Kamala D. Harris,341
+Humboldt,2SH-4,U.S. Senate,,DEM,Loretta L. Sanchez,118
+Humboldt,2SH-5,U.S. Senate,,DEM,Kamala D. Harris,439
+Humboldt,2SH-5,U.S. Senate,,DEM,Loretta L. Sanchez,202
+Humboldt,2SH-7,U.S. Senate,,DEM,Kamala D. Harris,27
+Humboldt,2SH-7,U.S. Senate,,DEM,Loretta L. Sanchez,14
+Humboldt,2SH-8,U.S. Senate,,DEM,Kamala D. Harris,63
+Humboldt,2SH-8,U.S. Senate,,DEM,Loretta L. Sanchez,40
+Humboldt,2SHF1,U.S. Senate,,DEM,Kamala D. Harris,80
+Humboldt,2SHF1,U.S. Senate,,DEM,Loretta L. Sanchez,38
+Humboldt,2SHR1,U.S. Senate,,DEM,Kamala D. Harris,90
+Humboldt,2SHR1,U.S. Senate,,DEM,Loretta L. Sanchez,41
+Humboldt,2SHR2,U.S. Senate,,DEM,Kamala D. Harris,55
+Humboldt,2SHR2,U.S. Senate,,DEM,Loretta L. Sanchez,53
+Humboldt,2SHS4,U.S. Senate,,DEM,Kamala D. Harris,265
+Humboldt,2SHS4,U.S. Senate,,DEM,Loretta L. Sanchez,134
+Humboldt,2SHS7,U.S. Senate,,DEM,Kamala D. Harris,459
+Humboldt,2SHS7,U.S. Senate,,DEM,Loretta L. Sanchez,229
+Humboldt,2SHVF,U.S. Senate,,DEM,Kamala D. Harris,65
+Humboldt,2SHVF,U.S. Senate,,DEM,Loretta L. Sanchez,23
+Humboldt,3A--1,U.S. Senate,,DEM,Kamala D. Harris,231
+Humboldt,3A--1,U.S. Senate,,DEM,Loretta L. Sanchez,114
+Humboldt,3A--2,U.S. Senate,,DEM,Kamala D. Harris,398
+Humboldt,3A--2,U.S. Senate,,DEM,Loretta L. Sanchez,148
+Humboldt,3A--3,U.S. Senate,,DEM,Kamala D. Harris,458
+Humboldt,3A--3,U.S. Senate,,DEM,Loretta L. Sanchez,168
+Humboldt,3A--4,U.S. Senate,,DEM,Kamala D. Harris,355
+Humboldt,3A--4,U.S. Senate,,DEM,Loretta L. Sanchez,152
+Humboldt,3A--7,U.S. Senate,,DEM,Kamala D. Harris,352
+Humboldt,3A--7,U.S. Senate,,DEM,Loretta L. Sanchez,144
+Humboldt,3A--9,U.S. Senate,,DEM,Kamala D. Harris,461
+Humboldt,3A--9,U.S. Senate,,DEM,Loretta L. Sanchez,184
+Humboldt,3A-10,U.S. Senate,,DEM,Kamala D. Harris,445
+Humboldt,3A-10,U.S. Senate,,DEM,Loretta L. Sanchez,256
+Humboldt,3A-11,U.S. Senate,,DEM,Kamala D. Harris,491
+Humboldt,3A-11,U.S. Senate,,DEM,Loretta L. Sanchez,231
+Humboldt,3A-12,U.S. Senate,,DEM,Kamala D. Harris,226
+Humboldt,3A-12,U.S. Senate,,DEM,Loretta L. Sanchez,182
+Humboldt,3A-13,U.S. Senate,,DEM,Kamala D. Harris,522
+Humboldt,3A-13,U.S. Senate,,DEM,Loretta L. Sanchez,241
+Humboldt,3A-J1,U.S. Senate,,DEM,Kamala D. Harris,409
+Humboldt,3A-J1,U.S. Senate,,DEM,Loretta L. Sanchez,107
+Humboldt,3A-P2,U.S. Senate,,DEM,Kamala D. Harris,463
+Humboldt,3A-P2,U.S. Senate,,DEM,Loretta L. Sanchez,205
+Humboldt,3A-P4,U.S. Senate,,DEM,Kamala D. Harris,460
+Humboldt,3A-P4,U.S. Senate,,DEM,Loretta L. Sanchez,234
+Humboldt,3AS-1,U.S. Senate,,DEM,Kamala D. Harris,82
+Humboldt,3AS-1,U.S. Senate,,DEM,Loretta L. Sanchez,27
+Humboldt,3AS-9,U.S. Senate,,DEM,Kamala D. Harris,55
+Humboldt,3AS-9,U.S. Senate,,DEM,Loretta L. Sanchez,27
+Humboldt,3B--1,U.S. Senate,,DEM,Kamala D. Harris,381
+Humboldt,3B--1,U.S. Senate,,DEM,Loretta L. Sanchez,164
+Humboldt,3BLF,U.S. Senate,,DEM,Kamala D. Harris,0
+Humboldt,3BLF,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Humboldt,3E-2J,U.S. Senate,,DEM,Kamala D. Harris,0
+Humboldt,3E-2J,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Humboldt,3ES-6,U.S. Senate,,DEM,Kamala D. Harris,212
+Humboldt,3ES-6,U.S. Senate,,DEM,Loretta L. Sanchez,106
+Humboldt,3FW,U.S. Senate,,DEM,Kamala D. Harris,455
+Humboldt,3FW,U.S. Senate,,DEM,Loretta L. Sanchez,191
+Humboldt,3FWS,U.S. Senate,,DEM,Kamala D. Harris,452
+Humboldt,3FWS,U.S. Senate,,DEM,Loretta L. Sanchez,167
+Humboldt,3JCFR,U.S. Senate,,DEM,Kamala D. Harris,315
+Humboldt,3JCFR,U.S. Senate,,DEM,Loretta L. Sanchez,111
+Humboldt,3JCWR,U.S. Senate,,DEM,Kamala D. Harris,395
+Humboldt,3JCWR,U.S. Senate,,DEM,Loretta L. Sanchez,145
+Humboldt,3KL,U.S. Senate,,DEM,Kamala D. Harris,25
+Humboldt,3KL,U.S. Senate,,DEM,Loretta L. Sanchez,13
+Humboldt,3KL-1,U.S. Senate,,DEM,Kamala D. Harris,89
+Humboldt,3KL-1,U.S. Senate,,DEM,Loretta L. Sanchez,43
+Humboldt,3MA-1,U.S. Senate,,DEM,Kamala D. Harris,236
+Humboldt,3MA-1,U.S. Senate,,DEM,Loretta L. Sanchez,94
+Humboldt,3PA-1,U.S. Senate,,DEM,Kamala D. Harris,393
+Humboldt,3PA-1,U.S. Senate,,DEM,Loretta L. Sanchez,156
+Humboldt,3PESF,U.S. Senate,,DEM,Kamala D. Harris,5
+Humboldt,3PESF,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Humboldt,4.00E-11,U.S. Senate,,DEM,Kamala D. Harris,309
+Humboldt,4.00E-11,U.S. Senate,,DEM,Loretta L. Sanchez,168
+Humboldt,4.00E-12,U.S. Senate,,DEM,Kamala D. Harris,244
+Humboldt,4.00E-12,U.S. Senate,,DEM,Loretta L. Sanchez,167
+Humboldt,4.00E-13,U.S. Senate,,DEM,Kamala D. Harris,237
+Humboldt,4.00E-13,U.S. Senate,,DEM,Loretta L. Sanchez,134
+Humboldt,4.00E-14,U.S. Senate,,DEM,Kamala D. Harris,388
+Humboldt,4.00E-14,U.S. Senate,,DEM,Loretta L. Sanchez,169
+Humboldt,4.00E-21,U.S. Senate,,DEM,Kamala D. Harris,271
+Humboldt,4.00E-21,U.S. Senate,,DEM,Loretta L. Sanchez,144
+Humboldt,4.00E-22,U.S. Senate,,DEM,Kamala D. Harris,292
+Humboldt,4.00E-22,U.S. Senate,,DEM,Loretta L. Sanchez,150
+Humboldt,4.00E-23,U.S. Senate,,DEM,Kamala D. Harris,266
+Humboldt,4.00E-23,U.S. Senate,,DEM,Loretta L. Sanchez,125
+Humboldt,4.00E-24,U.S. Senate,,DEM,Kamala D. Harris,280
+Humboldt,4.00E-24,U.S. Senate,,DEM,Loretta L. Sanchez,127
+Humboldt,4.00E-25,U.S. Senate,,DEM,Kamala D. Harris,370
+Humboldt,4.00E-25,U.S. Senate,,DEM,Loretta L. Sanchez,163
+Humboldt,4E-2J,U.S. Senate,,DEM,Kamala D. Harris,0
+Humboldt,4E-2J,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Humboldt,4.00E-31,U.S. Senate,,DEM,Kamala D. Harris,237
+Humboldt,4.00E-31,U.S. Senate,,DEM,Loretta L. Sanchez,128
+Humboldt,4.00E-32,U.S. Senate,,DEM,Kamala D. Harris,256
+Humboldt,4.00E-32,U.S. Senate,,DEM,Loretta L. Sanchez,122
+Humboldt,4.00E-33,U.S. Senate,,DEM,Kamala D. Harris,282
+Humboldt,4.00E-33,U.S. Senate,,DEM,Loretta L. Sanchez,142
+Humboldt,4.00E-34,U.S. Senate,,DEM,Kamala D. Harris,340
+Humboldt,4.00E-34,U.S. Senate,,DEM,Loretta L. Sanchez,161
+Humboldt,4.00E-51,U.S. Senate,,DEM,Kamala D. Harris,274
+Humboldt,4.00E-51,U.S. Senate,,DEM,Loretta L. Sanchez,117
+Humboldt,4.00E-52,U.S. Senate,,DEM,Kamala D. Harris,191
+Humboldt,4.00E-52,U.S. Senate,,DEM,Loretta L. Sanchez,95
+Humboldt,4.00E-54,U.S. Senate,,DEM,Kamala D. Harris,405
+Humboldt,4.00E-54,U.S. Senate,,DEM,Loretta L. Sanchez,242
+Humboldt,4ES-4,U.S. Senate,,DEM,Kamala D. Harris,299
+Humboldt,4ES-4,U.S. Senate,,DEM,Loretta L. Sanchez,182
+Humboldt,4ES-5,U.S. Senate,,DEM,Kamala D. Harris,392
+Humboldt,4ES-5,U.S. Senate,,DEM,Loretta L. Sanchez,185
+Humboldt,4ES-6,U.S. Senate,,DEM,Kamala D. Harris,323
+Humboldt,4ES-6,U.S. Senate,,DEM,Loretta L. Sanchez,183
+Humboldt,4PEF,U.S. Senate,,DEM,Kamala D. Harris,81
+Humboldt,4PEF,U.S. Senate,,DEM,Loretta L. Sanchez,39
+Humboldt,5AS-4,U.S. Senate,,DEM,Kamala D. Harris,62
+Humboldt,5AS-4,U.S. Senate,,DEM,Loretta L. Sanchez,37
+Humboldt,5BL,U.S. Senate,,DEM,Kamala D. Harris,323
+Humboldt,5BL,U.S. Senate,,DEM,Loretta L. Sanchez,172
+Humboldt,5FB,U.S. Senate,,DEM,Kamala D. Harris,313
+Humboldt,5FB,U.S. Senate,,DEM,Loretta L. Sanchez,125
+Humboldt,5GP,U.S. Senate,,DEM,Kamala D. Harris,54
+Humboldt,5GP,U.S. Senate,,DEM,Loretta L. Sanchez,21
+Humboldt,5KT-1,U.S. Senate,,DEM,Kamala D. Harris,42
+Humboldt,5KT-1,U.S. Senate,,DEM,Loretta L. Sanchez,20
+Humboldt,5KT-3,U.S. Senate,,DEM,Kamala D. Harris,70
+Humboldt,5KT-3,U.S. Senate,,DEM,Loretta L. Sanchez,30
+Humboldt,5KT-4,U.S. Senate,,DEM,Kamala D. Harris,231
+Humboldt,5KT-4,U.S. Senate,,DEM,Loretta L. Sanchez,181
+Humboldt,5KT-6,U.S. Senate,,DEM,Kamala D. Harris,347
+Humboldt,5KT-6,U.S. Senate,,DEM,Loretta L. Sanchez,239
+Humboldt,5KTS3,U.S. Senate,,DEM,Kamala D. Harris,64
+Humboldt,5KTS3,U.S. Senate,,DEM,Loretta L. Sanchez,27
+Humboldt,5MC,U.S. Senate,,DEM,Kamala D. Harris,18
+Humboldt,5MC,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Humboldt,5MK-1,U.S. Senate,,DEM,Kamala D. Harris,490
+Humboldt,5MK-1,U.S. Senate,,DEM,Loretta L. Sanchez,217
+Humboldt,5MK-2,U.S. Senate,,DEM,Kamala D. Harris,407
+Humboldt,5MK-2,U.S. Senate,,DEM,Loretta L. Sanchez,179
+Humboldt,5MK-3,U.S. Senate,,DEM,Kamala D. Harris,327
+Humboldt,5MK-3,U.S. Senate,,DEM,Loretta L. Sanchez,129
+Humboldt,5MK-4,U.S. Senate,,DEM,Kamala D. Harris,446
+Humboldt,5MK-4,U.S. Senate,,DEM,Loretta L. Sanchez,232
+Humboldt,5MK-4A,U.S. Senate,,DEM,Kamala D. Harris,286
+Humboldt,5MK-4A,U.S. Senate,,DEM,Loretta L. Sanchez,145
+Humboldt,5MK-5,U.S. Senate,,DEM,Kamala D. Harris,448
+Humboldt,5MK-5,U.S. Senate,,DEM,Loretta L. Sanchez,174
+Humboldt,5MK-5A,U.S. Senate,,DEM,Kamala D. Harris,375
+Humboldt,5MK-5A,U.S. Senate,,DEM,Loretta L. Sanchez,186
+Humboldt,5MK-6,U.S. Senate,,DEM,Kamala D. Harris,368
+Humboldt,5MK-6,U.S. Senate,,DEM,Loretta L. Sanchez,197
+Humboldt,5MK-6A,U.S. Senate,,DEM,Kamala D. Harris,271
+Humboldt,5MK-6A,U.S. Senate,,DEM,Loretta L. Sanchez,133
+Humboldt,5MK-7,U.S. Senate,,DEM,Kamala D. Harris,322
+Humboldt,5MK-7,U.S. Senate,,DEM,Loretta L. Sanchez,148
+Humboldt,5MK-8,U.S. Senate,,DEM,Kamala D. Harris,394
+Humboldt,5MK-8,U.S. Senate,,DEM,Loretta L. Sanchez,189
+Humboldt,5OR,U.S. Senate,,DEM,Kamala D. Harris,61
+Humboldt,5OR,U.S. Senate,,DEM,Loretta L. Sanchez,32
+Humboldt,5PA-3,U.S. Senate,,DEM,Kamala D. Harris,62
+Humboldt,5PA-3,U.S. Senate,,DEM,Loretta L. Sanchez,18
+Humboldt,5T--1,U.S. Senate,,DEM,Kamala D. Harris,130
+Humboldt,5T--1,U.S. Senate,,DEM,Loretta L. Sanchez,61
+Humboldt,5TU-1,U.S. Senate,,DEM,Kamala D. Harris,427
+Humboldt,5TU-1,U.S. Senate,,DEM,Loretta L. Sanchez,176
+Humboldt,5TU-4,U.S. Senate,,DEM,Kamala D. Harris,376
+Humboldt,5TU-4,U.S. Senate,,DEM,Loretta L. Sanchez,141

--- a/2016/20161108__ca__general__imperial__precinct.csv
+++ b/2016/20161108__ca__general__imperial__precinct.csv
@@ -7559,381 +7559,381 @@ Imperial,588263,Proposition 67,,N/A,Yes,0
 Imperial,588263,Proposition 67,,N/A,No,0
 Imperial,588264,Proposition 67,,N/A,Yes,0
 Imperial,588264,Proposition 67,,N/A,No,2
-Imperial,121004,U.S. Senate,,DEM,Kamala Harris,165
-Imperial,121004,U.S. Senate,,DEM,Loretta Sanchez,478
-Imperial,121005,U.S. Senate,,DEM,Kamala Harris,259
-Imperial,121005,U.S. Senate,,DEM,Loretta Sanchez,758
-Imperial,121006,U.S. Senate,,DEM,Kamala Harris,229
-Imperial,121006,U.S. Senate,,DEM,Loretta Sanchez,616
-Imperial,121009,U.S. Senate,,DEM,Kamala Harris,32
-Imperial,121009,U.S. Senate,,DEM,Loretta Sanchez,57
-Imperial,121010,U.S. Senate,,DEM,Kamala Harris,226
-Imperial,121010,U.S. Senate,,DEM,Loretta Sanchez,469
-Imperial,121012,U.S. Senate,,DEM,Kamala Harris,105
-Imperial,121012,U.S. Senate,,DEM,Loretta Sanchez,325
-Imperial,121014,U.S. Senate,,DEM,Kamala Harris,333
-Imperial,121014,U.S. Senate,,DEM,Loretta Sanchez,956
-Imperial,121015,U.S. Senate,,DEM,Kamala Harris,24
-Imperial,121015,U.S. Senate,,DEM,Loretta Sanchez,90
-Imperial,121016,U.S. Senate,,DEM,Kamala Harris,197
-Imperial,121016,U.S. Senate,,DEM,Loretta Sanchez,525
-Imperial,121017,U.S. Senate,,DEM,Kamala Harris,219
-Imperial,121017,U.S. Senate,,DEM,Loretta Sanchez,566
-Imperial,121018,U.S. Senate,,DEM,Kamala Harris,253
-Imperial,121018,U.S. Senate,,DEM,Loretta Sanchez,669
-Imperial,121019,U.S. Senate,,DEM,Kamala Harris,372
-Imperial,121019,U.S. Senate,,DEM,Loretta Sanchez,952
-Imperial,121020,U.S. Senate,,DEM,Kamala Harris,204
-Imperial,121020,U.S. Senate,,DEM,Loretta Sanchez,532
-Imperial,121021,U.S. Senate,,DEM,Kamala Harris,6
-Imperial,121021,U.S. Senate,,DEM,Loretta Sanchez,33
-Imperial,181001,U.S. Senate,,DEM,Kamala Harris,4
-Imperial,181001,U.S. Senate,,DEM,Loretta Sanchez,11
-Imperial,181002,U.S. Senate,,DEM,Kamala Harris,19
-Imperial,181002,U.S. Senate,,DEM,Loretta Sanchez,31
-Imperial,181066,U.S. Senate,,DEM,Kamala Harris,6
-Imperial,181066,U.S. Senate,,DEM,Loretta Sanchez,19
-Imperial,184003,U.S. Senate,,DEM,Kamala Harris,1
-Imperial,184003,U.S. Senate,,DEM,Loretta Sanchez,7
-Imperial,186005,U.S. Senate,,DEM,Kamala Harris,10
-Imperial,186005,U.S. Senate,,DEM,Loretta Sanchez,13
-Imperial,186006,U.S. Senate,,DEM,Kamala Harris,20
-Imperial,186006,U.S. Senate,,DEM,Loretta Sanchez,36
-Imperial,186007,U.S. Senate,,DEM,Kamala Harris,0
-Imperial,186007,U.S. Senate,,DEM,Loretta Sanchez,7
-Imperial,186067,U.S. Senate,,DEM,Kamala Harris,2
-Imperial,186067,U.S. Senate,,DEM,Loretta Sanchez,3
-Imperial,245205,U.S. Senate,,DEM,Kamala Harris,395
-Imperial,245205,U.S. Senate,,DEM,Loretta Sanchez,669
-Imperial,245214,U.S. Senate,,DEM,Kamala Harris,435
-Imperial,245214,U.S. Senate,,DEM,Loretta Sanchez,672
-Imperial,245215,U.S. Senate,,DEM,Kamala Harris,150
-Imperial,245215,U.S. Senate,,DEM,Loretta Sanchez,401
-Imperial,245217,U.S. Senate,,DEM,Kamala Harris,63
-Imperial,245217,U.S. Senate,,DEM,Loretta Sanchez,191
-Imperial,245220,U.S. Senate,,DEM,Kamala Harris,261
-Imperial,245220,U.S. Senate,,DEM,Loretta Sanchez,534
-Imperial,245224,U.S. Senate,,DEM,Kamala Harris,266
-Imperial,245224,U.S. Senate,,DEM,Loretta Sanchez,626
-Imperial,245225,U.S. Senate,,DEM,Kamala Harris,65
-Imperial,245225,U.S. Senate,,DEM,Loretta Sanchez,103
-Imperial,245226,U.S. Senate,,DEM,Kamala Harris,341
-Imperial,245226,U.S. Senate,,DEM,Loretta Sanchez,599
-Imperial,245228,U.S. Senate,,DEM,Kamala Harris,191
-Imperial,245228,U.S. Senate,,DEM,Loretta Sanchez,273
-Imperial,247229,U.S. Senate,,DEM,Kamala Harris,218
-Imperial,247229,U.S. Senate,,DEM,Loretta Sanchez,209
-Imperial,247234,U.S. Senate,,DEM,Kamala Harris,257
-Imperial,247234,U.S. Senate,,DEM,Loretta Sanchez,413
-Imperial,281011,U.S. Senate,,DEM,Kamala Harris,0
-Imperial,281011,U.S. Senate,,DEM,Loretta Sanchez,7
-Imperial,281045,U.S. Senate,,DEM,Kamala Harris,4
-Imperial,281045,U.S. Senate,,DEM,Loretta Sanchez,9
-Imperial,285001,U.S. Senate,,DEM,Kamala Harris,11
-Imperial,285001,U.S. Senate,,DEM,Loretta Sanchez,19
-Imperial,285002,U.S. Senate,,DEM,Kamala Harris,0
-Imperial,285002,U.S. Senate,,DEM,Loretta Sanchez,0
-Imperial,285004,U.S. Senate,,DEM,Kamala Harris,2
-Imperial,285004,U.S. Senate,,DEM,Loretta Sanchez,5
-Imperial,285006,U.S. Senate,,DEM,Kamala Harris,0
-Imperial,285006,U.S. Senate,,DEM,Loretta Sanchez,0
-Imperial,285007,U.S. Senate,,DEM,Kamala Harris,0
-Imperial,285007,U.S. Senate,,DEM,Loretta Sanchez,0
-Imperial,285033,U.S. Senate,,DEM,Kamala Harris,33
-Imperial,285033,U.S. Senate,,DEM,Loretta Sanchez,45
-Imperial,285042,U.S. Senate,,DEM,Kamala Harris,0
-Imperial,285042,U.S. Senate,,DEM,Loretta Sanchez,0
-Imperial,285246,U.S. Senate,,DEM,Kamala Harris,21
-Imperial,285246,U.S. Senate,,DEM,Loretta Sanchez,22
-Imperial,286210,U.S. Senate,,DEM,Kamala Harris,0
-Imperial,286210,U.S. Senate,,DEM,Loretta Sanchez,0
-Imperial,286212,U.S. Senate,,DEM,Kamala Harris,0
-Imperial,286212,U.S. Senate,,DEM,Loretta Sanchez,3
-Imperial,286213,U.S. Senate,,DEM,Kamala Harris,194
-Imperial,286213,U.S. Senate,,DEM,Loretta Sanchez,549
-Imperial,286232,U.S. Senate,,DEM,Kamala Harris,196
-Imperial,286232,U.S. Senate,,DEM,Loretta Sanchez,705
-Imperial,286238,U.S. Senate,,DEM,Kamala Harris,0
-Imperial,286238,U.S. Senate,,DEM,Loretta Sanchez,0
-Imperial,286244,U.S. Senate,,DEM,Kamala Harris,34
-Imperial,286244,U.S. Senate,,DEM,Loretta Sanchez,128
-Imperial,286245,U.S. Senate,,DEM,Kamala Harris,0
-Imperial,286245,U.S. Senate,,DEM,Loretta Sanchez,0
-Imperial,286247,U.S. Senate,,DEM,Kamala Harris,0
-Imperial,286247,U.S. Senate,,DEM,Loretta Sanchez,0
-Imperial,287205,U.S. Senate,,DEM,Kamala Harris,0
-Imperial,287205,U.S. Senate,,DEM,Loretta Sanchez,0
-Imperial,287208,U.S. Senate,,DEM,Kamala Harris,10
-Imperial,287208,U.S. Senate,,DEM,Loretta Sanchez,34
-Imperial,287209,U.S. Senate,,DEM,Kamala Harris,3
-Imperial,287209,U.S. Senate,,DEM,Loretta Sanchez,8
-Imperial,287239,U.S. Senate,,DEM,Kamala Harris,22
-Imperial,287239,U.S. Senate,,DEM,Loretta Sanchez,7
-Imperial,287240,U.S. Senate,,DEM,Kamala Harris,9
-Imperial,287240,U.S. Senate,,DEM,Loretta Sanchez,6
-Imperial,287241,U.S. Senate,,DEM,Kamala Harris,30
-Imperial,287241,U.S. Senate,,DEM,Loretta Sanchez,44
-Imperial,287243,U.S. Senate,,DEM,Kamala Harris,3
-Imperial,287243,U.S. Senate,,DEM,Loretta Sanchez,0
-Imperial,287248,U.S. Senate,,DEM,Kamala Harris,0
-Imperial,287248,U.S. Senate,,DEM,Loretta Sanchez,0
-Imperial,287249,U.S. Senate,,DEM,Kamala Harris,0
-Imperial,287249,U.S. Senate,,DEM,Loretta Sanchez,0
-Imperial,289203,U.S. Senate,,DEM,Kamala Harris,22
-Imperial,289203,U.S. Senate,,DEM,Loretta Sanchez,27
-Imperial,345201,U.S. Senate,,DEM,Kamala Harris,165
-Imperial,345201,U.S. Senate,,DEM,Loretta Sanchez,525
-Imperial,345202,U.S. Senate,,DEM,Kamala Harris,167
-Imperial,345202,U.S. Senate,,DEM,Loretta Sanchez,531
-Imperial,345203,U.S. Senate,,DEM,Kamala Harris,255
-Imperial,345203,U.S. Senate,,DEM,Loretta Sanchez,547
-Imperial,345223,U.S. Senate,,DEM,Kamala Harris,162
-Imperial,345223,U.S. Senate,,DEM,Loretta Sanchez,341
-Imperial,365018,U.S. Senate,,DEM,Kamala Harris,248
-Imperial,365018,U.S. Senate,,DEM,Loretta Sanchez,481
-Imperial,365020,U.S. Senate,,DEM,Kamala Harris,384
-Imperial,365020,U.S. Senate,,DEM,Loretta Sanchez,610
-Imperial,365021,U.S. Senate,,DEM,Kamala Harris,615
-Imperial,365021,U.S. Senate,,DEM,Loretta Sanchez,970
-Imperial,365027,U.S. Senate,,DEM,Kamala Harris,432
-Imperial,365027,U.S. Senate,,DEM,Loretta Sanchez,682
-Imperial,365229,U.S. Senate,,DEM,Kamala Harris,73
-Imperial,365229,U.S. Senate,,DEM,Loretta Sanchez,166
-Imperial,381116,U.S. Senate,,DEM,Kamala Harris,3
-Imperial,381116,U.S. Senate,,DEM,Loretta Sanchez,5
-Imperial,384122,U.S. Senate,,DEM,Kamala Harris,0
-Imperial,384122,U.S. Senate,,DEM,Loretta Sanchez,1
-Imperial,385005,U.S. Senate,,DEM,Kamala Harris,11
-Imperial,385005,U.S. Senate,,DEM,Loretta Sanchez,18
-Imperial,385009,U.S. Senate,,DEM,Kamala Harris,11
-Imperial,385009,U.S. Senate,,DEM,Loretta Sanchez,23
-Imperial,385011,U.S. Senate,,DEM,Kamala Harris,0
-Imperial,385011,U.S. Senate,,DEM,Loretta Sanchez,2
-Imperial,385014,U.S. Senate,,DEM,Kamala Harris,234
-Imperial,385014,U.S. Senate,,DEM,Loretta Sanchez,271
-Imperial,385015,U.S. Senate,,DEM,Kamala Harris,11
-Imperial,385015,U.S. Senate,,DEM,Loretta Sanchez,6
-Imperial,385017,U.S. Senate,,DEM,Kamala Harris,5
-Imperial,385017,U.S. Senate,,DEM,Loretta Sanchez,9
-Imperial,385024,U.S. Senate,,DEM,Kamala Harris,4
-Imperial,385024,U.S. Senate,,DEM,Loretta Sanchez,10
-Imperial,385046,U.S. Senate,,DEM,Kamala Harris,0
-Imperial,385046,U.S. Senate,,DEM,Loretta Sanchez,0
-Imperial,387206,U.S. Senate,,DEM,Kamala Harris,38
-Imperial,387206,U.S. Senate,,DEM,Loretta Sanchez,40
-Imperial,387210,U.S. Senate,,DEM,Kamala Harris,23
-Imperial,387210,U.S. Senate,,DEM,Loretta Sanchez,24
-Imperial,387213,U.S. Senate,,DEM,Kamala Harris,13
-Imperial,387213,U.S. Senate,,DEM,Loretta Sanchez,15
-Imperial,387245,U.S. Senate,,DEM,Kamala Harris,0
-Imperial,387245,U.S. Senate,,DEM,Loretta Sanchez,0
-Imperial,389207,U.S. Senate,,DEM,Kamala Harris,60
-Imperial,389207,U.S. Senate,,DEM,Loretta Sanchez,104
-Imperial,389208,U.S. Senate,,DEM,Kamala Harris,125
-Imperial,389208,U.S. Senate,,DEM,Loretta Sanchez,273
-Imperial,389225,U.S. Senate,,DEM,Kamala Harris,0
-Imperial,389225,U.S. Senate,,DEM,Loretta Sanchez,0
-Imperial,411102,U.S. Senate,,DEM,Kamala Harris,193
-Imperial,411102,U.S. Senate,,DEM,Loretta Sanchez,173
-Imperial,411105,U.S. Senate,,DEM,Kamala Harris,260
-Imperial,411105,U.S. Senate,,DEM,Loretta Sanchez,508
-Imperial,411106,U.S. Senate,,DEM,Kamala Harris,353
-Imperial,411106,U.S. Senate,,DEM,Loretta Sanchez,826
-Imperial,411107,U.S. Senate,,DEM,Kamala Harris,235
-Imperial,411107,U.S. Senate,,DEM,Loretta Sanchez,258
-Imperial,411108,U.S. Senate,,DEM,Kamala Harris,266
-Imperial,411108,U.S. Senate,,DEM,Loretta Sanchez,392
-Imperial,411109,U.S. Senate,,DEM,Kamala Harris,211
-Imperial,411109,U.S. Senate,,DEM,Loretta Sanchez,414
-Imperial,411136,U.S. Senate,,DEM,Kamala Harris,23
-Imperial,411136,U.S. Senate,,DEM,Loretta Sanchez,51
-Imperial,432034,U.S. Senate,,DEM,Kamala Harris,238
-Imperial,432034,U.S. Senate,,DEM,Loretta Sanchez,465
-Imperial,474117,U.S. Senate,,DEM,Kamala Harris,122
-Imperial,474117,U.S. Senate,,DEM,Loretta Sanchez,322
-Imperial,481101,U.S. Senate,,DEM,Kamala Harris,2
-Imperial,481101,U.S. Senate,,DEM,Loretta Sanchez,12
-Imperial,481115,U.S. Senate,,DEM,Kamala Harris,0
-Imperial,481115,U.S. Senate,,DEM,Loretta Sanchez,0
-Imperial,481116,U.S. Senate,,DEM,Kamala Harris,37
-Imperial,481116,U.S. Senate,,DEM,Loretta Sanchez,79
-Imperial,481137,U.S. Senate,,DEM,Kamala Harris,3
-Imperial,481137,U.S. Senate,,DEM,Loretta Sanchez,0
-Imperial,482018,U.S. Senate,,DEM,Kamala Harris,22
-Imperial,482018,U.S. Senate,,DEM,Loretta Sanchez,46
-Imperial,482024,U.S. Senate,,DEM,Kamala Harris,19
-Imperial,482024,U.S. Senate,,DEM,Loretta Sanchez,25
-Imperial,482025,U.S. Senate,,DEM,Kamala Harris,10
-Imperial,482025,U.S. Senate,,DEM,Loretta Sanchez,8
-Imperial,482026,U.S. Senate,,DEM,Kamala Harris,30
-Imperial,482026,U.S. Senate,,DEM,Loretta Sanchez,29
-Imperial,482027,U.S. Senate,,DEM,Kamala Harris,1
-Imperial,482027,U.S. Senate,,DEM,Loretta Sanchez,0
-Imperial,482028,U.S. Senate,,DEM,Kamala Harris,78
-Imperial,482028,U.S. Senate,,DEM,Loretta Sanchez,107
-Imperial,482029,U.S. Senate,,DEM,Kamala Harris,37
-Imperial,482029,U.S. Senate,,DEM,Loretta Sanchez,37
-Imperial,482030,U.S. Senate,,DEM,Kamala Harris,0
-Imperial,482030,U.S. Senate,,DEM,Loretta Sanchez,0
-Imperial,482031,U.S. Senate,,DEM,Kamala Harris,0
-Imperial,482031,U.S. Senate,,DEM,Loretta Sanchez,0
-Imperial,482033,U.S. Senate,,DEM,Kamala Harris,0
-Imperial,482033,U.S. Senate,,DEM,Loretta Sanchez,0
-Imperial,482040,U.S. Senate,,DEM,Kamala Harris,0
-Imperial,482040,U.S. Senate,,DEM,Loretta Sanchez,0
-Imperial,482042,U.S. Senate,,DEM,Kamala Harris,0
-Imperial,482042,U.S. Senate,,DEM,Loretta Sanchez,0
-Imperial,482043,U.S. Senate,,DEM,Kamala Harris,0
-Imperial,482043,U.S. Senate,,DEM,Loretta Sanchez,0
-Imperial,482044,U.S. Senate,,DEM,Kamala Harris,0
-Imperial,482044,U.S. Senate,,DEM,Loretta Sanchez,0
-Imperial,482110,U.S. Senate,,DEM,Kamala Harris,3
-Imperial,482110,U.S. Senate,,DEM,Loretta Sanchez,5
-Imperial,483020,U.S. Senate,,DEM,Kamala Harris,69
-Imperial,483020,U.S. Senate,,DEM,Loretta Sanchez,99
-Imperial,483021,U.S. Senate,,DEM,Kamala Harris,204
-Imperial,483021,U.S. Senate,,DEM,Loretta Sanchez,275
-Imperial,483022,U.S. Senate,,DEM,Kamala Harris,44
-Imperial,483022,U.S. Senate,,DEM,Loretta Sanchez,33
-Imperial,483023,U.S. Senate,,DEM,Kamala Harris,48
-Imperial,483023,U.S. Senate,,DEM,Loretta Sanchez,89
-Imperial,483112,U.S. Senate,,DEM,Kamala Harris,12
-Imperial,483112,U.S. Senate,,DEM,Loretta Sanchez,8
-Imperial,483113,U.S. Senate,,DEM,Kamala Harris,14
-Imperial,483113,U.S. Senate,,DEM,Loretta Sanchez,15
-Imperial,483138,U.S. Senate,,DEM,Kamala Harris,0
-Imperial,483138,U.S. Senate,,DEM,Loretta Sanchez,0
-Imperial,484111,U.S. Senate,,DEM,Kamala Harris,2
-Imperial,484111,U.S. Senate,,DEM,Loretta Sanchez,5
-Imperial,484114,U.S. Senate,,DEM,Kamala Harris,9
-Imperial,484114,U.S. Senate,,DEM,Loretta Sanchez,9
-Imperial,484115,U.S. Senate,,DEM,Kamala Harris,10
-Imperial,484115,U.S. Senate,,DEM,Loretta Sanchez,15
-Imperial,484132,U.S. Senate,,DEM,Kamala Harris,4
-Imperial,484132,U.S. Senate,,DEM,Loretta Sanchez,7
-Imperial,484135,U.S. Senate,,DEM,Kamala Harris,1
-Imperial,484135,U.S. Senate,,DEM,Loretta Sanchez,8
-Imperial,484160,U.S. Senate,,DEM,Kamala Harris,0
-Imperial,484160,U.S. Senate,,DEM,Loretta Sanchez,0
-Imperial,511127,U.S. Senate,,DEM,Kamala Harris,205
-Imperial,511127,U.S. Senate,,DEM,Loretta Sanchez,485
-Imperial,511129,U.S. Senate,,DEM,Kamala Harris,287
-Imperial,511129,U.S. Senate,,DEM,Loretta Sanchez,714
-Imperial,521041,U.S. Senate,,DEM,Kamala Harris,50
-Imperial,521041,U.S. Senate,,DEM,Loretta Sanchez,149
-Imperial,521042,U.S. Senate,,DEM,Kamala Harris,307
-Imperial,521042,U.S. Senate,,DEM,Loretta Sanchez,954
-Imperial,521043,U.S. Senate,,DEM,Kamala Harris,27
-Imperial,521043,U.S. Senate,,DEM,Loretta Sanchez,94
-Imperial,521044,U.S. Senate,,DEM,Kamala Harris,0
-Imperial,521044,U.S. Senate,,DEM,Loretta Sanchez,0
-Imperial,545209,U.S. Senate,,DEM,Kamala Harris,71
-Imperial,545209,U.S. Senate,,DEM,Loretta Sanchez,155
-Imperial,545210,U.S. Senate,,DEM,Kamala Harris,228
-Imperial,545210,U.S. Senate,,DEM,Loretta Sanchez,456
-Imperial,545238,U.S. Senate,,DEM,Kamala Harris,24
-Imperial,545238,U.S. Senate,,DEM,Loretta Sanchez,22
-Imperial,547239,U.S. Senate,,DEM,Kamala Harris,173
-Imperial,547239,U.S. Senate,,DEM,Loretta Sanchez,338
-Imperial,547240,U.S. Senate,,DEM,Kamala Harris,0
-Imperial,547240,U.S. Senate,,DEM,Loretta Sanchez,0
-Imperial,547265,U.S. Senate,,DEM,Kamala Harris,0
-Imperial,547265,U.S. Senate,,DEM,Loretta Sanchez,0
-Imperial,548211,U.S. Senate,,DEM,Kamala Harris,5
-Imperial,548211,U.S. Senate,,DEM,Loretta Sanchez,17
-Imperial,548241,U.S. Senate,,DEM,Kamala Harris,0
-Imperial,548241,U.S. Senate,,DEM,Loretta Sanchez,0
-Imperial,554021,U.S. Senate,,DEM,Kamala Harris,219
-Imperial,554021,U.S. Senate,,DEM,Loretta Sanchez,586
-Imperial,554023,U.S. Senate,,DEM,Kamala Harris,217
-Imperial,554023,U.S. Senate,,DEM,Loretta Sanchez,428
-Imperial,581002,U.S. Senate,,DEM,Kamala Harris,1
-Imperial,581002,U.S. Senate,,DEM,Loretta Sanchez,1
-Imperial,581125,U.S. Senate,,DEM,Kamala Harris,5
-Imperial,581125,U.S. Senate,,DEM,Loretta Sanchez,15
-Imperial,582134,U.S. Senate,,DEM,Kamala Harris,4
-Imperial,582134,U.S. Senate,,DEM,Loretta Sanchez,7
-Imperial,582135,U.S. Senate,,DEM,Kamala Harris,0
-Imperial,582135,U.S. Senate,,DEM,Loretta Sanchez,0
-Imperial,584003,U.S. Senate,,DEM,Kamala Harris,12
-Imperial,584003,U.S. Senate,,DEM,Loretta Sanchez,16
-Imperial,584004,U.S. Senate,,DEM,Kamala Harris,8
-Imperial,584004,U.S. Senate,,DEM,Loretta Sanchez,12
-Imperial,584006,U.S. Senate,,DEM,Kamala Harris,0
-Imperial,584006,U.S. Senate,,DEM,Loretta Sanchez,0
-Imperial,584007,U.S. Senate,,DEM,Kamala Harris,0
-Imperial,584007,U.S. Senate,,DEM,Loretta Sanchez,0
-Imperial,584014,U.S. Senate,,DEM,Kamala Harris,8
-Imperial,584014,U.S. Senate,,DEM,Loretta Sanchez,9
-Imperial,584017,U.S. Senate,,DEM,Kamala Harris,19
-Imperial,584017,U.S. Senate,,DEM,Loretta Sanchez,23
-Imperial,584018,U.S. Senate,,DEM,Kamala Harris,15
-Imperial,584018,U.S. Senate,,DEM,Loretta Sanchez,29
-Imperial,584020,U.S. Senate,,DEM,Kamala Harris,174
-Imperial,584020,U.S. Senate,,DEM,Loretta Sanchez,261
-Imperial,584026,U.S. Senate,,DEM,Kamala Harris,0
-Imperial,584026,U.S. Senate,,DEM,Loretta Sanchez,2
-Imperial,584050,U.S. Senate,,DEM,Kamala Harris,5
-Imperial,584050,U.S. Senate,,DEM,Loretta Sanchez,8
-Imperial,584051,U.S. Senate,,DEM,Kamala Harris,24
-Imperial,584051,U.S. Senate,,DEM,Loretta Sanchez,68
-Imperial,584054,U.S. Senate,,DEM,Kamala Harris,12
-Imperial,584054,U.S. Senate,,DEM,Loretta Sanchez,17
-Imperial,585016,U.S. Senate,,DEM,Kamala Harris,18
-Imperial,585016,U.S. Senate,,DEM,Loretta Sanchez,37
-Imperial,585019,U.S. Senate,,DEM,Kamala Harris,8
-Imperial,585019,U.S. Senate,,DEM,Loretta Sanchez,5
-Imperial,585024,U.S. Senate,,DEM,Kamala Harris,1
-Imperial,585024,U.S. Senate,,DEM,Loretta Sanchez,0
-Imperial,585049,U.S. Senate,,DEM,Kamala Harris,27
-Imperial,585049,U.S. Senate,,DEM,Loretta Sanchez,59
-Imperial,585256,U.S. Senate,,DEM,Kamala Harris,14
-Imperial,585256,U.S. Senate,,DEM,Loretta Sanchez,22
-Imperial,585272,U.S. Senate,,DEM,Kamala Harris,0
-Imperial,585272,U.S. Senate,,DEM,Loretta Sanchez,1
-Imperial,586005,U.S. Senate,,DEM,Kamala Harris,35
-Imperial,586005,U.S. Senate,,DEM,Loretta Sanchez,19
-Imperial,586008,U.S. Senate,,DEM,Kamala Harris,52
-Imperial,586008,U.S. Senate,,DEM,Loretta Sanchez,63
-Imperial,586032,U.S. Senate,,DEM,Kamala Harris,8
-Imperial,586032,U.S. Senate,,DEM,Loretta Sanchez,5
-Imperial,586037,U.S. Senate,,DEM,Kamala Harris,17
-Imperial,586037,U.S. Senate,,DEM,Loretta Sanchez,17
-Imperial,586066,U.S. Senate,,DEM,Kamala Harris,0
-Imperial,586066,U.S. Senate,,DEM,Loretta Sanchez,0
-Imperial,586071,U.S. Senate,,DEM,Kamala Harris,0
-Imperial,586071,U.S. Senate,,DEM,Loretta Sanchez,0
-Imperial,586201,U.S. Senate,,DEM,Kamala Harris,2
-Imperial,586201,U.S. Senate,,DEM,Loretta Sanchez,4
-Imperial,586213,U.S. Senate,,DEM,Kamala Harris,2
-Imperial,586213,U.S. Senate,,DEM,Loretta Sanchez,0
-Imperial,586248,U.S. Senate,,DEM,Kamala Harris,0
-Imperial,586248,U.S. Senate,,DEM,Loretta Sanchez,0
-Imperial,586249,U.S. Senate,,DEM,Kamala Harris,0
-Imperial,586249,U.S. Senate,,DEM,Loretta Sanchez,0
-Imperial,587233,U.S. Senate,,DEM,Kamala Harris,27
-Imperial,587233,U.S. Senate,,DEM,Loretta Sanchez,24
-Imperial,588215,U.S. Senate,,DEM,Kamala Harris,11
-Imperial,588215,U.S. Senate,,DEM,Loretta Sanchez,23
-Imperial,588252,U.S. Senate,,DEM,Kamala Harris,5
-Imperial,588252,U.S. Senate,,DEM,Loretta Sanchez,8
-Imperial,588253,U.S. Senate,,DEM,Kamala Harris,1
-Imperial,588253,U.S. Senate,,DEM,Loretta Sanchez,16
-Imperial,588255,U.S. Senate,,DEM,Kamala Harris,63
-Imperial,588255,U.S. Senate,,DEM,Loretta Sanchez,58
-Imperial,588257,U.S. Senate,,DEM,Kamala Harris,0
-Imperial,588257,U.S. Senate,,DEM,Loretta Sanchez,0
-Imperial,588258,U.S. Senate,,DEM,Kamala Harris,2
-Imperial,588258,U.S. Senate,,DEM,Loretta Sanchez,2
-Imperial,588259,U.S. Senate,,DEM,Kamala Harris,0
-Imperial,588259,U.S. Senate,,DEM,Loretta Sanchez,0
-Imperial,588260,U.S. Senate,,DEM,Kamala Harris,51
-Imperial,588260,U.S. Senate,,DEM,Loretta Sanchez,171
-Imperial,588261,U.S. Senate,,DEM,Kamala Harris,9
-Imperial,588261,U.S. Senate,,DEM,Loretta Sanchez,36
-Imperial,588262,U.S. Senate,,DEM,Kamala Harris,0
-Imperial,588262,U.S. Senate,,DEM,Loretta Sanchez,0
-Imperial,588263,U.S. Senate,,DEM,Kamala Harris,0
-Imperial,588263,U.S. Senate,,DEM,Loretta Sanchez,0
-Imperial,588264,U.S. Senate,,DEM,Kamala Harris,1
-Imperial,588264,U.S. Senate,,DEM,Loretta Sanchez,1
+Imperial,121004,U.S. Senate,,DEM,Kamala D. Harris,165
+Imperial,121004,U.S. Senate,,DEM,Loretta L. Sanchez,478
+Imperial,121005,U.S. Senate,,DEM,Kamala D. Harris,259
+Imperial,121005,U.S. Senate,,DEM,Loretta L. Sanchez,758
+Imperial,121006,U.S. Senate,,DEM,Kamala D. Harris,229
+Imperial,121006,U.S. Senate,,DEM,Loretta L. Sanchez,616
+Imperial,121009,U.S. Senate,,DEM,Kamala D. Harris,32
+Imperial,121009,U.S. Senate,,DEM,Loretta L. Sanchez,57
+Imperial,121010,U.S. Senate,,DEM,Kamala D. Harris,226
+Imperial,121010,U.S. Senate,,DEM,Loretta L. Sanchez,469
+Imperial,121012,U.S. Senate,,DEM,Kamala D. Harris,105
+Imperial,121012,U.S. Senate,,DEM,Loretta L. Sanchez,325
+Imperial,121014,U.S. Senate,,DEM,Kamala D. Harris,333
+Imperial,121014,U.S. Senate,,DEM,Loretta L. Sanchez,956
+Imperial,121015,U.S. Senate,,DEM,Kamala D. Harris,24
+Imperial,121015,U.S. Senate,,DEM,Loretta L. Sanchez,90
+Imperial,121016,U.S. Senate,,DEM,Kamala D. Harris,197
+Imperial,121016,U.S. Senate,,DEM,Loretta L. Sanchez,525
+Imperial,121017,U.S. Senate,,DEM,Kamala D. Harris,219
+Imperial,121017,U.S. Senate,,DEM,Loretta L. Sanchez,566
+Imperial,121018,U.S. Senate,,DEM,Kamala D. Harris,253
+Imperial,121018,U.S. Senate,,DEM,Loretta L. Sanchez,669
+Imperial,121019,U.S. Senate,,DEM,Kamala D. Harris,372
+Imperial,121019,U.S. Senate,,DEM,Loretta L. Sanchez,952
+Imperial,121020,U.S. Senate,,DEM,Kamala D. Harris,204
+Imperial,121020,U.S. Senate,,DEM,Loretta L. Sanchez,532
+Imperial,121021,U.S. Senate,,DEM,Kamala D. Harris,6
+Imperial,121021,U.S. Senate,,DEM,Loretta L. Sanchez,33
+Imperial,181001,U.S. Senate,,DEM,Kamala D. Harris,4
+Imperial,181001,U.S. Senate,,DEM,Loretta L. Sanchez,11
+Imperial,181002,U.S. Senate,,DEM,Kamala D. Harris,19
+Imperial,181002,U.S. Senate,,DEM,Loretta L. Sanchez,31
+Imperial,181066,U.S. Senate,,DEM,Kamala D. Harris,6
+Imperial,181066,U.S. Senate,,DEM,Loretta L. Sanchez,19
+Imperial,184003,U.S. Senate,,DEM,Kamala D. Harris,1
+Imperial,184003,U.S. Senate,,DEM,Loretta L. Sanchez,7
+Imperial,186005,U.S. Senate,,DEM,Kamala D. Harris,10
+Imperial,186005,U.S. Senate,,DEM,Loretta L. Sanchez,13
+Imperial,186006,U.S. Senate,,DEM,Kamala D. Harris,20
+Imperial,186006,U.S. Senate,,DEM,Loretta L. Sanchez,36
+Imperial,186007,U.S. Senate,,DEM,Kamala D. Harris,0
+Imperial,186007,U.S. Senate,,DEM,Loretta L. Sanchez,7
+Imperial,186067,U.S. Senate,,DEM,Kamala D. Harris,2
+Imperial,186067,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Imperial,245205,U.S. Senate,,DEM,Kamala D. Harris,395
+Imperial,245205,U.S. Senate,,DEM,Loretta L. Sanchez,669
+Imperial,245214,U.S. Senate,,DEM,Kamala D. Harris,435
+Imperial,245214,U.S. Senate,,DEM,Loretta L. Sanchez,672
+Imperial,245215,U.S. Senate,,DEM,Kamala D. Harris,150
+Imperial,245215,U.S. Senate,,DEM,Loretta L. Sanchez,401
+Imperial,245217,U.S. Senate,,DEM,Kamala D. Harris,63
+Imperial,245217,U.S. Senate,,DEM,Loretta L. Sanchez,191
+Imperial,245220,U.S. Senate,,DEM,Kamala D. Harris,261
+Imperial,245220,U.S. Senate,,DEM,Loretta L. Sanchez,534
+Imperial,245224,U.S. Senate,,DEM,Kamala D. Harris,266
+Imperial,245224,U.S. Senate,,DEM,Loretta L. Sanchez,626
+Imperial,245225,U.S. Senate,,DEM,Kamala D. Harris,65
+Imperial,245225,U.S. Senate,,DEM,Loretta L. Sanchez,103
+Imperial,245226,U.S. Senate,,DEM,Kamala D. Harris,341
+Imperial,245226,U.S. Senate,,DEM,Loretta L. Sanchez,599
+Imperial,245228,U.S. Senate,,DEM,Kamala D. Harris,191
+Imperial,245228,U.S. Senate,,DEM,Loretta L. Sanchez,273
+Imperial,247229,U.S. Senate,,DEM,Kamala D. Harris,218
+Imperial,247229,U.S. Senate,,DEM,Loretta L. Sanchez,209
+Imperial,247234,U.S. Senate,,DEM,Kamala D. Harris,257
+Imperial,247234,U.S. Senate,,DEM,Loretta L. Sanchez,413
+Imperial,281011,U.S. Senate,,DEM,Kamala D. Harris,0
+Imperial,281011,U.S. Senate,,DEM,Loretta L. Sanchez,7
+Imperial,281045,U.S. Senate,,DEM,Kamala D. Harris,4
+Imperial,281045,U.S. Senate,,DEM,Loretta L. Sanchez,9
+Imperial,285001,U.S. Senate,,DEM,Kamala D. Harris,11
+Imperial,285001,U.S. Senate,,DEM,Loretta L. Sanchez,19
+Imperial,285002,U.S. Senate,,DEM,Kamala D. Harris,0
+Imperial,285002,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Imperial,285004,U.S. Senate,,DEM,Kamala D. Harris,2
+Imperial,285004,U.S. Senate,,DEM,Loretta L. Sanchez,5
+Imperial,285006,U.S. Senate,,DEM,Kamala D. Harris,0
+Imperial,285006,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Imperial,285007,U.S. Senate,,DEM,Kamala D. Harris,0
+Imperial,285007,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Imperial,285033,U.S. Senate,,DEM,Kamala D. Harris,33
+Imperial,285033,U.S. Senate,,DEM,Loretta L. Sanchez,45
+Imperial,285042,U.S. Senate,,DEM,Kamala D. Harris,0
+Imperial,285042,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Imperial,285246,U.S. Senate,,DEM,Kamala D. Harris,21
+Imperial,285246,U.S. Senate,,DEM,Loretta L. Sanchez,22
+Imperial,286210,U.S. Senate,,DEM,Kamala D. Harris,0
+Imperial,286210,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Imperial,286212,U.S. Senate,,DEM,Kamala D. Harris,0
+Imperial,286212,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Imperial,286213,U.S. Senate,,DEM,Kamala D. Harris,194
+Imperial,286213,U.S. Senate,,DEM,Loretta L. Sanchez,549
+Imperial,286232,U.S. Senate,,DEM,Kamala D. Harris,196
+Imperial,286232,U.S. Senate,,DEM,Loretta L. Sanchez,705
+Imperial,286238,U.S. Senate,,DEM,Kamala D. Harris,0
+Imperial,286238,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Imperial,286244,U.S. Senate,,DEM,Kamala D. Harris,34
+Imperial,286244,U.S. Senate,,DEM,Loretta L. Sanchez,128
+Imperial,286245,U.S. Senate,,DEM,Kamala D. Harris,0
+Imperial,286245,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Imperial,286247,U.S. Senate,,DEM,Kamala D. Harris,0
+Imperial,286247,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Imperial,287205,U.S. Senate,,DEM,Kamala D. Harris,0
+Imperial,287205,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Imperial,287208,U.S. Senate,,DEM,Kamala D. Harris,10
+Imperial,287208,U.S. Senate,,DEM,Loretta L. Sanchez,34
+Imperial,287209,U.S. Senate,,DEM,Kamala D. Harris,3
+Imperial,287209,U.S. Senate,,DEM,Loretta L. Sanchez,8
+Imperial,287239,U.S. Senate,,DEM,Kamala D. Harris,22
+Imperial,287239,U.S. Senate,,DEM,Loretta L. Sanchez,7
+Imperial,287240,U.S. Senate,,DEM,Kamala D. Harris,9
+Imperial,287240,U.S. Senate,,DEM,Loretta L. Sanchez,6
+Imperial,287241,U.S. Senate,,DEM,Kamala D. Harris,30
+Imperial,287241,U.S. Senate,,DEM,Loretta L. Sanchez,44
+Imperial,287243,U.S. Senate,,DEM,Kamala D. Harris,3
+Imperial,287243,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Imperial,287248,U.S. Senate,,DEM,Kamala D. Harris,0
+Imperial,287248,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Imperial,287249,U.S. Senate,,DEM,Kamala D. Harris,0
+Imperial,287249,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Imperial,289203,U.S. Senate,,DEM,Kamala D. Harris,22
+Imperial,289203,U.S. Senate,,DEM,Loretta L. Sanchez,27
+Imperial,345201,U.S. Senate,,DEM,Kamala D. Harris,165
+Imperial,345201,U.S. Senate,,DEM,Loretta L. Sanchez,525
+Imperial,345202,U.S. Senate,,DEM,Kamala D. Harris,167
+Imperial,345202,U.S. Senate,,DEM,Loretta L. Sanchez,531
+Imperial,345203,U.S. Senate,,DEM,Kamala D. Harris,255
+Imperial,345203,U.S. Senate,,DEM,Loretta L. Sanchez,547
+Imperial,345223,U.S. Senate,,DEM,Kamala D. Harris,162
+Imperial,345223,U.S. Senate,,DEM,Loretta L. Sanchez,341
+Imperial,365018,U.S. Senate,,DEM,Kamala D. Harris,248
+Imperial,365018,U.S. Senate,,DEM,Loretta L. Sanchez,481
+Imperial,365020,U.S. Senate,,DEM,Kamala D. Harris,384
+Imperial,365020,U.S. Senate,,DEM,Loretta L. Sanchez,610
+Imperial,365021,U.S. Senate,,DEM,Kamala D. Harris,615
+Imperial,365021,U.S. Senate,,DEM,Loretta L. Sanchez,970
+Imperial,365027,U.S. Senate,,DEM,Kamala D. Harris,432
+Imperial,365027,U.S. Senate,,DEM,Loretta L. Sanchez,682
+Imperial,365229,U.S. Senate,,DEM,Kamala D. Harris,73
+Imperial,365229,U.S. Senate,,DEM,Loretta L. Sanchez,166
+Imperial,381116,U.S. Senate,,DEM,Kamala D. Harris,3
+Imperial,381116,U.S. Senate,,DEM,Loretta L. Sanchez,5
+Imperial,384122,U.S. Senate,,DEM,Kamala D. Harris,0
+Imperial,384122,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Imperial,385005,U.S. Senate,,DEM,Kamala D. Harris,11
+Imperial,385005,U.S. Senate,,DEM,Loretta L. Sanchez,18
+Imperial,385009,U.S. Senate,,DEM,Kamala D. Harris,11
+Imperial,385009,U.S. Senate,,DEM,Loretta L. Sanchez,23
+Imperial,385011,U.S. Senate,,DEM,Kamala D. Harris,0
+Imperial,385011,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Imperial,385014,U.S. Senate,,DEM,Kamala D. Harris,234
+Imperial,385014,U.S. Senate,,DEM,Loretta L. Sanchez,271
+Imperial,385015,U.S. Senate,,DEM,Kamala D. Harris,11
+Imperial,385015,U.S. Senate,,DEM,Loretta L. Sanchez,6
+Imperial,385017,U.S. Senate,,DEM,Kamala D. Harris,5
+Imperial,385017,U.S. Senate,,DEM,Loretta L. Sanchez,9
+Imperial,385024,U.S. Senate,,DEM,Kamala D. Harris,4
+Imperial,385024,U.S. Senate,,DEM,Loretta L. Sanchez,10
+Imperial,385046,U.S. Senate,,DEM,Kamala D. Harris,0
+Imperial,385046,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Imperial,387206,U.S. Senate,,DEM,Kamala D. Harris,38
+Imperial,387206,U.S. Senate,,DEM,Loretta L. Sanchez,40
+Imperial,387210,U.S. Senate,,DEM,Kamala D. Harris,23
+Imperial,387210,U.S. Senate,,DEM,Loretta L. Sanchez,24
+Imperial,387213,U.S. Senate,,DEM,Kamala D. Harris,13
+Imperial,387213,U.S. Senate,,DEM,Loretta L. Sanchez,15
+Imperial,387245,U.S. Senate,,DEM,Kamala D. Harris,0
+Imperial,387245,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Imperial,389207,U.S. Senate,,DEM,Kamala D. Harris,60
+Imperial,389207,U.S. Senate,,DEM,Loretta L. Sanchez,104
+Imperial,389208,U.S. Senate,,DEM,Kamala D. Harris,125
+Imperial,389208,U.S. Senate,,DEM,Loretta L. Sanchez,273
+Imperial,389225,U.S. Senate,,DEM,Kamala D. Harris,0
+Imperial,389225,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Imperial,411102,U.S. Senate,,DEM,Kamala D. Harris,193
+Imperial,411102,U.S. Senate,,DEM,Loretta L. Sanchez,173
+Imperial,411105,U.S. Senate,,DEM,Kamala D. Harris,260
+Imperial,411105,U.S. Senate,,DEM,Loretta L. Sanchez,508
+Imperial,411106,U.S. Senate,,DEM,Kamala D. Harris,353
+Imperial,411106,U.S. Senate,,DEM,Loretta L. Sanchez,826
+Imperial,411107,U.S. Senate,,DEM,Kamala D. Harris,235
+Imperial,411107,U.S. Senate,,DEM,Loretta L. Sanchez,258
+Imperial,411108,U.S. Senate,,DEM,Kamala D. Harris,266
+Imperial,411108,U.S. Senate,,DEM,Loretta L. Sanchez,392
+Imperial,411109,U.S. Senate,,DEM,Kamala D. Harris,211
+Imperial,411109,U.S. Senate,,DEM,Loretta L. Sanchez,414
+Imperial,411136,U.S. Senate,,DEM,Kamala D. Harris,23
+Imperial,411136,U.S. Senate,,DEM,Loretta L. Sanchez,51
+Imperial,432034,U.S. Senate,,DEM,Kamala D. Harris,238
+Imperial,432034,U.S. Senate,,DEM,Loretta L. Sanchez,465
+Imperial,474117,U.S. Senate,,DEM,Kamala D. Harris,122
+Imperial,474117,U.S. Senate,,DEM,Loretta L. Sanchez,322
+Imperial,481101,U.S. Senate,,DEM,Kamala D. Harris,2
+Imperial,481101,U.S. Senate,,DEM,Loretta L. Sanchez,12
+Imperial,481115,U.S. Senate,,DEM,Kamala D. Harris,0
+Imperial,481115,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Imperial,481116,U.S. Senate,,DEM,Kamala D. Harris,37
+Imperial,481116,U.S. Senate,,DEM,Loretta L. Sanchez,79
+Imperial,481137,U.S. Senate,,DEM,Kamala D. Harris,3
+Imperial,481137,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Imperial,482018,U.S. Senate,,DEM,Kamala D. Harris,22
+Imperial,482018,U.S. Senate,,DEM,Loretta L. Sanchez,46
+Imperial,482024,U.S. Senate,,DEM,Kamala D. Harris,19
+Imperial,482024,U.S. Senate,,DEM,Loretta L. Sanchez,25
+Imperial,482025,U.S. Senate,,DEM,Kamala D. Harris,10
+Imperial,482025,U.S. Senate,,DEM,Loretta L. Sanchez,8
+Imperial,482026,U.S. Senate,,DEM,Kamala D. Harris,30
+Imperial,482026,U.S. Senate,,DEM,Loretta L. Sanchez,29
+Imperial,482027,U.S. Senate,,DEM,Kamala D. Harris,1
+Imperial,482027,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Imperial,482028,U.S. Senate,,DEM,Kamala D. Harris,78
+Imperial,482028,U.S. Senate,,DEM,Loretta L. Sanchez,107
+Imperial,482029,U.S. Senate,,DEM,Kamala D. Harris,37
+Imperial,482029,U.S. Senate,,DEM,Loretta L. Sanchez,37
+Imperial,482030,U.S. Senate,,DEM,Kamala D. Harris,0
+Imperial,482030,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Imperial,482031,U.S. Senate,,DEM,Kamala D. Harris,0
+Imperial,482031,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Imperial,482033,U.S. Senate,,DEM,Kamala D. Harris,0
+Imperial,482033,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Imperial,482040,U.S. Senate,,DEM,Kamala D. Harris,0
+Imperial,482040,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Imperial,482042,U.S. Senate,,DEM,Kamala D. Harris,0
+Imperial,482042,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Imperial,482043,U.S. Senate,,DEM,Kamala D. Harris,0
+Imperial,482043,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Imperial,482044,U.S. Senate,,DEM,Kamala D. Harris,0
+Imperial,482044,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Imperial,482110,U.S. Senate,,DEM,Kamala D. Harris,3
+Imperial,482110,U.S. Senate,,DEM,Loretta L. Sanchez,5
+Imperial,483020,U.S. Senate,,DEM,Kamala D. Harris,69
+Imperial,483020,U.S. Senate,,DEM,Loretta L. Sanchez,99
+Imperial,483021,U.S. Senate,,DEM,Kamala D. Harris,204
+Imperial,483021,U.S. Senate,,DEM,Loretta L. Sanchez,275
+Imperial,483022,U.S. Senate,,DEM,Kamala D. Harris,44
+Imperial,483022,U.S. Senate,,DEM,Loretta L. Sanchez,33
+Imperial,483023,U.S. Senate,,DEM,Kamala D. Harris,48
+Imperial,483023,U.S. Senate,,DEM,Loretta L. Sanchez,89
+Imperial,483112,U.S. Senate,,DEM,Kamala D. Harris,12
+Imperial,483112,U.S. Senate,,DEM,Loretta L. Sanchez,8
+Imperial,483113,U.S. Senate,,DEM,Kamala D. Harris,14
+Imperial,483113,U.S. Senate,,DEM,Loretta L. Sanchez,15
+Imperial,483138,U.S. Senate,,DEM,Kamala D. Harris,0
+Imperial,483138,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Imperial,484111,U.S. Senate,,DEM,Kamala D. Harris,2
+Imperial,484111,U.S. Senate,,DEM,Loretta L. Sanchez,5
+Imperial,484114,U.S. Senate,,DEM,Kamala D. Harris,9
+Imperial,484114,U.S. Senate,,DEM,Loretta L. Sanchez,9
+Imperial,484115,U.S. Senate,,DEM,Kamala D. Harris,10
+Imperial,484115,U.S. Senate,,DEM,Loretta L. Sanchez,15
+Imperial,484132,U.S. Senate,,DEM,Kamala D. Harris,4
+Imperial,484132,U.S. Senate,,DEM,Loretta L. Sanchez,7
+Imperial,484135,U.S. Senate,,DEM,Kamala D. Harris,1
+Imperial,484135,U.S. Senate,,DEM,Loretta L. Sanchez,8
+Imperial,484160,U.S. Senate,,DEM,Kamala D. Harris,0
+Imperial,484160,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Imperial,511127,U.S. Senate,,DEM,Kamala D. Harris,205
+Imperial,511127,U.S. Senate,,DEM,Loretta L. Sanchez,485
+Imperial,511129,U.S. Senate,,DEM,Kamala D. Harris,287
+Imperial,511129,U.S. Senate,,DEM,Loretta L. Sanchez,714
+Imperial,521041,U.S. Senate,,DEM,Kamala D. Harris,50
+Imperial,521041,U.S. Senate,,DEM,Loretta L. Sanchez,149
+Imperial,521042,U.S. Senate,,DEM,Kamala D. Harris,307
+Imperial,521042,U.S. Senate,,DEM,Loretta L. Sanchez,954
+Imperial,521043,U.S. Senate,,DEM,Kamala D. Harris,27
+Imperial,521043,U.S. Senate,,DEM,Loretta L. Sanchez,94
+Imperial,521044,U.S. Senate,,DEM,Kamala D. Harris,0
+Imperial,521044,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Imperial,545209,U.S. Senate,,DEM,Kamala D. Harris,71
+Imperial,545209,U.S. Senate,,DEM,Loretta L. Sanchez,155
+Imperial,545210,U.S. Senate,,DEM,Kamala D. Harris,228
+Imperial,545210,U.S. Senate,,DEM,Loretta L. Sanchez,456
+Imperial,545238,U.S. Senate,,DEM,Kamala D. Harris,24
+Imperial,545238,U.S. Senate,,DEM,Loretta L. Sanchez,22
+Imperial,547239,U.S. Senate,,DEM,Kamala D. Harris,173
+Imperial,547239,U.S. Senate,,DEM,Loretta L. Sanchez,338
+Imperial,547240,U.S. Senate,,DEM,Kamala D. Harris,0
+Imperial,547240,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Imperial,547265,U.S. Senate,,DEM,Kamala D. Harris,0
+Imperial,547265,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Imperial,548211,U.S. Senate,,DEM,Kamala D. Harris,5
+Imperial,548211,U.S. Senate,,DEM,Loretta L. Sanchez,17
+Imperial,548241,U.S. Senate,,DEM,Kamala D. Harris,0
+Imperial,548241,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Imperial,554021,U.S. Senate,,DEM,Kamala D. Harris,219
+Imperial,554021,U.S. Senate,,DEM,Loretta L. Sanchez,586
+Imperial,554023,U.S. Senate,,DEM,Kamala D. Harris,217
+Imperial,554023,U.S. Senate,,DEM,Loretta L. Sanchez,428
+Imperial,581002,U.S. Senate,,DEM,Kamala D. Harris,1
+Imperial,581002,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Imperial,581125,U.S. Senate,,DEM,Kamala D. Harris,5
+Imperial,581125,U.S. Senate,,DEM,Loretta L. Sanchez,15
+Imperial,582134,U.S. Senate,,DEM,Kamala D. Harris,4
+Imperial,582134,U.S. Senate,,DEM,Loretta L. Sanchez,7
+Imperial,582135,U.S. Senate,,DEM,Kamala D. Harris,0
+Imperial,582135,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Imperial,584003,U.S. Senate,,DEM,Kamala D. Harris,12
+Imperial,584003,U.S. Senate,,DEM,Loretta L. Sanchez,16
+Imperial,584004,U.S. Senate,,DEM,Kamala D. Harris,8
+Imperial,584004,U.S. Senate,,DEM,Loretta L. Sanchez,12
+Imperial,584006,U.S. Senate,,DEM,Kamala D. Harris,0
+Imperial,584006,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Imperial,584007,U.S. Senate,,DEM,Kamala D. Harris,0
+Imperial,584007,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Imperial,584014,U.S. Senate,,DEM,Kamala D. Harris,8
+Imperial,584014,U.S. Senate,,DEM,Loretta L. Sanchez,9
+Imperial,584017,U.S. Senate,,DEM,Kamala D. Harris,19
+Imperial,584017,U.S. Senate,,DEM,Loretta L. Sanchez,23
+Imperial,584018,U.S. Senate,,DEM,Kamala D. Harris,15
+Imperial,584018,U.S. Senate,,DEM,Loretta L. Sanchez,29
+Imperial,584020,U.S. Senate,,DEM,Kamala D. Harris,174
+Imperial,584020,U.S. Senate,,DEM,Loretta L. Sanchez,261
+Imperial,584026,U.S. Senate,,DEM,Kamala D. Harris,0
+Imperial,584026,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Imperial,584050,U.S. Senate,,DEM,Kamala D. Harris,5
+Imperial,584050,U.S. Senate,,DEM,Loretta L. Sanchez,8
+Imperial,584051,U.S. Senate,,DEM,Kamala D. Harris,24
+Imperial,584051,U.S. Senate,,DEM,Loretta L. Sanchez,68
+Imperial,584054,U.S. Senate,,DEM,Kamala D. Harris,12
+Imperial,584054,U.S. Senate,,DEM,Loretta L. Sanchez,17
+Imperial,585016,U.S. Senate,,DEM,Kamala D. Harris,18
+Imperial,585016,U.S. Senate,,DEM,Loretta L. Sanchez,37
+Imperial,585019,U.S. Senate,,DEM,Kamala D. Harris,8
+Imperial,585019,U.S. Senate,,DEM,Loretta L. Sanchez,5
+Imperial,585024,U.S. Senate,,DEM,Kamala D. Harris,1
+Imperial,585024,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Imperial,585049,U.S. Senate,,DEM,Kamala D. Harris,27
+Imperial,585049,U.S. Senate,,DEM,Loretta L. Sanchez,59
+Imperial,585256,U.S. Senate,,DEM,Kamala D. Harris,14
+Imperial,585256,U.S. Senate,,DEM,Loretta L. Sanchez,22
+Imperial,585272,U.S. Senate,,DEM,Kamala D. Harris,0
+Imperial,585272,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Imperial,586005,U.S. Senate,,DEM,Kamala D. Harris,35
+Imperial,586005,U.S. Senate,,DEM,Loretta L. Sanchez,19
+Imperial,586008,U.S. Senate,,DEM,Kamala D. Harris,52
+Imperial,586008,U.S. Senate,,DEM,Loretta L. Sanchez,63
+Imperial,586032,U.S. Senate,,DEM,Kamala D. Harris,8
+Imperial,586032,U.S. Senate,,DEM,Loretta L. Sanchez,5
+Imperial,586037,U.S. Senate,,DEM,Kamala D. Harris,17
+Imperial,586037,U.S. Senate,,DEM,Loretta L. Sanchez,17
+Imperial,586066,U.S. Senate,,DEM,Kamala D. Harris,0
+Imperial,586066,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Imperial,586071,U.S. Senate,,DEM,Kamala D. Harris,0
+Imperial,586071,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Imperial,586201,U.S. Senate,,DEM,Kamala D. Harris,2
+Imperial,586201,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Imperial,586213,U.S. Senate,,DEM,Kamala D. Harris,2
+Imperial,586213,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Imperial,586248,U.S. Senate,,DEM,Kamala D. Harris,0
+Imperial,586248,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Imperial,586249,U.S. Senate,,DEM,Kamala D. Harris,0
+Imperial,586249,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Imperial,587233,U.S. Senate,,DEM,Kamala D. Harris,27
+Imperial,587233,U.S. Senate,,DEM,Loretta L. Sanchez,24
+Imperial,588215,U.S. Senate,,DEM,Kamala D. Harris,11
+Imperial,588215,U.S. Senate,,DEM,Loretta L. Sanchez,23
+Imperial,588252,U.S. Senate,,DEM,Kamala D. Harris,5
+Imperial,588252,U.S. Senate,,DEM,Loretta L. Sanchez,8
+Imperial,588253,U.S. Senate,,DEM,Kamala D. Harris,1
+Imperial,588253,U.S. Senate,,DEM,Loretta L. Sanchez,16
+Imperial,588255,U.S. Senate,,DEM,Kamala D. Harris,63
+Imperial,588255,U.S. Senate,,DEM,Loretta L. Sanchez,58
+Imperial,588257,U.S. Senate,,DEM,Kamala D. Harris,0
+Imperial,588257,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Imperial,588258,U.S. Senate,,DEM,Kamala D. Harris,2
+Imperial,588258,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Imperial,588259,U.S. Senate,,DEM,Kamala D. Harris,0
+Imperial,588259,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Imperial,588260,U.S. Senate,,DEM,Kamala D. Harris,51
+Imperial,588260,U.S. Senate,,DEM,Loretta L. Sanchez,171
+Imperial,588261,U.S. Senate,,DEM,Kamala D. Harris,9
+Imperial,588261,U.S. Senate,,DEM,Loretta L. Sanchez,36
+Imperial,588262,U.S. Senate,,DEM,Kamala D. Harris,0
+Imperial,588262,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Imperial,588263,U.S. Senate,,DEM,Kamala D. Harris,0
+Imperial,588263,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Imperial,588264,U.S. Senate,,DEM,Kamala D. Harris,1
+Imperial,588264,U.S. Senate,,DEM,Loretta L. Sanchez,1

--- a/2016/20161108__ca__general__inyo__precinct.csv
+++ b/2016/20161108__ca__general__inyo__precinct.csv
@@ -959,51 +959,51 @@ Inyo,123,Proposition 67,,N/A,Yes,66
 Inyo,123,Proposition 67,,N/A,No,62
 Inyo,124,Proposition 67,,N/A,Yes,60
 Inyo,124,Proposition 67,,N/A,No,42
-Inyo,101,U.S. Senate,,DEM,Kamala Harris,284
-Inyo,101,U.S. Senate,,DEM,Loretta Sanchez,154
-Inyo,102,U.S. Senate,,DEM,Kamala Harris,322
-Inyo,102,U.S. Senate,,DEM,Loretta Sanchez,209
-Inyo,103,U.S. Senate,,DEM,Kamala Harris,246
-Inyo,103,U.S. Senate,,DEM,Loretta Sanchez,133
-Inyo,104,U.S. Senate,,DEM,Kamala Harris,32
-Inyo,104,U.S. Senate,,DEM,Loretta Sanchez,15
-Inyo,105,U.S. Senate,,DEM,Kamala Harris,15
-Inyo,105,U.S. Senate,,DEM,Loretta Sanchez,20
-Inyo,106,U.S. Senate,,DEM,Kamala Harris,338
-Inyo,106,U.S. Senate,,DEM,Loretta Sanchez,183
-Inyo,107,U.S. Senate,,DEM,Kamala Harris,195
-Inyo,107,U.S. Senate,,DEM,Loretta Sanchez,95
-Inyo,108,U.S. Senate,,DEM,Kamala Harris,182
-Inyo,108,U.S. Senate,,DEM,Loretta Sanchez,74
-Inyo,109,U.S. Senate,,DEM,Kamala Harris,353
-Inyo,109,U.S. Senate,,DEM,Loretta Sanchez,203
-Inyo,110,U.S. Senate,,DEM,Kamala Harris,389
-Inyo,110,U.S. Senate,,DEM,Loretta Sanchez,180
-Inyo,111,U.S. Senate,,DEM,Kamala Harris,132
-Inyo,111,U.S. Senate,,DEM,Loretta Sanchez,116
-Inyo,112,U.S. Senate,,DEM,Kamala Harris,67
-Inyo,112,U.S. Senate,,DEM,Loretta Sanchez,37
-Inyo,113,U.S. Senate,,DEM,Kamala Harris,137
-Inyo,113,U.S. Senate,,DEM,Loretta Sanchez,95
-Inyo,114,U.S. Senate,,DEM,Kamala Harris,220
-Inyo,114,U.S. Senate,,DEM,Loretta Sanchez,184
-Inyo,115,U.S. Senate,,DEM,Kamala Harris,161
-Inyo,115,U.S. Senate,,DEM,Loretta Sanchez,75
-Inyo,116,U.S. Senate,,DEM,Kamala Harris,40
-Inyo,116,U.S. Senate,,DEM,Loretta Sanchez,8
-Inyo,117,U.S. Senate,,DEM,Kamala Harris,162
-Inyo,117,U.S. Senate,,DEM,Loretta Sanchez,92
-Inyo,118,U.S. Senate,,DEM,Kamala Harris,0
-Inyo,118,U.S. Senate,,DEM,Loretta Sanchez,0
-Inyo,119,U.S. Senate,,DEM,Kamala Harris,168
-Inyo,119,U.S. Senate,,DEM,Loretta Sanchez,119
-Inyo,120,U.S. Senate,,DEM,Kamala Harris,192
-Inyo,120,U.S. Senate,,DEM,Loretta Sanchez,130
-Inyo,121,U.S. Senate,,DEM,Kamala Harris,43
-Inyo,121,U.S. Senate,,DEM,Loretta Sanchez,21
-Inyo,122,U.S. Senate,,DEM,Kamala Harris,60
-Inyo,122,U.S. Senate,,DEM,Loretta Sanchez,42
-Inyo,123,U.S. Senate,,DEM,Kamala Harris,66
-Inyo,123,U.S. Senate,,DEM,Loretta Sanchez,40
-Inyo,124,U.S. Senate,,DEM,Kamala Harris,59
-Inyo,124,U.S. Senate,,DEM,Loretta Sanchez,33
+Inyo,101,U.S. Senate,,DEM,Kamala D. Harris,284
+Inyo,101,U.S. Senate,,DEM,Loretta L. Sanchez,154
+Inyo,102,U.S. Senate,,DEM,Kamala D. Harris,322
+Inyo,102,U.S. Senate,,DEM,Loretta L. Sanchez,209
+Inyo,103,U.S. Senate,,DEM,Kamala D. Harris,246
+Inyo,103,U.S. Senate,,DEM,Loretta L. Sanchez,133
+Inyo,104,U.S. Senate,,DEM,Kamala D. Harris,32
+Inyo,104,U.S. Senate,,DEM,Loretta L. Sanchez,15
+Inyo,105,U.S. Senate,,DEM,Kamala D. Harris,15
+Inyo,105,U.S. Senate,,DEM,Loretta L. Sanchez,20
+Inyo,106,U.S. Senate,,DEM,Kamala D. Harris,338
+Inyo,106,U.S. Senate,,DEM,Loretta L. Sanchez,183
+Inyo,107,U.S. Senate,,DEM,Kamala D. Harris,195
+Inyo,107,U.S. Senate,,DEM,Loretta L. Sanchez,95
+Inyo,108,U.S. Senate,,DEM,Kamala D. Harris,182
+Inyo,108,U.S. Senate,,DEM,Loretta L. Sanchez,74
+Inyo,109,U.S. Senate,,DEM,Kamala D. Harris,353
+Inyo,109,U.S. Senate,,DEM,Loretta L. Sanchez,203
+Inyo,110,U.S. Senate,,DEM,Kamala D. Harris,389
+Inyo,110,U.S. Senate,,DEM,Loretta L. Sanchez,180
+Inyo,111,U.S. Senate,,DEM,Kamala D. Harris,132
+Inyo,111,U.S. Senate,,DEM,Loretta L. Sanchez,116
+Inyo,112,U.S. Senate,,DEM,Kamala D. Harris,67
+Inyo,112,U.S. Senate,,DEM,Loretta L. Sanchez,37
+Inyo,113,U.S. Senate,,DEM,Kamala D. Harris,137
+Inyo,113,U.S. Senate,,DEM,Loretta L. Sanchez,95
+Inyo,114,U.S. Senate,,DEM,Kamala D. Harris,220
+Inyo,114,U.S. Senate,,DEM,Loretta L. Sanchez,184
+Inyo,115,U.S. Senate,,DEM,Kamala D. Harris,161
+Inyo,115,U.S. Senate,,DEM,Loretta L. Sanchez,75
+Inyo,116,U.S. Senate,,DEM,Kamala D. Harris,40
+Inyo,116,U.S. Senate,,DEM,Loretta L. Sanchez,8
+Inyo,117,U.S. Senate,,DEM,Kamala D. Harris,162
+Inyo,117,U.S. Senate,,DEM,Loretta L. Sanchez,92
+Inyo,118,U.S. Senate,,DEM,Kamala D. Harris,0
+Inyo,118,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Inyo,119,U.S. Senate,,DEM,Kamala D. Harris,168
+Inyo,119,U.S. Senate,,DEM,Loretta L. Sanchez,119
+Inyo,120,U.S. Senate,,DEM,Kamala D. Harris,192
+Inyo,120,U.S. Senate,,DEM,Loretta L. Sanchez,130
+Inyo,121,U.S. Senate,,DEM,Kamala D. Harris,43
+Inyo,121,U.S. Senate,,DEM,Loretta L. Sanchez,21
+Inyo,122,U.S. Senate,,DEM,Kamala D. Harris,60
+Inyo,122,U.S. Senate,,DEM,Loretta L. Sanchez,42
+Inyo,123,U.S. Senate,,DEM,Kamala D. Harris,66
+Inyo,123,U.S. Senate,,DEM,Loretta L. Sanchez,40
+Inyo,124,U.S. Senate,,DEM,Kamala D. Harris,59
+Inyo,124,U.S. Senate,,DEM,Loretta L. Sanchez,33

--- a/2016/20161108__ca__general__kern__precinct.csv
+++ b/2016/20161108__ca__general__kern__precinct.csv
@@ -25679,1287 +25679,1287 @@ Kern,7053752,Proposition 67,,N/A,Yes,0
 Kern,7053752,Proposition 67,,N/A,No,8
 Kern,7053765,Proposition 67,,N/A,Yes,2
 Kern,7053765,Proposition 67,,N/A,No,0
-Kern,11155,U.S. Senate,,DEM,Kamala Harris,360
-Kern,11155,U.S. Senate,,DEM,Loretta Sanchez,223
-Kern,11190,U.S. Senate,,DEM,Kamala Harris,475
-Kern,11190,U.S. Senate,,DEM,Loretta Sanchez,282
-Kern,11195,U.S. Senate,,DEM,Kamala Harris,363
-Kern,11195,U.S. Senate,,DEM,Loretta Sanchez,352
-Kern,11530,U.S. Senate,,DEM,Kamala Harris,168
-Kern,11530,U.S. Senate,,DEM,Loretta Sanchez,237
-Kern,11540,U.S. Senate,,DEM,Kamala Harris,186
-Kern,11540,U.S. Senate,,DEM,Loretta Sanchez,236
-Kern,11546,U.S. Senate,,DEM,Kamala Harris,206
-Kern,11546,U.S. Senate,,DEM,Loretta Sanchez,272
-Kern,11548,U.S. Senate,,DEM,Kamala Harris,385
-Kern,11548,U.S. Senate,,DEM,Loretta Sanchez,446
-Kern,11550,U.S. Senate,,DEM,Kamala Harris,273
-Kern,11550,U.S. Senate,,DEM,Loretta Sanchez,364
-Kern,11552,U.S. Senate,,DEM,Kamala Harris,260
-Kern,11552,U.S. Senate,,DEM,Loretta Sanchez,397
-Kern,11554,U.S. Senate,,DEM,Kamala Harris,224
-Kern,11554,U.S. Senate,,DEM,Loretta Sanchez,479
-Kern,11570,U.S. Senate,,DEM,Kamala Harris,175
-Kern,11570,U.S. Senate,,DEM,Loretta Sanchez,276
-Kern,11580,U.S. Senate,,DEM,Kamala Harris,220
-Kern,11580,U.S. Senate,,DEM,Loretta Sanchez,318
-Kern,11590,U.S. Senate,,DEM,Kamala Harris,223
-Kern,11590,U.S. Senate,,DEM,Loretta Sanchez,339
-Kern,11610,U.S. Senate,,DEM,Kamala Harris,169
-Kern,11610,U.S. Senate,,DEM,Loretta Sanchez,262
-Kern,11626,U.S. Senate,,DEM,Kamala Harris,334
-Kern,11626,U.S. Senate,,DEM,Loretta Sanchez,500
-Kern,11725,U.S. Senate,,DEM,Kamala Harris,397
-Kern,11725,U.S. Senate,,DEM,Loretta Sanchez,241
-Kern,11990,U.S. Senate,,DEM,Kamala Harris,268
-Kern,11990,U.S. Senate,,DEM,Loretta Sanchez,199
-Kern,11991,U.S. Senate,,DEM,Kamala Harris,241
-Kern,11991,U.S. Senate,,DEM,Loretta Sanchez,195
-Kern,12171,U.S. Senate,,DEM,Kamala Harris,252
-Kern,12171,U.S. Senate,,DEM,Loretta Sanchez,158
-Kern,12173,U.S. Senate,,DEM,Kamala Harris,164
-Kern,12173,U.S. Senate,,DEM,Loretta Sanchez,109
-Kern,12505,U.S. Senate,,DEM,Kamala Harris,361
-Kern,12505,U.S. Senate,,DEM,Loretta Sanchez,239
-Kern,12591,U.S. Senate,,DEM,Kamala Harris,172
-Kern,12591,U.S. Senate,,DEM,Loretta Sanchez,435
-Kern,12592,U.S. Senate,,DEM,Kamala Harris,163
-Kern,12592,U.S. Senate,,DEM,Loretta Sanchez,354
-Kern,12593,U.S. Senate,,DEM,Kamala Harris,227
-Kern,12593,U.S. Senate,,DEM,Loretta Sanchez,491
-Kern,12620,U.S. Senate,,DEM,Kamala Harris,367
-Kern,12620,U.S. Senate,,DEM,Loretta Sanchez,293
-Kern,12622,U.S. Senate,,DEM,Kamala Harris,389
-Kern,12622,U.S. Senate,,DEM,Loretta Sanchez,298
-Kern,12623,U.S. Senate,,DEM,Kamala Harris,474
-Kern,12623,U.S. Senate,,DEM,Loretta Sanchez,379
-Kern,12650,U.S. Senate,,DEM,Kamala Harris,372
-Kern,12650,U.S. Senate,,DEM,Loretta Sanchez,310
-Kern,12670,U.S. Senate,,DEM,Kamala Harris,422
-Kern,12670,U.S. Senate,,DEM,Loretta Sanchez,311
-Kern,12709,U.S. Senate,,DEM,Kamala Harris,290
-Kern,12709,U.S. Senate,,DEM,Loretta Sanchez,217
-Kern,12921,U.S. Senate,,DEM,Kamala Harris,521
-Kern,12921,U.S. Senate,,DEM,Loretta Sanchez,403
-Kern,12922,U.S. Senate,,DEM,Kamala Harris,297
-Kern,12922,U.S. Senate,,DEM,Loretta Sanchez,206
-Kern,12923,U.S. Senate,,DEM,Kamala Harris,252
-Kern,12923,U.S. Senate,,DEM,Loretta Sanchez,202
-Kern,12924,U.S. Senate,,DEM,Kamala Harris,482
-Kern,12924,U.S. Senate,,DEM,Loretta Sanchez,348
-Kern,12925,U.S. Senate,,DEM,Kamala Harris,351
-Kern,12925,U.S. Senate,,DEM,Loretta Sanchez,285
-Kern,12927,U.S. Senate,,DEM,Kamala Harris,251
-Kern,12927,U.S. Senate,,DEM,Loretta Sanchez,191
-Kern,12928,U.S. Senate,,DEM,Kamala Harris,490
-Kern,12928,U.S. Senate,,DEM,Loretta Sanchez,380
-Kern,12929,U.S. Senate,,DEM,Kamala Harris,452
-Kern,12929,U.S. Senate,,DEM,Loretta Sanchez,378
-Kern,12933,U.S. Senate,,DEM,Kamala Harris,452
-Kern,12933,U.S. Senate,,DEM,Loretta Sanchez,407
-Kern,12934,U.S. Senate,,DEM,Kamala Harris,332
-Kern,12934,U.S. Senate,,DEM,Loretta Sanchez,259
-Kern,12935,U.S. Senate,,DEM,Kamala Harris,351
-Kern,12935,U.S. Senate,,DEM,Loretta Sanchez,241
-Kern,12941,U.S. Senate,,DEM,Kamala Harris,403
-Kern,12941,U.S. Senate,,DEM,Loretta Sanchez,363
-Kern,12996,U.S. Senate,,DEM,Kamala Harris,288
-Kern,12996,U.S. Senate,,DEM,Loretta Sanchez,169
-Kern,13070,U.S. Senate,,DEM,Kamala Harris,301
-Kern,13070,U.S. Senate,,DEM,Loretta Sanchez,210
-Kern,13072,U.S. Senate,,DEM,Kamala Harris,235
-Kern,13072,U.S. Senate,,DEM,Loretta Sanchez,187
-Kern,13076,U.S. Senate,,DEM,Kamala Harris,127
-Kern,13076,U.S. Senate,,DEM,Loretta Sanchez,117
-Kern,13078,U.S. Senate,,DEM,Kamala Harris,235
-Kern,13078,U.S. Senate,,DEM,Loretta Sanchez,173
-Kern,13100,U.S. Senate,,DEM,Kamala Harris,244
-Kern,13100,U.S. Senate,,DEM,Loretta Sanchez,392
-Kern,13107,U.S. Senate,,DEM,Kamala Harris,165
-Kern,13107,U.S. Senate,,DEM,Loretta Sanchez,378
-Kern,13110,U.S. Senate,,DEM,Kamala Harris,255
-Kern,13110,U.S. Senate,,DEM,Loretta Sanchez,435
-Kern,13120,U.S. Senate,,DEM,Kamala Harris,101
-Kern,13120,U.S. Senate,,DEM,Loretta Sanchez,232
-Kern,13121,U.S. Senate,,DEM,Kamala Harris,220
-Kern,13121,U.S. Senate,,DEM,Loretta Sanchez,423
-Kern,13194,U.S. Senate,,DEM,Kamala Harris,148
-Kern,13194,U.S. Senate,,DEM,Loretta Sanchez,115
-Kern,15106,U.S. Senate,,DEM,Kamala Harris,413
-Kern,15106,U.S. Senate,,DEM,Loretta Sanchez,306
-Kern,15109,U.S. Senate,,DEM,Kamala Harris,271
-Kern,15109,U.S. Senate,,DEM,Loretta Sanchez,247
-Kern,15110,U.S. Senate,,DEM,Kamala Harris,333
-Kern,15110,U.S. Senate,,DEM,Loretta Sanchez,232
-Kern,15113,U.S. Senate,,DEM,Kamala Harris,298
-Kern,15113,U.S. Senate,,DEM,Loretta Sanchez,272
-Kern,15114,U.S. Senate,,DEM,Kamala Harris,203
-Kern,15114,U.S. Senate,,DEM,Loretta Sanchez,167
-Kern,15123,U.S. Senate,,DEM,Kamala Harris,231
-Kern,15123,U.S. Senate,,DEM,Loretta Sanchez,258
-Kern,15124,U.S. Senate,,DEM,Kamala Harris,273
-Kern,15124,U.S. Senate,,DEM,Loretta Sanchez,224
-Kern,15132,U.S. Senate,,DEM,Kamala Harris,292
-Kern,15132,U.S. Senate,,DEM,Loretta Sanchez,249
-Kern,15133,U.S. Senate,,DEM,Kamala Harris,252
-Kern,15133,U.S. Senate,,DEM,Loretta Sanchez,212
-Kern,15135,U.S. Senate,,DEM,Kamala Harris,296
-Kern,15135,U.S. Senate,,DEM,Loretta Sanchez,251
-Kern,20121,U.S. Senate,,DEM,Kamala Harris,211
-Kern,20121,U.S. Senate,,DEM,Loretta Sanchez,182
-Kern,20232,U.S. Senate,,DEM,Kamala Harris,165
-Kern,20232,U.S. Senate,,DEM,Loretta Sanchez,201
-Kern,20236,U.S. Senate,,DEM,Kamala Harris,243
-Kern,20236,U.S. Senate,,DEM,Loretta Sanchez,339
-Kern,20243,U.S. Senate,,DEM,Kamala Harris,396
-Kern,20243,U.S. Senate,,DEM,Loretta Sanchez,351
-Kern,20245,U.S. Senate,,DEM,Kamala Harris,183
-Kern,20245,U.S. Senate,,DEM,Loretta Sanchez,220
-Kern,20246,U.S. Senate,,DEM,Kamala Harris,296
-Kern,20246,U.S. Senate,,DEM,Loretta Sanchez,298
-Kern,20248,U.S. Senate,,DEM,Kamala Harris,345
-Kern,20248,U.S. Senate,,DEM,Loretta Sanchez,465
-Kern,20249,U.S. Senate,,DEM,Kamala Harris,255
-Kern,20249,U.S. Senate,,DEM,Loretta Sanchez,192
-Kern,20253,U.S. Senate,,DEM,Kamala Harris,166
-Kern,20253,U.S. Senate,,DEM,Loretta Sanchez,162
-Kern,20254,U.S. Senate,,DEM,Kamala Harris,363
-Kern,20254,U.S. Senate,,DEM,Loretta Sanchez,363
-Kern,20256,U.S. Senate,,DEM,Kamala Harris,438
-Kern,20256,U.S. Senate,,DEM,Loretta Sanchez,380
-Kern,20260,U.S. Senate,,DEM,Kamala Harris,242
-Kern,20260,U.S. Senate,,DEM,Loretta Sanchez,233
-Kern,20262,U.S. Senate,,DEM,Kamala Harris,446
-Kern,20262,U.S. Senate,,DEM,Loretta Sanchez,445
-Kern,20263,U.S. Senate,,DEM,Kamala Harris,224
-Kern,20263,U.S. Senate,,DEM,Loretta Sanchez,199
-Kern,20271,U.S. Senate,,DEM,Kamala Harris,289
-Kern,20271,U.S. Senate,,DEM,Loretta Sanchez,369
-Kern,20272,U.S. Senate,,DEM,Kamala Harris,328
-Kern,20272,U.S. Senate,,DEM,Loretta Sanchez,378
-Kern,20283,U.S. Senate,,DEM,Kamala Harris,542
-Kern,20283,U.S. Senate,,DEM,Loretta Sanchez,541
-Kern,20284,U.S. Senate,,DEM,Kamala Harris,167
-Kern,20284,U.S. Senate,,DEM,Loretta Sanchez,245
-Kern,20286,U.S. Senate,,DEM,Kamala Harris,348
-Kern,20286,U.S. Senate,,DEM,Loretta Sanchez,355
-Kern,20288,U.S. Senate,,DEM,Kamala Harris,214
-Kern,20288,U.S. Senate,,DEM,Loretta Sanchez,254
-Kern,20289,U.S. Senate,,DEM,Kamala Harris,297
-Kern,20289,U.S. Senate,,DEM,Loretta Sanchez,347
-Kern,20294,U.S. Senate,,DEM,Kamala Harris,271
-Kern,20294,U.S. Senate,,DEM,Loretta Sanchez,283
-Kern,21143,U.S. Senate,,DEM,Kamala Harris,316
-Kern,21143,U.S. Senate,,DEM,Loretta Sanchez,250
-Kern,21144,U.S. Senate,,DEM,Kamala Harris,264
-Kern,21144,U.S. Senate,,DEM,Loretta Sanchez,224
-Kern,21145,U.S. Senate,,DEM,Kamala Harris,402
-Kern,21145,U.S. Senate,,DEM,Loretta Sanchez,342
-Kern,21148,U.S. Senate,,DEM,Kamala Harris,246
-Kern,21148,U.S. Senate,,DEM,Loretta Sanchez,160
-Kern,21275,U.S. Senate,,DEM,Kamala Harris,472
-Kern,21275,U.S. Senate,,DEM,Loretta Sanchez,333
-Kern,21280,U.S. Senate,,DEM,Kamala Harris,269
-Kern,21280,U.S. Senate,,DEM,Loretta Sanchez,178
-Kern,21281,U.S. Senate,,DEM,Kamala Harris,356
-Kern,21281,U.S. Senate,,DEM,Loretta Sanchez,250
-Kern,21282,U.S. Senate,,DEM,Kamala Harris,333
-Kern,21282,U.S. Senate,,DEM,Loretta Sanchez,240
-Kern,21283,U.S. Senate,,DEM,Kamala Harris,454
-Kern,21283,U.S. Senate,,DEM,Loretta Sanchez,333
-Kern,21511,U.S. Senate,,DEM,Kamala Harris,185
-Kern,21511,U.S. Senate,,DEM,Loretta Sanchez,153
-Kern,21512,U.S. Senate,,DEM,Kamala Harris,258
-Kern,21512,U.S. Senate,,DEM,Loretta Sanchez,264
-Kern,21660,U.S. Senate,,DEM,Kamala Harris,107
-Kern,21660,U.S. Senate,,DEM,Loretta Sanchez,80
-Kern,21710,U.S. Senate,,DEM,Kamala Harris,177
-Kern,21710,U.S. Senate,,DEM,Loretta Sanchez,138
-Kern,21781,U.S. Senate,,DEM,Kamala Harris,132
-Kern,21781,U.S. Senate,,DEM,Loretta Sanchez,137
-Kern,21885,U.S. Senate,,DEM,Kamala Harris,500
-Kern,21885,U.S. Senate,,DEM,Loretta Sanchez,432
-Kern,21886,U.S. Senate,,DEM,Kamala Harris,251
-Kern,21886,U.S. Senate,,DEM,Loretta Sanchez,205
-Kern,21888,U.S. Senate,,DEM,Kamala Harris,329
-Kern,21888,U.S. Senate,,DEM,Loretta Sanchez,295
-Kern,21889,U.S. Senate,,DEM,Kamala Harris,414
-Kern,21889,U.S. Senate,,DEM,Loretta Sanchez,343
-Kern,22003,U.S. Senate,,DEM,Kamala Harris,192
-Kern,22003,U.S. Senate,,DEM,Loretta Sanchez,179
-Kern,22004,U.S. Senate,,DEM,Kamala Harris,209
-Kern,22004,U.S. Senate,,DEM,Loretta Sanchez,176
-Kern,22005,U.S. Senate,,DEM,Kamala Harris,230
-Kern,22005,U.S. Senate,,DEM,Loretta Sanchez,207
-Kern,22006,U.S. Senate,,DEM,Kamala Harris,392
-Kern,22006,U.S. Senate,,DEM,Loretta Sanchez,374
-Kern,22008,U.S. Senate,,DEM,Kamala Harris,363
-Kern,22008,U.S. Senate,,DEM,Loretta Sanchez,365
-Kern,22018,U.S. Senate,,DEM,Kamala Harris,441
-Kern,22018,U.S. Senate,,DEM,Loretta Sanchez,419
-Kern,22030,U.S. Senate,,DEM,Kamala Harris,350
-Kern,22030,U.S. Senate,,DEM,Loretta Sanchez,340
-Kern,22033,U.S. Senate,,DEM,Kamala Harris,288
-Kern,22033,U.S. Senate,,DEM,Loretta Sanchez,272
-Kern,22450,U.S. Senate,,DEM,Kamala Harris,385
-Kern,22450,U.S. Senate,,DEM,Loretta Sanchez,329
-Kern,22480,U.S. Senate,,DEM,Kamala Harris,148
-Kern,22480,U.S. Senate,,DEM,Loretta Sanchez,106
-Kern,23020,U.S. Senate,,DEM,Kamala Harris,257
-Kern,23020,U.S. Senate,,DEM,Loretta Sanchez,239
-Kern,23021,U.S. Senate,,DEM,Kamala Harris,389
-Kern,23021,U.S. Senate,,DEM,Loretta Sanchez,327
-Kern,23023,U.S. Senate,,DEM,Kamala Harris,385
-Kern,23023,U.S. Senate,,DEM,Loretta Sanchez,273
-Kern,23025,U.S. Senate,,DEM,Kamala Harris,269
-Kern,23025,U.S. Senate,,DEM,Loretta Sanchez,211
-Kern,23030,U.S. Senate,,DEM,Kamala Harris,334
-Kern,23030,U.S. Senate,,DEM,Loretta Sanchez,242
-Kern,23031,U.S. Senate,,DEM,Kamala Harris,228
-Kern,23031,U.S. Senate,,DEM,Loretta Sanchez,219
-Kern,23035,U.S. Senate,,DEM,Kamala Harris,344
-Kern,23035,U.S. Senate,,DEM,Loretta Sanchez,317
-Kern,23208,U.S. Senate,,DEM,Kamala Harris,511
-Kern,23208,U.S. Senate,,DEM,Loretta Sanchez,407
-Kern,23239,U.S. Senate,,DEM,Kamala Harris,305
-Kern,23239,U.S. Senate,,DEM,Loretta Sanchez,265
-Kern,23241,U.S. Senate,,DEM,Kamala Harris,161
-Kern,23241,U.S. Senate,,DEM,Loretta Sanchez,164
-Kern,23401,U.S. Senate,,DEM,Kamala Harris,416
-Kern,23401,U.S. Senate,,DEM,Loretta Sanchez,324
-Kern,23402,U.S. Senate,,DEM,Kamala Harris,212
-Kern,23402,U.S. Senate,,DEM,Loretta Sanchez,171
-Kern,23403,U.S. Senate,,DEM,Kamala Harris,343
-Kern,23403,U.S. Senate,,DEM,Loretta Sanchez,312
-Kern,23404,U.S. Senate,,DEM,Kamala Harris,344
-Kern,23404,U.S. Senate,,DEM,Loretta Sanchez,315
-Kern,23450,U.S. Senate,,DEM,Kamala Harris,267
-Kern,23450,U.S. Senate,,DEM,Loretta Sanchez,278
-Kern,23451,U.S. Senate,,DEM,Kamala Harris,120
-Kern,23451,U.S. Senate,,DEM,Loretta Sanchez,113
-Kern,23452,U.S. Senate,,DEM,Kamala Harris,215
-Kern,23452,U.S. Senate,,DEM,Loretta Sanchez,174
-Kern,25270,U.S. Senate,,DEM,Kamala Harris,261
-Kern,25270,U.S. Senate,,DEM,Loretta Sanchez,221
-Kern,25271,U.S. Senate,,DEM,Kamala Harris,256
-Kern,25271,U.S. Senate,,DEM,Loretta Sanchez,208
-Kern,25272,U.S. Senate,,DEM,Kamala Harris,257
-Kern,25272,U.S. Senate,,DEM,Loretta Sanchez,227
-Kern,25289,U.S. Senate,,DEM,Kamala Harris,227
-Kern,25289,U.S. Senate,,DEM,Loretta Sanchez,235
-Kern,25292,U.S. Senate,,DEM,Kamala Harris,296
-Kern,25292,U.S. Senate,,DEM,Loretta Sanchez,340
-Kern,30040,U.S. Senate,,DEM,Kamala Harris,318
-Kern,30040,U.S. Senate,,DEM,Loretta Sanchez,209
-Kern,30060,U.S. Senate,,DEM,Kamala Harris,249
-Kern,30060,U.S. Senate,,DEM,Loretta Sanchez,161
-Kern,30150,U.S. Senate,,DEM,Kamala Harris,300
-Kern,30150,U.S. Senate,,DEM,Loretta Sanchez,272
-Kern,30170,U.S. Senate,,DEM,Kamala Harris,250
-Kern,30170,U.S. Senate,,DEM,Loretta Sanchez,180
-Kern,30302,U.S. Senate,,DEM,Kamala Harris,274
-Kern,30302,U.S. Senate,,DEM,Loretta Sanchez,246
-Kern,30304,U.S. Senate,,DEM,Kamala Harris,308
-Kern,30304,U.S. Senate,,DEM,Loretta Sanchez,370
-Kern,30308,U.S. Senate,,DEM,Kamala Harris,302
-Kern,30308,U.S. Senate,,DEM,Loretta Sanchez,356
-Kern,30312,U.S. Senate,,DEM,Kamala Harris,304
-Kern,30312,U.S. Senate,,DEM,Loretta Sanchez,274
-Kern,30314,U.S. Senate,,DEM,Kamala Harris,279
-Kern,30314,U.S. Senate,,DEM,Loretta Sanchez,282
-Kern,30316,U.S. Senate,,DEM,Kamala Harris,240
-Kern,30316,U.S. Senate,,DEM,Loretta Sanchez,244
-Kern,30317,U.S. Senate,,DEM,Kamala Harris,121
-Kern,30317,U.S. Senate,,DEM,Loretta Sanchez,116
-Kern,30318,U.S. Senate,,DEM,Kamala Harris,343
-Kern,30318,U.S. Senate,,DEM,Loretta Sanchez,357
-Kern,30321,U.S. Senate,,DEM,Kamala Harris,226
-Kern,30321,U.S. Senate,,DEM,Loretta Sanchez,218
-Kern,30322,U.S. Senate,,DEM,Kamala Harris,369
-Kern,30322,U.S. Senate,,DEM,Loretta Sanchez,323
-Kern,30325,U.S. Senate,,DEM,Kamala Harris,234
-Kern,30325,U.S. Senate,,DEM,Loretta Sanchez,177
-Kern,30332,U.S. Senate,,DEM,Kamala Harris,303
-Kern,30332,U.S. Senate,,DEM,Loretta Sanchez,274
-Kern,30337,U.S. Senate,,DEM,Kamala Harris,346
-Kern,30337,U.S. Senate,,DEM,Loretta Sanchez,347
-Kern,30338,U.S. Senate,,DEM,Kamala Harris,202
-Kern,30338,U.S. Senate,,DEM,Loretta Sanchez,247
-Kern,30339,U.S. Senate,,DEM,Kamala Harris,405
-Kern,30339,U.S. Senate,,DEM,Loretta Sanchez,400
-Kern,30348,U.S. Senate,,DEM,Kamala Harris,256
-Kern,30348,U.S. Senate,,DEM,Loretta Sanchez,233
-Kern,30351,U.S. Senate,,DEM,Kamala Harris,366
-Kern,30351,U.S. Senate,,DEM,Loretta Sanchez,362
-Kern,30352,U.S. Senate,,DEM,Kamala Harris,277
-Kern,30352,U.S. Senate,,DEM,Loretta Sanchez,273
-Kern,30354,U.S. Senate,,DEM,Kamala Harris,210
-Kern,30354,U.S. Senate,,DEM,Loretta Sanchez,185
-Kern,30364,U.S. Senate,,DEM,Kamala Harris,251
-Kern,30364,U.S. Senate,,DEM,Loretta Sanchez,208
-Kern,30367,U.S. Senate,,DEM,Kamala Harris,393
-Kern,30367,U.S. Senate,,DEM,Loretta Sanchez,364
-Kern,30370,U.S. Senate,,DEM,Kamala Harris,169
-Kern,30370,U.S. Senate,,DEM,Loretta Sanchez,174
-Kern,30372,U.S. Senate,,DEM,Kamala Harris,391
-Kern,30372,U.S. Senate,,DEM,Loretta Sanchez,314
-Kern,30374,U.S. Senate,,DEM,Kamala Harris,317
-Kern,30374,U.S. Senate,,DEM,Loretta Sanchez,218
-Kern,30385,U.S. Senate,,DEM,Kamala Harris,441
-Kern,30385,U.S. Senate,,DEM,Loretta Sanchez,364
-Kern,30387,U.S. Senate,,DEM,Kamala Harris,317
-Kern,30387,U.S. Senate,,DEM,Loretta Sanchez,285
-Kern,30389,U.S. Senate,,DEM,Kamala Harris,209
-Kern,30389,U.S. Senate,,DEM,Loretta Sanchez,196
-Kern,30390,U.S. Senate,,DEM,Kamala Harris,352
-Kern,30390,U.S. Senate,,DEM,Loretta Sanchez,303
-Kern,30396,U.S. Senate,,DEM,Kamala Harris,437
-Kern,30396,U.S. Senate,,DEM,Loretta Sanchez,409
-Kern,31478,U.S. Senate,,DEM,Kamala Harris,139
-Kern,31478,U.S. Senate,,DEM,Loretta Sanchez,158
-Kern,31641,U.S. Senate,,DEM,Kamala Harris,176
-Kern,31641,U.S. Senate,,DEM,Loretta Sanchez,322
-Kern,31772,U.S. Senate,,DEM,Kamala Harris,286
-Kern,31772,U.S. Senate,,DEM,Loretta Sanchez,186
-Kern,31935,U.S. Senate,,DEM,Kamala Harris,272
-Kern,31935,U.S. Senate,,DEM,Loretta Sanchez,428
-Kern,31950,U.S. Senate,,DEM,Kamala Harris,175
-Kern,31950,U.S. Senate,,DEM,Loretta Sanchez,149
-Kern,31953,U.S. Senate,,DEM,Kamala Harris,305
-Kern,31953,U.S. Senate,,DEM,Loretta Sanchez,361
-Kern,31960,U.S. Senate,,DEM,Kamala Harris,289
-Kern,31960,U.S. Senate,,DEM,Loretta Sanchez,346
-Kern,32170,U.S. Senate,,DEM,Kamala Harris,253
-Kern,32170,U.S. Senate,,DEM,Loretta Sanchez,228
-Kern,32214,U.S. Senate,,DEM,Kamala Harris,161
-Kern,32214,U.S. Senate,,DEM,Loretta Sanchez,131
-Kern,32240,U.S. Senate,,DEM,Kamala Harris,174
-Kern,32240,U.S. Senate,,DEM,Loretta Sanchez,152
-Kern,32310,U.S. Senate,,DEM,Kamala Harris,273
-Kern,32310,U.S. Senate,,DEM,Loretta Sanchez,269
-Kern,32330,U.S. Senate,,DEM,Kamala Harris,335
-Kern,32330,U.S. Senate,,DEM,Loretta Sanchez,360
-Kern,32360,U.S. Senate,,DEM,Kamala Harris,187
-Kern,32360,U.S. Senate,,DEM,Loretta Sanchez,294
-Kern,32380,U.S. Senate,,DEM,Kamala Harris,184
-Kern,32380,U.S. Senate,,DEM,Loretta Sanchez,144
-Kern,32441,U.S. Senate,,DEM,Kamala Harris,252
-Kern,32441,U.S. Senate,,DEM,Loretta Sanchez,172
-Kern,32531,U.S. Senate,,DEM,Kamala Harris,144
-Kern,32531,U.S. Senate,,DEM,Loretta Sanchez,360
-Kern,32532,U.S. Senate,,DEM,Kamala Harris,151
-Kern,32532,U.S. Senate,,DEM,Loretta Sanchez,261
-Kern,32640,U.S. Senate,,DEM,Kamala Harris,437
-Kern,32640,U.S. Senate,,DEM,Loretta Sanchez,320
-Kern,32652,U.S. Senate,,DEM,Kamala Harris,453
-Kern,32652,U.S. Senate,,DEM,Loretta Sanchez,362
-Kern,32731,U.S. Senate,,DEM,Kamala Harris,410
-Kern,32731,U.S. Senate,,DEM,Loretta Sanchez,326
-Kern,32750,U.S. Senate,,DEM,Kamala Harris,228
-Kern,32750,U.S. Senate,,DEM,Loretta Sanchez,327
-Kern,32751,U.S. Senate,,DEM,Kamala Harris,221
-Kern,32751,U.S. Senate,,DEM,Loretta Sanchez,328
-Kern,32762,U.S. Senate,,DEM,Kamala Harris,137
-Kern,32762,U.S. Senate,,DEM,Loretta Sanchez,218
-Kern,33040,U.S. Senate,,DEM,Kamala Harris,420
-Kern,33040,U.S. Senate,,DEM,Loretta Sanchez,341
-Kern,33042,U.S. Senate,,DEM,Kamala Harris,316
-Kern,33042,U.S. Senate,,DEM,Loretta Sanchez,226
-Kern,33150,U.S. Senate,,DEM,Kamala Harris,149
-Kern,33150,U.S. Senate,,DEM,Loretta Sanchez,100
-Kern,33161,U.S. Senate,,DEM,Kamala Harris,88
-Kern,33161,U.S. Senate,,DEM,Loretta Sanchez,79
-Kern,33222,U.S. Senate,,DEM,Kamala Harris,128
-Kern,33222,U.S. Senate,,DEM,Loretta Sanchez,277
-Kern,33492,U.S. Senate,,DEM,Kamala Harris,143
-Kern,33492,U.S. Senate,,DEM,Loretta Sanchez,311
-Kern,35601,U.S. Senate,,DEM,Kamala Harris,246
-Kern,35601,U.S. Senate,,DEM,Loretta Sanchez,189
-Kern,35602,U.S. Senate,,DEM,Kamala Harris,181
-Kern,35602,U.S. Senate,,DEM,Loretta Sanchez,117
-Kern,35604,U.S. Senate,,DEM,Kamala Harris,351
-Kern,35604,U.S. Senate,,DEM,Loretta Sanchez,286
-Kern,35624,U.S. Senate,,DEM,Kamala Harris,115
-Kern,35624,U.S. Senate,,DEM,Loretta Sanchez,97
-Kern,35628,U.S. Senate,,DEM,Kamala Harris,475
-Kern,35628,U.S. Senate,,DEM,Loretta Sanchez,429
-Kern,35629,U.S. Senate,,DEM,Kamala Harris,291
-Kern,35629,U.S. Senate,,DEM,Loretta Sanchez,259
-Kern,35631,U.S. Senate,,DEM,Kamala Harris,283
-Kern,35631,U.S. Senate,,DEM,Loretta Sanchez,219
-Kern,35633,U.S. Senate,,DEM,Kamala Harris,271
-Kern,35633,U.S. Senate,,DEM,Loretta Sanchez,211
-Kern,35634,U.S. Senate,,DEM,Kamala Harris,219
-Kern,35634,U.S. Senate,,DEM,Loretta Sanchez,167
-Kern,35635,U.S. Senate,,DEM,Kamala Harris,277
-Kern,35635,U.S. Senate,,DEM,Loretta Sanchez,284
-Kern,35640,U.S. Senate,,DEM,Kamala Harris,341
-Kern,35640,U.S. Senate,,DEM,Loretta Sanchez,260
-Kern,35658,U.S. Senate,,DEM,Kamala Harris,276
-Kern,35658,U.S. Senate,,DEM,Loretta Sanchez,241
-Kern,35661,U.S. Senate,,DEM,Kamala Harris,183
-Kern,35661,U.S. Senate,,DEM,Loretta Sanchez,166
-Kern,35675,U.S. Senate,,DEM,Kamala Harris,344
-Kern,35675,U.S. Senate,,DEM,Loretta Sanchez,292
-Kern,35677,U.S. Senate,,DEM,Kamala Harris,108
-Kern,35677,U.S. Senate,,DEM,Loretta Sanchez,272
-Kern,40401,U.S. Senate,,DEM,Kamala Harris,211
-Kern,40401,U.S. Senate,,DEM,Loretta Sanchez,129
-Kern,40405,U.S. Senate,,DEM,Kamala Harris,428
-Kern,40405,U.S. Senate,,DEM,Loretta Sanchez,384
-Kern,40406,U.S. Senate,,DEM,Kamala Harris,319
-Kern,40406,U.S. Senate,,DEM,Loretta Sanchez,269
-Kern,40407,U.S. Senate,,DEM,Kamala Harris,227
-Kern,40407,U.S. Senate,,DEM,Loretta Sanchez,174
-Kern,40409,U.S. Senate,,DEM,Kamala Harris,339
-Kern,40409,U.S. Senate,,DEM,Loretta Sanchez,250
-Kern,40411,U.S. Senate,,DEM,Kamala Harris,361
-Kern,40411,U.S. Senate,,DEM,Loretta Sanchez,352
-Kern,40414,U.S. Senate,,DEM,Kamala Harris,360
-Kern,40414,U.S. Senate,,DEM,Loretta Sanchez,365
-Kern,40415,U.S. Senate,,DEM,Kamala Harris,488
-Kern,40415,U.S. Senate,,DEM,Loretta Sanchez,402
-Kern,40419,U.S. Senate,,DEM,Kamala Harris,299
-Kern,40419,U.S. Senate,,DEM,Loretta Sanchez,252
-Kern,40421,U.S. Senate,,DEM,Kamala Harris,257
-Kern,40421,U.S. Senate,,DEM,Loretta Sanchez,250
-Kern,40424,U.S. Senate,,DEM,Kamala Harris,300
-Kern,40424,U.S. Senate,,DEM,Loretta Sanchez,235
-Kern,40428,U.S. Senate,,DEM,Kamala Harris,210
-Kern,40428,U.S. Senate,,DEM,Loretta Sanchez,209
-Kern,40429,U.S. Senate,,DEM,Kamala Harris,384
-Kern,40429,U.S. Senate,,DEM,Loretta Sanchez,303
-Kern,40430,U.S. Senate,,DEM,Kamala Harris,384
-Kern,40430,U.S. Senate,,DEM,Loretta Sanchez,337
-Kern,40433,U.S. Senate,,DEM,Kamala Harris,272
-Kern,40433,U.S. Senate,,DEM,Loretta Sanchez,254
-Kern,40434,U.S. Senate,,DEM,Kamala Harris,210
-Kern,40434,U.S. Senate,,DEM,Loretta Sanchez,166
-Kern,40435,U.S. Senate,,DEM,Kamala Harris,343
-Kern,40435,U.S. Senate,,DEM,Loretta Sanchez,292
-Kern,40436,U.S. Senate,,DEM,Kamala Harris,240
-Kern,40436,U.S. Senate,,DEM,Loretta Sanchez,177
-Kern,40440,U.S. Senate,,DEM,Kamala Harris,296
-Kern,40440,U.S. Senate,,DEM,Loretta Sanchez,270
-Kern,40441,U.S. Senate,,DEM,Kamala Harris,436
-Kern,40441,U.S. Senate,,DEM,Loretta Sanchez,324
-Kern,40442,U.S. Senate,,DEM,Kamala Harris,273
-Kern,40442,U.S. Senate,,DEM,Loretta Sanchez,180
-Kern,40443,U.S. Senate,,DEM,Kamala Harris,215
-Kern,40443,U.S. Senate,,DEM,Loretta Sanchez,167
-Kern,40444,U.S. Senate,,DEM,Kamala Harris,172
-Kern,40444,U.S. Senate,,DEM,Loretta Sanchez,155
-Kern,40447,U.S. Senate,,DEM,Kamala Harris,293
-Kern,40447,U.S. Senate,,DEM,Loretta Sanchez,253
-Kern,40454,U.S. Senate,,DEM,Kamala Harris,278
-Kern,40454,U.S. Senate,,DEM,Loretta Sanchez,193
-Kern,40455,U.S. Senate,,DEM,Kamala Harris,492
-Kern,40455,U.S. Senate,,DEM,Loretta Sanchez,454
-Kern,40460,U.S. Senate,,DEM,Kamala Harris,257
-Kern,40460,U.S. Senate,,DEM,Loretta Sanchez,205
-Kern,40461,U.S. Senate,,DEM,Kamala Harris,350
-Kern,40461,U.S. Senate,,DEM,Loretta Sanchez,360
-Kern,40462,U.S. Senate,,DEM,Kamala Harris,456
-Kern,40462,U.S. Senate,,DEM,Loretta Sanchez,346
-Kern,40463,U.S. Senate,,DEM,Kamala Harris,323
-Kern,40463,U.S. Senate,,DEM,Loretta Sanchez,301
-Kern,40464,U.S. Senate,,DEM,Kamala Harris,367
-Kern,40464,U.S. Senate,,DEM,Loretta Sanchez,270
-Kern,40466,U.S. Senate,,DEM,Kamala Harris,351
-Kern,40466,U.S. Senate,,DEM,Loretta Sanchez,327
-Kern,40469,U.S. Senate,,DEM,Kamala Harris,199
-Kern,40469,U.S. Senate,,DEM,Loretta Sanchez,221
-Kern,40470,U.S. Senate,,DEM,Kamala Harris,277
-Kern,40470,U.S. Senate,,DEM,Loretta Sanchez,242
-Kern,40471,U.S. Senate,,DEM,Kamala Harris,341
-Kern,40471,U.S. Senate,,DEM,Loretta Sanchez,391
-Kern,40475,U.S. Senate,,DEM,Kamala Harris,270
-Kern,40475,U.S. Senate,,DEM,Loretta Sanchez,275
-Kern,40480,U.S. Senate,,DEM,Kamala Harris,332
-Kern,40480,U.S. Senate,,DEM,Loretta Sanchez,312
-Kern,40494,U.S. Senate,,DEM,Kamala Harris,273
-Kern,40494,U.S. Senate,,DEM,Loretta Sanchez,227
-Kern,40495,U.S. Senate,,DEM,Kamala Harris,492
-Kern,40495,U.S. Senate,,DEM,Loretta Sanchez,406
-Kern,40496,U.S. Senate,,DEM,Kamala Harris,220
-Kern,40496,U.S. Senate,,DEM,Loretta Sanchez,198
-Kern,40497,U.S. Senate,,DEM,Kamala Harris,239
-Kern,40497,U.S. Senate,,DEM,Loretta Sanchez,213
-Kern,41240,U.S. Senate,,DEM,Kamala Harris,81
-Kern,41240,U.S. Senate,,DEM,Loretta Sanchez,96
-Kern,41780,U.S. Senate,,DEM,Kamala Harris,354
-Kern,41780,U.S. Senate,,DEM,Loretta Sanchez,300
-Kern,41820,U.S. Senate,,DEM,Kamala Harris,415
-Kern,41820,U.S. Senate,,DEM,Loretta Sanchez,370
-Kern,41910,U.S. Senate,,DEM,Kamala Harris,159
-Kern,41910,U.S. Senate,,DEM,Loretta Sanchez,133
-Kern,41913,U.S. Senate,,DEM,Kamala Harris,203
-Kern,41913,U.S. Senate,,DEM,Loretta Sanchez,165
-Kern,41915,U.S. Senate,,DEM,Kamala Harris,362
-Kern,41915,U.S. Senate,,DEM,Loretta Sanchez,395
-Kern,42218,U.S. Senate,,DEM,Kamala Harris,192
-Kern,42218,U.S. Senate,,DEM,Loretta Sanchez,169
-Kern,42261,U.S. Senate,,DEM,Kamala Harris,24
-Kern,42261,U.S. Senate,,DEM,Loretta Sanchez,124
-Kern,42390,U.S. Senate,,DEM,Kamala Harris,156
-Kern,42390,U.S. Senate,,DEM,Loretta Sanchez,84
-Kern,42630,U.S. Senate,,DEM,Kamala Harris,185
-Kern,42630,U.S. Senate,,DEM,Loretta Sanchez,151
-Kern,42842,U.S. Senate,,DEM,Kamala Harris,455
-Kern,42842,U.S. Senate,,DEM,Loretta Sanchez,235
-Kern,42845,U.S. Senate,,DEM,Kamala Harris,350
-Kern,42845,U.S. Senate,,DEM,Loretta Sanchez,276
-Kern,43043,U.S. Senate,,DEM,Kamala Harris,345
-Kern,43043,U.S. Senate,,DEM,Loretta Sanchez,327
-Kern,43048,U.S. Senate,,DEM,Kamala Harris,291
-Kern,43048,U.S. Senate,,DEM,Loretta Sanchez,256
-Kern,43050,U.S. Senate,,DEM,Kamala Harris,340
-Kern,43050,U.S. Senate,,DEM,Loretta Sanchez,308
-Kern,43051,U.S. Senate,,DEM,Kamala Harris,162
-Kern,43051,U.S. Senate,,DEM,Loretta Sanchez,149
-Kern,43052,U.S. Senate,,DEM,Kamala Harris,236
-Kern,43052,U.S. Senate,,DEM,Loretta Sanchez,207
-Kern,43053,U.S. Senate,,DEM,Kamala Harris,323
-Kern,43053,U.S. Senate,,DEM,Loretta Sanchez,294
-Kern,43055,U.S. Senate,,DEM,Kamala Harris,262
-Kern,43055,U.S. Senate,,DEM,Loretta Sanchez,246
-Kern,43059,U.S. Senate,,DEM,Kamala Harris,323
-Kern,43059,U.S. Senate,,DEM,Loretta Sanchez,304
-Kern,43170,U.S. Senate,,DEM,Kamala Harris,305
-Kern,43170,U.S. Senate,,DEM,Loretta Sanchez,258
-Kern,43290,U.S. Senate,,DEM,Kamala Harris,123
-Kern,43290,U.S. Senate,,DEM,Loretta Sanchez,141
-Kern,43310,U.S. Senate,,DEM,Kamala Harris,179
-Kern,43310,U.S. Senate,,DEM,Loretta Sanchez,117
-Kern,43320,U.S. Senate,,DEM,Kamala Harris,451
-Kern,43320,U.S. Senate,,DEM,Loretta Sanchez,331
-Kern,43340,U.S. Senate,,DEM,Kamala Harris,279
-Kern,43340,U.S. Senate,,DEM,Loretta Sanchez,193
-Kern,43510,U.S. Senate,,DEM,Kamala Harris,182
-Kern,43510,U.S. Senate,,DEM,Loretta Sanchez,325
-Kern,43520,U.S. Senate,,DEM,Kamala Harris,233
-Kern,43520,U.S. Senate,,DEM,Loretta Sanchez,350
-Kern,43540,U.S. Senate,,DEM,Kamala Harris,155
-Kern,43540,U.S. Senate,,DEM,Loretta Sanchez,188
-Kern,43550,U.S. Senate,,DEM,Kamala Harris,225
-Kern,43550,U.S. Senate,,DEM,Loretta Sanchez,388
-Kern,43560,U.S. Senate,,DEM,Kamala Harris,171
-Kern,43560,U.S. Senate,,DEM,Loretta Sanchez,276
-Kern,43567,U.S. Senate,,DEM,Kamala Harris,251
-Kern,43567,U.S. Senate,,DEM,Loretta Sanchez,441
-Kern,44103,U.S. Senate,,DEM,Kamala Harris,317
-Kern,44103,U.S. Senate,,DEM,Loretta Sanchez,266
-Kern,44104,U.S. Senate,,DEM,Kamala Harris,365
-Kern,44104,U.S. Senate,,DEM,Loretta Sanchez,316
-Kern,44105,U.S. Senate,,DEM,Kamala Harris,271
-Kern,44105,U.S. Senate,,DEM,Loretta Sanchez,256
-Kern,44106,U.S. Senate,,DEM,Kamala Harris,277
-Kern,44106,U.S. Senate,,DEM,Loretta Sanchez,266
-Kern,44107,U.S. Senate,,DEM,Kamala Harris,359
-Kern,44107,U.S. Senate,,DEM,Loretta Sanchez,288
-Kern,44112,U.S. Senate,,DEM,Kamala Harris,249
-Kern,44112,U.S. Senate,,DEM,Loretta Sanchez,246
-Kern,44113,U.S. Senate,,DEM,Kamala Harris,207
-Kern,44113,U.S. Senate,,DEM,Loretta Sanchez,208
-Kern,50020,U.S. Senate,,DEM,Kamala Harris,183
-Kern,50020,U.S. Senate,,DEM,Loretta Sanchez,238
-Kern,50180,U.S. Senate,,DEM,Kamala Harris,168
-Kern,50180,U.S. Senate,,DEM,Loretta Sanchez,328
-Kern,50190,U.S. Senate,,DEM,Kamala Harris,235
-Kern,50190,U.S. Senate,,DEM,Loretta Sanchez,404
-Kern,50200,U.S. Senate,,DEM,Kamala Harris,139
-Kern,50200,U.S. Senate,,DEM,Loretta Sanchez,340
-Kern,50211,U.S. Senate,,DEM,Kamala Harris,201
-Kern,50211,U.S. Senate,,DEM,Loretta Sanchez,469
-Kern,50501,U.S. Senate,,DEM,Kamala Harris,140
-Kern,50501,U.S. Senate,,DEM,Loretta Sanchez,252
-Kern,50505,U.S. Senate,,DEM,Kamala Harris,113
-Kern,50505,U.S. Senate,,DEM,Loretta Sanchez,191
-Kern,50506,U.S. Senate,,DEM,Kamala Harris,138
-Kern,50506,U.S. Senate,,DEM,Loretta Sanchez,173
-Kern,50507,U.S. Senate,,DEM,Kamala Harris,179
-Kern,50507,U.S. Senate,,DEM,Loretta Sanchez,241
-Kern,50509,U.S. Senate,,DEM,Kamala Harris,248
-Kern,50509,U.S. Senate,,DEM,Loretta Sanchez,332
-Kern,50511,U.S. Senate,,DEM,Kamala Harris,247
-Kern,50511,U.S. Senate,,DEM,Loretta Sanchez,322
-Kern,50514,U.S. Senate,,DEM,Kamala Harris,193
-Kern,50514,U.S. Senate,,DEM,Loretta Sanchez,295
-Kern,50516,U.S. Senate,,DEM,Kamala Harris,190
-Kern,50516,U.S. Senate,,DEM,Loretta Sanchez,140
-Kern,50518,U.S. Senate,,DEM,Kamala Harris,150
-Kern,50518,U.S. Senate,,DEM,Loretta Sanchez,209
-Kern,50519,U.S. Senate,,DEM,Kamala Harris,309
-Kern,50519,U.S. Senate,,DEM,Loretta Sanchez,257
-Kern,50520,U.S. Senate,,DEM,Kamala Harris,368
-Kern,50520,U.S. Senate,,DEM,Loretta Sanchez,273
-Kern,50523,U.S. Senate,,DEM,Kamala Harris,117
-Kern,50523,U.S. Senate,,DEM,Loretta Sanchez,95
-Kern,50524,U.S. Senate,,DEM,Kamala Harris,344
-Kern,50524,U.S. Senate,,DEM,Loretta Sanchez,300
-Kern,50532,U.S. Senate,,DEM,Kamala Harris,300
-Kern,50532,U.S. Senate,,DEM,Loretta Sanchez,197
-Kern,50538,U.S. Senate,,DEM,Kamala Harris,139
-Kern,50538,U.S. Senate,,DEM,Loretta Sanchez,210
-Kern,50541,U.S. Senate,,DEM,Kamala Harris,171
-Kern,50541,U.S. Senate,,DEM,Loretta Sanchez,169
-Kern,50543,U.S. Senate,,DEM,Kamala Harris,132
-Kern,50543,U.S. Senate,,DEM,Loretta Sanchez,223
-Kern,50545,U.S. Senate,,DEM,Kamala Harris,205
-Kern,50545,U.S. Senate,,DEM,Loretta Sanchez,399
-Kern,50548,U.S. Senate,,DEM,Kamala Harris,214
-Kern,50548,U.S. Senate,,DEM,Loretta Sanchez,275
-Kern,50552,U.S. Senate,,DEM,Kamala Harris,123
-Kern,50552,U.S. Senate,,DEM,Loretta Sanchez,269
-Kern,50560,U.S. Senate,,DEM,Kamala Harris,140
-Kern,50560,U.S. Senate,,DEM,Loretta Sanchez,233
-Kern,50576,U.S. Senate,,DEM,Kamala Harris,237
-Kern,50576,U.S. Senate,,DEM,Loretta Sanchez,409
-Kern,50731,U.S. Senate,,DEM,Kamala Harris,210
-Kern,50731,U.S. Senate,,DEM,Loretta Sanchez,259
-Kern,50741,U.S. Senate,,DEM,Kamala Harris,236
-Kern,50741,U.S. Senate,,DEM,Loretta Sanchez,245
-Kern,50742,U.S. Senate,,DEM,Kamala Harris,191
-Kern,50742,U.S. Senate,,DEM,Loretta Sanchez,273
-Kern,50749,U.S. Senate,,DEM,Kamala Harris,247
-Kern,50749,U.S. Senate,,DEM,Loretta Sanchez,185
-Kern,50752,U.S. Senate,,DEM,Kamala Harris,348
-Kern,50752,U.S. Senate,,DEM,Loretta Sanchez,351
-Kern,50765,U.S. Senate,,DEM,Kamala Harris,364
-Kern,50765,U.S. Senate,,DEM,Loretta Sanchez,293
-Kern,51180,U.S. Senate,,DEM,Kamala Harris,119
-Kern,51180,U.S. Senate,,DEM,Loretta Sanchez,192
-Kern,51227,U.S. Senate,,DEM,Kamala Harris,179
-Kern,51227,U.S. Senate,,DEM,Loretta Sanchez,190
-Kern,51228,U.S. Senate,,DEM,Kamala Harris,185
-Kern,51228,U.S. Senate,,DEM,Loretta Sanchez,170
-Kern,51310,U.S. Senate,,DEM,Kamala Harris,159
-Kern,51310,U.S. Senate,,DEM,Loretta Sanchez,256
-Kern,51331,U.S. Senate,,DEM,Kamala Harris,317
-Kern,51331,U.S. Senate,,DEM,Loretta Sanchez,384
-Kern,51332,U.S. Senate,,DEM,Kamala Harris,166
-Kern,51332,U.S. Senate,,DEM,Loretta Sanchez,181
-Kern,51690,U.S. Senate,,DEM,Kamala Harris,99
-Kern,51690,U.S. Senate,,DEM,Loretta Sanchez,199
-Kern,51727,U.S. Senate,,DEM,Kamala Harris,232
-Kern,51727,U.S. Senate,,DEM,Loretta Sanchez,358
-Kern,52034,U.S. Senate,,DEM,Kamala Harris,106
-Kern,52034,U.S. Senate,,DEM,Loretta Sanchez,203
-Kern,52070,U.S. Senate,,DEM,Kamala Harris,138
-Kern,52070,U.S. Senate,,DEM,Loretta Sanchez,270
-Kern,52080,U.S. Senate,,DEM,Kamala Harris,130
-Kern,52080,U.S. Senate,,DEM,Loretta Sanchez,242
-Kern,52110,U.S. Senate,,DEM,Kamala Harris,100
-Kern,52110,U.S. Senate,,DEM,Loretta Sanchez,205
-Kern,52180,U.S. Senate,,DEM,Kamala Harris,113
-Kern,52180,U.S. Senate,,DEM,Loretta Sanchez,240
-Kern,52182,U.S. Senate,,DEM,Kamala Harris,100
-Kern,52182,U.S. Senate,,DEM,Loretta Sanchez,161
-Kern,52183,U.S. Senate,,DEM,Kamala Harris,120
-Kern,52183,U.S. Senate,,DEM,Loretta Sanchez,277
-Kern,52184,U.S. Senate,,DEM,Kamala Harris,103
-Kern,52184,U.S. Senate,,DEM,Loretta Sanchez,263
-Kern,52185,U.S. Senate,,DEM,Kamala Harris,64
-Kern,52185,U.S. Senate,,DEM,Loretta Sanchez,95
-Kern,52400,U.S. Senate,,DEM,Kamala Harris,146
-Kern,52400,U.S. Senate,,DEM,Loretta Sanchez,313
-Kern,52490,U.S. Senate,,DEM,Kamala Harris,162
-Kern,52490,U.S. Senate,,DEM,Loretta Sanchez,272
-Kern,7010010,U.S. Senate,,DEM,Kamala Harris,56
-Kern,7010010,U.S. Senate,,DEM,Loretta Sanchez,46
-Kern,7010015,U.S. Senate,,DEM,Kamala Harris,2
-Kern,7010015,U.S. Senate,,DEM,Loretta Sanchez,1
-Kern,7010050,U.S. Senate,,DEM,Kamala Harris,12
-Kern,7010050,U.S. Senate,,DEM,Loretta Sanchez,16
-Kern,7010080,U.S. Senate,,DEM,Kamala Harris,26
-Kern,7010080,U.S. Senate,,DEM,Loretta Sanchez,26
-Kern,7010084,U.S. Senate,,DEM,Kamala Harris,14
-Kern,7010084,U.S. Senate,,DEM,Loretta Sanchez,17
-Kern,7010085,U.S. Senate,,DEM,Kamala Harris,53
-Kern,7010085,U.S. Senate,,DEM,Loretta Sanchez,50
-Kern,7010090,U.S. Senate,,DEM,Kamala Harris,46
-Kern,7010090,U.S. Senate,,DEM,Loretta Sanchez,74
-Kern,7010215,U.S. Senate,,DEM,Kamala Harris,12
-Kern,7010215,U.S. Senate,,DEM,Loretta Sanchez,16
-Kern,7010225,U.S. Senate,,DEM,Kamala Harris,0
-Kern,7010225,U.S. Senate,,DEM,Loretta Sanchez,0
-Kern,7010226,U.S. Senate,,DEM,Kamala Harris,20
-Kern,7010226,U.S. Senate,,DEM,Loretta Sanchez,21
-Kern,7011135,U.S. Senate,,DEM,Kamala Harris,16
-Kern,7011135,U.S. Senate,,DEM,Loretta Sanchez,10
-Kern,7011153,U.S. Senate,,DEM,Kamala Harris,12
-Kern,7011153,U.S. Senate,,DEM,Loretta Sanchez,18
-Kern,7011170,U.S. Senate,,DEM,Kamala Harris,41
-Kern,7011170,U.S. Senate,,DEM,Loretta Sanchez,58
-Kern,7011171,U.S. Senate,,DEM,Kamala Harris,19
-Kern,7011171,U.S. Senate,,DEM,Loretta Sanchez,18
-Kern,7011200,U.S. Senate,,DEM,Kamala Harris,0
-Kern,7011200,U.S. Senate,,DEM,Loretta Sanchez,0
-Kern,7011208,U.S. Senate,,DEM,Kamala Harris,0
-Kern,7011208,U.S. Senate,,DEM,Loretta Sanchez,3
-Kern,7011209,U.S. Senate,,DEM,Kamala Harris,38
-Kern,7011209,U.S. Senate,,DEM,Loretta Sanchez,62
-Kern,7011290,U.S. Senate,,DEM,Kamala Harris,3
-Kern,7011290,U.S. Senate,,DEM,Loretta Sanchez,5
-Kern,7011382,U.S. Senate,,DEM,Kamala Harris,0
-Kern,7011382,U.S. Senate,,DEM,Loretta Sanchez,0
-Kern,7011538,U.S. Senate,,DEM,Kamala Harris,43
-Kern,7011538,U.S. Senate,,DEM,Loretta Sanchez,29
-Kern,7011541,U.S. Senate,,DEM,Kamala Harris,0
-Kern,7011541,U.S. Senate,,DEM,Loretta Sanchez,0
-Kern,7011542,U.S. Senate,,DEM,Kamala Harris,0
-Kern,7011542,U.S. Senate,,DEM,Loretta Sanchez,1
-Kern,7011627,U.S. Senate,,DEM,Kamala Harris,0
-Kern,7011627,U.S. Senate,,DEM,Loretta Sanchez,0
-Kern,7011683,U.S. Senate,,DEM,Kamala Harris,14
-Kern,7011683,U.S. Senate,,DEM,Loretta Sanchez,18
-Kern,7011703,U.S. Senate,,DEM,Kamala Harris,9
-Kern,7011703,U.S. Senate,,DEM,Loretta Sanchez,18
-Kern,7011719,U.S. Senate,,DEM,Kamala Harris,78
-Kern,7011719,U.S. Senate,,DEM,Loretta Sanchez,37
-Kern,7011760,U.S. Senate,,DEM,Kamala Harris,0
-Kern,7011760,U.S. Senate,,DEM,Loretta Sanchez,2
-Kern,7011773,U.S. Senate,,DEM,Kamala Harris,57
-Kern,7011773,U.S. Senate,,DEM,Loretta Sanchez,50
-Kern,7011820,U.S. Senate,,DEM,Kamala Harris,18
-Kern,7011820,U.S. Senate,,DEM,Loretta Sanchez,28
-Kern,7011835,U.S. Senate,,DEM,Kamala Harris,0
-Kern,7011835,U.S. Senate,,DEM,Loretta Sanchez,0
-Kern,7011860,U.S. Senate,,DEM,Kamala Harris,3
-Kern,7011860,U.S. Senate,,DEM,Loretta Sanchez,10
-Kern,7011880,U.S. Senate,,DEM,Kamala Harris,0
-Kern,7011880,U.S. Senate,,DEM,Loretta Sanchez,0
-Kern,7011900,U.S. Senate,,DEM,Kamala Harris,30
-Kern,7011900,U.S. Senate,,DEM,Loretta Sanchez,37
-Kern,7011922,U.S. Senate,,DEM,Kamala Harris,63
-Kern,7011922,U.S. Senate,,DEM,Loretta Sanchez,36
-Kern,7011937,U.S. Senate,,DEM,Kamala Harris,0
-Kern,7011937,U.S. Senate,,DEM,Loretta Sanchez,0
-Kern,7011983,U.S. Senate,,DEM,Kamala Harris,13
-Kern,7011983,U.S. Senate,,DEM,Loretta Sanchez,5
-Kern,7012013,U.S. Senate,,DEM,Kamala Harris,0
-Kern,7012013,U.S. Senate,,DEM,Loretta Sanchez,0
-Kern,7012160,U.S. Senate,,DEM,Kamala Harris,77
-Kern,7012160,U.S. Senate,,DEM,Loretta Sanchez,36
-Kern,7012162,U.S. Senate,,DEM,Kamala Harris,0
-Kern,7012162,U.S. Senate,,DEM,Loretta Sanchez,0
-Kern,7012163,U.S. Senate,,DEM,Kamala Harris,4
-Kern,7012163,U.S. Senate,,DEM,Loretta Sanchez,2
-Kern,7012164,U.S. Senate,,DEM,Kamala Harris,43
-Kern,7012164,U.S. Senate,,DEM,Loretta Sanchez,31
-Kern,7012250,U.S. Senate,,DEM,Kamala Harris,46
-Kern,7012250,U.S. Senate,,DEM,Loretta Sanchez,42
-Kern,7012277,U.S. Senate,,DEM,Kamala Harris,7
-Kern,7012277,U.S. Senate,,DEM,Loretta Sanchez,37
-Kern,7012395,U.S. Senate,,DEM,Kamala Harris,0
-Kern,7012395,U.S. Senate,,DEM,Loretta Sanchez,0
-Kern,7012413,U.S. Senate,,DEM,Kamala Harris,44
-Kern,7012413,U.S. Senate,,DEM,Loretta Sanchez,81
-Kern,7012725,U.S. Senate,,DEM,Kamala Harris,57
-Kern,7012725,U.S. Senate,,DEM,Loretta Sanchez,48
-Kern,7012849,U.S. Senate,,DEM,Kamala Harris,0
-Kern,7012849,U.S. Senate,,DEM,Loretta Sanchez,0
-Kern,7012937,U.S. Senate,,DEM,Kamala Harris,28
-Kern,7012937,U.S. Senate,,DEM,Loretta Sanchez,19
-Kern,7012993,U.S. Senate,,DEM,Kamala Harris,0
-Kern,7012993,U.S. Senate,,DEM,Loretta Sanchez,1
-Kern,7012998,U.S. Senate,,DEM,Kamala Harris,1
-Kern,7012998,U.S. Senate,,DEM,Loretta Sanchez,1
-Kern,7013047,U.S. Senate,,DEM,Kamala Harris,0
-Kern,7013047,U.S. Senate,,DEM,Loretta Sanchez,0
-Kern,7013061,U.S. Senate,,DEM,Kamala Harris,0
-Kern,7013061,U.S. Senate,,DEM,Loretta Sanchez,0
-Kern,7013068,U.S. Senate,,DEM,Kamala Harris,0
-Kern,7013068,U.S. Senate,,DEM,Loretta Sanchez,0
-Kern,7013092,U.S. Senate,,DEM,Kamala Harris,15
-Kern,7013092,U.S. Senate,,DEM,Loretta Sanchez,16
-Kern,7013094,U.S. Senate,,DEM,Kamala Harris,46
-Kern,7013094,U.S. Senate,,DEM,Loretta Sanchez,67
-Kern,7013102,U.S. Senate,,DEM,Kamala Harris,3
-Kern,7013102,U.S. Senate,,DEM,Loretta Sanchez,4
-Kern,7013103,U.S. Senate,,DEM,Kamala Harris,1
-Kern,7013103,U.S. Senate,,DEM,Loretta Sanchez,5
-Kern,7013104,U.S. Senate,,DEM,Kamala Harris,0
-Kern,7013104,U.S. Senate,,DEM,Loretta Sanchez,1
-Kern,7013105,U.S. Senate,,DEM,Kamala Harris,0
-Kern,7013105,U.S. Senate,,DEM,Loretta Sanchez,0
-Kern,7013112,U.S. Senate,,DEM,Kamala Harris,23
-Kern,7013112,U.S. Senate,,DEM,Loretta Sanchez,18
-Kern,7013122,U.S. Senate,,DEM,Kamala Harris,0
-Kern,7013122,U.S. Senate,,DEM,Loretta Sanchez,0
-Kern,7013123,U.S. Senate,,DEM,Kamala Harris,0
-Kern,7013123,U.S. Senate,,DEM,Loretta Sanchez,0
-Kern,7013128,U.S. Senate,,DEM,Kamala Harris,42
-Kern,7013128,U.S. Senate,,DEM,Loretta Sanchez,62
-Kern,7013133,U.S. Senate,,DEM,Kamala Harris,0
-Kern,7013133,U.S. Senate,,DEM,Loretta Sanchez,0
-Kern,7013182,U.S. Senate,,DEM,Kamala Harris,9
-Kern,7013182,U.S. Senate,,DEM,Loretta Sanchez,17
-Kern,7013183,U.S. Senate,,DEM,Kamala Harris,1
-Kern,7013183,U.S. Senate,,DEM,Loretta Sanchez,0
-Kern,7013569,U.S. Senate,,DEM,Kamala Harris,0
-Kern,7013569,U.S. Senate,,DEM,Loretta Sanchez,0
-Kern,7013701,U.S. Senate,,DEM,Kamala Harris,11
-Kern,7013701,U.S. Senate,,DEM,Loretta Sanchez,9
-Kern,7015125,U.S. Senate,,DEM,Kamala Harris,22
-Kern,7015125,U.S. Senate,,DEM,Loretta Sanchez,25
-Kern,7015131,U.S. Senate,,DEM,Kamala Harris,0
-Kern,7015131,U.S. Senate,,DEM,Loretta Sanchez,0
-Kern,7015134,U.S. Senate,,DEM,Kamala Harris,0
-Kern,7015134,U.S. Senate,,DEM,Loretta Sanchez,0
-Kern,7020012,U.S. Senate,,DEM,Kamala Harris,13
-Kern,7020012,U.S. Senate,,DEM,Loretta Sanchez,16
-Kern,7020014,U.S. Senate,,DEM,Kamala Harris,9
-Kern,7020014,U.S. Senate,,DEM,Loretta Sanchez,8
-Kern,7020034,U.S. Senate,,DEM,Kamala Harris,15
-Kern,7020034,U.S. Senate,,DEM,Loretta Sanchez,15
-Kern,7020110,U.S. Senate,,DEM,Kamala Harris,71
-Kern,7020110,U.S. Senate,,DEM,Loretta Sanchez,53
-Kern,7020176,U.S. Senate,,DEM,Kamala Harris,53
-Kern,7020176,U.S. Senate,,DEM,Loretta Sanchez,48
-Kern,7020250,U.S. Senate,,DEM,Kamala Harris,56
-Kern,7020250,U.S. Senate,,DEM,Loretta Sanchez,59
-Kern,7020264,U.S. Senate,,DEM,Kamala Harris,1
-Kern,7020264,U.S. Senate,,DEM,Loretta Sanchez,2
-Kern,7020266,U.S. Senate,,DEM,Kamala Harris,28
-Kern,7020266,U.S. Senate,,DEM,Loretta Sanchez,63
-Kern,7021136,U.S. Senate,,DEM,Kamala Harris,0
-Kern,7021136,U.S. Senate,,DEM,Loretta Sanchez,1
-Kern,7021137,U.S. Senate,,DEM,Kamala Harris,0
-Kern,7021137,U.S. Senate,,DEM,Loretta Sanchez,0
-Kern,7021222,U.S. Senate,,DEM,Kamala Harris,28
-Kern,7021222,U.S. Senate,,DEM,Loretta Sanchez,11
-Kern,7021231,U.S. Senate,,DEM,Kamala Harris,0
-Kern,7021231,U.S. Senate,,DEM,Loretta Sanchez,0
-Kern,7021235,U.S. Senate,,DEM,Kamala Harris,28
-Kern,7021235,U.S. Senate,,DEM,Loretta Sanchez,42
-Kern,7021261,U.S. Senate,,DEM,Kamala Harris,27
-Kern,7021261,U.S. Senate,,DEM,Loretta Sanchez,20
-Kern,7021270,U.S. Senate,,DEM,Kamala Harris,43
-Kern,7021270,U.S. Senate,,DEM,Loretta Sanchez,30
-Kern,7021276,U.S. Senate,,DEM,Kamala Harris,24
-Kern,7021276,U.S. Senate,,DEM,Loretta Sanchez,5
-Kern,7021301,U.S. Senate,,DEM,Kamala Harris,33
-Kern,7021301,U.S. Senate,,DEM,Loretta Sanchez,17
-Kern,7021381,U.S. Senate,,DEM,Kamala Harris,0
-Kern,7021381,U.S. Senate,,DEM,Loretta Sanchez,0
-Kern,7021387,U.S. Senate,,DEM,Kamala Harris,52
-Kern,7021387,U.S. Senate,,DEM,Loretta Sanchez,69
-Kern,7021389,U.S. Senate,,DEM,Kamala Harris,5
-Kern,7021389,U.S. Senate,,DEM,Loretta Sanchez,10
-Kern,7021477,U.S. Senate,,DEM,Kamala Harris,1
-Kern,7021477,U.S. Senate,,DEM,Loretta Sanchez,11
-Kern,7021531,U.S. Senate,,DEM,Kamala Harris,5
-Kern,7021531,U.S. Senate,,DEM,Loretta Sanchez,2
-Kern,7021634,U.S. Senate,,DEM,Kamala Harris,30
-Kern,7021634,U.S. Senate,,DEM,Loretta Sanchez,51
-Kern,7021637,U.S. Senate,,DEM,Kamala Harris,70
-Kern,7021637,U.S. Senate,,DEM,Loretta Sanchez,49
-Kern,7021717,U.S. Senate,,DEM,Kamala Harris,0
-Kern,7021717,U.S. Senate,,DEM,Loretta Sanchez,0
-Kern,7021752,U.S. Senate,,DEM,Kamala Harris,13
-Kern,7021752,U.S. Senate,,DEM,Loretta Sanchez,7
-Kern,7021879,U.S. Senate,,DEM,Kamala Harris,0
-Kern,7021879,U.S. Senate,,DEM,Loretta Sanchez,0
-Kern,7021925,U.S. Senate,,DEM,Kamala Harris,74
-Kern,7021925,U.S. Senate,,DEM,Loretta Sanchez,56
-Kern,7022001,U.S. Senate,,DEM,Kamala Harris,19
-Kern,7022001,U.S. Senate,,DEM,Loretta Sanchez,7
-Kern,7022007,U.S. Senate,,DEM,Kamala Harris,32
-Kern,7022007,U.S. Senate,,DEM,Loretta Sanchez,25
-Kern,7022014,U.S. Senate,,DEM,Kamala Harris,70
-Kern,7022014,U.S. Senate,,DEM,Loretta Sanchez,94
-Kern,7022015,U.S. Senate,,DEM,Kamala Harris,6
-Kern,7022015,U.S. Senate,,DEM,Loretta Sanchez,11
-Kern,7022019,U.S. Senate,,DEM,Kamala Harris,57
-Kern,7022019,U.S. Senate,,DEM,Loretta Sanchez,56
-Kern,7022022,U.S. Senate,,DEM,Kamala Harris,1
-Kern,7022022,U.S. Senate,,DEM,Loretta Sanchez,1
-Kern,7022025,U.S. Senate,,DEM,Kamala Harris,0
-Kern,7022025,U.S. Senate,,DEM,Loretta Sanchez,0
-Kern,7022028,U.S. Senate,,DEM,Kamala Harris,32
-Kern,7022028,U.S. Senate,,DEM,Loretta Sanchez,30
-Kern,7022209,U.S. Senate,,DEM,Kamala Harris,61
-Kern,7022209,U.S. Senate,,DEM,Loretta Sanchez,57
-Kern,7022234,U.S. Senate,,DEM,Kamala Harris,4
-Kern,7022234,U.S. Senate,,DEM,Loretta Sanchez,1
-Kern,7022283,U.S. Senate,,DEM,Kamala Harris,33
-Kern,7022283,U.S. Senate,,DEM,Loretta Sanchez,37
-Kern,7022421,U.S. Senate,,DEM,Kamala Harris,10
-Kern,7022421,U.S. Senate,,DEM,Loretta Sanchez,13
-Kern,7022461,U.S. Senate,,DEM,Kamala Harris,56
-Kern,7022461,U.S. Senate,,DEM,Loretta Sanchez,33
-Kern,7022479,U.S. Senate,,DEM,Kamala Harris,16
-Kern,7022479,U.S. Senate,,DEM,Loretta Sanchez,16
-Kern,7022520,U.S. Senate,,DEM,Kamala Harris,72
-Kern,7022520,U.S. Senate,,DEM,Loretta Sanchez,38
-Kern,7022600,U.S. Senate,,DEM,Kamala Harris,0
-Kern,7022600,U.S. Senate,,DEM,Loretta Sanchez,2
-Kern,7022793,U.S. Senate,,DEM,Kamala Harris,16
-Kern,7022793,U.S. Senate,,DEM,Loretta Sanchez,27
-Kern,7022803,U.S. Senate,,DEM,Kamala Harris,0
-Kern,7022803,U.S. Senate,,DEM,Loretta Sanchez,0
-Kern,7022805,U.S. Senate,,DEM,Kamala Harris,3
-Kern,7022805,U.S. Senate,,DEM,Loretta Sanchez,9
-Kern,7022900,U.S. Senate,,DEM,Kamala Harris,40
-Kern,7022900,U.S. Senate,,DEM,Loretta Sanchez,25
-Kern,7023011,U.S. Senate,,DEM,Kamala Harris,2
-Kern,7023011,U.S. Senate,,DEM,Loretta Sanchez,6
-Kern,7023018,U.S. Senate,,DEM,Kamala Harris,0
-Kern,7023018,U.S. Senate,,DEM,Loretta Sanchez,0
-Kern,7023019,U.S. Senate,,DEM,Kamala Harris,0
-Kern,7023019,U.S. Senate,,DEM,Loretta Sanchez,0
-Kern,7023024,U.S. Senate,,DEM,Kamala Harris,36
-Kern,7023024,U.S. Senate,,DEM,Loretta Sanchez,18
-Kern,7023037,U.S. Senate,,DEM,Kamala Harris,11
-Kern,7023037,U.S. Senate,,DEM,Loretta Sanchez,5
-Kern,7023082,U.S. Senate,,DEM,Kamala Harris,42
-Kern,7023082,U.S. Senate,,DEM,Loretta Sanchez,48
-Kern,7023084,U.S. Senate,,DEM,Kamala Harris,0
-Kern,7023084,U.S. Senate,,DEM,Loretta Sanchez,0
-Kern,7023148,U.S. Senate,,DEM,Kamala Harris,1
-Kern,7023148,U.S. Senate,,DEM,Loretta Sanchez,2
-Kern,7023198,U.S. Senate,,DEM,Kamala Harris,1
-Kern,7023198,U.S. Senate,,DEM,Loretta Sanchez,0
-Kern,7023201,U.S. Senate,,DEM,Kamala Harris,1
-Kern,7023201,U.S. Senate,,DEM,Loretta Sanchez,0
-Kern,7023221,U.S. Senate,,DEM,Kamala Harris,0
-Kern,7023221,U.S. Senate,,DEM,Loretta Sanchez,0
-Kern,7023395,U.S. Senate,,DEM,Kamala Harris,0
-Kern,7023395,U.S. Senate,,DEM,Loretta Sanchez,0
-Kern,7023405,U.S. Senate,,DEM,Kamala Harris,2
-Kern,7023405,U.S. Senate,,DEM,Loretta Sanchez,0
-Kern,7023454,U.S. Senate,,DEM,Kamala Harris,61
-Kern,7023454,U.S. Senate,,DEM,Loretta Sanchez,66
-Kern,7023470,U.S. Senate,,DEM,Kamala Harris,41
-Kern,7023470,U.S. Senate,,DEM,Loretta Sanchez,64
-Kern,7023476,U.S. Senate,,DEM,Kamala Harris,65
-Kern,7023476,U.S. Senate,,DEM,Loretta Sanchez,44
-Kern,7023500,U.S. Senate,,DEM,Kamala Harris,54
-Kern,7023500,U.S. Senate,,DEM,Loretta Sanchez,55
-Kern,7023505,U.S. Senate,,DEM,Kamala Harris,0
-Kern,7023505,U.S. Senate,,DEM,Loretta Sanchez,0
-Kern,7023604,U.S. Senate,,DEM,Kamala Harris,0
-Kern,7023604,U.S. Senate,,DEM,Loretta Sanchez,0
-Kern,7023606,U.S. Senate,,DEM,Kamala Harris,0
-Kern,7023606,U.S. Senate,,DEM,Loretta Sanchez,0
-Kern,7023610,U.S. Senate,,DEM,Kamala Harris,52
-Kern,7023610,U.S. Senate,,DEM,Loretta Sanchez,66
-Kern,7023766,U.S. Senate,,DEM,Kamala Harris,2
-Kern,7023766,U.S. Senate,,DEM,Loretta Sanchez,0
-Kern,7025274,U.S. Senate,,DEM,Kamala Harris,1
-Kern,7025274,U.S. Senate,,DEM,Loretta Sanchez,0
-Kern,7025276,U.S. Senate,,DEM,Kamala Harris,0
-Kern,7025276,U.S. Senate,,DEM,Loretta Sanchez,0
-Kern,7025277,U.S. Senate,,DEM,Kamala Harris,0
-Kern,7025277,U.S. Senate,,DEM,Loretta Sanchez,0
-Kern,7025278,U.S. Senate,,DEM,Kamala Harris,0
-Kern,7025278,U.S. Senate,,DEM,Loretta Sanchez,0
-Kern,7025279,U.S. Senate,,DEM,Kamala Harris,0
-Kern,7025279,U.S. Senate,,DEM,Loretta Sanchez,0
-Kern,7025293,U.S. Senate,,DEM,Kamala Harris,0
-Kern,7025293,U.S. Senate,,DEM,Loretta Sanchez,0
-Kern,7030037,U.S. Senate,,DEM,Kamala Harris,46
-Kern,7030037,U.S. Senate,,DEM,Loretta Sanchez,35
-Kern,7030082,U.S. Senate,,DEM,Kamala Harris,55
-Kern,7030082,U.S. Senate,,DEM,Loretta Sanchez,52
-Kern,7030303,U.S. Senate,,DEM,Kamala Harris,62
-Kern,7030303,U.S. Senate,,DEM,Loretta Sanchez,50
-Kern,7030319,U.S. Senate,,DEM,Kamala Harris,70
-Kern,7030319,U.S. Senate,,DEM,Loretta Sanchez,51
-Kern,7030324,U.S. Senate,,DEM,Kamala Harris,53
-Kern,7030324,U.S. Senate,,DEM,Loretta Sanchez,51
-Kern,7030327,U.S. Senate,,DEM,Kamala Harris,26
-Kern,7030327,U.S. Senate,,DEM,Loretta Sanchez,23
-Kern,7030329,U.S. Senate,,DEM,Kamala Harris,2
-Kern,7030329,U.S. Senate,,DEM,Loretta Sanchez,0
-Kern,7030331,U.S. Senate,,DEM,Kamala Harris,25
-Kern,7030331,U.S. Senate,,DEM,Loretta Sanchez,25
-Kern,7030336,U.S. Senate,,DEM,Kamala Harris,0
-Kern,7030336,U.S. Senate,,DEM,Loretta Sanchez,0
-Kern,7030344,U.S. Senate,,DEM,Kamala Harris,20
-Kern,7030344,U.S. Senate,,DEM,Loretta Sanchez,24
-Kern,7030345,U.S. Senate,,DEM,Kamala Harris,0
-Kern,7030345,U.S. Senate,,DEM,Loretta Sanchez,0
-Kern,7030395,U.S. Senate,,DEM,Kamala Harris,0
-Kern,7030395,U.S. Senate,,DEM,Loretta Sanchez,0
-Kern,7031178,U.S. Senate,,DEM,Kamala Harris,33
-Kern,7031178,U.S. Senate,,DEM,Loretta Sanchez,48
-Kern,7031211,U.S. Senate,,DEM,Kamala Harris,45
-Kern,7031211,U.S. Senate,,DEM,Loretta Sanchez,65
-Kern,7031389,U.S. Senate,,DEM,Kamala Harris,53
-Kern,7031389,U.S. Senate,,DEM,Loretta Sanchez,32
-Kern,7031473,U.S. Senate,,DEM,Kamala Harris,1
-Kern,7031473,U.S. Senate,,DEM,Loretta Sanchez,4
-Kern,7031705,U.S. Senate,,DEM,Kamala Harris,10
-Kern,7031705,U.S. Senate,,DEM,Loretta Sanchez,11
-Kern,7031740,U.S. Senate,,DEM,Kamala Harris,28
-Kern,7031740,U.S. Senate,,DEM,Loretta Sanchez,30
-Kern,7032253,U.S. Senate,,DEM,Kamala Harris,17
-Kern,7032253,U.S. Senate,,DEM,Loretta Sanchez,12
-Kern,7032442,U.S. Senate,,DEM,Kamala Harris,68
-Kern,7032442,U.S. Senate,,DEM,Loretta Sanchez,27
-Kern,7032740,U.S. Senate,,DEM,Kamala Harris,27
-Kern,7032740,U.S. Senate,,DEM,Loretta Sanchez,23
-Kern,7033210,U.S. Senate,,DEM,Kamala Harris,74
-Kern,7033210,U.S. Senate,,DEM,Loretta Sanchez,64
-Kern,7033223,U.S. Senate,,DEM,Kamala Harris,28
-Kern,7033223,U.S. Senate,,DEM,Loretta Sanchez,59
-Kern,7033226,U.S. Senate,,DEM,Kamala Harris,48
-Kern,7033226,U.S. Senate,,DEM,Loretta Sanchez,46
-Kern,7035639,U.S. Senate,,DEM,Kamala Harris,16
-Kern,7035639,U.S. Senate,,DEM,Loretta Sanchez,17
-Kern,7035654,U.S. Senate,,DEM,Kamala Harris,31
-Kern,7035654,U.S. Senate,,DEM,Loretta Sanchez,45
-Kern,7035663,U.S. Senate,,DEM,Kamala Harris,5
-Kern,7035663,U.S. Senate,,DEM,Loretta Sanchez,2
-Kern,7035667,U.S. Senate,,DEM,Kamala Harris,0
-Kern,7035667,U.S. Senate,,DEM,Loretta Sanchez,0
-Kern,7035676,U.S. Senate,,DEM,Kamala Harris,0
-Kern,7035676,U.S. Senate,,DEM,Loretta Sanchez,0
-Kern,7035683,U.S. Senate,,DEM,Kamala Harris,0
-Kern,7035683,U.S. Senate,,DEM,Loretta Sanchez,0
-Kern,7035685,U.S. Senate,,DEM,Kamala Harris,0
-Kern,7035685,U.S. Senate,,DEM,Loretta Sanchez,0
-Kern,7040086,U.S. Senate,,DEM,Kamala Harris,63
-Kern,7040086,U.S. Senate,,DEM,Loretta Sanchez,41
-Kern,7040140,U.S. Senate,,DEM,Kamala Harris,1
-Kern,7040140,U.S. Senate,,DEM,Loretta Sanchez,10
-Kern,7040141,U.S. Senate,,DEM,Kamala Harris,0
-Kern,7040141,U.S. Senate,,DEM,Loretta Sanchez,0
-Kern,7040142,U.S. Senate,,DEM,Kamala Harris,0
-Kern,7040142,U.S. Senate,,DEM,Loretta Sanchez,5
-Kern,7040144,U.S. Senate,,DEM,Kamala Harris,29
-Kern,7040144,U.S. Senate,,DEM,Loretta Sanchez,36
-Kern,7040413,U.S. Senate,,DEM,Kamala Harris,71
-Kern,7040413,U.S. Senate,,DEM,Loretta Sanchez,42
-Kern,7040420,U.S. Senate,,DEM,Kamala Harris,57
-Kern,7040420,U.S. Senate,,DEM,Loretta Sanchez,39
-Kern,7040437,U.S. Senate,,DEM,Kamala Harris,0
-Kern,7040437,U.S. Senate,,DEM,Loretta Sanchez,0
-Kern,7040438,U.S. Senate,,DEM,Kamala Harris,0
-Kern,7040438,U.S. Senate,,DEM,Loretta Sanchez,0
-Kern,7040439,U.S. Senate,,DEM,Kamala Harris,10
-Kern,7040439,U.S. Senate,,DEM,Loretta Sanchez,2
-Kern,7040472,U.S. Senate,,DEM,Kamala Harris,21
-Kern,7040472,U.S. Senate,,DEM,Loretta Sanchez,18
-Kern,7040478,U.S. Senate,,DEM,Kamala Harris,0
-Kern,7040478,U.S. Senate,,DEM,Loretta Sanchez,0
-Kern,7040492,U.S. Senate,,DEM,Kamala Harris,0
-Kern,7040492,U.S. Senate,,DEM,Loretta Sanchez,0
-Kern,7040498,U.S. Senate,,DEM,Kamala Harris,129
-Kern,7040498,U.S. Senate,,DEM,Loretta Sanchez,105
-Kern,7041139,U.S. Senate,,DEM,Kamala Harris,34
-Kern,7041139,U.S. Senate,,DEM,Loretta Sanchez,11
-Kern,7041149,U.S. Senate,,DEM,Kamala Harris,0
-Kern,7041149,U.S. Senate,,DEM,Loretta Sanchez,0
-Kern,7041184,U.S. Senate,,DEM,Kamala Harris,41
-Kern,7041184,U.S. Senate,,DEM,Loretta Sanchez,95
-Kern,7041241,U.S. Senate,,DEM,Kamala Harris,32
-Kern,7041241,U.S. Senate,,DEM,Loretta Sanchez,26
-Kern,7041242,U.S. Senate,,DEM,Kamala Harris,4
-Kern,7041242,U.S. Senate,,DEM,Loretta Sanchez,12
-Kern,7041305,U.S. Senate,,DEM,Kamala Harris,24
-Kern,7041305,U.S. Senate,,DEM,Loretta Sanchez,22
-Kern,7041306,U.S. Senate,,DEM,Kamala Harris,6
-Kern,7041306,U.S. Senate,,DEM,Loretta Sanchez,17
-Kern,7041320,U.S. Senate,,DEM,Kamala Harris,0
-Kern,7041320,U.S. Senate,,DEM,Loretta Sanchez,0
-Kern,7041388,U.S. Senate,,DEM,Kamala Harris,13
-Kern,7041388,U.S. Senate,,DEM,Loretta Sanchez,18
-Kern,7041496,U.S. Senate,,DEM,Kamala Harris,6
-Kern,7041496,U.S. Senate,,DEM,Loretta Sanchez,2
-Kern,7041500,U.S. Senate,,DEM,Kamala Harris,7
-Kern,7041500,U.S. Senate,,DEM,Loretta Sanchez,7
-Kern,7041504,U.S. Senate,,DEM,Kamala Harris,2
-Kern,7041504,U.S. Senate,,DEM,Loretta Sanchez,3
-Kern,7041506,U.S. Senate,,DEM,Kamala Harris,11
-Kern,7041506,U.S. Senate,,DEM,Loretta Sanchez,4
-Kern,7041507,U.S. Senate,,DEM,Kamala Harris,64
-Kern,7041507,U.S. Senate,,DEM,Loretta Sanchez,58
-Kern,7041526,U.S. Senate,,DEM,Kamala Harris,3
-Kern,7041526,U.S. Senate,,DEM,Loretta Sanchez,6
-Kern,7041528,U.S. Senate,,DEM,Kamala Harris,53
-Kern,7041528,U.S. Senate,,DEM,Loretta Sanchez,53
-Kern,7041720,U.S. Senate,,DEM,Kamala Harris,8
-Kern,7041720,U.S. Senate,,DEM,Loretta Sanchez,8
-Kern,7041768,U.S. Senate,,DEM,Kamala Harris,20
-Kern,7041768,U.S. Senate,,DEM,Loretta Sanchez,14
-Kern,7041778,U.S. Senate,,DEM,Kamala Harris,0
-Kern,7041778,U.S. Senate,,DEM,Loretta Sanchez,0
-Kern,7041875,U.S. Senate,,DEM,Kamala Harris,0
-Kern,7041875,U.S. Senate,,DEM,Loretta Sanchez,16
-Kern,7041876,U.S. Senate,,DEM,Kamala Harris,1
-Kern,7041876,U.S. Senate,,DEM,Loretta Sanchez,1
-Kern,7041908,U.S. Senate,,DEM,Kamala Harris,6
-Kern,7041908,U.S. Senate,,DEM,Loretta Sanchez,4
-Kern,7041933,U.S. Senate,,DEM,Kamala Harris,27
-Kern,7041933,U.S. Senate,,DEM,Loretta Sanchez,51
-Kern,7041934,U.S. Senate,,DEM,Kamala Harris,0
-Kern,7041934,U.S. Senate,,DEM,Loretta Sanchez,0
-Kern,7042000,U.S. Senate,,DEM,Kamala Harris,7
-Kern,7042000,U.S. Senate,,DEM,Loretta Sanchez,12
-Kern,7042003,U.S. Senate,,DEM,Kamala Harris,0
-Kern,7042003,U.S. Senate,,DEM,Loretta Sanchez,0
-Kern,7042223,U.S. Senate,,DEM,Kamala Harris,0
-Kern,7042223,U.S. Senate,,DEM,Loretta Sanchez,0
-Kern,7042427,U.S. Senate,,DEM,Kamala Harris,14
-Kern,7042427,U.S. Senate,,DEM,Loretta Sanchez,13
-Kern,7042438,U.S. Senate,,DEM,Kamala Harris,0
-Kern,7042438,U.S. Senate,,DEM,Loretta Sanchez,0
-Kern,7042441,U.S. Senate,,DEM,Kamala Harris,0
-Kern,7042441,U.S. Senate,,DEM,Loretta Sanchez,0
-Kern,7042517,U.S. Senate,,DEM,Kamala Harris,0
-Kern,7042517,U.S. Senate,,DEM,Loretta Sanchez,4
-Kern,7042637,U.S. Senate,,DEM,Kamala Harris,98
-Kern,7042637,U.S. Senate,,DEM,Loretta Sanchez,105
-Kern,7042769,U.S. Senate,,DEM,Kamala Harris,68
-Kern,7042769,U.S. Senate,,DEM,Loretta Sanchez,38
-Kern,7042783,U.S. Senate,,DEM,Kamala Harris,0
-Kern,7042783,U.S. Senate,,DEM,Loretta Sanchez,0
-Kern,7042784,U.S. Senate,,DEM,Kamala Harris,1
-Kern,7042784,U.S. Senate,,DEM,Loretta Sanchez,1
-Kern,7042785,U.S. Senate,,DEM,Kamala Harris,0
-Kern,7042785,U.S. Senate,,DEM,Loretta Sanchez,0
-Kern,7042789,U.S. Senate,,DEM,Kamala Harris,0
-Kern,7042789,U.S. Senate,,DEM,Loretta Sanchez,0
-Kern,7043047,U.S. Senate,,DEM,Kamala Harris,6
-Kern,7043047,U.S. Senate,,DEM,Loretta Sanchez,11
-Kern,7043101,U.S. Senate,,DEM,Kamala Harris,0
-Kern,7043101,U.S. Senate,,DEM,Loretta Sanchez,0
-Kern,7043295,U.S. Senate,,DEM,Kamala Harris,82
-Kern,7043295,U.S. Senate,,DEM,Loretta Sanchez,149
-Kern,7043561,U.S. Senate,,DEM,Kamala Harris,20
-Kern,7043561,U.S. Senate,,DEM,Loretta Sanchez,34
-Kern,7044110,U.S. Senate,,DEM,Kamala Harris,13
-Kern,7044110,U.S. Senate,,DEM,Loretta Sanchez,12
-Kern,7050025,U.S. Senate,,DEM,Kamala Harris,10
-Kern,7050025,U.S. Senate,,DEM,Loretta Sanchez,12
-Kern,7050030,U.S. Senate,,DEM,Kamala Harris,25
-Kern,7050030,U.S. Senate,,DEM,Loretta Sanchez,64
-Kern,7050032,U.S. Senate,,DEM,Kamala Harris,1
-Kern,7050032,U.S. Senate,,DEM,Loretta Sanchez,0
-Kern,7050212,U.S. Senate,,DEM,Kamala Harris,0
-Kern,7050212,U.S. Senate,,DEM,Loretta Sanchez,0
-Kern,7050217,U.S. Senate,,DEM,Kamala Harris,0
-Kern,7050217,U.S. Senate,,DEM,Loretta Sanchez,0
-Kern,7050220,U.S. Senate,,DEM,Kamala Harris,16
-Kern,7050220,U.S. Senate,,DEM,Loretta Sanchez,48
-Kern,7050221,U.S. Senate,,DEM,Kamala Harris,29
-Kern,7050221,U.S. Senate,,DEM,Loretta Sanchez,54
-Kern,7050504,U.S. Senate,,DEM,Kamala Harris,16
-Kern,7050504,U.S. Senate,,DEM,Loretta Sanchez,10
-Kern,7050513,U.S. Senate,,DEM,Kamala Harris,61
-Kern,7050513,U.S. Senate,,DEM,Loretta Sanchez,57
-Kern,7050515,U.S. Senate,,DEM,Kamala Harris,50
-Kern,7050515,U.S. Senate,,DEM,Loretta Sanchez,35
-Kern,7050525,U.S. Senate,,DEM,Kamala Harris,19
-Kern,7050525,U.S. Senate,,DEM,Loretta Sanchez,32
-Kern,7050529,U.S. Senate,,DEM,Kamala Harris,1
-Kern,7050529,U.S. Senate,,DEM,Loretta Sanchez,0
-Kern,7050539,U.S. Senate,,DEM,Kamala Harris,53
-Kern,7050539,U.S. Senate,,DEM,Loretta Sanchez,82
-Kern,7050542,U.S. Senate,,DEM,Kamala Harris,54
-Kern,7050542,U.S. Senate,,DEM,Loretta Sanchez,74
-Kern,7050546,U.S. Senate,,DEM,Kamala Harris,0
-Kern,7050546,U.S. Senate,,DEM,Loretta Sanchez,0
-Kern,7050547,U.S. Senate,,DEM,Kamala Harris,26
-Kern,7050547,U.S. Senate,,DEM,Loretta Sanchez,36
-Kern,7050549,U.S. Senate,,DEM,Kamala Harris,70
-Kern,7050549,U.S. Senate,,DEM,Loretta Sanchez,53
-Kern,7050556,U.S. Senate,,DEM,Kamala Harris,0
-Kern,7050556,U.S. Senate,,DEM,Loretta Sanchez,0
-Kern,7050561,U.S. Senate,,DEM,Kamala Harris,37
-Kern,7050561,U.S. Senate,,DEM,Loretta Sanchez,54
-Kern,7050563,U.S. Senate,,DEM,Kamala Harris,0
-Kern,7050563,U.S. Senate,,DEM,Loretta Sanchez,0
-Kern,7050566,U.S. Senate,,DEM,Kamala Harris,0
-Kern,7050566,U.S. Senate,,DEM,Loretta Sanchez,0
-Kern,7050586,U.S. Senate,,DEM,Kamala Harris,57
-Kern,7050586,U.S. Senate,,DEM,Loretta Sanchez,60
-Kern,7050593,U.S. Senate,,DEM,Kamala Harris,61
-Kern,7050593,U.S. Senate,,DEM,Loretta Sanchez,69
-Kern,7050597,U.S. Senate,,DEM,Kamala Harris,0
-Kern,7050597,U.S. Senate,,DEM,Loretta Sanchez,1
-Kern,7050705,U.S. Senate,,DEM,Kamala Harris,0
-Kern,7050705,U.S. Senate,,DEM,Loretta Sanchez,0
-Kern,7050707,U.S. Senate,,DEM,Kamala Harris,45
-Kern,7050707,U.S. Senate,,DEM,Loretta Sanchez,61
-Kern,7050712,U.S. Senate,,DEM,Kamala Harris,0
-Kern,7050712,U.S. Senate,,DEM,Loretta Sanchez,0
-Kern,7050714,U.S. Senate,,DEM,Kamala Harris,6
-Kern,7050714,U.S. Senate,,DEM,Loretta Sanchez,12
-Kern,7050730,U.S. Senate,,DEM,Kamala Harris,13
-Kern,7050730,U.S. Senate,,DEM,Loretta Sanchez,28
-Kern,7050737,U.S. Senate,,DEM,Kamala Harris,25
-Kern,7050737,U.S. Senate,,DEM,Loretta Sanchez,26
-Kern,7050748,U.S. Senate,,DEM,Kamala Harris,21
-Kern,7050748,U.S. Senate,,DEM,Loretta Sanchez,16
-Kern,7050751,U.S. Senate,,DEM,Kamala Harris,70
-Kern,7050751,U.S. Senate,,DEM,Loretta Sanchez,88
-Kern,7050759,U.S. Senate,,DEM,Kamala Harris,8
-Kern,7050759,U.S. Senate,,DEM,Loretta Sanchez,4
-Kern,7050768,U.S. Senate,,DEM,Kamala Harris,0
-Kern,7050768,U.S. Senate,,DEM,Loretta Sanchez,0
-Kern,7050769,U.S. Senate,,DEM,Kamala Harris,0
-Kern,7050769,U.S. Senate,,DEM,Loretta Sanchez,0
-Kern,7051188,U.S. Senate,,DEM,Kamala Harris,1
-Kern,7051188,U.S. Senate,,DEM,Loretta Sanchez,9
-Kern,7051205,U.S. Senate,,DEM,Kamala Harris,53
-Kern,7051205,U.S. Senate,,DEM,Loretta Sanchez,44
-Kern,7051226,U.S. Senate,,DEM,Kamala Harris,28
-Kern,7051226,U.S. Senate,,DEM,Loretta Sanchez,39
-Kern,7051233,U.S. Senate,,DEM,Kamala Harris,19
-Kern,7051233,U.S. Senate,,DEM,Loretta Sanchez,30
-Kern,7051293,U.S. Senate,,DEM,Kamala Harris,39
-Kern,7051293,U.S. Senate,,DEM,Loretta Sanchez,42
-Kern,7051294,U.S. Senate,,DEM,Kamala Harris,43
-Kern,7051294,U.S. Senate,,DEM,Loretta Sanchez,61
-Kern,7051298,U.S. Senate,,DEM,Kamala Harris,35
-Kern,7051298,U.S. Senate,,DEM,Loretta Sanchez,82
-Kern,7051333,U.S. Senate,,DEM,Kamala Harris,5
-Kern,7051333,U.S. Senate,,DEM,Loretta Sanchez,6
-Kern,7051490,U.S. Senate,,DEM,Kamala Harris,4
-Kern,7051490,U.S. Senate,,DEM,Loretta Sanchez,2
-Kern,7051494,U.S. Senate,,DEM,Kamala Harris,1
-Kern,7051494,U.S. Senate,,DEM,Loretta Sanchez,1
-Kern,7051679,U.S. Senate,,DEM,Kamala Harris,4
-Kern,7051679,U.S. Senate,,DEM,Loretta Sanchez,16
-Kern,7051680,U.S. Senate,,DEM,Kamala Harris,4
-Kern,7051680,U.S. Senate,,DEM,Loretta Sanchez,0
-Kern,7051704,U.S. Senate,,DEM,Kamala Harris,50
-Kern,7051704,U.S. Senate,,DEM,Loretta Sanchez,43
-Kern,7051716,U.S. Senate,,DEM,Kamala Harris,1
-Kern,7051716,U.S. Senate,,DEM,Loretta Sanchez,4
-Kern,7051729,U.S. Senate,,DEM,Kamala Harris,26
-Kern,7051729,U.S. Senate,,DEM,Loretta Sanchez,20
-Kern,7051751,U.S. Senate,,DEM,Kamala Harris,44
-Kern,7051751,U.S. Senate,,DEM,Loretta Sanchez,76
-Kern,7051779,U.S. Senate,,DEM,Kamala Harris,0
-Kern,7051779,U.S. Senate,,DEM,Loretta Sanchez,0
-Kern,7051972,U.S. Senate,,DEM,Kamala Harris,0
-Kern,7051972,U.S. Senate,,DEM,Loretta Sanchez,0
-Kern,7052036,U.S. Senate,,DEM,Kamala Harris,3
-Kern,7052036,U.S. Senate,,DEM,Loretta Sanchez,6
-Kern,7052037,U.S. Senate,,DEM,Kamala Harris,27
-Kern,7052037,U.S. Senate,,DEM,Loretta Sanchez,26
-Kern,7052140,U.S. Senate,,DEM,Kamala Harris,46
-Kern,7052140,U.S. Senate,,DEM,Loretta Sanchez,42
-Kern,7052143,U.S. Senate,,DEM,Kamala Harris,29
-Kern,7052143,U.S. Senate,,DEM,Loretta Sanchez,29
-Kern,7052186,U.S. Senate,,DEM,Kamala Harris,8
-Kern,7052186,U.S. Senate,,DEM,Loretta Sanchez,8
-Kern,7052188,U.S. Senate,,DEM,Kamala Harris,6
-Kern,7052188,U.S. Senate,,DEM,Loretta Sanchez,6
-Kern,7053012,U.S. Senate,,DEM,Kamala Harris,23
-Kern,7053012,U.S. Senate,,DEM,Loretta Sanchez,22
-Kern,7053449,U.S. Senate,,DEM,Kamala Harris,1
-Kern,7053449,U.S. Senate,,DEM,Loretta Sanchez,9
-Kern,7053450,U.S. Senate,,DEM,Kamala Harris,0
-Kern,7053450,U.S. Senate,,DEM,Loretta Sanchez,0
-Kern,7053495,U.S. Senate,,DEM,Kamala Harris,0
-Kern,7053495,U.S. Senate,,DEM,Loretta Sanchez,0
-Kern,7053752,U.S. Senate,,DEM,Kamala Harris,1
-Kern,7053752,U.S. Senate,,DEM,Loretta Sanchez,2
-Kern,7053765,U.S. Senate,,DEM,Kamala Harris,1
-Kern,7053765,U.S. Senate,,DEM,Loretta Sanchez,1
+Kern,11155,U.S. Senate,,DEM,Kamala D. Harris,360
+Kern,11155,U.S. Senate,,DEM,Loretta L. Sanchez,223
+Kern,11190,U.S. Senate,,DEM,Kamala D. Harris,475
+Kern,11190,U.S. Senate,,DEM,Loretta L. Sanchez,282
+Kern,11195,U.S. Senate,,DEM,Kamala D. Harris,363
+Kern,11195,U.S. Senate,,DEM,Loretta L. Sanchez,352
+Kern,11530,U.S. Senate,,DEM,Kamala D. Harris,168
+Kern,11530,U.S. Senate,,DEM,Loretta L. Sanchez,237
+Kern,11540,U.S. Senate,,DEM,Kamala D. Harris,186
+Kern,11540,U.S. Senate,,DEM,Loretta L. Sanchez,236
+Kern,11546,U.S. Senate,,DEM,Kamala D. Harris,206
+Kern,11546,U.S. Senate,,DEM,Loretta L. Sanchez,272
+Kern,11548,U.S. Senate,,DEM,Kamala D. Harris,385
+Kern,11548,U.S. Senate,,DEM,Loretta L. Sanchez,446
+Kern,11550,U.S. Senate,,DEM,Kamala D. Harris,273
+Kern,11550,U.S. Senate,,DEM,Loretta L. Sanchez,364
+Kern,11552,U.S. Senate,,DEM,Kamala D. Harris,260
+Kern,11552,U.S. Senate,,DEM,Loretta L. Sanchez,397
+Kern,11554,U.S. Senate,,DEM,Kamala D. Harris,224
+Kern,11554,U.S. Senate,,DEM,Loretta L. Sanchez,479
+Kern,11570,U.S. Senate,,DEM,Kamala D. Harris,175
+Kern,11570,U.S. Senate,,DEM,Loretta L. Sanchez,276
+Kern,11580,U.S. Senate,,DEM,Kamala D. Harris,220
+Kern,11580,U.S. Senate,,DEM,Loretta L. Sanchez,318
+Kern,11590,U.S. Senate,,DEM,Kamala D. Harris,223
+Kern,11590,U.S. Senate,,DEM,Loretta L. Sanchez,339
+Kern,11610,U.S. Senate,,DEM,Kamala D. Harris,169
+Kern,11610,U.S. Senate,,DEM,Loretta L. Sanchez,262
+Kern,11626,U.S. Senate,,DEM,Kamala D. Harris,334
+Kern,11626,U.S. Senate,,DEM,Loretta L. Sanchez,500
+Kern,11725,U.S. Senate,,DEM,Kamala D. Harris,397
+Kern,11725,U.S. Senate,,DEM,Loretta L. Sanchez,241
+Kern,11990,U.S. Senate,,DEM,Kamala D. Harris,268
+Kern,11990,U.S. Senate,,DEM,Loretta L. Sanchez,199
+Kern,11991,U.S. Senate,,DEM,Kamala D. Harris,241
+Kern,11991,U.S. Senate,,DEM,Loretta L. Sanchez,195
+Kern,12171,U.S. Senate,,DEM,Kamala D. Harris,252
+Kern,12171,U.S. Senate,,DEM,Loretta L. Sanchez,158
+Kern,12173,U.S. Senate,,DEM,Kamala D. Harris,164
+Kern,12173,U.S. Senate,,DEM,Loretta L. Sanchez,109
+Kern,12505,U.S. Senate,,DEM,Kamala D. Harris,361
+Kern,12505,U.S. Senate,,DEM,Loretta L. Sanchez,239
+Kern,12591,U.S. Senate,,DEM,Kamala D. Harris,172
+Kern,12591,U.S. Senate,,DEM,Loretta L. Sanchez,435
+Kern,12592,U.S. Senate,,DEM,Kamala D. Harris,163
+Kern,12592,U.S. Senate,,DEM,Loretta L. Sanchez,354
+Kern,12593,U.S. Senate,,DEM,Kamala D. Harris,227
+Kern,12593,U.S. Senate,,DEM,Loretta L. Sanchez,491
+Kern,12620,U.S. Senate,,DEM,Kamala D. Harris,367
+Kern,12620,U.S. Senate,,DEM,Loretta L. Sanchez,293
+Kern,12622,U.S. Senate,,DEM,Kamala D. Harris,389
+Kern,12622,U.S. Senate,,DEM,Loretta L. Sanchez,298
+Kern,12623,U.S. Senate,,DEM,Kamala D. Harris,474
+Kern,12623,U.S. Senate,,DEM,Loretta L. Sanchez,379
+Kern,12650,U.S. Senate,,DEM,Kamala D. Harris,372
+Kern,12650,U.S. Senate,,DEM,Loretta L. Sanchez,310
+Kern,12670,U.S. Senate,,DEM,Kamala D. Harris,422
+Kern,12670,U.S. Senate,,DEM,Loretta L. Sanchez,311
+Kern,12709,U.S. Senate,,DEM,Kamala D. Harris,290
+Kern,12709,U.S. Senate,,DEM,Loretta L. Sanchez,217
+Kern,12921,U.S. Senate,,DEM,Kamala D. Harris,521
+Kern,12921,U.S. Senate,,DEM,Loretta L. Sanchez,403
+Kern,12922,U.S. Senate,,DEM,Kamala D. Harris,297
+Kern,12922,U.S. Senate,,DEM,Loretta L. Sanchez,206
+Kern,12923,U.S. Senate,,DEM,Kamala D. Harris,252
+Kern,12923,U.S. Senate,,DEM,Loretta L. Sanchez,202
+Kern,12924,U.S. Senate,,DEM,Kamala D. Harris,482
+Kern,12924,U.S. Senate,,DEM,Loretta L. Sanchez,348
+Kern,12925,U.S. Senate,,DEM,Kamala D. Harris,351
+Kern,12925,U.S. Senate,,DEM,Loretta L. Sanchez,285
+Kern,12927,U.S. Senate,,DEM,Kamala D. Harris,251
+Kern,12927,U.S. Senate,,DEM,Loretta L. Sanchez,191
+Kern,12928,U.S. Senate,,DEM,Kamala D. Harris,490
+Kern,12928,U.S. Senate,,DEM,Loretta L. Sanchez,380
+Kern,12929,U.S. Senate,,DEM,Kamala D. Harris,452
+Kern,12929,U.S. Senate,,DEM,Loretta L. Sanchez,378
+Kern,12933,U.S. Senate,,DEM,Kamala D. Harris,452
+Kern,12933,U.S. Senate,,DEM,Loretta L. Sanchez,407
+Kern,12934,U.S. Senate,,DEM,Kamala D. Harris,332
+Kern,12934,U.S. Senate,,DEM,Loretta L. Sanchez,259
+Kern,12935,U.S. Senate,,DEM,Kamala D. Harris,351
+Kern,12935,U.S. Senate,,DEM,Loretta L. Sanchez,241
+Kern,12941,U.S. Senate,,DEM,Kamala D. Harris,403
+Kern,12941,U.S. Senate,,DEM,Loretta L. Sanchez,363
+Kern,12996,U.S. Senate,,DEM,Kamala D. Harris,288
+Kern,12996,U.S. Senate,,DEM,Loretta L. Sanchez,169
+Kern,13070,U.S. Senate,,DEM,Kamala D. Harris,301
+Kern,13070,U.S. Senate,,DEM,Loretta L. Sanchez,210
+Kern,13072,U.S. Senate,,DEM,Kamala D. Harris,235
+Kern,13072,U.S. Senate,,DEM,Loretta L. Sanchez,187
+Kern,13076,U.S. Senate,,DEM,Kamala D. Harris,127
+Kern,13076,U.S. Senate,,DEM,Loretta L. Sanchez,117
+Kern,13078,U.S. Senate,,DEM,Kamala D. Harris,235
+Kern,13078,U.S. Senate,,DEM,Loretta L. Sanchez,173
+Kern,13100,U.S. Senate,,DEM,Kamala D. Harris,244
+Kern,13100,U.S. Senate,,DEM,Loretta L. Sanchez,392
+Kern,13107,U.S. Senate,,DEM,Kamala D. Harris,165
+Kern,13107,U.S. Senate,,DEM,Loretta L. Sanchez,378
+Kern,13110,U.S. Senate,,DEM,Kamala D. Harris,255
+Kern,13110,U.S. Senate,,DEM,Loretta L. Sanchez,435
+Kern,13120,U.S. Senate,,DEM,Kamala D. Harris,101
+Kern,13120,U.S. Senate,,DEM,Loretta L. Sanchez,232
+Kern,13121,U.S. Senate,,DEM,Kamala D. Harris,220
+Kern,13121,U.S. Senate,,DEM,Loretta L. Sanchez,423
+Kern,13194,U.S. Senate,,DEM,Kamala D. Harris,148
+Kern,13194,U.S. Senate,,DEM,Loretta L. Sanchez,115
+Kern,15106,U.S. Senate,,DEM,Kamala D. Harris,413
+Kern,15106,U.S. Senate,,DEM,Loretta L. Sanchez,306
+Kern,15109,U.S. Senate,,DEM,Kamala D. Harris,271
+Kern,15109,U.S. Senate,,DEM,Loretta L. Sanchez,247
+Kern,15110,U.S. Senate,,DEM,Kamala D. Harris,333
+Kern,15110,U.S. Senate,,DEM,Loretta L. Sanchez,232
+Kern,15113,U.S. Senate,,DEM,Kamala D. Harris,298
+Kern,15113,U.S. Senate,,DEM,Loretta L. Sanchez,272
+Kern,15114,U.S. Senate,,DEM,Kamala D. Harris,203
+Kern,15114,U.S. Senate,,DEM,Loretta L. Sanchez,167
+Kern,15123,U.S. Senate,,DEM,Kamala D. Harris,231
+Kern,15123,U.S. Senate,,DEM,Loretta L. Sanchez,258
+Kern,15124,U.S. Senate,,DEM,Kamala D. Harris,273
+Kern,15124,U.S. Senate,,DEM,Loretta L. Sanchez,224
+Kern,15132,U.S. Senate,,DEM,Kamala D. Harris,292
+Kern,15132,U.S. Senate,,DEM,Loretta L. Sanchez,249
+Kern,15133,U.S. Senate,,DEM,Kamala D. Harris,252
+Kern,15133,U.S. Senate,,DEM,Loretta L. Sanchez,212
+Kern,15135,U.S. Senate,,DEM,Kamala D. Harris,296
+Kern,15135,U.S. Senate,,DEM,Loretta L. Sanchez,251
+Kern,20121,U.S. Senate,,DEM,Kamala D. Harris,211
+Kern,20121,U.S. Senate,,DEM,Loretta L. Sanchez,182
+Kern,20232,U.S. Senate,,DEM,Kamala D. Harris,165
+Kern,20232,U.S. Senate,,DEM,Loretta L. Sanchez,201
+Kern,20236,U.S. Senate,,DEM,Kamala D. Harris,243
+Kern,20236,U.S. Senate,,DEM,Loretta L. Sanchez,339
+Kern,20243,U.S. Senate,,DEM,Kamala D. Harris,396
+Kern,20243,U.S. Senate,,DEM,Loretta L. Sanchez,351
+Kern,20245,U.S. Senate,,DEM,Kamala D. Harris,183
+Kern,20245,U.S. Senate,,DEM,Loretta L. Sanchez,220
+Kern,20246,U.S. Senate,,DEM,Kamala D. Harris,296
+Kern,20246,U.S. Senate,,DEM,Loretta L. Sanchez,298
+Kern,20248,U.S. Senate,,DEM,Kamala D. Harris,345
+Kern,20248,U.S. Senate,,DEM,Loretta L. Sanchez,465
+Kern,20249,U.S. Senate,,DEM,Kamala D. Harris,255
+Kern,20249,U.S. Senate,,DEM,Loretta L. Sanchez,192
+Kern,20253,U.S. Senate,,DEM,Kamala D. Harris,166
+Kern,20253,U.S. Senate,,DEM,Loretta L. Sanchez,162
+Kern,20254,U.S. Senate,,DEM,Kamala D. Harris,363
+Kern,20254,U.S. Senate,,DEM,Loretta L. Sanchez,363
+Kern,20256,U.S. Senate,,DEM,Kamala D. Harris,438
+Kern,20256,U.S. Senate,,DEM,Loretta L. Sanchez,380
+Kern,20260,U.S. Senate,,DEM,Kamala D. Harris,242
+Kern,20260,U.S. Senate,,DEM,Loretta L. Sanchez,233
+Kern,20262,U.S. Senate,,DEM,Kamala D. Harris,446
+Kern,20262,U.S. Senate,,DEM,Loretta L. Sanchez,445
+Kern,20263,U.S. Senate,,DEM,Kamala D. Harris,224
+Kern,20263,U.S. Senate,,DEM,Loretta L. Sanchez,199
+Kern,20271,U.S. Senate,,DEM,Kamala D. Harris,289
+Kern,20271,U.S. Senate,,DEM,Loretta L. Sanchez,369
+Kern,20272,U.S. Senate,,DEM,Kamala D. Harris,328
+Kern,20272,U.S. Senate,,DEM,Loretta L. Sanchez,378
+Kern,20283,U.S. Senate,,DEM,Kamala D. Harris,542
+Kern,20283,U.S. Senate,,DEM,Loretta L. Sanchez,541
+Kern,20284,U.S. Senate,,DEM,Kamala D. Harris,167
+Kern,20284,U.S. Senate,,DEM,Loretta L. Sanchez,245
+Kern,20286,U.S. Senate,,DEM,Kamala D. Harris,348
+Kern,20286,U.S. Senate,,DEM,Loretta L. Sanchez,355
+Kern,20288,U.S. Senate,,DEM,Kamala D. Harris,214
+Kern,20288,U.S. Senate,,DEM,Loretta L. Sanchez,254
+Kern,20289,U.S. Senate,,DEM,Kamala D. Harris,297
+Kern,20289,U.S. Senate,,DEM,Loretta L. Sanchez,347
+Kern,20294,U.S. Senate,,DEM,Kamala D. Harris,271
+Kern,20294,U.S. Senate,,DEM,Loretta L. Sanchez,283
+Kern,21143,U.S. Senate,,DEM,Kamala D. Harris,316
+Kern,21143,U.S. Senate,,DEM,Loretta L. Sanchez,250
+Kern,21144,U.S. Senate,,DEM,Kamala D. Harris,264
+Kern,21144,U.S. Senate,,DEM,Loretta L. Sanchez,224
+Kern,21145,U.S. Senate,,DEM,Kamala D. Harris,402
+Kern,21145,U.S. Senate,,DEM,Loretta L. Sanchez,342
+Kern,21148,U.S. Senate,,DEM,Kamala D. Harris,246
+Kern,21148,U.S. Senate,,DEM,Loretta L. Sanchez,160
+Kern,21275,U.S. Senate,,DEM,Kamala D. Harris,472
+Kern,21275,U.S. Senate,,DEM,Loretta L. Sanchez,333
+Kern,21280,U.S. Senate,,DEM,Kamala D. Harris,269
+Kern,21280,U.S. Senate,,DEM,Loretta L. Sanchez,178
+Kern,21281,U.S. Senate,,DEM,Kamala D. Harris,356
+Kern,21281,U.S. Senate,,DEM,Loretta L. Sanchez,250
+Kern,21282,U.S. Senate,,DEM,Kamala D. Harris,333
+Kern,21282,U.S. Senate,,DEM,Loretta L. Sanchez,240
+Kern,21283,U.S. Senate,,DEM,Kamala D. Harris,454
+Kern,21283,U.S. Senate,,DEM,Loretta L. Sanchez,333
+Kern,21511,U.S. Senate,,DEM,Kamala D. Harris,185
+Kern,21511,U.S. Senate,,DEM,Loretta L. Sanchez,153
+Kern,21512,U.S. Senate,,DEM,Kamala D. Harris,258
+Kern,21512,U.S. Senate,,DEM,Loretta L. Sanchez,264
+Kern,21660,U.S. Senate,,DEM,Kamala D. Harris,107
+Kern,21660,U.S. Senate,,DEM,Loretta L. Sanchez,80
+Kern,21710,U.S. Senate,,DEM,Kamala D. Harris,177
+Kern,21710,U.S. Senate,,DEM,Loretta L. Sanchez,138
+Kern,21781,U.S. Senate,,DEM,Kamala D. Harris,132
+Kern,21781,U.S. Senate,,DEM,Loretta L. Sanchez,137
+Kern,21885,U.S. Senate,,DEM,Kamala D. Harris,500
+Kern,21885,U.S. Senate,,DEM,Loretta L. Sanchez,432
+Kern,21886,U.S. Senate,,DEM,Kamala D. Harris,251
+Kern,21886,U.S. Senate,,DEM,Loretta L. Sanchez,205
+Kern,21888,U.S. Senate,,DEM,Kamala D. Harris,329
+Kern,21888,U.S. Senate,,DEM,Loretta L. Sanchez,295
+Kern,21889,U.S. Senate,,DEM,Kamala D. Harris,414
+Kern,21889,U.S. Senate,,DEM,Loretta L. Sanchez,343
+Kern,22003,U.S. Senate,,DEM,Kamala D. Harris,192
+Kern,22003,U.S. Senate,,DEM,Loretta L. Sanchez,179
+Kern,22004,U.S. Senate,,DEM,Kamala D. Harris,209
+Kern,22004,U.S. Senate,,DEM,Loretta L. Sanchez,176
+Kern,22005,U.S. Senate,,DEM,Kamala D. Harris,230
+Kern,22005,U.S. Senate,,DEM,Loretta L. Sanchez,207
+Kern,22006,U.S. Senate,,DEM,Kamala D. Harris,392
+Kern,22006,U.S. Senate,,DEM,Loretta L. Sanchez,374
+Kern,22008,U.S. Senate,,DEM,Kamala D. Harris,363
+Kern,22008,U.S. Senate,,DEM,Loretta L. Sanchez,365
+Kern,22018,U.S. Senate,,DEM,Kamala D. Harris,441
+Kern,22018,U.S. Senate,,DEM,Loretta L. Sanchez,419
+Kern,22030,U.S. Senate,,DEM,Kamala D. Harris,350
+Kern,22030,U.S. Senate,,DEM,Loretta L. Sanchez,340
+Kern,22033,U.S. Senate,,DEM,Kamala D. Harris,288
+Kern,22033,U.S. Senate,,DEM,Loretta L. Sanchez,272
+Kern,22450,U.S. Senate,,DEM,Kamala D. Harris,385
+Kern,22450,U.S. Senate,,DEM,Loretta L. Sanchez,329
+Kern,22480,U.S. Senate,,DEM,Kamala D. Harris,148
+Kern,22480,U.S. Senate,,DEM,Loretta L. Sanchez,106
+Kern,23020,U.S. Senate,,DEM,Kamala D. Harris,257
+Kern,23020,U.S. Senate,,DEM,Loretta L. Sanchez,239
+Kern,23021,U.S. Senate,,DEM,Kamala D. Harris,389
+Kern,23021,U.S. Senate,,DEM,Loretta L. Sanchez,327
+Kern,23023,U.S. Senate,,DEM,Kamala D. Harris,385
+Kern,23023,U.S. Senate,,DEM,Loretta L. Sanchez,273
+Kern,23025,U.S. Senate,,DEM,Kamala D. Harris,269
+Kern,23025,U.S. Senate,,DEM,Loretta L. Sanchez,211
+Kern,23030,U.S. Senate,,DEM,Kamala D. Harris,334
+Kern,23030,U.S. Senate,,DEM,Loretta L. Sanchez,242
+Kern,23031,U.S. Senate,,DEM,Kamala D. Harris,228
+Kern,23031,U.S. Senate,,DEM,Loretta L. Sanchez,219
+Kern,23035,U.S. Senate,,DEM,Kamala D. Harris,344
+Kern,23035,U.S. Senate,,DEM,Loretta L. Sanchez,317
+Kern,23208,U.S. Senate,,DEM,Kamala D. Harris,511
+Kern,23208,U.S. Senate,,DEM,Loretta L. Sanchez,407
+Kern,23239,U.S. Senate,,DEM,Kamala D. Harris,305
+Kern,23239,U.S. Senate,,DEM,Loretta L. Sanchez,265
+Kern,23241,U.S. Senate,,DEM,Kamala D. Harris,161
+Kern,23241,U.S. Senate,,DEM,Loretta L. Sanchez,164
+Kern,23401,U.S. Senate,,DEM,Kamala D. Harris,416
+Kern,23401,U.S. Senate,,DEM,Loretta L. Sanchez,324
+Kern,23402,U.S. Senate,,DEM,Kamala D. Harris,212
+Kern,23402,U.S. Senate,,DEM,Loretta L. Sanchez,171
+Kern,23403,U.S. Senate,,DEM,Kamala D. Harris,343
+Kern,23403,U.S. Senate,,DEM,Loretta L. Sanchez,312
+Kern,23404,U.S. Senate,,DEM,Kamala D. Harris,344
+Kern,23404,U.S. Senate,,DEM,Loretta L. Sanchez,315
+Kern,23450,U.S. Senate,,DEM,Kamala D. Harris,267
+Kern,23450,U.S. Senate,,DEM,Loretta L. Sanchez,278
+Kern,23451,U.S. Senate,,DEM,Kamala D. Harris,120
+Kern,23451,U.S. Senate,,DEM,Loretta L. Sanchez,113
+Kern,23452,U.S. Senate,,DEM,Kamala D. Harris,215
+Kern,23452,U.S. Senate,,DEM,Loretta L. Sanchez,174
+Kern,25270,U.S. Senate,,DEM,Kamala D. Harris,261
+Kern,25270,U.S. Senate,,DEM,Loretta L. Sanchez,221
+Kern,25271,U.S. Senate,,DEM,Kamala D. Harris,256
+Kern,25271,U.S. Senate,,DEM,Loretta L. Sanchez,208
+Kern,25272,U.S. Senate,,DEM,Kamala D. Harris,257
+Kern,25272,U.S. Senate,,DEM,Loretta L. Sanchez,227
+Kern,25289,U.S. Senate,,DEM,Kamala D. Harris,227
+Kern,25289,U.S. Senate,,DEM,Loretta L. Sanchez,235
+Kern,25292,U.S. Senate,,DEM,Kamala D. Harris,296
+Kern,25292,U.S. Senate,,DEM,Loretta L. Sanchez,340
+Kern,30040,U.S. Senate,,DEM,Kamala D. Harris,318
+Kern,30040,U.S. Senate,,DEM,Loretta L. Sanchez,209
+Kern,30060,U.S. Senate,,DEM,Kamala D. Harris,249
+Kern,30060,U.S. Senate,,DEM,Loretta L. Sanchez,161
+Kern,30150,U.S. Senate,,DEM,Kamala D. Harris,300
+Kern,30150,U.S. Senate,,DEM,Loretta L. Sanchez,272
+Kern,30170,U.S. Senate,,DEM,Kamala D. Harris,250
+Kern,30170,U.S. Senate,,DEM,Loretta L. Sanchez,180
+Kern,30302,U.S. Senate,,DEM,Kamala D. Harris,274
+Kern,30302,U.S. Senate,,DEM,Loretta L. Sanchez,246
+Kern,30304,U.S. Senate,,DEM,Kamala D. Harris,308
+Kern,30304,U.S. Senate,,DEM,Loretta L. Sanchez,370
+Kern,30308,U.S. Senate,,DEM,Kamala D. Harris,302
+Kern,30308,U.S. Senate,,DEM,Loretta L. Sanchez,356
+Kern,30312,U.S. Senate,,DEM,Kamala D. Harris,304
+Kern,30312,U.S. Senate,,DEM,Loretta L. Sanchez,274
+Kern,30314,U.S. Senate,,DEM,Kamala D. Harris,279
+Kern,30314,U.S. Senate,,DEM,Loretta L. Sanchez,282
+Kern,30316,U.S. Senate,,DEM,Kamala D. Harris,240
+Kern,30316,U.S. Senate,,DEM,Loretta L. Sanchez,244
+Kern,30317,U.S. Senate,,DEM,Kamala D. Harris,121
+Kern,30317,U.S. Senate,,DEM,Loretta L. Sanchez,116
+Kern,30318,U.S. Senate,,DEM,Kamala D. Harris,343
+Kern,30318,U.S. Senate,,DEM,Loretta L. Sanchez,357
+Kern,30321,U.S. Senate,,DEM,Kamala D. Harris,226
+Kern,30321,U.S. Senate,,DEM,Loretta L. Sanchez,218
+Kern,30322,U.S. Senate,,DEM,Kamala D. Harris,369
+Kern,30322,U.S. Senate,,DEM,Loretta L. Sanchez,323
+Kern,30325,U.S. Senate,,DEM,Kamala D. Harris,234
+Kern,30325,U.S. Senate,,DEM,Loretta L. Sanchez,177
+Kern,30332,U.S. Senate,,DEM,Kamala D. Harris,303
+Kern,30332,U.S. Senate,,DEM,Loretta L. Sanchez,274
+Kern,30337,U.S. Senate,,DEM,Kamala D. Harris,346
+Kern,30337,U.S. Senate,,DEM,Loretta L. Sanchez,347
+Kern,30338,U.S. Senate,,DEM,Kamala D. Harris,202
+Kern,30338,U.S. Senate,,DEM,Loretta L. Sanchez,247
+Kern,30339,U.S. Senate,,DEM,Kamala D. Harris,405
+Kern,30339,U.S. Senate,,DEM,Loretta L. Sanchez,400
+Kern,30348,U.S. Senate,,DEM,Kamala D. Harris,256
+Kern,30348,U.S. Senate,,DEM,Loretta L. Sanchez,233
+Kern,30351,U.S. Senate,,DEM,Kamala D. Harris,366
+Kern,30351,U.S. Senate,,DEM,Loretta L. Sanchez,362
+Kern,30352,U.S. Senate,,DEM,Kamala D. Harris,277
+Kern,30352,U.S. Senate,,DEM,Loretta L. Sanchez,273
+Kern,30354,U.S. Senate,,DEM,Kamala D. Harris,210
+Kern,30354,U.S. Senate,,DEM,Loretta L. Sanchez,185
+Kern,30364,U.S. Senate,,DEM,Kamala D. Harris,251
+Kern,30364,U.S. Senate,,DEM,Loretta L. Sanchez,208
+Kern,30367,U.S. Senate,,DEM,Kamala D. Harris,393
+Kern,30367,U.S. Senate,,DEM,Loretta L. Sanchez,364
+Kern,30370,U.S. Senate,,DEM,Kamala D. Harris,169
+Kern,30370,U.S. Senate,,DEM,Loretta L. Sanchez,174
+Kern,30372,U.S. Senate,,DEM,Kamala D. Harris,391
+Kern,30372,U.S. Senate,,DEM,Loretta L. Sanchez,314
+Kern,30374,U.S. Senate,,DEM,Kamala D. Harris,317
+Kern,30374,U.S. Senate,,DEM,Loretta L. Sanchez,218
+Kern,30385,U.S. Senate,,DEM,Kamala D. Harris,441
+Kern,30385,U.S. Senate,,DEM,Loretta L. Sanchez,364
+Kern,30387,U.S. Senate,,DEM,Kamala D. Harris,317
+Kern,30387,U.S. Senate,,DEM,Loretta L. Sanchez,285
+Kern,30389,U.S. Senate,,DEM,Kamala D. Harris,209
+Kern,30389,U.S. Senate,,DEM,Loretta L. Sanchez,196
+Kern,30390,U.S. Senate,,DEM,Kamala D. Harris,352
+Kern,30390,U.S. Senate,,DEM,Loretta L. Sanchez,303
+Kern,30396,U.S. Senate,,DEM,Kamala D. Harris,437
+Kern,30396,U.S. Senate,,DEM,Loretta L. Sanchez,409
+Kern,31478,U.S. Senate,,DEM,Kamala D. Harris,139
+Kern,31478,U.S. Senate,,DEM,Loretta L. Sanchez,158
+Kern,31641,U.S. Senate,,DEM,Kamala D. Harris,176
+Kern,31641,U.S. Senate,,DEM,Loretta L. Sanchez,322
+Kern,31772,U.S. Senate,,DEM,Kamala D. Harris,286
+Kern,31772,U.S. Senate,,DEM,Loretta L. Sanchez,186
+Kern,31935,U.S. Senate,,DEM,Kamala D. Harris,272
+Kern,31935,U.S. Senate,,DEM,Loretta L. Sanchez,428
+Kern,31950,U.S. Senate,,DEM,Kamala D. Harris,175
+Kern,31950,U.S. Senate,,DEM,Loretta L. Sanchez,149
+Kern,31953,U.S. Senate,,DEM,Kamala D. Harris,305
+Kern,31953,U.S. Senate,,DEM,Loretta L. Sanchez,361
+Kern,31960,U.S. Senate,,DEM,Kamala D. Harris,289
+Kern,31960,U.S. Senate,,DEM,Loretta L. Sanchez,346
+Kern,32170,U.S. Senate,,DEM,Kamala D. Harris,253
+Kern,32170,U.S. Senate,,DEM,Loretta L. Sanchez,228
+Kern,32214,U.S. Senate,,DEM,Kamala D. Harris,161
+Kern,32214,U.S. Senate,,DEM,Loretta L. Sanchez,131
+Kern,32240,U.S. Senate,,DEM,Kamala D. Harris,174
+Kern,32240,U.S. Senate,,DEM,Loretta L. Sanchez,152
+Kern,32310,U.S. Senate,,DEM,Kamala D. Harris,273
+Kern,32310,U.S. Senate,,DEM,Loretta L. Sanchez,269
+Kern,32330,U.S. Senate,,DEM,Kamala D. Harris,335
+Kern,32330,U.S. Senate,,DEM,Loretta L. Sanchez,360
+Kern,32360,U.S. Senate,,DEM,Kamala D. Harris,187
+Kern,32360,U.S. Senate,,DEM,Loretta L. Sanchez,294
+Kern,32380,U.S. Senate,,DEM,Kamala D. Harris,184
+Kern,32380,U.S. Senate,,DEM,Loretta L. Sanchez,144
+Kern,32441,U.S. Senate,,DEM,Kamala D. Harris,252
+Kern,32441,U.S. Senate,,DEM,Loretta L. Sanchez,172
+Kern,32531,U.S. Senate,,DEM,Kamala D. Harris,144
+Kern,32531,U.S. Senate,,DEM,Loretta L. Sanchez,360
+Kern,32532,U.S. Senate,,DEM,Kamala D. Harris,151
+Kern,32532,U.S. Senate,,DEM,Loretta L. Sanchez,261
+Kern,32640,U.S. Senate,,DEM,Kamala D. Harris,437
+Kern,32640,U.S. Senate,,DEM,Loretta L. Sanchez,320
+Kern,32652,U.S. Senate,,DEM,Kamala D. Harris,453
+Kern,32652,U.S. Senate,,DEM,Loretta L. Sanchez,362
+Kern,32731,U.S. Senate,,DEM,Kamala D. Harris,410
+Kern,32731,U.S. Senate,,DEM,Loretta L. Sanchez,326
+Kern,32750,U.S. Senate,,DEM,Kamala D. Harris,228
+Kern,32750,U.S. Senate,,DEM,Loretta L. Sanchez,327
+Kern,32751,U.S. Senate,,DEM,Kamala D. Harris,221
+Kern,32751,U.S. Senate,,DEM,Loretta L. Sanchez,328
+Kern,32762,U.S. Senate,,DEM,Kamala D. Harris,137
+Kern,32762,U.S. Senate,,DEM,Loretta L. Sanchez,218
+Kern,33040,U.S. Senate,,DEM,Kamala D. Harris,420
+Kern,33040,U.S. Senate,,DEM,Loretta L. Sanchez,341
+Kern,33042,U.S. Senate,,DEM,Kamala D. Harris,316
+Kern,33042,U.S. Senate,,DEM,Loretta L. Sanchez,226
+Kern,33150,U.S. Senate,,DEM,Kamala D. Harris,149
+Kern,33150,U.S. Senate,,DEM,Loretta L. Sanchez,100
+Kern,33161,U.S. Senate,,DEM,Kamala D. Harris,88
+Kern,33161,U.S. Senate,,DEM,Loretta L. Sanchez,79
+Kern,33222,U.S. Senate,,DEM,Kamala D. Harris,128
+Kern,33222,U.S. Senate,,DEM,Loretta L. Sanchez,277
+Kern,33492,U.S. Senate,,DEM,Kamala D. Harris,143
+Kern,33492,U.S. Senate,,DEM,Loretta L. Sanchez,311
+Kern,35601,U.S. Senate,,DEM,Kamala D. Harris,246
+Kern,35601,U.S. Senate,,DEM,Loretta L. Sanchez,189
+Kern,35602,U.S. Senate,,DEM,Kamala D. Harris,181
+Kern,35602,U.S. Senate,,DEM,Loretta L. Sanchez,117
+Kern,35604,U.S. Senate,,DEM,Kamala D. Harris,351
+Kern,35604,U.S. Senate,,DEM,Loretta L. Sanchez,286
+Kern,35624,U.S. Senate,,DEM,Kamala D. Harris,115
+Kern,35624,U.S. Senate,,DEM,Loretta L. Sanchez,97
+Kern,35628,U.S. Senate,,DEM,Kamala D. Harris,475
+Kern,35628,U.S. Senate,,DEM,Loretta L. Sanchez,429
+Kern,35629,U.S. Senate,,DEM,Kamala D. Harris,291
+Kern,35629,U.S. Senate,,DEM,Loretta L. Sanchez,259
+Kern,35631,U.S. Senate,,DEM,Kamala D. Harris,283
+Kern,35631,U.S. Senate,,DEM,Loretta L. Sanchez,219
+Kern,35633,U.S. Senate,,DEM,Kamala D. Harris,271
+Kern,35633,U.S. Senate,,DEM,Loretta L. Sanchez,211
+Kern,35634,U.S. Senate,,DEM,Kamala D. Harris,219
+Kern,35634,U.S. Senate,,DEM,Loretta L. Sanchez,167
+Kern,35635,U.S. Senate,,DEM,Kamala D. Harris,277
+Kern,35635,U.S. Senate,,DEM,Loretta L. Sanchez,284
+Kern,35640,U.S. Senate,,DEM,Kamala D. Harris,341
+Kern,35640,U.S. Senate,,DEM,Loretta L. Sanchez,260
+Kern,35658,U.S. Senate,,DEM,Kamala D. Harris,276
+Kern,35658,U.S. Senate,,DEM,Loretta L. Sanchez,241
+Kern,35661,U.S. Senate,,DEM,Kamala D. Harris,183
+Kern,35661,U.S. Senate,,DEM,Loretta L. Sanchez,166
+Kern,35675,U.S. Senate,,DEM,Kamala D. Harris,344
+Kern,35675,U.S. Senate,,DEM,Loretta L. Sanchez,292
+Kern,35677,U.S. Senate,,DEM,Kamala D. Harris,108
+Kern,35677,U.S. Senate,,DEM,Loretta L. Sanchez,272
+Kern,40401,U.S. Senate,,DEM,Kamala D. Harris,211
+Kern,40401,U.S. Senate,,DEM,Loretta L. Sanchez,129
+Kern,40405,U.S. Senate,,DEM,Kamala D. Harris,428
+Kern,40405,U.S. Senate,,DEM,Loretta L. Sanchez,384
+Kern,40406,U.S. Senate,,DEM,Kamala D. Harris,319
+Kern,40406,U.S. Senate,,DEM,Loretta L. Sanchez,269
+Kern,40407,U.S. Senate,,DEM,Kamala D. Harris,227
+Kern,40407,U.S. Senate,,DEM,Loretta L. Sanchez,174
+Kern,40409,U.S. Senate,,DEM,Kamala D. Harris,339
+Kern,40409,U.S. Senate,,DEM,Loretta L. Sanchez,250
+Kern,40411,U.S. Senate,,DEM,Kamala D. Harris,361
+Kern,40411,U.S. Senate,,DEM,Loretta L. Sanchez,352
+Kern,40414,U.S. Senate,,DEM,Kamala D. Harris,360
+Kern,40414,U.S. Senate,,DEM,Loretta L. Sanchez,365
+Kern,40415,U.S. Senate,,DEM,Kamala D. Harris,488
+Kern,40415,U.S. Senate,,DEM,Loretta L. Sanchez,402
+Kern,40419,U.S. Senate,,DEM,Kamala D. Harris,299
+Kern,40419,U.S. Senate,,DEM,Loretta L. Sanchez,252
+Kern,40421,U.S. Senate,,DEM,Kamala D. Harris,257
+Kern,40421,U.S. Senate,,DEM,Loretta L. Sanchez,250
+Kern,40424,U.S. Senate,,DEM,Kamala D. Harris,300
+Kern,40424,U.S. Senate,,DEM,Loretta L. Sanchez,235
+Kern,40428,U.S. Senate,,DEM,Kamala D. Harris,210
+Kern,40428,U.S. Senate,,DEM,Loretta L. Sanchez,209
+Kern,40429,U.S. Senate,,DEM,Kamala D. Harris,384
+Kern,40429,U.S. Senate,,DEM,Loretta L. Sanchez,303
+Kern,40430,U.S. Senate,,DEM,Kamala D. Harris,384
+Kern,40430,U.S. Senate,,DEM,Loretta L. Sanchez,337
+Kern,40433,U.S. Senate,,DEM,Kamala D. Harris,272
+Kern,40433,U.S. Senate,,DEM,Loretta L. Sanchez,254
+Kern,40434,U.S. Senate,,DEM,Kamala D. Harris,210
+Kern,40434,U.S. Senate,,DEM,Loretta L. Sanchez,166
+Kern,40435,U.S. Senate,,DEM,Kamala D. Harris,343
+Kern,40435,U.S. Senate,,DEM,Loretta L. Sanchez,292
+Kern,40436,U.S. Senate,,DEM,Kamala D. Harris,240
+Kern,40436,U.S. Senate,,DEM,Loretta L. Sanchez,177
+Kern,40440,U.S. Senate,,DEM,Kamala D. Harris,296
+Kern,40440,U.S. Senate,,DEM,Loretta L. Sanchez,270
+Kern,40441,U.S. Senate,,DEM,Kamala D. Harris,436
+Kern,40441,U.S. Senate,,DEM,Loretta L. Sanchez,324
+Kern,40442,U.S. Senate,,DEM,Kamala D. Harris,273
+Kern,40442,U.S. Senate,,DEM,Loretta L. Sanchez,180
+Kern,40443,U.S. Senate,,DEM,Kamala D. Harris,215
+Kern,40443,U.S. Senate,,DEM,Loretta L. Sanchez,167
+Kern,40444,U.S. Senate,,DEM,Kamala D. Harris,172
+Kern,40444,U.S. Senate,,DEM,Loretta L. Sanchez,155
+Kern,40447,U.S. Senate,,DEM,Kamala D. Harris,293
+Kern,40447,U.S. Senate,,DEM,Loretta L. Sanchez,253
+Kern,40454,U.S. Senate,,DEM,Kamala D. Harris,278
+Kern,40454,U.S. Senate,,DEM,Loretta L. Sanchez,193
+Kern,40455,U.S. Senate,,DEM,Kamala D. Harris,492
+Kern,40455,U.S. Senate,,DEM,Loretta L. Sanchez,454
+Kern,40460,U.S. Senate,,DEM,Kamala D. Harris,257
+Kern,40460,U.S. Senate,,DEM,Loretta L. Sanchez,205
+Kern,40461,U.S. Senate,,DEM,Kamala D. Harris,350
+Kern,40461,U.S. Senate,,DEM,Loretta L. Sanchez,360
+Kern,40462,U.S. Senate,,DEM,Kamala D. Harris,456
+Kern,40462,U.S. Senate,,DEM,Loretta L. Sanchez,346
+Kern,40463,U.S. Senate,,DEM,Kamala D. Harris,323
+Kern,40463,U.S. Senate,,DEM,Loretta L. Sanchez,301
+Kern,40464,U.S. Senate,,DEM,Kamala D. Harris,367
+Kern,40464,U.S. Senate,,DEM,Loretta L. Sanchez,270
+Kern,40466,U.S. Senate,,DEM,Kamala D. Harris,351
+Kern,40466,U.S. Senate,,DEM,Loretta L. Sanchez,327
+Kern,40469,U.S. Senate,,DEM,Kamala D. Harris,199
+Kern,40469,U.S. Senate,,DEM,Loretta L. Sanchez,221
+Kern,40470,U.S. Senate,,DEM,Kamala D. Harris,277
+Kern,40470,U.S. Senate,,DEM,Loretta L. Sanchez,242
+Kern,40471,U.S. Senate,,DEM,Kamala D. Harris,341
+Kern,40471,U.S. Senate,,DEM,Loretta L. Sanchez,391
+Kern,40475,U.S. Senate,,DEM,Kamala D. Harris,270
+Kern,40475,U.S. Senate,,DEM,Loretta L. Sanchez,275
+Kern,40480,U.S. Senate,,DEM,Kamala D. Harris,332
+Kern,40480,U.S. Senate,,DEM,Loretta L. Sanchez,312
+Kern,40494,U.S. Senate,,DEM,Kamala D. Harris,273
+Kern,40494,U.S. Senate,,DEM,Loretta L. Sanchez,227
+Kern,40495,U.S. Senate,,DEM,Kamala D. Harris,492
+Kern,40495,U.S. Senate,,DEM,Loretta L. Sanchez,406
+Kern,40496,U.S. Senate,,DEM,Kamala D. Harris,220
+Kern,40496,U.S. Senate,,DEM,Loretta L. Sanchez,198
+Kern,40497,U.S. Senate,,DEM,Kamala D. Harris,239
+Kern,40497,U.S. Senate,,DEM,Loretta L. Sanchez,213
+Kern,41240,U.S. Senate,,DEM,Kamala D. Harris,81
+Kern,41240,U.S. Senate,,DEM,Loretta L. Sanchez,96
+Kern,41780,U.S. Senate,,DEM,Kamala D. Harris,354
+Kern,41780,U.S. Senate,,DEM,Loretta L. Sanchez,300
+Kern,41820,U.S. Senate,,DEM,Kamala D. Harris,415
+Kern,41820,U.S. Senate,,DEM,Loretta L. Sanchez,370
+Kern,41910,U.S. Senate,,DEM,Kamala D. Harris,159
+Kern,41910,U.S. Senate,,DEM,Loretta L. Sanchez,133
+Kern,41913,U.S. Senate,,DEM,Kamala D. Harris,203
+Kern,41913,U.S. Senate,,DEM,Loretta L. Sanchez,165
+Kern,41915,U.S. Senate,,DEM,Kamala D. Harris,362
+Kern,41915,U.S. Senate,,DEM,Loretta L. Sanchez,395
+Kern,42218,U.S. Senate,,DEM,Kamala D. Harris,192
+Kern,42218,U.S. Senate,,DEM,Loretta L. Sanchez,169
+Kern,42261,U.S. Senate,,DEM,Kamala D. Harris,24
+Kern,42261,U.S. Senate,,DEM,Loretta L. Sanchez,124
+Kern,42390,U.S. Senate,,DEM,Kamala D. Harris,156
+Kern,42390,U.S. Senate,,DEM,Loretta L. Sanchez,84
+Kern,42630,U.S. Senate,,DEM,Kamala D. Harris,185
+Kern,42630,U.S. Senate,,DEM,Loretta L. Sanchez,151
+Kern,42842,U.S. Senate,,DEM,Kamala D. Harris,455
+Kern,42842,U.S. Senate,,DEM,Loretta L. Sanchez,235
+Kern,42845,U.S. Senate,,DEM,Kamala D. Harris,350
+Kern,42845,U.S. Senate,,DEM,Loretta L. Sanchez,276
+Kern,43043,U.S. Senate,,DEM,Kamala D. Harris,345
+Kern,43043,U.S. Senate,,DEM,Loretta L. Sanchez,327
+Kern,43048,U.S. Senate,,DEM,Kamala D. Harris,291
+Kern,43048,U.S. Senate,,DEM,Loretta L. Sanchez,256
+Kern,43050,U.S. Senate,,DEM,Kamala D. Harris,340
+Kern,43050,U.S. Senate,,DEM,Loretta L. Sanchez,308
+Kern,43051,U.S. Senate,,DEM,Kamala D. Harris,162
+Kern,43051,U.S. Senate,,DEM,Loretta L. Sanchez,149
+Kern,43052,U.S. Senate,,DEM,Kamala D. Harris,236
+Kern,43052,U.S. Senate,,DEM,Loretta L. Sanchez,207
+Kern,43053,U.S. Senate,,DEM,Kamala D. Harris,323
+Kern,43053,U.S. Senate,,DEM,Loretta L. Sanchez,294
+Kern,43055,U.S. Senate,,DEM,Kamala D. Harris,262
+Kern,43055,U.S. Senate,,DEM,Loretta L. Sanchez,246
+Kern,43059,U.S. Senate,,DEM,Kamala D. Harris,323
+Kern,43059,U.S. Senate,,DEM,Loretta L. Sanchez,304
+Kern,43170,U.S. Senate,,DEM,Kamala D. Harris,305
+Kern,43170,U.S. Senate,,DEM,Loretta L. Sanchez,258
+Kern,43290,U.S. Senate,,DEM,Kamala D. Harris,123
+Kern,43290,U.S. Senate,,DEM,Loretta L. Sanchez,141
+Kern,43310,U.S. Senate,,DEM,Kamala D. Harris,179
+Kern,43310,U.S. Senate,,DEM,Loretta L. Sanchez,117
+Kern,43320,U.S. Senate,,DEM,Kamala D. Harris,451
+Kern,43320,U.S. Senate,,DEM,Loretta L. Sanchez,331
+Kern,43340,U.S. Senate,,DEM,Kamala D. Harris,279
+Kern,43340,U.S. Senate,,DEM,Loretta L. Sanchez,193
+Kern,43510,U.S. Senate,,DEM,Kamala D. Harris,182
+Kern,43510,U.S. Senate,,DEM,Loretta L. Sanchez,325
+Kern,43520,U.S. Senate,,DEM,Kamala D. Harris,233
+Kern,43520,U.S. Senate,,DEM,Loretta L. Sanchez,350
+Kern,43540,U.S. Senate,,DEM,Kamala D. Harris,155
+Kern,43540,U.S. Senate,,DEM,Loretta L. Sanchez,188
+Kern,43550,U.S. Senate,,DEM,Kamala D. Harris,225
+Kern,43550,U.S. Senate,,DEM,Loretta L. Sanchez,388
+Kern,43560,U.S. Senate,,DEM,Kamala D. Harris,171
+Kern,43560,U.S. Senate,,DEM,Loretta L. Sanchez,276
+Kern,43567,U.S. Senate,,DEM,Kamala D. Harris,251
+Kern,43567,U.S. Senate,,DEM,Loretta L. Sanchez,441
+Kern,44103,U.S. Senate,,DEM,Kamala D. Harris,317
+Kern,44103,U.S. Senate,,DEM,Loretta L. Sanchez,266
+Kern,44104,U.S. Senate,,DEM,Kamala D. Harris,365
+Kern,44104,U.S. Senate,,DEM,Loretta L. Sanchez,316
+Kern,44105,U.S. Senate,,DEM,Kamala D. Harris,271
+Kern,44105,U.S. Senate,,DEM,Loretta L. Sanchez,256
+Kern,44106,U.S. Senate,,DEM,Kamala D. Harris,277
+Kern,44106,U.S. Senate,,DEM,Loretta L. Sanchez,266
+Kern,44107,U.S. Senate,,DEM,Kamala D. Harris,359
+Kern,44107,U.S. Senate,,DEM,Loretta L. Sanchez,288
+Kern,44112,U.S. Senate,,DEM,Kamala D. Harris,249
+Kern,44112,U.S. Senate,,DEM,Loretta L. Sanchez,246
+Kern,44113,U.S. Senate,,DEM,Kamala D. Harris,207
+Kern,44113,U.S. Senate,,DEM,Loretta L. Sanchez,208
+Kern,50020,U.S. Senate,,DEM,Kamala D. Harris,183
+Kern,50020,U.S. Senate,,DEM,Loretta L. Sanchez,238
+Kern,50180,U.S. Senate,,DEM,Kamala D. Harris,168
+Kern,50180,U.S. Senate,,DEM,Loretta L. Sanchez,328
+Kern,50190,U.S. Senate,,DEM,Kamala D. Harris,235
+Kern,50190,U.S. Senate,,DEM,Loretta L. Sanchez,404
+Kern,50200,U.S. Senate,,DEM,Kamala D. Harris,139
+Kern,50200,U.S. Senate,,DEM,Loretta L. Sanchez,340
+Kern,50211,U.S. Senate,,DEM,Kamala D. Harris,201
+Kern,50211,U.S. Senate,,DEM,Loretta L. Sanchez,469
+Kern,50501,U.S. Senate,,DEM,Kamala D. Harris,140
+Kern,50501,U.S. Senate,,DEM,Loretta L. Sanchez,252
+Kern,50505,U.S. Senate,,DEM,Kamala D. Harris,113
+Kern,50505,U.S. Senate,,DEM,Loretta L. Sanchez,191
+Kern,50506,U.S. Senate,,DEM,Kamala D. Harris,138
+Kern,50506,U.S. Senate,,DEM,Loretta L. Sanchez,173
+Kern,50507,U.S. Senate,,DEM,Kamala D. Harris,179
+Kern,50507,U.S. Senate,,DEM,Loretta L. Sanchez,241
+Kern,50509,U.S. Senate,,DEM,Kamala D. Harris,248
+Kern,50509,U.S. Senate,,DEM,Loretta L. Sanchez,332
+Kern,50511,U.S. Senate,,DEM,Kamala D. Harris,247
+Kern,50511,U.S. Senate,,DEM,Loretta L. Sanchez,322
+Kern,50514,U.S. Senate,,DEM,Kamala D. Harris,193
+Kern,50514,U.S. Senate,,DEM,Loretta L. Sanchez,295
+Kern,50516,U.S. Senate,,DEM,Kamala D. Harris,190
+Kern,50516,U.S. Senate,,DEM,Loretta L. Sanchez,140
+Kern,50518,U.S. Senate,,DEM,Kamala D. Harris,150
+Kern,50518,U.S. Senate,,DEM,Loretta L. Sanchez,209
+Kern,50519,U.S. Senate,,DEM,Kamala D. Harris,309
+Kern,50519,U.S. Senate,,DEM,Loretta L. Sanchez,257
+Kern,50520,U.S. Senate,,DEM,Kamala D. Harris,368
+Kern,50520,U.S. Senate,,DEM,Loretta L. Sanchez,273
+Kern,50523,U.S. Senate,,DEM,Kamala D. Harris,117
+Kern,50523,U.S. Senate,,DEM,Loretta L. Sanchez,95
+Kern,50524,U.S. Senate,,DEM,Kamala D. Harris,344
+Kern,50524,U.S. Senate,,DEM,Loretta L. Sanchez,300
+Kern,50532,U.S. Senate,,DEM,Kamala D. Harris,300
+Kern,50532,U.S. Senate,,DEM,Loretta L. Sanchez,197
+Kern,50538,U.S. Senate,,DEM,Kamala D. Harris,139
+Kern,50538,U.S. Senate,,DEM,Loretta L. Sanchez,210
+Kern,50541,U.S. Senate,,DEM,Kamala D. Harris,171
+Kern,50541,U.S. Senate,,DEM,Loretta L. Sanchez,169
+Kern,50543,U.S. Senate,,DEM,Kamala D. Harris,132
+Kern,50543,U.S. Senate,,DEM,Loretta L. Sanchez,223
+Kern,50545,U.S. Senate,,DEM,Kamala D. Harris,205
+Kern,50545,U.S. Senate,,DEM,Loretta L. Sanchez,399
+Kern,50548,U.S. Senate,,DEM,Kamala D. Harris,214
+Kern,50548,U.S. Senate,,DEM,Loretta L. Sanchez,275
+Kern,50552,U.S. Senate,,DEM,Kamala D. Harris,123
+Kern,50552,U.S. Senate,,DEM,Loretta L. Sanchez,269
+Kern,50560,U.S. Senate,,DEM,Kamala D. Harris,140
+Kern,50560,U.S. Senate,,DEM,Loretta L. Sanchez,233
+Kern,50576,U.S. Senate,,DEM,Kamala D. Harris,237
+Kern,50576,U.S. Senate,,DEM,Loretta L. Sanchez,409
+Kern,50731,U.S. Senate,,DEM,Kamala D. Harris,210
+Kern,50731,U.S. Senate,,DEM,Loretta L. Sanchez,259
+Kern,50741,U.S. Senate,,DEM,Kamala D. Harris,236
+Kern,50741,U.S. Senate,,DEM,Loretta L. Sanchez,245
+Kern,50742,U.S. Senate,,DEM,Kamala D. Harris,191
+Kern,50742,U.S. Senate,,DEM,Loretta L. Sanchez,273
+Kern,50749,U.S. Senate,,DEM,Kamala D. Harris,247
+Kern,50749,U.S. Senate,,DEM,Loretta L. Sanchez,185
+Kern,50752,U.S. Senate,,DEM,Kamala D. Harris,348
+Kern,50752,U.S. Senate,,DEM,Loretta L. Sanchez,351
+Kern,50765,U.S. Senate,,DEM,Kamala D. Harris,364
+Kern,50765,U.S. Senate,,DEM,Loretta L. Sanchez,293
+Kern,51180,U.S. Senate,,DEM,Kamala D. Harris,119
+Kern,51180,U.S. Senate,,DEM,Loretta L. Sanchez,192
+Kern,51227,U.S. Senate,,DEM,Kamala D. Harris,179
+Kern,51227,U.S. Senate,,DEM,Loretta L. Sanchez,190
+Kern,51228,U.S. Senate,,DEM,Kamala D. Harris,185
+Kern,51228,U.S. Senate,,DEM,Loretta L. Sanchez,170
+Kern,51310,U.S. Senate,,DEM,Kamala D. Harris,159
+Kern,51310,U.S. Senate,,DEM,Loretta L. Sanchez,256
+Kern,51331,U.S. Senate,,DEM,Kamala D. Harris,317
+Kern,51331,U.S. Senate,,DEM,Loretta L. Sanchez,384
+Kern,51332,U.S. Senate,,DEM,Kamala D. Harris,166
+Kern,51332,U.S. Senate,,DEM,Loretta L. Sanchez,181
+Kern,51690,U.S. Senate,,DEM,Kamala D. Harris,99
+Kern,51690,U.S. Senate,,DEM,Loretta L. Sanchez,199
+Kern,51727,U.S. Senate,,DEM,Kamala D. Harris,232
+Kern,51727,U.S. Senate,,DEM,Loretta L. Sanchez,358
+Kern,52034,U.S. Senate,,DEM,Kamala D. Harris,106
+Kern,52034,U.S. Senate,,DEM,Loretta L. Sanchez,203
+Kern,52070,U.S. Senate,,DEM,Kamala D. Harris,138
+Kern,52070,U.S. Senate,,DEM,Loretta L. Sanchez,270
+Kern,52080,U.S. Senate,,DEM,Kamala D. Harris,130
+Kern,52080,U.S. Senate,,DEM,Loretta L. Sanchez,242
+Kern,52110,U.S. Senate,,DEM,Kamala D. Harris,100
+Kern,52110,U.S. Senate,,DEM,Loretta L. Sanchez,205
+Kern,52180,U.S. Senate,,DEM,Kamala D. Harris,113
+Kern,52180,U.S. Senate,,DEM,Loretta L. Sanchez,240
+Kern,52182,U.S. Senate,,DEM,Kamala D. Harris,100
+Kern,52182,U.S. Senate,,DEM,Loretta L. Sanchez,161
+Kern,52183,U.S. Senate,,DEM,Kamala D. Harris,120
+Kern,52183,U.S. Senate,,DEM,Loretta L. Sanchez,277
+Kern,52184,U.S. Senate,,DEM,Kamala D. Harris,103
+Kern,52184,U.S. Senate,,DEM,Loretta L. Sanchez,263
+Kern,52185,U.S. Senate,,DEM,Kamala D. Harris,64
+Kern,52185,U.S. Senate,,DEM,Loretta L. Sanchez,95
+Kern,52400,U.S. Senate,,DEM,Kamala D. Harris,146
+Kern,52400,U.S. Senate,,DEM,Loretta L. Sanchez,313
+Kern,52490,U.S. Senate,,DEM,Kamala D. Harris,162
+Kern,52490,U.S. Senate,,DEM,Loretta L. Sanchez,272
+Kern,7010010,U.S. Senate,,DEM,Kamala D. Harris,56
+Kern,7010010,U.S. Senate,,DEM,Loretta L. Sanchez,46
+Kern,7010015,U.S. Senate,,DEM,Kamala D. Harris,2
+Kern,7010015,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Kern,7010050,U.S. Senate,,DEM,Kamala D. Harris,12
+Kern,7010050,U.S. Senate,,DEM,Loretta L. Sanchez,16
+Kern,7010080,U.S. Senate,,DEM,Kamala D. Harris,26
+Kern,7010080,U.S. Senate,,DEM,Loretta L. Sanchez,26
+Kern,7010084,U.S. Senate,,DEM,Kamala D. Harris,14
+Kern,7010084,U.S. Senate,,DEM,Loretta L. Sanchez,17
+Kern,7010085,U.S. Senate,,DEM,Kamala D. Harris,53
+Kern,7010085,U.S. Senate,,DEM,Loretta L. Sanchez,50
+Kern,7010090,U.S. Senate,,DEM,Kamala D. Harris,46
+Kern,7010090,U.S. Senate,,DEM,Loretta L. Sanchez,74
+Kern,7010215,U.S. Senate,,DEM,Kamala D. Harris,12
+Kern,7010215,U.S. Senate,,DEM,Loretta L. Sanchez,16
+Kern,7010225,U.S. Senate,,DEM,Kamala D. Harris,0
+Kern,7010225,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Kern,7010226,U.S. Senate,,DEM,Kamala D. Harris,20
+Kern,7010226,U.S. Senate,,DEM,Loretta L. Sanchez,21
+Kern,7011135,U.S. Senate,,DEM,Kamala D. Harris,16
+Kern,7011135,U.S. Senate,,DEM,Loretta L. Sanchez,10
+Kern,7011153,U.S. Senate,,DEM,Kamala D. Harris,12
+Kern,7011153,U.S. Senate,,DEM,Loretta L. Sanchez,18
+Kern,7011170,U.S. Senate,,DEM,Kamala D. Harris,41
+Kern,7011170,U.S. Senate,,DEM,Loretta L. Sanchez,58
+Kern,7011171,U.S. Senate,,DEM,Kamala D. Harris,19
+Kern,7011171,U.S. Senate,,DEM,Loretta L. Sanchez,18
+Kern,7011200,U.S. Senate,,DEM,Kamala D. Harris,0
+Kern,7011200,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Kern,7011208,U.S. Senate,,DEM,Kamala D. Harris,0
+Kern,7011208,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Kern,7011209,U.S. Senate,,DEM,Kamala D. Harris,38
+Kern,7011209,U.S. Senate,,DEM,Loretta L. Sanchez,62
+Kern,7011290,U.S. Senate,,DEM,Kamala D. Harris,3
+Kern,7011290,U.S. Senate,,DEM,Loretta L. Sanchez,5
+Kern,7011382,U.S. Senate,,DEM,Kamala D. Harris,0
+Kern,7011382,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Kern,7011538,U.S. Senate,,DEM,Kamala D. Harris,43
+Kern,7011538,U.S. Senate,,DEM,Loretta L. Sanchez,29
+Kern,7011541,U.S. Senate,,DEM,Kamala D. Harris,0
+Kern,7011541,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Kern,7011542,U.S. Senate,,DEM,Kamala D. Harris,0
+Kern,7011542,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Kern,7011627,U.S. Senate,,DEM,Kamala D. Harris,0
+Kern,7011627,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Kern,7011683,U.S. Senate,,DEM,Kamala D. Harris,14
+Kern,7011683,U.S. Senate,,DEM,Loretta L. Sanchez,18
+Kern,7011703,U.S. Senate,,DEM,Kamala D. Harris,9
+Kern,7011703,U.S. Senate,,DEM,Loretta L. Sanchez,18
+Kern,7011719,U.S. Senate,,DEM,Kamala D. Harris,78
+Kern,7011719,U.S. Senate,,DEM,Loretta L. Sanchez,37
+Kern,7011760,U.S. Senate,,DEM,Kamala D. Harris,0
+Kern,7011760,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Kern,7011773,U.S. Senate,,DEM,Kamala D. Harris,57
+Kern,7011773,U.S. Senate,,DEM,Loretta L. Sanchez,50
+Kern,7011820,U.S. Senate,,DEM,Kamala D. Harris,18
+Kern,7011820,U.S. Senate,,DEM,Loretta L. Sanchez,28
+Kern,7011835,U.S. Senate,,DEM,Kamala D. Harris,0
+Kern,7011835,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Kern,7011860,U.S. Senate,,DEM,Kamala D. Harris,3
+Kern,7011860,U.S. Senate,,DEM,Loretta L. Sanchez,10
+Kern,7011880,U.S. Senate,,DEM,Kamala D. Harris,0
+Kern,7011880,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Kern,7011900,U.S. Senate,,DEM,Kamala D. Harris,30
+Kern,7011900,U.S. Senate,,DEM,Loretta L. Sanchez,37
+Kern,7011922,U.S. Senate,,DEM,Kamala D. Harris,63
+Kern,7011922,U.S. Senate,,DEM,Loretta L. Sanchez,36
+Kern,7011937,U.S. Senate,,DEM,Kamala D. Harris,0
+Kern,7011937,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Kern,7011983,U.S. Senate,,DEM,Kamala D. Harris,13
+Kern,7011983,U.S. Senate,,DEM,Loretta L. Sanchez,5
+Kern,7012013,U.S. Senate,,DEM,Kamala D. Harris,0
+Kern,7012013,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Kern,7012160,U.S. Senate,,DEM,Kamala D. Harris,77
+Kern,7012160,U.S. Senate,,DEM,Loretta L. Sanchez,36
+Kern,7012162,U.S. Senate,,DEM,Kamala D. Harris,0
+Kern,7012162,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Kern,7012163,U.S. Senate,,DEM,Kamala D. Harris,4
+Kern,7012163,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Kern,7012164,U.S. Senate,,DEM,Kamala D. Harris,43
+Kern,7012164,U.S. Senate,,DEM,Loretta L. Sanchez,31
+Kern,7012250,U.S. Senate,,DEM,Kamala D. Harris,46
+Kern,7012250,U.S. Senate,,DEM,Loretta L. Sanchez,42
+Kern,7012277,U.S. Senate,,DEM,Kamala D. Harris,7
+Kern,7012277,U.S. Senate,,DEM,Loretta L. Sanchez,37
+Kern,7012395,U.S. Senate,,DEM,Kamala D. Harris,0
+Kern,7012395,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Kern,7012413,U.S. Senate,,DEM,Kamala D. Harris,44
+Kern,7012413,U.S. Senate,,DEM,Loretta L. Sanchez,81
+Kern,7012725,U.S. Senate,,DEM,Kamala D. Harris,57
+Kern,7012725,U.S. Senate,,DEM,Loretta L. Sanchez,48
+Kern,7012849,U.S. Senate,,DEM,Kamala D. Harris,0
+Kern,7012849,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Kern,7012937,U.S. Senate,,DEM,Kamala D. Harris,28
+Kern,7012937,U.S. Senate,,DEM,Loretta L. Sanchez,19
+Kern,7012993,U.S. Senate,,DEM,Kamala D. Harris,0
+Kern,7012993,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Kern,7012998,U.S. Senate,,DEM,Kamala D. Harris,1
+Kern,7012998,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Kern,7013047,U.S. Senate,,DEM,Kamala D. Harris,0
+Kern,7013047,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Kern,7013061,U.S. Senate,,DEM,Kamala D. Harris,0
+Kern,7013061,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Kern,7013068,U.S. Senate,,DEM,Kamala D. Harris,0
+Kern,7013068,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Kern,7013092,U.S. Senate,,DEM,Kamala D. Harris,15
+Kern,7013092,U.S. Senate,,DEM,Loretta L. Sanchez,16
+Kern,7013094,U.S. Senate,,DEM,Kamala D. Harris,46
+Kern,7013094,U.S. Senate,,DEM,Loretta L. Sanchez,67
+Kern,7013102,U.S. Senate,,DEM,Kamala D. Harris,3
+Kern,7013102,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Kern,7013103,U.S. Senate,,DEM,Kamala D. Harris,1
+Kern,7013103,U.S. Senate,,DEM,Loretta L. Sanchez,5
+Kern,7013104,U.S. Senate,,DEM,Kamala D. Harris,0
+Kern,7013104,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Kern,7013105,U.S. Senate,,DEM,Kamala D. Harris,0
+Kern,7013105,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Kern,7013112,U.S. Senate,,DEM,Kamala D. Harris,23
+Kern,7013112,U.S. Senate,,DEM,Loretta L. Sanchez,18
+Kern,7013122,U.S. Senate,,DEM,Kamala D. Harris,0
+Kern,7013122,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Kern,7013123,U.S. Senate,,DEM,Kamala D. Harris,0
+Kern,7013123,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Kern,7013128,U.S. Senate,,DEM,Kamala D. Harris,42
+Kern,7013128,U.S. Senate,,DEM,Loretta L. Sanchez,62
+Kern,7013133,U.S. Senate,,DEM,Kamala D. Harris,0
+Kern,7013133,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Kern,7013182,U.S. Senate,,DEM,Kamala D. Harris,9
+Kern,7013182,U.S. Senate,,DEM,Loretta L. Sanchez,17
+Kern,7013183,U.S. Senate,,DEM,Kamala D. Harris,1
+Kern,7013183,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Kern,7013569,U.S. Senate,,DEM,Kamala D. Harris,0
+Kern,7013569,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Kern,7013701,U.S. Senate,,DEM,Kamala D. Harris,11
+Kern,7013701,U.S. Senate,,DEM,Loretta L. Sanchez,9
+Kern,7015125,U.S. Senate,,DEM,Kamala D. Harris,22
+Kern,7015125,U.S. Senate,,DEM,Loretta L. Sanchez,25
+Kern,7015131,U.S. Senate,,DEM,Kamala D. Harris,0
+Kern,7015131,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Kern,7015134,U.S. Senate,,DEM,Kamala D. Harris,0
+Kern,7015134,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Kern,7020012,U.S. Senate,,DEM,Kamala D. Harris,13
+Kern,7020012,U.S. Senate,,DEM,Loretta L. Sanchez,16
+Kern,7020014,U.S. Senate,,DEM,Kamala D. Harris,9
+Kern,7020014,U.S. Senate,,DEM,Loretta L. Sanchez,8
+Kern,7020034,U.S. Senate,,DEM,Kamala D. Harris,15
+Kern,7020034,U.S. Senate,,DEM,Loretta L. Sanchez,15
+Kern,7020110,U.S. Senate,,DEM,Kamala D. Harris,71
+Kern,7020110,U.S. Senate,,DEM,Loretta L. Sanchez,53
+Kern,7020176,U.S. Senate,,DEM,Kamala D. Harris,53
+Kern,7020176,U.S. Senate,,DEM,Loretta L. Sanchez,48
+Kern,7020250,U.S. Senate,,DEM,Kamala D. Harris,56
+Kern,7020250,U.S. Senate,,DEM,Loretta L. Sanchez,59
+Kern,7020264,U.S. Senate,,DEM,Kamala D. Harris,1
+Kern,7020264,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Kern,7020266,U.S. Senate,,DEM,Kamala D. Harris,28
+Kern,7020266,U.S. Senate,,DEM,Loretta L. Sanchez,63
+Kern,7021136,U.S. Senate,,DEM,Kamala D. Harris,0
+Kern,7021136,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Kern,7021137,U.S. Senate,,DEM,Kamala D. Harris,0
+Kern,7021137,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Kern,7021222,U.S. Senate,,DEM,Kamala D. Harris,28
+Kern,7021222,U.S. Senate,,DEM,Loretta L. Sanchez,11
+Kern,7021231,U.S. Senate,,DEM,Kamala D. Harris,0
+Kern,7021231,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Kern,7021235,U.S. Senate,,DEM,Kamala D. Harris,28
+Kern,7021235,U.S. Senate,,DEM,Loretta L. Sanchez,42
+Kern,7021261,U.S. Senate,,DEM,Kamala D. Harris,27
+Kern,7021261,U.S. Senate,,DEM,Loretta L. Sanchez,20
+Kern,7021270,U.S. Senate,,DEM,Kamala D. Harris,43
+Kern,7021270,U.S. Senate,,DEM,Loretta L. Sanchez,30
+Kern,7021276,U.S. Senate,,DEM,Kamala D. Harris,24
+Kern,7021276,U.S. Senate,,DEM,Loretta L. Sanchez,5
+Kern,7021301,U.S. Senate,,DEM,Kamala D. Harris,33
+Kern,7021301,U.S. Senate,,DEM,Loretta L. Sanchez,17
+Kern,7021381,U.S. Senate,,DEM,Kamala D. Harris,0
+Kern,7021381,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Kern,7021387,U.S. Senate,,DEM,Kamala D. Harris,52
+Kern,7021387,U.S. Senate,,DEM,Loretta L. Sanchez,69
+Kern,7021389,U.S. Senate,,DEM,Kamala D. Harris,5
+Kern,7021389,U.S. Senate,,DEM,Loretta L. Sanchez,10
+Kern,7021477,U.S. Senate,,DEM,Kamala D. Harris,1
+Kern,7021477,U.S. Senate,,DEM,Loretta L. Sanchez,11
+Kern,7021531,U.S. Senate,,DEM,Kamala D. Harris,5
+Kern,7021531,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Kern,7021634,U.S. Senate,,DEM,Kamala D. Harris,30
+Kern,7021634,U.S. Senate,,DEM,Loretta L. Sanchez,51
+Kern,7021637,U.S. Senate,,DEM,Kamala D. Harris,70
+Kern,7021637,U.S. Senate,,DEM,Loretta L. Sanchez,49
+Kern,7021717,U.S. Senate,,DEM,Kamala D. Harris,0
+Kern,7021717,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Kern,7021752,U.S. Senate,,DEM,Kamala D. Harris,13
+Kern,7021752,U.S. Senate,,DEM,Loretta L. Sanchez,7
+Kern,7021879,U.S. Senate,,DEM,Kamala D. Harris,0
+Kern,7021879,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Kern,7021925,U.S. Senate,,DEM,Kamala D. Harris,74
+Kern,7021925,U.S. Senate,,DEM,Loretta L. Sanchez,56
+Kern,7022001,U.S. Senate,,DEM,Kamala D. Harris,19
+Kern,7022001,U.S. Senate,,DEM,Loretta L. Sanchez,7
+Kern,7022007,U.S. Senate,,DEM,Kamala D. Harris,32
+Kern,7022007,U.S. Senate,,DEM,Loretta L. Sanchez,25
+Kern,7022014,U.S. Senate,,DEM,Kamala D. Harris,70
+Kern,7022014,U.S. Senate,,DEM,Loretta L. Sanchez,94
+Kern,7022015,U.S. Senate,,DEM,Kamala D. Harris,6
+Kern,7022015,U.S. Senate,,DEM,Loretta L. Sanchez,11
+Kern,7022019,U.S. Senate,,DEM,Kamala D. Harris,57
+Kern,7022019,U.S. Senate,,DEM,Loretta L. Sanchez,56
+Kern,7022022,U.S. Senate,,DEM,Kamala D. Harris,1
+Kern,7022022,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Kern,7022025,U.S. Senate,,DEM,Kamala D. Harris,0
+Kern,7022025,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Kern,7022028,U.S. Senate,,DEM,Kamala D. Harris,32
+Kern,7022028,U.S. Senate,,DEM,Loretta L. Sanchez,30
+Kern,7022209,U.S. Senate,,DEM,Kamala D. Harris,61
+Kern,7022209,U.S. Senate,,DEM,Loretta L. Sanchez,57
+Kern,7022234,U.S. Senate,,DEM,Kamala D. Harris,4
+Kern,7022234,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Kern,7022283,U.S. Senate,,DEM,Kamala D. Harris,33
+Kern,7022283,U.S. Senate,,DEM,Loretta L. Sanchez,37
+Kern,7022421,U.S. Senate,,DEM,Kamala D. Harris,10
+Kern,7022421,U.S. Senate,,DEM,Loretta L. Sanchez,13
+Kern,7022461,U.S. Senate,,DEM,Kamala D. Harris,56
+Kern,7022461,U.S. Senate,,DEM,Loretta L. Sanchez,33
+Kern,7022479,U.S. Senate,,DEM,Kamala D. Harris,16
+Kern,7022479,U.S. Senate,,DEM,Loretta L. Sanchez,16
+Kern,7022520,U.S. Senate,,DEM,Kamala D. Harris,72
+Kern,7022520,U.S. Senate,,DEM,Loretta L. Sanchez,38
+Kern,7022600,U.S. Senate,,DEM,Kamala D. Harris,0
+Kern,7022600,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Kern,7022793,U.S. Senate,,DEM,Kamala D. Harris,16
+Kern,7022793,U.S. Senate,,DEM,Loretta L. Sanchez,27
+Kern,7022803,U.S. Senate,,DEM,Kamala D. Harris,0
+Kern,7022803,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Kern,7022805,U.S. Senate,,DEM,Kamala D. Harris,3
+Kern,7022805,U.S. Senate,,DEM,Loretta L. Sanchez,9
+Kern,7022900,U.S. Senate,,DEM,Kamala D. Harris,40
+Kern,7022900,U.S. Senate,,DEM,Loretta L. Sanchez,25
+Kern,7023011,U.S. Senate,,DEM,Kamala D. Harris,2
+Kern,7023011,U.S. Senate,,DEM,Loretta L. Sanchez,6
+Kern,7023018,U.S. Senate,,DEM,Kamala D. Harris,0
+Kern,7023018,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Kern,7023019,U.S. Senate,,DEM,Kamala D. Harris,0
+Kern,7023019,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Kern,7023024,U.S. Senate,,DEM,Kamala D. Harris,36
+Kern,7023024,U.S. Senate,,DEM,Loretta L. Sanchez,18
+Kern,7023037,U.S. Senate,,DEM,Kamala D. Harris,11
+Kern,7023037,U.S. Senate,,DEM,Loretta L. Sanchez,5
+Kern,7023082,U.S. Senate,,DEM,Kamala D. Harris,42
+Kern,7023082,U.S. Senate,,DEM,Loretta L. Sanchez,48
+Kern,7023084,U.S. Senate,,DEM,Kamala D. Harris,0
+Kern,7023084,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Kern,7023148,U.S. Senate,,DEM,Kamala D. Harris,1
+Kern,7023148,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Kern,7023198,U.S. Senate,,DEM,Kamala D. Harris,1
+Kern,7023198,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Kern,7023201,U.S. Senate,,DEM,Kamala D. Harris,1
+Kern,7023201,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Kern,7023221,U.S. Senate,,DEM,Kamala D. Harris,0
+Kern,7023221,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Kern,7023395,U.S. Senate,,DEM,Kamala D. Harris,0
+Kern,7023395,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Kern,7023405,U.S. Senate,,DEM,Kamala D. Harris,2
+Kern,7023405,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Kern,7023454,U.S. Senate,,DEM,Kamala D. Harris,61
+Kern,7023454,U.S. Senate,,DEM,Loretta L. Sanchez,66
+Kern,7023470,U.S. Senate,,DEM,Kamala D. Harris,41
+Kern,7023470,U.S. Senate,,DEM,Loretta L. Sanchez,64
+Kern,7023476,U.S. Senate,,DEM,Kamala D. Harris,65
+Kern,7023476,U.S. Senate,,DEM,Loretta L. Sanchez,44
+Kern,7023500,U.S. Senate,,DEM,Kamala D. Harris,54
+Kern,7023500,U.S. Senate,,DEM,Loretta L. Sanchez,55
+Kern,7023505,U.S. Senate,,DEM,Kamala D. Harris,0
+Kern,7023505,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Kern,7023604,U.S. Senate,,DEM,Kamala D. Harris,0
+Kern,7023604,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Kern,7023606,U.S. Senate,,DEM,Kamala D. Harris,0
+Kern,7023606,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Kern,7023610,U.S. Senate,,DEM,Kamala D. Harris,52
+Kern,7023610,U.S. Senate,,DEM,Loretta L. Sanchez,66
+Kern,7023766,U.S. Senate,,DEM,Kamala D. Harris,2
+Kern,7023766,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Kern,7025274,U.S. Senate,,DEM,Kamala D. Harris,1
+Kern,7025274,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Kern,7025276,U.S. Senate,,DEM,Kamala D. Harris,0
+Kern,7025276,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Kern,7025277,U.S. Senate,,DEM,Kamala D. Harris,0
+Kern,7025277,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Kern,7025278,U.S. Senate,,DEM,Kamala D. Harris,0
+Kern,7025278,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Kern,7025279,U.S. Senate,,DEM,Kamala D. Harris,0
+Kern,7025279,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Kern,7025293,U.S. Senate,,DEM,Kamala D. Harris,0
+Kern,7025293,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Kern,7030037,U.S. Senate,,DEM,Kamala D. Harris,46
+Kern,7030037,U.S. Senate,,DEM,Loretta L. Sanchez,35
+Kern,7030082,U.S. Senate,,DEM,Kamala D. Harris,55
+Kern,7030082,U.S. Senate,,DEM,Loretta L. Sanchez,52
+Kern,7030303,U.S. Senate,,DEM,Kamala D. Harris,62
+Kern,7030303,U.S. Senate,,DEM,Loretta L. Sanchez,50
+Kern,7030319,U.S. Senate,,DEM,Kamala D. Harris,70
+Kern,7030319,U.S. Senate,,DEM,Loretta L. Sanchez,51
+Kern,7030324,U.S. Senate,,DEM,Kamala D. Harris,53
+Kern,7030324,U.S. Senate,,DEM,Loretta L. Sanchez,51
+Kern,7030327,U.S. Senate,,DEM,Kamala D. Harris,26
+Kern,7030327,U.S. Senate,,DEM,Loretta L. Sanchez,23
+Kern,7030329,U.S. Senate,,DEM,Kamala D. Harris,2
+Kern,7030329,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Kern,7030331,U.S. Senate,,DEM,Kamala D. Harris,25
+Kern,7030331,U.S. Senate,,DEM,Loretta L. Sanchez,25
+Kern,7030336,U.S. Senate,,DEM,Kamala D. Harris,0
+Kern,7030336,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Kern,7030344,U.S. Senate,,DEM,Kamala D. Harris,20
+Kern,7030344,U.S. Senate,,DEM,Loretta L. Sanchez,24
+Kern,7030345,U.S. Senate,,DEM,Kamala D. Harris,0
+Kern,7030345,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Kern,7030395,U.S. Senate,,DEM,Kamala D. Harris,0
+Kern,7030395,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Kern,7031178,U.S. Senate,,DEM,Kamala D. Harris,33
+Kern,7031178,U.S. Senate,,DEM,Loretta L. Sanchez,48
+Kern,7031211,U.S. Senate,,DEM,Kamala D. Harris,45
+Kern,7031211,U.S. Senate,,DEM,Loretta L. Sanchez,65
+Kern,7031389,U.S. Senate,,DEM,Kamala D. Harris,53
+Kern,7031389,U.S. Senate,,DEM,Loretta L. Sanchez,32
+Kern,7031473,U.S. Senate,,DEM,Kamala D. Harris,1
+Kern,7031473,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Kern,7031705,U.S. Senate,,DEM,Kamala D. Harris,10
+Kern,7031705,U.S. Senate,,DEM,Loretta L. Sanchez,11
+Kern,7031740,U.S. Senate,,DEM,Kamala D. Harris,28
+Kern,7031740,U.S. Senate,,DEM,Loretta L. Sanchez,30
+Kern,7032253,U.S. Senate,,DEM,Kamala D. Harris,17
+Kern,7032253,U.S. Senate,,DEM,Loretta L. Sanchez,12
+Kern,7032442,U.S. Senate,,DEM,Kamala D. Harris,68
+Kern,7032442,U.S. Senate,,DEM,Loretta L. Sanchez,27
+Kern,7032740,U.S. Senate,,DEM,Kamala D. Harris,27
+Kern,7032740,U.S. Senate,,DEM,Loretta L. Sanchez,23
+Kern,7033210,U.S. Senate,,DEM,Kamala D. Harris,74
+Kern,7033210,U.S. Senate,,DEM,Loretta L. Sanchez,64
+Kern,7033223,U.S. Senate,,DEM,Kamala D. Harris,28
+Kern,7033223,U.S. Senate,,DEM,Loretta L. Sanchez,59
+Kern,7033226,U.S. Senate,,DEM,Kamala D. Harris,48
+Kern,7033226,U.S. Senate,,DEM,Loretta L. Sanchez,46
+Kern,7035639,U.S. Senate,,DEM,Kamala D. Harris,16
+Kern,7035639,U.S. Senate,,DEM,Loretta L. Sanchez,17
+Kern,7035654,U.S. Senate,,DEM,Kamala D. Harris,31
+Kern,7035654,U.S. Senate,,DEM,Loretta L. Sanchez,45
+Kern,7035663,U.S. Senate,,DEM,Kamala D. Harris,5
+Kern,7035663,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Kern,7035667,U.S. Senate,,DEM,Kamala D. Harris,0
+Kern,7035667,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Kern,7035676,U.S. Senate,,DEM,Kamala D. Harris,0
+Kern,7035676,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Kern,7035683,U.S. Senate,,DEM,Kamala D. Harris,0
+Kern,7035683,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Kern,7035685,U.S. Senate,,DEM,Kamala D. Harris,0
+Kern,7035685,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Kern,7040086,U.S. Senate,,DEM,Kamala D. Harris,63
+Kern,7040086,U.S. Senate,,DEM,Loretta L. Sanchez,41
+Kern,7040140,U.S. Senate,,DEM,Kamala D. Harris,1
+Kern,7040140,U.S. Senate,,DEM,Loretta L. Sanchez,10
+Kern,7040141,U.S. Senate,,DEM,Kamala D. Harris,0
+Kern,7040141,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Kern,7040142,U.S. Senate,,DEM,Kamala D. Harris,0
+Kern,7040142,U.S. Senate,,DEM,Loretta L. Sanchez,5
+Kern,7040144,U.S. Senate,,DEM,Kamala D. Harris,29
+Kern,7040144,U.S. Senate,,DEM,Loretta L. Sanchez,36
+Kern,7040413,U.S. Senate,,DEM,Kamala D. Harris,71
+Kern,7040413,U.S. Senate,,DEM,Loretta L. Sanchez,42
+Kern,7040420,U.S. Senate,,DEM,Kamala D. Harris,57
+Kern,7040420,U.S. Senate,,DEM,Loretta L. Sanchez,39
+Kern,7040437,U.S. Senate,,DEM,Kamala D. Harris,0
+Kern,7040437,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Kern,7040438,U.S. Senate,,DEM,Kamala D. Harris,0
+Kern,7040438,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Kern,7040439,U.S. Senate,,DEM,Kamala D. Harris,10
+Kern,7040439,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Kern,7040472,U.S. Senate,,DEM,Kamala D. Harris,21
+Kern,7040472,U.S. Senate,,DEM,Loretta L. Sanchez,18
+Kern,7040478,U.S. Senate,,DEM,Kamala D. Harris,0
+Kern,7040478,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Kern,7040492,U.S. Senate,,DEM,Kamala D. Harris,0
+Kern,7040492,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Kern,7040498,U.S. Senate,,DEM,Kamala D. Harris,129
+Kern,7040498,U.S. Senate,,DEM,Loretta L. Sanchez,105
+Kern,7041139,U.S. Senate,,DEM,Kamala D. Harris,34
+Kern,7041139,U.S. Senate,,DEM,Loretta L. Sanchez,11
+Kern,7041149,U.S. Senate,,DEM,Kamala D. Harris,0
+Kern,7041149,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Kern,7041184,U.S. Senate,,DEM,Kamala D. Harris,41
+Kern,7041184,U.S. Senate,,DEM,Loretta L. Sanchez,95
+Kern,7041241,U.S. Senate,,DEM,Kamala D. Harris,32
+Kern,7041241,U.S. Senate,,DEM,Loretta L. Sanchez,26
+Kern,7041242,U.S. Senate,,DEM,Kamala D. Harris,4
+Kern,7041242,U.S. Senate,,DEM,Loretta L. Sanchez,12
+Kern,7041305,U.S. Senate,,DEM,Kamala D. Harris,24
+Kern,7041305,U.S. Senate,,DEM,Loretta L. Sanchez,22
+Kern,7041306,U.S. Senate,,DEM,Kamala D. Harris,6
+Kern,7041306,U.S. Senate,,DEM,Loretta L. Sanchez,17
+Kern,7041320,U.S. Senate,,DEM,Kamala D. Harris,0
+Kern,7041320,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Kern,7041388,U.S. Senate,,DEM,Kamala D. Harris,13
+Kern,7041388,U.S. Senate,,DEM,Loretta L. Sanchez,18
+Kern,7041496,U.S. Senate,,DEM,Kamala D. Harris,6
+Kern,7041496,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Kern,7041500,U.S. Senate,,DEM,Kamala D. Harris,7
+Kern,7041500,U.S. Senate,,DEM,Loretta L. Sanchez,7
+Kern,7041504,U.S. Senate,,DEM,Kamala D. Harris,2
+Kern,7041504,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Kern,7041506,U.S. Senate,,DEM,Kamala D. Harris,11
+Kern,7041506,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Kern,7041507,U.S. Senate,,DEM,Kamala D. Harris,64
+Kern,7041507,U.S. Senate,,DEM,Loretta L. Sanchez,58
+Kern,7041526,U.S. Senate,,DEM,Kamala D. Harris,3
+Kern,7041526,U.S. Senate,,DEM,Loretta L. Sanchez,6
+Kern,7041528,U.S. Senate,,DEM,Kamala D. Harris,53
+Kern,7041528,U.S. Senate,,DEM,Loretta L. Sanchez,53
+Kern,7041720,U.S. Senate,,DEM,Kamala D. Harris,8
+Kern,7041720,U.S. Senate,,DEM,Loretta L. Sanchez,8
+Kern,7041768,U.S. Senate,,DEM,Kamala D. Harris,20
+Kern,7041768,U.S. Senate,,DEM,Loretta L. Sanchez,14
+Kern,7041778,U.S. Senate,,DEM,Kamala D. Harris,0
+Kern,7041778,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Kern,7041875,U.S. Senate,,DEM,Kamala D. Harris,0
+Kern,7041875,U.S. Senate,,DEM,Loretta L. Sanchez,16
+Kern,7041876,U.S. Senate,,DEM,Kamala D. Harris,1
+Kern,7041876,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Kern,7041908,U.S. Senate,,DEM,Kamala D. Harris,6
+Kern,7041908,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Kern,7041933,U.S. Senate,,DEM,Kamala D. Harris,27
+Kern,7041933,U.S. Senate,,DEM,Loretta L. Sanchez,51
+Kern,7041934,U.S. Senate,,DEM,Kamala D. Harris,0
+Kern,7041934,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Kern,7042000,U.S. Senate,,DEM,Kamala D. Harris,7
+Kern,7042000,U.S. Senate,,DEM,Loretta L. Sanchez,12
+Kern,7042003,U.S. Senate,,DEM,Kamala D. Harris,0
+Kern,7042003,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Kern,7042223,U.S. Senate,,DEM,Kamala D. Harris,0
+Kern,7042223,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Kern,7042427,U.S. Senate,,DEM,Kamala D. Harris,14
+Kern,7042427,U.S. Senate,,DEM,Loretta L. Sanchez,13
+Kern,7042438,U.S. Senate,,DEM,Kamala D. Harris,0
+Kern,7042438,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Kern,7042441,U.S. Senate,,DEM,Kamala D. Harris,0
+Kern,7042441,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Kern,7042517,U.S. Senate,,DEM,Kamala D. Harris,0
+Kern,7042517,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Kern,7042637,U.S. Senate,,DEM,Kamala D. Harris,98
+Kern,7042637,U.S. Senate,,DEM,Loretta L. Sanchez,105
+Kern,7042769,U.S. Senate,,DEM,Kamala D. Harris,68
+Kern,7042769,U.S. Senate,,DEM,Loretta L. Sanchez,38
+Kern,7042783,U.S. Senate,,DEM,Kamala D. Harris,0
+Kern,7042783,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Kern,7042784,U.S. Senate,,DEM,Kamala D. Harris,1
+Kern,7042784,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Kern,7042785,U.S. Senate,,DEM,Kamala D. Harris,0
+Kern,7042785,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Kern,7042789,U.S. Senate,,DEM,Kamala D. Harris,0
+Kern,7042789,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Kern,7043047,U.S. Senate,,DEM,Kamala D. Harris,6
+Kern,7043047,U.S. Senate,,DEM,Loretta L. Sanchez,11
+Kern,7043101,U.S. Senate,,DEM,Kamala D. Harris,0
+Kern,7043101,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Kern,7043295,U.S. Senate,,DEM,Kamala D. Harris,82
+Kern,7043295,U.S. Senate,,DEM,Loretta L. Sanchez,149
+Kern,7043561,U.S. Senate,,DEM,Kamala D. Harris,20
+Kern,7043561,U.S. Senate,,DEM,Loretta L. Sanchez,34
+Kern,7044110,U.S. Senate,,DEM,Kamala D. Harris,13
+Kern,7044110,U.S. Senate,,DEM,Loretta L. Sanchez,12
+Kern,7050025,U.S. Senate,,DEM,Kamala D. Harris,10
+Kern,7050025,U.S. Senate,,DEM,Loretta L. Sanchez,12
+Kern,7050030,U.S. Senate,,DEM,Kamala D. Harris,25
+Kern,7050030,U.S. Senate,,DEM,Loretta L. Sanchez,64
+Kern,7050032,U.S. Senate,,DEM,Kamala D. Harris,1
+Kern,7050032,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Kern,7050212,U.S. Senate,,DEM,Kamala D. Harris,0
+Kern,7050212,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Kern,7050217,U.S. Senate,,DEM,Kamala D. Harris,0
+Kern,7050217,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Kern,7050220,U.S. Senate,,DEM,Kamala D. Harris,16
+Kern,7050220,U.S. Senate,,DEM,Loretta L. Sanchez,48
+Kern,7050221,U.S. Senate,,DEM,Kamala D. Harris,29
+Kern,7050221,U.S. Senate,,DEM,Loretta L. Sanchez,54
+Kern,7050504,U.S. Senate,,DEM,Kamala D. Harris,16
+Kern,7050504,U.S. Senate,,DEM,Loretta L. Sanchez,10
+Kern,7050513,U.S. Senate,,DEM,Kamala D. Harris,61
+Kern,7050513,U.S. Senate,,DEM,Loretta L. Sanchez,57
+Kern,7050515,U.S. Senate,,DEM,Kamala D. Harris,50
+Kern,7050515,U.S. Senate,,DEM,Loretta L. Sanchez,35
+Kern,7050525,U.S. Senate,,DEM,Kamala D. Harris,19
+Kern,7050525,U.S. Senate,,DEM,Loretta L. Sanchez,32
+Kern,7050529,U.S. Senate,,DEM,Kamala D. Harris,1
+Kern,7050529,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Kern,7050539,U.S. Senate,,DEM,Kamala D. Harris,53
+Kern,7050539,U.S. Senate,,DEM,Loretta L. Sanchez,82
+Kern,7050542,U.S. Senate,,DEM,Kamala D. Harris,54
+Kern,7050542,U.S. Senate,,DEM,Loretta L. Sanchez,74
+Kern,7050546,U.S. Senate,,DEM,Kamala D. Harris,0
+Kern,7050546,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Kern,7050547,U.S. Senate,,DEM,Kamala D. Harris,26
+Kern,7050547,U.S. Senate,,DEM,Loretta L. Sanchez,36
+Kern,7050549,U.S. Senate,,DEM,Kamala D. Harris,70
+Kern,7050549,U.S. Senate,,DEM,Loretta L. Sanchez,53
+Kern,7050556,U.S. Senate,,DEM,Kamala D. Harris,0
+Kern,7050556,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Kern,7050561,U.S. Senate,,DEM,Kamala D. Harris,37
+Kern,7050561,U.S. Senate,,DEM,Loretta L. Sanchez,54
+Kern,7050563,U.S. Senate,,DEM,Kamala D. Harris,0
+Kern,7050563,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Kern,7050566,U.S. Senate,,DEM,Kamala D. Harris,0
+Kern,7050566,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Kern,7050586,U.S. Senate,,DEM,Kamala D. Harris,57
+Kern,7050586,U.S. Senate,,DEM,Loretta L. Sanchez,60
+Kern,7050593,U.S. Senate,,DEM,Kamala D. Harris,61
+Kern,7050593,U.S. Senate,,DEM,Loretta L. Sanchez,69
+Kern,7050597,U.S. Senate,,DEM,Kamala D. Harris,0
+Kern,7050597,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Kern,7050705,U.S. Senate,,DEM,Kamala D. Harris,0
+Kern,7050705,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Kern,7050707,U.S. Senate,,DEM,Kamala D. Harris,45
+Kern,7050707,U.S. Senate,,DEM,Loretta L. Sanchez,61
+Kern,7050712,U.S. Senate,,DEM,Kamala D. Harris,0
+Kern,7050712,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Kern,7050714,U.S. Senate,,DEM,Kamala D. Harris,6
+Kern,7050714,U.S. Senate,,DEM,Loretta L. Sanchez,12
+Kern,7050730,U.S. Senate,,DEM,Kamala D. Harris,13
+Kern,7050730,U.S. Senate,,DEM,Loretta L. Sanchez,28
+Kern,7050737,U.S. Senate,,DEM,Kamala D. Harris,25
+Kern,7050737,U.S. Senate,,DEM,Loretta L. Sanchez,26
+Kern,7050748,U.S. Senate,,DEM,Kamala D. Harris,21
+Kern,7050748,U.S. Senate,,DEM,Loretta L. Sanchez,16
+Kern,7050751,U.S. Senate,,DEM,Kamala D. Harris,70
+Kern,7050751,U.S. Senate,,DEM,Loretta L. Sanchez,88
+Kern,7050759,U.S. Senate,,DEM,Kamala D. Harris,8
+Kern,7050759,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Kern,7050768,U.S. Senate,,DEM,Kamala D. Harris,0
+Kern,7050768,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Kern,7050769,U.S. Senate,,DEM,Kamala D. Harris,0
+Kern,7050769,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Kern,7051188,U.S. Senate,,DEM,Kamala D. Harris,1
+Kern,7051188,U.S. Senate,,DEM,Loretta L. Sanchez,9
+Kern,7051205,U.S. Senate,,DEM,Kamala D. Harris,53
+Kern,7051205,U.S. Senate,,DEM,Loretta L. Sanchez,44
+Kern,7051226,U.S. Senate,,DEM,Kamala D. Harris,28
+Kern,7051226,U.S. Senate,,DEM,Loretta L. Sanchez,39
+Kern,7051233,U.S. Senate,,DEM,Kamala D. Harris,19
+Kern,7051233,U.S. Senate,,DEM,Loretta L. Sanchez,30
+Kern,7051293,U.S. Senate,,DEM,Kamala D. Harris,39
+Kern,7051293,U.S. Senate,,DEM,Loretta L. Sanchez,42
+Kern,7051294,U.S. Senate,,DEM,Kamala D. Harris,43
+Kern,7051294,U.S. Senate,,DEM,Loretta L. Sanchez,61
+Kern,7051298,U.S. Senate,,DEM,Kamala D. Harris,35
+Kern,7051298,U.S. Senate,,DEM,Loretta L. Sanchez,82
+Kern,7051333,U.S. Senate,,DEM,Kamala D. Harris,5
+Kern,7051333,U.S. Senate,,DEM,Loretta L. Sanchez,6
+Kern,7051490,U.S. Senate,,DEM,Kamala D. Harris,4
+Kern,7051490,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Kern,7051494,U.S. Senate,,DEM,Kamala D. Harris,1
+Kern,7051494,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Kern,7051679,U.S. Senate,,DEM,Kamala D. Harris,4
+Kern,7051679,U.S. Senate,,DEM,Loretta L. Sanchez,16
+Kern,7051680,U.S. Senate,,DEM,Kamala D. Harris,4
+Kern,7051680,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Kern,7051704,U.S. Senate,,DEM,Kamala D. Harris,50
+Kern,7051704,U.S. Senate,,DEM,Loretta L. Sanchez,43
+Kern,7051716,U.S. Senate,,DEM,Kamala D. Harris,1
+Kern,7051716,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Kern,7051729,U.S. Senate,,DEM,Kamala D. Harris,26
+Kern,7051729,U.S. Senate,,DEM,Loretta L. Sanchez,20
+Kern,7051751,U.S. Senate,,DEM,Kamala D. Harris,44
+Kern,7051751,U.S. Senate,,DEM,Loretta L. Sanchez,76
+Kern,7051779,U.S. Senate,,DEM,Kamala D. Harris,0
+Kern,7051779,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Kern,7051972,U.S. Senate,,DEM,Kamala D. Harris,0
+Kern,7051972,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Kern,7052036,U.S. Senate,,DEM,Kamala D. Harris,3
+Kern,7052036,U.S. Senate,,DEM,Loretta L. Sanchez,6
+Kern,7052037,U.S. Senate,,DEM,Kamala D. Harris,27
+Kern,7052037,U.S. Senate,,DEM,Loretta L. Sanchez,26
+Kern,7052140,U.S. Senate,,DEM,Kamala D. Harris,46
+Kern,7052140,U.S. Senate,,DEM,Loretta L. Sanchez,42
+Kern,7052143,U.S. Senate,,DEM,Kamala D. Harris,29
+Kern,7052143,U.S. Senate,,DEM,Loretta L. Sanchez,29
+Kern,7052186,U.S. Senate,,DEM,Kamala D. Harris,8
+Kern,7052186,U.S. Senate,,DEM,Loretta L. Sanchez,8
+Kern,7052188,U.S. Senate,,DEM,Kamala D. Harris,6
+Kern,7052188,U.S. Senate,,DEM,Loretta L. Sanchez,6
+Kern,7053012,U.S. Senate,,DEM,Kamala D. Harris,23
+Kern,7053012,U.S. Senate,,DEM,Loretta L. Sanchez,22
+Kern,7053449,U.S. Senate,,DEM,Kamala D. Harris,1
+Kern,7053449,U.S. Senate,,DEM,Loretta L. Sanchez,9
+Kern,7053450,U.S. Senate,,DEM,Kamala D. Harris,0
+Kern,7053450,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Kern,7053495,U.S. Senate,,DEM,Kamala D. Harris,0
+Kern,7053495,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Kern,7053752,U.S. Senate,,DEM,Kamala D. Harris,1
+Kern,7053752,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Kern,7053765,U.S. Senate,,DEM,Kamala D. Harris,1
+Kern,7053765,U.S. Senate,,DEM,Loretta L. Sanchez,1

--- a/2016/20161108__ca__general__kings__precinct.csv
+++ b/2016/20161108__ca__general__kings__precinct.csv
@@ -7279,367 +7279,367 @@ Kings,1541,Proposition 67,,N/A,Yes,6
 Kings,1541,Proposition 67,,N/A,No,21
 Kings,1542,Proposition 67,,N/A,Yes,5
 Kings,1542,Proposition 67,,N/A,No,7
-Kings,101,U.S. Senate,,DEM,Kamala Harris,306
-Kings,101,U.S. Senate,,DEM,Loretta Sanchez,212
-Kings,102,U.S. Senate,,DEM,Kamala Harris,339
-Kings,102,U.S. Senate,,DEM,Loretta Sanchez,361
-Kings,103,U.S. Senate,,DEM,Kamala Harris,677
-Kings,103,U.S. Senate,,DEM,Loretta Sanchez,512
-Kings,104,U.S. Senate,,DEM,Kamala Harris,136
-Kings,104,U.S. Senate,,DEM,Loretta Sanchez,104
-Kings,105,U.S. Senate,,DEM,Kamala Harris,128
-Kings,105,U.S. Senate,,DEM,Loretta Sanchez,114
-Kings,106,U.S. Senate,,DEM,Kamala Harris,355
-Kings,106,U.S. Senate,,DEM,Loretta Sanchez,248
-Kings,107,U.S. Senate,,DEM,Kamala Harris,212
-Kings,107,U.S. Senate,,DEM,Loretta Sanchez,162
-Kings,108,U.S. Senate,,DEM,Kamala Harris,89
-Kings,108,U.S. Senate,,DEM,Loretta Sanchez,103
-Kings,201,U.S. Senate,,DEM,Kamala Harris,168
-Kings,201,U.S. Senate,,DEM,Loretta Sanchez,169
-Kings,202,U.S. Senate,,DEM,Kamala Harris,204
-Kings,202,U.S. Senate,,DEM,Loretta Sanchez,252
-Kings,203,U.S. Senate,,DEM,Kamala Harris,303
-Kings,203,U.S. Senate,,DEM,Loretta Sanchez,590
-Kings,204,U.S. Senate,,DEM,Kamala Harris,192
-Kings,204,U.S. Senate,,DEM,Loretta Sanchez,360
-Kings,205,U.S. Senate,,DEM,Kamala Harris,153
-Kings,205,U.S. Senate,,DEM,Loretta Sanchez,240
-Kings,301,U.S. Senate,,DEM,Kamala Harris,510
-Kings,301,U.S. Senate,,DEM,Loretta Sanchez,314
-Kings,302,U.S. Senate,,DEM,Kamala Harris,366
-Kings,302,U.S. Senate,,DEM,Loretta Sanchez,278
-Kings,303,U.S. Senate,,DEM,Kamala Harris,381
-Kings,303,U.S. Senate,,DEM,Loretta Sanchez,248
-Kings,304,U.S. Senate,,DEM,Kamala Harris,311
-Kings,304,U.S. Senate,,DEM,Loretta Sanchez,210
-Kings,305,U.S. Senate,,DEM,Kamala Harris,162
-Kings,305,U.S. Senate,,DEM,Loretta Sanchez,124
-Kings,306,U.S. Senate,,DEM,Kamala Harris,190
-Kings,306,U.S. Senate,,DEM,Loretta Sanchez,164
-Kings,307,U.S. Senate,,DEM,Kamala Harris,432
-Kings,307,U.S. Senate,,DEM,Loretta Sanchez,304
-Kings,308,U.S. Senate,,DEM,Kamala Harris,205
-Kings,308,U.S. Senate,,DEM,Loretta Sanchez,158
-Kings,309,U.S. Senate,,DEM,Kamala Harris,209
-Kings,309,U.S. Senate,,DEM,Loretta Sanchez,199
-Kings,401,U.S. Senate,,DEM,Kamala Harris,424
-Kings,401,U.S. Senate,,DEM,Loretta Sanchez,325
-Kings,402,U.S. Senate,,DEM,Kamala Harris,401
-Kings,402,U.S. Senate,,DEM,Loretta Sanchez,298
-Kings,403,U.S. Senate,,DEM,Kamala Harris,222
-Kings,403,U.S. Senate,,DEM,Loretta Sanchez,138
-Kings,404,U.S. Senate,,DEM,Kamala Harris,81
-Kings,404,U.S. Senate,,DEM,Loretta Sanchez,93
-Kings,405,U.S. Senate,,DEM,Kamala Harris,409
-Kings,405,U.S. Senate,,DEM,Loretta Sanchez,436
-Kings,406,U.S. Senate,,DEM,Kamala Harris,125
-Kings,406,U.S. Senate,,DEM,Loretta Sanchez,227
-Kings,407,U.S. Senate,,DEM,Kamala Harris,220
-Kings,407,U.S. Senate,,DEM,Loretta Sanchez,201
-Kings,501,U.S. Senate,,DEM,Kamala Harris,192
-Kings,501,U.S. Senate,,DEM,Loretta Sanchez,147
-Kings,502,U.S. Senate,,DEM,Kamala Harris,355
-Kings,502,U.S. Senate,,DEM,Loretta Sanchez,269
-Kings,503,U.S. Senate,,DEM,Kamala Harris,643
-Kings,503,U.S. Senate,,DEM,Loretta Sanchez,486
-Kings,504,U.S. Senate,,DEM,Kamala Harris,452
-Kings,504,U.S. Senate,,DEM,Loretta Sanchez,307
-Kings,505,U.S. Senate,,DEM,Kamala Harris,616
-Kings,505,U.S. Senate,,DEM,Loretta Sanchez,460
-Kings,1101,U.S. Senate,,DEM,Kamala Harris,104
-Kings,1101,U.S. Senate,,DEM,Loretta Sanchez,78
-Kings,1102,U.S. Senate,,DEM,Kamala Harris,5
-Kings,1102,U.S. Senate,,DEM,Loretta Sanchez,1
-Kings,1103,U.S. Senate,,DEM,Kamala Harris,41
-Kings,1103,U.S. Senate,,DEM,Loretta Sanchez,45
-Kings,1104,U.S. Senate,,DEM,Kamala Harris,3
-Kings,1104,U.S. Senate,,DEM,Loretta Sanchez,4
-Kings,1105,U.S. Senate,,DEM,Kamala Harris,109
-Kings,1105,U.S. Senate,,DEM,Loretta Sanchez,75
-Kings,1106,U.S. Senate,,DEM,Kamala Harris,47
-Kings,1106,U.S. Senate,,DEM,Loretta Sanchez,30
-Kings,1107,U.S. Senate,,DEM,Kamala Harris,10
-Kings,1107,U.S. Senate,,DEM,Loretta Sanchez,25
-Kings,1108,U.S. Senate,,DEM,Kamala Harris,30
-Kings,1108,U.S. Senate,,DEM,Loretta Sanchez,33
-Kings,1201,U.S. Senate,,DEM,Kamala Harris,0
-Kings,1201,U.S. Senate,,DEM,Loretta Sanchez,0
-Kings,1202,U.S. Senate,,DEM,Kamala Harris,1
-Kings,1202,U.S. Senate,,DEM,Loretta Sanchez,1
-Kings,1203,U.S. Senate,,DEM,Kamala Harris,0
-Kings,1203,U.S. Senate,,DEM,Loretta Sanchez,0
-Kings,1204,U.S. Senate,,DEM,Kamala Harris,41
-Kings,1204,U.S. Senate,,DEM,Loretta Sanchez,59
-Kings,1205,U.S. Senate,,DEM,Kamala Harris,0
-Kings,1205,U.S. Senate,,DEM,Loretta Sanchez,1
-Kings,1206,U.S. Senate,,DEM,Kamala Harris,26
-Kings,1206,U.S. Senate,,DEM,Loretta Sanchez,29
-Kings,1207,U.S. Senate,,DEM,Kamala Harris,32
-Kings,1207,U.S. Senate,,DEM,Loretta Sanchez,32
-Kings,1208,U.S. Senate,,DEM,Kamala Harris,41
-Kings,1208,U.S. Senate,,DEM,Loretta Sanchez,33
-Kings,1209,U.S. Senate,,DEM,Kamala Harris,57
-Kings,1209,U.S. Senate,,DEM,Loretta Sanchez,54
-Kings,1210,U.S. Senate,,DEM,Kamala Harris,5
-Kings,1210,U.S. Senate,,DEM,Loretta Sanchez,14
-Kings,1211,U.S. Senate,,DEM,Kamala Harris,3
-Kings,1211,U.S. Senate,,DEM,Loretta Sanchez,4
-Kings,1212,U.S. Senate,,DEM,Kamala Harris,2
-Kings,1212,U.S. Senate,,DEM,Loretta Sanchez,2
-Kings,1213,U.S. Senate,,DEM,Kamala Harris,72
-Kings,1213,U.S. Senate,,DEM,Loretta Sanchez,57
-Kings,1214,U.S. Senate,,DEM,Kamala Harris,45
-Kings,1214,U.S. Senate,,DEM,Loretta Sanchez,63
-Kings,1215,U.S. Senate,,DEM,Kamala Harris,47
-Kings,1215,U.S. Senate,,DEM,Loretta Sanchez,29
-Kings,1216,U.S. Senate,,DEM,Kamala Harris,46
-Kings,1216,U.S. Senate,,DEM,Loretta Sanchez,60
-Kings,1217,U.S. Senate,,DEM,Kamala Harris,33
-Kings,1217,U.S. Senate,,DEM,Loretta Sanchez,28
-Kings,1218,U.S. Senate,,DEM,Kamala Harris,23
-Kings,1218,U.S. Senate,,DEM,Loretta Sanchez,12
-Kings,1219,U.S. Senate,,DEM,Kamala Harris,16
-Kings,1219,U.S. Senate,,DEM,Loretta Sanchez,26
-Kings,1220,U.S. Senate,,DEM,Kamala Harris,2
-Kings,1220,U.S. Senate,,DEM,Loretta Sanchez,4
-Kings,1221,U.S. Senate,,DEM,Kamala Harris,1
-Kings,1221,U.S. Senate,,DEM,Loretta Sanchez,2
-Kings,1222,U.S. Senate,,DEM,Kamala Harris,1
-Kings,1222,U.S. Senate,,DEM,Loretta Sanchez,7
-Kings,1223,U.S. Senate,,DEM,Kamala Harris,0
-Kings,1223,U.S. Senate,,DEM,Loretta Sanchez,0
-Kings,1224,U.S. Senate,,DEM,Kamala Harris,0
-Kings,1224,U.S. Senate,,DEM,Loretta Sanchez,0
-Kings,1225,U.S. Senate,,DEM,Kamala Harris,8
-Kings,1225,U.S. Senate,,DEM,Loretta Sanchez,15
-Kings,1226,U.S. Senate,,DEM,Kamala Harris,4
-Kings,1226,U.S. Senate,,DEM,Loretta Sanchez,24
-Kings,1227,U.S. Senate,,DEM,Kamala Harris,1
-Kings,1227,U.S. Senate,,DEM,Loretta Sanchez,3
-Kings,1228,U.S. Senate,,DEM,Kamala Harris,25
-Kings,1228,U.S. Senate,,DEM,Loretta Sanchez,39
-Kings,1229,U.S. Senate,,DEM,Kamala Harris,0
-Kings,1229,U.S. Senate,,DEM,Loretta Sanchez,3
-Kings,1230,U.S. Senate,,DEM,Kamala Harris,0
-Kings,1230,U.S. Senate,,DEM,Loretta Sanchez,0
-Kings,1231,U.S. Senate,,DEM,Kamala Harris,37
-Kings,1231,U.S. Senate,,DEM,Loretta Sanchez,77
-Kings,1232,U.S. Senate,,DEM,Kamala Harris,6
-Kings,1232,U.S. Senate,,DEM,Loretta Sanchez,4
-Kings,1233,U.S. Senate,,DEM,Kamala Harris,0
-Kings,1233,U.S. Senate,,DEM,Loretta Sanchez,0
-Kings,1234,U.S. Senate,,DEM,Kamala Harris,22
-Kings,1234,U.S. Senate,,DEM,Loretta Sanchez,36
-Kings,1235,U.S. Senate,,DEM,Kamala Harris,15
-Kings,1235,U.S. Senate,,DEM,Loretta Sanchez,6
-Kings,1301,U.S. Senate,,DEM,Kamala Harris,69
-Kings,1301,U.S. Senate,,DEM,Loretta Sanchez,51
-Kings,1302,U.S. Senate,,DEM,Kamala Harris,112
-Kings,1302,U.S. Senate,,DEM,Loretta Sanchez,85
-Kings,1303,U.S. Senate,,DEM,Kamala Harris,21
-Kings,1303,U.S. Senate,,DEM,Loretta Sanchez,31
-Kings,1304,U.S. Senate,,DEM,Kamala Harris,0
-Kings,1304,U.S. Senate,,DEM,Loretta Sanchez,2
-Kings,1305,U.S. Senate,,DEM,Kamala Harris,46
-Kings,1305,U.S. Senate,,DEM,Loretta Sanchez,63
-Kings,1306,U.S. Senate,,DEM,Kamala Harris,55
-Kings,1306,U.S. Senate,,DEM,Loretta Sanchez,82
-Kings,1307,U.S. Senate,,DEM,Kamala Harris,64
-Kings,1307,U.S. Senate,,DEM,Loretta Sanchez,77
-Kings,1308,U.S. Senate,,DEM,Kamala Harris,97
-Kings,1308,U.S. Senate,,DEM,Loretta Sanchez,73
-Kings,1309,U.S. Senate,,DEM,Kamala Harris,23
-Kings,1309,U.S. Senate,,DEM,Loretta Sanchez,26
-Kings,1310,U.S. Senate,,DEM,Kamala Harris,10
-Kings,1310,U.S. Senate,,DEM,Loretta Sanchez,13
-Kings,1311,U.S. Senate,,DEM,Kamala Harris,77
-Kings,1311,U.S. Senate,,DEM,Loretta Sanchez,93
-Kings,1312,U.S. Senate,,DEM,Kamala Harris,69
-Kings,1312,U.S. Senate,,DEM,Loretta Sanchez,55
-Kings,1313,U.S. Senate,,DEM,Kamala Harris,10
-Kings,1313,U.S. Senate,,DEM,Loretta Sanchez,18
-Kings,1314,U.S. Senate,,DEM,Kamala Harris,2
-Kings,1314,U.S. Senate,,DEM,Loretta Sanchez,2
-Kings,1315,U.S. Senate,,DEM,Kamala Harris,57
-Kings,1315,U.S. Senate,,DEM,Loretta Sanchez,44
-Kings,1316,U.S. Senate,,DEM,Kamala Harris,8
-Kings,1316,U.S. Senate,,DEM,Loretta Sanchez,3
-Kings,1317,U.S. Senate,,DEM,Kamala Harris,11
-Kings,1317,U.S. Senate,,DEM,Loretta Sanchez,12
-Kings,1318,U.S. Senate,,DEM,Kamala Harris,70
-Kings,1318,U.S. Senate,,DEM,Loretta Sanchez,62
-Kings,1319,U.S. Senate,,DEM,Kamala Harris,0
-Kings,1319,U.S. Senate,,DEM,Loretta Sanchez,4
-Kings,1320,U.S. Senate,,DEM,Kamala Harris,9
-Kings,1320,U.S. Senate,,DEM,Loretta Sanchez,8
-Kings,1321,U.S. Senate,,DEM,Kamala Harris,0
-Kings,1321,U.S. Senate,,DEM,Loretta Sanchez,0
-Kings,1322,U.S. Senate,,DEM,Kamala Harris,30
-Kings,1322,U.S. Senate,,DEM,Loretta Sanchez,15
-Kings,1323,U.S. Senate,,DEM,Kamala Harris,2
-Kings,1323,U.S. Senate,,DEM,Loretta Sanchez,5
-Kings,1324,U.S. Senate,,DEM,Kamala Harris,16
-Kings,1324,U.S. Senate,,DEM,Loretta Sanchez,23
-Kings,1325,U.S. Senate,,DEM,Kamala Harris,8
-Kings,1325,U.S. Senate,,DEM,Loretta Sanchez,3
-Kings,1326,U.S. Senate,,DEM,Kamala Harris,26
-Kings,1326,U.S. Senate,,DEM,Loretta Sanchez,41
-Kings,1327,U.S. Senate,,DEM,Kamala Harris,8
-Kings,1327,U.S. Senate,,DEM,Loretta Sanchez,13
-Kings,1401,U.S. Senate,,DEM,Kamala Harris,10
-Kings,1401,U.S. Senate,,DEM,Loretta Sanchez,8
-Kings,1402,U.S. Senate,,DEM,Kamala Harris,37
-Kings,1402,U.S. Senate,,DEM,Loretta Sanchez,28
-Kings,1403,U.S. Senate,,DEM,Kamala Harris,41
-Kings,1403,U.S. Senate,,DEM,Loretta Sanchez,55
-Kings,1404,U.S. Senate,,DEM,Kamala Harris,12
-Kings,1404,U.S. Senate,,DEM,Loretta Sanchez,16
-Kings,1405,U.S. Senate,,DEM,Kamala Harris,13
-Kings,1405,U.S. Senate,,DEM,Loretta Sanchez,14
-Kings,1406,U.S. Senate,,DEM,Kamala Harris,73
-Kings,1406,U.S. Senate,,DEM,Loretta Sanchez,55
-Kings,1407,U.S. Senate,,DEM,Kamala Harris,52
-Kings,1407,U.S. Senate,,DEM,Loretta Sanchez,58
-Kings,1408,U.S. Senate,,DEM,Kamala Harris,32
-Kings,1408,U.S. Senate,,DEM,Loretta Sanchez,40
-Kings,1409,U.S. Senate,,DEM,Kamala Harris,64
-Kings,1409,U.S. Senate,,DEM,Loretta Sanchez,93
-Kings,1410,U.S. Senate,,DEM,Kamala Harris,85
-Kings,1410,U.S. Senate,,DEM,Loretta Sanchez,91
-Kings,1411,U.S. Senate,,DEM,Kamala Harris,37
-Kings,1411,U.S. Senate,,DEM,Loretta Sanchez,46
-Kings,1412,U.S. Senate,,DEM,Kamala Harris,108
-Kings,1412,U.S. Senate,,DEM,Loretta Sanchez,109
-Kings,1413,U.S. Senate,,DEM,Kamala Harris,95
-Kings,1413,U.S. Senate,,DEM,Loretta Sanchez,60
-Kings,1414,U.S. Senate,,DEM,Kamala Harris,3
-Kings,1414,U.S. Senate,,DEM,Loretta Sanchez,13
-Kings,1415,U.S. Senate,,DEM,Kamala Harris,50
-Kings,1415,U.S. Senate,,DEM,Loretta Sanchez,49
-Kings,1416,U.S. Senate,,DEM,Kamala Harris,2
-Kings,1416,U.S. Senate,,DEM,Loretta Sanchez,1
-Kings,1417,U.S. Senate,,DEM,Kamala Harris,2
-Kings,1417,U.S. Senate,,DEM,Loretta Sanchez,1
-Kings,1418,U.S. Senate,,DEM,Kamala Harris,9
-Kings,1418,U.S. Senate,,DEM,Loretta Sanchez,9
-Kings,1419,U.S. Senate,,DEM,Kamala Harris,50
-Kings,1419,U.S. Senate,,DEM,Loretta Sanchez,53
-Kings,1420,U.S. Senate,,DEM,Kamala Harris,40
-Kings,1420,U.S. Senate,,DEM,Loretta Sanchez,55
-Kings,1421,U.S. Senate,,DEM,Kamala Harris,5
-Kings,1421,U.S. Senate,,DEM,Loretta Sanchez,6
-Kings,1422,U.S. Senate,,DEM,Kamala Harris,19
-Kings,1422,U.S. Senate,,DEM,Loretta Sanchez,23
-Kings,1423,U.S. Senate,,DEM,Kamala Harris,6
-Kings,1423,U.S. Senate,,DEM,Loretta Sanchez,8
-Kings,1424,U.S. Senate,,DEM,Kamala Harris,5
-Kings,1424,U.S. Senate,,DEM,Loretta Sanchez,2
-Kings,1425,U.S. Senate,,DEM,Kamala Harris,3
-Kings,1425,U.S. Senate,,DEM,Loretta Sanchez,0
-Kings,1426,U.S. Senate,,DEM,Kamala Harris,13
-Kings,1426,U.S. Senate,,DEM,Loretta Sanchez,18
-Kings,1427,U.S. Senate,,DEM,Kamala Harris,19
-Kings,1427,U.S. Senate,,DEM,Loretta Sanchez,39
-Kings,1428,U.S. Senate,,DEM,Kamala Harris,22
-Kings,1428,U.S. Senate,,DEM,Loretta Sanchez,15
-Kings,1429,U.S. Senate,,DEM,Kamala Harris,12
-Kings,1429,U.S. Senate,,DEM,Loretta Sanchez,17
-Kings,1430,U.S. Senate,,DEM,Kamala Harris,0
-Kings,1430,U.S. Senate,,DEM,Loretta Sanchez,3
-Kings,1431,U.S. Senate,,DEM,Kamala Harris,5
-Kings,1431,U.S. Senate,,DEM,Loretta Sanchez,5
-Kings,1432,U.S. Senate,,DEM,Kamala Harris,11
-Kings,1432,U.S. Senate,,DEM,Loretta Sanchez,9
-Kings,1433,U.S. Senate,,DEM,Kamala Harris,8
-Kings,1433,U.S. Senate,,DEM,Loretta Sanchez,4
-Kings,1434,U.S. Senate,,DEM,Kamala Harris,52
-Kings,1434,U.S. Senate,,DEM,Loretta Sanchez,31
-Kings,1435,U.S. Senate,,DEM,Kamala Harris,22
-Kings,1435,U.S. Senate,,DEM,Loretta Sanchez,16
-Kings,1436,U.S. Senate,,DEM,Kamala Harris,0
-Kings,1436,U.S. Senate,,DEM,Loretta Sanchez,4
-Kings,1501,U.S. Senate,,DEM,Kamala Harris,11
-Kings,1501,U.S. Senate,,DEM,Loretta Sanchez,5
-Kings,1502,U.S. Senate,,DEM,Kamala Harris,43
-Kings,1502,U.S. Senate,,DEM,Loretta Sanchez,55
-Kings,1503,U.S. Senate,,DEM,Kamala Harris,144
-Kings,1503,U.S. Senate,,DEM,Loretta Sanchez,78
-Kings,1504,U.S. Senate,,DEM,Kamala Harris,88
-Kings,1504,U.S. Senate,,DEM,Loretta Sanchez,67
-Kings,1505,U.S. Senate,,DEM,Kamala Harris,70
-Kings,1505,U.S. Senate,,DEM,Loretta Sanchez,37
-Kings,1506,U.S. Senate,,DEM,Kamala Harris,3
-Kings,1506,U.S. Senate,,DEM,Loretta Sanchez,5
-Kings,1507,U.S. Senate,,DEM,Kamala Harris,55
-Kings,1507,U.S. Senate,,DEM,Loretta Sanchez,66
-Kings,1508,U.S. Senate,,DEM,Kamala Harris,15
-Kings,1508,U.S. Senate,,DEM,Loretta Sanchez,30
-Kings,1509,U.S. Senate,,DEM,Kamala Harris,24
-Kings,1509,U.S. Senate,,DEM,Loretta Sanchez,45
-Kings,1510,U.S. Senate,,DEM,Kamala Harris,0
-Kings,1510,U.S. Senate,,DEM,Loretta Sanchez,0
-Kings,1511,U.S. Senate,,DEM,Kamala Harris,80
-Kings,1511,U.S. Senate,,DEM,Loretta Sanchez,76
-Kings,1512,U.S. Senate,,DEM,Kamala Harris,39
-Kings,1512,U.S. Senate,,DEM,Loretta Sanchez,33
-Kings,1513,U.S. Senate,,DEM,Kamala Harris,97
-Kings,1513,U.S. Senate,,DEM,Loretta Sanchez,58
-Kings,1514,U.S. Senate,,DEM,Kamala Harris,2
-Kings,1514,U.S. Senate,,DEM,Loretta Sanchez,0
-Kings,1515,U.S. Senate,,DEM,Kamala Harris,72
-Kings,1515,U.S. Senate,,DEM,Loretta Sanchez,61
-Kings,1516,U.S. Senate,,DEM,Kamala Harris,87
-Kings,1516,U.S. Senate,,DEM,Loretta Sanchez,69
-Kings,1517,U.S. Senate,,DEM,Kamala Harris,88
-Kings,1517,U.S. Senate,,DEM,Loretta Sanchez,75
-Kings,1518,U.S. Senate,,DEM,Kamala Harris,59
-Kings,1518,U.S. Senate,,DEM,Loretta Sanchez,40
-Kings,1519,U.S. Senate,,DEM,Kamala Harris,4
-Kings,1519,U.S. Senate,,DEM,Loretta Sanchez,2
-Kings,1520,U.S. Senate,,DEM,Kamala Harris,55
-Kings,1520,U.S. Senate,,DEM,Loretta Sanchez,69
-Kings,1521,U.S. Senate,,DEM,Kamala Harris,34
-Kings,1521,U.S. Senate,,DEM,Loretta Sanchez,40
-Kings,1522,U.S. Senate,,DEM,Kamala Harris,1
-Kings,1522,U.S. Senate,,DEM,Loretta Sanchez,3
-Kings,1523,U.S. Senate,,DEM,Kamala Harris,15
-Kings,1523,U.S. Senate,,DEM,Loretta Sanchez,8
-Kings,1524,U.S. Senate,,DEM,Kamala Harris,59
-Kings,1524,U.S. Senate,,DEM,Loretta Sanchez,70
-Kings,1525,U.S. Senate,,DEM,Kamala Harris,42
-Kings,1525,U.S. Senate,,DEM,Loretta Sanchez,41
-Kings,1526,U.S. Senate,,DEM,Kamala Harris,10
-Kings,1526,U.S. Senate,,DEM,Loretta Sanchez,3
-Kings,1527,U.S. Senate,,DEM,Kamala Harris,10
-Kings,1527,U.S. Senate,,DEM,Loretta Sanchez,2
-Kings,1528,U.S. Senate,,DEM,Kamala Harris,1
-Kings,1528,U.S. Senate,,DEM,Loretta Sanchez,0
-Kings,1529,U.S. Senate,,DEM,Kamala Harris,3
-Kings,1529,U.S. Senate,,DEM,Loretta Sanchez,3
-Kings,1530,U.S. Senate,,DEM,Kamala Harris,51
-Kings,1530,U.S. Senate,,DEM,Loretta Sanchez,44
-Kings,1531,U.S. Senate,,DEM,Kamala Harris,0
-Kings,1531,U.S. Senate,,DEM,Loretta Sanchez,0
-Kings,1532,U.S. Senate,,DEM,Kamala Harris,57
-Kings,1532,U.S. Senate,,DEM,Loretta Sanchez,43
-Kings,1533,U.S. Senate,,DEM,Kamala Harris,3
-Kings,1533,U.S. Senate,,DEM,Loretta Sanchez,11
-Kings,1534,U.S. Senate,,DEM,Kamala Harris,32
-Kings,1534,U.S. Senate,,DEM,Loretta Sanchez,20
-Kings,1535,U.S. Senate,,DEM,Kamala Harris,39
-Kings,1535,U.S. Senate,,DEM,Loretta Sanchez,26
-Kings,1536,U.S. Senate,,DEM,Kamala Harris,5
-Kings,1536,U.S. Senate,,DEM,Loretta Sanchez,23
-Kings,1537,U.S. Senate,,DEM,Kamala Harris,67
-Kings,1537,U.S. Senate,,DEM,Loretta Sanchez,54
-Kings,1538,U.S. Senate,,DEM,Kamala Harris,20
-Kings,1538,U.S. Senate,,DEM,Loretta Sanchez,11
-Kings,1539,U.S. Senate,,DEM,Kamala Harris,30
-Kings,1539,U.S. Senate,,DEM,Loretta Sanchez,35
-Kings,1540,U.S. Senate,,DEM,Kamala Harris,70
-Kings,1540,U.S. Senate,,DEM,Loretta Sanchez,55
-Kings,1541,U.S. Senate,,DEM,Kamala Harris,16
-Kings,1541,U.S. Senate,,DEM,Loretta Sanchez,7
-Kings,1542,U.S. Senate,,DEM,Kamala Harris,8
-Kings,1542,U.S. Senate,,DEM,Loretta Sanchez,2
+Kings,101,U.S. Senate,,DEM,Kamala D. Harris,306
+Kings,101,U.S. Senate,,DEM,Loretta L. Sanchez,212
+Kings,102,U.S. Senate,,DEM,Kamala D. Harris,339
+Kings,102,U.S. Senate,,DEM,Loretta L. Sanchez,361
+Kings,103,U.S. Senate,,DEM,Kamala D. Harris,677
+Kings,103,U.S. Senate,,DEM,Loretta L. Sanchez,512
+Kings,104,U.S. Senate,,DEM,Kamala D. Harris,136
+Kings,104,U.S. Senate,,DEM,Loretta L. Sanchez,104
+Kings,105,U.S. Senate,,DEM,Kamala D. Harris,128
+Kings,105,U.S. Senate,,DEM,Loretta L. Sanchez,114
+Kings,106,U.S. Senate,,DEM,Kamala D. Harris,355
+Kings,106,U.S. Senate,,DEM,Loretta L. Sanchez,248
+Kings,107,U.S. Senate,,DEM,Kamala D. Harris,212
+Kings,107,U.S. Senate,,DEM,Loretta L. Sanchez,162
+Kings,108,U.S. Senate,,DEM,Kamala D. Harris,89
+Kings,108,U.S. Senate,,DEM,Loretta L. Sanchez,103
+Kings,201,U.S. Senate,,DEM,Kamala D. Harris,168
+Kings,201,U.S. Senate,,DEM,Loretta L. Sanchez,169
+Kings,202,U.S. Senate,,DEM,Kamala D. Harris,204
+Kings,202,U.S. Senate,,DEM,Loretta L. Sanchez,252
+Kings,203,U.S. Senate,,DEM,Kamala D. Harris,303
+Kings,203,U.S. Senate,,DEM,Loretta L. Sanchez,590
+Kings,204,U.S. Senate,,DEM,Kamala D. Harris,192
+Kings,204,U.S. Senate,,DEM,Loretta L. Sanchez,360
+Kings,205,U.S. Senate,,DEM,Kamala D. Harris,153
+Kings,205,U.S. Senate,,DEM,Loretta L. Sanchez,240
+Kings,301,U.S. Senate,,DEM,Kamala D. Harris,510
+Kings,301,U.S. Senate,,DEM,Loretta L. Sanchez,314
+Kings,302,U.S. Senate,,DEM,Kamala D. Harris,366
+Kings,302,U.S. Senate,,DEM,Loretta L. Sanchez,278
+Kings,303,U.S. Senate,,DEM,Kamala D. Harris,381
+Kings,303,U.S. Senate,,DEM,Loretta L. Sanchez,248
+Kings,304,U.S. Senate,,DEM,Kamala D. Harris,311
+Kings,304,U.S. Senate,,DEM,Loretta L. Sanchez,210
+Kings,305,U.S. Senate,,DEM,Kamala D. Harris,162
+Kings,305,U.S. Senate,,DEM,Loretta L. Sanchez,124
+Kings,306,U.S. Senate,,DEM,Kamala D. Harris,190
+Kings,306,U.S. Senate,,DEM,Loretta L. Sanchez,164
+Kings,307,U.S. Senate,,DEM,Kamala D. Harris,432
+Kings,307,U.S. Senate,,DEM,Loretta L. Sanchez,304
+Kings,308,U.S. Senate,,DEM,Kamala D. Harris,205
+Kings,308,U.S. Senate,,DEM,Loretta L. Sanchez,158
+Kings,309,U.S. Senate,,DEM,Kamala D. Harris,209
+Kings,309,U.S. Senate,,DEM,Loretta L. Sanchez,199
+Kings,401,U.S. Senate,,DEM,Kamala D. Harris,424
+Kings,401,U.S. Senate,,DEM,Loretta L. Sanchez,325
+Kings,402,U.S. Senate,,DEM,Kamala D. Harris,401
+Kings,402,U.S. Senate,,DEM,Loretta L. Sanchez,298
+Kings,403,U.S. Senate,,DEM,Kamala D. Harris,222
+Kings,403,U.S. Senate,,DEM,Loretta L. Sanchez,138
+Kings,404,U.S. Senate,,DEM,Kamala D. Harris,81
+Kings,404,U.S. Senate,,DEM,Loretta L. Sanchez,93
+Kings,405,U.S. Senate,,DEM,Kamala D. Harris,409
+Kings,405,U.S. Senate,,DEM,Loretta L. Sanchez,436
+Kings,406,U.S. Senate,,DEM,Kamala D. Harris,125
+Kings,406,U.S. Senate,,DEM,Loretta L. Sanchez,227
+Kings,407,U.S. Senate,,DEM,Kamala D. Harris,220
+Kings,407,U.S. Senate,,DEM,Loretta L. Sanchez,201
+Kings,501,U.S. Senate,,DEM,Kamala D. Harris,192
+Kings,501,U.S. Senate,,DEM,Loretta L. Sanchez,147
+Kings,502,U.S. Senate,,DEM,Kamala D. Harris,355
+Kings,502,U.S. Senate,,DEM,Loretta L. Sanchez,269
+Kings,503,U.S. Senate,,DEM,Kamala D. Harris,643
+Kings,503,U.S. Senate,,DEM,Loretta L. Sanchez,486
+Kings,504,U.S. Senate,,DEM,Kamala D. Harris,452
+Kings,504,U.S. Senate,,DEM,Loretta L. Sanchez,307
+Kings,505,U.S. Senate,,DEM,Kamala D. Harris,616
+Kings,505,U.S. Senate,,DEM,Loretta L. Sanchez,460
+Kings,1101,U.S. Senate,,DEM,Kamala D. Harris,104
+Kings,1101,U.S. Senate,,DEM,Loretta L. Sanchez,78
+Kings,1102,U.S. Senate,,DEM,Kamala D. Harris,5
+Kings,1102,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Kings,1103,U.S. Senate,,DEM,Kamala D. Harris,41
+Kings,1103,U.S. Senate,,DEM,Loretta L. Sanchez,45
+Kings,1104,U.S. Senate,,DEM,Kamala D. Harris,3
+Kings,1104,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Kings,1105,U.S. Senate,,DEM,Kamala D. Harris,109
+Kings,1105,U.S. Senate,,DEM,Loretta L. Sanchez,75
+Kings,1106,U.S. Senate,,DEM,Kamala D. Harris,47
+Kings,1106,U.S. Senate,,DEM,Loretta L. Sanchez,30
+Kings,1107,U.S. Senate,,DEM,Kamala D. Harris,10
+Kings,1107,U.S. Senate,,DEM,Loretta L. Sanchez,25
+Kings,1108,U.S. Senate,,DEM,Kamala D. Harris,30
+Kings,1108,U.S. Senate,,DEM,Loretta L. Sanchez,33
+Kings,1201,U.S. Senate,,DEM,Kamala D. Harris,0
+Kings,1201,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Kings,1202,U.S. Senate,,DEM,Kamala D. Harris,1
+Kings,1202,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Kings,1203,U.S. Senate,,DEM,Kamala D. Harris,0
+Kings,1203,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Kings,1204,U.S. Senate,,DEM,Kamala D. Harris,41
+Kings,1204,U.S. Senate,,DEM,Loretta L. Sanchez,59
+Kings,1205,U.S. Senate,,DEM,Kamala D. Harris,0
+Kings,1205,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Kings,1206,U.S. Senate,,DEM,Kamala D. Harris,26
+Kings,1206,U.S. Senate,,DEM,Loretta L. Sanchez,29
+Kings,1207,U.S. Senate,,DEM,Kamala D. Harris,32
+Kings,1207,U.S. Senate,,DEM,Loretta L. Sanchez,32
+Kings,1208,U.S. Senate,,DEM,Kamala D. Harris,41
+Kings,1208,U.S. Senate,,DEM,Loretta L. Sanchez,33
+Kings,1209,U.S. Senate,,DEM,Kamala D. Harris,57
+Kings,1209,U.S. Senate,,DEM,Loretta L. Sanchez,54
+Kings,1210,U.S. Senate,,DEM,Kamala D. Harris,5
+Kings,1210,U.S. Senate,,DEM,Loretta L. Sanchez,14
+Kings,1211,U.S. Senate,,DEM,Kamala D. Harris,3
+Kings,1211,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Kings,1212,U.S. Senate,,DEM,Kamala D. Harris,2
+Kings,1212,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Kings,1213,U.S. Senate,,DEM,Kamala D. Harris,72
+Kings,1213,U.S. Senate,,DEM,Loretta L. Sanchez,57
+Kings,1214,U.S. Senate,,DEM,Kamala D. Harris,45
+Kings,1214,U.S. Senate,,DEM,Loretta L. Sanchez,63
+Kings,1215,U.S. Senate,,DEM,Kamala D. Harris,47
+Kings,1215,U.S. Senate,,DEM,Loretta L. Sanchez,29
+Kings,1216,U.S. Senate,,DEM,Kamala D. Harris,46
+Kings,1216,U.S. Senate,,DEM,Loretta L. Sanchez,60
+Kings,1217,U.S. Senate,,DEM,Kamala D. Harris,33
+Kings,1217,U.S. Senate,,DEM,Loretta L. Sanchez,28
+Kings,1218,U.S. Senate,,DEM,Kamala D. Harris,23
+Kings,1218,U.S. Senate,,DEM,Loretta L. Sanchez,12
+Kings,1219,U.S. Senate,,DEM,Kamala D. Harris,16
+Kings,1219,U.S. Senate,,DEM,Loretta L. Sanchez,26
+Kings,1220,U.S. Senate,,DEM,Kamala D. Harris,2
+Kings,1220,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Kings,1221,U.S. Senate,,DEM,Kamala D. Harris,1
+Kings,1221,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Kings,1222,U.S. Senate,,DEM,Kamala D. Harris,1
+Kings,1222,U.S. Senate,,DEM,Loretta L. Sanchez,7
+Kings,1223,U.S. Senate,,DEM,Kamala D. Harris,0
+Kings,1223,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Kings,1224,U.S. Senate,,DEM,Kamala D. Harris,0
+Kings,1224,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Kings,1225,U.S. Senate,,DEM,Kamala D. Harris,8
+Kings,1225,U.S. Senate,,DEM,Loretta L. Sanchez,15
+Kings,1226,U.S. Senate,,DEM,Kamala D. Harris,4
+Kings,1226,U.S. Senate,,DEM,Loretta L. Sanchez,24
+Kings,1227,U.S. Senate,,DEM,Kamala D. Harris,1
+Kings,1227,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Kings,1228,U.S. Senate,,DEM,Kamala D. Harris,25
+Kings,1228,U.S. Senate,,DEM,Loretta L. Sanchez,39
+Kings,1229,U.S. Senate,,DEM,Kamala D. Harris,0
+Kings,1229,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Kings,1230,U.S. Senate,,DEM,Kamala D. Harris,0
+Kings,1230,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Kings,1231,U.S. Senate,,DEM,Kamala D. Harris,37
+Kings,1231,U.S. Senate,,DEM,Loretta L. Sanchez,77
+Kings,1232,U.S. Senate,,DEM,Kamala D. Harris,6
+Kings,1232,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Kings,1233,U.S. Senate,,DEM,Kamala D. Harris,0
+Kings,1233,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Kings,1234,U.S. Senate,,DEM,Kamala D. Harris,22
+Kings,1234,U.S. Senate,,DEM,Loretta L. Sanchez,36
+Kings,1235,U.S. Senate,,DEM,Kamala D. Harris,15
+Kings,1235,U.S. Senate,,DEM,Loretta L. Sanchez,6
+Kings,1301,U.S. Senate,,DEM,Kamala D. Harris,69
+Kings,1301,U.S. Senate,,DEM,Loretta L. Sanchez,51
+Kings,1302,U.S. Senate,,DEM,Kamala D. Harris,112
+Kings,1302,U.S. Senate,,DEM,Loretta L. Sanchez,85
+Kings,1303,U.S. Senate,,DEM,Kamala D. Harris,21
+Kings,1303,U.S. Senate,,DEM,Loretta L. Sanchez,31
+Kings,1304,U.S. Senate,,DEM,Kamala D. Harris,0
+Kings,1304,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Kings,1305,U.S. Senate,,DEM,Kamala D. Harris,46
+Kings,1305,U.S. Senate,,DEM,Loretta L. Sanchez,63
+Kings,1306,U.S. Senate,,DEM,Kamala D. Harris,55
+Kings,1306,U.S. Senate,,DEM,Loretta L. Sanchez,82
+Kings,1307,U.S. Senate,,DEM,Kamala D. Harris,64
+Kings,1307,U.S. Senate,,DEM,Loretta L. Sanchez,77
+Kings,1308,U.S. Senate,,DEM,Kamala D. Harris,97
+Kings,1308,U.S. Senate,,DEM,Loretta L. Sanchez,73
+Kings,1309,U.S. Senate,,DEM,Kamala D. Harris,23
+Kings,1309,U.S. Senate,,DEM,Loretta L. Sanchez,26
+Kings,1310,U.S. Senate,,DEM,Kamala D. Harris,10
+Kings,1310,U.S. Senate,,DEM,Loretta L. Sanchez,13
+Kings,1311,U.S. Senate,,DEM,Kamala D. Harris,77
+Kings,1311,U.S. Senate,,DEM,Loretta L. Sanchez,93
+Kings,1312,U.S. Senate,,DEM,Kamala D. Harris,69
+Kings,1312,U.S. Senate,,DEM,Loretta L. Sanchez,55
+Kings,1313,U.S. Senate,,DEM,Kamala D. Harris,10
+Kings,1313,U.S. Senate,,DEM,Loretta L. Sanchez,18
+Kings,1314,U.S. Senate,,DEM,Kamala D. Harris,2
+Kings,1314,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Kings,1315,U.S. Senate,,DEM,Kamala D. Harris,57
+Kings,1315,U.S. Senate,,DEM,Loretta L. Sanchez,44
+Kings,1316,U.S. Senate,,DEM,Kamala D. Harris,8
+Kings,1316,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Kings,1317,U.S. Senate,,DEM,Kamala D. Harris,11
+Kings,1317,U.S. Senate,,DEM,Loretta L. Sanchez,12
+Kings,1318,U.S. Senate,,DEM,Kamala D. Harris,70
+Kings,1318,U.S. Senate,,DEM,Loretta L. Sanchez,62
+Kings,1319,U.S. Senate,,DEM,Kamala D. Harris,0
+Kings,1319,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Kings,1320,U.S. Senate,,DEM,Kamala D. Harris,9
+Kings,1320,U.S. Senate,,DEM,Loretta L. Sanchez,8
+Kings,1321,U.S. Senate,,DEM,Kamala D. Harris,0
+Kings,1321,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Kings,1322,U.S. Senate,,DEM,Kamala D. Harris,30
+Kings,1322,U.S. Senate,,DEM,Loretta L. Sanchez,15
+Kings,1323,U.S. Senate,,DEM,Kamala D. Harris,2
+Kings,1323,U.S. Senate,,DEM,Loretta L. Sanchez,5
+Kings,1324,U.S. Senate,,DEM,Kamala D. Harris,16
+Kings,1324,U.S. Senate,,DEM,Loretta L. Sanchez,23
+Kings,1325,U.S. Senate,,DEM,Kamala D. Harris,8
+Kings,1325,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Kings,1326,U.S. Senate,,DEM,Kamala D. Harris,26
+Kings,1326,U.S. Senate,,DEM,Loretta L. Sanchez,41
+Kings,1327,U.S. Senate,,DEM,Kamala D. Harris,8
+Kings,1327,U.S. Senate,,DEM,Loretta L. Sanchez,13
+Kings,1401,U.S. Senate,,DEM,Kamala D. Harris,10
+Kings,1401,U.S. Senate,,DEM,Loretta L. Sanchez,8
+Kings,1402,U.S. Senate,,DEM,Kamala D. Harris,37
+Kings,1402,U.S. Senate,,DEM,Loretta L. Sanchez,28
+Kings,1403,U.S. Senate,,DEM,Kamala D. Harris,41
+Kings,1403,U.S. Senate,,DEM,Loretta L. Sanchez,55
+Kings,1404,U.S. Senate,,DEM,Kamala D. Harris,12
+Kings,1404,U.S. Senate,,DEM,Loretta L. Sanchez,16
+Kings,1405,U.S. Senate,,DEM,Kamala D. Harris,13
+Kings,1405,U.S. Senate,,DEM,Loretta L. Sanchez,14
+Kings,1406,U.S. Senate,,DEM,Kamala D. Harris,73
+Kings,1406,U.S. Senate,,DEM,Loretta L. Sanchez,55
+Kings,1407,U.S. Senate,,DEM,Kamala D. Harris,52
+Kings,1407,U.S. Senate,,DEM,Loretta L. Sanchez,58
+Kings,1408,U.S. Senate,,DEM,Kamala D. Harris,32
+Kings,1408,U.S. Senate,,DEM,Loretta L. Sanchez,40
+Kings,1409,U.S. Senate,,DEM,Kamala D. Harris,64
+Kings,1409,U.S. Senate,,DEM,Loretta L. Sanchez,93
+Kings,1410,U.S. Senate,,DEM,Kamala D. Harris,85
+Kings,1410,U.S. Senate,,DEM,Loretta L. Sanchez,91
+Kings,1411,U.S. Senate,,DEM,Kamala D. Harris,37
+Kings,1411,U.S. Senate,,DEM,Loretta L. Sanchez,46
+Kings,1412,U.S. Senate,,DEM,Kamala D. Harris,108
+Kings,1412,U.S. Senate,,DEM,Loretta L. Sanchez,109
+Kings,1413,U.S. Senate,,DEM,Kamala D. Harris,95
+Kings,1413,U.S. Senate,,DEM,Loretta L. Sanchez,60
+Kings,1414,U.S. Senate,,DEM,Kamala D. Harris,3
+Kings,1414,U.S. Senate,,DEM,Loretta L. Sanchez,13
+Kings,1415,U.S. Senate,,DEM,Kamala D. Harris,50
+Kings,1415,U.S. Senate,,DEM,Loretta L. Sanchez,49
+Kings,1416,U.S. Senate,,DEM,Kamala D. Harris,2
+Kings,1416,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Kings,1417,U.S. Senate,,DEM,Kamala D. Harris,2
+Kings,1417,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Kings,1418,U.S. Senate,,DEM,Kamala D. Harris,9
+Kings,1418,U.S. Senate,,DEM,Loretta L. Sanchez,9
+Kings,1419,U.S. Senate,,DEM,Kamala D. Harris,50
+Kings,1419,U.S. Senate,,DEM,Loretta L. Sanchez,53
+Kings,1420,U.S. Senate,,DEM,Kamala D. Harris,40
+Kings,1420,U.S. Senate,,DEM,Loretta L. Sanchez,55
+Kings,1421,U.S. Senate,,DEM,Kamala D. Harris,5
+Kings,1421,U.S. Senate,,DEM,Loretta L. Sanchez,6
+Kings,1422,U.S. Senate,,DEM,Kamala D. Harris,19
+Kings,1422,U.S. Senate,,DEM,Loretta L. Sanchez,23
+Kings,1423,U.S. Senate,,DEM,Kamala D. Harris,6
+Kings,1423,U.S. Senate,,DEM,Loretta L. Sanchez,8
+Kings,1424,U.S. Senate,,DEM,Kamala D. Harris,5
+Kings,1424,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Kings,1425,U.S. Senate,,DEM,Kamala D. Harris,3
+Kings,1425,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Kings,1426,U.S. Senate,,DEM,Kamala D. Harris,13
+Kings,1426,U.S. Senate,,DEM,Loretta L. Sanchez,18
+Kings,1427,U.S. Senate,,DEM,Kamala D. Harris,19
+Kings,1427,U.S. Senate,,DEM,Loretta L. Sanchez,39
+Kings,1428,U.S. Senate,,DEM,Kamala D. Harris,22
+Kings,1428,U.S. Senate,,DEM,Loretta L. Sanchez,15
+Kings,1429,U.S. Senate,,DEM,Kamala D. Harris,12
+Kings,1429,U.S. Senate,,DEM,Loretta L. Sanchez,17
+Kings,1430,U.S. Senate,,DEM,Kamala D. Harris,0
+Kings,1430,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Kings,1431,U.S. Senate,,DEM,Kamala D. Harris,5
+Kings,1431,U.S. Senate,,DEM,Loretta L. Sanchez,5
+Kings,1432,U.S. Senate,,DEM,Kamala D. Harris,11
+Kings,1432,U.S. Senate,,DEM,Loretta L. Sanchez,9
+Kings,1433,U.S. Senate,,DEM,Kamala D. Harris,8
+Kings,1433,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Kings,1434,U.S. Senate,,DEM,Kamala D. Harris,52
+Kings,1434,U.S. Senate,,DEM,Loretta L. Sanchez,31
+Kings,1435,U.S. Senate,,DEM,Kamala D. Harris,22
+Kings,1435,U.S. Senate,,DEM,Loretta L. Sanchez,16
+Kings,1436,U.S. Senate,,DEM,Kamala D. Harris,0
+Kings,1436,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Kings,1501,U.S. Senate,,DEM,Kamala D. Harris,11
+Kings,1501,U.S. Senate,,DEM,Loretta L. Sanchez,5
+Kings,1502,U.S. Senate,,DEM,Kamala D. Harris,43
+Kings,1502,U.S. Senate,,DEM,Loretta L. Sanchez,55
+Kings,1503,U.S. Senate,,DEM,Kamala D. Harris,144
+Kings,1503,U.S. Senate,,DEM,Loretta L. Sanchez,78
+Kings,1504,U.S. Senate,,DEM,Kamala D. Harris,88
+Kings,1504,U.S. Senate,,DEM,Loretta L. Sanchez,67
+Kings,1505,U.S. Senate,,DEM,Kamala D. Harris,70
+Kings,1505,U.S. Senate,,DEM,Loretta L. Sanchez,37
+Kings,1506,U.S. Senate,,DEM,Kamala D. Harris,3
+Kings,1506,U.S. Senate,,DEM,Loretta L. Sanchez,5
+Kings,1507,U.S. Senate,,DEM,Kamala D. Harris,55
+Kings,1507,U.S. Senate,,DEM,Loretta L. Sanchez,66
+Kings,1508,U.S. Senate,,DEM,Kamala D. Harris,15
+Kings,1508,U.S. Senate,,DEM,Loretta L. Sanchez,30
+Kings,1509,U.S. Senate,,DEM,Kamala D. Harris,24
+Kings,1509,U.S. Senate,,DEM,Loretta L. Sanchez,45
+Kings,1510,U.S. Senate,,DEM,Kamala D. Harris,0
+Kings,1510,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Kings,1511,U.S. Senate,,DEM,Kamala D. Harris,80
+Kings,1511,U.S. Senate,,DEM,Loretta L. Sanchez,76
+Kings,1512,U.S. Senate,,DEM,Kamala D. Harris,39
+Kings,1512,U.S. Senate,,DEM,Loretta L. Sanchez,33
+Kings,1513,U.S. Senate,,DEM,Kamala D. Harris,97
+Kings,1513,U.S. Senate,,DEM,Loretta L. Sanchez,58
+Kings,1514,U.S. Senate,,DEM,Kamala D. Harris,2
+Kings,1514,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Kings,1515,U.S. Senate,,DEM,Kamala D. Harris,72
+Kings,1515,U.S. Senate,,DEM,Loretta L. Sanchez,61
+Kings,1516,U.S. Senate,,DEM,Kamala D. Harris,87
+Kings,1516,U.S. Senate,,DEM,Loretta L. Sanchez,69
+Kings,1517,U.S. Senate,,DEM,Kamala D. Harris,88
+Kings,1517,U.S. Senate,,DEM,Loretta L. Sanchez,75
+Kings,1518,U.S. Senate,,DEM,Kamala D. Harris,59
+Kings,1518,U.S. Senate,,DEM,Loretta L. Sanchez,40
+Kings,1519,U.S. Senate,,DEM,Kamala D. Harris,4
+Kings,1519,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Kings,1520,U.S. Senate,,DEM,Kamala D. Harris,55
+Kings,1520,U.S. Senate,,DEM,Loretta L. Sanchez,69
+Kings,1521,U.S. Senate,,DEM,Kamala D. Harris,34
+Kings,1521,U.S. Senate,,DEM,Loretta L. Sanchez,40
+Kings,1522,U.S. Senate,,DEM,Kamala D. Harris,1
+Kings,1522,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Kings,1523,U.S. Senate,,DEM,Kamala D. Harris,15
+Kings,1523,U.S. Senate,,DEM,Loretta L. Sanchez,8
+Kings,1524,U.S. Senate,,DEM,Kamala D. Harris,59
+Kings,1524,U.S. Senate,,DEM,Loretta L. Sanchez,70
+Kings,1525,U.S. Senate,,DEM,Kamala D. Harris,42
+Kings,1525,U.S. Senate,,DEM,Loretta L. Sanchez,41
+Kings,1526,U.S. Senate,,DEM,Kamala D. Harris,10
+Kings,1526,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Kings,1527,U.S. Senate,,DEM,Kamala D. Harris,10
+Kings,1527,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Kings,1528,U.S. Senate,,DEM,Kamala D. Harris,1
+Kings,1528,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Kings,1529,U.S. Senate,,DEM,Kamala D. Harris,3
+Kings,1529,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Kings,1530,U.S. Senate,,DEM,Kamala D. Harris,51
+Kings,1530,U.S. Senate,,DEM,Loretta L. Sanchez,44
+Kings,1531,U.S. Senate,,DEM,Kamala D. Harris,0
+Kings,1531,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Kings,1532,U.S. Senate,,DEM,Kamala D. Harris,57
+Kings,1532,U.S. Senate,,DEM,Loretta L. Sanchez,43
+Kings,1533,U.S. Senate,,DEM,Kamala D. Harris,3
+Kings,1533,U.S. Senate,,DEM,Loretta L. Sanchez,11
+Kings,1534,U.S. Senate,,DEM,Kamala D. Harris,32
+Kings,1534,U.S. Senate,,DEM,Loretta L. Sanchez,20
+Kings,1535,U.S. Senate,,DEM,Kamala D. Harris,39
+Kings,1535,U.S. Senate,,DEM,Loretta L. Sanchez,26
+Kings,1536,U.S. Senate,,DEM,Kamala D. Harris,5
+Kings,1536,U.S. Senate,,DEM,Loretta L. Sanchez,23
+Kings,1537,U.S. Senate,,DEM,Kamala D. Harris,67
+Kings,1537,U.S. Senate,,DEM,Loretta L. Sanchez,54
+Kings,1538,U.S. Senate,,DEM,Kamala D. Harris,20
+Kings,1538,U.S. Senate,,DEM,Loretta L. Sanchez,11
+Kings,1539,U.S. Senate,,DEM,Kamala D. Harris,30
+Kings,1539,U.S. Senate,,DEM,Loretta L. Sanchez,35
+Kings,1540,U.S. Senate,,DEM,Kamala D. Harris,70
+Kings,1540,U.S. Senate,,DEM,Loretta L. Sanchez,55
+Kings,1541,U.S. Senate,,DEM,Kamala D. Harris,16
+Kings,1541,U.S. Senate,,DEM,Loretta L. Sanchez,7
+Kings,1542,U.S. Senate,,DEM,Kamala D. Harris,8
+Kings,1542,U.S. Senate,,DEM,Loretta L. Sanchez,2

--- a/2016/20161108__ca__general__lake__precinct.csv
+++ b/2016/20161108__ca__general__lake__precinct.csv
@@ -2799,143 +2799,143 @@ Lake,WHEELER_POINT,Proposition 67,,N/A,Yes,293
 Lake,WHEELER_POINT,Proposition 67,,N/A,No,293
 Lake,W_PINE_HOBERGS,Proposition 67,,N/A,Yes,370
 Lake,W_PINE_HOBERGS,Proposition 67,,N/A,No,226
-Lake,ADOBE,U.S. Senate,,DEM,Kamala Harris,198
-Lake,ADOBE,U.S. Senate,,DEM,Loretta Sanchez,120
-Lake,BACHELOR,U.S. Senate,,DEM,Kamala Harris,258
-Lake,BACHELOR,U.S. Senate,,DEM,Loretta Sanchez,148
-Lake,BALD_MTN,U.S. Senate,,DEM,Kamala Harris,4
-Lake,BALD_MTN,U.S. Senate,,DEM,Loretta Sanchez,1
-Lake,BALLY_PEAK,U.S. Senate,,DEM,Kamala Harris,4
-Lake,BALLY_PEAK,U.S. Senate,,DEM,Loretta Sanchez,2
-Lake,BARTLETT,U.S. Senate,,DEM,Kamala Harris,2
-Lake,BARTLETT,U.S. Senate,,DEM,Loretta Sanchez,2
-Lake,BELL_PARK,U.S. Senate,,DEM,Kamala Harris,45
-Lake,BELL_PARK,U.S. Senate,,DEM,Loretta Sanchez,17
-Lake,BIG_VALLEY,U.S. Senate,,DEM,Kamala Harris,154
-Lake,BIG_VALLEY,U.S. Senate,,DEM,Loretta Sanchez,92
-Lake,BUCK_ISLAND,U.S. Senate,,DEM,Kamala Harris,0
-Lake,BUCK_ISLAND,U.S. Senate,,DEM,Loretta Sanchez,0
-Lake,CENTRAL_PARK,U.S. Senate,,DEM,Kamala Harris,164
-Lake,CENTRAL_PARK,U.S. Senate,,DEM,Loretta Sanchez,98
-Lake,CL_AUSTIN_PARK,U.S. Senate,,DEM,Kamala Harris,280
-Lake,CL_AUSTIN_PARK,U.S. Senate,,DEM,Loretta Sanchez,160
-Lake,CL_BURNS_VALLEY,U.S. Senate,,DEM,Kamala Harris,278
-Lake,CL_BURNS_VALLEY,U.S. Senate,,DEM,Loretta Sanchez,136
-Lake,CL_DAVIS,U.S. Senate,,DEM,Kamala Harris,262
-Lake,CL_DAVIS,U.S. Senate,,DEM,Loretta Sanchez,139
-Lake,CL_MOLESWORTH,U.S. Senate,,DEM,Kamala Harris,269
-Lake,CL_MOLESWORTH,U.S. Senate,,DEM,Loretta Sanchez,137
-Lake,CL_MONITOR_PT,U.S. Senate,,DEM,Kamala Harris,301
-Lake,CL_MONITOR_PT,U.S. Senate,,DEM,Loretta Sanchez,172
-Lake,CL_PALMER,U.S. Senate,,DEM,Kamala Harris,274
-Lake,CL_PALMER,U.S. Senate,,DEM,Loretta Sanchez,119
-Lake,CL_PIERCE,U.S. Senate,,DEM,Kamala Harris,232
-Lake,CL_PIERCE,U.S. Senate,,DEM,Loretta Sanchez,142
-Lake,CL_REDBUD,U.S. Senate,,DEM,Kamala Harris,189
-Lake,CL_REDBUD,U.S. Senate,,DEM,Loretta Sanchez,101
-Lake,CL_VILLAGE,U.S. Senate,,DEM,Kamala Harris,158
-Lake,CL_VILLAGE,U.S. Senate,,DEM,Loretta Sanchez,73
-Lake,COLE_CREEK,U.S. Senate,,DEM,Kamala Harris,247
-Lake,COLE_CREEK,U.S. Senate,,DEM,Loretta Sanchez,174
-Lake,COW_MTN,U.S. Senate,,DEM,Kamala Harris,191
-Lake,COW_MTN,U.S. Senate,,DEM,Loretta Sanchez,85
-Lake,COYOTE_VALLEY,U.S. Senate,,DEM,Kamala Harris,39
-Lake,COYOTE_VALLEY,U.S. Senate,,DEM,Loretta Sanchez,29
-Lake,DONOVAN_VALLEY,U.S. Senate,,DEM,Kamala Harris,12
-Lake,DONOVAN_VALLEY,U.S. Senate,,DEM,Loretta Sanchez,20
-Lake,EAST_LAKE,U.S. Senate,,DEM,Kamala Harris,162
-Lake,EAST_LAKE,U.S. Senate,,DEM,Loretta Sanchez,107
-Lake,FORTY_SPRINGS,U.S. Senate,,DEM,Kamala Harris,10
-Lake,FORTY_SPRINGS,U.S. Senate,,DEM,Loretta Sanchez,0
-Lake,GLENBROOK,U.S. Senate,,DEM,Kamala Harris,220
-Lake,GLENBROOK,U.S. Senate,,DEM,Loretta Sanchez,94
-Lake,GLENHAVEN,U.S. Senate,,DEM,Kamala Harris,57
-Lake,GLENHAVEN,U.S. Senate,,DEM,Loretta Sanchez,24
-Lake,GRAVELLY,U.S. Senate,,DEM,Kamala Harris,18
-Lake,GRAVELLY,U.S. Senate,,DEM,Loretta Sanchez,9
-Lake,HIDDEN_VALLEY_1,U.S. Senate,,DEM,Kamala Harris,338
-Lake,HIDDEN_VALLEY_1,U.S. Senate,,DEM,Loretta Sanchez,180
-Lake,HIDDEN_VALLEY_2,U.S. Senate,,DEM,Kamala Harris,308
-Lake,HIDDEN_VALLEY_2,U.S. Senate,,DEM,Loretta Sanchez,115
-Lake,HIDDEN_VALLEY_3,U.S. Senate,,DEM,Kamala Harris,296
-Lake,HIDDEN_VALLEY_3,U.S. Senate,,DEM,Loretta Sanchez,151
-Lake,HIDDEN_VALLEY_4,U.S. Senate,,DEM,Kamala Harris,365
-Lake,HIDDEN_VALLEY_4,U.S. Senate,,DEM,Loretta Sanchez,150
-Lake,HIGHLAND_SPGS,U.S. Senate,,DEM,Kamala Harris,14
-Lake,HIGHLAND_SPGS,U.S. Senate,,DEM,Loretta Sanchez,12
-Lake,HV_RANCHOS,U.S. Senate,,DEM,Kamala Harris,83
-Lake,HV_RANCHOS,U.S. Senate,,DEM,Loretta Sanchez,27
-Lake,JERUSALEM,U.S. Senate,,DEM,Kamala Harris,10
-Lake,JERUSALEM,U.S. Senate,,DEM,Loretta Sanchez,3
-Lake,KELSEYVILLE,U.S. Senate,,DEM,Kamala Harris,228
-Lake,KELSEYVILLE,U.S. Senate,,DEM,Loretta Sanchez,156
-Lake,KELSEY_CREEK,U.S. Senate,,DEM,Kamala Harris,293
-Lake,KELSEY_CREEK,U.S. Senate,,DEM,Loretta Sanchez,158
-Lake,KEYS_EAST,U.S. Senate,,DEM,Kamala Harris,160
-Lake,KEYS_EAST,U.S. Senate,,DEM,Loretta Sanchez,75
-Lake,KEYS_WEST,U.S. Senate,,DEM,Kamala Harris,179
-Lake,KEYS_WEST,U.S. Senate,,DEM,Loretta Sanchez,82
-Lake,KONO_TAYEE,U.S. Senate,,DEM,Kamala Harris,221
-Lake,KONO_TAYEE,U.S. Senate,,DEM,Loretta Sanchez,113
-Lake,LAKESHORE_PARK,U.S. Senate,,DEM,Kamala Harris,65
-Lake,LAKESHORE_PARK,U.S. Senate,,DEM,Loretta Sanchez,32
-Lake,LAKESIDE_PARK,U.S. Senate,,DEM,Kamala Harris,51
-Lake,LAKESIDE_PARK,U.S. Senate,,DEM,Loretta Sanchez,25
-Lake,LANDS_END,U.S. Senate,,DEM,Kamala Harris,131
-Lake,LANDS_END,U.S. Senate,,DEM,Loretta Sanchez,83
-Lake,LITTLE_BORAX,U.S. Senate,,DEM,Kamala Harris,345
-Lake,LITTLE_BORAX,U.S. Senate,,DEM,Loretta Sanchez,136
-Lake,LOCH_LOMOND,U.S. Senate,,DEM,Kamala Harris,301
-Lake,LOCH_LOMOND,U.S. Senate,,DEM,Loretta Sanchez,150
-Lake,LONG_VALLEY,U.S. Senate,,DEM,Kamala Harris,247
-Lake,LONG_VALLEY,U.S. Senate,,DEM,Loretta Sanchez,131
-Lake,LOWER_LAKE,U.S. Senate,,DEM,Kamala Harris,198
-Lake,LOWER_LAKE,U.S. Senate,,DEM,Loretta Sanchez,100
-Lake,LP_FAIRGROUNDS,U.S. Senate,,DEM,Kamala Harris,296
-Lake,LP_FAIRGROUNDS,U.S. Senate,,DEM,Loretta Sanchez,160
-Lake,LP_GOVERNMENT,U.S. Senate,,DEM,Kamala Harris,271
-Lake,LP_GOVERNMENT,U.S. Senate,,DEM,Loretta Sanchez,120
-Lake,LP_LANGE,U.S. Senate,,DEM,Kamala Harris,261
-Lake,LP_LANGE,U.S. Senate,,DEM,Loretta Sanchez,145
-Lake,LP_WILLOW_TREE,U.S. Senate,,DEM,Kamala Harris,300
-Lake,LP_WILLOW_TREE,U.S. Senate,,DEM,Loretta Sanchez,177
-Lake,LUCERNE,U.S. Senate,,DEM,Kamala Harris,199
-Lake,LUCERNE,U.S. Senate,,DEM,Loretta Sanchez,97
-Lake,MIDDLETOWN,U.S. Senate,,DEM,Kamala Harris,246
-Lake,MIDDLETOWN,U.S. Senate,,DEM,Loretta Sanchez,156
-Lake,MORGAN_VALLEY,U.S. Senate,,DEM,Kamala Harris,19
-Lake,MORGAN_VALLEY,U.S. Senate,,DEM,Loretta Sanchez,11
-Lake,MOUNTAIN_PEAK,U.S. Senate,,DEM,Kamala Harris,317
-Lake,MOUNTAIN_PEAK,U.S. Senate,,DEM,Loretta Sanchez,190
-Lake,NICE,U.S. Senate,,DEM,Kamala Harris,287
-Lake,NICE,U.S. Senate,,DEM,Loretta Sanchez,140
-Lake,NICE_HARBOR,U.S. Senate,,DEM,Kamala Harris,219
-Lake,NICE_HARBOR,U.S. Senate,,DEM,Loretta Sanchez,117
-Lake,PERINI_HILL,U.S. Senate,,DEM,Kamala Harris,8
-Lake,PERINI_HILL,U.S. Senate,,DEM,Loretta Sanchez,2
-Lake,RIVIERA,U.S. Senate,,DEM,Kamala Harris,250
-Lake,RIVIERA,U.S. Senate,,DEM,Loretta Sanchez,148
-Lake,ROBIN_HILL,U.S. Senate,,DEM,Kamala Harris,356
-Lake,ROBIN_HILL,U.S. Senate,,DEM,Loretta Sanchez,219
-Lake,SCOTTS_VALLEY,U.S. Senate,,DEM,Kamala Harris,178
-Lake,SCOTTS_VALLEY,U.S. Senate,,DEM,Loretta Sanchez,106
-Lake,SODA_BAY,U.S. Senate,,DEM,Kamala Harris,268
-Lake,SODA_BAY,U.S. Senate,,DEM,Loretta Sanchez,127
-Lake,SPRUCE_GROVE,U.S. Senate,,DEM,Kamala Harris,90
-Lake,SPRUCE_GROVE,U.S. Senate,,DEM,Loretta Sanchez,43
-Lake,SULPHUR_PARK,U.S. Senate,,DEM,Kamala Harris,73
-Lake,SULPHUR_PARK,U.S. Senate,,DEM,Loretta Sanchez,43
-Lake,THE_CASTLE,U.S. Senate,,DEM,Kamala Harris,142
-Lake,THE_CASTLE,U.S. Senate,,DEM,Loretta Sanchez,98
-Lake,THURSTON_LAKE,U.S. Senate,,DEM,Kamala Harris,55
-Lake,THURSTON_LAKE,U.S. Senate,,DEM,Loretta Sanchez,33
-Lake,TWIN_LAKES,U.S. Senate,,DEM,Kamala Harris,217
-Lake,TWIN_LAKES,U.S. Senate,,DEM,Loretta Sanchez,119
-Lake,UPPER_LAKE,U.S. Senate,,DEM,Kamala Harris,274
-Lake,UPPER_LAKE,U.S. Senate,,DEM,Loretta Sanchez,170
-Lake,WESTLAKE,U.S. Senate,,DEM,Kamala Harris,294
-Lake,WESTLAKE,U.S. Senate,,DEM,Loretta Sanchez,190
-Lake,WHEELER_POINT,U.S. Senate,,DEM,Kamala Harris,333
-Lake,WHEELER_POINT,U.S. Senate,,DEM,Loretta Sanchez,169
-Lake,W_PINE_HOBERGS,U.S. Senate,,DEM,Kamala Harris,380
-Lake,W_PINE_HOBERGS,U.S. Senate,,DEM,Loretta Sanchez,143
+Lake,ADOBE,U.S. Senate,,DEM,Kamala D. Harris,198
+Lake,ADOBE,U.S. Senate,,DEM,Loretta L. Sanchez,120
+Lake,BACHELOR,U.S. Senate,,DEM,Kamala D. Harris,258
+Lake,BACHELOR,U.S. Senate,,DEM,Loretta L. Sanchez,148
+Lake,BALD_MTN,U.S. Senate,,DEM,Kamala D. Harris,4
+Lake,BALD_MTN,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Lake,BALLY_PEAK,U.S. Senate,,DEM,Kamala D. Harris,4
+Lake,BALLY_PEAK,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Lake,BARTLETT,U.S. Senate,,DEM,Kamala D. Harris,2
+Lake,BARTLETT,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Lake,BELL_PARK,U.S. Senate,,DEM,Kamala D. Harris,45
+Lake,BELL_PARK,U.S. Senate,,DEM,Loretta L. Sanchez,17
+Lake,BIG_VALLEY,U.S. Senate,,DEM,Kamala D. Harris,154
+Lake,BIG_VALLEY,U.S. Senate,,DEM,Loretta L. Sanchez,92
+Lake,BUCK_ISLAND,U.S. Senate,,DEM,Kamala D. Harris,0
+Lake,BUCK_ISLAND,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Lake,CENTRAL_PARK,U.S. Senate,,DEM,Kamala D. Harris,164
+Lake,CENTRAL_PARK,U.S. Senate,,DEM,Loretta L. Sanchez,98
+Lake,CL_AUSTIN_PARK,U.S. Senate,,DEM,Kamala D. Harris,280
+Lake,CL_AUSTIN_PARK,U.S. Senate,,DEM,Loretta L. Sanchez,160
+Lake,CL_BURNS_VALLEY,U.S. Senate,,DEM,Kamala D. Harris,278
+Lake,CL_BURNS_VALLEY,U.S. Senate,,DEM,Loretta L. Sanchez,136
+Lake,CL_DAVIS,U.S. Senate,,DEM,Kamala D. Harris,262
+Lake,CL_DAVIS,U.S. Senate,,DEM,Loretta L. Sanchez,139
+Lake,CL_MOLESWORTH,U.S. Senate,,DEM,Kamala D. Harris,269
+Lake,CL_MOLESWORTH,U.S. Senate,,DEM,Loretta L. Sanchez,137
+Lake,CL_MONITOR_PT,U.S. Senate,,DEM,Kamala D. Harris,301
+Lake,CL_MONITOR_PT,U.S. Senate,,DEM,Loretta L. Sanchez,172
+Lake,CL_PALMER,U.S. Senate,,DEM,Kamala D. Harris,274
+Lake,CL_PALMER,U.S. Senate,,DEM,Loretta L. Sanchez,119
+Lake,CL_PIERCE,U.S. Senate,,DEM,Kamala D. Harris,232
+Lake,CL_PIERCE,U.S. Senate,,DEM,Loretta L. Sanchez,142
+Lake,CL_REDBUD,U.S. Senate,,DEM,Kamala D. Harris,189
+Lake,CL_REDBUD,U.S. Senate,,DEM,Loretta L. Sanchez,101
+Lake,CL_VILLAGE,U.S. Senate,,DEM,Kamala D. Harris,158
+Lake,CL_VILLAGE,U.S. Senate,,DEM,Loretta L. Sanchez,73
+Lake,COLE_CREEK,U.S. Senate,,DEM,Kamala D. Harris,247
+Lake,COLE_CREEK,U.S. Senate,,DEM,Loretta L. Sanchez,174
+Lake,COW_MTN,U.S. Senate,,DEM,Kamala D. Harris,191
+Lake,COW_MTN,U.S. Senate,,DEM,Loretta L. Sanchez,85
+Lake,COYOTE_VALLEY,U.S. Senate,,DEM,Kamala D. Harris,39
+Lake,COYOTE_VALLEY,U.S. Senate,,DEM,Loretta L. Sanchez,29
+Lake,DONOVAN_VALLEY,U.S. Senate,,DEM,Kamala D. Harris,12
+Lake,DONOVAN_VALLEY,U.S. Senate,,DEM,Loretta L. Sanchez,20
+Lake,EAST_LAKE,U.S. Senate,,DEM,Kamala D. Harris,162
+Lake,EAST_LAKE,U.S. Senate,,DEM,Loretta L. Sanchez,107
+Lake,FORTY_SPRINGS,U.S. Senate,,DEM,Kamala D. Harris,10
+Lake,FORTY_SPRINGS,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Lake,GLENBROOK,U.S. Senate,,DEM,Kamala D. Harris,220
+Lake,GLENBROOK,U.S. Senate,,DEM,Loretta L. Sanchez,94
+Lake,GLENHAVEN,U.S. Senate,,DEM,Kamala D. Harris,57
+Lake,GLENHAVEN,U.S. Senate,,DEM,Loretta L. Sanchez,24
+Lake,GRAVELLY,U.S. Senate,,DEM,Kamala D. Harris,18
+Lake,GRAVELLY,U.S. Senate,,DEM,Loretta L. Sanchez,9
+Lake,HIDDEN_VALLEY_1,U.S. Senate,,DEM,Kamala D. Harris,338
+Lake,HIDDEN_VALLEY_1,U.S. Senate,,DEM,Loretta L. Sanchez,180
+Lake,HIDDEN_VALLEY_2,U.S. Senate,,DEM,Kamala D. Harris,308
+Lake,HIDDEN_VALLEY_2,U.S. Senate,,DEM,Loretta L. Sanchez,115
+Lake,HIDDEN_VALLEY_3,U.S. Senate,,DEM,Kamala D. Harris,296
+Lake,HIDDEN_VALLEY_3,U.S. Senate,,DEM,Loretta L. Sanchez,151
+Lake,HIDDEN_VALLEY_4,U.S. Senate,,DEM,Kamala D. Harris,365
+Lake,HIDDEN_VALLEY_4,U.S. Senate,,DEM,Loretta L. Sanchez,150
+Lake,HIGHLAND_SPGS,U.S. Senate,,DEM,Kamala D. Harris,14
+Lake,HIGHLAND_SPGS,U.S. Senate,,DEM,Loretta L. Sanchez,12
+Lake,HV_RANCHOS,U.S. Senate,,DEM,Kamala D. Harris,83
+Lake,HV_RANCHOS,U.S. Senate,,DEM,Loretta L. Sanchez,27
+Lake,JERUSALEM,U.S. Senate,,DEM,Kamala D. Harris,10
+Lake,JERUSALEM,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Lake,KELSEYVILLE,U.S. Senate,,DEM,Kamala D. Harris,228
+Lake,KELSEYVILLE,U.S. Senate,,DEM,Loretta L. Sanchez,156
+Lake,KELSEY_CREEK,U.S. Senate,,DEM,Kamala D. Harris,293
+Lake,KELSEY_CREEK,U.S. Senate,,DEM,Loretta L. Sanchez,158
+Lake,KEYS_EAST,U.S. Senate,,DEM,Kamala D. Harris,160
+Lake,KEYS_EAST,U.S. Senate,,DEM,Loretta L. Sanchez,75
+Lake,KEYS_WEST,U.S. Senate,,DEM,Kamala D. Harris,179
+Lake,KEYS_WEST,U.S. Senate,,DEM,Loretta L. Sanchez,82
+Lake,KONO_TAYEE,U.S. Senate,,DEM,Kamala D. Harris,221
+Lake,KONO_TAYEE,U.S. Senate,,DEM,Loretta L. Sanchez,113
+Lake,LAKESHORE_PARK,U.S. Senate,,DEM,Kamala D. Harris,65
+Lake,LAKESHORE_PARK,U.S. Senate,,DEM,Loretta L. Sanchez,32
+Lake,LAKESIDE_PARK,U.S. Senate,,DEM,Kamala D. Harris,51
+Lake,LAKESIDE_PARK,U.S. Senate,,DEM,Loretta L. Sanchez,25
+Lake,LANDS_END,U.S. Senate,,DEM,Kamala D. Harris,131
+Lake,LANDS_END,U.S. Senate,,DEM,Loretta L. Sanchez,83
+Lake,LITTLE_BORAX,U.S. Senate,,DEM,Kamala D. Harris,345
+Lake,LITTLE_BORAX,U.S. Senate,,DEM,Loretta L. Sanchez,136
+Lake,LOCH_LOMOND,U.S. Senate,,DEM,Kamala D. Harris,301
+Lake,LOCH_LOMOND,U.S. Senate,,DEM,Loretta L. Sanchez,150
+Lake,LONG_VALLEY,U.S. Senate,,DEM,Kamala D. Harris,247
+Lake,LONG_VALLEY,U.S. Senate,,DEM,Loretta L. Sanchez,131
+Lake,LOWER_LAKE,U.S. Senate,,DEM,Kamala D. Harris,198
+Lake,LOWER_LAKE,U.S. Senate,,DEM,Loretta L. Sanchez,100
+Lake,LP_FAIRGROUNDS,U.S. Senate,,DEM,Kamala D. Harris,296
+Lake,LP_FAIRGROUNDS,U.S. Senate,,DEM,Loretta L. Sanchez,160
+Lake,LP_GOVERNMENT,U.S. Senate,,DEM,Kamala D. Harris,271
+Lake,LP_GOVERNMENT,U.S. Senate,,DEM,Loretta L. Sanchez,120
+Lake,LP_LANGE,U.S. Senate,,DEM,Kamala D. Harris,261
+Lake,LP_LANGE,U.S. Senate,,DEM,Loretta L. Sanchez,145
+Lake,LP_WILLOW_TREE,U.S. Senate,,DEM,Kamala D. Harris,300
+Lake,LP_WILLOW_TREE,U.S. Senate,,DEM,Loretta L. Sanchez,177
+Lake,LUCERNE,U.S. Senate,,DEM,Kamala D. Harris,199
+Lake,LUCERNE,U.S. Senate,,DEM,Loretta L. Sanchez,97
+Lake,MIDDLETOWN,U.S. Senate,,DEM,Kamala D. Harris,246
+Lake,MIDDLETOWN,U.S. Senate,,DEM,Loretta L. Sanchez,156
+Lake,MORGAN_VALLEY,U.S. Senate,,DEM,Kamala D. Harris,19
+Lake,MORGAN_VALLEY,U.S. Senate,,DEM,Loretta L. Sanchez,11
+Lake,MOUNTAIN_PEAK,U.S. Senate,,DEM,Kamala D. Harris,317
+Lake,MOUNTAIN_PEAK,U.S. Senate,,DEM,Loretta L. Sanchez,190
+Lake,NICE,U.S. Senate,,DEM,Kamala D. Harris,287
+Lake,NICE,U.S. Senate,,DEM,Loretta L. Sanchez,140
+Lake,NICE_HARBOR,U.S. Senate,,DEM,Kamala D. Harris,219
+Lake,NICE_HARBOR,U.S. Senate,,DEM,Loretta L. Sanchez,117
+Lake,PERINI_HILL,U.S. Senate,,DEM,Kamala D. Harris,8
+Lake,PERINI_HILL,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Lake,RIVIERA,U.S. Senate,,DEM,Kamala D. Harris,250
+Lake,RIVIERA,U.S. Senate,,DEM,Loretta L. Sanchez,148
+Lake,ROBIN_HILL,U.S. Senate,,DEM,Kamala D. Harris,356
+Lake,ROBIN_HILL,U.S. Senate,,DEM,Loretta L. Sanchez,219
+Lake,SCOTTS_VALLEY,U.S. Senate,,DEM,Kamala D. Harris,178
+Lake,SCOTTS_VALLEY,U.S. Senate,,DEM,Loretta L. Sanchez,106
+Lake,SODA_BAY,U.S. Senate,,DEM,Kamala D. Harris,268
+Lake,SODA_BAY,U.S. Senate,,DEM,Loretta L. Sanchez,127
+Lake,SPRUCE_GROVE,U.S. Senate,,DEM,Kamala D. Harris,90
+Lake,SPRUCE_GROVE,U.S. Senate,,DEM,Loretta L. Sanchez,43
+Lake,SULPHUR_PARK,U.S. Senate,,DEM,Kamala D. Harris,73
+Lake,SULPHUR_PARK,U.S. Senate,,DEM,Loretta L. Sanchez,43
+Lake,THE_CASTLE,U.S. Senate,,DEM,Kamala D. Harris,142
+Lake,THE_CASTLE,U.S. Senate,,DEM,Loretta L. Sanchez,98
+Lake,THURSTON_LAKE,U.S. Senate,,DEM,Kamala D. Harris,55
+Lake,THURSTON_LAKE,U.S. Senate,,DEM,Loretta L. Sanchez,33
+Lake,TWIN_LAKES,U.S. Senate,,DEM,Kamala D. Harris,217
+Lake,TWIN_LAKES,U.S. Senate,,DEM,Loretta L. Sanchez,119
+Lake,UPPER_LAKE,U.S. Senate,,DEM,Kamala D. Harris,274
+Lake,UPPER_LAKE,U.S. Senate,,DEM,Loretta L. Sanchez,170
+Lake,WESTLAKE,U.S. Senate,,DEM,Kamala D. Harris,294
+Lake,WESTLAKE,U.S. Senate,,DEM,Loretta L. Sanchez,190
+Lake,WHEELER_POINT,U.S. Senate,,DEM,Kamala D. Harris,333
+Lake,WHEELER_POINT,U.S. Senate,,DEM,Loretta L. Sanchez,169
+Lake,W_PINE_HOBERGS,U.S. Senate,,DEM,Kamala D. Harris,380
+Lake,W_PINE_HOBERGS,U.S. Senate,,DEM,Loretta L. Sanchez,143

--- a/2016/20161108__ca__general__lassen__precinct.csv
+++ b/2016/20161108__ca__general__lassen__precinct.csv
@@ -2039,105 +2039,105 @@ Lassen,MB6,Proposition 67,,N/A,Yes,37
 Lassen,MB6,Proposition 67,,N/A,No,85
 Lassen,MB8,Proposition 67,,N/A,Yes,50
 Lassen,MB8,Proposition 67,,N/A,No,104
-Lassen,CP1,U.S. Senate,,DEM,Kamala Harris,204
-Lassen,CP1,U.S. Senate,,DEM,Loretta Sanchez,303
-Lassen,CP11,U.S. Senate,,DEM,Kamala Harris,184
-Lassen,CP11,U.S. Senate,,DEM,Loretta Sanchez,238
-Lassen,CP12,U.S. Senate,,DEM,Kamala Harris,297
-Lassen,CP12,U.S. Senate,,DEM,Loretta Sanchez,356
-Lassen,CP13,U.S. Senate,,DEM,Kamala Harris,181
-Lassen,CP13,U.S. Senate,,DEM,Loretta Sanchez,254
-Lassen,CP16,U.S. Senate,,DEM,Kamala Harris,136
-Lassen,CP16,U.S. Senate,,DEM,Loretta Sanchez,117
-Lassen,CP18,U.S. Senate,,DEM,Kamala Harris,265
-Lassen,CP18,U.S. Senate,,DEM,Loretta Sanchez,279
-Lassen,CP19,U.S. Senate,,DEM,Kamala Harris,128
-Lassen,CP19,U.S. Senate,,DEM,Loretta Sanchez,215
-Lassen,CP20,U.S. Senate,,DEM,Kamala Harris,102
-Lassen,CP20,U.S. Senate,,DEM,Loretta Sanchez,152
-Lassen,CP21,U.S. Senate,,DEM,Kamala Harris,80
-Lassen,CP21,U.S. Senate,,DEM,Loretta Sanchez,95
-Lassen,CP23,U.S. Senate,,DEM,Kamala Harris,116
-Lassen,CP23,U.S. Senate,,DEM,Loretta Sanchez,152
-Lassen,CP4,U.S. Senate,,DEM,Kamala Harris,202
-Lassen,CP4,U.S. Senate,,DEM,Loretta Sanchez,289
-Lassen,CP5,U.S. Senate,,DEM,Kamala Harris,99
-Lassen,CP5,U.S. Senate,,DEM,Loretta Sanchez,112
-Lassen,CP7,U.S. Senate,,DEM,Kamala Harris,67
-Lassen,CP7,U.S. Senate,,DEM,Loretta Sanchez,85
-Lassen,CP9,U.S. Senate,,DEM,Kamala Harris,84
-Lassen,CP9,U.S. Senate,,DEM,Loretta Sanchez,98
-Lassen,MB10,U.S. Senate,,DEM,Kamala Harris,42
-Lassen,MB10,U.S. Senate,,DEM,Loretta Sanchez,73
-Lassen,MB14,U.S. Senate,,DEM,Kamala Harris,46
-Lassen,MB14,U.S. Senate,,DEM,Loretta Sanchez,58
-Lassen,MB15,U.S. Senate,,DEM,Kamala Harris,58
-Lassen,MB15,U.S. Senate,,DEM,Loretta Sanchez,55
-Lassen,MB17,U.S. Senate,,DEM,Kamala Harris,57
-Lassen,MB17,U.S. Senate,,DEM,Loretta Sanchez,47
-Lassen,MB2,U.S. Senate,,DEM,Kamala Harris,19
-Lassen,MB2,U.S. Senate,,DEM,Loretta Sanchez,32
-Lassen,MB22,U.S. Senate,,DEM,Kamala Harris,22
-Lassen,MB22,U.S. Senate,,DEM,Loretta Sanchez,26
-Lassen,MB24,U.S. Senate,,DEM,Kamala Harris,12
-Lassen,MB24,U.S. Senate,,DEM,Loretta Sanchez,15
-Lassen,MB25,U.S. Senate,,DEM,Kamala Harris,8
-Lassen,MB25,U.S. Senate,,DEM,Loretta Sanchez,17
-Lassen,MB26,U.S. Senate,,DEM,Kamala Harris,28
-Lassen,MB26,U.S. Senate,,DEM,Loretta Sanchez,20
-Lassen,MB27,U.S. Senate,,DEM,Kamala Harris,13
-Lassen,MB27,U.S. Senate,,DEM,Loretta Sanchez,16
-Lassen,MB28,U.S. Senate,,DEM,Kamala Harris,20
-Lassen,MB28,U.S. Senate,,DEM,Loretta Sanchez,17
-Lassen,MB29,U.S. Senate,,DEM,Kamala Harris,8
-Lassen,MB29,U.S. Senate,,DEM,Loretta Sanchez,9
-Lassen,MB3,U.S. Senate,,DEM,Kamala Harris,68
-Lassen,MB3,U.S. Senate,,DEM,Loretta Sanchez,69
-Lassen,MB30,U.S. Senate,,DEM,Kamala Harris,9
-Lassen,MB30,U.S. Senate,,DEM,Loretta Sanchez,12
-Lassen,MB31,U.S. Senate,,DEM,Kamala Harris,1
-Lassen,MB31,U.S. Senate,,DEM,Loretta Sanchez,1
-Lassen,MB32,U.S. Senate,,DEM,Kamala Harris,24
-Lassen,MB32,U.S. Senate,,DEM,Loretta Sanchez,34
-Lassen,MB33,U.S. Senate,,DEM,Kamala Harris,10
-Lassen,MB33,U.S. Senate,,DEM,Loretta Sanchez,23
-Lassen,MB34,U.S. Senate,,DEM,Kamala Harris,7
-Lassen,MB34,U.S. Senate,,DEM,Loretta Sanchez,20
-Lassen,MB35,U.S. Senate,,DEM,Kamala Harris,0
-Lassen,MB35,U.S. Senate,,DEM,Loretta Sanchez,0
-Lassen,MB36,U.S. Senate,,DEM,Kamala Harris,30
-Lassen,MB36,U.S. Senate,,DEM,Loretta Sanchez,49
-Lassen,MB37,U.S. Senate,,DEM,Kamala Harris,44
-Lassen,MB37,U.S. Senate,,DEM,Loretta Sanchez,75
-Lassen,MB38,U.S. Senate,,DEM,Kamala Harris,18
-Lassen,MB38,U.S. Senate,,DEM,Loretta Sanchez,24
-Lassen,MB39,U.S. Senate,,DEM,Kamala Harris,46
-Lassen,MB39,U.S. Senate,,DEM,Loretta Sanchez,50
-Lassen,MB40,U.S. Senate,,DEM,Kamala Harris,27
-Lassen,MB40,U.S. Senate,,DEM,Loretta Sanchez,24
-Lassen,MB41,U.S. Senate,,DEM,Kamala Harris,38
-Lassen,MB41,U.S. Senate,,DEM,Loretta Sanchez,39
-Lassen,MB42,U.S. Senate,,DEM,Kamala Harris,43
-Lassen,MB42,U.S. Senate,,DEM,Loretta Sanchez,67
-Lassen,MB43,U.S. Senate,,DEM,Kamala Harris,26
-Lassen,MB43,U.S. Senate,,DEM,Loretta Sanchez,52
-Lassen,MB44,U.S. Senate,,DEM,Kamala Harris,29
-Lassen,MB44,U.S. Senate,,DEM,Loretta Sanchez,59
-Lassen,MB45,U.S. Senate,,DEM,Kamala Harris,43
-Lassen,MB45,U.S. Senate,,DEM,Loretta Sanchez,46
-Lassen,MB46,U.S. Senate,,DEM,Kamala Harris,48
-Lassen,MB46,U.S. Senate,,DEM,Loretta Sanchez,88
-Lassen,MB47,U.S. Senate,,DEM,Kamala Harris,28
-Lassen,MB47,U.S. Senate,,DEM,Loretta Sanchez,40
-Lassen,MB48,U.S. Senate,,DEM,Kamala Harris,22
-Lassen,MB48,U.S. Senate,,DEM,Loretta Sanchez,22
-Lassen,MB49,U.S. Senate,,DEM,Kamala Harris,25
-Lassen,MB49,U.S. Senate,,DEM,Loretta Sanchez,32
-Lassen,MB50,U.S. Senate,,DEM,Kamala Harris,34
-Lassen,MB50,U.S. Senate,,DEM,Loretta Sanchez,55
-Lassen,MB51,U.S. Senate,,DEM,Kamala Harris,41
-Lassen,MB51,U.S. Senate,,DEM,Loretta Sanchez,33
-Lassen,MB6,U.S. Senate,,DEM,Kamala Harris,36
-Lassen,MB6,U.S. Senate,,DEM,Loretta Sanchez,44
-Lassen,MB8,U.S. Senate,,DEM,Kamala Harris,51
-Lassen,MB8,U.S. Senate,,DEM,Loretta Sanchez,63
+Lassen,CP1,U.S. Senate,,DEM,Kamala D. Harris,204
+Lassen,CP1,U.S. Senate,,DEM,Loretta L. Sanchez,303
+Lassen,CP11,U.S. Senate,,DEM,Kamala D. Harris,184
+Lassen,CP11,U.S. Senate,,DEM,Loretta L. Sanchez,238
+Lassen,CP12,U.S. Senate,,DEM,Kamala D. Harris,297
+Lassen,CP12,U.S. Senate,,DEM,Loretta L. Sanchez,356
+Lassen,CP13,U.S. Senate,,DEM,Kamala D. Harris,181
+Lassen,CP13,U.S. Senate,,DEM,Loretta L. Sanchez,254
+Lassen,CP16,U.S. Senate,,DEM,Kamala D. Harris,136
+Lassen,CP16,U.S. Senate,,DEM,Loretta L. Sanchez,117
+Lassen,CP18,U.S. Senate,,DEM,Kamala D. Harris,265
+Lassen,CP18,U.S. Senate,,DEM,Loretta L. Sanchez,279
+Lassen,CP19,U.S. Senate,,DEM,Kamala D. Harris,128
+Lassen,CP19,U.S. Senate,,DEM,Loretta L. Sanchez,215
+Lassen,CP20,U.S. Senate,,DEM,Kamala D. Harris,102
+Lassen,CP20,U.S. Senate,,DEM,Loretta L. Sanchez,152
+Lassen,CP21,U.S. Senate,,DEM,Kamala D. Harris,80
+Lassen,CP21,U.S. Senate,,DEM,Loretta L. Sanchez,95
+Lassen,CP23,U.S. Senate,,DEM,Kamala D. Harris,116
+Lassen,CP23,U.S. Senate,,DEM,Loretta L. Sanchez,152
+Lassen,CP4,U.S. Senate,,DEM,Kamala D. Harris,202
+Lassen,CP4,U.S. Senate,,DEM,Loretta L. Sanchez,289
+Lassen,CP5,U.S. Senate,,DEM,Kamala D. Harris,99
+Lassen,CP5,U.S. Senate,,DEM,Loretta L. Sanchez,112
+Lassen,CP7,U.S. Senate,,DEM,Kamala D. Harris,67
+Lassen,CP7,U.S. Senate,,DEM,Loretta L. Sanchez,85
+Lassen,CP9,U.S. Senate,,DEM,Kamala D. Harris,84
+Lassen,CP9,U.S. Senate,,DEM,Loretta L. Sanchez,98
+Lassen,MB10,U.S. Senate,,DEM,Kamala D. Harris,42
+Lassen,MB10,U.S. Senate,,DEM,Loretta L. Sanchez,73
+Lassen,MB14,U.S. Senate,,DEM,Kamala D. Harris,46
+Lassen,MB14,U.S. Senate,,DEM,Loretta L. Sanchez,58
+Lassen,MB15,U.S. Senate,,DEM,Kamala D. Harris,58
+Lassen,MB15,U.S. Senate,,DEM,Loretta L. Sanchez,55
+Lassen,MB17,U.S. Senate,,DEM,Kamala D. Harris,57
+Lassen,MB17,U.S. Senate,,DEM,Loretta L. Sanchez,47
+Lassen,MB2,U.S. Senate,,DEM,Kamala D. Harris,19
+Lassen,MB2,U.S. Senate,,DEM,Loretta L. Sanchez,32
+Lassen,MB22,U.S. Senate,,DEM,Kamala D. Harris,22
+Lassen,MB22,U.S. Senate,,DEM,Loretta L. Sanchez,26
+Lassen,MB24,U.S. Senate,,DEM,Kamala D. Harris,12
+Lassen,MB24,U.S. Senate,,DEM,Loretta L. Sanchez,15
+Lassen,MB25,U.S. Senate,,DEM,Kamala D. Harris,8
+Lassen,MB25,U.S. Senate,,DEM,Loretta L. Sanchez,17
+Lassen,MB26,U.S. Senate,,DEM,Kamala D. Harris,28
+Lassen,MB26,U.S. Senate,,DEM,Loretta L. Sanchez,20
+Lassen,MB27,U.S. Senate,,DEM,Kamala D. Harris,13
+Lassen,MB27,U.S. Senate,,DEM,Loretta L. Sanchez,16
+Lassen,MB28,U.S. Senate,,DEM,Kamala D. Harris,20
+Lassen,MB28,U.S. Senate,,DEM,Loretta L. Sanchez,17
+Lassen,MB29,U.S. Senate,,DEM,Kamala D. Harris,8
+Lassen,MB29,U.S. Senate,,DEM,Loretta L. Sanchez,9
+Lassen,MB3,U.S. Senate,,DEM,Kamala D. Harris,68
+Lassen,MB3,U.S. Senate,,DEM,Loretta L. Sanchez,69
+Lassen,MB30,U.S. Senate,,DEM,Kamala D. Harris,9
+Lassen,MB30,U.S. Senate,,DEM,Loretta L. Sanchez,12
+Lassen,MB31,U.S. Senate,,DEM,Kamala D. Harris,1
+Lassen,MB31,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Lassen,MB32,U.S. Senate,,DEM,Kamala D. Harris,24
+Lassen,MB32,U.S. Senate,,DEM,Loretta L. Sanchez,34
+Lassen,MB33,U.S. Senate,,DEM,Kamala D. Harris,10
+Lassen,MB33,U.S. Senate,,DEM,Loretta L. Sanchez,23
+Lassen,MB34,U.S. Senate,,DEM,Kamala D. Harris,7
+Lassen,MB34,U.S. Senate,,DEM,Loretta L. Sanchez,20
+Lassen,MB35,U.S. Senate,,DEM,Kamala D. Harris,0
+Lassen,MB35,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Lassen,MB36,U.S. Senate,,DEM,Kamala D. Harris,30
+Lassen,MB36,U.S. Senate,,DEM,Loretta L. Sanchez,49
+Lassen,MB37,U.S. Senate,,DEM,Kamala D. Harris,44
+Lassen,MB37,U.S. Senate,,DEM,Loretta L. Sanchez,75
+Lassen,MB38,U.S. Senate,,DEM,Kamala D. Harris,18
+Lassen,MB38,U.S. Senate,,DEM,Loretta L. Sanchez,24
+Lassen,MB39,U.S. Senate,,DEM,Kamala D. Harris,46
+Lassen,MB39,U.S. Senate,,DEM,Loretta L. Sanchez,50
+Lassen,MB40,U.S. Senate,,DEM,Kamala D. Harris,27
+Lassen,MB40,U.S. Senate,,DEM,Loretta L. Sanchez,24
+Lassen,MB41,U.S. Senate,,DEM,Kamala D. Harris,38
+Lassen,MB41,U.S. Senate,,DEM,Loretta L. Sanchez,39
+Lassen,MB42,U.S. Senate,,DEM,Kamala D. Harris,43
+Lassen,MB42,U.S. Senate,,DEM,Loretta L. Sanchez,67
+Lassen,MB43,U.S. Senate,,DEM,Kamala D. Harris,26
+Lassen,MB43,U.S. Senate,,DEM,Loretta L. Sanchez,52
+Lassen,MB44,U.S. Senate,,DEM,Kamala D. Harris,29
+Lassen,MB44,U.S. Senate,,DEM,Loretta L. Sanchez,59
+Lassen,MB45,U.S. Senate,,DEM,Kamala D. Harris,43
+Lassen,MB45,U.S. Senate,,DEM,Loretta L. Sanchez,46
+Lassen,MB46,U.S. Senate,,DEM,Kamala D. Harris,48
+Lassen,MB46,U.S. Senate,,DEM,Loretta L. Sanchez,88
+Lassen,MB47,U.S. Senate,,DEM,Kamala D. Harris,28
+Lassen,MB47,U.S. Senate,,DEM,Loretta L. Sanchez,40
+Lassen,MB48,U.S. Senate,,DEM,Kamala D. Harris,22
+Lassen,MB48,U.S. Senate,,DEM,Loretta L. Sanchez,22
+Lassen,MB49,U.S. Senate,,DEM,Kamala D. Harris,25
+Lassen,MB49,U.S. Senate,,DEM,Loretta L. Sanchez,32
+Lassen,MB50,U.S. Senate,,DEM,Kamala D. Harris,34
+Lassen,MB50,U.S. Senate,,DEM,Loretta L. Sanchez,55
+Lassen,MB51,U.S. Senate,,DEM,Kamala D. Harris,41
+Lassen,MB51,U.S. Senate,,DEM,Loretta L. Sanchez,33
+Lassen,MB6,U.S. Senate,,DEM,Kamala D. Harris,36
+Lassen,MB6,U.S. Senate,,DEM,Loretta L. Sanchez,44
+Lassen,MB8,U.S. Senate,,DEM,Kamala D. Harris,51
+Lassen,MB8,U.S. Senate,,DEM,Loretta L. Sanchez,63

--- a/2016/20161108__ca__general__madera__precinct.csv
+++ b/2016/20161108__ca__general__madera__precinct.csv
@@ -2719,139 +2719,139 @@ Madera,5431,Proposition 67,,N/A,Yes,0
 Madera,5431,Proposition 67,,N/A,No,2
 Madera,5432,Proposition 67,,N/A,Yes,2
 Madera,5432,Proposition 67,,N/A,No,2
-Madera,1002,U.S. Senate,,DEM,Kamala Harris,131
-Madera,1002,U.S. Senate,,DEM,Loretta Sanchez,222
-Madera,1004,U.S. Senate,,DEM,Kamala Harris,47
-Madera,1004,U.S. Senate,,DEM,Loretta Sanchez,69
-Madera,1307,U.S. Senate,,DEM,Kamala Harris,91
-Madera,1307,U.S. Senate,,DEM,Loretta Sanchez,136
-Madera,1308,U.S. Senate,,DEM,Kamala Harris,78
-Madera,1308,U.S. Senate,,DEM,Loretta Sanchez,70
-Madera,1309-1310,U.S. Senate,,DEM,Kamala Harris,492
-Madera,1309-1310,U.S. Senate,,DEM,Loretta Sanchez,501
-Madera,1311,U.S. Senate,,DEM,Kamala Harris,10
-Madera,1311,U.S. Senate,,DEM,Loretta Sanchez,10
-Madera,1313,U.S. Senate,,DEM,Kamala Harris,0
-Madera,1313,U.S. Senate,,DEM,Loretta Sanchez,0
-Madera,1314,U.S. Senate,,DEM,Kamala Harris,0
-Madera,1314,U.S. Senate,,DEM,Loretta Sanchez,0
-Madera,1315,U.S. Senate,,DEM,Kamala Harris,4
-Madera,1315,U.S. Senate,,DEM,Loretta Sanchez,8
-Madera,1316,U.S. Senate,,DEM,Kamala Harris,106
-Madera,1316,U.S. Senate,,DEM,Loretta Sanchez,232
-Madera,1317,U.S. Senate,,DEM,Kamala Harris,109
-Madera,1317,U.S. Senate,,DEM,Loretta Sanchez,143
-Madera,1318,U.S. Senate,,DEM,Kamala Harris,176
-Madera,1318,U.S. Senate,,DEM,Loretta Sanchez,331
-Madera,1319,U.S. Senate,,DEM,Kamala Harris,38
-Madera,1319,U.S. Senate,,DEM,Loretta Sanchez,64
-Madera,1415,U.S. Senate,,DEM,Kamala Harris,114
-Madera,1415,U.S. Senate,,DEM,Loretta Sanchez,94
-Madera,1502-1503,U.S. Senate,,DEM,Kamala Harris,547
-Madera,1502-1503,U.S. Senate,,DEM,Loretta Sanchez,671
-Madera,1509-1514,U.S. Senate,,DEM,Kamala Harris,1089
-Madera,1509-1514,U.S. Senate,,DEM,Loretta Sanchez,1119
-Madera,1515,U.S. Senate,,DEM,Kamala Harris,233
-Madera,1515,U.S. Senate,,DEM,Loretta Sanchez,271
-Madera,2001,U.S. Senate,,DEM,Kamala Harris,141
-Madera,2001,U.S. Senate,,DEM,Loretta Sanchez,174
-Madera,2003,U.S. Senate,,DEM,Kamala Harris,139
-Madera,2003,U.S. Senate,,DEM,Loretta Sanchez,190
-Madera,2007,U.S. Senate,,DEM,Kamala Harris,2
-Madera,2007,U.S. Senate,,DEM,Loretta Sanchez,3
-Madera,2012-2015,U.S. Senate,,DEM,Kamala Harris,1067
-Madera,2012-2015,U.S. Senate,,DEM,Loretta Sanchez,1315
-Madera,2104,U.S. Senate,,DEM,Kamala Harris,162
-Madera,2104,U.S. Senate,,DEM,Loretta Sanchez,142
-Madera,2105,U.S. Senate,,DEM,Kamala Harris,126
-Madera,2105,U.S. Senate,,DEM,Loretta Sanchez,124
-Madera,2106-2107,U.S. Senate,,DEM,Kamala Harris,457
-Madera,2106-2107,U.S. Senate,,DEM,Loretta Sanchez,420
-Madera,2108,U.S. Senate,,DEM,Kamala Harris,184
-Madera,2108,U.S. Senate,,DEM,Loretta Sanchez,267
-Madera,2109-2110,U.S. Senate,,DEM,Kamala Harris,487
-Madera,2109-2110,U.S. Senate,,DEM,Loretta Sanchez,346
-Madera,2305,U.S. Senate,,DEM,Kamala Harris,0
-Madera,2305,U.S. Senate,,DEM,Loretta Sanchez,0
-Madera,2306,U.S. Senate,,DEM,Kamala Harris,208
-Madera,2306,U.S. Senate,,DEM,Loretta Sanchez,173
-Madera,2309,U.S. Senate,,DEM,Kamala Harris,136
-Madera,2309,U.S. Senate,,DEM,Loretta Sanchez,141
-Madera,2324,U.S. Senate,,DEM,Kamala Harris,0
-Madera,2324,U.S. Senate,,DEM,Loretta Sanchez,0
-Madera,2327,U.S. Senate,,DEM,Kamala Harris,0
-Madera,2327,U.S. Senate,,DEM,Loretta Sanchez,0
-Madera,3201,U.S. Senate,,DEM,Kamala Harris,238
-Madera,3201,U.S. Senate,,DEM,Loretta Sanchez,302
-Madera,3202,U.S. Senate,,DEM,Kamala Harris,374
-Madera,3202,U.S. Senate,,DEM,Loretta Sanchez,357
-Madera,3207,U.S. Senate,,DEM,Kamala Harris,236
-Madera,3207,U.S. Senate,,DEM,Loretta Sanchez,236
-Madera,3208,U.S. Senate,,DEM,Kamala Harris,316
-Madera,3208,U.S. Senate,,DEM,Loretta Sanchez,309
-Madera,3210-3220,U.S. Senate,,DEM,Kamala Harris,607
-Madera,3210-3220,U.S. Senate,,DEM,Loretta Sanchez,630
-Madera,3211-3221,U.S. Senate,,DEM,Kamala Harris,429
-Madera,3211-3221,U.S. Senate,,DEM,Loretta Sanchez,440
-Madera,3212-3222,U.S. Senate,,DEM,Kamala Harris,377
-Madera,3212-3222,U.S. Senate,,DEM,Loretta Sanchez,355
-Madera,3213,U.S. Senate,,DEM,Kamala Harris,189
-Madera,3213,U.S. Senate,,DEM,Loretta Sanchez,261
-Madera,3214-3224,U.S. Senate,,DEM,Kamala Harris,347
-Madera,3214-3224,U.S. Senate,,DEM,Loretta Sanchez,421
-Madera,3215,U.S. Senate,,DEM,Kamala Harris,264
-Madera,3215,U.S. Senate,,DEM,Loretta Sanchez,303
-Madera,3216,U.S. Senate,,DEM,Kamala Harris,16
-Madera,3216,U.S. Senate,,DEM,Loretta Sanchez,18
-Madera,3217,U.S. Senate,,DEM,Kamala Harris,11
-Madera,3217,U.S. Senate,,DEM,Loretta Sanchez,7
-Madera,3218,U.S. Senate,,DEM,Kamala Harris,9
-Madera,3218,U.S. Senate,,DEM,Loretta Sanchez,7
-Madera,3219,U.S. Senate,,DEM,Kamala Harris,13
-Madera,3219,U.S. Senate,,DEM,Loretta Sanchez,7
-Madera,3223,U.S. Senate,,DEM,Kamala Harris,0
-Madera,3223,U.S. Senate,,DEM,Loretta Sanchez,0
-Madera,4200,U.S. Senate,,DEM,Kamala Harris,154
-Madera,4200,U.S. Senate,,DEM,Loretta Sanchez,195
-Madera,4201,U.S. Senate,,DEM,Kamala Harris,77
-Madera,4201,U.S. Senate,,DEM,Loretta Sanchez,139
-Madera,4202,U.S. Senate,,DEM,Kamala Harris,301
-Madera,4202,U.S. Senate,,DEM,Loretta Sanchez,450
-Madera,4203,U.S. Senate,,DEM,Kamala Harris,134
-Madera,4203,U.S. Senate,,DEM,Loretta Sanchez,306
-Madera,4204,U.S. Senate,,DEM,Kamala Harris,101
-Madera,4204,U.S. Senate,,DEM,Loretta Sanchez,111
-Madera,4205-4215,U.S. Senate,,DEM,Kamala Harris,159
-Madera,4205-4215,U.S. Senate,,DEM,Loretta Sanchez,351
-Madera,4207,U.S. Senate,,DEM,Kamala Harris,106
-Madera,4207,U.S. Senate,,DEM,Loretta Sanchez,172
-Madera,4208,U.S. Senate,,DEM,Kamala Harris,79
-Madera,4208,U.S. Senate,,DEM,Loretta Sanchez,107
-Madera,4310,U.S. Senate,,DEM,Kamala Harris,161
-Madera,4310,U.S. Senate,,DEM,Loretta Sanchez,260
-Madera,4311,U.S. Senate,,DEM,Kamala Harris,1
-Madera,4311,U.S. Senate,,DEM,Loretta Sanchez,5
-Madera,4312,U.S. Senate,,DEM,Kamala Harris,0
-Madera,4312,U.S. Senate,,DEM,Loretta Sanchez,0
-Madera,5400-5402,U.S. Senate,,DEM,Kamala Harris,706
-Madera,5400-5402,U.S. Senate,,DEM,Loretta Sanchez,551
-Madera,5403,U.S. Senate,,DEM,Kamala Harris,220
-Madera,5403,U.S. Senate,,DEM,Loretta Sanchez,172
-Madera,5404-5406,U.S. Senate,,DEM,Kamala Harris,670
-Madera,5404-5406,U.S. Senate,,DEM,Loretta Sanchez,516
-Madera,5409-5416,U.S. Senate,,DEM,Kamala Harris,1552
-Madera,5409-5416,U.S. Senate,,DEM,Loretta Sanchez,1320
-Madera,5419-5423,U.S. Senate,,DEM,Kamala Harris,1260
-Madera,5419-5423,U.S. Senate,,DEM,Loretta Sanchez,1002
-Madera,5424,U.S. Senate,,DEM,Kamala Harris,18
-Madera,5424,U.S. Senate,,DEM,Loretta Sanchez,17
-Madera,5425-5428,U.S. Senate,,DEM,Kamala Harris,971
-Madera,5425-5428,U.S. Senate,,DEM,Loretta Sanchez,726
-Madera,5429,U.S. Senate,,DEM,Kamala Harris,99
-Madera,5429,U.S. Senate,,DEM,Loretta Sanchez,88
-Madera,5430,U.S. Senate,,DEM,Kamala Harris,197
-Madera,5430,U.S. Senate,,DEM,Loretta Sanchez,183
-Madera,5431,U.S. Senate,,DEM,Kamala Harris,0
-Madera,5431,U.S. Senate,,DEM,Loretta Sanchez,1
-Madera,5432,U.S. Senate,,DEM,Kamala Harris,3
-Madera,5432,U.S. Senate,,DEM,Loretta Sanchez,1
+Madera,1002,U.S. Senate,,DEM,Kamala D. Harris,131
+Madera,1002,U.S. Senate,,DEM,Loretta L. Sanchez,222
+Madera,1004,U.S. Senate,,DEM,Kamala D. Harris,47
+Madera,1004,U.S. Senate,,DEM,Loretta L. Sanchez,69
+Madera,1307,U.S. Senate,,DEM,Kamala D. Harris,91
+Madera,1307,U.S. Senate,,DEM,Loretta L. Sanchez,136
+Madera,1308,U.S. Senate,,DEM,Kamala D. Harris,78
+Madera,1308,U.S. Senate,,DEM,Loretta L. Sanchez,70
+Madera,1309-1310,U.S. Senate,,DEM,Kamala D. Harris,492
+Madera,1309-1310,U.S. Senate,,DEM,Loretta L. Sanchez,501
+Madera,1311,U.S. Senate,,DEM,Kamala D. Harris,10
+Madera,1311,U.S. Senate,,DEM,Loretta L. Sanchez,10
+Madera,1313,U.S. Senate,,DEM,Kamala D. Harris,0
+Madera,1313,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Madera,1314,U.S. Senate,,DEM,Kamala D. Harris,0
+Madera,1314,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Madera,1315,U.S. Senate,,DEM,Kamala D. Harris,4
+Madera,1315,U.S. Senate,,DEM,Loretta L. Sanchez,8
+Madera,1316,U.S. Senate,,DEM,Kamala D. Harris,106
+Madera,1316,U.S. Senate,,DEM,Loretta L. Sanchez,232
+Madera,1317,U.S. Senate,,DEM,Kamala D. Harris,109
+Madera,1317,U.S. Senate,,DEM,Loretta L. Sanchez,143
+Madera,1318,U.S. Senate,,DEM,Kamala D. Harris,176
+Madera,1318,U.S. Senate,,DEM,Loretta L. Sanchez,331
+Madera,1319,U.S. Senate,,DEM,Kamala D. Harris,38
+Madera,1319,U.S. Senate,,DEM,Loretta L. Sanchez,64
+Madera,1415,U.S. Senate,,DEM,Kamala D. Harris,114
+Madera,1415,U.S. Senate,,DEM,Loretta L. Sanchez,94
+Madera,1502-1503,U.S. Senate,,DEM,Kamala D. Harris,547
+Madera,1502-1503,U.S. Senate,,DEM,Loretta L. Sanchez,671
+Madera,1509-1514,U.S. Senate,,DEM,Kamala D. Harris,1089
+Madera,1509-1514,U.S. Senate,,DEM,Loretta L. Sanchez,1119
+Madera,1515,U.S. Senate,,DEM,Kamala D. Harris,233
+Madera,1515,U.S. Senate,,DEM,Loretta L. Sanchez,271
+Madera,2001,U.S. Senate,,DEM,Kamala D. Harris,141
+Madera,2001,U.S. Senate,,DEM,Loretta L. Sanchez,174
+Madera,2003,U.S. Senate,,DEM,Kamala D. Harris,139
+Madera,2003,U.S. Senate,,DEM,Loretta L. Sanchez,190
+Madera,2007,U.S. Senate,,DEM,Kamala D. Harris,2
+Madera,2007,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Madera,2012-2015,U.S. Senate,,DEM,Kamala D. Harris,1067
+Madera,2012-2015,U.S. Senate,,DEM,Loretta L. Sanchez,1315
+Madera,2104,U.S. Senate,,DEM,Kamala D. Harris,162
+Madera,2104,U.S. Senate,,DEM,Loretta L. Sanchez,142
+Madera,2105,U.S. Senate,,DEM,Kamala D. Harris,126
+Madera,2105,U.S. Senate,,DEM,Loretta L. Sanchez,124
+Madera,2106-2107,U.S. Senate,,DEM,Kamala D. Harris,457
+Madera,2106-2107,U.S. Senate,,DEM,Loretta L. Sanchez,420
+Madera,2108,U.S. Senate,,DEM,Kamala D. Harris,184
+Madera,2108,U.S. Senate,,DEM,Loretta L. Sanchez,267
+Madera,2109-2110,U.S. Senate,,DEM,Kamala D. Harris,487
+Madera,2109-2110,U.S. Senate,,DEM,Loretta L. Sanchez,346
+Madera,2305,U.S. Senate,,DEM,Kamala D. Harris,0
+Madera,2305,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Madera,2306,U.S. Senate,,DEM,Kamala D. Harris,208
+Madera,2306,U.S. Senate,,DEM,Loretta L. Sanchez,173
+Madera,2309,U.S. Senate,,DEM,Kamala D. Harris,136
+Madera,2309,U.S. Senate,,DEM,Loretta L. Sanchez,141
+Madera,2324,U.S. Senate,,DEM,Kamala D. Harris,0
+Madera,2324,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Madera,2327,U.S. Senate,,DEM,Kamala D. Harris,0
+Madera,2327,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Madera,3201,U.S. Senate,,DEM,Kamala D. Harris,238
+Madera,3201,U.S. Senate,,DEM,Loretta L. Sanchez,302
+Madera,3202,U.S. Senate,,DEM,Kamala D. Harris,374
+Madera,3202,U.S. Senate,,DEM,Loretta L. Sanchez,357
+Madera,3207,U.S. Senate,,DEM,Kamala D. Harris,236
+Madera,3207,U.S. Senate,,DEM,Loretta L. Sanchez,236
+Madera,3208,U.S. Senate,,DEM,Kamala D. Harris,316
+Madera,3208,U.S. Senate,,DEM,Loretta L. Sanchez,309
+Madera,3210-3220,U.S. Senate,,DEM,Kamala D. Harris,607
+Madera,3210-3220,U.S. Senate,,DEM,Loretta L. Sanchez,630
+Madera,3211-3221,U.S. Senate,,DEM,Kamala D. Harris,429
+Madera,3211-3221,U.S. Senate,,DEM,Loretta L. Sanchez,440
+Madera,3212-3222,U.S. Senate,,DEM,Kamala D. Harris,377
+Madera,3212-3222,U.S. Senate,,DEM,Loretta L. Sanchez,355
+Madera,3213,U.S. Senate,,DEM,Kamala D. Harris,189
+Madera,3213,U.S. Senate,,DEM,Loretta L. Sanchez,261
+Madera,3214-3224,U.S. Senate,,DEM,Kamala D. Harris,347
+Madera,3214-3224,U.S. Senate,,DEM,Loretta L. Sanchez,421
+Madera,3215,U.S. Senate,,DEM,Kamala D. Harris,264
+Madera,3215,U.S. Senate,,DEM,Loretta L. Sanchez,303
+Madera,3216,U.S. Senate,,DEM,Kamala D. Harris,16
+Madera,3216,U.S. Senate,,DEM,Loretta L. Sanchez,18
+Madera,3217,U.S. Senate,,DEM,Kamala D. Harris,11
+Madera,3217,U.S. Senate,,DEM,Loretta L. Sanchez,7
+Madera,3218,U.S. Senate,,DEM,Kamala D. Harris,9
+Madera,3218,U.S. Senate,,DEM,Loretta L. Sanchez,7
+Madera,3219,U.S. Senate,,DEM,Kamala D. Harris,13
+Madera,3219,U.S. Senate,,DEM,Loretta L. Sanchez,7
+Madera,3223,U.S. Senate,,DEM,Kamala D. Harris,0
+Madera,3223,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Madera,4200,U.S. Senate,,DEM,Kamala D. Harris,154
+Madera,4200,U.S. Senate,,DEM,Loretta L. Sanchez,195
+Madera,4201,U.S. Senate,,DEM,Kamala D. Harris,77
+Madera,4201,U.S. Senate,,DEM,Loretta L. Sanchez,139
+Madera,4202,U.S. Senate,,DEM,Kamala D. Harris,301
+Madera,4202,U.S. Senate,,DEM,Loretta L. Sanchez,450
+Madera,4203,U.S. Senate,,DEM,Kamala D. Harris,134
+Madera,4203,U.S. Senate,,DEM,Loretta L. Sanchez,306
+Madera,4204,U.S. Senate,,DEM,Kamala D. Harris,101
+Madera,4204,U.S. Senate,,DEM,Loretta L. Sanchez,111
+Madera,4205-4215,U.S. Senate,,DEM,Kamala D. Harris,159
+Madera,4205-4215,U.S. Senate,,DEM,Loretta L. Sanchez,351
+Madera,4207,U.S. Senate,,DEM,Kamala D. Harris,106
+Madera,4207,U.S. Senate,,DEM,Loretta L. Sanchez,172
+Madera,4208,U.S. Senate,,DEM,Kamala D. Harris,79
+Madera,4208,U.S. Senate,,DEM,Loretta L. Sanchez,107
+Madera,4310,U.S. Senate,,DEM,Kamala D. Harris,161
+Madera,4310,U.S. Senate,,DEM,Loretta L. Sanchez,260
+Madera,4311,U.S. Senate,,DEM,Kamala D. Harris,1
+Madera,4311,U.S. Senate,,DEM,Loretta L. Sanchez,5
+Madera,4312,U.S. Senate,,DEM,Kamala D. Harris,0
+Madera,4312,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Madera,5400-5402,U.S. Senate,,DEM,Kamala D. Harris,706
+Madera,5400-5402,U.S. Senate,,DEM,Loretta L. Sanchez,551
+Madera,5403,U.S. Senate,,DEM,Kamala D. Harris,220
+Madera,5403,U.S. Senate,,DEM,Loretta L. Sanchez,172
+Madera,5404-5406,U.S. Senate,,DEM,Kamala D. Harris,670
+Madera,5404-5406,U.S. Senate,,DEM,Loretta L. Sanchez,516
+Madera,5409-5416,U.S. Senate,,DEM,Kamala D. Harris,1552
+Madera,5409-5416,U.S. Senate,,DEM,Loretta L. Sanchez,1320
+Madera,5419-5423,U.S. Senate,,DEM,Kamala D. Harris,1260
+Madera,5419-5423,U.S. Senate,,DEM,Loretta L. Sanchez,1002
+Madera,5424,U.S. Senate,,DEM,Kamala D. Harris,18
+Madera,5424,U.S. Senate,,DEM,Loretta L. Sanchez,17
+Madera,5425-5428,U.S. Senate,,DEM,Kamala D. Harris,971
+Madera,5425-5428,U.S. Senate,,DEM,Loretta L. Sanchez,726
+Madera,5429,U.S. Senate,,DEM,Kamala D. Harris,99
+Madera,5429,U.S. Senate,,DEM,Loretta L. Sanchez,88
+Madera,5430,U.S. Senate,,DEM,Kamala D. Harris,197
+Madera,5430,U.S. Senate,,DEM,Loretta L. Sanchez,183
+Madera,5431,U.S. Senate,,DEM,Kamala D. Harris,0
+Madera,5431,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Madera,5432,U.S. Senate,,DEM,Kamala D. Harris,3
+Madera,5432,U.S. Senate,,DEM,Loretta L. Sanchez,1

--- a/2016/20161108__ca__general__marin__precinct.csv
+++ b/2016/20161108__ca__general__marin__precinct.csv
@@ -7279,367 +7279,367 @@ Marin,641209,Proposition 67,,N/A,Yes,139
 Marin,641209,Proposition 67,,N/A,No,64
 Marin,641210,Proposition 67,,N/A,Yes,11
 Marin,641210,Proposition 67,,N/A,No,1
-Marin,109019,U.S. Senate,,DEM,Kamala Harris,572
-Marin,109019,U.S. Senate,,DEM,Loretta Sanchez,140
-Marin,109029,U.S. Senate,,DEM,Kamala Harris,914
-Marin,109029,U.S. Senate,,DEM,Loretta Sanchez,287
-Marin,109039,U.S. Senate,,DEM,Kamala Harris,793
-Marin,109039,U.S. Senate,,DEM,Loretta Sanchez,164
-Marin,109049,U.S. Senate,,DEM,Kamala Harris,402
-Marin,109049,U.S. Senate,,DEM,Loretta Sanchez,126
-Marin,109050,U.S. Senate,,DEM,Kamala Harris,531
-Marin,109050,U.S. Senate,,DEM,Loretta Sanchez,108
-Marin,109059,U.S. Senate,,DEM,Kamala Harris,860
-Marin,109059,U.S. Senate,,DEM,Loretta Sanchez,304
-Marin,109060,U.S. Senate,,DEM,Kamala Harris,511
-Marin,109060,U.S. Senate,,DEM,Loretta Sanchez,124
-Marin,109069,U.S. Senate,,DEM,Kamala Harris,1027
-Marin,109069,U.S. Senate,,DEM,Loretta Sanchez,232
-Marin,109079,U.S. Senate,,DEM,Kamala Harris,983
-Marin,109079,U.S. Senate,,DEM,Loretta Sanchez,207
-Marin,109080,U.S. Senate,,DEM,Kamala Harris,639
-Marin,109080,U.S. Senate,,DEM,Loretta Sanchez,223
-Marin,109089,U.S. Senate,,DEM,Kamala Harris,467
-Marin,109089,U.S. Senate,,DEM,Loretta Sanchez,157
-Marin,109099,U.S. Senate,,DEM,Kamala Harris,511
-Marin,109099,U.S. Senate,,DEM,Loretta Sanchez,139
-Marin,109100,U.S. Senate,,DEM,Kamala Harris,506
-Marin,109100,U.S. Senate,,DEM,Loretta Sanchez,105
-Marin,109109,U.S. Senate,,DEM,Kamala Harris,364
-Marin,109109,U.S. Senate,,DEM,Loretta Sanchez,130
-Marin,109119,U.S. Senate,,DEM,Kamala Harris,838
-Marin,109119,U.S. Senate,,DEM,Loretta Sanchez,256
-Marin,109129,U.S. Senate,,DEM,Kamala Harris,545
-Marin,109129,U.S. Senate,,DEM,Loretta Sanchez,157
-Marin,109130,U.S. Senate,,DEM,Kamala Harris,367
-Marin,109130,U.S. Senate,,DEM,Loretta Sanchez,97
-Marin,109139,U.S. Senate,,DEM,Kamala Harris,441
-Marin,109139,U.S. Senate,,DEM,Loretta Sanchez,159
-Marin,109149,U.S. Senate,,DEM,Kamala Harris,521
-Marin,109149,U.S. Senate,,DEM,Loretta Sanchez,142
-Marin,109159,U.S. Senate,,DEM,Kamala Harris,880
-Marin,109159,U.S. Senate,,DEM,Loretta Sanchez,264
-Marin,109169,U.S. Senate,,DEM,Kamala Harris,382
-Marin,109169,U.S. Senate,,DEM,Loretta Sanchez,126
-Marin,109290,U.S. Senate,,DEM,Kamala Harris,515
-Marin,109290,U.S. Senate,,DEM,Loretta Sanchez,118
-Marin,109340,U.S. Senate,,DEM,Kamala Harris,487
-Marin,109340,U.S. Senate,,DEM,Loretta Sanchez,143
-Marin,109360,U.S. Senate,,DEM,Kamala Harris,552
-Marin,109360,U.S. Senate,,DEM,Loretta Sanchez,171
-Marin,109470,U.S. Senate,,DEM,Kamala Harris,550
-Marin,109470,U.S. Senate,,DEM,Loretta Sanchez,138
-Marin,112070,U.S. Senate,,DEM,Kamala Harris,477
-Marin,112070,U.S. Senate,,DEM,Loretta Sanchez,95
-Marin,112160,U.S. Senate,,DEM,Kamala Harris,510
-Marin,112160,U.S. Senate,,DEM,Loretta Sanchez,138
-Marin,112179,U.S. Senate,,DEM,Kamala Harris,1061
-Marin,112179,U.S. Senate,,DEM,Loretta Sanchez,235
-Marin,112189,U.S. Senate,,DEM,Kamala Harris,820
-Marin,112189,U.S. Senate,,DEM,Loretta Sanchez,235
-Marin,112199,U.S. Senate,,DEM,Kamala Harris,188
-Marin,112199,U.S. Senate,,DEM,Loretta Sanchez,56
-Marin,112209,U.S. Senate,,DEM,Kamala Harris,727
-Marin,112209,U.S. Senate,,DEM,Loretta Sanchez,189
-Marin,112219,U.S. Senate,,DEM,Kamala Harris,456
-Marin,112219,U.S. Senate,,DEM,Loretta Sanchez,134
-Marin,112229,U.S. Senate,,DEM,Kamala Harris,414
-Marin,112229,U.S. Senate,,DEM,Loretta Sanchez,139
-Marin,112239,U.S. Senate,,DEM,Kamala Harris,482
-Marin,112239,U.S. Senate,,DEM,Loretta Sanchez,139
-Marin,203019,U.S. Senate,,DEM,Kamala Harris,909
-Marin,203019,U.S. Senate,,DEM,Loretta Sanchez,157
-Marin,203029,U.S. Senate,,DEM,Kamala Harris,877
-Marin,203029,U.S. Senate,,DEM,Loretta Sanchez,198
-Marin,203040,U.S. Senate,,DEM,Kamala Harris,528
-Marin,203040,U.S. Senate,,DEM,Loretta Sanchez,112
-Marin,203060,U.S. Senate,,DEM,Kamala Harris,450
-Marin,203060,U.S. Senate,,DEM,Loretta Sanchez,105
-Marin,203080,U.S. Senate,,DEM,Kamala Harris,475
-Marin,203080,U.S. Senate,,DEM,Loretta Sanchez,83
-Marin,203130,U.S. Senate,,DEM,Kamala Harris,545
-Marin,203130,U.S. Senate,,DEM,Loretta Sanchez,107
-Marin,204039,U.S. Senate,,DEM,Kamala Harris,251
-Marin,204039,U.S. Senate,,DEM,Loretta Sanchez,60
-Marin,204049,U.S. Senate,,DEM,Kamala Harris,384
-Marin,204049,U.S. Senate,,DEM,Loretta Sanchez,89
-Marin,204059,U.S. Senate,,DEM,Kamala Harris,693
-Marin,204059,U.S. Senate,,DEM,Loretta Sanchez,154
-Marin,204069,U.S. Senate,,DEM,Kamala Harris,623
-Marin,204069,U.S. Senate,,DEM,Loretta Sanchez,215
-Marin,204079,U.S. Senate,,DEM,Kamala Harris,477
-Marin,204079,U.S. Senate,,DEM,Loretta Sanchez,76
-Marin,204089,U.S. Senate,,DEM,Kamala Harris,1065
-Marin,204089,U.S. Senate,,DEM,Loretta Sanchez,290
-Marin,204350,U.S. Senate,,DEM,Kamala Harris,522
-Marin,204350,U.S. Senate,,DEM,Loretta Sanchez,138
-Marin,204390,U.S. Senate,,DEM,Kamala Harris,441
-Marin,204390,U.S. Senate,,DEM,Loretta Sanchez,104
-Marin,204410,U.S. Senate,,DEM,Kamala Harris,422
-Marin,204410,U.S. Senate,,DEM,Loretta Sanchez,111
-Marin,207099,U.S. Senate,,DEM,Kamala Harris,604
-Marin,207099,U.S. Senate,,DEM,Loretta Sanchez,218
-Marin,207180,U.S. Senate,,DEM,Kamala Harris,328
-Marin,207180,U.S. Senate,,DEM,Loretta Sanchez,93
-Marin,208100,U.S. Senate,,DEM,Kamala Harris,585
-Marin,208100,U.S. Senate,,DEM,Loretta Sanchez,125
-Marin,208109,U.S. Senate,,DEM,Kamala Harris,1007
-Marin,208109,U.S. Senate,,DEM,Loretta Sanchez,173
-Marin,208119,U.S. Senate,,DEM,Kamala Harris,942
-Marin,208119,U.S. Senate,,DEM,Loretta Sanchez,207
-Marin,208129,U.S. Senate,,DEM,Kamala Harris,527
-Marin,208129,U.S. Senate,,DEM,Loretta Sanchez,113
-Marin,208139,U.S. Senate,,DEM,Kamala Harris,544
-Marin,208139,U.S. Senate,,DEM,Loretta Sanchez,103
-Marin,208149,U.S. Senate,,DEM,Kamala Harris,942
-Marin,208149,U.S. Senate,,DEM,Loretta Sanchez,191
-Marin,208160,U.S. Senate,,DEM,Kamala Harris,558
-Marin,208160,U.S. Senate,,DEM,Loretta Sanchez,112
-Marin,208240,U.S. Senate,,DEM,Kamala Harris,420
-Marin,208240,U.S. Senate,,DEM,Loretta Sanchez,74
-Marin,208250,U.S. Senate,,DEM,Kamala Harris,542
-Marin,208250,U.S. Senate,,DEM,Loretta Sanchez,129
-Marin,209159,U.S. Senate,,DEM,Kamala Harris,552
-Marin,209159,U.S. Senate,,DEM,Loretta Sanchez,128
-Marin,209169,U.S. Senate,,DEM,Kamala Harris,510
-Marin,209169,U.S. Senate,,DEM,Loretta Sanchez,108
-Marin,209179,U.S. Senate,,DEM,Kamala Harris,508
-Marin,209179,U.S. Senate,,DEM,Loretta Sanchez,143
-Marin,209189,U.S. Senate,,DEM,Kamala Harris,522
-Marin,209189,U.S. Senate,,DEM,Loretta Sanchez,153
-Marin,209199,U.S. Senate,,DEM,Kamala Harris,527
-Marin,209199,U.S. Senate,,DEM,Loretta Sanchez,129
-Marin,212209,U.S. Senate,,DEM,Kamala Harris,607
-Marin,212209,U.S. Senate,,DEM,Loretta Sanchez,172
-Marin,212219,U.S. Senate,,DEM,Kamala Harris,551
-Marin,212219,U.S. Senate,,DEM,Loretta Sanchez,148
-Marin,212229,U.S. Senate,,DEM,Kamala Harris,432
-Marin,212229,U.S. Senate,,DEM,Loretta Sanchez,96
-Marin,212239,U.S. Senate,,DEM,Kamala Harris,649
-Marin,212239,U.S. Senate,,DEM,Loretta Sanchez,195
-Marin,212249,U.S. Senate,,DEM,Kamala Harris,265
-Marin,212249,U.S. Senate,,DEM,Loretta Sanchez,70
-Marin,212259,U.S. Senate,,DEM,Kamala Harris,615
-Marin,212259,U.S. Senate,,DEM,Loretta Sanchez,156
-Marin,212269,U.S. Senate,,DEM,Kamala Harris,724
-Marin,212269,U.S. Senate,,DEM,Loretta Sanchez,171
-Marin,212300,U.S. Senate,,DEM,Kamala Harris,499
-Marin,212300,U.S. Senate,,DEM,Loretta Sanchez,98
-Marin,301019,U.S. Senate,,DEM,Kamala Harris,885
-Marin,301019,U.S. Senate,,DEM,Loretta Sanchez,226
-Marin,305010,U.S. Senate,,DEM,Kamala Harris,552
-Marin,305010,U.S. Senate,,DEM,Loretta Sanchez,118
-Marin,305020,U.S. Senate,,DEM,Kamala Harris,444
-Marin,305020,U.S. Senate,,DEM,Loretta Sanchez,79
-Marin,305029,U.S. Senate,,DEM,Kamala Harris,512
-Marin,305029,U.S. Senate,,DEM,Loretta Sanchez,124
-Marin,305030,U.S. Senate,,DEM,Kamala Harris,587
-Marin,305030,U.S. Senate,,DEM,Loretta Sanchez,93
-Marin,305039,U.S. Senate,,DEM,Kamala Harris,989
-Marin,305039,U.S. Senate,,DEM,Loretta Sanchez,180
-Marin,305049,U.S. Senate,,DEM,Kamala Harris,546
-Marin,305049,U.S. Senate,,DEM,Loretta Sanchez,93
-Marin,305050,U.S. Senate,,DEM,Kamala Harris,491
-Marin,305050,U.S. Senate,,DEM,Loretta Sanchez,108
-Marin,305059,U.S. Senate,,DEM,Kamala Harris,1084
-Marin,305059,U.S. Senate,,DEM,Loretta Sanchez,269
-Marin,305069,U.S. Senate,,DEM,Kamala Harris,1151
-Marin,305069,U.S. Senate,,DEM,Loretta Sanchez,275
-Marin,305090,U.S. Senate,,DEM,Kamala Harris,517
-Marin,305090,U.S. Senate,,DEM,Loretta Sanchez,74
-Marin,310079,U.S. Senate,,DEM,Kamala Harris,664
-Marin,310079,U.S. Senate,,DEM,Loretta Sanchez,158
-Marin,310089,U.S. Senate,,DEM,Kamala Harris,894
-Marin,310089,U.S. Senate,,DEM,Loretta Sanchez,202
-Marin,310099,U.S. Senate,,DEM,Kamala Harris,834
-Marin,310099,U.S. Senate,,DEM,Loretta Sanchez,179
-Marin,310310,U.S. Senate,,DEM,Kamala Harris,466
-Marin,310310,U.S. Senate,,DEM,Loretta Sanchez,116
-Marin,310410,U.S. Senate,,DEM,Kamala Harris,576
-Marin,310410,U.S. Senate,,DEM,Loretta Sanchez,153
-Marin,311109,U.S. Senate,,DEM,Kamala Harris,822
-Marin,311109,U.S. Senate,,DEM,Loretta Sanchez,280
-Marin,311119,U.S. Senate,,DEM,Kamala Harris,781
-Marin,311119,U.S. Senate,,DEM,Loretta Sanchez,223
-Marin,311129,U.S. Senate,,DEM,Kamala Harris,905
-Marin,311129,U.S. Senate,,DEM,Loretta Sanchez,252
-Marin,311139,U.S. Senate,,DEM,Kamala Harris,982
-Marin,311139,U.S. Senate,,DEM,Loretta Sanchez,315
-Marin,312149,U.S. Senate,,DEM,Kamala Harris,316
-Marin,312149,U.S. Senate,,DEM,Loretta Sanchez,68
-Marin,312159,U.S. Senate,,DEM,Kamala Harris,856
-Marin,312159,U.S. Senate,,DEM,Loretta Sanchez,179
-Marin,312169,U.S. Senate,,DEM,Kamala Harris,1085
-Marin,312169,U.S. Senate,,DEM,Loretta Sanchez,230
-Marin,312179,U.S. Senate,,DEM,Kamala Harris,498
-Marin,312179,U.S. Senate,,DEM,Loretta Sanchez,108
-Marin,312189,U.S. Senate,,DEM,Kamala Harris,853
-Marin,312189,U.S. Senate,,DEM,Loretta Sanchez,166
-Marin,312199,U.S. Senate,,DEM,Kamala Harris,467
-Marin,312199,U.S. Senate,,DEM,Loretta Sanchez,101
-Marin,312209,U.S. Senate,,DEM,Kamala Harris,935
-Marin,312209,U.S. Senate,,DEM,Loretta Sanchez,207
-Marin,312219,U.S. Senate,,DEM,Kamala Harris,671
-Marin,312219,U.S. Senate,,DEM,Loretta Sanchez,209
-Marin,312229,U.S. Senate,,DEM,Kamala Harris,242
-Marin,312229,U.S. Senate,,DEM,Loretta Sanchez,92
-Marin,312239,U.S. Senate,,DEM,Kamala Harris,832
-Marin,312239,U.S. Senate,,DEM,Loretta Sanchez,262
-Marin,312249,U.S. Senate,,DEM,Kamala Harris,279
-Marin,312249,U.S. Senate,,DEM,Loretta Sanchez,99
-Marin,312250,U.S. Senate,,DEM,Kamala Harris,409
-Marin,312250,U.S. Senate,,DEM,Loretta Sanchez,83
-Marin,402019,U.S. Senate,,DEM,Kamala Harris,787
-Marin,402019,U.S. Senate,,DEM,Loretta Sanchez,212
-Marin,402029,U.S. Senate,,DEM,Kamala Harris,957
-Marin,402029,U.S. Senate,,DEM,Loretta Sanchez,201
-Marin,402039,U.S. Senate,,DEM,Kamala Harris,418
-Marin,402039,U.S. Senate,,DEM,Loretta Sanchez,116
-Marin,402049,U.S. Senate,,DEM,Kamala Harris,817
-Marin,402049,U.S. Senate,,DEM,Loretta Sanchez,231
-Marin,402059,U.S. Senate,,DEM,Kamala Harris,466
-Marin,402059,U.S. Senate,,DEM,Loretta Sanchez,124
-Marin,402230,U.S. Senate,,DEM,Kamala Harris,517
-Marin,402230,U.S. Senate,,DEM,Loretta Sanchez,123
-Marin,404069,U.S. Senate,,DEM,Kamala Harris,209
-Marin,404069,U.S. Senate,,DEM,Loretta Sanchez,71
-Marin,404079,U.S. Senate,,DEM,Kamala Harris,341
-Marin,404079,U.S. Senate,,DEM,Loretta Sanchez,117
-Marin,406089,U.S. Senate,,DEM,Kamala Harris,706
-Marin,406089,U.S. Senate,,DEM,Loretta Sanchez,249
-Marin,406099,U.S. Senate,,DEM,Kamala Harris,681
-Marin,406099,U.S. Senate,,DEM,Loretta Sanchez,256
-Marin,406109,U.S. Senate,,DEM,Kamala Harris,889
-Marin,406109,U.S. Senate,,DEM,Loretta Sanchez,290
-Marin,406119,U.S. Senate,,DEM,Kamala Harris,432
-Marin,406119,U.S. Senate,,DEM,Loretta Sanchez,203
-Marin,409129,U.S. Senate,,DEM,Kamala Harris,647
-Marin,409129,U.S. Senate,,DEM,Loretta Sanchez,295
-Marin,409460,U.S. Senate,,DEM,Kamala Harris,266
-Marin,409460,U.S. Senate,,DEM,Loretta Sanchez,231
-Marin,412139,U.S. Senate,,DEM,Kamala Harris,406
-Marin,412139,U.S. Senate,,DEM,Loretta Sanchez,110
-Marin,412149,U.S. Senate,,DEM,Kamala Harris,792
-Marin,412149,U.S. Senate,,DEM,Loretta Sanchez,182
-Marin,412159,U.S. Senate,,DEM,Kamala Harris,270
-Marin,412159,U.S. Senate,,DEM,Loretta Sanchez,68
-Marin,412169,U.S. Senate,,DEM,Kamala Harris,536
-Marin,412169,U.S. Senate,,DEM,Loretta Sanchez,101
-Marin,412179,U.S. Senate,,DEM,Kamala Harris,688
-Marin,412179,U.S. Senate,,DEM,Loretta Sanchez,112
-Marin,412189,U.S. Senate,,DEM,Kamala Harris,425
-Marin,412189,U.S. Senate,,DEM,Loretta Sanchez,192
-Marin,412199,U.S. Senate,,DEM,Kamala Harris,331
-Marin,412199,U.S. Senate,,DEM,Loretta Sanchez,55
-Marin,412209,U.S. Senate,,DEM,Kamala Harris,603
-Marin,412209,U.S. Senate,,DEM,Loretta Sanchez,110
-Marin,412219,U.S. Senate,,DEM,Kamala Harris,757
-Marin,412219,U.S. Senate,,DEM,Loretta Sanchez,203
-Marin,412229,U.S. Senate,,DEM,Kamala Harris,219
-Marin,412229,U.S. Senate,,DEM,Loretta Sanchez,41
-Marin,412239,U.S. Senate,,DEM,Kamala Harris,370
-Marin,412239,U.S. Senate,,DEM,Loretta Sanchez,81
-Marin,412249,U.S. Senate,,DEM,Kamala Harris,800
-Marin,412249,U.S. Senate,,DEM,Loretta Sanchez,166
-Marin,412259,U.S. Senate,,DEM,Kamala Harris,397
-Marin,412259,U.S. Senate,,DEM,Loretta Sanchez,71
-Marin,412300,U.S. Senate,,DEM,Kamala Harris,481
-Marin,412300,U.S. Senate,,DEM,Loretta Sanchez,95
-Marin,506010,U.S. Senate,,DEM,Kamala Harris,451
-Marin,506010,U.S. Senate,,DEM,Loretta Sanchez,138
-Marin,506019,U.S. Senate,,DEM,Kamala Harris,680
-Marin,506019,U.S. Senate,,DEM,Loretta Sanchez,231
-Marin,506029,U.S. Senate,,DEM,Kamala Harris,422
-Marin,506029,U.S. Senate,,DEM,Loretta Sanchez,190
-Marin,506030,U.S. Senate,,DEM,Kamala Harris,456
-Marin,506030,U.S. Senate,,DEM,Loretta Sanchez,189
-Marin,506039,U.S. Senate,,DEM,Kamala Harris,384
-Marin,506039,U.S. Senate,,DEM,Loretta Sanchez,161
-Marin,506040,U.S. Senate,,DEM,Kamala Harris,440
-Marin,506040,U.S. Senate,,DEM,Loretta Sanchez,149
-Marin,506049,U.S. Senate,,DEM,Kamala Harris,436
-Marin,506049,U.S. Senate,,DEM,Loretta Sanchez,170
-Marin,506050,U.S. Senate,,DEM,Kamala Harris,426
-Marin,506050,U.S. Senate,,DEM,Loretta Sanchez,178
-Marin,506059,U.S. Senate,,DEM,Kamala Harris,883
-Marin,506059,U.S. Senate,,DEM,Loretta Sanchez,339
-Marin,506069,U.S. Senate,,DEM,Kamala Harris,417
-Marin,506069,U.S. Senate,,DEM,Loretta Sanchez,176
-Marin,506079,U.S. Senate,,DEM,Kamala Harris,429
-Marin,506079,U.S. Senate,,DEM,Loretta Sanchez,124
-Marin,506089,U.S. Senate,,DEM,Kamala Harris,471
-Marin,506089,U.S. Senate,,DEM,Loretta Sanchez,161
-Marin,506099,U.S. Senate,,DEM,Kamala Harris,462
-Marin,506099,U.S. Senate,,DEM,Loretta Sanchez,195
-Marin,506100,U.S. Senate,,DEM,Kamala Harris,425
-Marin,506100,U.S. Senate,,DEM,Loretta Sanchez,215
-Marin,506109,U.S. Senate,,DEM,Kamala Harris,957
-Marin,506109,U.S. Senate,,DEM,Loretta Sanchez,335
-Marin,506119,U.S. Senate,,DEM,Kamala Harris,944
-Marin,506119,U.S. Senate,,DEM,Loretta Sanchez,363
-Marin,506120,U.S. Senate,,DEM,Kamala Harris,418
-Marin,506120,U.S. Senate,,DEM,Loretta Sanchez,199
-Marin,506129,U.S. Senate,,DEM,Kamala Harris,907
-Marin,506129,U.S. Senate,,DEM,Loretta Sanchez,332
-Marin,506139,U.S. Senate,,DEM,Kamala Harris,752
-Marin,506139,U.S. Senate,,DEM,Loretta Sanchez,267
-Marin,506149,U.S. Senate,,DEM,Kamala Harris,953
-Marin,506149,U.S. Senate,,DEM,Loretta Sanchez,308
-Marin,506159,U.S. Senate,,DEM,Kamala Harris,686
-Marin,506159,U.S. Senate,,DEM,Loretta Sanchez,243
-Marin,506169,U.S. Senate,,DEM,Kamala Harris,863
-Marin,506169,U.S. Senate,,DEM,Loretta Sanchez,285
-Marin,506179,U.S. Senate,,DEM,Kamala Harris,795
-Marin,506179,U.S. Senate,,DEM,Loretta Sanchez,307
-Marin,506189,U.S. Senate,,DEM,Kamala Harris,413
-Marin,506189,U.S. Senate,,DEM,Loretta Sanchez,161
-Marin,512199,U.S. Senate,,DEM,Kamala Harris,737
-Marin,512199,U.S. Senate,,DEM,Loretta Sanchez,302
-Marin,512209,U.S. Senate,,DEM,Kamala Harris,690
-Marin,512209,U.S. Senate,,DEM,Loretta Sanchez,234
-Marin,512219,U.S. Senate,,DEM,Kamala Harris,384
-Marin,512219,U.S. Senate,,DEM,Loretta Sanchez,126
-Marin,512340,U.S. Senate,,DEM,Kamala Harris,491
-Marin,512340,U.S. Senate,,DEM,Loretta Sanchez,161
-Marin,611201,U.S. Senate,,DEM,Kamala Harris,17
-Marin,611201,U.S. Senate,,DEM,Loretta Sanchez,8
-Marin,620701,U.S. Senate,,DEM,Kamala Harris,0
-Marin,620701,U.S. Senate,,DEM,Loretta Sanchez,0
-Marin,620702,U.S. Senate,,DEM,Kamala Harris,4
-Marin,620702,U.S. Senate,,DEM,Loretta Sanchez,0
-Marin,621203,U.S. Senate,,DEM,Kamala Harris,132
-Marin,621203,U.S. Senate,,DEM,Loretta Sanchez,52
-Marin,621204,U.S. Senate,,DEM,Kamala Harris,174
-Marin,621204,U.S. Senate,,DEM,Loretta Sanchez,38
-Marin,621205,U.S. Senate,,DEM,Kamala Harris,117
-Marin,621205,U.S. Senate,,DEM,Loretta Sanchez,19
-Marin,630501,U.S. Senate,,DEM,Kamala Harris,5
-Marin,630501,U.S. Senate,,DEM,Loretta Sanchez,4
-Marin,631102,U.S. Senate,,DEM,Kamala Harris,75
-Marin,631102,U.S. Senate,,DEM,Loretta Sanchez,23
-Marin,631203,U.S. Senate,,DEM,Kamala Harris,61
-Marin,631203,U.S. Senate,,DEM,Loretta Sanchez,19
-Marin,631204,U.S. Senate,,DEM,Kamala Harris,127
-Marin,631204,U.S. Senate,,DEM,Loretta Sanchez,25
-Marin,631205,U.S. Senate,,DEM,Kamala Harris,106
-Marin,631205,U.S. Senate,,DEM,Loretta Sanchez,40
-Marin,640401,U.S. Senate,,DEM,Kamala Harris,0
-Marin,640401,U.S. Senate,,DEM,Loretta Sanchez,0
-Marin,641202,U.S. Senate,,DEM,Kamala Harris,111
-Marin,641202,U.S. Senate,,DEM,Loretta Sanchez,50
-Marin,641203,U.S. Senate,,DEM,Kamala Harris,60
-Marin,641203,U.S. Senate,,DEM,Loretta Sanchez,35
-Marin,641204,U.S. Senate,,DEM,Kamala Harris,12
-Marin,641204,U.S. Senate,,DEM,Loretta Sanchez,4
-Marin,641205,U.S. Senate,,DEM,Kamala Harris,1
-Marin,641205,U.S. Senate,,DEM,Loretta Sanchez,1
-Marin,641206,U.S. Senate,,DEM,Kamala Harris,3
-Marin,641206,U.S. Senate,,DEM,Loretta Sanchez,0
-Marin,641207,U.S. Senate,,DEM,Kamala Harris,0
-Marin,641207,U.S. Senate,,DEM,Loretta Sanchez,0
-Marin,641208,U.S. Senate,,DEM,Kamala Harris,10
-Marin,641208,U.S. Senate,,DEM,Loretta Sanchez,2
-Marin,641209,U.S. Senate,,DEM,Kamala Harris,153
-Marin,641209,U.S. Senate,,DEM,Loretta Sanchez,32
-Marin,641210,U.S. Senate,,DEM,Kamala Harris,8
-Marin,641210,U.S. Senate,,DEM,Loretta Sanchez,2
+Marin,109019,U.S. Senate,,DEM,Kamala D. Harris,572
+Marin,109019,U.S. Senate,,DEM,Loretta L. Sanchez,140
+Marin,109029,U.S. Senate,,DEM,Kamala D. Harris,914
+Marin,109029,U.S. Senate,,DEM,Loretta L. Sanchez,287
+Marin,109039,U.S. Senate,,DEM,Kamala D. Harris,793
+Marin,109039,U.S. Senate,,DEM,Loretta L. Sanchez,164
+Marin,109049,U.S. Senate,,DEM,Kamala D. Harris,402
+Marin,109049,U.S. Senate,,DEM,Loretta L. Sanchez,126
+Marin,109050,U.S. Senate,,DEM,Kamala D. Harris,531
+Marin,109050,U.S. Senate,,DEM,Loretta L. Sanchez,108
+Marin,109059,U.S. Senate,,DEM,Kamala D. Harris,860
+Marin,109059,U.S. Senate,,DEM,Loretta L. Sanchez,304
+Marin,109060,U.S. Senate,,DEM,Kamala D. Harris,511
+Marin,109060,U.S. Senate,,DEM,Loretta L. Sanchez,124
+Marin,109069,U.S. Senate,,DEM,Kamala D. Harris,1027
+Marin,109069,U.S. Senate,,DEM,Loretta L. Sanchez,232
+Marin,109079,U.S. Senate,,DEM,Kamala D. Harris,983
+Marin,109079,U.S. Senate,,DEM,Loretta L. Sanchez,207
+Marin,109080,U.S. Senate,,DEM,Kamala D. Harris,639
+Marin,109080,U.S. Senate,,DEM,Loretta L. Sanchez,223
+Marin,109089,U.S. Senate,,DEM,Kamala D. Harris,467
+Marin,109089,U.S. Senate,,DEM,Loretta L. Sanchez,157
+Marin,109099,U.S. Senate,,DEM,Kamala D. Harris,511
+Marin,109099,U.S. Senate,,DEM,Loretta L. Sanchez,139
+Marin,109100,U.S. Senate,,DEM,Kamala D. Harris,506
+Marin,109100,U.S. Senate,,DEM,Loretta L. Sanchez,105
+Marin,109109,U.S. Senate,,DEM,Kamala D. Harris,364
+Marin,109109,U.S. Senate,,DEM,Loretta L. Sanchez,130
+Marin,109119,U.S. Senate,,DEM,Kamala D. Harris,838
+Marin,109119,U.S. Senate,,DEM,Loretta L. Sanchez,256
+Marin,109129,U.S. Senate,,DEM,Kamala D. Harris,545
+Marin,109129,U.S. Senate,,DEM,Loretta L. Sanchez,157
+Marin,109130,U.S. Senate,,DEM,Kamala D. Harris,367
+Marin,109130,U.S. Senate,,DEM,Loretta L. Sanchez,97
+Marin,109139,U.S. Senate,,DEM,Kamala D. Harris,441
+Marin,109139,U.S. Senate,,DEM,Loretta L. Sanchez,159
+Marin,109149,U.S. Senate,,DEM,Kamala D. Harris,521
+Marin,109149,U.S. Senate,,DEM,Loretta L. Sanchez,142
+Marin,109159,U.S. Senate,,DEM,Kamala D. Harris,880
+Marin,109159,U.S. Senate,,DEM,Loretta L. Sanchez,264
+Marin,109169,U.S. Senate,,DEM,Kamala D. Harris,382
+Marin,109169,U.S. Senate,,DEM,Loretta L. Sanchez,126
+Marin,109290,U.S. Senate,,DEM,Kamala D. Harris,515
+Marin,109290,U.S. Senate,,DEM,Loretta L. Sanchez,118
+Marin,109340,U.S. Senate,,DEM,Kamala D. Harris,487
+Marin,109340,U.S. Senate,,DEM,Loretta L. Sanchez,143
+Marin,109360,U.S. Senate,,DEM,Kamala D. Harris,552
+Marin,109360,U.S. Senate,,DEM,Loretta L. Sanchez,171
+Marin,109470,U.S. Senate,,DEM,Kamala D. Harris,550
+Marin,109470,U.S. Senate,,DEM,Loretta L. Sanchez,138
+Marin,112070,U.S. Senate,,DEM,Kamala D. Harris,477
+Marin,112070,U.S. Senate,,DEM,Loretta L. Sanchez,95
+Marin,112160,U.S. Senate,,DEM,Kamala D. Harris,510
+Marin,112160,U.S. Senate,,DEM,Loretta L. Sanchez,138
+Marin,112179,U.S. Senate,,DEM,Kamala D. Harris,1061
+Marin,112179,U.S. Senate,,DEM,Loretta L. Sanchez,235
+Marin,112189,U.S. Senate,,DEM,Kamala D. Harris,820
+Marin,112189,U.S. Senate,,DEM,Loretta L. Sanchez,235
+Marin,112199,U.S. Senate,,DEM,Kamala D. Harris,188
+Marin,112199,U.S. Senate,,DEM,Loretta L. Sanchez,56
+Marin,112209,U.S. Senate,,DEM,Kamala D. Harris,727
+Marin,112209,U.S. Senate,,DEM,Loretta L. Sanchez,189
+Marin,112219,U.S. Senate,,DEM,Kamala D. Harris,456
+Marin,112219,U.S. Senate,,DEM,Loretta L. Sanchez,134
+Marin,112229,U.S. Senate,,DEM,Kamala D. Harris,414
+Marin,112229,U.S. Senate,,DEM,Loretta L. Sanchez,139
+Marin,112239,U.S. Senate,,DEM,Kamala D. Harris,482
+Marin,112239,U.S. Senate,,DEM,Loretta L. Sanchez,139
+Marin,203019,U.S. Senate,,DEM,Kamala D. Harris,909
+Marin,203019,U.S. Senate,,DEM,Loretta L. Sanchez,157
+Marin,203029,U.S. Senate,,DEM,Kamala D. Harris,877
+Marin,203029,U.S. Senate,,DEM,Loretta L. Sanchez,198
+Marin,203040,U.S. Senate,,DEM,Kamala D. Harris,528
+Marin,203040,U.S. Senate,,DEM,Loretta L. Sanchez,112
+Marin,203060,U.S. Senate,,DEM,Kamala D. Harris,450
+Marin,203060,U.S. Senate,,DEM,Loretta L. Sanchez,105
+Marin,203080,U.S. Senate,,DEM,Kamala D. Harris,475
+Marin,203080,U.S. Senate,,DEM,Loretta L. Sanchez,83
+Marin,203130,U.S. Senate,,DEM,Kamala D. Harris,545
+Marin,203130,U.S. Senate,,DEM,Loretta L. Sanchez,107
+Marin,204039,U.S. Senate,,DEM,Kamala D. Harris,251
+Marin,204039,U.S. Senate,,DEM,Loretta L. Sanchez,60
+Marin,204049,U.S. Senate,,DEM,Kamala D. Harris,384
+Marin,204049,U.S. Senate,,DEM,Loretta L. Sanchez,89
+Marin,204059,U.S. Senate,,DEM,Kamala D. Harris,693
+Marin,204059,U.S. Senate,,DEM,Loretta L. Sanchez,154
+Marin,204069,U.S. Senate,,DEM,Kamala D. Harris,623
+Marin,204069,U.S. Senate,,DEM,Loretta L. Sanchez,215
+Marin,204079,U.S. Senate,,DEM,Kamala D. Harris,477
+Marin,204079,U.S. Senate,,DEM,Loretta L. Sanchez,76
+Marin,204089,U.S. Senate,,DEM,Kamala D. Harris,1065
+Marin,204089,U.S. Senate,,DEM,Loretta L. Sanchez,290
+Marin,204350,U.S. Senate,,DEM,Kamala D. Harris,522
+Marin,204350,U.S. Senate,,DEM,Loretta L. Sanchez,138
+Marin,204390,U.S. Senate,,DEM,Kamala D. Harris,441
+Marin,204390,U.S. Senate,,DEM,Loretta L. Sanchez,104
+Marin,204410,U.S. Senate,,DEM,Kamala D. Harris,422
+Marin,204410,U.S. Senate,,DEM,Loretta L. Sanchez,111
+Marin,207099,U.S. Senate,,DEM,Kamala D. Harris,604
+Marin,207099,U.S. Senate,,DEM,Loretta L. Sanchez,218
+Marin,207180,U.S. Senate,,DEM,Kamala D. Harris,328
+Marin,207180,U.S. Senate,,DEM,Loretta L. Sanchez,93
+Marin,208100,U.S. Senate,,DEM,Kamala D. Harris,585
+Marin,208100,U.S. Senate,,DEM,Loretta L. Sanchez,125
+Marin,208109,U.S. Senate,,DEM,Kamala D. Harris,1007
+Marin,208109,U.S. Senate,,DEM,Loretta L. Sanchez,173
+Marin,208119,U.S. Senate,,DEM,Kamala D. Harris,942
+Marin,208119,U.S. Senate,,DEM,Loretta L. Sanchez,207
+Marin,208129,U.S. Senate,,DEM,Kamala D. Harris,527
+Marin,208129,U.S. Senate,,DEM,Loretta L. Sanchez,113
+Marin,208139,U.S. Senate,,DEM,Kamala D. Harris,544
+Marin,208139,U.S. Senate,,DEM,Loretta L. Sanchez,103
+Marin,208149,U.S. Senate,,DEM,Kamala D. Harris,942
+Marin,208149,U.S. Senate,,DEM,Loretta L. Sanchez,191
+Marin,208160,U.S. Senate,,DEM,Kamala D. Harris,558
+Marin,208160,U.S. Senate,,DEM,Loretta L. Sanchez,112
+Marin,208240,U.S. Senate,,DEM,Kamala D. Harris,420
+Marin,208240,U.S. Senate,,DEM,Loretta L. Sanchez,74
+Marin,208250,U.S. Senate,,DEM,Kamala D. Harris,542
+Marin,208250,U.S. Senate,,DEM,Loretta L. Sanchez,129
+Marin,209159,U.S. Senate,,DEM,Kamala D. Harris,552
+Marin,209159,U.S. Senate,,DEM,Loretta L. Sanchez,128
+Marin,209169,U.S. Senate,,DEM,Kamala D. Harris,510
+Marin,209169,U.S. Senate,,DEM,Loretta L. Sanchez,108
+Marin,209179,U.S. Senate,,DEM,Kamala D. Harris,508
+Marin,209179,U.S. Senate,,DEM,Loretta L. Sanchez,143
+Marin,209189,U.S. Senate,,DEM,Kamala D. Harris,522
+Marin,209189,U.S. Senate,,DEM,Loretta L. Sanchez,153
+Marin,209199,U.S. Senate,,DEM,Kamala D. Harris,527
+Marin,209199,U.S. Senate,,DEM,Loretta L. Sanchez,129
+Marin,212209,U.S. Senate,,DEM,Kamala D. Harris,607
+Marin,212209,U.S. Senate,,DEM,Loretta L. Sanchez,172
+Marin,212219,U.S. Senate,,DEM,Kamala D. Harris,551
+Marin,212219,U.S. Senate,,DEM,Loretta L. Sanchez,148
+Marin,212229,U.S. Senate,,DEM,Kamala D. Harris,432
+Marin,212229,U.S. Senate,,DEM,Loretta L. Sanchez,96
+Marin,212239,U.S. Senate,,DEM,Kamala D. Harris,649
+Marin,212239,U.S. Senate,,DEM,Loretta L. Sanchez,195
+Marin,212249,U.S. Senate,,DEM,Kamala D. Harris,265
+Marin,212249,U.S. Senate,,DEM,Loretta L. Sanchez,70
+Marin,212259,U.S. Senate,,DEM,Kamala D. Harris,615
+Marin,212259,U.S. Senate,,DEM,Loretta L. Sanchez,156
+Marin,212269,U.S. Senate,,DEM,Kamala D. Harris,724
+Marin,212269,U.S. Senate,,DEM,Loretta L. Sanchez,171
+Marin,212300,U.S. Senate,,DEM,Kamala D. Harris,499
+Marin,212300,U.S. Senate,,DEM,Loretta L. Sanchez,98
+Marin,301019,U.S. Senate,,DEM,Kamala D. Harris,885
+Marin,301019,U.S. Senate,,DEM,Loretta L. Sanchez,226
+Marin,305010,U.S. Senate,,DEM,Kamala D. Harris,552
+Marin,305010,U.S. Senate,,DEM,Loretta L. Sanchez,118
+Marin,305020,U.S. Senate,,DEM,Kamala D. Harris,444
+Marin,305020,U.S. Senate,,DEM,Loretta L. Sanchez,79
+Marin,305029,U.S. Senate,,DEM,Kamala D. Harris,512
+Marin,305029,U.S. Senate,,DEM,Loretta L. Sanchez,124
+Marin,305030,U.S. Senate,,DEM,Kamala D. Harris,587
+Marin,305030,U.S. Senate,,DEM,Loretta L. Sanchez,93
+Marin,305039,U.S. Senate,,DEM,Kamala D. Harris,989
+Marin,305039,U.S. Senate,,DEM,Loretta L. Sanchez,180
+Marin,305049,U.S. Senate,,DEM,Kamala D. Harris,546
+Marin,305049,U.S. Senate,,DEM,Loretta L. Sanchez,93
+Marin,305050,U.S. Senate,,DEM,Kamala D. Harris,491
+Marin,305050,U.S. Senate,,DEM,Loretta L. Sanchez,108
+Marin,305059,U.S. Senate,,DEM,Kamala D. Harris,1084
+Marin,305059,U.S. Senate,,DEM,Loretta L. Sanchez,269
+Marin,305069,U.S. Senate,,DEM,Kamala D. Harris,1151
+Marin,305069,U.S. Senate,,DEM,Loretta L. Sanchez,275
+Marin,305090,U.S. Senate,,DEM,Kamala D. Harris,517
+Marin,305090,U.S. Senate,,DEM,Loretta L. Sanchez,74
+Marin,310079,U.S. Senate,,DEM,Kamala D. Harris,664
+Marin,310079,U.S. Senate,,DEM,Loretta L. Sanchez,158
+Marin,310089,U.S. Senate,,DEM,Kamala D. Harris,894
+Marin,310089,U.S. Senate,,DEM,Loretta L. Sanchez,202
+Marin,310099,U.S. Senate,,DEM,Kamala D. Harris,834
+Marin,310099,U.S. Senate,,DEM,Loretta L. Sanchez,179
+Marin,310310,U.S. Senate,,DEM,Kamala D. Harris,466
+Marin,310310,U.S. Senate,,DEM,Loretta L. Sanchez,116
+Marin,310410,U.S. Senate,,DEM,Kamala D. Harris,576
+Marin,310410,U.S. Senate,,DEM,Loretta L. Sanchez,153
+Marin,311109,U.S. Senate,,DEM,Kamala D. Harris,822
+Marin,311109,U.S. Senate,,DEM,Loretta L. Sanchez,280
+Marin,311119,U.S. Senate,,DEM,Kamala D. Harris,781
+Marin,311119,U.S. Senate,,DEM,Loretta L. Sanchez,223
+Marin,311129,U.S. Senate,,DEM,Kamala D. Harris,905
+Marin,311129,U.S. Senate,,DEM,Loretta L. Sanchez,252
+Marin,311139,U.S. Senate,,DEM,Kamala D. Harris,982
+Marin,311139,U.S. Senate,,DEM,Loretta L. Sanchez,315
+Marin,312149,U.S. Senate,,DEM,Kamala D. Harris,316
+Marin,312149,U.S. Senate,,DEM,Loretta L. Sanchez,68
+Marin,312159,U.S. Senate,,DEM,Kamala D. Harris,856
+Marin,312159,U.S. Senate,,DEM,Loretta L. Sanchez,179
+Marin,312169,U.S. Senate,,DEM,Kamala D. Harris,1085
+Marin,312169,U.S. Senate,,DEM,Loretta L. Sanchez,230
+Marin,312179,U.S. Senate,,DEM,Kamala D. Harris,498
+Marin,312179,U.S. Senate,,DEM,Loretta L. Sanchez,108
+Marin,312189,U.S. Senate,,DEM,Kamala D. Harris,853
+Marin,312189,U.S. Senate,,DEM,Loretta L. Sanchez,166
+Marin,312199,U.S. Senate,,DEM,Kamala D. Harris,467
+Marin,312199,U.S. Senate,,DEM,Loretta L. Sanchez,101
+Marin,312209,U.S. Senate,,DEM,Kamala D. Harris,935
+Marin,312209,U.S. Senate,,DEM,Loretta L. Sanchez,207
+Marin,312219,U.S. Senate,,DEM,Kamala D. Harris,671
+Marin,312219,U.S. Senate,,DEM,Loretta L. Sanchez,209
+Marin,312229,U.S. Senate,,DEM,Kamala D. Harris,242
+Marin,312229,U.S. Senate,,DEM,Loretta L. Sanchez,92
+Marin,312239,U.S. Senate,,DEM,Kamala D. Harris,832
+Marin,312239,U.S. Senate,,DEM,Loretta L. Sanchez,262
+Marin,312249,U.S. Senate,,DEM,Kamala D. Harris,279
+Marin,312249,U.S. Senate,,DEM,Loretta L. Sanchez,99
+Marin,312250,U.S. Senate,,DEM,Kamala D. Harris,409
+Marin,312250,U.S. Senate,,DEM,Loretta L. Sanchez,83
+Marin,402019,U.S. Senate,,DEM,Kamala D. Harris,787
+Marin,402019,U.S. Senate,,DEM,Loretta L. Sanchez,212
+Marin,402029,U.S. Senate,,DEM,Kamala D. Harris,957
+Marin,402029,U.S. Senate,,DEM,Loretta L. Sanchez,201
+Marin,402039,U.S. Senate,,DEM,Kamala D. Harris,418
+Marin,402039,U.S. Senate,,DEM,Loretta L. Sanchez,116
+Marin,402049,U.S. Senate,,DEM,Kamala D. Harris,817
+Marin,402049,U.S. Senate,,DEM,Loretta L. Sanchez,231
+Marin,402059,U.S. Senate,,DEM,Kamala D. Harris,466
+Marin,402059,U.S. Senate,,DEM,Loretta L. Sanchez,124
+Marin,402230,U.S. Senate,,DEM,Kamala D. Harris,517
+Marin,402230,U.S. Senate,,DEM,Loretta L. Sanchez,123
+Marin,404069,U.S. Senate,,DEM,Kamala D. Harris,209
+Marin,404069,U.S. Senate,,DEM,Loretta L. Sanchez,71
+Marin,404079,U.S. Senate,,DEM,Kamala D. Harris,341
+Marin,404079,U.S. Senate,,DEM,Loretta L. Sanchez,117
+Marin,406089,U.S. Senate,,DEM,Kamala D. Harris,706
+Marin,406089,U.S. Senate,,DEM,Loretta L. Sanchez,249
+Marin,406099,U.S. Senate,,DEM,Kamala D. Harris,681
+Marin,406099,U.S. Senate,,DEM,Loretta L. Sanchez,256
+Marin,406109,U.S. Senate,,DEM,Kamala D. Harris,889
+Marin,406109,U.S. Senate,,DEM,Loretta L. Sanchez,290
+Marin,406119,U.S. Senate,,DEM,Kamala D. Harris,432
+Marin,406119,U.S. Senate,,DEM,Loretta L. Sanchez,203
+Marin,409129,U.S. Senate,,DEM,Kamala D. Harris,647
+Marin,409129,U.S. Senate,,DEM,Loretta L. Sanchez,295
+Marin,409460,U.S. Senate,,DEM,Kamala D. Harris,266
+Marin,409460,U.S. Senate,,DEM,Loretta L. Sanchez,231
+Marin,412139,U.S. Senate,,DEM,Kamala D. Harris,406
+Marin,412139,U.S. Senate,,DEM,Loretta L. Sanchez,110
+Marin,412149,U.S. Senate,,DEM,Kamala D. Harris,792
+Marin,412149,U.S. Senate,,DEM,Loretta L. Sanchez,182
+Marin,412159,U.S. Senate,,DEM,Kamala D. Harris,270
+Marin,412159,U.S. Senate,,DEM,Loretta L. Sanchez,68
+Marin,412169,U.S. Senate,,DEM,Kamala D. Harris,536
+Marin,412169,U.S. Senate,,DEM,Loretta L. Sanchez,101
+Marin,412179,U.S. Senate,,DEM,Kamala D. Harris,688
+Marin,412179,U.S. Senate,,DEM,Loretta L. Sanchez,112
+Marin,412189,U.S. Senate,,DEM,Kamala D. Harris,425
+Marin,412189,U.S. Senate,,DEM,Loretta L. Sanchez,192
+Marin,412199,U.S. Senate,,DEM,Kamala D. Harris,331
+Marin,412199,U.S. Senate,,DEM,Loretta L. Sanchez,55
+Marin,412209,U.S. Senate,,DEM,Kamala D. Harris,603
+Marin,412209,U.S. Senate,,DEM,Loretta L. Sanchez,110
+Marin,412219,U.S. Senate,,DEM,Kamala D. Harris,757
+Marin,412219,U.S. Senate,,DEM,Loretta L. Sanchez,203
+Marin,412229,U.S. Senate,,DEM,Kamala D. Harris,219
+Marin,412229,U.S. Senate,,DEM,Loretta L. Sanchez,41
+Marin,412239,U.S. Senate,,DEM,Kamala D. Harris,370
+Marin,412239,U.S. Senate,,DEM,Loretta L. Sanchez,81
+Marin,412249,U.S. Senate,,DEM,Kamala D. Harris,800
+Marin,412249,U.S. Senate,,DEM,Loretta L. Sanchez,166
+Marin,412259,U.S. Senate,,DEM,Kamala D. Harris,397
+Marin,412259,U.S. Senate,,DEM,Loretta L. Sanchez,71
+Marin,412300,U.S. Senate,,DEM,Kamala D. Harris,481
+Marin,412300,U.S. Senate,,DEM,Loretta L. Sanchez,95
+Marin,506010,U.S. Senate,,DEM,Kamala D. Harris,451
+Marin,506010,U.S. Senate,,DEM,Loretta L. Sanchez,138
+Marin,506019,U.S. Senate,,DEM,Kamala D. Harris,680
+Marin,506019,U.S. Senate,,DEM,Loretta L. Sanchez,231
+Marin,506029,U.S. Senate,,DEM,Kamala D. Harris,422
+Marin,506029,U.S. Senate,,DEM,Loretta L. Sanchez,190
+Marin,506030,U.S. Senate,,DEM,Kamala D. Harris,456
+Marin,506030,U.S. Senate,,DEM,Loretta L. Sanchez,189
+Marin,506039,U.S. Senate,,DEM,Kamala D. Harris,384
+Marin,506039,U.S. Senate,,DEM,Loretta L. Sanchez,161
+Marin,506040,U.S. Senate,,DEM,Kamala D. Harris,440
+Marin,506040,U.S. Senate,,DEM,Loretta L. Sanchez,149
+Marin,506049,U.S. Senate,,DEM,Kamala D. Harris,436
+Marin,506049,U.S. Senate,,DEM,Loretta L. Sanchez,170
+Marin,506050,U.S. Senate,,DEM,Kamala D. Harris,426
+Marin,506050,U.S. Senate,,DEM,Loretta L. Sanchez,178
+Marin,506059,U.S. Senate,,DEM,Kamala D. Harris,883
+Marin,506059,U.S. Senate,,DEM,Loretta L. Sanchez,339
+Marin,506069,U.S. Senate,,DEM,Kamala D. Harris,417
+Marin,506069,U.S. Senate,,DEM,Loretta L. Sanchez,176
+Marin,506079,U.S. Senate,,DEM,Kamala D. Harris,429
+Marin,506079,U.S. Senate,,DEM,Loretta L. Sanchez,124
+Marin,506089,U.S. Senate,,DEM,Kamala D. Harris,471
+Marin,506089,U.S. Senate,,DEM,Loretta L. Sanchez,161
+Marin,506099,U.S. Senate,,DEM,Kamala D. Harris,462
+Marin,506099,U.S. Senate,,DEM,Loretta L. Sanchez,195
+Marin,506100,U.S. Senate,,DEM,Kamala D. Harris,425
+Marin,506100,U.S. Senate,,DEM,Loretta L. Sanchez,215
+Marin,506109,U.S. Senate,,DEM,Kamala D. Harris,957
+Marin,506109,U.S. Senate,,DEM,Loretta L. Sanchez,335
+Marin,506119,U.S. Senate,,DEM,Kamala D. Harris,944
+Marin,506119,U.S. Senate,,DEM,Loretta L. Sanchez,363
+Marin,506120,U.S. Senate,,DEM,Kamala D. Harris,418
+Marin,506120,U.S. Senate,,DEM,Loretta L. Sanchez,199
+Marin,506129,U.S. Senate,,DEM,Kamala D. Harris,907
+Marin,506129,U.S. Senate,,DEM,Loretta L. Sanchez,332
+Marin,506139,U.S. Senate,,DEM,Kamala D. Harris,752
+Marin,506139,U.S. Senate,,DEM,Loretta L. Sanchez,267
+Marin,506149,U.S. Senate,,DEM,Kamala D. Harris,953
+Marin,506149,U.S. Senate,,DEM,Loretta L. Sanchez,308
+Marin,506159,U.S. Senate,,DEM,Kamala D. Harris,686
+Marin,506159,U.S. Senate,,DEM,Loretta L. Sanchez,243
+Marin,506169,U.S. Senate,,DEM,Kamala D. Harris,863
+Marin,506169,U.S. Senate,,DEM,Loretta L. Sanchez,285
+Marin,506179,U.S. Senate,,DEM,Kamala D. Harris,795
+Marin,506179,U.S. Senate,,DEM,Loretta L. Sanchez,307
+Marin,506189,U.S. Senate,,DEM,Kamala D. Harris,413
+Marin,506189,U.S. Senate,,DEM,Loretta L. Sanchez,161
+Marin,512199,U.S. Senate,,DEM,Kamala D. Harris,737
+Marin,512199,U.S. Senate,,DEM,Loretta L. Sanchez,302
+Marin,512209,U.S. Senate,,DEM,Kamala D. Harris,690
+Marin,512209,U.S. Senate,,DEM,Loretta L. Sanchez,234
+Marin,512219,U.S. Senate,,DEM,Kamala D. Harris,384
+Marin,512219,U.S. Senate,,DEM,Loretta L. Sanchez,126
+Marin,512340,U.S. Senate,,DEM,Kamala D. Harris,491
+Marin,512340,U.S. Senate,,DEM,Loretta L. Sanchez,161
+Marin,611201,U.S. Senate,,DEM,Kamala D. Harris,17
+Marin,611201,U.S. Senate,,DEM,Loretta L. Sanchez,8
+Marin,620701,U.S. Senate,,DEM,Kamala D. Harris,0
+Marin,620701,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Marin,620702,U.S. Senate,,DEM,Kamala D. Harris,4
+Marin,620702,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Marin,621203,U.S. Senate,,DEM,Kamala D. Harris,132
+Marin,621203,U.S. Senate,,DEM,Loretta L. Sanchez,52
+Marin,621204,U.S. Senate,,DEM,Kamala D. Harris,174
+Marin,621204,U.S. Senate,,DEM,Loretta L. Sanchez,38
+Marin,621205,U.S. Senate,,DEM,Kamala D. Harris,117
+Marin,621205,U.S. Senate,,DEM,Loretta L. Sanchez,19
+Marin,630501,U.S. Senate,,DEM,Kamala D. Harris,5
+Marin,630501,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Marin,631102,U.S. Senate,,DEM,Kamala D. Harris,75
+Marin,631102,U.S. Senate,,DEM,Loretta L. Sanchez,23
+Marin,631203,U.S. Senate,,DEM,Kamala D. Harris,61
+Marin,631203,U.S. Senate,,DEM,Loretta L. Sanchez,19
+Marin,631204,U.S. Senate,,DEM,Kamala D. Harris,127
+Marin,631204,U.S. Senate,,DEM,Loretta L. Sanchez,25
+Marin,631205,U.S. Senate,,DEM,Kamala D. Harris,106
+Marin,631205,U.S. Senate,,DEM,Loretta L. Sanchez,40
+Marin,640401,U.S. Senate,,DEM,Kamala D. Harris,0
+Marin,640401,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Marin,641202,U.S. Senate,,DEM,Kamala D. Harris,111
+Marin,641202,U.S. Senate,,DEM,Loretta L. Sanchez,50
+Marin,641203,U.S. Senate,,DEM,Kamala D. Harris,60
+Marin,641203,U.S. Senate,,DEM,Loretta L. Sanchez,35
+Marin,641204,U.S. Senate,,DEM,Kamala D. Harris,12
+Marin,641204,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Marin,641205,U.S. Senate,,DEM,Kamala D. Harris,1
+Marin,641205,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Marin,641206,U.S. Senate,,DEM,Kamala D. Harris,3
+Marin,641206,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Marin,641207,U.S. Senate,,DEM,Kamala D. Harris,0
+Marin,641207,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Marin,641208,U.S. Senate,,DEM,Kamala D. Harris,10
+Marin,641208,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Marin,641209,U.S. Senate,,DEM,Kamala D. Harris,153
+Marin,641209,U.S. Senate,,DEM,Loretta L. Sanchez,32
+Marin,641210,U.S. Senate,,DEM,Kamala D. Harris,8
+Marin,641210,U.S. Senate,,DEM,Loretta L. Sanchez,2

--- a/2016/20161108__ca__general__mariposa__precinct.csv
+++ b/2016/20161108__ca__general__mariposa__precinct.csv
@@ -999,53 +999,53 @@ Mariposa,Westfall,Proposition 67,,N/A,Yes,256
 Mariposa,Westfall,Proposition 67,,N/A,No,316
 Mariposa,Yosemite,Proposition 67,,N/A,Yes,211
 Mariposa,Yosemite,Proposition 67,,N/A,No,74
-Mariposa,Bull_Creek,U.S. Senate,,DEM,Kamala Harris,13
-Mariposa,Bull_Creek,U.S. Senate,,DEM,Loretta Sanchez,6
-Mariposa,Catheys_Valley,U.S. Senate,,DEM,Kamala Harris,220
-Mariposa,Catheys_Valley,U.S. Senate,,DEM,Loretta Sanchez,149
-Mariposa,Coulterville,U.S. Senate,,DEM,Kamala Harris,219
-Mariposa,Coulterville,U.S. Senate,,DEM,Loretta Sanchez,134
-Mariposa,Darrah,U.S. Senate,,DEM,Kamala Harris,215
-Mariposa,Darrah,U.S. Senate,,DEM,Loretta Sanchez,125
-Mariposa,El_Portal,U.S. Senate,,DEM,Kamala Harris,202
-Mariposa,El_Portal,U.S. Senate,,DEM,Loretta Sanchez,58
-Mariposa,Exchequer,U.S. Senate,,DEM,Kamala Harris,235
-Mariposa,Exchequer,U.S. Senate,,DEM,Loretta Sanchez,163
-Mariposa,Gold_Creek,U.S. Senate,,DEM,Kamala Harris,190
-Mariposa,Gold_Creek,U.S. Senate,,DEM,Loretta Sanchez,113
-Mariposa,Hornitos,U.S. Senate,,DEM,Kamala Harris,36
-Mariposa,Hornitos,U.S. Senate,,DEM,Loretta Sanchez,32
-Mariposa,Humbug_Creek,U.S. Senate,,DEM,Kamala Harris,207
-Mariposa,Humbug_Creek,U.S. Senate,,DEM,Loretta Sanchez,127
-Mariposa,Indian_Peak,U.S. Senate,,DEM,Kamala Harris,176
-Mariposa,Indian_Peak,U.S. Senate,,DEM,Loretta Sanchez,128
-Mariposa,Iron_Oak,U.S. Senate,,DEM,Kamala Harris,134
-Mariposa,Iron_Oak,U.S. Senate,,DEM,Loretta Sanchez,88
-Mariposa,Jerseydale,U.S. Senate,,DEM,Kamala Harris,142
-Mariposa,Jerseydale,U.S. Senate,,DEM,Loretta Sanchez,88
-Mariposa,Mariposa_East,U.S. Senate,,DEM,Kamala Harris,275
-Mariposa,Mariposa_East,U.S. Senate,,DEM,Loretta Sanchez,162
-Mariposa,Mariposa_West,U.S. Senate,,DEM,Kamala Harris,191
-Mariposa,Mariposa_West,U.S. Senate,,DEM,Loretta Sanchez,121
-Mariposa,Midpines,U.S. Senate,,DEM,Kamala Harris,246
-Mariposa,Midpines,U.S. Senate,,DEM,Loretta Sanchez,130
-Mariposa,Morman_Bar,U.S. Senate,,DEM,Kamala Harris,285
-Mariposa,Morman_Bar,U.S. Senate,,DEM,Loretta Sanchez,178
-Mariposa,Mt_Bullion,U.S. Senate,,DEM,Kamala Harris,71
-Mariposa,Mt_Bullion,U.S. Senate,,DEM,Loretta Sanchez,58
-Mariposa,Oakvale,U.S. Senate,,DEM,Kamala Harris,23
-Mariposa,Oakvale,U.S. Senate,,DEM,Loretta Sanchez,14
-Mariposa,Ponderosa,U.S. Senate,,DEM,Kamala Harris,239
-Mariposa,Ponderosa,U.S. Senate,,DEM,Loretta Sanchez,162
-Mariposa,Redcloud,U.S. Senate,,DEM,Kamala Harris,215
-Mariposa,Redcloud,U.S. Senate,,DEM,Loretta Sanchez,134
-Mariposa,Strawberry_Creek,U.S. Senate,,DEM,Kamala Harris,22
-Mariposa,Strawberry_Creek,U.S. Senate,,DEM,Loretta Sanchez,7
-Mariposa,Sweetwater,U.S. Senate,,DEM,Kamala Harris,84
-Mariposa,Sweetwater,U.S. Senate,,DEM,Loretta Sanchez,42
-Mariposa,Wawona,U.S. Senate,,DEM,Kamala Harris,68
-Mariposa,Wawona,U.S. Senate,,DEM,Loretta Sanchez,42
-Mariposa,Westfall,U.S. Senate,,DEM,Kamala Harris,259
-Mariposa,Westfall,U.S. Senate,,DEM,Loretta Sanchez,183
-Mariposa,Yosemite,U.S. Senate,,DEM,Kamala Harris,167
-Mariposa,Yosemite,U.S. Senate,,DEM,Loretta Sanchez,75
+Mariposa,Bull_Creek,U.S. Senate,,DEM,Kamala D. Harris,13
+Mariposa,Bull_Creek,U.S. Senate,,DEM,Loretta L. Sanchez,6
+Mariposa,Catheys_Valley,U.S. Senate,,DEM,Kamala D. Harris,220
+Mariposa,Catheys_Valley,U.S. Senate,,DEM,Loretta L. Sanchez,149
+Mariposa,Coulterville,U.S. Senate,,DEM,Kamala D. Harris,219
+Mariposa,Coulterville,U.S. Senate,,DEM,Loretta L. Sanchez,134
+Mariposa,Darrah,U.S. Senate,,DEM,Kamala D. Harris,215
+Mariposa,Darrah,U.S. Senate,,DEM,Loretta L. Sanchez,125
+Mariposa,El_Portal,U.S. Senate,,DEM,Kamala D. Harris,202
+Mariposa,El_Portal,U.S. Senate,,DEM,Loretta L. Sanchez,58
+Mariposa,Exchequer,U.S. Senate,,DEM,Kamala D. Harris,235
+Mariposa,Exchequer,U.S. Senate,,DEM,Loretta L. Sanchez,163
+Mariposa,Gold_Creek,U.S. Senate,,DEM,Kamala D. Harris,190
+Mariposa,Gold_Creek,U.S. Senate,,DEM,Loretta L. Sanchez,113
+Mariposa,Hornitos,U.S. Senate,,DEM,Kamala D. Harris,36
+Mariposa,Hornitos,U.S. Senate,,DEM,Loretta L. Sanchez,32
+Mariposa,Humbug_Creek,U.S. Senate,,DEM,Kamala D. Harris,207
+Mariposa,Humbug_Creek,U.S. Senate,,DEM,Loretta L. Sanchez,127
+Mariposa,Indian_Peak,U.S. Senate,,DEM,Kamala D. Harris,176
+Mariposa,Indian_Peak,U.S. Senate,,DEM,Loretta L. Sanchez,128
+Mariposa,Iron_Oak,U.S. Senate,,DEM,Kamala D. Harris,134
+Mariposa,Iron_Oak,U.S. Senate,,DEM,Loretta L. Sanchez,88
+Mariposa,Jerseydale,U.S. Senate,,DEM,Kamala D. Harris,142
+Mariposa,Jerseydale,U.S. Senate,,DEM,Loretta L. Sanchez,88
+Mariposa,Mariposa_East,U.S. Senate,,DEM,Kamala D. Harris,275
+Mariposa,Mariposa_East,U.S. Senate,,DEM,Loretta L. Sanchez,162
+Mariposa,Mariposa_West,U.S. Senate,,DEM,Kamala D. Harris,191
+Mariposa,Mariposa_West,U.S. Senate,,DEM,Loretta L. Sanchez,121
+Mariposa,Midpines,U.S. Senate,,DEM,Kamala D. Harris,246
+Mariposa,Midpines,U.S. Senate,,DEM,Loretta L. Sanchez,130
+Mariposa,Morman_Bar,U.S. Senate,,DEM,Kamala D. Harris,285
+Mariposa,Morman_Bar,U.S. Senate,,DEM,Loretta L. Sanchez,178
+Mariposa,Mt_Bullion,U.S. Senate,,DEM,Kamala D. Harris,71
+Mariposa,Mt_Bullion,U.S. Senate,,DEM,Loretta L. Sanchez,58
+Mariposa,Oakvale,U.S. Senate,,DEM,Kamala D. Harris,23
+Mariposa,Oakvale,U.S. Senate,,DEM,Loretta L. Sanchez,14
+Mariposa,Ponderosa,U.S. Senate,,DEM,Kamala D. Harris,239
+Mariposa,Ponderosa,U.S. Senate,,DEM,Loretta L. Sanchez,162
+Mariposa,Redcloud,U.S. Senate,,DEM,Kamala D. Harris,215
+Mariposa,Redcloud,U.S. Senate,,DEM,Loretta L. Sanchez,134
+Mariposa,Strawberry_Creek,U.S. Senate,,DEM,Kamala D. Harris,22
+Mariposa,Strawberry_Creek,U.S. Senate,,DEM,Loretta L. Sanchez,7
+Mariposa,Sweetwater,U.S. Senate,,DEM,Kamala D. Harris,84
+Mariposa,Sweetwater,U.S. Senate,,DEM,Loretta L. Sanchez,42
+Mariposa,Wawona,U.S. Senate,,DEM,Kamala D. Harris,68
+Mariposa,Wawona,U.S. Senate,,DEM,Loretta L. Sanchez,42
+Mariposa,Westfall,U.S. Senate,,DEM,Kamala D. Harris,259
+Mariposa,Westfall,U.S. Senate,,DEM,Loretta L. Sanchez,183
+Mariposa,Yosemite,U.S. Senate,,DEM,Kamala D. Harris,167
+Mariposa,Yosemite,U.S. Senate,,DEM,Loretta L. Sanchez,75

--- a/2016/20161108__ca__general__mendocino__precinct.csv
+++ b/2016/20161108__ca__general__mendocino__precinct.csv
@@ -9999,503 +9999,503 @@ Mendocino,999557,Proposition 67,,N/A,Yes,35
 Mendocino,999557,Proposition 67,,N/A,No,19
 Mendocino,999558,Proposition 67,,N/A,Yes,111
 Mendocino,999558,Proposition 67,,N/A,No,69
-Mendocino,100001,U.S. Senate,,DEM,Kamala Harris,173
-Mendocino,100001,U.S. Senate,,DEM,Loretta Sanchez,95
-Mendocino,100002,U.S. Senate,,DEM,Kamala Harris,300
-Mendocino,100002,U.S. Senate,,DEM,Loretta Sanchez,145
-Mendocino,100003,U.S. Senate,,DEM,Kamala Harris,273
-Mendocino,100003,U.S. Senate,,DEM,Loretta Sanchez,151
-Mendocino,100004,U.S. Senate,,DEM,Kamala Harris,291
-Mendocino,100004,U.S. Senate,,DEM,Loretta Sanchez,144
-Mendocino,100005,U.S. Senate,,DEM,Kamala Harris,133
-Mendocino,100005,U.S. Senate,,DEM,Loretta Sanchez,66
-Mendocino,100006,U.S. Senate,,DEM,Kamala Harris,265
-Mendocino,100006,U.S. Senate,,DEM,Loretta Sanchez,102
-Mendocino,100007,U.S. Senate,,DEM,Kamala Harris,138
-Mendocino,100007,U.S. Senate,,DEM,Loretta Sanchez,71
-Mendocino,100008,U.S. Senate,,DEM,Kamala Harris,256
-Mendocino,100008,U.S. Senate,,DEM,Loretta Sanchez,150
-Mendocino,100009,U.S. Senate,,DEM,Kamala Harris,283
-Mendocino,100009,U.S. Senate,,DEM,Loretta Sanchez,157
-Mendocino,100500,U.S. Senate,,DEM,Kamala Harris,145
-Mendocino,100500,U.S. Senate,,DEM,Loretta Sanchez,71
-Mendocino,200001,U.S. Senate,,DEM,Kamala Harris,146
-Mendocino,200001,U.S. Senate,,DEM,Loretta Sanchez,77
-Mendocino,200003,U.S. Senate,,DEM,Kamala Harris,400
-Mendocino,200003,U.S. Senate,,DEM,Loretta Sanchez,204
-Mendocino,200004,U.S. Senate,,DEM,Kamala Harris,380
-Mendocino,200004,U.S. Senate,,DEM,Loretta Sanchez,141
-Mendocino,300001,U.S. Senate,,DEM,Kamala Harris,349
-Mendocino,300001,U.S. Senate,,DEM,Loretta Sanchez,159
-Mendocino,300002,U.S. Senate,,DEM,Kamala Harris,352
-Mendocino,300002,U.S. Senate,,DEM,Loretta Sanchez,186
-Mendocino,300003,U.S. Senate,,DEM,Kamala Harris,270
-Mendocino,300003,U.S. Senate,,DEM,Loretta Sanchez,140
-Mendocino,300004,U.S. Senate,,DEM,Kamala Harris,214
-Mendocino,300004,U.S. Senate,,DEM,Loretta Sanchez,118
-Mendocino,300005,U.S. Senate,,DEM,Kamala Harris,260
-Mendocino,300005,U.S. Senate,,DEM,Loretta Sanchez,106
-Mendocino,300006,U.S. Senate,,DEM,Kamala Harris,315
-Mendocino,300006,U.S. Senate,,DEM,Loretta Sanchez,157
-Mendocino,300007,U.S. Senate,,DEM,Kamala Harris,320
-Mendocino,300007,U.S. Senate,,DEM,Loretta Sanchez,131
-Mendocino,300008,U.S. Senate,,DEM,Kamala Harris,361
-Mendocino,300008,U.S. Senate,,DEM,Loretta Sanchez,159
-Mendocino,400001,U.S. Senate,,DEM,Kamala Harris,368
-Mendocino,400001,U.S. Senate,,DEM,Loretta Sanchez,150
-Mendocino,400002,U.S. Senate,,DEM,Kamala Harris,231
-Mendocino,400002,U.S. Senate,,DEM,Loretta Sanchez,59
-Mendocino,400003,U.S. Senate,,DEM,Kamala Harris,157
-Mendocino,400003,U.S. Senate,,DEM,Loretta Sanchez,33
-Mendocino,400004,U.S. Senate,,DEM,Kamala Harris,425
-Mendocino,400004,U.S. Senate,,DEM,Loretta Sanchez,194
-Mendocino,400005,U.S. Senate,,DEM,Kamala Harris,499
-Mendocino,400005,U.S. Senate,,DEM,Loretta Sanchez,169
-Mendocino,400006,U.S. Senate,,DEM,Kamala Harris,258
-Mendocino,400006,U.S. Senate,,DEM,Loretta Sanchez,54
-Mendocino,400007,U.S. Senate,,DEM,Kamala Harris,175
-Mendocino,400007,U.S. Senate,,DEM,Loretta Sanchez,41
-Mendocino,500001,U.S. Senate,,DEM,Kamala Harris,118
-Mendocino,500001,U.S. Senate,,DEM,Loretta Sanchez,44
-Mendocino,500002,U.S. Senate,,DEM,Kamala Harris,318
-Mendocino,500002,U.S. Senate,,DEM,Loretta Sanchez,60
-Mendocino,500003,U.S. Senate,,DEM,Kamala Harris,171
-Mendocino,500003,U.S. Senate,,DEM,Loretta Sanchez,54
-Mendocino,500004,U.S. Senate,,DEM,Kamala Harris,404
-Mendocino,500004,U.S. Senate,,DEM,Loretta Sanchez,111
-Mendocino,500005,U.S. Senate,,DEM,Kamala Harris,461
-Mendocino,500005,U.S. Senate,,DEM,Loretta Sanchez,218
-Mendocino,500006,U.S. Senate,,DEM,Kamala Harris,173
-Mendocino,500006,U.S. Senate,,DEM,Loretta Sanchez,41
-Mendocino,500007,U.S. Senate,,DEM,Kamala Harris,425
-Mendocino,500007,U.S. Senate,,DEM,Loretta Sanchez,127
-Mendocino,500008,U.S. Senate,,DEM,Kamala Harris,248
-Mendocino,500008,U.S. Senate,,DEM,Loretta Sanchez,79
-Mendocino,500009,U.S. Senate,,DEM,Kamala Harris,126
-Mendocino,500009,U.S. Senate,,DEM,Loretta Sanchez,62
-Mendocino,999102,U.S. Senate,,DEM,Kamala Harris,52
-Mendocino,999102,U.S. Senate,,DEM,Loretta Sanchez,20
-Mendocino,999103,U.S. Senate,,DEM,Kamala Harris,73
-Mendocino,999103,U.S. Senate,,DEM,Loretta Sanchez,55
-Mendocino,999104,U.S. Senate,,DEM,Kamala Harris,71
-Mendocino,999104,U.S. Senate,,DEM,Loretta Sanchez,36
-Mendocino,999105,U.S. Senate,,DEM,Kamala Harris,51
-Mendocino,999105,U.S. Senate,,DEM,Loretta Sanchez,33
-Mendocino,999106,U.S. Senate,,DEM,Kamala Harris,63
-Mendocino,999106,U.S. Senate,,DEM,Loretta Sanchez,18
-Mendocino,999107,U.S. Senate,,DEM,Kamala Harris,4
-Mendocino,999107,U.S. Senate,,DEM,Loretta Sanchez,6
-Mendocino,999108,U.S. Senate,,DEM,Kamala Harris,69
-Mendocino,999108,U.S. Senate,,DEM,Loretta Sanchez,44
-Mendocino,999109,U.S. Senate,,DEM,Kamala Harris,5
-Mendocino,999109,U.S. Senate,,DEM,Loretta Sanchez,7
-Mendocino,999110,U.S. Senate,,DEM,Kamala Harris,76
-Mendocino,999110,U.S. Senate,,DEM,Loretta Sanchez,37
-Mendocino,999111,U.S. Senate,,DEM,Kamala Harris,62
-Mendocino,999111,U.S. Senate,,DEM,Loretta Sanchez,41
-Mendocino,999112,U.S. Senate,,DEM,Kamala Harris,74
-Mendocino,999112,U.S. Senate,,DEM,Loretta Sanchez,30
-Mendocino,999113,U.S. Senate,,DEM,Kamala Harris,86
-Mendocino,999113,U.S. Senate,,DEM,Loretta Sanchez,53
-Mendocino,999114,U.S. Senate,,DEM,Kamala Harris,11
-Mendocino,999114,U.S. Senate,,DEM,Loretta Sanchez,7
-Mendocino,999115,U.S. Senate,,DEM,Kamala Harris,23
-Mendocino,999115,U.S. Senate,,DEM,Loretta Sanchez,13
-Mendocino,999116,U.S. Senate,,DEM,Kamala Harris,54
-Mendocino,999116,U.S. Senate,,DEM,Loretta Sanchez,42
-Mendocino,999117,U.S. Senate,,DEM,Kamala Harris,53
-Mendocino,999117,U.S. Senate,,DEM,Loretta Sanchez,13
-Mendocino,999118,U.S. Senate,,DEM,Kamala Harris,6
-Mendocino,999118,U.S. Senate,,DEM,Loretta Sanchez,2
-Mendocino,999119,U.S. Senate,,DEM,Kamala Harris,6
-Mendocino,999119,U.S. Senate,,DEM,Loretta Sanchez,1
-Mendocino,999120,U.S. Senate,,DEM,Kamala Harris,77
-Mendocino,999120,U.S. Senate,,DEM,Loretta Sanchez,35
-Mendocino,999121,U.S. Senate,,DEM,Kamala Harris,25
-Mendocino,999121,U.S. Senate,,DEM,Loretta Sanchez,15
-Mendocino,999122,U.S. Senate,,DEM,Kamala Harris,2
-Mendocino,999122,U.S. Senate,,DEM,Loretta Sanchez,1
-Mendocino,999124,U.S. Senate,,DEM,Kamala Harris,81
-Mendocino,999124,U.S. Senate,,DEM,Loretta Sanchez,38
-Mendocino,999125,U.S. Senate,,DEM,Kamala Harris,22
-Mendocino,999125,U.S. Senate,,DEM,Loretta Sanchez,6
-Mendocino,999126,U.S. Senate,,DEM,Kamala Harris,37
-Mendocino,999126,U.S. Senate,,DEM,Loretta Sanchez,52
-Mendocino,999127,U.S. Senate,,DEM,Kamala Harris,30
-Mendocino,999127,U.S. Senate,,DEM,Loretta Sanchez,19
-Mendocino,999128,U.S. Senate,,DEM,Kamala Harris,53
-Mendocino,999128,U.S. Senate,,DEM,Loretta Sanchez,33
-Mendocino,999129,U.S. Senate,,DEM,Kamala Harris,4
-Mendocino,999129,U.S. Senate,,DEM,Loretta Sanchez,2
-Mendocino,999130,U.S. Senate,,DEM,Kamala Harris,0
-Mendocino,999130,U.S. Senate,,DEM,Loretta Sanchez,0
-Mendocino,999131,U.S. Senate,,DEM,Kamala Harris,15
-Mendocino,999131,U.S. Senate,,DEM,Loretta Sanchez,8
-Mendocino,999132,U.S. Senate,,DEM,Kamala Harris,0
-Mendocino,999132,U.S. Senate,,DEM,Loretta Sanchez,0
-Mendocino,999133,U.S. Senate,,DEM,Kamala Harris,1
-Mendocino,999133,U.S. Senate,,DEM,Loretta Sanchez,0
-Mendocino,999134,U.S. Senate,,DEM,Kamala Harris,47
-Mendocino,999134,U.S. Senate,,DEM,Loretta Sanchez,45
-Mendocino,999135,U.S. Senate,,DEM,Kamala Harris,9
-Mendocino,999135,U.S. Senate,,DEM,Loretta Sanchez,3
-Mendocino,999136,U.S. Senate,,DEM,Kamala Harris,0
-Mendocino,999136,U.S. Senate,,DEM,Loretta Sanchez,0
-Mendocino,999137,U.S. Senate,,DEM,Kamala Harris,1
-Mendocino,999137,U.S. Senate,,DEM,Loretta Sanchez,0
-Mendocino,999138,U.S. Senate,,DEM,Kamala Harris,4
-Mendocino,999138,U.S. Senate,,DEM,Loretta Sanchez,0
-Mendocino,999139,U.S. Senate,,DEM,Kamala Harris,0
-Mendocino,999139,U.S. Senate,,DEM,Loretta Sanchez,0
-Mendocino,999140,U.S. Senate,,DEM,Kamala Harris,24
-Mendocino,999140,U.S. Senate,,DEM,Loretta Sanchez,17
-Mendocino,999141,U.S. Senate,,DEM,Kamala Harris,83
-Mendocino,999141,U.S. Senate,,DEM,Loretta Sanchez,59
-Mendocino,999142,U.S. Senate,,DEM,Kamala Harris,0
-Mendocino,999142,U.S. Senate,,DEM,Loretta Sanchez,0
-Mendocino,999143,U.S. Senate,,DEM,Kamala Harris,0
-Mendocino,999143,U.S. Senate,,DEM,Loretta Sanchez,0
-Mendocino,999144,U.S. Senate,,DEM,Kamala Harris,2
-Mendocino,999144,U.S. Senate,,DEM,Loretta Sanchez,2
-Mendocino,999145,U.S. Senate,,DEM,Kamala Harris,0
-Mendocino,999145,U.S. Senate,,DEM,Loretta Sanchez,0
-Mendocino,999146,U.S. Senate,,DEM,Kamala Harris,0
-Mendocino,999146,U.S. Senate,,DEM,Loretta Sanchez,0
-Mendocino,999147,U.S. Senate,,DEM,Kamala Harris,0
-Mendocino,999147,U.S. Senate,,DEM,Loretta Sanchez,2
-Mendocino,999148,U.S. Senate,,DEM,Kamala Harris,111
-Mendocino,999148,U.S. Senate,,DEM,Loretta Sanchez,40
-Mendocino,999149,U.S. Senate,,DEM,Kamala Harris,0
-Mendocino,999149,U.S. Senate,,DEM,Loretta Sanchez,0
-Mendocino,999150,U.S. Senate,,DEM,Kamala Harris,45
-Mendocino,999150,U.S. Senate,,DEM,Loretta Sanchez,33
-Mendocino,999151,U.S. Senate,,DEM,Kamala Harris,3
-Mendocino,999151,U.S. Senate,,DEM,Loretta Sanchez,2
-Mendocino,999201,U.S. Senate,,DEM,Kamala Harris,0
-Mendocino,999201,U.S. Senate,,DEM,Loretta Sanchez,0
-Mendocino,999202,U.S. Senate,,DEM,Kamala Harris,144
-Mendocino,999202,U.S. Senate,,DEM,Loretta Sanchez,45
-Mendocino,999203,U.S. Senate,,DEM,Kamala Harris,107
-Mendocino,999203,U.S. Senate,,DEM,Loretta Sanchez,35
-Mendocino,999204,U.S. Senate,,DEM,Kamala Harris,96
-Mendocino,999204,U.S. Senate,,DEM,Loretta Sanchez,45
-Mendocino,999205,U.S. Senate,,DEM,Kamala Harris,193
-Mendocino,999205,U.S. Senate,,DEM,Loretta Sanchez,97
-Mendocino,999206,U.S. Senate,,DEM,Kamala Harris,70
-Mendocino,999206,U.S. Senate,,DEM,Loretta Sanchez,55
-Mendocino,999207,U.S. Senate,,DEM,Kamala Harris,55
-Mendocino,999207,U.S. Senate,,DEM,Loretta Sanchez,51
-Mendocino,999208,U.S. Senate,,DEM,Kamala Harris,84
-Mendocino,999208,U.S. Senate,,DEM,Loretta Sanchez,57
-Mendocino,999209,U.S. Senate,,DEM,Kamala Harris,43
-Mendocino,999209,U.S. Senate,,DEM,Loretta Sanchez,38
-Mendocino,999210,U.S. Senate,,DEM,Kamala Harris,0
-Mendocino,999210,U.S. Senate,,DEM,Loretta Sanchez,0
-Mendocino,999211,U.S. Senate,,DEM,Kamala Harris,87
-Mendocino,999211,U.S. Senate,,DEM,Loretta Sanchez,37
-Mendocino,999212,U.S. Senate,,DEM,Kamala Harris,74
-Mendocino,999212,U.S. Senate,,DEM,Loretta Sanchez,34
-Mendocino,999213,U.S. Senate,,DEM,Kamala Harris,107
-Mendocino,999213,U.S. Senate,,DEM,Loretta Sanchez,49
-Mendocino,999214,U.S. Senate,,DEM,Kamala Harris,82
-Mendocino,999214,U.S. Senate,,DEM,Loretta Sanchez,40
-Mendocino,999215,U.S. Senate,,DEM,Kamala Harris,108
-Mendocino,999215,U.S. Senate,,DEM,Loretta Sanchez,38
-Mendocino,999216,U.S. Senate,,DEM,Kamala Harris,250
-Mendocino,999216,U.S. Senate,,DEM,Loretta Sanchez,76
-Mendocino,999217,U.S. Senate,,DEM,Kamala Harris,52
-Mendocino,999217,U.S. Senate,,DEM,Loretta Sanchez,11
-Mendocino,999218,U.S. Senate,,DEM,Kamala Harris,95
-Mendocino,999218,U.S. Senate,,DEM,Loretta Sanchez,60
-Mendocino,999219,U.S. Senate,,DEM,Kamala Harris,77
-Mendocino,999219,U.S. Senate,,DEM,Loretta Sanchez,60
-Mendocino,999220,U.S. Senate,,DEM,Kamala Harris,111
-Mendocino,999220,U.S. Senate,,DEM,Loretta Sanchez,28
-Mendocino,999221,U.S. Senate,,DEM,Kamala Harris,0
-Mendocino,999221,U.S. Senate,,DEM,Loretta Sanchez,0
-Mendocino,999222,U.S. Senate,,DEM,Kamala Harris,92
-Mendocino,999222,U.S. Senate,,DEM,Loretta Sanchez,37
-Mendocino,999223,U.S. Senate,,DEM,Kamala Harris,119
-Mendocino,999223,U.S. Senate,,DEM,Loretta Sanchez,35
-Mendocino,999224,U.S. Senate,,DEM,Kamala Harris,0
-Mendocino,999224,U.S. Senate,,DEM,Loretta Sanchez,0
-Mendocino,999225,U.S. Senate,,DEM,Kamala Harris,25
-Mendocino,999225,U.S. Senate,,DEM,Loretta Sanchez,15
-Mendocino,999226,U.S. Senate,,DEM,Kamala Harris,44
-Mendocino,999226,U.S. Senate,,DEM,Loretta Sanchez,41
-Mendocino,999227,U.S. Senate,,DEM,Kamala Harris,64
-Mendocino,999227,U.S. Senate,,DEM,Loretta Sanchez,39
-Mendocino,999228,U.S. Senate,,DEM,Kamala Harris,57
-Mendocino,999228,U.S. Senate,,DEM,Loretta Sanchez,29
-Mendocino,999229,U.S. Senate,,DEM,Kamala Harris,92
-Mendocino,999229,U.S. Senate,,DEM,Loretta Sanchez,55
-Mendocino,999230,U.S. Senate,,DEM,Kamala Harris,47
-Mendocino,999230,U.S. Senate,,DEM,Loretta Sanchez,47
-Mendocino,999231,U.S. Senate,,DEM,Kamala Harris,117
-Mendocino,999231,U.S. Senate,,DEM,Loretta Sanchez,78
-Mendocino,999232,U.S. Senate,,DEM,Kamala Harris,87
-Mendocino,999232,U.S. Senate,,DEM,Loretta Sanchez,61
-Mendocino,999233,U.S. Senate,,DEM,Kamala Harris,92
-Mendocino,999233,U.S. Senate,,DEM,Loretta Sanchez,22
-Mendocino,999234,U.S. Senate,,DEM,Kamala Harris,61
-Mendocino,999234,U.S. Senate,,DEM,Loretta Sanchez,38
-Mendocino,999235,U.S. Senate,,DEM,Kamala Harris,0
-Mendocino,999235,U.S. Senate,,DEM,Loretta Sanchez,1
-Mendocino,999236,U.S. Senate,,DEM,Kamala Harris,2
-Mendocino,999236,U.S. Senate,,DEM,Loretta Sanchez,0
-Mendocino,999301,U.S. Senate,,DEM,Kamala Harris,115
-Mendocino,999301,U.S. Senate,,DEM,Loretta Sanchez,44
-Mendocino,999302,U.S. Senate,,DEM,Kamala Harris,58
-Mendocino,999302,U.S. Senate,,DEM,Loretta Sanchez,24
-Mendocino,999303,U.S. Senate,,DEM,Kamala Harris,77
-Mendocino,999303,U.S. Senate,,DEM,Loretta Sanchez,57
-Mendocino,999304,U.S. Senate,,DEM,Kamala Harris,54
-Mendocino,999304,U.S. Senate,,DEM,Loretta Sanchez,28
-Mendocino,999305,U.S. Senate,,DEM,Kamala Harris,74
-Mendocino,999305,U.S. Senate,,DEM,Loretta Sanchez,37
-Mendocino,999306,U.S. Senate,,DEM,Kamala Harris,64
-Mendocino,999306,U.S. Senate,,DEM,Loretta Sanchez,20
-Mendocino,999307,U.S. Senate,,DEM,Kamala Harris,62
-Mendocino,999307,U.S. Senate,,DEM,Loretta Sanchez,35
-Mendocino,999308,U.S. Senate,,DEM,Kamala Harris,32
-Mendocino,999308,U.S. Senate,,DEM,Loretta Sanchez,37
-Mendocino,999309,U.S. Senate,,DEM,Kamala Harris,29
-Mendocino,999309,U.S. Senate,,DEM,Loretta Sanchez,9
-Mendocino,999310,U.S. Senate,,DEM,Kamala Harris,25
-Mendocino,999310,U.S. Senate,,DEM,Loretta Sanchez,14
-Mendocino,999311,U.S. Senate,,DEM,Kamala Harris,42
-Mendocino,999311,U.S. Senate,,DEM,Loretta Sanchez,23
-Mendocino,999312,U.S. Senate,,DEM,Kamala Harris,58
-Mendocino,999312,U.S. Senate,,DEM,Loretta Sanchez,40
-Mendocino,999313,U.S. Senate,,DEM,Kamala Harris,70
-Mendocino,999313,U.S. Senate,,DEM,Loretta Sanchez,34
-Mendocino,999314,U.S. Senate,,DEM,Kamala Harris,129
-Mendocino,999314,U.S. Senate,,DEM,Loretta Sanchez,29
-Mendocino,999315,U.S. Senate,,DEM,Kamala Harris,73
-Mendocino,999315,U.S. Senate,,DEM,Loretta Sanchez,38
-Mendocino,999316,U.S. Senate,,DEM,Kamala Harris,67
-Mendocino,999316,U.S. Senate,,DEM,Loretta Sanchez,33
-Mendocino,999317,U.S. Senate,,DEM,Kamala Harris,0
-Mendocino,999317,U.S. Senate,,DEM,Loretta Sanchez,0
-Mendocino,999318,U.S. Senate,,DEM,Kamala Harris,65
-Mendocino,999318,U.S. Senate,,DEM,Loretta Sanchez,32
-Mendocino,999319,U.S. Senate,,DEM,Kamala Harris,64
-Mendocino,999319,U.S. Senate,,DEM,Loretta Sanchez,41
-Mendocino,999320,U.S. Senate,,DEM,Kamala Harris,104
-Mendocino,999320,U.S. Senate,,DEM,Loretta Sanchez,36
-Mendocino,999322,U.S. Senate,,DEM,Kamala Harris,91
-Mendocino,999322,U.S. Senate,,DEM,Loretta Sanchez,56
-Mendocino,999323,U.S. Senate,,DEM,Kamala Harris,115
-Mendocino,999323,U.S. Senate,,DEM,Loretta Sanchez,69
-Mendocino,999324,U.S. Senate,,DEM,Kamala Harris,57
-Mendocino,999324,U.S. Senate,,DEM,Loretta Sanchez,34
-Mendocino,999325,U.S. Senate,,DEM,Kamala Harris,40
-Mendocino,999325,U.S. Senate,,DEM,Loretta Sanchez,18
-Mendocino,999326,U.S. Senate,,DEM,Kamala Harris,90
-Mendocino,999326,U.S. Senate,,DEM,Loretta Sanchez,44
-Mendocino,999327,U.S. Senate,,DEM,Kamala Harris,0
-Mendocino,999327,U.S. Senate,,DEM,Loretta Sanchez,0
-Mendocino,999328,U.S. Senate,,DEM,Kamala Harris,0
-Mendocino,999328,U.S. Senate,,DEM,Loretta Sanchez,0
-Mendocino,999329,U.S. Senate,,DEM,Kamala Harris,24
-Mendocino,999329,U.S. Senate,,DEM,Loretta Sanchez,6
-Mendocino,999330,U.S. Senate,,DEM,Kamala Harris,53
-Mendocino,999330,U.S. Senate,,DEM,Loretta Sanchez,23
-Mendocino,999401,U.S. Senate,,DEM,Kamala Harris,44
-Mendocino,999401,U.S. Senate,,DEM,Loretta Sanchez,22
-Mendocino,999402,U.S. Senate,,DEM,Kamala Harris,54
-Mendocino,999402,U.S. Senate,,DEM,Loretta Sanchez,20
-Mendocino,999403,U.S. Senate,,DEM,Kamala Harris,0
-Mendocino,999403,U.S. Senate,,DEM,Loretta Sanchez,1
-Mendocino,999404,U.S. Senate,,DEM,Kamala Harris,84
-Mendocino,999404,U.S. Senate,,DEM,Loretta Sanchez,38
-Mendocino,999405,U.S. Senate,,DEM,Kamala Harris,42
-Mendocino,999405,U.S. Senate,,DEM,Loretta Sanchez,11
-Mendocino,999406,U.S. Senate,,DEM,Kamala Harris,77
-Mendocino,999406,U.S. Senate,,DEM,Loretta Sanchez,21
-Mendocino,999407,U.S. Senate,,DEM,Kamala Harris,50
-Mendocino,999407,U.S. Senate,,DEM,Loretta Sanchez,13
-Mendocino,999408,U.S. Senate,,DEM,Kamala Harris,56
-Mendocino,999408,U.S. Senate,,DEM,Loretta Sanchez,17
-Mendocino,999409,U.S. Senate,,DEM,Kamala Harris,161
-Mendocino,999409,U.S. Senate,,DEM,Loretta Sanchez,41
-Mendocino,999410,U.S. Senate,,DEM,Kamala Harris,78
-Mendocino,999410,U.S. Senate,,DEM,Loretta Sanchez,49
-Mendocino,999411,U.S. Senate,,DEM,Kamala Harris,98
-Mendocino,999411,U.S. Senate,,DEM,Loretta Sanchez,32
-Mendocino,999412,U.S. Senate,,DEM,Kamala Harris,74
-Mendocino,999412,U.S. Senate,,DEM,Loretta Sanchez,26
-Mendocino,999413,U.S. Senate,,DEM,Kamala Harris,46
-Mendocino,999413,U.S. Senate,,DEM,Loretta Sanchez,10
-Mendocino,999414,U.S. Senate,,DEM,Kamala Harris,111
-Mendocino,999414,U.S. Senate,,DEM,Loretta Sanchez,29
-Mendocino,999415,U.S. Senate,,DEM,Kamala Harris,71
-Mendocino,999415,U.S. Senate,,DEM,Loretta Sanchez,32
-Mendocino,999416,U.S. Senate,,DEM,Kamala Harris,99
-Mendocino,999416,U.S. Senate,,DEM,Loretta Sanchez,27
-Mendocino,999417,U.S. Senate,,DEM,Kamala Harris,26
-Mendocino,999417,U.S. Senate,,DEM,Loretta Sanchez,11
-Mendocino,999418,U.S. Senate,,DEM,Kamala Harris,1
-Mendocino,999418,U.S. Senate,,DEM,Loretta Sanchez,0
-Mendocino,999419,U.S. Senate,,DEM,Kamala Harris,98
-Mendocino,999419,U.S. Senate,,DEM,Loretta Sanchez,40
-Mendocino,999420,U.S. Senate,,DEM,Kamala Harris,87
-Mendocino,999420,U.S. Senate,,DEM,Loretta Sanchez,38
-Mendocino,999421,U.S. Senate,,DEM,Kamala Harris,112
-Mendocino,999421,U.S. Senate,,DEM,Loretta Sanchez,32
-Mendocino,999422,U.S. Senate,,DEM,Kamala Harris,30
-Mendocino,999422,U.S. Senate,,DEM,Loretta Sanchez,5
-Mendocino,999423,U.S. Senate,,DEM,Kamala Harris,34
-Mendocino,999423,U.S. Senate,,DEM,Loretta Sanchez,17
-Mendocino,999424,U.S. Senate,,DEM,Kamala Harris,129
-Mendocino,999424,U.S. Senate,,DEM,Loretta Sanchez,47
-Mendocino,999425,U.S. Senate,,DEM,Kamala Harris,125
-Mendocino,999425,U.S. Senate,,DEM,Loretta Sanchez,41
-Mendocino,999426,U.S. Senate,,DEM,Kamala Harris,71
-Mendocino,999426,U.S. Senate,,DEM,Loretta Sanchez,26
-Mendocino,999427,U.S. Senate,,DEM,Kamala Harris,75
-Mendocino,999427,U.S. Senate,,DEM,Loretta Sanchez,34
-Mendocino,999428,U.S. Senate,,DEM,Kamala Harris,113
-Mendocino,999428,U.S. Senate,,DEM,Loretta Sanchez,35
-Mendocino,999429,U.S. Senate,,DEM,Kamala Harris,105
-Mendocino,999429,U.S. Senate,,DEM,Loretta Sanchez,50
-Mendocino,999430,U.S. Senate,,DEM,Kamala Harris,0
-Mendocino,999430,U.S. Senate,,DEM,Loretta Sanchez,0
-Mendocino,999431,U.S. Senate,,DEM,Kamala Harris,0
-Mendocino,999431,U.S. Senate,,DEM,Loretta Sanchez,0
-Mendocino,999432,U.S. Senate,,DEM,Kamala Harris,96
-Mendocino,999432,U.S. Senate,,DEM,Loretta Sanchez,36
-Mendocino,999433,U.S. Senate,,DEM,Kamala Harris,45
-Mendocino,999433,U.S. Senate,,DEM,Loretta Sanchez,30
-Mendocino,999434,U.S. Senate,,DEM,Kamala Harris,95
-Mendocino,999434,U.S. Senate,,DEM,Loretta Sanchez,47
-Mendocino,999435,U.S. Senate,,DEM,Kamala Harris,60
-Mendocino,999435,U.S. Senate,,DEM,Loretta Sanchez,47
-Mendocino,999436,U.S. Senate,,DEM,Kamala Harris,90
-Mendocino,999436,U.S. Senate,,DEM,Loretta Sanchez,35
-Mendocino,999437,U.S. Senate,,DEM,Kamala Harris,106
-Mendocino,999437,U.S. Senate,,DEM,Loretta Sanchez,54
-Mendocino,999438,U.S. Senate,,DEM,Kamala Harris,61
-Mendocino,999438,U.S. Senate,,DEM,Loretta Sanchez,29
-Mendocino,999439,U.S. Senate,,DEM,Kamala Harris,11
-Mendocino,999439,U.S. Senate,,DEM,Loretta Sanchez,1
-Mendocino,999440,U.S. Senate,,DEM,Kamala Harris,5
-Mendocino,999440,U.S. Senate,,DEM,Loretta Sanchez,1
-Mendocino,999441,U.S. Senate,,DEM,Kamala Harris,57
-Mendocino,999441,U.S. Senate,,DEM,Loretta Sanchez,27
-Mendocino,999442,U.S. Senate,,DEM,Kamala Harris,5
-Mendocino,999442,U.S. Senate,,DEM,Loretta Sanchez,7
-Mendocino,999501,U.S. Senate,,DEM,Kamala Harris,114
-Mendocino,999501,U.S. Senate,,DEM,Loretta Sanchez,20
-Mendocino,999502,U.S. Senate,,DEM,Kamala Harris,155
-Mendocino,999502,U.S. Senate,,DEM,Loretta Sanchez,27
-Mendocino,999503,U.S. Senate,,DEM,Kamala Harris,55
-Mendocino,999503,U.S. Senate,,DEM,Loretta Sanchez,19
-Mendocino,999504,U.S. Senate,,DEM,Kamala Harris,116
-Mendocino,999504,U.S. Senate,,DEM,Loretta Sanchez,24
-Mendocino,999505,U.S. Senate,,DEM,Kamala Harris,127
-Mendocino,999505,U.S. Senate,,DEM,Loretta Sanchez,24
-Mendocino,999506,U.S. Senate,,DEM,Kamala Harris,127
-Mendocino,999506,U.S. Senate,,DEM,Loretta Sanchez,27
-Mendocino,999507,U.S. Senate,,DEM,Kamala Harris,115
-Mendocino,999507,U.S. Senate,,DEM,Loretta Sanchez,34
-Mendocino,999508,U.S. Senate,,DEM,Kamala Harris,73
-Mendocino,999508,U.S. Senate,,DEM,Loretta Sanchez,23
-Mendocino,999509,U.S. Senate,,DEM,Kamala Harris,41
-Mendocino,999509,U.S. Senate,,DEM,Loretta Sanchez,6
-Mendocino,999510,U.S. Senate,,DEM,Kamala Harris,149
-Mendocino,999510,U.S. Senate,,DEM,Loretta Sanchez,27
-Mendocino,999511,U.S. Senate,,DEM,Kamala Harris,42
-Mendocino,999511,U.S. Senate,,DEM,Loretta Sanchez,8
-Mendocino,999512,U.S. Senate,,DEM,Kamala Harris,68
-Mendocino,999512,U.S. Senate,,DEM,Loretta Sanchez,25
-Mendocino,999513,U.S. Senate,,DEM,Kamala Harris,111
-Mendocino,999513,U.S. Senate,,DEM,Loretta Sanchez,38
-Mendocino,999514,U.S. Senate,,DEM,Kamala Harris,135
-Mendocino,999514,U.S. Senate,,DEM,Loretta Sanchez,48
-Mendocino,999515,U.S. Senate,,DEM,Kamala Harris,9
-Mendocino,999515,U.S. Senate,,DEM,Loretta Sanchez,2
-Mendocino,999516,U.S. Senate,,DEM,Kamala Harris,112
-Mendocino,999516,U.S. Senate,,DEM,Loretta Sanchez,17
-Mendocino,999517,U.S. Senate,,DEM,Kamala Harris,63
-Mendocino,999517,U.S. Senate,,DEM,Loretta Sanchez,14
-Mendocino,999518,U.S. Senate,,DEM,Kamala Harris,21
-Mendocino,999518,U.S. Senate,,DEM,Loretta Sanchez,9
-Mendocino,999519,U.S. Senate,,DEM,Kamala Harris,60
-Mendocino,999519,U.S. Senate,,DEM,Loretta Sanchez,18
-Mendocino,999520,U.S. Senate,,DEM,Kamala Harris,52
-Mendocino,999520,U.S. Senate,,DEM,Loretta Sanchez,17
-Mendocino,999521,U.S. Senate,,DEM,Kamala Harris,141
-Mendocino,999521,U.S. Senate,,DEM,Loretta Sanchez,34
-Mendocino,999522,U.S. Senate,,DEM,Kamala Harris,43
-Mendocino,999522,U.S. Senate,,DEM,Loretta Sanchez,8
-Mendocino,999523,U.S. Senate,,DEM,Kamala Harris,0
-Mendocino,999523,U.S. Senate,,DEM,Loretta Sanchez,1
-Mendocino,999525,U.S. Senate,,DEM,Kamala Harris,113
-Mendocino,999525,U.S. Senate,,DEM,Loretta Sanchez,59
-Mendocino,999526,U.S. Senate,,DEM,Kamala Harris,74
-Mendocino,999526,U.S. Senate,,DEM,Loretta Sanchez,44
-Mendocino,999527,U.S. Senate,,DEM,Kamala Harris,48
-Mendocino,999527,U.S. Senate,,DEM,Loretta Sanchez,30
-Mendocino,999528,U.S. Senate,,DEM,Kamala Harris,84
-Mendocino,999528,U.S. Senate,,DEM,Loretta Sanchez,60
-Mendocino,999529,U.S. Senate,,DEM,Kamala Harris,93
-Mendocino,999529,U.S. Senate,,DEM,Loretta Sanchez,29
-Mendocino,999530,U.S. Senate,,DEM,Kamala Harris,93
-Mendocino,999530,U.S. Senate,,DEM,Loretta Sanchez,53
-Mendocino,999531,U.S. Senate,,DEM,Kamala Harris,19
-Mendocino,999531,U.S. Senate,,DEM,Loretta Sanchez,2
-Mendocino,999532,U.S. Senate,,DEM,Kamala Harris,48
-Mendocino,999532,U.S. Senate,,DEM,Loretta Sanchez,17
-Mendocino,999533,U.S. Senate,,DEM,Kamala Harris,96
-Mendocino,999533,U.S. Senate,,DEM,Loretta Sanchez,51
-Mendocino,999534,U.S. Senate,,DEM,Kamala Harris,39
-Mendocino,999534,U.S. Senate,,DEM,Loretta Sanchez,16
-Mendocino,999535,U.S. Senate,,DEM,Kamala Harris,61
-Mendocino,999535,U.S. Senate,,DEM,Loretta Sanchez,17
-Mendocino,999536,U.S. Senate,,DEM,Kamala Harris,101
-Mendocino,999536,U.S. Senate,,DEM,Loretta Sanchez,47
-Mendocino,999537,U.S. Senate,,DEM,Kamala Harris,12
-Mendocino,999537,U.S. Senate,,DEM,Loretta Sanchez,0
-Mendocino,999538,U.S. Senate,,DEM,Kamala Harris,70
-Mendocino,999538,U.S. Senate,,DEM,Loretta Sanchez,52
-Mendocino,999539,U.S. Senate,,DEM,Kamala Harris,92
-Mendocino,999539,U.S. Senate,,DEM,Loretta Sanchez,39
-Mendocino,999540,U.S. Senate,,DEM,Kamala Harris,10
-Mendocino,999540,U.S. Senate,,DEM,Loretta Sanchez,3
-Mendocino,999541,U.S. Senate,,DEM,Kamala Harris,91
-Mendocino,999541,U.S. Senate,,DEM,Loretta Sanchez,20
-Mendocino,999542,U.S. Senate,,DEM,Kamala Harris,46
-Mendocino,999542,U.S. Senate,,DEM,Loretta Sanchez,32
-Mendocino,999543,U.S. Senate,,DEM,Kamala Harris,7
-Mendocino,999543,U.S. Senate,,DEM,Loretta Sanchez,0
-Mendocino,999544,U.S. Senate,,DEM,Kamala Harris,0
-Mendocino,999544,U.S. Senate,,DEM,Loretta Sanchez,0
-Mendocino,999545,U.S. Senate,,DEM,Kamala Harris,2
-Mendocino,999545,U.S. Senate,,DEM,Loretta Sanchez,0
-Mendocino,999546,U.S. Senate,,DEM,Kamala Harris,0
-Mendocino,999546,U.S. Senate,,DEM,Loretta Sanchez,0
-Mendocino,999547,U.S. Senate,,DEM,Kamala Harris,3
-Mendocino,999547,U.S. Senate,,DEM,Loretta Sanchez,1
-Mendocino,999548,U.S. Senate,,DEM,Kamala Harris,0
-Mendocino,999548,U.S. Senate,,DEM,Loretta Sanchez,0
-Mendocino,999549,U.S. Senate,,DEM,Kamala Harris,0
-Mendocino,999549,U.S. Senate,,DEM,Loretta Sanchez,0
-Mendocino,999550,U.S. Senate,,DEM,Kamala Harris,1
-Mendocino,999550,U.S. Senate,,DEM,Loretta Sanchez,3
-Mendocino,999551,U.S. Senate,,DEM,Kamala Harris,61
-Mendocino,999551,U.S. Senate,,DEM,Loretta Sanchez,15
-Mendocino,999552,U.S. Senate,,DEM,Kamala Harris,0
-Mendocino,999552,U.S. Senate,,DEM,Loretta Sanchez,0
-Mendocino,999553,U.S. Senate,,DEM,Kamala Harris,0
-Mendocino,999553,U.S. Senate,,DEM,Loretta Sanchez,0
-Mendocino,999554,U.S. Senate,,DEM,Kamala Harris,0
-Mendocino,999554,U.S. Senate,,DEM,Loretta Sanchez,0
-Mendocino,999555,U.S. Senate,,DEM,Kamala Harris,7
-Mendocino,999555,U.S. Senate,,DEM,Loretta Sanchez,4
-Mendocino,999556,U.S. Senate,,DEM,Kamala Harris,72
-Mendocino,999556,U.S. Senate,,DEM,Loretta Sanchez,32
-Mendocino,999557,U.S. Senate,,DEM,Kamala Harris,28
-Mendocino,999557,U.S. Senate,,DEM,Loretta Sanchez,22
-Mendocino,999558,U.S. Senate,,DEM,Kamala Harris,91
-Mendocino,999558,U.S. Senate,,DEM,Loretta Sanchez,56
+Mendocino,100001,U.S. Senate,,DEM,Kamala D. Harris,173
+Mendocino,100001,U.S. Senate,,DEM,Loretta L. Sanchez,95
+Mendocino,100002,U.S. Senate,,DEM,Kamala D. Harris,300
+Mendocino,100002,U.S. Senate,,DEM,Loretta L. Sanchez,145
+Mendocino,100003,U.S. Senate,,DEM,Kamala D. Harris,273
+Mendocino,100003,U.S. Senate,,DEM,Loretta L. Sanchez,151
+Mendocino,100004,U.S. Senate,,DEM,Kamala D. Harris,291
+Mendocino,100004,U.S. Senate,,DEM,Loretta L. Sanchez,144
+Mendocino,100005,U.S. Senate,,DEM,Kamala D. Harris,133
+Mendocino,100005,U.S. Senate,,DEM,Loretta L. Sanchez,66
+Mendocino,100006,U.S. Senate,,DEM,Kamala D. Harris,265
+Mendocino,100006,U.S. Senate,,DEM,Loretta L. Sanchez,102
+Mendocino,100007,U.S. Senate,,DEM,Kamala D. Harris,138
+Mendocino,100007,U.S. Senate,,DEM,Loretta L. Sanchez,71
+Mendocino,100008,U.S. Senate,,DEM,Kamala D. Harris,256
+Mendocino,100008,U.S. Senate,,DEM,Loretta L. Sanchez,150
+Mendocino,100009,U.S. Senate,,DEM,Kamala D. Harris,283
+Mendocino,100009,U.S. Senate,,DEM,Loretta L. Sanchez,157
+Mendocino,100500,U.S. Senate,,DEM,Kamala D. Harris,145
+Mendocino,100500,U.S. Senate,,DEM,Loretta L. Sanchez,71
+Mendocino,200001,U.S. Senate,,DEM,Kamala D. Harris,146
+Mendocino,200001,U.S. Senate,,DEM,Loretta L. Sanchez,77
+Mendocino,200003,U.S. Senate,,DEM,Kamala D. Harris,400
+Mendocino,200003,U.S. Senate,,DEM,Loretta L. Sanchez,204
+Mendocino,200004,U.S. Senate,,DEM,Kamala D. Harris,380
+Mendocino,200004,U.S. Senate,,DEM,Loretta L. Sanchez,141
+Mendocino,300001,U.S. Senate,,DEM,Kamala D. Harris,349
+Mendocino,300001,U.S. Senate,,DEM,Loretta L. Sanchez,159
+Mendocino,300002,U.S. Senate,,DEM,Kamala D. Harris,352
+Mendocino,300002,U.S. Senate,,DEM,Loretta L. Sanchez,186
+Mendocino,300003,U.S. Senate,,DEM,Kamala D. Harris,270
+Mendocino,300003,U.S. Senate,,DEM,Loretta L. Sanchez,140
+Mendocino,300004,U.S. Senate,,DEM,Kamala D. Harris,214
+Mendocino,300004,U.S. Senate,,DEM,Loretta L. Sanchez,118
+Mendocino,300005,U.S. Senate,,DEM,Kamala D. Harris,260
+Mendocino,300005,U.S. Senate,,DEM,Loretta L. Sanchez,106
+Mendocino,300006,U.S. Senate,,DEM,Kamala D. Harris,315
+Mendocino,300006,U.S. Senate,,DEM,Loretta L. Sanchez,157
+Mendocino,300007,U.S. Senate,,DEM,Kamala D. Harris,320
+Mendocino,300007,U.S. Senate,,DEM,Loretta L. Sanchez,131
+Mendocino,300008,U.S. Senate,,DEM,Kamala D. Harris,361
+Mendocino,300008,U.S. Senate,,DEM,Loretta L. Sanchez,159
+Mendocino,400001,U.S. Senate,,DEM,Kamala D. Harris,368
+Mendocino,400001,U.S. Senate,,DEM,Loretta L. Sanchez,150
+Mendocino,400002,U.S. Senate,,DEM,Kamala D. Harris,231
+Mendocino,400002,U.S. Senate,,DEM,Loretta L. Sanchez,59
+Mendocino,400003,U.S. Senate,,DEM,Kamala D. Harris,157
+Mendocino,400003,U.S. Senate,,DEM,Loretta L. Sanchez,33
+Mendocino,400004,U.S. Senate,,DEM,Kamala D. Harris,425
+Mendocino,400004,U.S. Senate,,DEM,Loretta L. Sanchez,194
+Mendocino,400005,U.S. Senate,,DEM,Kamala D. Harris,499
+Mendocino,400005,U.S. Senate,,DEM,Loretta L. Sanchez,169
+Mendocino,400006,U.S. Senate,,DEM,Kamala D. Harris,258
+Mendocino,400006,U.S. Senate,,DEM,Loretta L. Sanchez,54
+Mendocino,400007,U.S. Senate,,DEM,Kamala D. Harris,175
+Mendocino,400007,U.S. Senate,,DEM,Loretta L. Sanchez,41
+Mendocino,500001,U.S. Senate,,DEM,Kamala D. Harris,118
+Mendocino,500001,U.S. Senate,,DEM,Loretta L. Sanchez,44
+Mendocino,500002,U.S. Senate,,DEM,Kamala D. Harris,318
+Mendocino,500002,U.S. Senate,,DEM,Loretta L. Sanchez,60
+Mendocino,500003,U.S. Senate,,DEM,Kamala D. Harris,171
+Mendocino,500003,U.S. Senate,,DEM,Loretta L. Sanchez,54
+Mendocino,500004,U.S. Senate,,DEM,Kamala D. Harris,404
+Mendocino,500004,U.S. Senate,,DEM,Loretta L. Sanchez,111
+Mendocino,500005,U.S. Senate,,DEM,Kamala D. Harris,461
+Mendocino,500005,U.S. Senate,,DEM,Loretta L. Sanchez,218
+Mendocino,500006,U.S. Senate,,DEM,Kamala D. Harris,173
+Mendocino,500006,U.S. Senate,,DEM,Loretta L. Sanchez,41
+Mendocino,500007,U.S. Senate,,DEM,Kamala D. Harris,425
+Mendocino,500007,U.S. Senate,,DEM,Loretta L. Sanchez,127
+Mendocino,500008,U.S. Senate,,DEM,Kamala D. Harris,248
+Mendocino,500008,U.S. Senate,,DEM,Loretta L. Sanchez,79
+Mendocino,500009,U.S. Senate,,DEM,Kamala D. Harris,126
+Mendocino,500009,U.S. Senate,,DEM,Loretta L. Sanchez,62
+Mendocino,999102,U.S. Senate,,DEM,Kamala D. Harris,52
+Mendocino,999102,U.S. Senate,,DEM,Loretta L. Sanchez,20
+Mendocino,999103,U.S. Senate,,DEM,Kamala D. Harris,73
+Mendocino,999103,U.S. Senate,,DEM,Loretta L. Sanchez,55
+Mendocino,999104,U.S. Senate,,DEM,Kamala D. Harris,71
+Mendocino,999104,U.S. Senate,,DEM,Loretta L. Sanchez,36
+Mendocino,999105,U.S. Senate,,DEM,Kamala D. Harris,51
+Mendocino,999105,U.S. Senate,,DEM,Loretta L. Sanchez,33
+Mendocino,999106,U.S. Senate,,DEM,Kamala D. Harris,63
+Mendocino,999106,U.S. Senate,,DEM,Loretta L. Sanchez,18
+Mendocino,999107,U.S. Senate,,DEM,Kamala D. Harris,4
+Mendocino,999107,U.S. Senate,,DEM,Loretta L. Sanchez,6
+Mendocino,999108,U.S. Senate,,DEM,Kamala D. Harris,69
+Mendocino,999108,U.S. Senate,,DEM,Loretta L. Sanchez,44
+Mendocino,999109,U.S. Senate,,DEM,Kamala D. Harris,5
+Mendocino,999109,U.S. Senate,,DEM,Loretta L. Sanchez,7
+Mendocino,999110,U.S. Senate,,DEM,Kamala D. Harris,76
+Mendocino,999110,U.S. Senate,,DEM,Loretta L. Sanchez,37
+Mendocino,999111,U.S. Senate,,DEM,Kamala D. Harris,62
+Mendocino,999111,U.S. Senate,,DEM,Loretta L. Sanchez,41
+Mendocino,999112,U.S. Senate,,DEM,Kamala D. Harris,74
+Mendocino,999112,U.S. Senate,,DEM,Loretta L. Sanchez,30
+Mendocino,999113,U.S. Senate,,DEM,Kamala D. Harris,86
+Mendocino,999113,U.S. Senate,,DEM,Loretta L. Sanchez,53
+Mendocino,999114,U.S. Senate,,DEM,Kamala D. Harris,11
+Mendocino,999114,U.S. Senate,,DEM,Loretta L. Sanchez,7
+Mendocino,999115,U.S. Senate,,DEM,Kamala D. Harris,23
+Mendocino,999115,U.S. Senate,,DEM,Loretta L. Sanchez,13
+Mendocino,999116,U.S. Senate,,DEM,Kamala D. Harris,54
+Mendocino,999116,U.S. Senate,,DEM,Loretta L. Sanchez,42
+Mendocino,999117,U.S. Senate,,DEM,Kamala D. Harris,53
+Mendocino,999117,U.S. Senate,,DEM,Loretta L. Sanchez,13
+Mendocino,999118,U.S. Senate,,DEM,Kamala D. Harris,6
+Mendocino,999118,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Mendocino,999119,U.S. Senate,,DEM,Kamala D. Harris,6
+Mendocino,999119,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Mendocino,999120,U.S. Senate,,DEM,Kamala D. Harris,77
+Mendocino,999120,U.S. Senate,,DEM,Loretta L. Sanchez,35
+Mendocino,999121,U.S. Senate,,DEM,Kamala D. Harris,25
+Mendocino,999121,U.S. Senate,,DEM,Loretta L. Sanchez,15
+Mendocino,999122,U.S. Senate,,DEM,Kamala D. Harris,2
+Mendocino,999122,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Mendocino,999124,U.S. Senate,,DEM,Kamala D. Harris,81
+Mendocino,999124,U.S. Senate,,DEM,Loretta L. Sanchez,38
+Mendocino,999125,U.S. Senate,,DEM,Kamala D. Harris,22
+Mendocino,999125,U.S. Senate,,DEM,Loretta L. Sanchez,6
+Mendocino,999126,U.S. Senate,,DEM,Kamala D. Harris,37
+Mendocino,999126,U.S. Senate,,DEM,Loretta L. Sanchez,52
+Mendocino,999127,U.S. Senate,,DEM,Kamala D. Harris,30
+Mendocino,999127,U.S. Senate,,DEM,Loretta L. Sanchez,19
+Mendocino,999128,U.S. Senate,,DEM,Kamala D. Harris,53
+Mendocino,999128,U.S. Senate,,DEM,Loretta L. Sanchez,33
+Mendocino,999129,U.S. Senate,,DEM,Kamala D. Harris,4
+Mendocino,999129,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Mendocino,999130,U.S. Senate,,DEM,Kamala D. Harris,0
+Mendocino,999130,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Mendocino,999131,U.S. Senate,,DEM,Kamala D. Harris,15
+Mendocino,999131,U.S. Senate,,DEM,Loretta L. Sanchez,8
+Mendocino,999132,U.S. Senate,,DEM,Kamala D. Harris,0
+Mendocino,999132,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Mendocino,999133,U.S. Senate,,DEM,Kamala D. Harris,1
+Mendocino,999133,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Mendocino,999134,U.S. Senate,,DEM,Kamala D. Harris,47
+Mendocino,999134,U.S. Senate,,DEM,Loretta L. Sanchez,45
+Mendocino,999135,U.S. Senate,,DEM,Kamala D. Harris,9
+Mendocino,999135,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Mendocino,999136,U.S. Senate,,DEM,Kamala D. Harris,0
+Mendocino,999136,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Mendocino,999137,U.S. Senate,,DEM,Kamala D. Harris,1
+Mendocino,999137,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Mendocino,999138,U.S. Senate,,DEM,Kamala D. Harris,4
+Mendocino,999138,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Mendocino,999139,U.S. Senate,,DEM,Kamala D. Harris,0
+Mendocino,999139,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Mendocino,999140,U.S. Senate,,DEM,Kamala D. Harris,24
+Mendocino,999140,U.S. Senate,,DEM,Loretta L. Sanchez,17
+Mendocino,999141,U.S. Senate,,DEM,Kamala D. Harris,83
+Mendocino,999141,U.S. Senate,,DEM,Loretta L. Sanchez,59
+Mendocino,999142,U.S. Senate,,DEM,Kamala D. Harris,0
+Mendocino,999142,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Mendocino,999143,U.S. Senate,,DEM,Kamala D. Harris,0
+Mendocino,999143,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Mendocino,999144,U.S. Senate,,DEM,Kamala D. Harris,2
+Mendocino,999144,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Mendocino,999145,U.S. Senate,,DEM,Kamala D. Harris,0
+Mendocino,999145,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Mendocino,999146,U.S. Senate,,DEM,Kamala D. Harris,0
+Mendocino,999146,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Mendocino,999147,U.S. Senate,,DEM,Kamala D. Harris,0
+Mendocino,999147,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Mendocino,999148,U.S. Senate,,DEM,Kamala D. Harris,111
+Mendocino,999148,U.S. Senate,,DEM,Loretta L. Sanchez,40
+Mendocino,999149,U.S. Senate,,DEM,Kamala D. Harris,0
+Mendocino,999149,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Mendocino,999150,U.S. Senate,,DEM,Kamala D. Harris,45
+Mendocino,999150,U.S. Senate,,DEM,Loretta L. Sanchez,33
+Mendocino,999151,U.S. Senate,,DEM,Kamala D. Harris,3
+Mendocino,999151,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Mendocino,999201,U.S. Senate,,DEM,Kamala D. Harris,0
+Mendocino,999201,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Mendocino,999202,U.S. Senate,,DEM,Kamala D. Harris,144
+Mendocino,999202,U.S. Senate,,DEM,Loretta L. Sanchez,45
+Mendocino,999203,U.S. Senate,,DEM,Kamala D. Harris,107
+Mendocino,999203,U.S. Senate,,DEM,Loretta L. Sanchez,35
+Mendocino,999204,U.S. Senate,,DEM,Kamala D. Harris,96
+Mendocino,999204,U.S. Senate,,DEM,Loretta L. Sanchez,45
+Mendocino,999205,U.S. Senate,,DEM,Kamala D. Harris,193
+Mendocino,999205,U.S. Senate,,DEM,Loretta L. Sanchez,97
+Mendocino,999206,U.S. Senate,,DEM,Kamala D. Harris,70
+Mendocino,999206,U.S. Senate,,DEM,Loretta L. Sanchez,55
+Mendocino,999207,U.S. Senate,,DEM,Kamala D. Harris,55
+Mendocino,999207,U.S. Senate,,DEM,Loretta L. Sanchez,51
+Mendocino,999208,U.S. Senate,,DEM,Kamala D. Harris,84
+Mendocino,999208,U.S. Senate,,DEM,Loretta L. Sanchez,57
+Mendocino,999209,U.S. Senate,,DEM,Kamala D. Harris,43
+Mendocino,999209,U.S. Senate,,DEM,Loretta L. Sanchez,38
+Mendocino,999210,U.S. Senate,,DEM,Kamala D. Harris,0
+Mendocino,999210,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Mendocino,999211,U.S. Senate,,DEM,Kamala D. Harris,87
+Mendocino,999211,U.S. Senate,,DEM,Loretta L. Sanchez,37
+Mendocino,999212,U.S. Senate,,DEM,Kamala D. Harris,74
+Mendocino,999212,U.S. Senate,,DEM,Loretta L. Sanchez,34
+Mendocino,999213,U.S. Senate,,DEM,Kamala D. Harris,107
+Mendocino,999213,U.S. Senate,,DEM,Loretta L. Sanchez,49
+Mendocino,999214,U.S. Senate,,DEM,Kamala D. Harris,82
+Mendocino,999214,U.S. Senate,,DEM,Loretta L. Sanchez,40
+Mendocino,999215,U.S. Senate,,DEM,Kamala D. Harris,108
+Mendocino,999215,U.S. Senate,,DEM,Loretta L. Sanchez,38
+Mendocino,999216,U.S. Senate,,DEM,Kamala D. Harris,250
+Mendocino,999216,U.S. Senate,,DEM,Loretta L. Sanchez,76
+Mendocino,999217,U.S. Senate,,DEM,Kamala D. Harris,52
+Mendocino,999217,U.S. Senate,,DEM,Loretta L. Sanchez,11
+Mendocino,999218,U.S. Senate,,DEM,Kamala D. Harris,95
+Mendocino,999218,U.S. Senate,,DEM,Loretta L. Sanchez,60
+Mendocino,999219,U.S. Senate,,DEM,Kamala D. Harris,77
+Mendocino,999219,U.S. Senate,,DEM,Loretta L. Sanchez,60
+Mendocino,999220,U.S. Senate,,DEM,Kamala D. Harris,111
+Mendocino,999220,U.S. Senate,,DEM,Loretta L. Sanchez,28
+Mendocino,999221,U.S. Senate,,DEM,Kamala D. Harris,0
+Mendocino,999221,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Mendocino,999222,U.S. Senate,,DEM,Kamala D. Harris,92
+Mendocino,999222,U.S. Senate,,DEM,Loretta L. Sanchez,37
+Mendocino,999223,U.S. Senate,,DEM,Kamala D. Harris,119
+Mendocino,999223,U.S. Senate,,DEM,Loretta L. Sanchez,35
+Mendocino,999224,U.S. Senate,,DEM,Kamala D. Harris,0
+Mendocino,999224,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Mendocino,999225,U.S. Senate,,DEM,Kamala D. Harris,25
+Mendocino,999225,U.S. Senate,,DEM,Loretta L. Sanchez,15
+Mendocino,999226,U.S. Senate,,DEM,Kamala D. Harris,44
+Mendocino,999226,U.S. Senate,,DEM,Loretta L. Sanchez,41
+Mendocino,999227,U.S. Senate,,DEM,Kamala D. Harris,64
+Mendocino,999227,U.S. Senate,,DEM,Loretta L. Sanchez,39
+Mendocino,999228,U.S. Senate,,DEM,Kamala D. Harris,57
+Mendocino,999228,U.S. Senate,,DEM,Loretta L. Sanchez,29
+Mendocino,999229,U.S. Senate,,DEM,Kamala D. Harris,92
+Mendocino,999229,U.S. Senate,,DEM,Loretta L. Sanchez,55
+Mendocino,999230,U.S. Senate,,DEM,Kamala D. Harris,47
+Mendocino,999230,U.S. Senate,,DEM,Loretta L. Sanchez,47
+Mendocino,999231,U.S. Senate,,DEM,Kamala D. Harris,117
+Mendocino,999231,U.S. Senate,,DEM,Loretta L. Sanchez,78
+Mendocino,999232,U.S. Senate,,DEM,Kamala D. Harris,87
+Mendocino,999232,U.S. Senate,,DEM,Loretta L. Sanchez,61
+Mendocino,999233,U.S. Senate,,DEM,Kamala D. Harris,92
+Mendocino,999233,U.S. Senate,,DEM,Loretta L. Sanchez,22
+Mendocino,999234,U.S. Senate,,DEM,Kamala D. Harris,61
+Mendocino,999234,U.S. Senate,,DEM,Loretta L. Sanchez,38
+Mendocino,999235,U.S. Senate,,DEM,Kamala D. Harris,0
+Mendocino,999235,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Mendocino,999236,U.S. Senate,,DEM,Kamala D. Harris,2
+Mendocino,999236,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Mendocino,999301,U.S. Senate,,DEM,Kamala D. Harris,115
+Mendocino,999301,U.S. Senate,,DEM,Loretta L. Sanchez,44
+Mendocino,999302,U.S. Senate,,DEM,Kamala D. Harris,58
+Mendocino,999302,U.S. Senate,,DEM,Loretta L. Sanchez,24
+Mendocino,999303,U.S. Senate,,DEM,Kamala D. Harris,77
+Mendocino,999303,U.S. Senate,,DEM,Loretta L. Sanchez,57
+Mendocino,999304,U.S. Senate,,DEM,Kamala D. Harris,54
+Mendocino,999304,U.S. Senate,,DEM,Loretta L. Sanchez,28
+Mendocino,999305,U.S. Senate,,DEM,Kamala D. Harris,74
+Mendocino,999305,U.S. Senate,,DEM,Loretta L. Sanchez,37
+Mendocino,999306,U.S. Senate,,DEM,Kamala D. Harris,64
+Mendocino,999306,U.S. Senate,,DEM,Loretta L. Sanchez,20
+Mendocino,999307,U.S. Senate,,DEM,Kamala D. Harris,62
+Mendocino,999307,U.S. Senate,,DEM,Loretta L. Sanchez,35
+Mendocino,999308,U.S. Senate,,DEM,Kamala D. Harris,32
+Mendocino,999308,U.S. Senate,,DEM,Loretta L. Sanchez,37
+Mendocino,999309,U.S. Senate,,DEM,Kamala D. Harris,29
+Mendocino,999309,U.S. Senate,,DEM,Loretta L. Sanchez,9
+Mendocino,999310,U.S. Senate,,DEM,Kamala D. Harris,25
+Mendocino,999310,U.S. Senate,,DEM,Loretta L. Sanchez,14
+Mendocino,999311,U.S. Senate,,DEM,Kamala D. Harris,42
+Mendocino,999311,U.S. Senate,,DEM,Loretta L. Sanchez,23
+Mendocino,999312,U.S. Senate,,DEM,Kamala D. Harris,58
+Mendocino,999312,U.S. Senate,,DEM,Loretta L. Sanchez,40
+Mendocino,999313,U.S. Senate,,DEM,Kamala D. Harris,70
+Mendocino,999313,U.S. Senate,,DEM,Loretta L. Sanchez,34
+Mendocino,999314,U.S. Senate,,DEM,Kamala D. Harris,129
+Mendocino,999314,U.S. Senate,,DEM,Loretta L. Sanchez,29
+Mendocino,999315,U.S. Senate,,DEM,Kamala D. Harris,73
+Mendocino,999315,U.S. Senate,,DEM,Loretta L. Sanchez,38
+Mendocino,999316,U.S. Senate,,DEM,Kamala D. Harris,67
+Mendocino,999316,U.S. Senate,,DEM,Loretta L. Sanchez,33
+Mendocino,999317,U.S. Senate,,DEM,Kamala D. Harris,0
+Mendocino,999317,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Mendocino,999318,U.S. Senate,,DEM,Kamala D. Harris,65
+Mendocino,999318,U.S. Senate,,DEM,Loretta L. Sanchez,32
+Mendocino,999319,U.S. Senate,,DEM,Kamala D. Harris,64
+Mendocino,999319,U.S. Senate,,DEM,Loretta L. Sanchez,41
+Mendocino,999320,U.S. Senate,,DEM,Kamala D. Harris,104
+Mendocino,999320,U.S. Senate,,DEM,Loretta L. Sanchez,36
+Mendocino,999322,U.S. Senate,,DEM,Kamala D. Harris,91
+Mendocino,999322,U.S. Senate,,DEM,Loretta L. Sanchez,56
+Mendocino,999323,U.S. Senate,,DEM,Kamala D. Harris,115
+Mendocino,999323,U.S. Senate,,DEM,Loretta L. Sanchez,69
+Mendocino,999324,U.S. Senate,,DEM,Kamala D. Harris,57
+Mendocino,999324,U.S. Senate,,DEM,Loretta L. Sanchez,34
+Mendocino,999325,U.S. Senate,,DEM,Kamala D. Harris,40
+Mendocino,999325,U.S. Senate,,DEM,Loretta L. Sanchez,18
+Mendocino,999326,U.S. Senate,,DEM,Kamala D. Harris,90
+Mendocino,999326,U.S. Senate,,DEM,Loretta L. Sanchez,44
+Mendocino,999327,U.S. Senate,,DEM,Kamala D. Harris,0
+Mendocino,999327,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Mendocino,999328,U.S. Senate,,DEM,Kamala D. Harris,0
+Mendocino,999328,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Mendocino,999329,U.S. Senate,,DEM,Kamala D. Harris,24
+Mendocino,999329,U.S. Senate,,DEM,Loretta L. Sanchez,6
+Mendocino,999330,U.S. Senate,,DEM,Kamala D. Harris,53
+Mendocino,999330,U.S. Senate,,DEM,Loretta L. Sanchez,23
+Mendocino,999401,U.S. Senate,,DEM,Kamala D. Harris,44
+Mendocino,999401,U.S. Senate,,DEM,Loretta L. Sanchez,22
+Mendocino,999402,U.S. Senate,,DEM,Kamala D. Harris,54
+Mendocino,999402,U.S. Senate,,DEM,Loretta L. Sanchez,20
+Mendocino,999403,U.S. Senate,,DEM,Kamala D. Harris,0
+Mendocino,999403,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Mendocino,999404,U.S. Senate,,DEM,Kamala D. Harris,84
+Mendocino,999404,U.S. Senate,,DEM,Loretta L. Sanchez,38
+Mendocino,999405,U.S. Senate,,DEM,Kamala D. Harris,42
+Mendocino,999405,U.S. Senate,,DEM,Loretta L. Sanchez,11
+Mendocino,999406,U.S. Senate,,DEM,Kamala D. Harris,77
+Mendocino,999406,U.S. Senate,,DEM,Loretta L. Sanchez,21
+Mendocino,999407,U.S. Senate,,DEM,Kamala D. Harris,50
+Mendocino,999407,U.S. Senate,,DEM,Loretta L. Sanchez,13
+Mendocino,999408,U.S. Senate,,DEM,Kamala D. Harris,56
+Mendocino,999408,U.S. Senate,,DEM,Loretta L. Sanchez,17
+Mendocino,999409,U.S. Senate,,DEM,Kamala D. Harris,161
+Mendocino,999409,U.S. Senate,,DEM,Loretta L. Sanchez,41
+Mendocino,999410,U.S. Senate,,DEM,Kamala D. Harris,78
+Mendocino,999410,U.S. Senate,,DEM,Loretta L. Sanchez,49
+Mendocino,999411,U.S. Senate,,DEM,Kamala D. Harris,98
+Mendocino,999411,U.S. Senate,,DEM,Loretta L. Sanchez,32
+Mendocino,999412,U.S. Senate,,DEM,Kamala D. Harris,74
+Mendocino,999412,U.S. Senate,,DEM,Loretta L. Sanchez,26
+Mendocino,999413,U.S. Senate,,DEM,Kamala D. Harris,46
+Mendocino,999413,U.S. Senate,,DEM,Loretta L. Sanchez,10
+Mendocino,999414,U.S. Senate,,DEM,Kamala D. Harris,111
+Mendocino,999414,U.S. Senate,,DEM,Loretta L. Sanchez,29
+Mendocino,999415,U.S. Senate,,DEM,Kamala D. Harris,71
+Mendocino,999415,U.S. Senate,,DEM,Loretta L. Sanchez,32
+Mendocino,999416,U.S. Senate,,DEM,Kamala D. Harris,99
+Mendocino,999416,U.S. Senate,,DEM,Loretta L. Sanchez,27
+Mendocino,999417,U.S. Senate,,DEM,Kamala D. Harris,26
+Mendocino,999417,U.S. Senate,,DEM,Loretta L. Sanchez,11
+Mendocino,999418,U.S. Senate,,DEM,Kamala D. Harris,1
+Mendocino,999418,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Mendocino,999419,U.S. Senate,,DEM,Kamala D. Harris,98
+Mendocino,999419,U.S. Senate,,DEM,Loretta L. Sanchez,40
+Mendocino,999420,U.S. Senate,,DEM,Kamala D. Harris,87
+Mendocino,999420,U.S. Senate,,DEM,Loretta L. Sanchez,38
+Mendocino,999421,U.S. Senate,,DEM,Kamala D. Harris,112
+Mendocino,999421,U.S. Senate,,DEM,Loretta L. Sanchez,32
+Mendocino,999422,U.S. Senate,,DEM,Kamala D. Harris,30
+Mendocino,999422,U.S. Senate,,DEM,Loretta L. Sanchez,5
+Mendocino,999423,U.S. Senate,,DEM,Kamala D. Harris,34
+Mendocino,999423,U.S. Senate,,DEM,Loretta L. Sanchez,17
+Mendocino,999424,U.S. Senate,,DEM,Kamala D. Harris,129
+Mendocino,999424,U.S. Senate,,DEM,Loretta L. Sanchez,47
+Mendocino,999425,U.S. Senate,,DEM,Kamala D. Harris,125
+Mendocino,999425,U.S. Senate,,DEM,Loretta L. Sanchez,41
+Mendocino,999426,U.S. Senate,,DEM,Kamala D. Harris,71
+Mendocino,999426,U.S. Senate,,DEM,Loretta L. Sanchez,26
+Mendocino,999427,U.S. Senate,,DEM,Kamala D. Harris,75
+Mendocino,999427,U.S. Senate,,DEM,Loretta L. Sanchez,34
+Mendocino,999428,U.S. Senate,,DEM,Kamala D. Harris,113
+Mendocino,999428,U.S. Senate,,DEM,Loretta L. Sanchez,35
+Mendocino,999429,U.S. Senate,,DEM,Kamala D. Harris,105
+Mendocino,999429,U.S. Senate,,DEM,Loretta L. Sanchez,50
+Mendocino,999430,U.S. Senate,,DEM,Kamala D. Harris,0
+Mendocino,999430,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Mendocino,999431,U.S. Senate,,DEM,Kamala D. Harris,0
+Mendocino,999431,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Mendocino,999432,U.S. Senate,,DEM,Kamala D. Harris,96
+Mendocino,999432,U.S. Senate,,DEM,Loretta L. Sanchez,36
+Mendocino,999433,U.S. Senate,,DEM,Kamala D. Harris,45
+Mendocino,999433,U.S. Senate,,DEM,Loretta L. Sanchez,30
+Mendocino,999434,U.S. Senate,,DEM,Kamala D. Harris,95
+Mendocino,999434,U.S. Senate,,DEM,Loretta L. Sanchez,47
+Mendocino,999435,U.S. Senate,,DEM,Kamala D. Harris,60
+Mendocino,999435,U.S. Senate,,DEM,Loretta L. Sanchez,47
+Mendocino,999436,U.S. Senate,,DEM,Kamala D. Harris,90
+Mendocino,999436,U.S. Senate,,DEM,Loretta L. Sanchez,35
+Mendocino,999437,U.S. Senate,,DEM,Kamala D. Harris,106
+Mendocino,999437,U.S. Senate,,DEM,Loretta L. Sanchez,54
+Mendocino,999438,U.S. Senate,,DEM,Kamala D. Harris,61
+Mendocino,999438,U.S. Senate,,DEM,Loretta L. Sanchez,29
+Mendocino,999439,U.S. Senate,,DEM,Kamala D. Harris,11
+Mendocino,999439,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Mendocino,999440,U.S. Senate,,DEM,Kamala D. Harris,5
+Mendocino,999440,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Mendocino,999441,U.S. Senate,,DEM,Kamala D. Harris,57
+Mendocino,999441,U.S. Senate,,DEM,Loretta L. Sanchez,27
+Mendocino,999442,U.S. Senate,,DEM,Kamala D. Harris,5
+Mendocino,999442,U.S. Senate,,DEM,Loretta L. Sanchez,7
+Mendocino,999501,U.S. Senate,,DEM,Kamala D. Harris,114
+Mendocino,999501,U.S. Senate,,DEM,Loretta L. Sanchez,20
+Mendocino,999502,U.S. Senate,,DEM,Kamala D. Harris,155
+Mendocino,999502,U.S. Senate,,DEM,Loretta L. Sanchez,27
+Mendocino,999503,U.S. Senate,,DEM,Kamala D. Harris,55
+Mendocino,999503,U.S. Senate,,DEM,Loretta L. Sanchez,19
+Mendocino,999504,U.S. Senate,,DEM,Kamala D. Harris,116
+Mendocino,999504,U.S. Senate,,DEM,Loretta L. Sanchez,24
+Mendocino,999505,U.S. Senate,,DEM,Kamala D. Harris,127
+Mendocino,999505,U.S. Senate,,DEM,Loretta L. Sanchez,24
+Mendocino,999506,U.S. Senate,,DEM,Kamala D. Harris,127
+Mendocino,999506,U.S. Senate,,DEM,Loretta L. Sanchez,27
+Mendocino,999507,U.S. Senate,,DEM,Kamala D. Harris,115
+Mendocino,999507,U.S. Senate,,DEM,Loretta L. Sanchez,34
+Mendocino,999508,U.S. Senate,,DEM,Kamala D. Harris,73
+Mendocino,999508,U.S. Senate,,DEM,Loretta L. Sanchez,23
+Mendocino,999509,U.S. Senate,,DEM,Kamala D. Harris,41
+Mendocino,999509,U.S. Senate,,DEM,Loretta L. Sanchez,6
+Mendocino,999510,U.S. Senate,,DEM,Kamala D. Harris,149
+Mendocino,999510,U.S. Senate,,DEM,Loretta L. Sanchez,27
+Mendocino,999511,U.S. Senate,,DEM,Kamala D. Harris,42
+Mendocino,999511,U.S. Senate,,DEM,Loretta L. Sanchez,8
+Mendocino,999512,U.S. Senate,,DEM,Kamala D. Harris,68
+Mendocino,999512,U.S. Senate,,DEM,Loretta L. Sanchez,25
+Mendocino,999513,U.S. Senate,,DEM,Kamala D. Harris,111
+Mendocino,999513,U.S. Senate,,DEM,Loretta L. Sanchez,38
+Mendocino,999514,U.S. Senate,,DEM,Kamala D. Harris,135
+Mendocino,999514,U.S. Senate,,DEM,Loretta L. Sanchez,48
+Mendocino,999515,U.S. Senate,,DEM,Kamala D. Harris,9
+Mendocino,999515,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Mendocino,999516,U.S. Senate,,DEM,Kamala D. Harris,112
+Mendocino,999516,U.S. Senate,,DEM,Loretta L. Sanchez,17
+Mendocino,999517,U.S. Senate,,DEM,Kamala D. Harris,63
+Mendocino,999517,U.S. Senate,,DEM,Loretta L. Sanchez,14
+Mendocino,999518,U.S. Senate,,DEM,Kamala D. Harris,21
+Mendocino,999518,U.S. Senate,,DEM,Loretta L. Sanchez,9
+Mendocino,999519,U.S. Senate,,DEM,Kamala D. Harris,60
+Mendocino,999519,U.S. Senate,,DEM,Loretta L. Sanchez,18
+Mendocino,999520,U.S. Senate,,DEM,Kamala D. Harris,52
+Mendocino,999520,U.S. Senate,,DEM,Loretta L. Sanchez,17
+Mendocino,999521,U.S. Senate,,DEM,Kamala D. Harris,141
+Mendocino,999521,U.S. Senate,,DEM,Loretta L. Sanchez,34
+Mendocino,999522,U.S. Senate,,DEM,Kamala D. Harris,43
+Mendocino,999522,U.S. Senate,,DEM,Loretta L. Sanchez,8
+Mendocino,999523,U.S. Senate,,DEM,Kamala D. Harris,0
+Mendocino,999523,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Mendocino,999525,U.S. Senate,,DEM,Kamala D. Harris,113
+Mendocino,999525,U.S. Senate,,DEM,Loretta L. Sanchez,59
+Mendocino,999526,U.S. Senate,,DEM,Kamala D. Harris,74
+Mendocino,999526,U.S. Senate,,DEM,Loretta L. Sanchez,44
+Mendocino,999527,U.S. Senate,,DEM,Kamala D. Harris,48
+Mendocino,999527,U.S. Senate,,DEM,Loretta L. Sanchez,30
+Mendocino,999528,U.S. Senate,,DEM,Kamala D. Harris,84
+Mendocino,999528,U.S. Senate,,DEM,Loretta L. Sanchez,60
+Mendocino,999529,U.S. Senate,,DEM,Kamala D. Harris,93
+Mendocino,999529,U.S. Senate,,DEM,Loretta L. Sanchez,29
+Mendocino,999530,U.S. Senate,,DEM,Kamala D. Harris,93
+Mendocino,999530,U.S. Senate,,DEM,Loretta L. Sanchez,53
+Mendocino,999531,U.S. Senate,,DEM,Kamala D. Harris,19
+Mendocino,999531,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Mendocino,999532,U.S. Senate,,DEM,Kamala D. Harris,48
+Mendocino,999532,U.S. Senate,,DEM,Loretta L. Sanchez,17
+Mendocino,999533,U.S. Senate,,DEM,Kamala D. Harris,96
+Mendocino,999533,U.S. Senate,,DEM,Loretta L. Sanchez,51
+Mendocino,999534,U.S. Senate,,DEM,Kamala D. Harris,39
+Mendocino,999534,U.S. Senate,,DEM,Loretta L. Sanchez,16
+Mendocino,999535,U.S. Senate,,DEM,Kamala D. Harris,61
+Mendocino,999535,U.S. Senate,,DEM,Loretta L. Sanchez,17
+Mendocino,999536,U.S. Senate,,DEM,Kamala D. Harris,101
+Mendocino,999536,U.S. Senate,,DEM,Loretta L. Sanchez,47
+Mendocino,999537,U.S. Senate,,DEM,Kamala D. Harris,12
+Mendocino,999537,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Mendocino,999538,U.S. Senate,,DEM,Kamala D. Harris,70
+Mendocino,999538,U.S. Senate,,DEM,Loretta L. Sanchez,52
+Mendocino,999539,U.S. Senate,,DEM,Kamala D. Harris,92
+Mendocino,999539,U.S. Senate,,DEM,Loretta L. Sanchez,39
+Mendocino,999540,U.S. Senate,,DEM,Kamala D. Harris,10
+Mendocino,999540,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Mendocino,999541,U.S. Senate,,DEM,Kamala D. Harris,91
+Mendocino,999541,U.S. Senate,,DEM,Loretta L. Sanchez,20
+Mendocino,999542,U.S. Senate,,DEM,Kamala D. Harris,46
+Mendocino,999542,U.S. Senate,,DEM,Loretta L. Sanchez,32
+Mendocino,999543,U.S. Senate,,DEM,Kamala D. Harris,7
+Mendocino,999543,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Mendocino,999544,U.S. Senate,,DEM,Kamala D. Harris,0
+Mendocino,999544,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Mendocino,999545,U.S. Senate,,DEM,Kamala D. Harris,2
+Mendocino,999545,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Mendocino,999546,U.S. Senate,,DEM,Kamala D. Harris,0
+Mendocino,999546,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Mendocino,999547,U.S. Senate,,DEM,Kamala D. Harris,3
+Mendocino,999547,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Mendocino,999548,U.S. Senate,,DEM,Kamala D. Harris,0
+Mendocino,999548,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Mendocino,999549,U.S. Senate,,DEM,Kamala D. Harris,0
+Mendocino,999549,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Mendocino,999550,U.S. Senate,,DEM,Kamala D. Harris,1
+Mendocino,999550,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Mendocino,999551,U.S. Senate,,DEM,Kamala D. Harris,61
+Mendocino,999551,U.S. Senate,,DEM,Loretta L. Sanchez,15
+Mendocino,999552,U.S. Senate,,DEM,Kamala D. Harris,0
+Mendocino,999552,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Mendocino,999553,U.S. Senate,,DEM,Kamala D. Harris,0
+Mendocino,999553,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Mendocino,999554,U.S. Senate,,DEM,Kamala D. Harris,0
+Mendocino,999554,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Mendocino,999555,U.S. Senate,,DEM,Kamala D. Harris,7
+Mendocino,999555,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Mendocino,999556,U.S. Senate,,DEM,Kamala D. Harris,72
+Mendocino,999556,U.S. Senate,,DEM,Loretta L. Sanchez,32
+Mendocino,999557,U.S. Senate,,DEM,Kamala D. Harris,28
+Mendocino,999557,U.S. Senate,,DEM,Loretta L. Sanchez,22
+Mendocino,999558,U.S. Senate,,DEM,Kamala D. Harris,91
+Mendocino,999558,U.S. Senate,,DEM,Loretta L. Sanchez,56

--- a/2016/20161108__ca__general__merced__precinct.csv
+++ b/2016/20161108__ca__general__merced__precinct.csv
@@ -10759,541 +10759,541 @@ Merced,95268,Proposition 67,,N/A,Yes,16
 Merced,95268,Proposition 67,,N/A,No,50
 Merced,95269,Proposition 67,,N/A,Yes,62
 Merced,95269,Proposition 67,,N/A,No,119
-Merced,1001,U.S. Senate,,DEM,Kamala Harris,187
-Merced,1001,U.S. Senate,,DEM,Loretta Sanchez,277
-Merced,1002,U.S. Senate,,DEM,Kamala Harris,269
-Merced,1002,U.S. Senate,,DEM,Loretta Sanchez,304
-Merced,1003,U.S. Senate,,DEM,Kamala Harris,269
-Merced,1003,U.S. Senate,,DEM,Loretta Sanchez,359
-Merced,1004,U.S. Senate,,DEM,Kamala Harris,183
-Merced,1004,U.S. Senate,,DEM,Loretta Sanchez,234
-Merced,1005,U.S. Senate,,DEM,Kamala Harris,386
-Merced,1005,U.S. Senate,,DEM,Loretta Sanchez,363
-Merced,1006,U.S. Senate,,DEM,Kamala Harris,225
-Merced,1006,U.S. Senate,,DEM,Loretta Sanchez,402
-Merced,1007,U.S. Senate,,DEM,Kamala Harris,151
-Merced,1007,U.S. Senate,,DEM,Loretta Sanchez,230
-Merced,1008,U.S. Senate,,DEM,Kamala Harris,212
-Merced,1008,U.S. Senate,,DEM,Loretta Sanchez,269
-Merced,1009,U.S. Senate,,DEM,Kamala Harris,124
-Merced,1009,U.S. Senate,,DEM,Loretta Sanchez,151
-Merced,1010,U.S. Senate,,DEM,Kamala Harris,182
-Merced,1010,U.S. Senate,,DEM,Loretta Sanchez,319
-Merced,1011,U.S. Senate,,DEM,Kamala Harris,101
-Merced,1011,U.S. Senate,,DEM,Loretta Sanchez,143
-Merced,1012,U.S. Senate,,DEM,Kamala Harris,119
-Merced,1012,U.S. Senate,,DEM,Loretta Sanchez,91
-Merced,1013,U.S. Senate,,DEM,Kamala Harris,93
-Merced,1013,U.S. Senate,,DEM,Loretta Sanchez,158
-Merced,1014,U.S. Senate,,DEM,Kamala Harris,88
-Merced,1014,U.S. Senate,,DEM,Loretta Sanchez,92
-Merced,1015,U.S. Senate,,DEM,Kamala Harris,121
-Merced,1015,U.S. Senate,,DEM,Loretta Sanchez,269
-Merced,1016,U.S. Senate,,DEM,Kamala Harris,137
-Merced,1016,U.S. Senate,,DEM,Loretta Sanchez,283
-Merced,1017,U.S. Senate,,DEM,Kamala Harris,123
-Merced,1017,U.S. Senate,,DEM,Loretta Sanchez,106
-Merced,2018,U.S. Senate,,DEM,Kamala Harris,209
-Merced,2018,U.S. Senate,,DEM,Loretta Sanchez,125
-Merced,2019,U.S. Senate,,DEM,Kamala Harris,166
-Merced,2019,U.S. Senate,,DEM,Loretta Sanchez,94
-Merced,2020,U.S. Senate,,DEM,Kamala Harris,170
-Merced,2020,U.S. Senate,,DEM,Loretta Sanchez,93
-Merced,2021,U.S. Senate,,DEM,Kamala Harris,213
-Merced,2021,U.S. Senate,,DEM,Loretta Sanchez,160
-Merced,2022,U.S. Senate,,DEM,Kamala Harris,132
-Merced,2022,U.S. Senate,,DEM,Loretta Sanchez,81
-Merced,2023,U.S. Senate,,DEM,Kamala Harris,222
-Merced,2023,U.S. Senate,,DEM,Loretta Sanchez,128
-Merced,2024,U.S. Senate,,DEM,Kamala Harris,124
-Merced,2024,U.S. Senate,,DEM,Loretta Sanchez,109
-Merced,2025,U.S. Senate,,DEM,Kamala Harris,353
-Merced,2025,U.S. Senate,,DEM,Loretta Sanchez,336
-Merced,2026,U.S. Senate,,DEM,Kamala Harris,185
-Merced,2026,U.S. Senate,,DEM,Loretta Sanchez,138
-Merced,2027,U.S. Senate,,DEM,Kamala Harris,307
-Merced,2027,U.S. Senate,,DEM,Loretta Sanchez,228
-Merced,2028,U.S. Senate,,DEM,Kamala Harris,134
-Merced,2028,U.S. Senate,,DEM,Loretta Sanchez,88
-Merced,2029,U.S. Senate,,DEM,Kamala Harris,249
-Merced,2029,U.S. Senate,,DEM,Loretta Sanchez,191
-Merced,2030,U.S. Senate,,DEM,Kamala Harris,316
-Merced,2030,U.S. Senate,,DEM,Loretta Sanchez,229
-Merced,2031,U.S. Senate,,DEM,Kamala Harris,244
-Merced,2031,U.S. Senate,,DEM,Loretta Sanchez,189
-Merced,2032,U.S. Senate,,DEM,Kamala Harris,261
-Merced,2032,U.S. Senate,,DEM,Loretta Sanchez,200
-Merced,2033,U.S. Senate,,DEM,Kamala Harris,184
-Merced,2033,U.S. Senate,,DEM,Loretta Sanchez,159
-Merced,2034,U.S. Senate,,DEM,Kamala Harris,205
-Merced,2034,U.S. Senate,,DEM,Loretta Sanchez,280
-Merced,2035,U.S. Senate,,DEM,Kamala Harris,102
-Merced,2035,U.S. Senate,,DEM,Loretta Sanchez,103
-Merced,2036,U.S. Senate,,DEM,Kamala Harris,218
-Merced,2036,U.S. Senate,,DEM,Loretta Sanchez,178
-Merced,2037,U.S. Senate,,DEM,Kamala Harris,278
-Merced,2037,U.S. Senate,,DEM,Loretta Sanchez,218
-Merced,2038,U.S. Senate,,DEM,Kamala Harris,108
-Merced,2038,U.S. Senate,,DEM,Loretta Sanchez,75
-Merced,2039,U.S. Senate,,DEM,Kamala Harris,168
-Merced,2039,U.S. Senate,,DEM,Loretta Sanchez,166
-Merced,2040,U.S. Senate,,DEM,Kamala Harris,146
-Merced,2040,U.S. Senate,,DEM,Loretta Sanchez,121
-Merced,2041,U.S. Senate,,DEM,Kamala Harris,346
-Merced,2041,U.S. Senate,,DEM,Loretta Sanchez,288
-Merced,2042,U.S. Senate,,DEM,Kamala Harris,354
-Merced,2042,U.S. Senate,,DEM,Loretta Sanchez,194
-Merced,2043,U.S. Senate,,DEM,Kamala Harris,348
-Merced,2043,U.S. Senate,,DEM,Loretta Sanchez,246
-Merced,2044,U.S. Senate,,DEM,Kamala Harris,96
-Merced,2044,U.S. Senate,,DEM,Loretta Sanchez,97
-Merced,2045,U.S. Senate,,DEM,Kamala Harris,277
-Merced,2045,U.S. Senate,,DEM,Loretta Sanchez,259
-Merced,2046,U.S. Senate,,DEM,Kamala Harris,182
-Merced,2046,U.S. Senate,,DEM,Loretta Sanchez,105
-Merced,2047,U.S. Senate,,DEM,Kamala Harris,382
-Merced,2047,U.S. Senate,,DEM,Loretta Sanchez,328
-Merced,2048,U.S. Senate,,DEM,Kamala Harris,230
-Merced,2048,U.S. Senate,,DEM,Loretta Sanchez,132
-Merced,2049,U.S. Senate,,DEM,Kamala Harris,87
-Merced,2049,U.S. Senate,,DEM,Loretta Sanchez,82
-Merced,2050,U.S. Senate,,DEM,Kamala Harris,82
-Merced,2050,U.S. Senate,,DEM,Loretta Sanchez,74
-Merced,2051,U.S. Senate,,DEM,Kamala Harris,270
-Merced,2051,U.S. Senate,,DEM,Loretta Sanchez,193
-Merced,2052,U.S. Senate,,DEM,Kamala Harris,277
-Merced,2052,U.S. Senate,,DEM,Loretta Sanchez,178
-Merced,2053,U.S. Senate,,DEM,Kamala Harris,124
-Merced,2053,U.S. Senate,,DEM,Loretta Sanchez,54
-Merced,2054,U.S. Senate,,DEM,Kamala Harris,162
-Merced,2054,U.S. Senate,,DEM,Loretta Sanchez,88
-Merced,2055,U.S. Senate,,DEM,Kamala Harris,136
-Merced,2055,U.S. Senate,,DEM,Loretta Sanchez,129
-Merced,2056,U.S. Senate,,DEM,Kamala Harris,194
-Merced,2056,U.S. Senate,,DEM,Loretta Sanchez,304
-Merced,3057,U.S. Senate,,DEM,Kamala Harris,319
-Merced,3057,U.S. Senate,,DEM,Loretta Sanchez,358
-Merced,3058,U.S. Senate,,DEM,Kamala Harris,241
-Merced,3058,U.S. Senate,,DEM,Loretta Sanchez,252
-Merced,3059,U.S. Senate,,DEM,Kamala Harris,341
-Merced,3059,U.S. Senate,,DEM,Loretta Sanchez,343
-Merced,3060,U.S. Senate,,DEM,Kamala Harris,319
-Merced,3060,U.S. Senate,,DEM,Loretta Sanchez,316
-Merced,3061,U.S. Senate,,DEM,Kamala Harris,399
-Merced,3061,U.S. Senate,,DEM,Loretta Sanchez,380
-Merced,3062,U.S. Senate,,DEM,Kamala Harris,242
-Merced,3062,U.S. Senate,,DEM,Loretta Sanchez,306
-Merced,3063,U.S. Senate,,DEM,Kamala Harris,147
-Merced,3063,U.S. Senate,,DEM,Loretta Sanchez,150
-Merced,3064,U.S. Senate,,DEM,Kamala Harris,333
-Merced,3064,U.S. Senate,,DEM,Loretta Sanchez,296
-Merced,3065,U.S. Senate,,DEM,Kamala Harris,293
-Merced,3065,U.S. Senate,,DEM,Loretta Sanchez,260
-Merced,3066,U.S. Senate,,DEM,Kamala Harris,208
-Merced,3066,U.S. Senate,,DEM,Loretta Sanchez,202
-Merced,3067,U.S. Senate,,DEM,Kamala Harris,327
-Merced,3067,U.S. Senate,,DEM,Loretta Sanchez,246
-Merced,3068,U.S. Senate,,DEM,Kamala Harris,237
-Merced,3068,U.S. Senate,,DEM,Loretta Sanchez,178
-Merced,3069,U.S. Senate,,DEM,Kamala Harris,127
-Merced,3069,U.S. Senate,,DEM,Loretta Sanchez,117
-Merced,3070,U.S. Senate,,DEM,Kamala Harris,313
-Merced,3070,U.S. Senate,,DEM,Loretta Sanchez,186
-Merced,3071,U.S. Senate,,DEM,Kamala Harris,66
-Merced,3071,U.S. Senate,,DEM,Loretta Sanchez,129
-Merced,3072,U.S. Senate,,DEM,Kamala Harris,253
-Merced,3072,U.S. Senate,,DEM,Loretta Sanchez,324
-Merced,3073,U.S. Senate,,DEM,Kamala Harris,202
-Merced,3073,U.S. Senate,,DEM,Loretta Sanchez,322
-Merced,3074,U.S. Senate,,DEM,Kamala Harris,333
-Merced,3074,U.S. Senate,,DEM,Loretta Sanchez,241
-Merced,3075,U.S. Senate,,DEM,Kamala Harris,224
-Merced,3075,U.S. Senate,,DEM,Loretta Sanchez,190
-Merced,3076,U.S. Senate,,DEM,Kamala Harris,101
-Merced,3076,U.S. Senate,,DEM,Loretta Sanchez,99
-Merced,3077,U.S. Senate,,DEM,Kamala Harris,347
-Merced,3077,U.S. Senate,,DEM,Loretta Sanchez,365
-Merced,3078,U.S. Senate,,DEM,Kamala Harris,448
-Merced,3078,U.S. Senate,,DEM,Loretta Sanchez,298
-Merced,3079,U.S. Senate,,DEM,Kamala Harris,259
-Merced,3079,U.S. Senate,,DEM,Loretta Sanchez,264
-Merced,3080,U.S. Senate,,DEM,Kamala Harris,164
-Merced,3080,U.S. Senate,,DEM,Loretta Sanchez,168
-Merced,4081,U.S. Senate,,DEM,Kamala Harris,80
-Merced,4081,U.S. Senate,,DEM,Loretta Sanchez,78
-Merced,4082,U.S. Senate,,DEM,Kamala Harris,170
-Merced,4082,U.S. Senate,,DEM,Loretta Sanchez,113
-Merced,4083,U.S. Senate,,DEM,Kamala Harris,93
-Merced,4083,U.S. Senate,,DEM,Loretta Sanchez,121
-Merced,4084,U.S. Senate,,DEM,Kamala Harris,72
-Merced,4084,U.S. Senate,,DEM,Loretta Sanchez,112
-Merced,4085,U.S. Senate,,DEM,Kamala Harris,147
-Merced,4085,U.S. Senate,,DEM,Loretta Sanchez,192
-Merced,4086,U.S. Senate,,DEM,Kamala Harris,299
-Merced,4086,U.S. Senate,,DEM,Loretta Sanchez,488
-Merced,4087,U.S. Senate,,DEM,Kamala Harris,329
-Merced,4087,U.S. Senate,,DEM,Loretta Sanchez,512
-Merced,4088,U.S. Senate,,DEM,Kamala Harris,182
-Merced,4088,U.S. Senate,,DEM,Loretta Sanchez,108
-Merced,4089,U.S. Senate,,DEM,Kamala Harris,236
-Merced,4089,U.S. Senate,,DEM,Loretta Sanchez,165
-Merced,4090,U.S. Senate,,DEM,Kamala Harris,183
-Merced,4090,U.S. Senate,,DEM,Loretta Sanchez,136
-Merced,4091,U.S. Senate,,DEM,Kamala Harris,200
-Merced,4091,U.S. Senate,,DEM,Loretta Sanchez,178
-Merced,4092,U.S. Senate,,DEM,Kamala Harris,108
-Merced,4092,U.S. Senate,,DEM,Loretta Sanchez,72
-Merced,4093,U.S. Senate,,DEM,Kamala Harris,379
-Merced,4093,U.S. Senate,,DEM,Loretta Sanchez,283
-Merced,4094,U.S. Senate,,DEM,Kamala Harris,129
-Merced,4094,U.S. Senate,,DEM,Loretta Sanchez,116
-Merced,4095,U.S. Senate,,DEM,Kamala Harris,302
-Merced,4095,U.S. Senate,,DEM,Loretta Sanchez,229
-Merced,4096,U.S. Senate,,DEM,Kamala Harris,168
-Merced,4096,U.S. Senate,,DEM,Loretta Sanchez,174
-Merced,4097,U.S. Senate,,DEM,Kamala Harris,116
-Merced,4097,U.S. Senate,,DEM,Loretta Sanchez,75
-Merced,4098,U.S. Senate,,DEM,Kamala Harris,179
-Merced,4098,U.S. Senate,,DEM,Loretta Sanchez,162
-Merced,4099,U.S. Senate,,DEM,Kamala Harris,113
-Merced,4099,U.S. Senate,,DEM,Loretta Sanchez,79
-Merced,4100,U.S. Senate,,DEM,Kamala Harris,170
-Merced,4100,U.S. Senate,,DEM,Loretta Sanchez,264
-Merced,4101,U.S. Senate,,DEM,Kamala Harris,238
-Merced,4101,U.S. Senate,,DEM,Loretta Sanchez,326
-Merced,4102,U.S. Senate,,DEM,Kamala Harris,211
-Merced,4102,U.S. Senate,,DEM,Loretta Sanchez,284
-Merced,4103,U.S. Senate,,DEM,Kamala Harris,67
-Merced,4103,U.S. Senate,,DEM,Loretta Sanchez,95
-Merced,5104,U.S. Senate,,DEM,Kamala Harris,168
-Merced,5104,U.S. Senate,,DEM,Loretta Sanchez,164
-Merced,5105,U.S. Senate,,DEM,Kamala Harris,254
-Merced,5105,U.S. Senate,,DEM,Loretta Sanchez,292
-Merced,5106,U.S. Senate,,DEM,Kamala Harris,279
-Merced,5106,U.S. Senate,,DEM,Loretta Sanchez,283
-Merced,5107,U.S. Senate,,DEM,Kamala Harris,233
-Merced,5107,U.S. Senate,,DEM,Loretta Sanchez,254
-Merced,5108,U.S. Senate,,DEM,Kamala Harris,285
-Merced,5108,U.S. Senate,,DEM,Loretta Sanchez,320
-Merced,5109,U.S. Senate,,DEM,Kamala Harris,315
-Merced,5109,U.S. Senate,,DEM,Loretta Sanchez,245
-Merced,5110,U.S. Senate,,DEM,Kamala Harris,284
-Merced,5110,U.S. Senate,,DEM,Loretta Sanchez,214
-Merced,5111,U.S. Senate,,DEM,Kamala Harris,246
-Merced,5111,U.S. Senate,,DEM,Loretta Sanchez,319
-Merced,5112,U.S. Senate,,DEM,Kamala Harris,163
-Merced,5112,U.S. Senate,,DEM,Loretta Sanchez,149
-Merced,5113,U.S. Senate,,DEM,Kamala Harris,284
-Merced,5113,U.S. Senate,,DEM,Loretta Sanchez,295
-Merced,5114,U.S. Senate,,DEM,Kamala Harris,194
-Merced,5114,U.S. Senate,,DEM,Loretta Sanchez,160
-Merced,5115,U.S. Senate,,DEM,Kamala Harris,296
-Merced,5115,U.S. Senate,,DEM,Loretta Sanchez,339
-Merced,5116,U.S. Senate,,DEM,Kamala Harris,248
-Merced,5116,U.S. Senate,,DEM,Loretta Sanchez,321
-Merced,5117,U.S. Senate,,DEM,Kamala Harris,318
-Merced,5117,U.S. Senate,,DEM,Loretta Sanchez,414
-Merced,5118,U.S. Senate,,DEM,Kamala Harris,353
-Merced,5118,U.S. Senate,,DEM,Loretta Sanchez,514
-Merced,5119,U.S. Senate,,DEM,Kamala Harris,309
-Merced,5119,U.S. Senate,,DEM,Loretta Sanchez,281
-Merced,5120,U.S. Senate,,DEM,Kamala Harris,174
-Merced,5120,U.S. Senate,,DEM,Loretta Sanchez,223
-Merced,5121,U.S. Senate,,DEM,Kamala Harris,142
-Merced,5121,U.S. Senate,,DEM,Loretta Sanchez,194
-Merced,5122,U.S. Senate,,DEM,Kamala Harris,81
-Merced,5122,U.S. Senate,,DEM,Loretta Sanchez,120
-Merced,5123,U.S. Senate,,DEM,Kamala Harris,83
-Merced,5123,U.S. Senate,,DEM,Loretta Sanchez,116
-Merced,5124,U.S. Senate,,DEM,Kamala Harris,74
-Merced,5124,U.S. Senate,,DEM,Loretta Sanchez,121
-Merced,5125,U.S. Senate,,DEM,Kamala Harris,113
-Merced,5125,U.S. Senate,,DEM,Loretta Sanchez,134
-Merced,5126,U.S. Senate,,DEM,Kamala Harris,163
-Merced,5126,U.S. Senate,,DEM,Loretta Sanchez,175
-Merced,5127,U.S. Senate,,DEM,Kamala Harris,124
-Merced,5127,U.S. Senate,,DEM,Loretta Sanchez,148
-Merced,91128,U.S. Senate,,DEM,Kamala Harris,1
-Merced,91128,U.S. Senate,,DEM,Loretta Sanchez,2
-Merced,91129,U.S. Senate,,DEM,Kamala Harris,14
-Merced,91129,U.S. Senate,,DEM,Loretta Sanchez,7
-Merced,91130,U.S. Senate,,DEM,Kamala Harris,25
-Merced,91130,U.S. Senate,,DEM,Loretta Sanchez,30
-Merced,91131,U.S. Senate,,DEM,Kamala Harris,4
-Merced,91131,U.S. Senate,,DEM,Loretta Sanchez,1
-Merced,91132,U.S. Senate,,DEM,Kamala Harris,0
-Merced,91132,U.S. Senate,,DEM,Loretta Sanchez,5
-Merced,91133,U.S. Senate,,DEM,Kamala Harris,42
-Merced,91133,U.S. Senate,,DEM,Loretta Sanchez,50
-Merced,91134,U.S. Senate,,DEM,Kamala Harris,27
-Merced,91134,U.S. Senate,,DEM,Loretta Sanchez,13
-Merced,91135,U.S. Senate,,DEM,Kamala Harris,2
-Merced,91135,U.S. Senate,,DEM,Loretta Sanchez,1
-Merced,91136,U.S. Senate,,DEM,Kamala Harris,9
-Merced,91136,U.S. Senate,,DEM,Loretta Sanchez,2
-Merced,91137,U.S. Senate,,DEM,Kamala Harris,7
-Merced,91137,U.S. Senate,,DEM,Loretta Sanchez,8
-Merced,91138,U.S. Senate,,DEM,Kamala Harris,74
-Merced,91138,U.S. Senate,,DEM,Loretta Sanchez,81
-Merced,91139,U.S. Senate,,DEM,Kamala Harris,16
-Merced,91139,U.S. Senate,,DEM,Loretta Sanchez,13
-Merced,91140,U.S. Senate,,DEM,Kamala Harris,13
-Merced,91140,U.S. Senate,,DEM,Loretta Sanchez,8
-Merced,91141,U.S. Senate,,DEM,Kamala Harris,4
-Merced,91141,U.S. Senate,,DEM,Loretta Sanchez,2
-Merced,91142,U.S. Senate,,DEM,Kamala Harris,56
-Merced,91142,U.S. Senate,,DEM,Loretta Sanchez,49
-Merced,91143,U.S. Senate,,DEM,Kamala Harris,1
-Merced,91143,U.S. Senate,,DEM,Loretta Sanchez,4
-Merced,91144,U.S. Senate,,DEM,Kamala Harris,21
-Merced,91144,U.S. Senate,,DEM,Loretta Sanchez,55
-Merced,91145,U.S. Senate,,DEM,Kamala Harris,38
-Merced,91145,U.S. Senate,,DEM,Loretta Sanchez,38
-Merced,91146,U.S. Senate,,DEM,Kamala Harris,45
-Merced,91146,U.S. Senate,,DEM,Loretta Sanchez,60
-Merced,91147,U.S. Senate,,DEM,Kamala Harris,0
-Merced,91147,U.S. Senate,,DEM,Loretta Sanchez,7
-Merced,91148,U.S. Senate,,DEM,Kamala Harris,59
-Merced,91148,U.S. Senate,,DEM,Loretta Sanchez,55
-Merced,91149,U.S. Senate,,DEM,Kamala Harris,40
-Merced,91149,U.S. Senate,,DEM,Loretta Sanchez,29
-Merced,91150,U.S. Senate,,DEM,Kamala Harris,17
-Merced,91150,U.S. Senate,,DEM,Loretta Sanchez,26
-Merced,91151,U.S. Senate,,DEM,Kamala Harris,3
-Merced,91151,U.S. Senate,,DEM,Loretta Sanchez,3
-Merced,91152,U.S. Senate,,DEM,Kamala Harris,0
-Merced,91152,U.S. Senate,,DEM,Loretta Sanchez,1
-Merced,91153,U.S. Senate,,DEM,Kamala Harris,2
-Merced,91153,U.S. Senate,,DEM,Loretta Sanchez,4
-Merced,91154,U.S. Senate,,DEM,Kamala Harris,0
-Merced,91154,U.S. Senate,,DEM,Loretta Sanchez,5
-Merced,91155,U.S. Senate,,DEM,Kamala Harris,0
-Merced,91155,U.S. Senate,,DEM,Loretta Sanchez,0
-Merced,91156,U.S. Senate,,DEM,Kamala Harris,70
-Merced,91156,U.S. Senate,,DEM,Loretta Sanchez,36
-Merced,91157,U.S. Senate,,DEM,Kamala Harris,35
-Merced,91157,U.S. Senate,,DEM,Loretta Sanchez,19
-Merced,91158,U.S. Senate,,DEM,Kamala Harris,0
-Merced,91158,U.S. Senate,,DEM,Loretta Sanchez,0
-Merced,91159,U.S. Senate,,DEM,Kamala Harris,0
-Merced,91159,U.S. Senate,,DEM,Loretta Sanchez,1
-Merced,91160,U.S. Senate,,DEM,Kamala Harris,71
-Merced,91160,U.S. Senate,,DEM,Loretta Sanchez,71
-Merced,91161,U.S. Senate,,DEM,Kamala Harris,32
-Merced,91161,U.S. Senate,,DEM,Loretta Sanchez,28
-Merced,91162,U.S. Senate,,DEM,Kamala Harris,0
-Merced,91162,U.S. Senate,,DEM,Loretta Sanchez,0
-Merced,91163,U.S. Senate,,DEM,Kamala Harris,18
-Merced,91163,U.S. Senate,,DEM,Loretta Sanchez,36
-Merced,91164,U.S. Senate,,DEM,Kamala Harris,0
-Merced,91164,U.S. Senate,,DEM,Loretta Sanchez,4
-Merced,91165,U.S. Senate,,DEM,Kamala Harris,40
-Merced,91165,U.S. Senate,,DEM,Loretta Sanchez,42
-Merced,91166,U.S. Senate,,DEM,Kamala Harris,17
-Merced,91166,U.S. Senate,,DEM,Loretta Sanchez,21
-Merced,91167,U.S. Senate,,DEM,Kamala Harris,45
-Merced,91167,U.S. Senate,,DEM,Loretta Sanchez,43
-Merced,91168,U.S. Senate,,DEM,Kamala Harris,11
-Merced,91168,U.S. Senate,,DEM,Loretta Sanchez,22
-Merced,91169,U.S. Senate,,DEM,Kamala Harris,4
-Merced,91169,U.S. Senate,,DEM,Loretta Sanchez,3
-Merced,91170,U.S. Senate,,DEM,Kamala Harris,7
-Merced,91170,U.S. Senate,,DEM,Loretta Sanchez,19
-Merced,91171,U.S. Senate,,DEM,Kamala Harris,3
-Merced,91171,U.S. Senate,,DEM,Loretta Sanchez,10
-Merced,91172,U.S. Senate,,DEM,Kamala Harris,28
-Merced,91172,U.S. Senate,,DEM,Loretta Sanchez,26
-Merced,91173,U.S. Senate,,DEM,Kamala Harris,14
-Merced,91173,U.S. Senate,,DEM,Loretta Sanchez,22
-Merced,92174,U.S. Senate,,DEM,Kamala Harris,26
-Merced,92174,U.S. Senate,,DEM,Loretta Sanchez,18
-Merced,92175,U.S. Senate,,DEM,Kamala Harris,66
-Merced,92175,U.S. Senate,,DEM,Loretta Sanchez,44
-Merced,92176,U.S. Senate,,DEM,Kamala Harris,6
-Merced,92176,U.S. Senate,,DEM,Loretta Sanchez,5
-Merced,92177,U.S. Senate,,DEM,Kamala Harris,7
-Merced,92177,U.S. Senate,,DEM,Loretta Sanchez,2
-Merced,92178,U.S. Senate,,DEM,Kamala Harris,5
-Merced,92178,U.S. Senate,,DEM,Loretta Sanchez,1
-Merced,92179,U.S. Senate,,DEM,Kamala Harris,50
-Merced,92179,U.S. Senate,,DEM,Loretta Sanchez,41
-Merced,92180,U.S. Senate,,DEM,Kamala Harris,0
-Merced,92180,U.S. Senate,,DEM,Loretta Sanchez,1
-Merced,92181,U.S. Senate,,DEM,Kamala Harris,1
-Merced,92181,U.S. Senate,,DEM,Loretta Sanchez,0
-Merced,92182,U.S. Senate,,DEM,Kamala Harris,21
-Merced,92182,U.S. Senate,,DEM,Loretta Sanchez,16
-Merced,92183,U.S. Senate,,DEM,Kamala Harris,41
-Merced,92183,U.S. Senate,,DEM,Loretta Sanchez,48
-Merced,92184,U.S. Senate,,DEM,Kamala Harris,5
-Merced,92184,U.S. Senate,,DEM,Loretta Sanchez,19
-Merced,92185,U.S. Senate,,DEM,Kamala Harris,2
-Merced,92185,U.S. Senate,,DEM,Loretta Sanchez,0
-Merced,92186,U.S. Senate,,DEM,Kamala Harris,34
-Merced,92186,U.S. Senate,,DEM,Loretta Sanchez,33
-Merced,92187,U.S. Senate,,DEM,Kamala Harris,58
-Merced,92187,U.S. Senate,,DEM,Loretta Sanchez,49
-Merced,92188,U.S. Senate,,DEM,Kamala Harris,88
-Merced,92188,U.S. Senate,,DEM,Loretta Sanchez,58
-Merced,92189,U.S. Senate,,DEM,Kamala Harris,81
-Merced,92189,U.S. Senate,,DEM,Loretta Sanchez,41
-Merced,92190,U.S. Senate,,DEM,Kamala Harris,82
-Merced,92190,U.S. Senate,,DEM,Loretta Sanchez,78
-Merced,92191,U.S. Senate,,DEM,Kamala Harris,42
-Merced,92191,U.S. Senate,,DEM,Loretta Sanchez,17
-Merced,92192,U.S. Senate,,DEM,Kamala Harris,4
-Merced,92192,U.S. Senate,,DEM,Loretta Sanchez,5
-Merced,92193,U.S. Senate,,DEM,Kamala Harris,48
-Merced,92193,U.S. Senate,,DEM,Loretta Sanchez,29
-Merced,93194,U.S. Senate,,DEM,Kamala Harris,7
-Merced,93194,U.S. Senate,,DEM,Loretta Sanchez,11
-Merced,93195,U.S. Senate,,DEM,Kamala Harris,62
-Merced,93195,U.S. Senate,,DEM,Loretta Sanchez,52
-Merced,93196,U.S. Senate,,DEM,Kamala Harris,14
-Merced,93196,U.S. Senate,,DEM,Loretta Sanchez,19
-Merced,93197,U.S. Senate,,DEM,Kamala Harris,1
-Merced,93197,U.S. Senate,,DEM,Loretta Sanchez,3
-Merced,93198,U.S. Senate,,DEM,Kamala Harris,59
-Merced,93198,U.S. Senate,,DEM,Loretta Sanchez,52
-Merced,93199,U.S. Senate,,DEM,Kamala Harris,2
-Merced,93199,U.S. Senate,,DEM,Loretta Sanchez,0
-Merced,93200,U.S. Senate,,DEM,Kamala Harris,1
-Merced,93200,U.S. Senate,,DEM,Loretta Sanchez,4
-Merced,93201,U.S. Senate,,DEM,Kamala Harris,47
-Merced,93201,U.S. Senate,,DEM,Loretta Sanchez,49
-Merced,93202,U.S. Senate,,DEM,Kamala Harris,44
-Merced,93202,U.S. Senate,,DEM,Loretta Sanchez,34
-Merced,93203,U.S. Senate,,DEM,Kamala Harris,3
-Merced,93203,U.S. Senate,,DEM,Loretta Sanchez,5
-Merced,93204,U.S. Senate,,DEM,Kamala Harris,12
-Merced,93204,U.S. Senate,,DEM,Loretta Sanchez,7
-Merced,93205,U.S. Senate,,DEM,Kamala Harris,4
-Merced,93205,U.S. Senate,,DEM,Loretta Sanchez,13
-Merced,93206,U.S. Senate,,DEM,Kamala Harris,10
-Merced,93206,U.S. Senate,,DEM,Loretta Sanchez,15
-Merced,93207,U.S. Senate,,DEM,Kamala Harris,28
-Merced,93207,U.S. Senate,,DEM,Loretta Sanchez,15
-Merced,93208,U.S. Senate,,DEM,Kamala Harris,18
-Merced,93208,U.S. Senate,,DEM,Loretta Sanchez,19
-Merced,93209,U.S. Senate,,DEM,Kamala Harris,17
-Merced,93209,U.S. Senate,,DEM,Loretta Sanchez,11
-Merced,93210,U.S. Senate,,DEM,Kamala Harris,18
-Merced,93210,U.S. Senate,,DEM,Loretta Sanchez,6
-Merced,93211,U.S. Senate,,DEM,Kamala Harris,55
-Merced,93211,U.S. Senate,,DEM,Loretta Sanchez,32
-Merced,93212,U.S. Senate,,DEM,Kamala Harris,1
-Merced,93212,U.S. Senate,,DEM,Loretta Sanchez,0
-Merced,94213,U.S. Senate,,DEM,Kamala Harris,23
-Merced,94213,U.S. Senate,,DEM,Loretta Sanchez,17
-Merced,94214,U.S. Senate,,DEM,Kamala Harris,4
-Merced,94214,U.S. Senate,,DEM,Loretta Sanchez,7
-Merced,94215,U.S. Senate,,DEM,Kamala Harris,22
-Merced,94215,U.S. Senate,,DEM,Loretta Sanchez,20
-Merced,94216,U.S. Senate,,DEM,Kamala Harris,32
-Merced,94216,U.S. Senate,,DEM,Loretta Sanchez,28
-Merced,94217,U.S. Senate,,DEM,Kamala Harris,72
-Merced,94217,U.S. Senate,,DEM,Loretta Sanchez,91
-Merced,94218,U.S. Senate,,DEM,Kamala Harris,30
-Merced,94218,U.S. Senate,,DEM,Loretta Sanchez,47
-Merced,94219,U.S. Senate,,DEM,Kamala Harris,5
-Merced,94219,U.S. Senate,,DEM,Loretta Sanchez,11
-Merced,94220,U.S. Senate,,DEM,Kamala Harris,50
-Merced,94220,U.S. Senate,,DEM,Loretta Sanchez,57
-Merced,94221,U.S. Senate,,DEM,Kamala Harris,7
-Merced,94221,U.S. Senate,,DEM,Loretta Sanchez,9
-Merced,94222,U.S. Senate,,DEM,Kamala Harris,31
-Merced,94222,U.S. Senate,,DEM,Loretta Sanchez,24
-Merced,94223,U.S. Senate,,DEM,Kamala Harris,26
-Merced,94223,U.S. Senate,,DEM,Loretta Sanchez,23
-Merced,94224,U.S. Senate,,DEM,Kamala Harris,22
-Merced,94224,U.S. Senate,,DEM,Loretta Sanchez,16
-Merced,94225,U.S. Senate,,DEM,Kamala Harris,43
-Merced,94225,U.S. Senate,,DEM,Loretta Sanchez,30
-Merced,94226,U.S. Senate,,DEM,Kamala Harris,45
-Merced,94226,U.S. Senate,,DEM,Loretta Sanchez,48
-Merced,94227,U.S. Senate,,DEM,Kamala Harris,23
-Merced,94227,U.S. Senate,,DEM,Loretta Sanchez,51
-Merced,94228,U.S. Senate,,DEM,Kamala Harris,13
-Merced,94228,U.S. Senate,,DEM,Loretta Sanchez,21
-Merced,94229,U.S. Senate,,DEM,Kamala Harris,58
-Merced,94229,U.S. Senate,,DEM,Loretta Sanchez,69
-Merced,94230,U.S. Senate,,DEM,Kamala Harris,12
-Merced,94230,U.S. Senate,,DEM,Loretta Sanchez,5
-Merced,94231,U.S. Senate,,DEM,Kamala Harris,4
-Merced,94231,U.S. Senate,,DEM,Loretta Sanchez,4
-Merced,94232,U.S. Senate,,DEM,Kamala Harris,0
-Merced,94232,U.S. Senate,,DEM,Loretta Sanchez,0
-Merced,94233,U.S. Senate,,DEM,Kamala Harris,39
-Merced,94233,U.S. Senate,,DEM,Loretta Sanchez,39
-Merced,94234,U.S. Senate,,DEM,Kamala Harris,0
-Merced,94234,U.S. Senate,,DEM,Loretta Sanchez,1
-Merced,94235,U.S. Senate,,DEM,Kamala Harris,1
-Merced,94235,U.S. Senate,,DEM,Loretta Sanchez,5
-Merced,94236,U.S. Senate,,DEM,Kamala Harris,24
-Merced,94236,U.S. Senate,,DEM,Loretta Sanchez,35
-Merced,94237,U.S. Senate,,DEM,Kamala Harris,25
-Merced,94237,U.S. Senate,,DEM,Loretta Sanchez,40
-Merced,94238,U.S. Senate,,DEM,Kamala Harris,33
-Merced,94238,U.S. Senate,,DEM,Loretta Sanchez,21
-Merced,94239,U.S. Senate,,DEM,Kamala Harris,20
-Merced,94239,U.S. Senate,,DEM,Loretta Sanchez,20
-Merced,94240,U.S. Senate,,DEM,Kamala Harris,47
-Merced,94240,U.S. Senate,,DEM,Loretta Sanchez,37
-Merced,94241,U.S. Senate,,DEM,Kamala Harris,19
-Merced,94241,U.S. Senate,,DEM,Loretta Sanchez,11
-Merced,94242,U.S. Senate,,DEM,Kamala Harris,62
-Merced,94242,U.S. Senate,,DEM,Loretta Sanchez,50
-Merced,94243,U.S. Senate,,DEM,Kamala Harris,30
-Merced,94243,U.S. Senate,,DEM,Loretta Sanchez,17
-Merced,94244,U.S. Senate,,DEM,Kamala Harris,48
-Merced,94244,U.S. Senate,,DEM,Loretta Sanchez,40
-Merced,94245,U.S. Senate,,DEM,Kamala Harris,16
-Merced,94245,U.S. Senate,,DEM,Loretta Sanchez,18
-Merced,94246,U.S. Senate,,DEM,Kamala Harris,5
-Merced,94246,U.S. Senate,,DEM,Loretta Sanchez,13
-Merced,95247,U.S. Senate,,DEM,Kamala Harris,22
-Merced,95247,U.S. Senate,,DEM,Loretta Sanchez,11
-Merced,95248,U.S. Senate,,DEM,Kamala Harris,3
-Merced,95248,U.S. Senate,,DEM,Loretta Sanchez,0
-Merced,95249,U.S. Senate,,DEM,Kamala Harris,10
-Merced,95249,U.S. Senate,,DEM,Loretta Sanchez,0
-Merced,95250,U.S. Senate,,DEM,Kamala Harris,48
-Merced,95250,U.S. Senate,,DEM,Loretta Sanchez,42
-Merced,95251,U.S. Senate,,DEM,Kamala Harris,15
-Merced,95251,U.S. Senate,,DEM,Loretta Sanchez,9
-Merced,95252,U.S. Senate,,DEM,Kamala Harris,0
-Merced,95252,U.S. Senate,,DEM,Loretta Sanchez,0
-Merced,95253,U.S. Senate,,DEM,Kamala Harris,51
-Merced,95253,U.S. Senate,,DEM,Loretta Sanchez,46
-Merced,95254,U.S. Senate,,DEM,Kamala Harris,47
-Merced,95254,U.S. Senate,,DEM,Loretta Sanchez,60
-Merced,95255,U.S. Senate,,DEM,Kamala Harris,19
-Merced,95255,U.S. Senate,,DEM,Loretta Sanchez,8
-Merced,95256,U.S. Senate,,DEM,Kamala Harris,38
-Merced,95256,U.S. Senate,,DEM,Loretta Sanchez,35
-Merced,95257,U.S. Senate,,DEM,Kamala Harris,4
-Merced,95257,U.S. Senate,,DEM,Loretta Sanchez,3
-Merced,95258,U.S. Senate,,DEM,Kamala Harris,0
-Merced,95258,U.S. Senate,,DEM,Loretta Sanchez,1
-Merced,95259,U.S. Senate,,DEM,Kamala Harris,65
-Merced,95259,U.S. Senate,,DEM,Loretta Sanchez,46
-Merced,95260,U.S. Senate,,DEM,Kamala Harris,4
-Merced,95260,U.S. Senate,,DEM,Loretta Sanchez,2
-Merced,95261,U.S. Senate,,DEM,Kamala Harris,3
-Merced,95261,U.S. Senate,,DEM,Loretta Sanchez,0
-Merced,95262,U.S. Senate,,DEM,Kamala Harris,0
-Merced,95262,U.S. Senate,,DEM,Loretta Sanchez,1
-Merced,95263,U.S. Senate,,DEM,Kamala Harris,4
-Merced,95263,U.S. Senate,,DEM,Loretta Sanchez,8
-Merced,95264,U.S. Senate,,DEM,Kamala Harris,56
-Merced,95264,U.S. Senate,,DEM,Loretta Sanchez,60
-Merced,95265,U.S. Senate,,DEM,Kamala Harris,1
-Merced,95265,U.S. Senate,,DEM,Loretta Sanchez,4
-Merced,95266,U.S. Senate,,DEM,Kamala Harris,0
-Merced,95266,U.S. Senate,,DEM,Loretta Sanchez,3
-Merced,95267,U.S. Senate,,DEM,Kamala Harris,0
-Merced,95267,U.S. Senate,,DEM,Loretta Sanchez,2
-Merced,95268,U.S. Senate,,DEM,Kamala Harris,31
-Merced,95268,U.S. Senate,,DEM,Loretta Sanchez,25
-Merced,95269,U.S. Senate,,DEM,Kamala Harris,67
-Merced,95269,U.S. Senate,,DEM,Loretta Sanchez,93
+Merced,1001,U.S. Senate,,DEM,Kamala D. Harris,187
+Merced,1001,U.S. Senate,,DEM,Loretta L. Sanchez,277
+Merced,1002,U.S. Senate,,DEM,Kamala D. Harris,269
+Merced,1002,U.S. Senate,,DEM,Loretta L. Sanchez,304
+Merced,1003,U.S. Senate,,DEM,Kamala D. Harris,269
+Merced,1003,U.S. Senate,,DEM,Loretta L. Sanchez,359
+Merced,1004,U.S. Senate,,DEM,Kamala D. Harris,183
+Merced,1004,U.S. Senate,,DEM,Loretta L. Sanchez,234
+Merced,1005,U.S. Senate,,DEM,Kamala D. Harris,386
+Merced,1005,U.S. Senate,,DEM,Loretta L. Sanchez,363
+Merced,1006,U.S. Senate,,DEM,Kamala D. Harris,225
+Merced,1006,U.S. Senate,,DEM,Loretta L. Sanchez,402
+Merced,1007,U.S. Senate,,DEM,Kamala D. Harris,151
+Merced,1007,U.S. Senate,,DEM,Loretta L. Sanchez,230
+Merced,1008,U.S. Senate,,DEM,Kamala D. Harris,212
+Merced,1008,U.S. Senate,,DEM,Loretta L. Sanchez,269
+Merced,1009,U.S. Senate,,DEM,Kamala D. Harris,124
+Merced,1009,U.S. Senate,,DEM,Loretta L. Sanchez,151
+Merced,1010,U.S. Senate,,DEM,Kamala D. Harris,182
+Merced,1010,U.S. Senate,,DEM,Loretta L. Sanchez,319
+Merced,1011,U.S. Senate,,DEM,Kamala D. Harris,101
+Merced,1011,U.S. Senate,,DEM,Loretta L. Sanchez,143
+Merced,1012,U.S. Senate,,DEM,Kamala D. Harris,119
+Merced,1012,U.S. Senate,,DEM,Loretta L. Sanchez,91
+Merced,1013,U.S. Senate,,DEM,Kamala D. Harris,93
+Merced,1013,U.S. Senate,,DEM,Loretta L. Sanchez,158
+Merced,1014,U.S. Senate,,DEM,Kamala D. Harris,88
+Merced,1014,U.S. Senate,,DEM,Loretta L. Sanchez,92
+Merced,1015,U.S. Senate,,DEM,Kamala D. Harris,121
+Merced,1015,U.S. Senate,,DEM,Loretta L. Sanchez,269
+Merced,1016,U.S. Senate,,DEM,Kamala D. Harris,137
+Merced,1016,U.S. Senate,,DEM,Loretta L. Sanchez,283
+Merced,1017,U.S. Senate,,DEM,Kamala D. Harris,123
+Merced,1017,U.S. Senate,,DEM,Loretta L. Sanchez,106
+Merced,2018,U.S. Senate,,DEM,Kamala D. Harris,209
+Merced,2018,U.S. Senate,,DEM,Loretta L. Sanchez,125
+Merced,2019,U.S. Senate,,DEM,Kamala D. Harris,166
+Merced,2019,U.S. Senate,,DEM,Loretta L. Sanchez,94
+Merced,2020,U.S. Senate,,DEM,Kamala D. Harris,170
+Merced,2020,U.S. Senate,,DEM,Loretta L. Sanchez,93
+Merced,2021,U.S. Senate,,DEM,Kamala D. Harris,213
+Merced,2021,U.S. Senate,,DEM,Loretta L. Sanchez,160
+Merced,2022,U.S. Senate,,DEM,Kamala D. Harris,132
+Merced,2022,U.S. Senate,,DEM,Loretta L. Sanchez,81
+Merced,2023,U.S. Senate,,DEM,Kamala D. Harris,222
+Merced,2023,U.S. Senate,,DEM,Loretta L. Sanchez,128
+Merced,2024,U.S. Senate,,DEM,Kamala D. Harris,124
+Merced,2024,U.S. Senate,,DEM,Loretta L. Sanchez,109
+Merced,2025,U.S. Senate,,DEM,Kamala D. Harris,353
+Merced,2025,U.S. Senate,,DEM,Loretta L. Sanchez,336
+Merced,2026,U.S. Senate,,DEM,Kamala D. Harris,185
+Merced,2026,U.S. Senate,,DEM,Loretta L. Sanchez,138
+Merced,2027,U.S. Senate,,DEM,Kamala D. Harris,307
+Merced,2027,U.S. Senate,,DEM,Loretta L. Sanchez,228
+Merced,2028,U.S. Senate,,DEM,Kamala D. Harris,134
+Merced,2028,U.S. Senate,,DEM,Loretta L. Sanchez,88
+Merced,2029,U.S. Senate,,DEM,Kamala D. Harris,249
+Merced,2029,U.S. Senate,,DEM,Loretta L. Sanchez,191
+Merced,2030,U.S. Senate,,DEM,Kamala D. Harris,316
+Merced,2030,U.S. Senate,,DEM,Loretta L. Sanchez,229
+Merced,2031,U.S. Senate,,DEM,Kamala D. Harris,244
+Merced,2031,U.S. Senate,,DEM,Loretta L. Sanchez,189
+Merced,2032,U.S. Senate,,DEM,Kamala D. Harris,261
+Merced,2032,U.S. Senate,,DEM,Loretta L. Sanchez,200
+Merced,2033,U.S. Senate,,DEM,Kamala D. Harris,184
+Merced,2033,U.S. Senate,,DEM,Loretta L. Sanchez,159
+Merced,2034,U.S. Senate,,DEM,Kamala D. Harris,205
+Merced,2034,U.S. Senate,,DEM,Loretta L. Sanchez,280
+Merced,2035,U.S. Senate,,DEM,Kamala D. Harris,102
+Merced,2035,U.S. Senate,,DEM,Loretta L. Sanchez,103
+Merced,2036,U.S. Senate,,DEM,Kamala D. Harris,218
+Merced,2036,U.S. Senate,,DEM,Loretta L. Sanchez,178
+Merced,2037,U.S. Senate,,DEM,Kamala D. Harris,278
+Merced,2037,U.S. Senate,,DEM,Loretta L. Sanchez,218
+Merced,2038,U.S. Senate,,DEM,Kamala D. Harris,108
+Merced,2038,U.S. Senate,,DEM,Loretta L. Sanchez,75
+Merced,2039,U.S. Senate,,DEM,Kamala D. Harris,168
+Merced,2039,U.S. Senate,,DEM,Loretta L. Sanchez,166
+Merced,2040,U.S. Senate,,DEM,Kamala D. Harris,146
+Merced,2040,U.S. Senate,,DEM,Loretta L. Sanchez,121
+Merced,2041,U.S. Senate,,DEM,Kamala D. Harris,346
+Merced,2041,U.S. Senate,,DEM,Loretta L. Sanchez,288
+Merced,2042,U.S. Senate,,DEM,Kamala D. Harris,354
+Merced,2042,U.S. Senate,,DEM,Loretta L. Sanchez,194
+Merced,2043,U.S. Senate,,DEM,Kamala D. Harris,348
+Merced,2043,U.S. Senate,,DEM,Loretta L. Sanchez,246
+Merced,2044,U.S. Senate,,DEM,Kamala D. Harris,96
+Merced,2044,U.S. Senate,,DEM,Loretta L. Sanchez,97
+Merced,2045,U.S. Senate,,DEM,Kamala D. Harris,277
+Merced,2045,U.S. Senate,,DEM,Loretta L. Sanchez,259
+Merced,2046,U.S. Senate,,DEM,Kamala D. Harris,182
+Merced,2046,U.S. Senate,,DEM,Loretta L. Sanchez,105
+Merced,2047,U.S. Senate,,DEM,Kamala D. Harris,382
+Merced,2047,U.S. Senate,,DEM,Loretta L. Sanchez,328
+Merced,2048,U.S. Senate,,DEM,Kamala D. Harris,230
+Merced,2048,U.S. Senate,,DEM,Loretta L. Sanchez,132
+Merced,2049,U.S. Senate,,DEM,Kamala D. Harris,87
+Merced,2049,U.S. Senate,,DEM,Loretta L. Sanchez,82
+Merced,2050,U.S. Senate,,DEM,Kamala D. Harris,82
+Merced,2050,U.S. Senate,,DEM,Loretta L. Sanchez,74
+Merced,2051,U.S. Senate,,DEM,Kamala D. Harris,270
+Merced,2051,U.S. Senate,,DEM,Loretta L. Sanchez,193
+Merced,2052,U.S. Senate,,DEM,Kamala D. Harris,277
+Merced,2052,U.S. Senate,,DEM,Loretta L. Sanchez,178
+Merced,2053,U.S. Senate,,DEM,Kamala D. Harris,124
+Merced,2053,U.S. Senate,,DEM,Loretta L. Sanchez,54
+Merced,2054,U.S. Senate,,DEM,Kamala D. Harris,162
+Merced,2054,U.S. Senate,,DEM,Loretta L. Sanchez,88
+Merced,2055,U.S. Senate,,DEM,Kamala D. Harris,136
+Merced,2055,U.S. Senate,,DEM,Loretta L. Sanchez,129
+Merced,2056,U.S. Senate,,DEM,Kamala D. Harris,194
+Merced,2056,U.S. Senate,,DEM,Loretta L. Sanchez,304
+Merced,3057,U.S. Senate,,DEM,Kamala D. Harris,319
+Merced,3057,U.S. Senate,,DEM,Loretta L. Sanchez,358
+Merced,3058,U.S. Senate,,DEM,Kamala D. Harris,241
+Merced,3058,U.S. Senate,,DEM,Loretta L. Sanchez,252
+Merced,3059,U.S. Senate,,DEM,Kamala D. Harris,341
+Merced,3059,U.S. Senate,,DEM,Loretta L. Sanchez,343
+Merced,3060,U.S. Senate,,DEM,Kamala D. Harris,319
+Merced,3060,U.S. Senate,,DEM,Loretta L. Sanchez,316
+Merced,3061,U.S. Senate,,DEM,Kamala D. Harris,399
+Merced,3061,U.S. Senate,,DEM,Loretta L. Sanchez,380
+Merced,3062,U.S. Senate,,DEM,Kamala D. Harris,242
+Merced,3062,U.S. Senate,,DEM,Loretta L. Sanchez,306
+Merced,3063,U.S. Senate,,DEM,Kamala D. Harris,147
+Merced,3063,U.S. Senate,,DEM,Loretta L. Sanchez,150
+Merced,3064,U.S. Senate,,DEM,Kamala D. Harris,333
+Merced,3064,U.S. Senate,,DEM,Loretta L. Sanchez,296
+Merced,3065,U.S. Senate,,DEM,Kamala D. Harris,293
+Merced,3065,U.S. Senate,,DEM,Loretta L. Sanchez,260
+Merced,3066,U.S. Senate,,DEM,Kamala D. Harris,208
+Merced,3066,U.S. Senate,,DEM,Loretta L. Sanchez,202
+Merced,3067,U.S. Senate,,DEM,Kamala D. Harris,327
+Merced,3067,U.S. Senate,,DEM,Loretta L. Sanchez,246
+Merced,3068,U.S. Senate,,DEM,Kamala D. Harris,237
+Merced,3068,U.S. Senate,,DEM,Loretta L. Sanchez,178
+Merced,3069,U.S. Senate,,DEM,Kamala D. Harris,127
+Merced,3069,U.S. Senate,,DEM,Loretta L. Sanchez,117
+Merced,3070,U.S. Senate,,DEM,Kamala D. Harris,313
+Merced,3070,U.S. Senate,,DEM,Loretta L. Sanchez,186
+Merced,3071,U.S. Senate,,DEM,Kamala D. Harris,66
+Merced,3071,U.S. Senate,,DEM,Loretta L. Sanchez,129
+Merced,3072,U.S. Senate,,DEM,Kamala D. Harris,253
+Merced,3072,U.S. Senate,,DEM,Loretta L. Sanchez,324
+Merced,3073,U.S. Senate,,DEM,Kamala D. Harris,202
+Merced,3073,U.S. Senate,,DEM,Loretta L. Sanchez,322
+Merced,3074,U.S. Senate,,DEM,Kamala D. Harris,333
+Merced,3074,U.S. Senate,,DEM,Loretta L. Sanchez,241
+Merced,3075,U.S. Senate,,DEM,Kamala D. Harris,224
+Merced,3075,U.S. Senate,,DEM,Loretta L. Sanchez,190
+Merced,3076,U.S. Senate,,DEM,Kamala D. Harris,101
+Merced,3076,U.S. Senate,,DEM,Loretta L. Sanchez,99
+Merced,3077,U.S. Senate,,DEM,Kamala D. Harris,347
+Merced,3077,U.S. Senate,,DEM,Loretta L. Sanchez,365
+Merced,3078,U.S. Senate,,DEM,Kamala D. Harris,448
+Merced,3078,U.S. Senate,,DEM,Loretta L. Sanchez,298
+Merced,3079,U.S. Senate,,DEM,Kamala D. Harris,259
+Merced,3079,U.S. Senate,,DEM,Loretta L. Sanchez,264
+Merced,3080,U.S. Senate,,DEM,Kamala D. Harris,164
+Merced,3080,U.S. Senate,,DEM,Loretta L. Sanchez,168
+Merced,4081,U.S. Senate,,DEM,Kamala D. Harris,80
+Merced,4081,U.S. Senate,,DEM,Loretta L. Sanchez,78
+Merced,4082,U.S. Senate,,DEM,Kamala D. Harris,170
+Merced,4082,U.S. Senate,,DEM,Loretta L. Sanchez,113
+Merced,4083,U.S. Senate,,DEM,Kamala D. Harris,93
+Merced,4083,U.S. Senate,,DEM,Loretta L. Sanchez,121
+Merced,4084,U.S. Senate,,DEM,Kamala D. Harris,72
+Merced,4084,U.S. Senate,,DEM,Loretta L. Sanchez,112
+Merced,4085,U.S. Senate,,DEM,Kamala D. Harris,147
+Merced,4085,U.S. Senate,,DEM,Loretta L. Sanchez,192
+Merced,4086,U.S. Senate,,DEM,Kamala D. Harris,299
+Merced,4086,U.S. Senate,,DEM,Loretta L. Sanchez,488
+Merced,4087,U.S. Senate,,DEM,Kamala D. Harris,329
+Merced,4087,U.S. Senate,,DEM,Loretta L. Sanchez,512
+Merced,4088,U.S. Senate,,DEM,Kamala D. Harris,182
+Merced,4088,U.S. Senate,,DEM,Loretta L. Sanchez,108
+Merced,4089,U.S. Senate,,DEM,Kamala D. Harris,236
+Merced,4089,U.S. Senate,,DEM,Loretta L. Sanchez,165
+Merced,4090,U.S. Senate,,DEM,Kamala D. Harris,183
+Merced,4090,U.S. Senate,,DEM,Loretta L. Sanchez,136
+Merced,4091,U.S. Senate,,DEM,Kamala D. Harris,200
+Merced,4091,U.S. Senate,,DEM,Loretta L. Sanchez,178
+Merced,4092,U.S. Senate,,DEM,Kamala D. Harris,108
+Merced,4092,U.S. Senate,,DEM,Loretta L. Sanchez,72
+Merced,4093,U.S. Senate,,DEM,Kamala D. Harris,379
+Merced,4093,U.S. Senate,,DEM,Loretta L. Sanchez,283
+Merced,4094,U.S. Senate,,DEM,Kamala D. Harris,129
+Merced,4094,U.S. Senate,,DEM,Loretta L. Sanchez,116
+Merced,4095,U.S. Senate,,DEM,Kamala D. Harris,302
+Merced,4095,U.S. Senate,,DEM,Loretta L. Sanchez,229
+Merced,4096,U.S. Senate,,DEM,Kamala D. Harris,168
+Merced,4096,U.S. Senate,,DEM,Loretta L. Sanchez,174
+Merced,4097,U.S. Senate,,DEM,Kamala D. Harris,116
+Merced,4097,U.S. Senate,,DEM,Loretta L. Sanchez,75
+Merced,4098,U.S. Senate,,DEM,Kamala D. Harris,179
+Merced,4098,U.S. Senate,,DEM,Loretta L. Sanchez,162
+Merced,4099,U.S. Senate,,DEM,Kamala D. Harris,113
+Merced,4099,U.S. Senate,,DEM,Loretta L. Sanchez,79
+Merced,4100,U.S. Senate,,DEM,Kamala D. Harris,170
+Merced,4100,U.S. Senate,,DEM,Loretta L. Sanchez,264
+Merced,4101,U.S. Senate,,DEM,Kamala D. Harris,238
+Merced,4101,U.S. Senate,,DEM,Loretta L. Sanchez,326
+Merced,4102,U.S. Senate,,DEM,Kamala D. Harris,211
+Merced,4102,U.S. Senate,,DEM,Loretta L. Sanchez,284
+Merced,4103,U.S. Senate,,DEM,Kamala D. Harris,67
+Merced,4103,U.S. Senate,,DEM,Loretta L. Sanchez,95
+Merced,5104,U.S. Senate,,DEM,Kamala D. Harris,168
+Merced,5104,U.S. Senate,,DEM,Loretta L. Sanchez,164
+Merced,5105,U.S. Senate,,DEM,Kamala D. Harris,254
+Merced,5105,U.S. Senate,,DEM,Loretta L. Sanchez,292
+Merced,5106,U.S. Senate,,DEM,Kamala D. Harris,279
+Merced,5106,U.S. Senate,,DEM,Loretta L. Sanchez,283
+Merced,5107,U.S. Senate,,DEM,Kamala D. Harris,233
+Merced,5107,U.S. Senate,,DEM,Loretta L. Sanchez,254
+Merced,5108,U.S. Senate,,DEM,Kamala D. Harris,285
+Merced,5108,U.S. Senate,,DEM,Loretta L. Sanchez,320
+Merced,5109,U.S. Senate,,DEM,Kamala D. Harris,315
+Merced,5109,U.S. Senate,,DEM,Loretta L. Sanchez,245
+Merced,5110,U.S. Senate,,DEM,Kamala D. Harris,284
+Merced,5110,U.S. Senate,,DEM,Loretta L. Sanchez,214
+Merced,5111,U.S. Senate,,DEM,Kamala D. Harris,246
+Merced,5111,U.S. Senate,,DEM,Loretta L. Sanchez,319
+Merced,5112,U.S. Senate,,DEM,Kamala D. Harris,163
+Merced,5112,U.S. Senate,,DEM,Loretta L. Sanchez,149
+Merced,5113,U.S. Senate,,DEM,Kamala D. Harris,284
+Merced,5113,U.S. Senate,,DEM,Loretta L. Sanchez,295
+Merced,5114,U.S. Senate,,DEM,Kamala D. Harris,194
+Merced,5114,U.S. Senate,,DEM,Loretta L. Sanchez,160
+Merced,5115,U.S. Senate,,DEM,Kamala D. Harris,296
+Merced,5115,U.S. Senate,,DEM,Loretta L. Sanchez,339
+Merced,5116,U.S. Senate,,DEM,Kamala D. Harris,248
+Merced,5116,U.S. Senate,,DEM,Loretta L. Sanchez,321
+Merced,5117,U.S. Senate,,DEM,Kamala D. Harris,318
+Merced,5117,U.S. Senate,,DEM,Loretta L. Sanchez,414
+Merced,5118,U.S. Senate,,DEM,Kamala D. Harris,353
+Merced,5118,U.S. Senate,,DEM,Loretta L. Sanchez,514
+Merced,5119,U.S. Senate,,DEM,Kamala D. Harris,309
+Merced,5119,U.S. Senate,,DEM,Loretta L. Sanchez,281
+Merced,5120,U.S. Senate,,DEM,Kamala D. Harris,174
+Merced,5120,U.S. Senate,,DEM,Loretta L. Sanchez,223
+Merced,5121,U.S. Senate,,DEM,Kamala D. Harris,142
+Merced,5121,U.S. Senate,,DEM,Loretta L. Sanchez,194
+Merced,5122,U.S. Senate,,DEM,Kamala D. Harris,81
+Merced,5122,U.S. Senate,,DEM,Loretta L. Sanchez,120
+Merced,5123,U.S. Senate,,DEM,Kamala D. Harris,83
+Merced,5123,U.S. Senate,,DEM,Loretta L. Sanchez,116
+Merced,5124,U.S. Senate,,DEM,Kamala D. Harris,74
+Merced,5124,U.S. Senate,,DEM,Loretta L. Sanchez,121
+Merced,5125,U.S. Senate,,DEM,Kamala D. Harris,113
+Merced,5125,U.S. Senate,,DEM,Loretta L. Sanchez,134
+Merced,5126,U.S. Senate,,DEM,Kamala D. Harris,163
+Merced,5126,U.S. Senate,,DEM,Loretta L. Sanchez,175
+Merced,5127,U.S. Senate,,DEM,Kamala D. Harris,124
+Merced,5127,U.S. Senate,,DEM,Loretta L. Sanchez,148
+Merced,91128,U.S. Senate,,DEM,Kamala D. Harris,1
+Merced,91128,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Merced,91129,U.S. Senate,,DEM,Kamala D. Harris,14
+Merced,91129,U.S. Senate,,DEM,Loretta L. Sanchez,7
+Merced,91130,U.S. Senate,,DEM,Kamala D. Harris,25
+Merced,91130,U.S. Senate,,DEM,Loretta L. Sanchez,30
+Merced,91131,U.S. Senate,,DEM,Kamala D. Harris,4
+Merced,91131,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Merced,91132,U.S. Senate,,DEM,Kamala D. Harris,0
+Merced,91132,U.S. Senate,,DEM,Loretta L. Sanchez,5
+Merced,91133,U.S. Senate,,DEM,Kamala D. Harris,42
+Merced,91133,U.S. Senate,,DEM,Loretta L. Sanchez,50
+Merced,91134,U.S. Senate,,DEM,Kamala D. Harris,27
+Merced,91134,U.S. Senate,,DEM,Loretta L. Sanchez,13
+Merced,91135,U.S. Senate,,DEM,Kamala D. Harris,2
+Merced,91135,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Merced,91136,U.S. Senate,,DEM,Kamala D. Harris,9
+Merced,91136,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Merced,91137,U.S. Senate,,DEM,Kamala D. Harris,7
+Merced,91137,U.S. Senate,,DEM,Loretta L. Sanchez,8
+Merced,91138,U.S. Senate,,DEM,Kamala D. Harris,74
+Merced,91138,U.S. Senate,,DEM,Loretta L. Sanchez,81
+Merced,91139,U.S. Senate,,DEM,Kamala D. Harris,16
+Merced,91139,U.S. Senate,,DEM,Loretta L. Sanchez,13
+Merced,91140,U.S. Senate,,DEM,Kamala D. Harris,13
+Merced,91140,U.S. Senate,,DEM,Loretta L. Sanchez,8
+Merced,91141,U.S. Senate,,DEM,Kamala D. Harris,4
+Merced,91141,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Merced,91142,U.S. Senate,,DEM,Kamala D. Harris,56
+Merced,91142,U.S. Senate,,DEM,Loretta L. Sanchez,49
+Merced,91143,U.S. Senate,,DEM,Kamala D. Harris,1
+Merced,91143,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Merced,91144,U.S. Senate,,DEM,Kamala D. Harris,21
+Merced,91144,U.S. Senate,,DEM,Loretta L. Sanchez,55
+Merced,91145,U.S. Senate,,DEM,Kamala D. Harris,38
+Merced,91145,U.S. Senate,,DEM,Loretta L. Sanchez,38
+Merced,91146,U.S. Senate,,DEM,Kamala D. Harris,45
+Merced,91146,U.S. Senate,,DEM,Loretta L. Sanchez,60
+Merced,91147,U.S. Senate,,DEM,Kamala D. Harris,0
+Merced,91147,U.S. Senate,,DEM,Loretta L. Sanchez,7
+Merced,91148,U.S. Senate,,DEM,Kamala D. Harris,59
+Merced,91148,U.S. Senate,,DEM,Loretta L. Sanchez,55
+Merced,91149,U.S. Senate,,DEM,Kamala D. Harris,40
+Merced,91149,U.S. Senate,,DEM,Loretta L. Sanchez,29
+Merced,91150,U.S. Senate,,DEM,Kamala D. Harris,17
+Merced,91150,U.S. Senate,,DEM,Loretta L. Sanchez,26
+Merced,91151,U.S. Senate,,DEM,Kamala D. Harris,3
+Merced,91151,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Merced,91152,U.S. Senate,,DEM,Kamala D. Harris,0
+Merced,91152,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Merced,91153,U.S. Senate,,DEM,Kamala D. Harris,2
+Merced,91153,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Merced,91154,U.S. Senate,,DEM,Kamala D. Harris,0
+Merced,91154,U.S. Senate,,DEM,Loretta L. Sanchez,5
+Merced,91155,U.S. Senate,,DEM,Kamala D. Harris,0
+Merced,91155,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Merced,91156,U.S. Senate,,DEM,Kamala D. Harris,70
+Merced,91156,U.S. Senate,,DEM,Loretta L. Sanchez,36
+Merced,91157,U.S. Senate,,DEM,Kamala D. Harris,35
+Merced,91157,U.S. Senate,,DEM,Loretta L. Sanchez,19
+Merced,91158,U.S. Senate,,DEM,Kamala D. Harris,0
+Merced,91158,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Merced,91159,U.S. Senate,,DEM,Kamala D. Harris,0
+Merced,91159,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Merced,91160,U.S. Senate,,DEM,Kamala D. Harris,71
+Merced,91160,U.S. Senate,,DEM,Loretta L. Sanchez,71
+Merced,91161,U.S. Senate,,DEM,Kamala D. Harris,32
+Merced,91161,U.S. Senate,,DEM,Loretta L. Sanchez,28
+Merced,91162,U.S. Senate,,DEM,Kamala D. Harris,0
+Merced,91162,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Merced,91163,U.S. Senate,,DEM,Kamala D. Harris,18
+Merced,91163,U.S. Senate,,DEM,Loretta L. Sanchez,36
+Merced,91164,U.S. Senate,,DEM,Kamala D. Harris,0
+Merced,91164,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Merced,91165,U.S. Senate,,DEM,Kamala D. Harris,40
+Merced,91165,U.S. Senate,,DEM,Loretta L. Sanchez,42
+Merced,91166,U.S. Senate,,DEM,Kamala D. Harris,17
+Merced,91166,U.S. Senate,,DEM,Loretta L. Sanchez,21
+Merced,91167,U.S. Senate,,DEM,Kamala D. Harris,45
+Merced,91167,U.S. Senate,,DEM,Loretta L. Sanchez,43
+Merced,91168,U.S. Senate,,DEM,Kamala D. Harris,11
+Merced,91168,U.S. Senate,,DEM,Loretta L. Sanchez,22
+Merced,91169,U.S. Senate,,DEM,Kamala D. Harris,4
+Merced,91169,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Merced,91170,U.S. Senate,,DEM,Kamala D. Harris,7
+Merced,91170,U.S. Senate,,DEM,Loretta L. Sanchez,19
+Merced,91171,U.S. Senate,,DEM,Kamala D. Harris,3
+Merced,91171,U.S. Senate,,DEM,Loretta L. Sanchez,10
+Merced,91172,U.S. Senate,,DEM,Kamala D. Harris,28
+Merced,91172,U.S. Senate,,DEM,Loretta L. Sanchez,26
+Merced,91173,U.S. Senate,,DEM,Kamala D. Harris,14
+Merced,91173,U.S. Senate,,DEM,Loretta L. Sanchez,22
+Merced,92174,U.S. Senate,,DEM,Kamala D. Harris,26
+Merced,92174,U.S. Senate,,DEM,Loretta L. Sanchez,18
+Merced,92175,U.S. Senate,,DEM,Kamala D. Harris,66
+Merced,92175,U.S. Senate,,DEM,Loretta L. Sanchez,44
+Merced,92176,U.S. Senate,,DEM,Kamala D. Harris,6
+Merced,92176,U.S. Senate,,DEM,Loretta L. Sanchez,5
+Merced,92177,U.S. Senate,,DEM,Kamala D. Harris,7
+Merced,92177,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Merced,92178,U.S. Senate,,DEM,Kamala D. Harris,5
+Merced,92178,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Merced,92179,U.S. Senate,,DEM,Kamala D. Harris,50
+Merced,92179,U.S. Senate,,DEM,Loretta L. Sanchez,41
+Merced,92180,U.S. Senate,,DEM,Kamala D. Harris,0
+Merced,92180,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Merced,92181,U.S. Senate,,DEM,Kamala D. Harris,1
+Merced,92181,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Merced,92182,U.S. Senate,,DEM,Kamala D. Harris,21
+Merced,92182,U.S. Senate,,DEM,Loretta L. Sanchez,16
+Merced,92183,U.S. Senate,,DEM,Kamala D. Harris,41
+Merced,92183,U.S. Senate,,DEM,Loretta L. Sanchez,48
+Merced,92184,U.S. Senate,,DEM,Kamala D. Harris,5
+Merced,92184,U.S. Senate,,DEM,Loretta L. Sanchez,19
+Merced,92185,U.S. Senate,,DEM,Kamala D. Harris,2
+Merced,92185,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Merced,92186,U.S. Senate,,DEM,Kamala D. Harris,34
+Merced,92186,U.S. Senate,,DEM,Loretta L. Sanchez,33
+Merced,92187,U.S. Senate,,DEM,Kamala D. Harris,58
+Merced,92187,U.S. Senate,,DEM,Loretta L. Sanchez,49
+Merced,92188,U.S. Senate,,DEM,Kamala D. Harris,88
+Merced,92188,U.S. Senate,,DEM,Loretta L. Sanchez,58
+Merced,92189,U.S. Senate,,DEM,Kamala D. Harris,81
+Merced,92189,U.S. Senate,,DEM,Loretta L. Sanchez,41
+Merced,92190,U.S. Senate,,DEM,Kamala D. Harris,82
+Merced,92190,U.S. Senate,,DEM,Loretta L. Sanchez,78
+Merced,92191,U.S. Senate,,DEM,Kamala D. Harris,42
+Merced,92191,U.S. Senate,,DEM,Loretta L. Sanchez,17
+Merced,92192,U.S. Senate,,DEM,Kamala D. Harris,4
+Merced,92192,U.S. Senate,,DEM,Loretta L. Sanchez,5
+Merced,92193,U.S. Senate,,DEM,Kamala D. Harris,48
+Merced,92193,U.S. Senate,,DEM,Loretta L. Sanchez,29
+Merced,93194,U.S. Senate,,DEM,Kamala D. Harris,7
+Merced,93194,U.S. Senate,,DEM,Loretta L. Sanchez,11
+Merced,93195,U.S. Senate,,DEM,Kamala D. Harris,62
+Merced,93195,U.S. Senate,,DEM,Loretta L. Sanchez,52
+Merced,93196,U.S. Senate,,DEM,Kamala D. Harris,14
+Merced,93196,U.S. Senate,,DEM,Loretta L. Sanchez,19
+Merced,93197,U.S. Senate,,DEM,Kamala D. Harris,1
+Merced,93197,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Merced,93198,U.S. Senate,,DEM,Kamala D. Harris,59
+Merced,93198,U.S. Senate,,DEM,Loretta L. Sanchez,52
+Merced,93199,U.S. Senate,,DEM,Kamala D. Harris,2
+Merced,93199,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Merced,93200,U.S. Senate,,DEM,Kamala D. Harris,1
+Merced,93200,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Merced,93201,U.S. Senate,,DEM,Kamala D. Harris,47
+Merced,93201,U.S. Senate,,DEM,Loretta L. Sanchez,49
+Merced,93202,U.S. Senate,,DEM,Kamala D. Harris,44
+Merced,93202,U.S. Senate,,DEM,Loretta L. Sanchez,34
+Merced,93203,U.S. Senate,,DEM,Kamala D. Harris,3
+Merced,93203,U.S. Senate,,DEM,Loretta L. Sanchez,5
+Merced,93204,U.S. Senate,,DEM,Kamala D. Harris,12
+Merced,93204,U.S. Senate,,DEM,Loretta L. Sanchez,7
+Merced,93205,U.S. Senate,,DEM,Kamala D. Harris,4
+Merced,93205,U.S. Senate,,DEM,Loretta L. Sanchez,13
+Merced,93206,U.S. Senate,,DEM,Kamala D. Harris,10
+Merced,93206,U.S. Senate,,DEM,Loretta L. Sanchez,15
+Merced,93207,U.S. Senate,,DEM,Kamala D. Harris,28
+Merced,93207,U.S. Senate,,DEM,Loretta L. Sanchez,15
+Merced,93208,U.S. Senate,,DEM,Kamala D. Harris,18
+Merced,93208,U.S. Senate,,DEM,Loretta L. Sanchez,19
+Merced,93209,U.S. Senate,,DEM,Kamala D. Harris,17
+Merced,93209,U.S. Senate,,DEM,Loretta L. Sanchez,11
+Merced,93210,U.S. Senate,,DEM,Kamala D. Harris,18
+Merced,93210,U.S. Senate,,DEM,Loretta L. Sanchez,6
+Merced,93211,U.S. Senate,,DEM,Kamala D. Harris,55
+Merced,93211,U.S. Senate,,DEM,Loretta L. Sanchez,32
+Merced,93212,U.S. Senate,,DEM,Kamala D. Harris,1
+Merced,93212,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Merced,94213,U.S. Senate,,DEM,Kamala D. Harris,23
+Merced,94213,U.S. Senate,,DEM,Loretta L. Sanchez,17
+Merced,94214,U.S. Senate,,DEM,Kamala D. Harris,4
+Merced,94214,U.S. Senate,,DEM,Loretta L. Sanchez,7
+Merced,94215,U.S. Senate,,DEM,Kamala D. Harris,22
+Merced,94215,U.S. Senate,,DEM,Loretta L. Sanchez,20
+Merced,94216,U.S. Senate,,DEM,Kamala D. Harris,32
+Merced,94216,U.S. Senate,,DEM,Loretta L. Sanchez,28
+Merced,94217,U.S. Senate,,DEM,Kamala D. Harris,72
+Merced,94217,U.S. Senate,,DEM,Loretta L. Sanchez,91
+Merced,94218,U.S. Senate,,DEM,Kamala D. Harris,30
+Merced,94218,U.S. Senate,,DEM,Loretta L. Sanchez,47
+Merced,94219,U.S. Senate,,DEM,Kamala D. Harris,5
+Merced,94219,U.S. Senate,,DEM,Loretta L. Sanchez,11
+Merced,94220,U.S. Senate,,DEM,Kamala D. Harris,50
+Merced,94220,U.S. Senate,,DEM,Loretta L. Sanchez,57
+Merced,94221,U.S. Senate,,DEM,Kamala D. Harris,7
+Merced,94221,U.S. Senate,,DEM,Loretta L. Sanchez,9
+Merced,94222,U.S. Senate,,DEM,Kamala D. Harris,31
+Merced,94222,U.S. Senate,,DEM,Loretta L. Sanchez,24
+Merced,94223,U.S. Senate,,DEM,Kamala D. Harris,26
+Merced,94223,U.S. Senate,,DEM,Loretta L. Sanchez,23
+Merced,94224,U.S. Senate,,DEM,Kamala D. Harris,22
+Merced,94224,U.S. Senate,,DEM,Loretta L. Sanchez,16
+Merced,94225,U.S. Senate,,DEM,Kamala D. Harris,43
+Merced,94225,U.S. Senate,,DEM,Loretta L. Sanchez,30
+Merced,94226,U.S. Senate,,DEM,Kamala D. Harris,45
+Merced,94226,U.S. Senate,,DEM,Loretta L. Sanchez,48
+Merced,94227,U.S. Senate,,DEM,Kamala D. Harris,23
+Merced,94227,U.S. Senate,,DEM,Loretta L. Sanchez,51
+Merced,94228,U.S. Senate,,DEM,Kamala D. Harris,13
+Merced,94228,U.S. Senate,,DEM,Loretta L. Sanchez,21
+Merced,94229,U.S. Senate,,DEM,Kamala D. Harris,58
+Merced,94229,U.S. Senate,,DEM,Loretta L. Sanchez,69
+Merced,94230,U.S. Senate,,DEM,Kamala D. Harris,12
+Merced,94230,U.S. Senate,,DEM,Loretta L. Sanchez,5
+Merced,94231,U.S. Senate,,DEM,Kamala D. Harris,4
+Merced,94231,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Merced,94232,U.S. Senate,,DEM,Kamala D. Harris,0
+Merced,94232,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Merced,94233,U.S. Senate,,DEM,Kamala D. Harris,39
+Merced,94233,U.S. Senate,,DEM,Loretta L. Sanchez,39
+Merced,94234,U.S. Senate,,DEM,Kamala D. Harris,0
+Merced,94234,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Merced,94235,U.S. Senate,,DEM,Kamala D. Harris,1
+Merced,94235,U.S. Senate,,DEM,Loretta L. Sanchez,5
+Merced,94236,U.S. Senate,,DEM,Kamala D. Harris,24
+Merced,94236,U.S. Senate,,DEM,Loretta L. Sanchez,35
+Merced,94237,U.S. Senate,,DEM,Kamala D. Harris,25
+Merced,94237,U.S. Senate,,DEM,Loretta L. Sanchez,40
+Merced,94238,U.S. Senate,,DEM,Kamala D. Harris,33
+Merced,94238,U.S. Senate,,DEM,Loretta L. Sanchez,21
+Merced,94239,U.S. Senate,,DEM,Kamala D. Harris,20
+Merced,94239,U.S. Senate,,DEM,Loretta L. Sanchez,20
+Merced,94240,U.S. Senate,,DEM,Kamala D. Harris,47
+Merced,94240,U.S. Senate,,DEM,Loretta L. Sanchez,37
+Merced,94241,U.S. Senate,,DEM,Kamala D. Harris,19
+Merced,94241,U.S. Senate,,DEM,Loretta L. Sanchez,11
+Merced,94242,U.S. Senate,,DEM,Kamala D. Harris,62
+Merced,94242,U.S. Senate,,DEM,Loretta L. Sanchez,50
+Merced,94243,U.S. Senate,,DEM,Kamala D. Harris,30
+Merced,94243,U.S. Senate,,DEM,Loretta L. Sanchez,17
+Merced,94244,U.S. Senate,,DEM,Kamala D. Harris,48
+Merced,94244,U.S. Senate,,DEM,Loretta L. Sanchez,40
+Merced,94245,U.S. Senate,,DEM,Kamala D. Harris,16
+Merced,94245,U.S. Senate,,DEM,Loretta L. Sanchez,18
+Merced,94246,U.S. Senate,,DEM,Kamala D. Harris,5
+Merced,94246,U.S. Senate,,DEM,Loretta L. Sanchez,13
+Merced,95247,U.S. Senate,,DEM,Kamala D. Harris,22
+Merced,95247,U.S. Senate,,DEM,Loretta L. Sanchez,11
+Merced,95248,U.S. Senate,,DEM,Kamala D. Harris,3
+Merced,95248,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Merced,95249,U.S. Senate,,DEM,Kamala D. Harris,10
+Merced,95249,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Merced,95250,U.S. Senate,,DEM,Kamala D. Harris,48
+Merced,95250,U.S. Senate,,DEM,Loretta L. Sanchez,42
+Merced,95251,U.S. Senate,,DEM,Kamala D. Harris,15
+Merced,95251,U.S. Senate,,DEM,Loretta L. Sanchez,9
+Merced,95252,U.S. Senate,,DEM,Kamala D. Harris,0
+Merced,95252,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Merced,95253,U.S. Senate,,DEM,Kamala D. Harris,51
+Merced,95253,U.S. Senate,,DEM,Loretta L. Sanchez,46
+Merced,95254,U.S. Senate,,DEM,Kamala D. Harris,47
+Merced,95254,U.S. Senate,,DEM,Loretta L. Sanchez,60
+Merced,95255,U.S. Senate,,DEM,Kamala D. Harris,19
+Merced,95255,U.S. Senate,,DEM,Loretta L. Sanchez,8
+Merced,95256,U.S. Senate,,DEM,Kamala D. Harris,38
+Merced,95256,U.S. Senate,,DEM,Loretta L. Sanchez,35
+Merced,95257,U.S. Senate,,DEM,Kamala D. Harris,4
+Merced,95257,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Merced,95258,U.S. Senate,,DEM,Kamala D. Harris,0
+Merced,95258,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Merced,95259,U.S. Senate,,DEM,Kamala D. Harris,65
+Merced,95259,U.S. Senate,,DEM,Loretta L. Sanchez,46
+Merced,95260,U.S. Senate,,DEM,Kamala D. Harris,4
+Merced,95260,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Merced,95261,U.S. Senate,,DEM,Kamala D. Harris,3
+Merced,95261,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Merced,95262,U.S. Senate,,DEM,Kamala D. Harris,0
+Merced,95262,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Merced,95263,U.S. Senate,,DEM,Kamala D. Harris,4
+Merced,95263,U.S. Senate,,DEM,Loretta L. Sanchez,8
+Merced,95264,U.S. Senate,,DEM,Kamala D. Harris,56
+Merced,95264,U.S. Senate,,DEM,Loretta L. Sanchez,60
+Merced,95265,U.S. Senate,,DEM,Kamala D. Harris,1
+Merced,95265,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Merced,95266,U.S. Senate,,DEM,Kamala D. Harris,0
+Merced,95266,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Merced,95267,U.S. Senate,,DEM,Kamala D. Harris,0
+Merced,95267,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Merced,95268,U.S. Senate,,DEM,Kamala D. Harris,31
+Merced,95268,U.S. Senate,,DEM,Loretta L. Sanchez,25
+Merced,95269,U.S. Senate,,DEM,Kamala D. Harris,67
+Merced,95269,U.S. Senate,,DEM,Loretta L. Sanchez,93

--- a/2016/20161108__ca__general__modoc__precinct.csv
+++ b/2016/20161108__ca__general__modoc__precinct.csv
@@ -839,45 +839,45 @@ Modoc,South-Fork,Proposition 67,,N/A,Yes,18
 Modoc,South-Fork,Proposition 67,,N/A,No,59
 Modoc,State-Line-Willow-Ranch,Proposition 67,,N/A,Yes,11
 Modoc,State-Line-Willow-Ranch,Proposition 67,,N/A,No,47
-Modoc,Adin,U.S. Senate,,DEM,Kamala Harris,50
-Modoc,Adin,U.S. Senate,,DEM,Loretta Sanchez,55
-Modoc,Alturas-A,U.S. Senate,,DEM,Kamala Harris,82
-Modoc,Alturas-A,U.S. Senate,,DEM,Loretta Sanchez,112
-Modoc,Alturas-B,U.S. Senate,,DEM,Kamala Harris,39
-Modoc,Alturas-B,U.S. Senate,,DEM,Loretta Sanchez,58
-Modoc,Alturas-C,U.S. Senate,,DEM,Kamala Harris,95
-Modoc,Alturas-C,U.S. Senate,,DEM,Loretta Sanchez,168
-Modoc,Alturas-D,U.S. Senate,,DEM,Kamala Harris,68
-Modoc,Alturas-D,U.S. Senate,,DEM,Loretta Sanchez,126
-Modoc,Cal-Pines,U.S. Senate,,DEM,Kamala Harris,70
-Modoc,Cal-Pines,U.S. Senate,,DEM,Loretta Sanchez,102
-Modoc,Canby,U.S. Senate,,DEM,Kamala Harris,37
-Modoc,Canby,U.S. Senate,,DEM,Loretta Sanchez,48
-Modoc,Cedarville,U.S. Senate,,DEM,Kamala Harris,90
-Modoc,Cedarville,U.S. Senate,,DEM,Loretta Sanchez,131
-Modoc,Davis-Creek,U.S. Senate,,DEM,Kamala Harris,19
-Modoc,Davis-Creek,U.S. Senate,,DEM,Loretta Sanchez,21
-Modoc,Dry-Creek,U.S. Senate,,DEM,Kamala Harris,41
-Modoc,Dry-Creek,U.S. Senate,,DEM,Loretta Sanchez,39
-Modoc,Eagleville,U.S. Senate,,DEM,Kamala Harris,12
-Modoc,Eagleville,U.S. Senate,,DEM,Loretta Sanchez,22
-Modoc,Ft-Bidwell,U.S. Senate,,DEM,Kamala Harris,26
-Modoc,Ft-Bidwell,U.S. Senate,,DEM,Loretta Sanchez,28
-Modoc,Hot-Springs,U.S. Senate,,DEM,Kamala Harris,74
-Modoc,Hot-Springs,U.S. Senate,,DEM,Loretta Sanchez,96
-Modoc,Lake-City,U.S. Senate,,DEM,Kamala Harris,25
-Modoc,Lake-City,U.S. Senate,,DEM,Loretta Sanchez,34
-Modoc,Little-Hot-Springs,U.S. Senate,,DEM,Kamala Harris,17
-Modoc,Little-Hot-Springs,U.S. Senate,,DEM,Loretta Sanchez,19
-Modoc,Lookout,U.S. Senate,,DEM,Kamala Harris,50
-Modoc,Lookout,U.S. Senate,,DEM,Loretta Sanchez,69
-Modoc,Newell,U.S. Senate,,DEM,Kamala Harris,90
-Modoc,Newell,U.S. Senate,,DEM,Loretta Sanchez,128
-Modoc,North-Fork,U.S. Senate,,DEM,Kamala Harris,97
-Modoc,North-Fork,U.S. Senate,,DEM,Loretta Sanchez,177
-Modoc,Parker-Creek,U.S. Senate,,DEM,Kamala Harris,23
-Modoc,Parker-Creek,U.S. Senate,,DEM,Loretta Sanchez,42
-Modoc,South-Fork,U.S. Senate,,DEM,Kamala Harris,20
-Modoc,South-Fork,U.S. Senate,,DEM,Loretta Sanchez,32
-Modoc,State-Line-Willow-Ranch,U.S. Senate,,DEM,Kamala Harris,19
-Modoc,State-Line-Willow-Ranch,U.S. Senate,,DEM,Loretta Sanchez,24
+Modoc,Adin,U.S. Senate,,DEM,Kamala D. Harris,50
+Modoc,Adin,U.S. Senate,,DEM,Loretta L. Sanchez,55
+Modoc,Alturas-A,U.S. Senate,,DEM,Kamala D. Harris,82
+Modoc,Alturas-A,U.S. Senate,,DEM,Loretta L. Sanchez,112
+Modoc,Alturas-B,U.S. Senate,,DEM,Kamala D. Harris,39
+Modoc,Alturas-B,U.S. Senate,,DEM,Loretta L. Sanchez,58
+Modoc,Alturas-C,U.S. Senate,,DEM,Kamala D. Harris,95
+Modoc,Alturas-C,U.S. Senate,,DEM,Loretta L. Sanchez,168
+Modoc,Alturas-D,U.S. Senate,,DEM,Kamala D. Harris,68
+Modoc,Alturas-D,U.S. Senate,,DEM,Loretta L. Sanchez,126
+Modoc,Cal-Pines,U.S. Senate,,DEM,Kamala D. Harris,70
+Modoc,Cal-Pines,U.S. Senate,,DEM,Loretta L. Sanchez,102
+Modoc,Canby,U.S. Senate,,DEM,Kamala D. Harris,37
+Modoc,Canby,U.S. Senate,,DEM,Loretta L. Sanchez,48
+Modoc,Cedarville,U.S. Senate,,DEM,Kamala D. Harris,90
+Modoc,Cedarville,U.S. Senate,,DEM,Loretta L. Sanchez,131
+Modoc,Davis-Creek,U.S. Senate,,DEM,Kamala D. Harris,19
+Modoc,Davis-Creek,U.S. Senate,,DEM,Loretta L. Sanchez,21
+Modoc,Dry-Creek,U.S. Senate,,DEM,Kamala D. Harris,41
+Modoc,Dry-Creek,U.S. Senate,,DEM,Loretta L. Sanchez,39
+Modoc,Eagleville,U.S. Senate,,DEM,Kamala D. Harris,12
+Modoc,Eagleville,U.S. Senate,,DEM,Loretta L. Sanchez,22
+Modoc,Ft-Bidwell,U.S. Senate,,DEM,Kamala D. Harris,26
+Modoc,Ft-Bidwell,U.S. Senate,,DEM,Loretta L. Sanchez,28
+Modoc,Hot-Springs,U.S. Senate,,DEM,Kamala D. Harris,74
+Modoc,Hot-Springs,U.S. Senate,,DEM,Loretta L. Sanchez,96
+Modoc,Lake-City,U.S. Senate,,DEM,Kamala D. Harris,25
+Modoc,Lake-City,U.S. Senate,,DEM,Loretta L. Sanchez,34
+Modoc,Little-Hot-Springs,U.S. Senate,,DEM,Kamala D. Harris,17
+Modoc,Little-Hot-Springs,U.S. Senate,,DEM,Loretta L. Sanchez,19
+Modoc,Lookout,U.S. Senate,,DEM,Kamala D. Harris,50
+Modoc,Lookout,U.S. Senate,,DEM,Loretta L. Sanchez,69
+Modoc,Newell,U.S. Senate,,DEM,Kamala D. Harris,90
+Modoc,Newell,U.S. Senate,,DEM,Loretta L. Sanchez,128
+Modoc,North-Fork,U.S. Senate,,DEM,Kamala D. Harris,97
+Modoc,North-Fork,U.S. Senate,,DEM,Loretta L. Sanchez,177
+Modoc,Parker-Creek,U.S. Senate,,DEM,Kamala D. Harris,23
+Modoc,Parker-Creek,U.S. Senate,,DEM,Loretta L. Sanchez,42
+Modoc,South-Fork,U.S. Senate,,DEM,Kamala D. Harris,20
+Modoc,South-Fork,U.S. Senate,,DEM,Loretta L. Sanchez,32
+Modoc,State-Line-Willow-Ranch,U.S. Senate,,DEM,Kamala D. Harris,19
+Modoc,State-Line-Willow-Ranch,U.S. Senate,,DEM,Loretta L. Sanchez,24

--- a/2016/20161108__ca__general__mono__precinct.csv
+++ b/2016/20161108__ca__general__mono__precinct.csv
@@ -479,27 +479,27 @@ Mono,12,Proposition 67,N/A,Yes,451
 Mono,12,Proposition 67,N/A,No,193
 Mono,13,Proposition 67,N/A,Yes,316
 Mono,13,Proposition 67,N/A,No,114
-Mono,01,U.S. Senate,DEM,Kamala Harris,209
-Mono,01,U.S. Senate,DEM,Loretta Sanchez,153
-Mono,03,U.S. Senate,DEM,Kamala Harris,156
-Mono,03,U.S. Senate,DEM,Loretta Sanchez,109
-Mono,04,U.S. Senate,DEM,Kamala Harris,217
-Mono,04,U.S. Senate,DEM,Loretta Sanchez,130
-Mono,05,U.S. Senate,DEM,Kamala Harris,154
-Mono,05,U.S. Senate,DEM,Loretta Sanchez,90
-Mono,06,U.S. Senate,DEM,Kamala Harris,112
-Mono,06,U.S. Senate,DEM,Loretta Sanchez,61
-Mono,07,U.S. Senate,DEM,Kamala Harris,313
-Mono,07,U.S. Senate,DEM,Loretta Sanchez,167
-Mono,08,U.S. Senate,DEM,Kamala Harris,180
-Mono,08,U.S. Senate,DEM,Loretta Sanchez,103
-Mono,09,U.S. Senate,DEM,Kamala Harris,353
-Mono,09,U.S. Senate,DEM,Loretta Sanchez,211
-Mono,10,U.S. Senate,DEM,Kamala Harris,239
-Mono,10,U.S. Senate,DEM,Loretta Sanchez,157
-Mono,11,U.S. Senate,DEM,Kamala Harris,147
-Mono,11,U.S. Senate,DEM,Loretta Sanchez,60
-Mono,12,U.S. Senate,DEM,Kamala Harris,311
-Mono,12,U.S. Senate,DEM,Loretta Sanchez,220
-Mono,13,U.S. Senate,DEM,Kamala Harris,220
-Mono,13,U.S. Senate,DEM,Loretta Sanchez,130
+Mono,01,U.S. Senate,DEM,Kamala D. Harris,209
+Mono,01,U.S. Senate,DEM,Loretta L. Sanchez,153
+Mono,03,U.S. Senate,DEM,Kamala D. Harris,156
+Mono,03,U.S. Senate,DEM,Loretta L. Sanchez,109
+Mono,04,U.S. Senate,DEM,Kamala D. Harris,217
+Mono,04,U.S. Senate,DEM,Loretta L. Sanchez,130
+Mono,05,U.S. Senate,DEM,Kamala D. Harris,154
+Mono,05,U.S. Senate,DEM,Loretta L. Sanchez,90
+Mono,06,U.S. Senate,DEM,Kamala D. Harris,112
+Mono,06,U.S. Senate,DEM,Loretta L. Sanchez,61
+Mono,07,U.S. Senate,DEM,Kamala D. Harris,313
+Mono,07,U.S. Senate,DEM,Loretta L. Sanchez,167
+Mono,08,U.S. Senate,DEM,Kamala D. Harris,180
+Mono,08,U.S. Senate,DEM,Loretta L. Sanchez,103
+Mono,09,U.S. Senate,DEM,Kamala D. Harris,353
+Mono,09,U.S. Senate,DEM,Loretta L. Sanchez,211
+Mono,10,U.S. Senate,DEM,Kamala D. Harris,239
+Mono,10,U.S. Senate,DEM,Loretta L. Sanchez,157
+Mono,11,U.S. Senate,DEM,Kamala D. Harris,147
+Mono,11,U.S. Senate,DEM,Loretta L. Sanchez,60
+Mono,12,U.S. Senate,DEM,Kamala D. Harris,311
+Mono,12,U.S. Senate,DEM,Loretta L. Sanchez,220
+Mono,13,U.S. Senate,DEM,Kamala D. Harris,220
+Mono,13,U.S. Senate,DEM,Loretta L. Sanchez,130

--- a/2016/20161108__ca__general__monterey__precinct.csv
+++ b/2016/20161108__ca__general__monterey__precinct.csv
@@ -7799,393 +7799,393 @@ Monterey,9565,Proposition 67,,N/A,Yes,39
 Monterey,9565,Proposition 67,,N/A,No,24
 Monterey,9567,Proposition 67,,N/A,Yes,67
 Monterey,9567,Proposition 67,,N/A,No,70
-Monterey,1001,U.S. Senate,,DEM,Kamala Harris,266
-Monterey,1001,U.S. Senate,,DEM,Loretta Sanchez,441
-Monterey,1002,U.S. Senate,,DEM,Kamala Harris,384
-Monterey,1002,U.S. Senate,,DEM,Loretta Sanchez,476
-Monterey,1003,U.S. Senate,,DEM,Kamala Harris,232
-Monterey,1003,U.S. Senate,,DEM,Loretta Sanchez,355
-Monterey,1004,U.S. Senate,,DEM,Kamala Harris,208
-Monterey,1004,U.S. Senate,,DEM,Loretta Sanchez,214
-Monterey,1005,U.S. Senate,,DEM,Kamala Harris,203
-Monterey,1005,U.S. Senate,,DEM,Loretta Sanchez,266
-Monterey,1006,U.S. Senate,,DEM,Kamala Harris,312
-Monterey,1006,U.S. Senate,,DEM,Loretta Sanchez,492
-Monterey,1007,U.S. Senate,,DEM,Kamala Harris,362
-Monterey,1007,U.S. Senate,,DEM,Loretta Sanchez,234
-Monterey,1008,U.S. Senate,,DEM,Kamala Harris,432
-Monterey,1008,U.S. Senate,,DEM,Loretta Sanchez,308
-Monterey,1009,U.S. Senate,,DEM,Kamala Harris,740
-Monterey,1009,U.S. Senate,,DEM,Loretta Sanchez,573
-Monterey,1010,U.S. Senate,,DEM,Kamala Harris,319
-Monterey,1010,U.S. Senate,,DEM,Loretta Sanchez,267
-Monterey,1011,U.S. Senate,,DEM,Kamala Harris,455
-Monterey,1011,U.S. Senate,,DEM,Loretta Sanchez,511
-Monterey,1012,U.S. Senate,,DEM,Kamala Harris,334
-Monterey,1012,U.S. Senate,,DEM,Loretta Sanchez,446
-Monterey,1013,U.S. Senate,,DEM,Kamala Harris,646
-Monterey,1013,U.S. Senate,,DEM,Loretta Sanchez,448
-Monterey,1014,U.S. Senate,,DEM,Kamala Harris,462
-Monterey,1014,U.S. Senate,,DEM,Loretta Sanchez,347
-Monterey,1015,U.S. Senate,,DEM,Kamala Harris,269
-Monterey,1015,U.S. Senate,,DEM,Loretta Sanchez,203
-Monterey,1016,U.S. Senate,,DEM,Kamala Harris,666
-Monterey,1016,U.S. Senate,,DEM,Loretta Sanchez,552
-Monterey,1017,U.S. Senate,,DEM,Kamala Harris,162
-Monterey,1017,U.S. Senate,,DEM,Loretta Sanchez,200
-Monterey,1018,U.S. Senate,,DEM,Kamala Harris,709
-Monterey,1018,U.S. Senate,,DEM,Loretta Sanchez,521
-Monterey,2019,U.S. Senate,,DEM,Kamala Harris,135
-Monterey,2019,U.S. Senate,,DEM,Loretta Sanchez,195
-Monterey,2020,U.S. Senate,,DEM,Kamala Harris,652
-Monterey,2020,U.S. Senate,,DEM,Loretta Sanchez,563
-Monterey,2021,U.S. Senate,,DEM,Kamala Harris,477
-Monterey,2021,U.S. Senate,,DEM,Loretta Sanchez,360
-Monterey,2022,U.S. Senate,,DEM,Kamala Harris,775
-Monterey,2022,U.S. Senate,,DEM,Loretta Sanchez,404
-Monterey,2023,U.S. Senate,,DEM,Kamala Harris,734
-Monterey,2023,U.S. Senate,,DEM,Loretta Sanchez,557
-Monterey,2024,U.S. Senate,,DEM,Kamala Harris,893
-Monterey,2024,U.S. Senate,,DEM,Loretta Sanchez,439
-Monterey,2025,U.S. Senate,,DEM,Kamala Harris,605
-Monterey,2025,U.S. Senate,,DEM,Loretta Sanchez,693
-Monterey,2027,U.S. Senate,,DEM,Kamala Harris,693
-Monterey,2027,U.S. Senate,,DEM,Loretta Sanchez,301
-Monterey,2028,U.S. Senate,,DEM,Kamala Harris,553
-Monterey,2028,U.S. Senate,,DEM,Loretta Sanchez,286
-Monterey,2029,U.S. Senate,,DEM,Kamala Harris,721
-Monterey,2029,U.S. Senate,,DEM,Loretta Sanchez,371
-Monterey,2030,U.S. Senate,,DEM,Kamala Harris,759
-Monterey,2030,U.S. Senate,,DEM,Loretta Sanchez,366
-Monterey,2031,U.S. Senate,,DEM,Kamala Harris,361
-Monterey,2031,U.S. Senate,,DEM,Loretta Sanchez,227
-Monterey,2032,U.S. Senate,,DEM,Kamala Harris,426
-Monterey,2032,U.S. Senate,,DEM,Loretta Sanchez,276
-Monterey,2033,U.S. Senate,,DEM,Kamala Harris,207
-Monterey,2033,U.S. Senate,,DEM,Loretta Sanchez,221
-Monterey,2034,U.S. Senate,,DEM,Kamala Harris,743
-Monterey,2034,U.S. Senate,,DEM,Loretta Sanchez,782
-Monterey,2035,U.S. Senate,,DEM,Kamala Harris,328
-Monterey,2035,U.S. Senate,,DEM,Loretta Sanchez,189
-Monterey,2036,U.S. Senate,,DEM,Kamala Harris,485
-Monterey,2036,U.S. Senate,,DEM,Loretta Sanchez,459
-Monterey,2037,U.S. Senate,,DEM,Kamala Harris,440
-Monterey,2037,U.S. Senate,,DEM,Loretta Sanchez,429
-Monterey,2038,U.S. Senate,,DEM,Kamala Harris,306
-Monterey,2038,U.S. Senate,,DEM,Loretta Sanchez,190
-Monterey,2039,U.S. Senate,,DEM,Kamala Harris,532
-Monterey,2039,U.S. Senate,,DEM,Loretta Sanchez,405
-Monterey,2040,U.S. Senate,,DEM,Kamala Harris,360
-Monterey,2040,U.S. Senate,,DEM,Loretta Sanchez,194
-Monterey,2041,U.S. Senate,,DEM,Kamala Harris,465
-Monterey,2041,U.S. Senate,,DEM,Loretta Sanchez,268
-Monterey,2042,U.S. Senate,,DEM,Kamala Harris,502
-Monterey,2042,U.S. Senate,,DEM,Loretta Sanchez,352
-Monterey,2043,U.S. Senate,,DEM,Kamala Harris,508
-Monterey,2043,U.S. Senate,,DEM,Loretta Sanchez,373
-Monterey,2044,U.S. Senate,,DEM,Kamala Harris,415
-Monterey,2044,U.S. Senate,,DEM,Loretta Sanchez,259
-Monterey,2045,U.S. Senate,,DEM,Kamala Harris,603
-Monterey,2045,U.S. Senate,,DEM,Loretta Sanchez,441
-Monterey,2046,U.S. Senate,,DEM,Kamala Harris,578
-Monterey,2046,U.S. Senate,,DEM,Loretta Sanchez,360
-Monterey,2047,U.S. Senate,,DEM,Kamala Harris,250
-Monterey,2047,U.S. Senate,,DEM,Loretta Sanchez,157
-Monterey,3048,U.S. Senate,,DEM,Kamala Harris,270
-Monterey,3048,U.S. Senate,,DEM,Loretta Sanchez,305
-Monterey,3049,U.S. Senate,,DEM,Kamala Harris,636
-Monterey,3049,U.S. Senate,,DEM,Loretta Sanchez,871
-Monterey,3050,U.S. Senate,,DEM,Kamala Harris,373
-Monterey,3050,U.S. Senate,,DEM,Loretta Sanchez,402
-Monterey,3051,U.S. Senate,,DEM,Kamala Harris,515
-Monterey,3051,U.S. Senate,,DEM,Loretta Sanchez,507
-Monterey,3052,U.S. Senate,,DEM,Kamala Harris,464
-Monterey,3052,U.S. Senate,,DEM,Loretta Sanchez,451
-Monterey,3053,U.S. Senate,,DEM,Kamala Harris,314
-Monterey,3053,U.S. Senate,,DEM,Loretta Sanchez,360
-Monterey,3054,U.S. Senate,,DEM,Kamala Harris,476
-Monterey,3054,U.S. Senate,,DEM,Loretta Sanchez,464
-Monterey,3055,U.S. Senate,,DEM,Kamala Harris,513
-Monterey,3055,U.S. Senate,,DEM,Loretta Sanchez,436
-Monterey,3056,U.S. Senate,,DEM,Kamala Harris,451
-Monterey,3056,U.S. Senate,,DEM,Loretta Sanchez,528
-Monterey,3057,U.S. Senate,,DEM,Kamala Harris,412
-Monterey,3057,U.S. Senate,,DEM,Loretta Sanchez,345
-Monterey,3058,U.S. Senate,,DEM,Kamala Harris,533
-Monterey,3058,U.S. Senate,,DEM,Loretta Sanchez,596
-Monterey,3059,U.S. Senate,,DEM,Kamala Harris,518
-Monterey,3059,U.S. Senate,,DEM,Loretta Sanchez,530
-Monterey,3062,U.S. Senate,,DEM,Kamala Harris,524
-Monterey,3062,U.S. Senate,,DEM,Loretta Sanchez,275
-Monterey,3063,U.S. Senate,,DEM,Kamala Harris,245
-Monterey,3063,U.S. Senate,,DEM,Loretta Sanchez,140
-Monterey,3160,U.S. Senate,,DEM,Kamala Harris,239
-Monterey,3160,U.S. Senate,,DEM,Loretta Sanchez,247
-Monterey,3260,U.S. Senate,,DEM,Kamala Harris,149
-Monterey,3260,U.S. Senate,,DEM,Loretta Sanchez,129
-Monterey,3360,U.S. Senate,,DEM,Kamala Harris,235
-Monterey,3360,U.S. Senate,,DEM,Loretta Sanchez,177
-Monterey,3460,U.S. Senate,,DEM,Kamala Harris,140
-Monterey,3460,U.S. Senate,,DEM,Loretta Sanchez,258
-Monterey,3560,U.S. Senate,,DEM,Kamala Harris,241
-Monterey,3560,U.S. Senate,,DEM,Loretta Sanchez,181
-Monterey,4064,U.S. Senate,,DEM,Kamala Harris,617
-Monterey,4064,U.S. Senate,,DEM,Loretta Sanchez,194
-Monterey,4065,U.S. Senate,,DEM,Kamala Harris,984
-Monterey,4065,U.S. Senate,,DEM,Loretta Sanchez,522
-Monterey,4066,U.S. Senate,,DEM,Kamala Harris,493
-Monterey,4066,U.S. Senate,,DEM,Loretta Sanchez,202
-Monterey,4067,U.S. Senate,,DEM,Kamala Harris,711
-Monterey,4067,U.S. Senate,,DEM,Loretta Sanchez,406
-Monterey,4068,U.S. Senate,,DEM,Kamala Harris,623
-Monterey,4068,U.S. Senate,,DEM,Loretta Sanchez,222
-Monterey,4069,U.S. Senate,,DEM,Kamala Harris,424
-Monterey,4069,U.S. Senate,,DEM,Loretta Sanchez,351
-Monterey,4070,U.S. Senate,,DEM,Kamala Harris,560
-Monterey,4070,U.S. Senate,,DEM,Loretta Sanchez,257
-Monterey,4071,U.S. Senate,,DEM,Kamala Harris,711
-Monterey,4071,U.S. Senate,,DEM,Loretta Sanchez,273
-Monterey,4072,U.S. Senate,,DEM,Kamala Harris,354
-Monterey,4072,U.S. Senate,,DEM,Loretta Sanchez,176
-Monterey,4073,U.S. Senate,,DEM,Kamala Harris,569
-Monterey,4073,U.S. Senate,,DEM,Loretta Sanchez,284
-Monterey,4074,U.S. Senate,,DEM,Kamala Harris,743
-Monterey,4074,U.S. Senate,,DEM,Loretta Sanchez,371
-Monterey,4075,U.S. Senate,,DEM,Kamala Harris,598
-Monterey,4075,U.S. Senate,,DEM,Loretta Sanchez,249
-Monterey,4076,U.S. Senate,,DEM,Kamala Harris,619
-Monterey,4076,U.S. Senate,,DEM,Loretta Sanchez,292
-Monterey,4077,U.S. Senate,,DEM,Kamala Harris,567
-Monterey,4077,U.S. Senate,,DEM,Loretta Sanchez,388
-Monterey,4078,U.S. Senate,,DEM,Kamala Harris,712
-Monterey,4078,U.S. Senate,,DEM,Loretta Sanchez,337
-Monterey,4079,U.S. Senate,,DEM,Kamala Harris,720
-Monterey,4079,U.S. Senate,,DEM,Loretta Sanchez,305
-Monterey,4080,U.S. Senate,,DEM,Kamala Harris,452
-Monterey,4080,U.S. Senate,,DEM,Loretta Sanchez,285
-Monterey,4081,U.S. Senate,,DEM,Kamala Harris,714
-Monterey,4081,U.S. Senate,,DEM,Loretta Sanchez,335
-Monterey,4082,U.S. Senate,,DEM,Kamala Harris,631
-Monterey,4082,U.S. Senate,,DEM,Loretta Sanchez,342
-Monterey,4083,U.S. Senate,,DEM,Kamala Harris,920
-Monterey,4083,U.S. Senate,,DEM,Loretta Sanchez,525
-Monterey,4084,U.S. Senate,,DEM,Kamala Harris,813
-Monterey,4084,U.S. Senate,,DEM,Loretta Sanchez,380
-Monterey,4085,U.S. Senate,,DEM,Kamala Harris,588
-Monterey,4085,U.S. Senate,,DEM,Loretta Sanchez,224
-Monterey,4086,U.S. Senate,,DEM,Kamala Harris,416
-Monterey,4086,U.S. Senate,,DEM,Loretta Sanchez,187
-Monterey,4087,U.S. Senate,,DEM,Kamala Harris,726
-Monterey,4087,U.S. Senate,,DEM,Loretta Sanchez,267
-Monterey,4088,U.S. Senate,,DEM,Kamala Harris,489
-Monterey,4088,U.S. Senate,,DEM,Loretta Sanchez,166
-Monterey,4089,U.S. Senate,,DEM,Kamala Harris,664
-Monterey,4089,U.S. Senate,,DEM,Loretta Sanchez,302
-Monterey,4090,U.S. Senate,,DEM,Kamala Harris,621
-Monterey,4090,U.S. Senate,,DEM,Loretta Sanchez,247
-Monterey,5091,U.S. Senate,,DEM,Kamala Harris,762
-Monterey,5091,U.S. Senate,,DEM,Loretta Sanchez,257
-Monterey,5092,U.S. Senate,,DEM,Kamala Harris,825
-Monterey,5092,U.S. Senate,,DEM,Loretta Sanchez,269
-Monterey,5093,U.S. Senate,,DEM,Kamala Harris,1021
-Monterey,5093,U.S. Senate,,DEM,Loretta Sanchez,372
-Monterey,5094,U.S. Senate,,DEM,Kamala Harris,751
-Monterey,5094,U.S. Senate,,DEM,Loretta Sanchez,308
-Monterey,5095,U.S. Senate,,DEM,Kamala Harris,689
-Monterey,5095,U.S. Senate,,DEM,Loretta Sanchez,264
-Monterey,5096,U.S. Senate,,DEM,Kamala Harris,535
-Monterey,5096,U.S. Senate,,DEM,Loretta Sanchez,132
-Monterey,5097,U.S. Senate,,DEM,Kamala Harris,659
-Monterey,5097,U.S. Senate,,DEM,Loretta Sanchez,182
-Monterey,5098,U.S. Senate,,DEM,Kamala Harris,735
-Monterey,5098,U.S. Senate,,DEM,Loretta Sanchez,200
-Monterey,5099,U.S. Senate,,DEM,Kamala Harris,744
-Monterey,5099,U.S. Senate,,DEM,Loretta Sanchez,214
-Monterey,5100,U.S. Senate,,DEM,Kamala Harris,1057
-Monterey,5100,U.S. Senate,,DEM,Loretta Sanchez,367
-Monterey,5101,U.S. Senate,,DEM,Kamala Harris,890
-Monterey,5101,U.S. Senate,,DEM,Loretta Sanchez,243
-Monterey,5102,U.S. Senate,,DEM,Kamala Harris,842
-Monterey,5102,U.S. Senate,,DEM,Loretta Sanchez,246
-Monterey,5103,U.S. Senate,,DEM,Kamala Harris,860
-Monterey,5103,U.S. Senate,,DEM,Loretta Sanchez,221
-Monterey,5104,U.S. Senate,,DEM,Kamala Harris,722
-Monterey,5104,U.S. Senate,,DEM,Loretta Sanchez,196
-Monterey,5105,U.S. Senate,,DEM,Kamala Harris,839
-Monterey,5105,U.S. Senate,,DEM,Loretta Sanchez,199
-Monterey,5106,U.S. Senate,,DEM,Kamala Harris,731
-Monterey,5106,U.S. Senate,,DEM,Loretta Sanchez,260
-Monterey,5107,U.S. Senate,,DEM,Kamala Harris,749
-Monterey,5107,U.S. Senate,,DEM,Loretta Sanchez,218
-Monterey,5108,U.S. Senate,,DEM,Kamala Harris,979
-Monterey,5108,U.S. Senate,,DEM,Loretta Sanchez,393
-Monterey,5109,U.S. Senate,,DEM,Kamala Harris,654
-Monterey,5109,U.S. Senate,,DEM,Loretta Sanchez,275
-Monterey,5110,U.S. Senate,,DEM,Kamala Harris,762
-Monterey,5110,U.S. Senate,,DEM,Loretta Sanchez,226
-Monterey,5111,U.S. Senate,,DEM,Kamala Harris,694
-Monterey,5111,U.S. Senate,,DEM,Loretta Sanchez,229
-Monterey,5112,U.S. Senate,,DEM,Kamala Harris,682
-Monterey,5112,U.S. Senate,,DEM,Loretta Sanchez,207
-Monterey,5113,U.S. Senate,,DEM,Kamala Harris,944
-Monterey,5113,U.S. Senate,,DEM,Loretta Sanchez,321
-Monterey,5114,U.S. Senate,,DEM,Kamala Harris,724
-Monterey,5114,U.S. Senate,,DEM,Loretta Sanchez,212
-Monterey,5115,U.S. Senate,,DEM,Kamala Harris,418
-Monterey,5115,U.S. Senate,,DEM,Loretta Sanchez,117
-Monterey,5116,U.S. Senate,,DEM,Kamala Harris,639
-Monterey,5116,U.S. Senate,,DEM,Loretta Sanchez,213
-Monterey,5117,U.S. Senate,,DEM,Kamala Harris,763
-Monterey,5117,U.S. Senate,,DEM,Loretta Sanchez,258
-Monterey,5118,U.S. Senate,,DEM,Kamala Harris,678
-Monterey,5118,U.S. Senate,,DEM,Loretta Sanchez,235
-Monterey,5119,U.S. Senate,,DEM,Kamala Harris,577
-Monterey,5119,U.S. Senate,,DEM,Loretta Sanchez,159
-Monterey,5120,U.S. Senate,,DEM,Kamala Harris,684
-Monterey,5120,U.S. Senate,,DEM,Loretta Sanchez,191
-Monterey,5121,U.S. Senate,,DEM,Kamala Harris,269
-Monterey,5121,U.S. Senate,,DEM,Loretta Sanchez,88
-Monterey,5122,U.S. Senate,,DEM,Kamala Harris,343
-Monterey,5122,U.S. Senate,,DEM,Loretta Sanchez,83
-Monterey,5123,U.S. Senate,,DEM,Kamala Harris,588
-Monterey,5123,U.S. Senate,,DEM,Loretta Sanchez,225
-Monterey,5124,U.S. Senate,,DEM,Kamala Harris,1054
-Monterey,5124,U.S. Senate,,DEM,Loretta Sanchez,297
-Monterey,5125,U.S. Senate,,DEM,Kamala Harris,738
-Monterey,5125,U.S. Senate,,DEM,Loretta Sanchez,259
-Monterey,5126,U.S. Senate,,DEM,Kamala Harris,851
-Monterey,5126,U.S. Senate,,DEM,Loretta Sanchez,326
-Monterey,5127,U.S. Senate,,DEM,Kamala Harris,710
-Monterey,5127,U.S. Senate,,DEM,Loretta Sanchez,272
-Monterey,9101,U.S. Senate,,DEM,Kamala Harris,15
-Monterey,9101,U.S. Senate,,DEM,Loretta Sanchez,14
-Monterey,9102,U.S. Senate,,DEM,Kamala Harris,107
-Monterey,9102,U.S. Senate,,DEM,Loretta Sanchez,69
-Monterey,9103,U.S. Senate,,DEM,Kamala Harris,53
-Monterey,9103,U.S. Senate,,DEM,Loretta Sanchez,19
-Monterey,9204,U.S. Senate,,DEM,Kamala Harris,0
-Monterey,9204,U.S. Senate,,DEM,Loretta Sanchez,0
-Monterey,9205,U.S. Senate,,DEM,Kamala Harris,0
-Monterey,9205,U.S. Senate,,DEM,Loretta Sanchez,0
-Monterey,9206,U.S. Senate,,DEM,Kamala Harris,0
-Monterey,9206,U.S. Senate,,DEM,Loretta Sanchez,0
-Monterey,9207,U.S. Senate,,DEM,Kamala Harris,149
-Monterey,9207,U.S. Senate,,DEM,Loretta Sanchez,108
-Monterey,9208,U.S. Senate,,DEM,Kamala Harris,22
-Monterey,9208,U.S. Senate,,DEM,Loretta Sanchez,16
-Monterey,9209,U.S. Senate,,DEM,Kamala Harris,44
-Monterey,9209,U.S. Senate,,DEM,Loretta Sanchez,31
-Monterey,9210,U.S. Senate,,DEM,Kamala Harris,14
-Monterey,9210,U.S. Senate,,DEM,Loretta Sanchez,9
-Monterey,9211,U.S. Senate,,DEM,Kamala Harris,15
-Monterey,9211,U.S. Senate,,DEM,Loretta Sanchez,10
-Monterey,9212,U.S. Senate,,DEM,Kamala Harris,79
-Monterey,9212,U.S. Senate,,DEM,Loretta Sanchez,40
-Monterey,9213,U.S. Senate,,DEM,Kamala Harris,22
-Monterey,9213,U.S. Senate,,DEM,Loretta Sanchez,5
-Monterey,9214,U.S. Senate,,DEM,Kamala Harris,67
-Monterey,9214,U.S. Senate,,DEM,Loretta Sanchez,38
-Monterey,9215,U.S. Senate,,DEM,Kamala Harris,20
-Monterey,9215,U.S. Senate,,DEM,Loretta Sanchez,13
-Monterey,9216,U.S. Senate,,DEM,Kamala Harris,24
-Monterey,9216,U.S. Senate,,DEM,Loretta Sanchez,23
-Monterey,9217,U.S. Senate,,DEM,Kamala Harris,16
-Monterey,9217,U.S. Senate,,DEM,Loretta Sanchez,10
-Monterey,9218,U.S. Senate,,DEM,Kamala Harris,0
-Monterey,9218,U.S. Senate,,DEM,Loretta Sanchez,0
-Monterey,9319,U.S. Senate,,DEM,Kamala Harris,310
-Monterey,9319,U.S. Senate,,DEM,Loretta Sanchez,103
-Monterey,9320,U.S. Senate,,DEM,Kamala Harris,0
-Monterey,9320,U.S. Senate,,DEM,Loretta Sanchez,0
-Monterey,9321,U.S. Senate,,DEM,Kamala Harris,11
-Monterey,9321,U.S. Senate,,DEM,Loretta Sanchez,3
-Monterey,9322,U.S. Senate,,DEM,Kamala Harris,90
-Monterey,9322,U.S. Senate,,DEM,Loretta Sanchez,57
-Monterey,9323,U.S. Senate,,DEM,Kamala Harris,10
-Monterey,9323,U.S. Senate,,DEM,Loretta Sanchez,6
-Monterey,9324,U.S. Senate,,DEM,Kamala Harris,55
-Monterey,9324,U.S. Senate,,DEM,Loretta Sanchez,21
-Monterey,9325,U.S. Senate,,DEM,Kamala Harris,24
-Monterey,9325,U.S. Senate,,DEM,Loretta Sanchez,13
-Monterey,9326,U.S. Senate,,DEM,Kamala Harris,56
-Monterey,9326,U.S. Senate,,DEM,Loretta Sanchez,57
-Monterey,9327,U.S. Senate,,DEM,Kamala Harris,27
-Monterey,9327,U.S. Senate,,DEM,Loretta Sanchez,6
-Monterey,9328,U.S. Senate,,DEM,Kamala Harris,82
-Monterey,9328,U.S. Senate,,DEM,Loretta Sanchez,52
-Monterey,9329,U.S. Senate,,DEM,Kamala Harris,39
-Monterey,9329,U.S. Senate,,DEM,Loretta Sanchez,48
-Monterey,9330,U.S. Senate,,DEM,Kamala Harris,13
-Monterey,9330,U.S. Senate,,DEM,Loretta Sanchez,8
-Monterey,9331,U.S. Senate,,DEM,Kamala Harris,13
-Monterey,9331,U.S. Senate,,DEM,Loretta Sanchez,9
-Monterey,9332,U.S. Senate,,DEM,Kamala Harris,119
-Monterey,9332,U.S. Senate,,DEM,Loretta Sanchez,65
-Monterey,9333,U.S. Senate,,DEM,Kamala Harris,70
-Monterey,9333,U.S. Senate,,DEM,Loretta Sanchez,32
-Monterey,9334,U.S. Senate,,DEM,Kamala Harris,20
-Monterey,9334,U.S. Senate,,DEM,Loretta Sanchez,8
-Monterey,9335,U.S. Senate,,DEM,Kamala Harris,3
-Monterey,9335,U.S. Senate,,DEM,Loretta Sanchez,3
-Monterey,9336,U.S. Senate,,DEM,Kamala Harris,64
-Monterey,9336,U.S. Senate,,DEM,Loretta Sanchez,56
-Monterey,9337,U.S. Senate,,DEM,Kamala Harris,42
-Monterey,9337,U.S. Senate,,DEM,Loretta Sanchez,36
-Monterey,9338,U.S. Senate,,DEM,Kamala Harris,5
-Monterey,9338,U.S. Senate,,DEM,Loretta Sanchez,5
-Monterey,9339,U.S. Senate,,DEM,Kamala Harris,33
-Monterey,9339,U.S. Senate,,DEM,Loretta Sanchez,28
-Monterey,9340,U.S. Senate,,DEM,Kamala Harris,30
-Monterey,9340,U.S. Senate,,DEM,Loretta Sanchez,12
-Monterey,9441,U.S. Senate,,DEM,Kamala Harris,1
-Monterey,9441,U.S. Senate,,DEM,Loretta Sanchez,4
-Monterey,9442,U.S. Senate,,DEM,Kamala Harris,0
-Monterey,9442,U.S. Senate,,DEM,Loretta Sanchez,2
-Monterey,9443,U.S. Senate,,DEM,Kamala Harris,0
-Monterey,9443,U.S. Senate,,DEM,Loretta Sanchez,0
-Monterey,9444,U.S. Senate,,DEM,Kamala Harris,17
-Monterey,9444,U.S. Senate,,DEM,Loretta Sanchez,17
-Monterey,9445,U.S. Senate,,DEM,Kamala Harris,68
-Monterey,9445,U.S. Senate,,DEM,Loretta Sanchez,16
-Monterey,9446,U.S. Senate,,DEM,Kamala Harris,5
-Monterey,9446,U.S. Senate,,DEM,Loretta Sanchez,4
-Monterey,9447,U.S. Senate,,DEM,Kamala Harris,4
-Monterey,9447,U.S. Senate,,DEM,Loretta Sanchez,7
-Monterey,9448,U.S. Senate,,DEM,Kamala Harris,0
-Monterey,9448,U.S. Senate,,DEM,Loretta Sanchez,0
-Monterey,9449,U.S. Senate,,DEM,Kamala Harris,215
-Monterey,9449,U.S. Senate,,DEM,Loretta Sanchez,85
-Monterey,9450,U.S. Senate,,DEM,Kamala Harris,99
-Monterey,9450,U.S. Senate,,DEM,Loretta Sanchez,35
-Monterey,9451,U.S. Senate,,DEM,Kamala Harris,24
-Monterey,9451,U.S. Senate,,DEM,Loretta Sanchez,28
-Monterey,9452,U.S. Senate,,DEM,Kamala Harris,18
-Monterey,9452,U.S. Senate,,DEM,Loretta Sanchez,17
-Monterey,9553,U.S. Senate,,DEM,Kamala Harris,80
-Monterey,9553,U.S. Senate,,DEM,Loretta Sanchez,56
-Monterey,9554,U.S. Senate,,DEM,Kamala Harris,278
-Monterey,9554,U.S. Senate,,DEM,Loretta Sanchez,64
-Monterey,9555,U.S. Senate,,DEM,Kamala Harris,150
-Monterey,9555,U.S. Senate,,DEM,Loretta Sanchez,54
-Monterey,9556,U.S. Senate,,DEM,Kamala Harris,234
-Monterey,9556,U.S. Senate,,DEM,Loretta Sanchez,97
-Monterey,9557,U.S. Senate,,DEM,Kamala Harris,358
-Monterey,9557,U.S. Senate,,DEM,Loretta Sanchez,143
-Monterey,9558,U.S. Senate,,DEM,Kamala Harris,246
-Monterey,9558,U.S. Senate,,DEM,Loretta Sanchez,91
-Monterey,9559,U.S. Senate,,DEM,Kamala Harris,485
-Monterey,9559,U.S. Senate,,DEM,Loretta Sanchez,143
-Monterey,9560,U.S. Senate,,DEM,Kamala Harris,187
-Monterey,9560,U.S. Senate,,DEM,Loretta Sanchez,46
-Monterey,9561,U.S. Senate,,DEM,Kamala Harris,107
-Monterey,9561,U.S. Senate,,DEM,Loretta Sanchez,37
-Monterey,9562,U.S. Senate,,DEM,Kamala Harris,52
-Monterey,9562,U.S. Senate,,DEM,Loretta Sanchez,20
-Monterey,9563,U.S. Senate,,DEM,Kamala Harris,10
-Monterey,9563,U.S. Senate,,DEM,Loretta Sanchez,1
-Monterey,9564,U.S. Senate,,DEM,Kamala Harris,41
-Monterey,9564,U.S. Senate,,DEM,Loretta Sanchez,18
-Monterey,9565,U.S. Senate,,DEM,Kamala Harris,37
-Monterey,9565,U.S. Senate,,DEM,Loretta Sanchez,14
-Monterey,9567,U.S. Senate,,DEM,Kamala Harris,64
-Monterey,9567,U.S. Senate,,DEM,Loretta Sanchez,32
+Monterey,1001,U.S. Senate,,DEM,Kamala D. Harris,266
+Monterey,1001,U.S. Senate,,DEM,Loretta L. Sanchez,441
+Monterey,1002,U.S. Senate,,DEM,Kamala D. Harris,384
+Monterey,1002,U.S. Senate,,DEM,Loretta L. Sanchez,476
+Monterey,1003,U.S. Senate,,DEM,Kamala D. Harris,232
+Monterey,1003,U.S. Senate,,DEM,Loretta L. Sanchez,355
+Monterey,1004,U.S. Senate,,DEM,Kamala D. Harris,208
+Monterey,1004,U.S. Senate,,DEM,Loretta L. Sanchez,214
+Monterey,1005,U.S. Senate,,DEM,Kamala D. Harris,203
+Monterey,1005,U.S. Senate,,DEM,Loretta L. Sanchez,266
+Monterey,1006,U.S. Senate,,DEM,Kamala D. Harris,312
+Monterey,1006,U.S. Senate,,DEM,Loretta L. Sanchez,492
+Monterey,1007,U.S. Senate,,DEM,Kamala D. Harris,362
+Monterey,1007,U.S. Senate,,DEM,Loretta L. Sanchez,234
+Monterey,1008,U.S. Senate,,DEM,Kamala D. Harris,432
+Monterey,1008,U.S. Senate,,DEM,Loretta L. Sanchez,308
+Monterey,1009,U.S. Senate,,DEM,Kamala D. Harris,740
+Monterey,1009,U.S. Senate,,DEM,Loretta L. Sanchez,573
+Monterey,1010,U.S. Senate,,DEM,Kamala D. Harris,319
+Monterey,1010,U.S. Senate,,DEM,Loretta L. Sanchez,267
+Monterey,1011,U.S. Senate,,DEM,Kamala D. Harris,455
+Monterey,1011,U.S. Senate,,DEM,Loretta L. Sanchez,511
+Monterey,1012,U.S. Senate,,DEM,Kamala D. Harris,334
+Monterey,1012,U.S. Senate,,DEM,Loretta L. Sanchez,446
+Monterey,1013,U.S. Senate,,DEM,Kamala D. Harris,646
+Monterey,1013,U.S. Senate,,DEM,Loretta L. Sanchez,448
+Monterey,1014,U.S. Senate,,DEM,Kamala D. Harris,462
+Monterey,1014,U.S. Senate,,DEM,Loretta L. Sanchez,347
+Monterey,1015,U.S. Senate,,DEM,Kamala D. Harris,269
+Monterey,1015,U.S. Senate,,DEM,Loretta L. Sanchez,203
+Monterey,1016,U.S. Senate,,DEM,Kamala D. Harris,666
+Monterey,1016,U.S. Senate,,DEM,Loretta L. Sanchez,552
+Monterey,1017,U.S. Senate,,DEM,Kamala D. Harris,162
+Monterey,1017,U.S. Senate,,DEM,Loretta L. Sanchez,200
+Monterey,1018,U.S. Senate,,DEM,Kamala D. Harris,709
+Monterey,1018,U.S. Senate,,DEM,Loretta L. Sanchez,521
+Monterey,2019,U.S. Senate,,DEM,Kamala D. Harris,135
+Monterey,2019,U.S. Senate,,DEM,Loretta L. Sanchez,195
+Monterey,2020,U.S. Senate,,DEM,Kamala D. Harris,652
+Monterey,2020,U.S. Senate,,DEM,Loretta L. Sanchez,563
+Monterey,2021,U.S. Senate,,DEM,Kamala D. Harris,477
+Monterey,2021,U.S. Senate,,DEM,Loretta L. Sanchez,360
+Monterey,2022,U.S. Senate,,DEM,Kamala D. Harris,775
+Monterey,2022,U.S. Senate,,DEM,Loretta L. Sanchez,404
+Monterey,2023,U.S. Senate,,DEM,Kamala D. Harris,734
+Monterey,2023,U.S. Senate,,DEM,Loretta L. Sanchez,557
+Monterey,2024,U.S. Senate,,DEM,Kamala D. Harris,893
+Monterey,2024,U.S. Senate,,DEM,Loretta L. Sanchez,439
+Monterey,2025,U.S. Senate,,DEM,Kamala D. Harris,605
+Monterey,2025,U.S. Senate,,DEM,Loretta L. Sanchez,693
+Monterey,2027,U.S. Senate,,DEM,Kamala D. Harris,693
+Monterey,2027,U.S. Senate,,DEM,Loretta L. Sanchez,301
+Monterey,2028,U.S. Senate,,DEM,Kamala D. Harris,553
+Monterey,2028,U.S. Senate,,DEM,Loretta L. Sanchez,286
+Monterey,2029,U.S. Senate,,DEM,Kamala D. Harris,721
+Monterey,2029,U.S. Senate,,DEM,Loretta L. Sanchez,371
+Monterey,2030,U.S. Senate,,DEM,Kamala D. Harris,759
+Monterey,2030,U.S. Senate,,DEM,Loretta L. Sanchez,366
+Monterey,2031,U.S. Senate,,DEM,Kamala D. Harris,361
+Monterey,2031,U.S. Senate,,DEM,Loretta L. Sanchez,227
+Monterey,2032,U.S. Senate,,DEM,Kamala D. Harris,426
+Monterey,2032,U.S. Senate,,DEM,Loretta L. Sanchez,276
+Monterey,2033,U.S. Senate,,DEM,Kamala D. Harris,207
+Monterey,2033,U.S. Senate,,DEM,Loretta L. Sanchez,221
+Monterey,2034,U.S. Senate,,DEM,Kamala D. Harris,743
+Monterey,2034,U.S. Senate,,DEM,Loretta L. Sanchez,782
+Monterey,2035,U.S. Senate,,DEM,Kamala D. Harris,328
+Monterey,2035,U.S. Senate,,DEM,Loretta L. Sanchez,189
+Monterey,2036,U.S. Senate,,DEM,Kamala D. Harris,485
+Monterey,2036,U.S. Senate,,DEM,Loretta L. Sanchez,459
+Monterey,2037,U.S. Senate,,DEM,Kamala D. Harris,440
+Monterey,2037,U.S. Senate,,DEM,Loretta L. Sanchez,429
+Monterey,2038,U.S. Senate,,DEM,Kamala D. Harris,306
+Monterey,2038,U.S. Senate,,DEM,Loretta L. Sanchez,190
+Monterey,2039,U.S. Senate,,DEM,Kamala D. Harris,532
+Monterey,2039,U.S. Senate,,DEM,Loretta L. Sanchez,405
+Monterey,2040,U.S. Senate,,DEM,Kamala D. Harris,360
+Monterey,2040,U.S. Senate,,DEM,Loretta L. Sanchez,194
+Monterey,2041,U.S. Senate,,DEM,Kamala D. Harris,465
+Monterey,2041,U.S. Senate,,DEM,Loretta L. Sanchez,268
+Monterey,2042,U.S. Senate,,DEM,Kamala D. Harris,502
+Monterey,2042,U.S. Senate,,DEM,Loretta L. Sanchez,352
+Monterey,2043,U.S. Senate,,DEM,Kamala D. Harris,508
+Monterey,2043,U.S. Senate,,DEM,Loretta L. Sanchez,373
+Monterey,2044,U.S. Senate,,DEM,Kamala D. Harris,415
+Monterey,2044,U.S. Senate,,DEM,Loretta L. Sanchez,259
+Monterey,2045,U.S. Senate,,DEM,Kamala D. Harris,603
+Monterey,2045,U.S. Senate,,DEM,Loretta L. Sanchez,441
+Monterey,2046,U.S. Senate,,DEM,Kamala D. Harris,578
+Monterey,2046,U.S. Senate,,DEM,Loretta L. Sanchez,360
+Monterey,2047,U.S. Senate,,DEM,Kamala D. Harris,250
+Monterey,2047,U.S. Senate,,DEM,Loretta L. Sanchez,157
+Monterey,3048,U.S. Senate,,DEM,Kamala D. Harris,270
+Monterey,3048,U.S. Senate,,DEM,Loretta L. Sanchez,305
+Monterey,3049,U.S. Senate,,DEM,Kamala D. Harris,636
+Monterey,3049,U.S. Senate,,DEM,Loretta L. Sanchez,871
+Monterey,3050,U.S. Senate,,DEM,Kamala D. Harris,373
+Monterey,3050,U.S. Senate,,DEM,Loretta L. Sanchez,402
+Monterey,3051,U.S. Senate,,DEM,Kamala D. Harris,515
+Monterey,3051,U.S. Senate,,DEM,Loretta L. Sanchez,507
+Monterey,3052,U.S. Senate,,DEM,Kamala D. Harris,464
+Monterey,3052,U.S. Senate,,DEM,Loretta L. Sanchez,451
+Monterey,3053,U.S. Senate,,DEM,Kamala D. Harris,314
+Monterey,3053,U.S. Senate,,DEM,Loretta L. Sanchez,360
+Monterey,3054,U.S. Senate,,DEM,Kamala D. Harris,476
+Monterey,3054,U.S. Senate,,DEM,Loretta L. Sanchez,464
+Monterey,3055,U.S. Senate,,DEM,Kamala D. Harris,513
+Monterey,3055,U.S. Senate,,DEM,Loretta L. Sanchez,436
+Monterey,3056,U.S. Senate,,DEM,Kamala D. Harris,451
+Monterey,3056,U.S. Senate,,DEM,Loretta L. Sanchez,528
+Monterey,3057,U.S. Senate,,DEM,Kamala D. Harris,412
+Monterey,3057,U.S. Senate,,DEM,Loretta L. Sanchez,345
+Monterey,3058,U.S. Senate,,DEM,Kamala D. Harris,533
+Monterey,3058,U.S. Senate,,DEM,Loretta L. Sanchez,596
+Monterey,3059,U.S. Senate,,DEM,Kamala D. Harris,518
+Monterey,3059,U.S. Senate,,DEM,Loretta L. Sanchez,530
+Monterey,3062,U.S. Senate,,DEM,Kamala D. Harris,524
+Monterey,3062,U.S. Senate,,DEM,Loretta L. Sanchez,275
+Monterey,3063,U.S. Senate,,DEM,Kamala D. Harris,245
+Monterey,3063,U.S. Senate,,DEM,Loretta L. Sanchez,140
+Monterey,3160,U.S. Senate,,DEM,Kamala D. Harris,239
+Monterey,3160,U.S. Senate,,DEM,Loretta L. Sanchez,247
+Monterey,3260,U.S. Senate,,DEM,Kamala D. Harris,149
+Monterey,3260,U.S. Senate,,DEM,Loretta L. Sanchez,129
+Monterey,3360,U.S. Senate,,DEM,Kamala D. Harris,235
+Monterey,3360,U.S. Senate,,DEM,Loretta L. Sanchez,177
+Monterey,3460,U.S. Senate,,DEM,Kamala D. Harris,140
+Monterey,3460,U.S. Senate,,DEM,Loretta L. Sanchez,258
+Monterey,3560,U.S. Senate,,DEM,Kamala D. Harris,241
+Monterey,3560,U.S. Senate,,DEM,Loretta L. Sanchez,181
+Monterey,4064,U.S. Senate,,DEM,Kamala D. Harris,617
+Monterey,4064,U.S. Senate,,DEM,Loretta L. Sanchez,194
+Monterey,4065,U.S. Senate,,DEM,Kamala D. Harris,984
+Monterey,4065,U.S. Senate,,DEM,Loretta L. Sanchez,522
+Monterey,4066,U.S. Senate,,DEM,Kamala D. Harris,493
+Monterey,4066,U.S. Senate,,DEM,Loretta L. Sanchez,202
+Monterey,4067,U.S. Senate,,DEM,Kamala D. Harris,711
+Monterey,4067,U.S. Senate,,DEM,Loretta L. Sanchez,406
+Monterey,4068,U.S. Senate,,DEM,Kamala D. Harris,623
+Monterey,4068,U.S. Senate,,DEM,Loretta L. Sanchez,222
+Monterey,4069,U.S. Senate,,DEM,Kamala D. Harris,424
+Monterey,4069,U.S. Senate,,DEM,Loretta L. Sanchez,351
+Monterey,4070,U.S. Senate,,DEM,Kamala D. Harris,560
+Monterey,4070,U.S. Senate,,DEM,Loretta L. Sanchez,257
+Monterey,4071,U.S. Senate,,DEM,Kamala D. Harris,711
+Monterey,4071,U.S. Senate,,DEM,Loretta L. Sanchez,273
+Monterey,4072,U.S. Senate,,DEM,Kamala D. Harris,354
+Monterey,4072,U.S. Senate,,DEM,Loretta L. Sanchez,176
+Monterey,4073,U.S. Senate,,DEM,Kamala D. Harris,569
+Monterey,4073,U.S. Senate,,DEM,Loretta L. Sanchez,284
+Monterey,4074,U.S. Senate,,DEM,Kamala D. Harris,743
+Monterey,4074,U.S. Senate,,DEM,Loretta L. Sanchez,371
+Monterey,4075,U.S. Senate,,DEM,Kamala D. Harris,598
+Monterey,4075,U.S. Senate,,DEM,Loretta L. Sanchez,249
+Monterey,4076,U.S. Senate,,DEM,Kamala D. Harris,619
+Monterey,4076,U.S. Senate,,DEM,Loretta L. Sanchez,292
+Monterey,4077,U.S. Senate,,DEM,Kamala D. Harris,567
+Monterey,4077,U.S. Senate,,DEM,Loretta L. Sanchez,388
+Monterey,4078,U.S. Senate,,DEM,Kamala D. Harris,712
+Monterey,4078,U.S. Senate,,DEM,Loretta L. Sanchez,337
+Monterey,4079,U.S. Senate,,DEM,Kamala D. Harris,720
+Monterey,4079,U.S. Senate,,DEM,Loretta L. Sanchez,305
+Monterey,4080,U.S. Senate,,DEM,Kamala D. Harris,452
+Monterey,4080,U.S. Senate,,DEM,Loretta L. Sanchez,285
+Monterey,4081,U.S. Senate,,DEM,Kamala D. Harris,714
+Monterey,4081,U.S. Senate,,DEM,Loretta L. Sanchez,335
+Monterey,4082,U.S. Senate,,DEM,Kamala D. Harris,631
+Monterey,4082,U.S. Senate,,DEM,Loretta L. Sanchez,342
+Monterey,4083,U.S. Senate,,DEM,Kamala D. Harris,920
+Monterey,4083,U.S. Senate,,DEM,Loretta L. Sanchez,525
+Monterey,4084,U.S. Senate,,DEM,Kamala D. Harris,813
+Monterey,4084,U.S. Senate,,DEM,Loretta L. Sanchez,380
+Monterey,4085,U.S. Senate,,DEM,Kamala D. Harris,588
+Monterey,4085,U.S. Senate,,DEM,Loretta L. Sanchez,224
+Monterey,4086,U.S. Senate,,DEM,Kamala D. Harris,416
+Monterey,4086,U.S. Senate,,DEM,Loretta L. Sanchez,187
+Monterey,4087,U.S. Senate,,DEM,Kamala D. Harris,726
+Monterey,4087,U.S. Senate,,DEM,Loretta L. Sanchez,267
+Monterey,4088,U.S. Senate,,DEM,Kamala D. Harris,489
+Monterey,4088,U.S. Senate,,DEM,Loretta L. Sanchez,166
+Monterey,4089,U.S. Senate,,DEM,Kamala D. Harris,664
+Monterey,4089,U.S. Senate,,DEM,Loretta L. Sanchez,302
+Monterey,4090,U.S. Senate,,DEM,Kamala D. Harris,621
+Monterey,4090,U.S. Senate,,DEM,Loretta L. Sanchez,247
+Monterey,5091,U.S. Senate,,DEM,Kamala D. Harris,762
+Monterey,5091,U.S. Senate,,DEM,Loretta L. Sanchez,257
+Monterey,5092,U.S. Senate,,DEM,Kamala D. Harris,825
+Monterey,5092,U.S. Senate,,DEM,Loretta L. Sanchez,269
+Monterey,5093,U.S. Senate,,DEM,Kamala D. Harris,1021
+Monterey,5093,U.S. Senate,,DEM,Loretta L. Sanchez,372
+Monterey,5094,U.S. Senate,,DEM,Kamala D. Harris,751
+Monterey,5094,U.S. Senate,,DEM,Loretta L. Sanchez,308
+Monterey,5095,U.S. Senate,,DEM,Kamala D. Harris,689
+Monterey,5095,U.S. Senate,,DEM,Loretta L. Sanchez,264
+Monterey,5096,U.S. Senate,,DEM,Kamala D. Harris,535
+Monterey,5096,U.S. Senate,,DEM,Loretta L. Sanchez,132
+Monterey,5097,U.S. Senate,,DEM,Kamala D. Harris,659
+Monterey,5097,U.S. Senate,,DEM,Loretta L. Sanchez,182
+Monterey,5098,U.S. Senate,,DEM,Kamala D. Harris,735
+Monterey,5098,U.S. Senate,,DEM,Loretta L. Sanchez,200
+Monterey,5099,U.S. Senate,,DEM,Kamala D. Harris,744
+Monterey,5099,U.S. Senate,,DEM,Loretta L. Sanchez,214
+Monterey,5100,U.S. Senate,,DEM,Kamala D. Harris,1057
+Monterey,5100,U.S. Senate,,DEM,Loretta L. Sanchez,367
+Monterey,5101,U.S. Senate,,DEM,Kamala D. Harris,890
+Monterey,5101,U.S. Senate,,DEM,Loretta L. Sanchez,243
+Monterey,5102,U.S. Senate,,DEM,Kamala D. Harris,842
+Monterey,5102,U.S. Senate,,DEM,Loretta L. Sanchez,246
+Monterey,5103,U.S. Senate,,DEM,Kamala D. Harris,860
+Monterey,5103,U.S. Senate,,DEM,Loretta L. Sanchez,221
+Monterey,5104,U.S. Senate,,DEM,Kamala D. Harris,722
+Monterey,5104,U.S. Senate,,DEM,Loretta L. Sanchez,196
+Monterey,5105,U.S. Senate,,DEM,Kamala D. Harris,839
+Monterey,5105,U.S. Senate,,DEM,Loretta L. Sanchez,199
+Monterey,5106,U.S. Senate,,DEM,Kamala D. Harris,731
+Monterey,5106,U.S. Senate,,DEM,Loretta L. Sanchez,260
+Monterey,5107,U.S. Senate,,DEM,Kamala D. Harris,749
+Monterey,5107,U.S. Senate,,DEM,Loretta L. Sanchez,218
+Monterey,5108,U.S. Senate,,DEM,Kamala D. Harris,979
+Monterey,5108,U.S. Senate,,DEM,Loretta L. Sanchez,393
+Monterey,5109,U.S. Senate,,DEM,Kamala D. Harris,654
+Monterey,5109,U.S. Senate,,DEM,Loretta L. Sanchez,275
+Monterey,5110,U.S. Senate,,DEM,Kamala D. Harris,762
+Monterey,5110,U.S. Senate,,DEM,Loretta L. Sanchez,226
+Monterey,5111,U.S. Senate,,DEM,Kamala D. Harris,694
+Monterey,5111,U.S. Senate,,DEM,Loretta L. Sanchez,229
+Monterey,5112,U.S. Senate,,DEM,Kamala D. Harris,682
+Monterey,5112,U.S. Senate,,DEM,Loretta L. Sanchez,207
+Monterey,5113,U.S. Senate,,DEM,Kamala D. Harris,944
+Monterey,5113,U.S. Senate,,DEM,Loretta L. Sanchez,321
+Monterey,5114,U.S. Senate,,DEM,Kamala D. Harris,724
+Monterey,5114,U.S. Senate,,DEM,Loretta L. Sanchez,212
+Monterey,5115,U.S. Senate,,DEM,Kamala D. Harris,418
+Monterey,5115,U.S. Senate,,DEM,Loretta L. Sanchez,117
+Monterey,5116,U.S. Senate,,DEM,Kamala D. Harris,639
+Monterey,5116,U.S. Senate,,DEM,Loretta L. Sanchez,213
+Monterey,5117,U.S. Senate,,DEM,Kamala D. Harris,763
+Monterey,5117,U.S. Senate,,DEM,Loretta L. Sanchez,258
+Monterey,5118,U.S. Senate,,DEM,Kamala D. Harris,678
+Monterey,5118,U.S. Senate,,DEM,Loretta L. Sanchez,235
+Monterey,5119,U.S. Senate,,DEM,Kamala D. Harris,577
+Monterey,5119,U.S. Senate,,DEM,Loretta L. Sanchez,159
+Monterey,5120,U.S. Senate,,DEM,Kamala D. Harris,684
+Monterey,5120,U.S. Senate,,DEM,Loretta L. Sanchez,191
+Monterey,5121,U.S. Senate,,DEM,Kamala D. Harris,269
+Monterey,5121,U.S. Senate,,DEM,Loretta L. Sanchez,88
+Monterey,5122,U.S. Senate,,DEM,Kamala D. Harris,343
+Monterey,5122,U.S. Senate,,DEM,Loretta L. Sanchez,83
+Monterey,5123,U.S. Senate,,DEM,Kamala D. Harris,588
+Monterey,5123,U.S. Senate,,DEM,Loretta L. Sanchez,225
+Monterey,5124,U.S. Senate,,DEM,Kamala D. Harris,1054
+Monterey,5124,U.S. Senate,,DEM,Loretta L. Sanchez,297
+Monterey,5125,U.S. Senate,,DEM,Kamala D. Harris,738
+Monterey,5125,U.S. Senate,,DEM,Loretta L. Sanchez,259
+Monterey,5126,U.S. Senate,,DEM,Kamala D. Harris,851
+Monterey,5126,U.S. Senate,,DEM,Loretta L. Sanchez,326
+Monterey,5127,U.S. Senate,,DEM,Kamala D. Harris,710
+Monterey,5127,U.S. Senate,,DEM,Loretta L. Sanchez,272
+Monterey,9101,U.S. Senate,,DEM,Kamala D. Harris,15
+Monterey,9101,U.S. Senate,,DEM,Loretta L. Sanchez,14
+Monterey,9102,U.S. Senate,,DEM,Kamala D. Harris,107
+Monterey,9102,U.S. Senate,,DEM,Loretta L. Sanchez,69
+Monterey,9103,U.S. Senate,,DEM,Kamala D. Harris,53
+Monterey,9103,U.S. Senate,,DEM,Loretta L. Sanchez,19
+Monterey,9204,U.S. Senate,,DEM,Kamala D. Harris,0
+Monterey,9204,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Monterey,9205,U.S. Senate,,DEM,Kamala D. Harris,0
+Monterey,9205,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Monterey,9206,U.S. Senate,,DEM,Kamala D. Harris,0
+Monterey,9206,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Monterey,9207,U.S. Senate,,DEM,Kamala D. Harris,149
+Monterey,9207,U.S. Senate,,DEM,Loretta L. Sanchez,108
+Monterey,9208,U.S. Senate,,DEM,Kamala D. Harris,22
+Monterey,9208,U.S. Senate,,DEM,Loretta L. Sanchez,16
+Monterey,9209,U.S. Senate,,DEM,Kamala D. Harris,44
+Monterey,9209,U.S. Senate,,DEM,Loretta L. Sanchez,31
+Monterey,9210,U.S. Senate,,DEM,Kamala D. Harris,14
+Monterey,9210,U.S. Senate,,DEM,Loretta L. Sanchez,9
+Monterey,9211,U.S. Senate,,DEM,Kamala D. Harris,15
+Monterey,9211,U.S. Senate,,DEM,Loretta L. Sanchez,10
+Monterey,9212,U.S. Senate,,DEM,Kamala D. Harris,79
+Monterey,9212,U.S. Senate,,DEM,Loretta L. Sanchez,40
+Monterey,9213,U.S. Senate,,DEM,Kamala D. Harris,22
+Monterey,9213,U.S. Senate,,DEM,Loretta L. Sanchez,5
+Monterey,9214,U.S. Senate,,DEM,Kamala D. Harris,67
+Monterey,9214,U.S. Senate,,DEM,Loretta L. Sanchez,38
+Monterey,9215,U.S. Senate,,DEM,Kamala D. Harris,20
+Monterey,9215,U.S. Senate,,DEM,Loretta L. Sanchez,13
+Monterey,9216,U.S. Senate,,DEM,Kamala D. Harris,24
+Monterey,9216,U.S. Senate,,DEM,Loretta L. Sanchez,23
+Monterey,9217,U.S. Senate,,DEM,Kamala D. Harris,16
+Monterey,9217,U.S. Senate,,DEM,Loretta L. Sanchez,10
+Monterey,9218,U.S. Senate,,DEM,Kamala D. Harris,0
+Monterey,9218,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Monterey,9319,U.S. Senate,,DEM,Kamala D. Harris,310
+Monterey,9319,U.S. Senate,,DEM,Loretta L. Sanchez,103
+Monterey,9320,U.S. Senate,,DEM,Kamala D. Harris,0
+Monterey,9320,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Monterey,9321,U.S. Senate,,DEM,Kamala D. Harris,11
+Monterey,9321,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Monterey,9322,U.S. Senate,,DEM,Kamala D. Harris,90
+Monterey,9322,U.S. Senate,,DEM,Loretta L. Sanchez,57
+Monterey,9323,U.S. Senate,,DEM,Kamala D. Harris,10
+Monterey,9323,U.S. Senate,,DEM,Loretta L. Sanchez,6
+Monterey,9324,U.S. Senate,,DEM,Kamala D. Harris,55
+Monterey,9324,U.S. Senate,,DEM,Loretta L. Sanchez,21
+Monterey,9325,U.S. Senate,,DEM,Kamala D. Harris,24
+Monterey,9325,U.S. Senate,,DEM,Loretta L. Sanchez,13
+Monterey,9326,U.S. Senate,,DEM,Kamala D. Harris,56
+Monterey,9326,U.S. Senate,,DEM,Loretta L. Sanchez,57
+Monterey,9327,U.S. Senate,,DEM,Kamala D. Harris,27
+Monterey,9327,U.S. Senate,,DEM,Loretta L. Sanchez,6
+Monterey,9328,U.S. Senate,,DEM,Kamala D. Harris,82
+Monterey,9328,U.S. Senate,,DEM,Loretta L. Sanchez,52
+Monterey,9329,U.S. Senate,,DEM,Kamala D. Harris,39
+Monterey,9329,U.S. Senate,,DEM,Loretta L. Sanchez,48
+Monterey,9330,U.S. Senate,,DEM,Kamala D. Harris,13
+Monterey,9330,U.S. Senate,,DEM,Loretta L. Sanchez,8
+Monterey,9331,U.S. Senate,,DEM,Kamala D. Harris,13
+Monterey,9331,U.S. Senate,,DEM,Loretta L. Sanchez,9
+Monterey,9332,U.S. Senate,,DEM,Kamala D. Harris,119
+Monterey,9332,U.S. Senate,,DEM,Loretta L. Sanchez,65
+Monterey,9333,U.S. Senate,,DEM,Kamala D. Harris,70
+Monterey,9333,U.S. Senate,,DEM,Loretta L. Sanchez,32
+Monterey,9334,U.S. Senate,,DEM,Kamala D. Harris,20
+Monterey,9334,U.S. Senate,,DEM,Loretta L. Sanchez,8
+Monterey,9335,U.S. Senate,,DEM,Kamala D. Harris,3
+Monterey,9335,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Monterey,9336,U.S. Senate,,DEM,Kamala D. Harris,64
+Monterey,9336,U.S. Senate,,DEM,Loretta L. Sanchez,56
+Monterey,9337,U.S. Senate,,DEM,Kamala D. Harris,42
+Monterey,9337,U.S. Senate,,DEM,Loretta L. Sanchez,36
+Monterey,9338,U.S. Senate,,DEM,Kamala D. Harris,5
+Monterey,9338,U.S. Senate,,DEM,Loretta L. Sanchez,5
+Monterey,9339,U.S. Senate,,DEM,Kamala D. Harris,33
+Monterey,9339,U.S. Senate,,DEM,Loretta L. Sanchez,28
+Monterey,9340,U.S. Senate,,DEM,Kamala D. Harris,30
+Monterey,9340,U.S. Senate,,DEM,Loretta L. Sanchez,12
+Monterey,9441,U.S. Senate,,DEM,Kamala D. Harris,1
+Monterey,9441,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Monterey,9442,U.S. Senate,,DEM,Kamala D. Harris,0
+Monterey,9442,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Monterey,9443,U.S. Senate,,DEM,Kamala D. Harris,0
+Monterey,9443,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Monterey,9444,U.S. Senate,,DEM,Kamala D. Harris,17
+Monterey,9444,U.S. Senate,,DEM,Loretta L. Sanchez,17
+Monterey,9445,U.S. Senate,,DEM,Kamala D. Harris,68
+Monterey,9445,U.S. Senate,,DEM,Loretta L. Sanchez,16
+Monterey,9446,U.S. Senate,,DEM,Kamala D. Harris,5
+Monterey,9446,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Monterey,9447,U.S. Senate,,DEM,Kamala D. Harris,4
+Monterey,9447,U.S. Senate,,DEM,Loretta L. Sanchez,7
+Monterey,9448,U.S. Senate,,DEM,Kamala D. Harris,0
+Monterey,9448,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Monterey,9449,U.S. Senate,,DEM,Kamala D. Harris,215
+Monterey,9449,U.S. Senate,,DEM,Loretta L. Sanchez,85
+Monterey,9450,U.S. Senate,,DEM,Kamala D. Harris,99
+Monterey,9450,U.S. Senate,,DEM,Loretta L. Sanchez,35
+Monterey,9451,U.S. Senate,,DEM,Kamala D. Harris,24
+Monterey,9451,U.S. Senate,,DEM,Loretta L. Sanchez,28
+Monterey,9452,U.S. Senate,,DEM,Kamala D. Harris,18
+Monterey,9452,U.S. Senate,,DEM,Loretta L. Sanchez,17
+Monterey,9553,U.S. Senate,,DEM,Kamala D. Harris,80
+Monterey,9553,U.S. Senate,,DEM,Loretta L. Sanchez,56
+Monterey,9554,U.S. Senate,,DEM,Kamala D. Harris,278
+Monterey,9554,U.S. Senate,,DEM,Loretta L. Sanchez,64
+Monterey,9555,U.S. Senate,,DEM,Kamala D. Harris,150
+Monterey,9555,U.S. Senate,,DEM,Loretta L. Sanchez,54
+Monterey,9556,U.S. Senate,,DEM,Kamala D. Harris,234
+Monterey,9556,U.S. Senate,,DEM,Loretta L. Sanchez,97
+Monterey,9557,U.S. Senate,,DEM,Kamala D. Harris,358
+Monterey,9557,U.S. Senate,,DEM,Loretta L. Sanchez,143
+Monterey,9558,U.S. Senate,,DEM,Kamala D. Harris,246
+Monterey,9558,U.S. Senate,,DEM,Loretta L. Sanchez,91
+Monterey,9559,U.S. Senate,,DEM,Kamala D. Harris,485
+Monterey,9559,U.S. Senate,,DEM,Loretta L. Sanchez,143
+Monterey,9560,U.S. Senate,,DEM,Kamala D. Harris,187
+Monterey,9560,U.S. Senate,,DEM,Loretta L. Sanchez,46
+Monterey,9561,U.S. Senate,,DEM,Kamala D. Harris,107
+Monterey,9561,U.S. Senate,,DEM,Loretta L. Sanchez,37
+Monterey,9562,U.S. Senate,,DEM,Kamala D. Harris,52
+Monterey,9562,U.S. Senate,,DEM,Loretta L. Sanchez,20
+Monterey,9563,U.S. Senate,,DEM,Kamala D. Harris,10
+Monterey,9563,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Monterey,9564,U.S. Senate,,DEM,Kamala D. Harris,41
+Monterey,9564,U.S. Senate,,DEM,Loretta L. Sanchez,18
+Monterey,9565,U.S. Senate,,DEM,Kamala D. Harris,37
+Monterey,9565,U.S. Senate,,DEM,Loretta L. Sanchez,14
+Monterey,9567,U.S. Senate,,DEM,Kamala D. Harris,64
+Monterey,9567,U.S. Senate,,DEM,Loretta L. Sanchez,32

--- a/2016/20161108__ca__general__napa__precinct.csv
+++ b/2016/20161108__ca__general__napa__precinct.csv
@@ -6639,335 +6639,335 @@ Napa,561347,Proposition 67,,N/A,Yes,1175
 Napa,561347,Proposition 67,,N/A,No,830
 Napa,561348,Proposition 67,,N/A,Yes,73
 Napa,561348,Proposition 67,,N/A,No,52
-Napa,111131,U.S. Senate,,DEM,Kamala Harris,135
-Napa,111131,U.S. Senate,,DEM,Loretta Sanchez,116
-Napa,111151,U.S. Senate,,DEM,Kamala Harris,32
-Napa,111151,U.S. Senate,,DEM,Loretta Sanchez,5
-Napa,111152,U.S. Senate,,DEM,Kamala Harris,212
-Napa,111152,U.S. Senate,,DEM,Loretta Sanchez,67
-Napa,111431,U.S. Senate,,DEM,Kamala Harris,12
-Napa,111431,U.S. Senate,,DEM,Loretta Sanchez,5
-Napa,111751,U.S. Senate,,DEM,Kamala Harris,52
-Napa,111751,U.S. Senate,,DEM,Loretta Sanchez,17
-Napa,111752,U.S. Senate,,DEM,Kamala Harris,119
-Napa,111752,U.S. Senate,,DEM,Loretta Sanchez,55
-Napa,121131,U.S. Senate,,DEM,Kamala Harris,81
-Napa,121131,U.S. Senate,,DEM,Loretta Sanchez,40
-Napa,121132,U.S. Senate,,DEM,Kamala Harris,185
-Napa,121132,U.S. Senate,,DEM,Loretta Sanchez,124
-Napa,121133,U.S. Senate,,DEM,Kamala Harris,215
-Napa,121133,U.S. Senate,,DEM,Loretta Sanchez,147
-Napa,121134,U.S. Senate,,DEM,Kamala Harris,115
-Napa,121134,U.S. Senate,,DEM,Loretta Sanchez,47
-Napa,121135,U.S. Senate,,DEM,Kamala Harris,272
-Napa,121135,U.S. Senate,,DEM,Loretta Sanchez,152
-Napa,121136,U.S. Senate,,DEM,Kamala Harris,363
-Napa,121136,U.S. Senate,,DEM,Loretta Sanchez,156
-Napa,121151,U.S. Senate,,DEM,Kamala Harris,111
-Napa,121151,U.S. Senate,,DEM,Loretta Sanchez,82
-Napa,121152,U.S. Senate,,DEM,Kamala Harris,493
-Napa,121152,U.S. Senate,,DEM,Loretta Sanchez,194
-Napa,121153,U.S. Senate,,DEM,Kamala Harris,76
-Napa,121153,U.S. Senate,,DEM,Loretta Sanchez,39
-Napa,121154,U.S. Senate,,DEM,Kamala Harris,41
-Napa,121154,U.S. Senate,,DEM,Loretta Sanchez,21
-Napa,121155,U.S. Senate,,DEM,Kamala Harris,81
-Napa,121155,U.S. Senate,,DEM,Loretta Sanchez,74
-Napa,121156,U.S. Senate,,DEM,Kamala Harris,219
-Napa,121156,U.S. Senate,,DEM,Loretta Sanchez,77
-Napa,121157,U.S. Senate,,DEM,Kamala Harris,170
-Napa,121157,U.S. Senate,,DEM,Loretta Sanchez,101
-Napa,121158,U.S. Senate,,DEM,Kamala Harris,299
-Napa,121158,U.S. Senate,,DEM,Loretta Sanchez,96
-Napa,121161,U.S. Senate,,DEM,Kamala Harris,151
-Napa,121161,U.S. Senate,,DEM,Loretta Sanchez,87
-Napa,121162,U.S. Senate,,DEM,Kamala Harris,308
-Napa,121162,U.S. Senate,,DEM,Loretta Sanchez,125
-Napa,121221,U.S. Senate,,DEM,Kamala Harris,115
-Napa,121221,U.S. Senate,,DEM,Loretta Sanchez,71
-Napa,121222,U.S. Senate,,DEM,Kamala Harris,40
-Napa,121222,U.S. Senate,,DEM,Loretta Sanchez,10
-Napa,121223,U.S. Senate,,DEM,Kamala Harris,48
-Napa,121223,U.S. Senate,,DEM,Loretta Sanchez,30
-Napa,121231,U.S. Senate,,DEM,Kamala Harris,10
-Napa,121231,U.S. Senate,,DEM,Loretta Sanchez,3
-Napa,121232,U.S. Senate,,DEM,Kamala Harris,111
-Napa,121232,U.S. Senate,,DEM,Loretta Sanchez,49
-Napa,121233,U.S. Senate,,DEM,Kamala Harris,346
-Napa,121233,U.S. Senate,,DEM,Loretta Sanchez,137
-Napa,121234,U.S. Senate,,DEM,Kamala Harris,254
-Napa,121234,U.S. Senate,,DEM,Loretta Sanchez,114
-Napa,121235,U.S. Senate,,DEM,Kamala Harris,228
-Napa,121235,U.S. Senate,,DEM,Loretta Sanchez,93
-Napa,121236,U.S. Senate,,DEM,Kamala Harris,205
-Napa,121236,U.S. Senate,,DEM,Loretta Sanchez,85
-Napa,121237,U.S. Senate,,DEM,Kamala Harris,21
-Napa,121237,U.S. Senate,,DEM,Loretta Sanchez,18
-Napa,121238,U.S. Senate,,DEM,Kamala Harris,193
-Napa,121238,U.S. Senate,,DEM,Loretta Sanchez,165
-Napa,121239,U.S. Senate,,DEM,Kamala Harris,246
-Napa,121239,U.S. Senate,,DEM,Loretta Sanchez,142
-Napa,121431,U.S. Senate,,DEM,Kamala Harris,345
-Napa,121431,U.S. Senate,,DEM,Loretta Sanchez,143
-Napa,121551,U.S. Senate,,DEM,Kamala Harris,71
-Napa,121551,U.S. Senate,,DEM,Loretta Sanchez,33
-Napa,121552,U.S. Senate,,DEM,Kamala Harris,81
-Napa,121552,U.S. Senate,,DEM,Loretta Sanchez,66
-Napa,121751,U.S. Senate,,DEM,Kamala Harris,203
-Napa,121751,U.S. Senate,,DEM,Loretta Sanchez,50
-Napa,121752,U.S. Senate,,DEM,Kamala Harris,324
-Napa,121752,U.S. Senate,,DEM,Loretta Sanchez,146
-Napa,211161,U.S. Senate,,DEM,Kamala Harris,33
-Napa,211161,U.S. Senate,,DEM,Loretta Sanchez,17
-Napa,211162,U.S. Senate,,DEM,Kamala Harris,5
-Napa,211162,U.S. Senate,,DEM,Loretta Sanchez,7
-Napa,211561,U.S. Senate,,DEM,Kamala Harris,168
-Napa,211561,U.S. Senate,,DEM,Loretta Sanchez,136
-Napa,211562,U.S. Senate,,DEM,Kamala Harris,196
-Napa,211562,U.S. Senate,,DEM,Loretta Sanchez,134
-Napa,211563,U.S. Senate,,DEM,Kamala Harris,20
-Napa,211563,U.S. Senate,,DEM,Loretta Sanchez,4
-Napa,211751,U.S. Senate,,DEM,Kamala Harris,31
-Napa,211751,U.S. Senate,,DEM,Loretta Sanchez,13
-Napa,211761,U.S. Senate,,DEM,Kamala Harris,204
-Napa,211761,U.S. Senate,,DEM,Loretta Sanchez,84
-Napa,221161,U.S. Senate,,DEM,Kamala Harris,155
-Napa,221161,U.S. Senate,,DEM,Loretta Sanchez,58
-Napa,221162,U.S. Senate,,DEM,Kamala Harris,251
-Napa,221162,U.S. Senate,,DEM,Loretta Sanchez,112
-Napa,221163,U.S. Senate,,DEM,Kamala Harris,195
-Napa,221163,U.S. Senate,,DEM,Loretta Sanchez,75
-Napa,221231,U.S. Senate,,DEM,Kamala Harris,181
-Napa,221231,U.S. Senate,,DEM,Loretta Sanchez,73
-Napa,221232,U.S. Senate,,DEM,Kamala Harris,212
-Napa,221232,U.S. Senate,,DEM,Loretta Sanchez,62
-Napa,221233,U.S. Senate,,DEM,Kamala Harris,20
-Napa,221233,U.S. Senate,,DEM,Loretta Sanchez,13
-Napa,221551,U.S. Senate,,DEM,Kamala Harris,180
-Napa,221551,U.S. Senate,,DEM,Loretta Sanchez,177
-Napa,221552,U.S. Senate,,DEM,Kamala Harris,126
-Napa,221552,U.S. Senate,,DEM,Loretta Sanchez,106
-Napa,221553,U.S. Senate,,DEM,Kamala Harris,105
-Napa,221553,U.S. Senate,,DEM,Loretta Sanchez,79
-Napa,221561,U.S. Senate,,DEM,Kamala Harris,64
-Napa,221561,U.S. Senate,,DEM,Loretta Sanchez,44
-Napa,221562,U.S. Senate,,DEM,Kamala Harris,264
-Napa,221562,U.S. Senate,,DEM,Loretta Sanchez,160
-Napa,221563,U.S. Senate,,DEM,Kamala Harris,316
-Napa,221563,U.S. Senate,,DEM,Loretta Sanchez,148
-Napa,221564,U.S. Senate,,DEM,Kamala Harris,304
-Napa,221564,U.S. Senate,,DEM,Loretta Sanchez,137
-Napa,221565,U.S. Senate,,DEM,Kamala Harris,298
-Napa,221565,U.S. Senate,,DEM,Loretta Sanchez,133
-Napa,221566,U.S. Senate,,DEM,Kamala Harris,169
-Napa,221566,U.S. Senate,,DEM,Loretta Sanchez,120
-Napa,221571,U.S. Senate,,DEM,Kamala Harris,1013
-Napa,221571,U.S. Senate,,DEM,Loretta Sanchez,601
-Napa,221572,U.S. Senate,,DEM,Kamala Harris,364
-Napa,221572,U.S. Senate,,DEM,Loretta Sanchez,203
-Napa,221573,U.S. Senate,,DEM,Kamala Harris,250
-Napa,221573,U.S. Senate,,DEM,Loretta Sanchez,149
-Napa,221574,U.S. Senate,,DEM,Kamala Harris,385
-Napa,221574,U.S. Senate,,DEM,Loretta Sanchez,187
-Napa,221671,U.S. Senate,,DEM,Kamala Harris,201
-Napa,221671,U.S. Senate,,DEM,Loretta Sanchez,52
-Napa,221672,U.S. Senate,,DEM,Kamala Harris,306
-Napa,221672,U.S. Senate,,DEM,Loretta Sanchez,210
-Napa,221673,U.S. Senate,,DEM,Kamala Harris,214
-Napa,221673,U.S. Senate,,DEM,Loretta Sanchez,85
-Napa,221674,U.S. Senate,,DEM,Kamala Harris,317
-Napa,221674,U.S. Senate,,DEM,Loretta Sanchez,165
-Napa,221675,U.S. Senate,,DEM,Kamala Harris,540
-Napa,221675,U.S. Senate,,DEM,Loretta Sanchez,323
-Napa,221676,U.S. Senate,,DEM,Kamala Harris,149
-Napa,221676,U.S. Senate,,DEM,Loretta Sanchez,110
-Napa,221762,U.S. Senate,,DEM,Kamala Harris,359
-Napa,221762,U.S. Senate,,DEM,Loretta Sanchez,124
-Napa,311411,U.S. Senate,,DEM,Kamala Harris,13
-Napa,311411,U.S. Senate,,DEM,Loretta Sanchez,6
-Napa,311471,U.S. Senate,,DEM,Kamala Harris,32
-Napa,311471,U.S. Senate,,DEM,Loretta Sanchez,10
-Napa,311571,U.S. Senate,,DEM,Kamala Harris,40
-Napa,311571,U.S. Senate,,DEM,Loretta Sanchez,32
-Napa,311611,U.S. Senate,,DEM,Kamala Harris,284
-Napa,311611,U.S. Senate,,DEM,Loretta Sanchez,148
-Napa,311671,U.S. Senate,,DEM,Kamala Harris,176
-Napa,311671,U.S. Senate,,DEM,Loretta Sanchez,89
-Napa,311712,U.S. Senate,,DEM,Kamala Harris,10
-Napa,311712,U.S. Senate,,DEM,Loretta Sanchez,7
-Napa,312401,U.S. Senate,,DEM,Kamala Harris,1
-Napa,312401,U.S. Senate,,DEM,Loretta Sanchez,2
-Napa,312601,U.S. Senate,,DEM,Kamala Harris,65
-Napa,312601,U.S. Senate,,DEM,Loretta Sanchez,40
-Napa,312602,U.S. Senate,,DEM,Kamala Harris,133
-Napa,312602,U.S. Senate,,DEM,Loretta Sanchez,112
-Napa,312701,U.S. Senate,,DEM,Kamala Harris,24
-Napa,312701,U.S. Senate,,DEM,Loretta Sanchez,25
-Napa,312702,U.S. Senate,,DEM,Kamala Harris,22
-Napa,312702,U.S. Senate,,DEM,Loretta Sanchez,13
-Napa,312703,U.S. Senate,,DEM,Kamala Harris,4
-Napa,312703,U.S. Senate,,DEM,Loretta Sanchez,0
-Napa,312704,U.S. Senate,,DEM,Kamala Harris,87
-Napa,312704,U.S. Senate,,DEM,Loretta Sanchez,39
-Napa,312705,U.S. Senate,,DEM,Kamala Harris,206
-Napa,312705,U.S. Senate,,DEM,Loretta Sanchez,83
-Napa,312706,U.S. Senate,,DEM,Kamala Harris,155
-Napa,312706,U.S. Senate,,DEM,Loretta Sanchez,52
-Napa,312707,U.S. Senate,,DEM,Kamala Harris,122
-Napa,312707,U.S. Senate,,DEM,Loretta Sanchez,55
-Napa,312708,U.S. Senate,,DEM,Kamala Harris,221
-Napa,312708,U.S. Senate,,DEM,Loretta Sanchez,76
-Napa,312709,U.S. Senate,,DEM,Kamala Harris,190
-Napa,312709,U.S. Senate,,DEM,Loretta Sanchez,85
-Napa,313701,U.S. Senate,,DEM,Kamala Harris,235
-Napa,313701,U.S. Senate,,DEM,Loretta Sanchez,109
-Napa,313702,U.S. Senate,,DEM,Kamala Harris,134
-Napa,313702,U.S. Senate,,DEM,Loretta Sanchez,57
-Napa,314701,U.S. Senate,,DEM,Kamala Harris,800
-Napa,314701,U.S. Senate,,DEM,Loretta Sanchez,431
-Napa,315701,U.S. Senate,,DEM,Kamala Harris,66
-Napa,315701,U.S. Senate,,DEM,Loretta Sanchez,55
-Napa,315702,U.S. Senate,,DEM,Kamala Harris,94
-Napa,315702,U.S. Senate,,DEM,Loretta Sanchez,57
-Napa,321671,U.S. Senate,,DEM,Kamala Harris,247
-Napa,321671,U.S. Senate,,DEM,Loretta Sanchez,152
-Napa,321672,U.S. Senate,,DEM,Kamala Harris,224
-Napa,321672,U.S. Senate,,DEM,Loretta Sanchez,133
-Napa,332601,U.S. Senate,,DEM,Kamala Harris,388
-Napa,332601,U.S. Senate,,DEM,Loretta Sanchez,173
-Napa,332602,U.S. Senate,,DEM,Kamala Harris,287
-Napa,332602,U.S. Senate,,DEM,Loretta Sanchez,91
-Napa,332603,U.S. Senate,,DEM,Kamala Harris,404
-Napa,332603,U.S. Senate,,DEM,Loretta Sanchez,113
-Napa,332604,U.S. Senate,,DEM,Kamala Harris,354
-Napa,332604,U.S. Senate,,DEM,Loretta Sanchez,166
-Napa,332605,U.S. Senate,,DEM,Kamala Harris,220
-Napa,332605,U.S. Senate,,DEM,Loretta Sanchez,92
-Napa,332606,U.S. Senate,,DEM,Kamala Harris,168
-Napa,332606,U.S. Senate,,DEM,Loretta Sanchez,36
-Napa,343701,U.S. Senate,,DEM,Kamala Harris,428
-Napa,343701,U.S. Senate,,DEM,Loretta Sanchez,238
-Napa,343702,U.S. Senate,,DEM,Kamala Harris,214
-Napa,343702,U.S. Senate,,DEM,Loretta Sanchez,79
-Napa,343703,U.S. Senate,,DEM,Kamala Harris,241
-Napa,343703,U.S. Senate,,DEM,Loretta Sanchez,68
-Napa,343704,U.S. Senate,,DEM,Kamala Harris,157
-Napa,343704,U.S. Senate,,DEM,Loretta Sanchez,90
-Napa,343705,U.S. Senate,,DEM,Kamala Harris,184
-Napa,343705,U.S. Senate,,DEM,Loretta Sanchez,69
-Napa,351611,U.S. Senate,,DEM,Kamala Harris,292
-Napa,351611,U.S. Senate,,DEM,Loretta Sanchez,124
-Napa,351612,U.S. Senate,,DEM,Kamala Harris,269
-Napa,351612,U.S. Senate,,DEM,Loretta Sanchez,86
-Napa,351613,U.S. Senate,,DEM,Kamala Harris,334
-Napa,351613,U.S. Senate,,DEM,Loretta Sanchez,109
-Napa,351614,U.S. Senate,,DEM,Kamala Harris,144
-Napa,351614,U.S. Senate,,DEM,Loretta Sanchez,49
-Napa,411221,U.S. Senate,,DEM,Kamala Harris,39
-Napa,411221,U.S. Senate,,DEM,Loretta Sanchez,26
-Napa,411411,U.S. Senate,,DEM,Kamala Harris,93
-Napa,411411,U.S. Senate,,DEM,Loretta Sanchez,40
-Napa,411412,U.S. Senate,,DEM,Kamala Harris,164
-Napa,411412,U.S. Senate,,DEM,Loretta Sanchez,83
-Napa,411413,U.S. Senate,,DEM,Kamala Harris,150
-Napa,411413,U.S. Senate,,DEM,Loretta Sanchez,74
-Napa,411414,U.S. Senate,,DEM,Kamala Harris,78
-Napa,411414,U.S. Senate,,DEM,Loretta Sanchez,30
-Napa,411415,U.S. Senate,,DEM,Kamala Harris,253
-Napa,411415,U.S. Senate,,DEM,Loretta Sanchez,139
-Napa,411416,U.S. Senate,,DEM,Kamala Harris,316
-Napa,411416,U.S. Senate,,DEM,Loretta Sanchez,165
-Napa,411417,U.S. Senate,,DEM,Kamala Harris,31
-Napa,411417,U.S. Senate,,DEM,Loretta Sanchez,15
-Napa,411418,U.S. Senate,,DEM,Kamala Harris,73
-Napa,411418,U.S. Senate,,DEM,Loretta Sanchez,61
-Napa,411419,U.S. Senate,,DEM,Kamala Harris,433
-Napa,411419,U.S. Senate,,DEM,Loretta Sanchez,222
-Napa,411711,U.S. Senate,,DEM,Kamala Harris,157
-Napa,411711,U.S. Senate,,DEM,Loretta Sanchez,109
-Napa,411712,U.S. Senate,,DEM,Kamala Harris,178
-Napa,411712,U.S. Senate,,DEM,Loretta Sanchez,93
-Napa,411713,U.S. Senate,,DEM,Kamala Harris,77
-Napa,411713,U.S. Senate,,DEM,Loretta Sanchez,25
-Napa,416801,U.S. Senate,,DEM,Kamala Harris,62
-Napa,416801,U.S. Senate,,DEM,Loretta Sanchez,54
-Napa,421221,U.S. Senate,,DEM,Kamala Harris,142
-Napa,421221,U.S. Senate,,DEM,Loretta Sanchez,131
-Napa,421222,U.S. Senate,,DEM,Kamala Harris,200
-Napa,421222,U.S. Senate,,DEM,Loretta Sanchez,127
-Napa,421223,U.S. Senate,,DEM,Kamala Harris,28
-Napa,421223,U.S. Senate,,DEM,Loretta Sanchez,30
-Napa,421224,U.S. Senate,,DEM,Kamala Harris,274
-Napa,421224,U.S. Senate,,DEM,Loretta Sanchez,148
-Napa,421225,U.S. Senate,,DEM,Kamala Harris,225
-Napa,421225,U.S. Senate,,DEM,Loretta Sanchez,89
-Napa,421226,U.S. Senate,,DEM,Kamala Harris,225
-Napa,421226,U.S. Senate,,DEM,Loretta Sanchez,95
-Napa,421227,U.S. Senate,,DEM,Kamala Harris,112
-Napa,421227,U.S. Senate,,DEM,Loretta Sanchez,59
-Napa,421421,U.S. Senate,,DEM,Kamala Harris,61
-Napa,421421,U.S. Senate,,DEM,Loretta Sanchez,26
-Napa,421422,U.S. Senate,,DEM,Kamala Harris,210
-Napa,421422,U.S. Senate,,DEM,Loretta Sanchez,169
-Napa,421423,U.S. Senate,,DEM,Kamala Harris,165
-Napa,421423,U.S. Senate,,DEM,Loretta Sanchez,131
-Napa,421424,U.S. Senate,,DEM,Kamala Harris,359
-Napa,421424,U.S. Senate,,DEM,Loretta Sanchez,200
-Napa,421425,U.S. Senate,,DEM,Kamala Harris,370
-Napa,421425,U.S. Senate,,DEM,Loretta Sanchez,168
-Napa,421426,U.S. Senate,,DEM,Kamala Harris,326
-Napa,421426,U.S. Senate,,DEM,Loretta Sanchez,173
-Napa,421427,U.S. Senate,,DEM,Kamala Harris,348
-Napa,421427,U.S. Senate,,DEM,Loretta Sanchez,158
-Napa,421471,U.S. Senate,,DEM,Kamala Harris,959
-Napa,421471,U.S. Senate,,DEM,Loretta Sanchez,437
-Napa,421521,U.S. Senate,,DEM,Kamala Harris,5
-Napa,421521,U.S. Senate,,DEM,Loretta Sanchez,1
-Napa,421571,U.S. Senate,,DEM,Kamala Harris,314
-Napa,421571,U.S. Senate,,DEM,Loretta Sanchez,191
-Napa,421671,U.S. Senate,,DEM,Kamala Harris,260
-Napa,421671,U.S. Senate,,DEM,Loretta Sanchez,205
-Napa,511141,U.S. Senate,,DEM,Kamala Harris,82
-Napa,511141,U.S. Senate,,DEM,Loretta Sanchez,49
-Napa,511211,U.S. Senate,,DEM,Kamala Harris,127
-Napa,511211,U.S. Senate,,DEM,Loretta Sanchez,53
-Napa,511221,U.S. Senate,,DEM,Kamala Harris,47
-Napa,511221,U.S. Senate,,DEM,Loretta Sanchez,15
-Napa,511411,U.S. Senate,,DEM,Kamala Harris,312
-Napa,511411,U.S. Senate,,DEM,Loretta Sanchez,148
-Napa,511431,U.S. Senate,,DEM,Kamala Harris,201
-Napa,511431,U.S. Senate,,DEM,Loretta Sanchez,103
-Napa,511441,U.S. Senate,,DEM,Kamala Harris,24
-Napa,511441,U.S. Senate,,DEM,Loretta Sanchez,5
-Napa,521141,U.S. Senate,,DEM,Kamala Harris,372
-Napa,521141,U.S. Senate,,DEM,Loretta Sanchez,213
-Napa,521142,U.S. Senate,,DEM,Kamala Harris,440
-Napa,521142,U.S. Senate,,DEM,Loretta Sanchez,169
-Napa,521143,U.S. Senate,,DEM,Kamala Harris,2
-Napa,521143,U.S. Senate,,DEM,Loretta Sanchez,0
-Napa,521221,U.S. Senate,,DEM,Kamala Harris,148
-Napa,521221,U.S. Senate,,DEM,Loretta Sanchez,39
-Napa,521222,U.S. Senate,,DEM,Kamala Harris,67
-Napa,521222,U.S. Senate,,DEM,Loretta Sanchez,29
-Napa,521223,U.S. Senate,,DEM,Kamala Harris,422
-Napa,521223,U.S. Senate,,DEM,Loretta Sanchez,106
-Napa,521224,U.S. Senate,,DEM,Kamala Harris,304
-Napa,521224,U.S. Senate,,DEM,Loretta Sanchez,85
-Napa,521225,U.S. Senate,,DEM,Kamala Harris,131
-Napa,521225,U.S. Senate,,DEM,Loretta Sanchez,40
-Napa,561141,U.S. Senate,,DEM,Kamala Harris,3
-Napa,561141,U.S. Senate,,DEM,Loretta Sanchez,5
-Napa,561340,U.S. Senate,,DEM,Kamala Harris,925
-Napa,561340,U.S. Senate,,DEM,Loretta Sanchez,352
-Napa,561341,U.S. Senate,,DEM,Kamala Harris,10
-Napa,561341,U.S. Senate,,DEM,Loretta Sanchez,3
-Napa,561342,U.S. Senate,,DEM,Kamala Harris,588
-Napa,561342,U.S. Senate,,DEM,Loretta Sanchez,297
-Napa,561343,U.S. Senate,,DEM,Kamala Harris,797
-Napa,561343,U.S. Senate,,DEM,Loretta Sanchez,447
-Napa,561345,U.S. Senate,,DEM,Kamala Harris,938
-Napa,561345,U.S. Senate,,DEM,Loretta Sanchez,557
-Napa,561347,U.S. Senate,,DEM,Kamala Harris,1369
-Napa,561347,U.S. Senate,,DEM,Loretta Sanchez,613
-Napa,561348,U.S. Senate,,DEM,Kamala Harris,82
-Napa,561348,U.S. Senate,,DEM,Loretta Sanchez,42
+Napa,111131,U.S. Senate,,DEM,Kamala D. Harris,135
+Napa,111131,U.S. Senate,,DEM,Loretta L. Sanchez,116
+Napa,111151,U.S. Senate,,DEM,Kamala D. Harris,32
+Napa,111151,U.S. Senate,,DEM,Loretta L. Sanchez,5
+Napa,111152,U.S. Senate,,DEM,Kamala D. Harris,212
+Napa,111152,U.S. Senate,,DEM,Loretta L. Sanchez,67
+Napa,111431,U.S. Senate,,DEM,Kamala D. Harris,12
+Napa,111431,U.S. Senate,,DEM,Loretta L. Sanchez,5
+Napa,111751,U.S. Senate,,DEM,Kamala D. Harris,52
+Napa,111751,U.S. Senate,,DEM,Loretta L. Sanchez,17
+Napa,111752,U.S. Senate,,DEM,Kamala D. Harris,119
+Napa,111752,U.S. Senate,,DEM,Loretta L. Sanchez,55
+Napa,121131,U.S. Senate,,DEM,Kamala D. Harris,81
+Napa,121131,U.S. Senate,,DEM,Loretta L. Sanchez,40
+Napa,121132,U.S. Senate,,DEM,Kamala D. Harris,185
+Napa,121132,U.S. Senate,,DEM,Loretta L. Sanchez,124
+Napa,121133,U.S. Senate,,DEM,Kamala D. Harris,215
+Napa,121133,U.S. Senate,,DEM,Loretta L. Sanchez,147
+Napa,121134,U.S. Senate,,DEM,Kamala D. Harris,115
+Napa,121134,U.S. Senate,,DEM,Loretta L. Sanchez,47
+Napa,121135,U.S. Senate,,DEM,Kamala D. Harris,272
+Napa,121135,U.S. Senate,,DEM,Loretta L. Sanchez,152
+Napa,121136,U.S. Senate,,DEM,Kamala D. Harris,363
+Napa,121136,U.S. Senate,,DEM,Loretta L. Sanchez,156
+Napa,121151,U.S. Senate,,DEM,Kamala D. Harris,111
+Napa,121151,U.S. Senate,,DEM,Loretta L. Sanchez,82
+Napa,121152,U.S. Senate,,DEM,Kamala D. Harris,493
+Napa,121152,U.S. Senate,,DEM,Loretta L. Sanchez,194
+Napa,121153,U.S. Senate,,DEM,Kamala D. Harris,76
+Napa,121153,U.S. Senate,,DEM,Loretta L. Sanchez,39
+Napa,121154,U.S. Senate,,DEM,Kamala D. Harris,41
+Napa,121154,U.S. Senate,,DEM,Loretta L. Sanchez,21
+Napa,121155,U.S. Senate,,DEM,Kamala D. Harris,81
+Napa,121155,U.S. Senate,,DEM,Loretta L. Sanchez,74
+Napa,121156,U.S. Senate,,DEM,Kamala D. Harris,219
+Napa,121156,U.S. Senate,,DEM,Loretta L. Sanchez,77
+Napa,121157,U.S. Senate,,DEM,Kamala D. Harris,170
+Napa,121157,U.S. Senate,,DEM,Loretta L. Sanchez,101
+Napa,121158,U.S. Senate,,DEM,Kamala D. Harris,299
+Napa,121158,U.S. Senate,,DEM,Loretta L. Sanchez,96
+Napa,121161,U.S. Senate,,DEM,Kamala D. Harris,151
+Napa,121161,U.S. Senate,,DEM,Loretta L. Sanchez,87
+Napa,121162,U.S. Senate,,DEM,Kamala D. Harris,308
+Napa,121162,U.S. Senate,,DEM,Loretta L. Sanchez,125
+Napa,121221,U.S. Senate,,DEM,Kamala D. Harris,115
+Napa,121221,U.S. Senate,,DEM,Loretta L. Sanchez,71
+Napa,121222,U.S. Senate,,DEM,Kamala D. Harris,40
+Napa,121222,U.S. Senate,,DEM,Loretta L. Sanchez,10
+Napa,121223,U.S. Senate,,DEM,Kamala D. Harris,48
+Napa,121223,U.S. Senate,,DEM,Loretta L. Sanchez,30
+Napa,121231,U.S. Senate,,DEM,Kamala D. Harris,10
+Napa,121231,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Napa,121232,U.S. Senate,,DEM,Kamala D. Harris,111
+Napa,121232,U.S. Senate,,DEM,Loretta L. Sanchez,49
+Napa,121233,U.S. Senate,,DEM,Kamala D. Harris,346
+Napa,121233,U.S. Senate,,DEM,Loretta L. Sanchez,137
+Napa,121234,U.S. Senate,,DEM,Kamala D. Harris,254
+Napa,121234,U.S. Senate,,DEM,Loretta L. Sanchez,114
+Napa,121235,U.S. Senate,,DEM,Kamala D. Harris,228
+Napa,121235,U.S. Senate,,DEM,Loretta L. Sanchez,93
+Napa,121236,U.S. Senate,,DEM,Kamala D. Harris,205
+Napa,121236,U.S. Senate,,DEM,Loretta L. Sanchez,85
+Napa,121237,U.S. Senate,,DEM,Kamala D. Harris,21
+Napa,121237,U.S. Senate,,DEM,Loretta L. Sanchez,18
+Napa,121238,U.S. Senate,,DEM,Kamala D. Harris,193
+Napa,121238,U.S. Senate,,DEM,Loretta L. Sanchez,165
+Napa,121239,U.S. Senate,,DEM,Kamala D. Harris,246
+Napa,121239,U.S. Senate,,DEM,Loretta L. Sanchez,142
+Napa,121431,U.S. Senate,,DEM,Kamala D. Harris,345
+Napa,121431,U.S. Senate,,DEM,Loretta L. Sanchez,143
+Napa,121551,U.S. Senate,,DEM,Kamala D. Harris,71
+Napa,121551,U.S. Senate,,DEM,Loretta L. Sanchez,33
+Napa,121552,U.S. Senate,,DEM,Kamala D. Harris,81
+Napa,121552,U.S. Senate,,DEM,Loretta L. Sanchez,66
+Napa,121751,U.S. Senate,,DEM,Kamala D. Harris,203
+Napa,121751,U.S. Senate,,DEM,Loretta L. Sanchez,50
+Napa,121752,U.S. Senate,,DEM,Kamala D. Harris,324
+Napa,121752,U.S. Senate,,DEM,Loretta L. Sanchez,146
+Napa,211161,U.S. Senate,,DEM,Kamala D. Harris,33
+Napa,211161,U.S. Senate,,DEM,Loretta L. Sanchez,17
+Napa,211162,U.S. Senate,,DEM,Kamala D. Harris,5
+Napa,211162,U.S. Senate,,DEM,Loretta L. Sanchez,7
+Napa,211561,U.S. Senate,,DEM,Kamala D. Harris,168
+Napa,211561,U.S. Senate,,DEM,Loretta L. Sanchez,136
+Napa,211562,U.S. Senate,,DEM,Kamala D. Harris,196
+Napa,211562,U.S. Senate,,DEM,Loretta L. Sanchez,134
+Napa,211563,U.S. Senate,,DEM,Kamala D. Harris,20
+Napa,211563,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Napa,211751,U.S. Senate,,DEM,Kamala D. Harris,31
+Napa,211751,U.S. Senate,,DEM,Loretta L. Sanchez,13
+Napa,211761,U.S. Senate,,DEM,Kamala D. Harris,204
+Napa,211761,U.S. Senate,,DEM,Loretta L. Sanchez,84
+Napa,221161,U.S. Senate,,DEM,Kamala D. Harris,155
+Napa,221161,U.S. Senate,,DEM,Loretta L. Sanchez,58
+Napa,221162,U.S. Senate,,DEM,Kamala D. Harris,251
+Napa,221162,U.S. Senate,,DEM,Loretta L. Sanchez,112
+Napa,221163,U.S. Senate,,DEM,Kamala D. Harris,195
+Napa,221163,U.S. Senate,,DEM,Loretta L. Sanchez,75
+Napa,221231,U.S. Senate,,DEM,Kamala D. Harris,181
+Napa,221231,U.S. Senate,,DEM,Loretta L. Sanchez,73
+Napa,221232,U.S. Senate,,DEM,Kamala D. Harris,212
+Napa,221232,U.S. Senate,,DEM,Loretta L. Sanchez,62
+Napa,221233,U.S. Senate,,DEM,Kamala D. Harris,20
+Napa,221233,U.S. Senate,,DEM,Loretta L. Sanchez,13
+Napa,221551,U.S. Senate,,DEM,Kamala D. Harris,180
+Napa,221551,U.S. Senate,,DEM,Loretta L. Sanchez,177
+Napa,221552,U.S. Senate,,DEM,Kamala D. Harris,126
+Napa,221552,U.S. Senate,,DEM,Loretta L. Sanchez,106
+Napa,221553,U.S. Senate,,DEM,Kamala D. Harris,105
+Napa,221553,U.S. Senate,,DEM,Loretta L. Sanchez,79
+Napa,221561,U.S. Senate,,DEM,Kamala D. Harris,64
+Napa,221561,U.S. Senate,,DEM,Loretta L. Sanchez,44
+Napa,221562,U.S. Senate,,DEM,Kamala D. Harris,264
+Napa,221562,U.S. Senate,,DEM,Loretta L. Sanchez,160
+Napa,221563,U.S. Senate,,DEM,Kamala D. Harris,316
+Napa,221563,U.S. Senate,,DEM,Loretta L. Sanchez,148
+Napa,221564,U.S. Senate,,DEM,Kamala D. Harris,304
+Napa,221564,U.S. Senate,,DEM,Loretta L. Sanchez,137
+Napa,221565,U.S. Senate,,DEM,Kamala D. Harris,298
+Napa,221565,U.S. Senate,,DEM,Loretta L. Sanchez,133
+Napa,221566,U.S. Senate,,DEM,Kamala D. Harris,169
+Napa,221566,U.S. Senate,,DEM,Loretta L. Sanchez,120
+Napa,221571,U.S. Senate,,DEM,Kamala D. Harris,1013
+Napa,221571,U.S. Senate,,DEM,Loretta L. Sanchez,601
+Napa,221572,U.S. Senate,,DEM,Kamala D. Harris,364
+Napa,221572,U.S. Senate,,DEM,Loretta L. Sanchez,203
+Napa,221573,U.S. Senate,,DEM,Kamala D. Harris,250
+Napa,221573,U.S. Senate,,DEM,Loretta L. Sanchez,149
+Napa,221574,U.S. Senate,,DEM,Kamala D. Harris,385
+Napa,221574,U.S. Senate,,DEM,Loretta L. Sanchez,187
+Napa,221671,U.S. Senate,,DEM,Kamala D. Harris,201
+Napa,221671,U.S. Senate,,DEM,Loretta L. Sanchez,52
+Napa,221672,U.S. Senate,,DEM,Kamala D. Harris,306
+Napa,221672,U.S. Senate,,DEM,Loretta L. Sanchez,210
+Napa,221673,U.S. Senate,,DEM,Kamala D. Harris,214
+Napa,221673,U.S. Senate,,DEM,Loretta L. Sanchez,85
+Napa,221674,U.S. Senate,,DEM,Kamala D. Harris,317
+Napa,221674,U.S. Senate,,DEM,Loretta L. Sanchez,165
+Napa,221675,U.S. Senate,,DEM,Kamala D. Harris,540
+Napa,221675,U.S. Senate,,DEM,Loretta L. Sanchez,323
+Napa,221676,U.S. Senate,,DEM,Kamala D. Harris,149
+Napa,221676,U.S. Senate,,DEM,Loretta L. Sanchez,110
+Napa,221762,U.S. Senate,,DEM,Kamala D. Harris,359
+Napa,221762,U.S. Senate,,DEM,Loretta L. Sanchez,124
+Napa,311411,U.S. Senate,,DEM,Kamala D. Harris,13
+Napa,311411,U.S. Senate,,DEM,Loretta L. Sanchez,6
+Napa,311471,U.S. Senate,,DEM,Kamala D. Harris,32
+Napa,311471,U.S. Senate,,DEM,Loretta L. Sanchez,10
+Napa,311571,U.S. Senate,,DEM,Kamala D. Harris,40
+Napa,311571,U.S. Senate,,DEM,Loretta L. Sanchez,32
+Napa,311611,U.S. Senate,,DEM,Kamala D. Harris,284
+Napa,311611,U.S. Senate,,DEM,Loretta L. Sanchez,148
+Napa,311671,U.S. Senate,,DEM,Kamala D. Harris,176
+Napa,311671,U.S. Senate,,DEM,Loretta L. Sanchez,89
+Napa,311712,U.S. Senate,,DEM,Kamala D. Harris,10
+Napa,311712,U.S. Senate,,DEM,Loretta L. Sanchez,7
+Napa,312401,U.S. Senate,,DEM,Kamala D. Harris,1
+Napa,312401,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Napa,312601,U.S. Senate,,DEM,Kamala D. Harris,65
+Napa,312601,U.S. Senate,,DEM,Loretta L. Sanchez,40
+Napa,312602,U.S. Senate,,DEM,Kamala D. Harris,133
+Napa,312602,U.S. Senate,,DEM,Loretta L. Sanchez,112
+Napa,312701,U.S. Senate,,DEM,Kamala D. Harris,24
+Napa,312701,U.S. Senate,,DEM,Loretta L. Sanchez,25
+Napa,312702,U.S. Senate,,DEM,Kamala D. Harris,22
+Napa,312702,U.S. Senate,,DEM,Loretta L. Sanchez,13
+Napa,312703,U.S. Senate,,DEM,Kamala D. Harris,4
+Napa,312703,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Napa,312704,U.S. Senate,,DEM,Kamala D. Harris,87
+Napa,312704,U.S. Senate,,DEM,Loretta L. Sanchez,39
+Napa,312705,U.S. Senate,,DEM,Kamala D. Harris,206
+Napa,312705,U.S. Senate,,DEM,Loretta L. Sanchez,83
+Napa,312706,U.S. Senate,,DEM,Kamala D. Harris,155
+Napa,312706,U.S. Senate,,DEM,Loretta L. Sanchez,52
+Napa,312707,U.S. Senate,,DEM,Kamala D. Harris,122
+Napa,312707,U.S. Senate,,DEM,Loretta L. Sanchez,55
+Napa,312708,U.S. Senate,,DEM,Kamala D. Harris,221
+Napa,312708,U.S. Senate,,DEM,Loretta L. Sanchez,76
+Napa,312709,U.S. Senate,,DEM,Kamala D. Harris,190
+Napa,312709,U.S. Senate,,DEM,Loretta L. Sanchez,85
+Napa,313701,U.S. Senate,,DEM,Kamala D. Harris,235
+Napa,313701,U.S. Senate,,DEM,Loretta L. Sanchez,109
+Napa,313702,U.S. Senate,,DEM,Kamala D. Harris,134
+Napa,313702,U.S. Senate,,DEM,Loretta L. Sanchez,57
+Napa,314701,U.S. Senate,,DEM,Kamala D. Harris,800
+Napa,314701,U.S. Senate,,DEM,Loretta L. Sanchez,431
+Napa,315701,U.S. Senate,,DEM,Kamala D. Harris,66
+Napa,315701,U.S. Senate,,DEM,Loretta L. Sanchez,55
+Napa,315702,U.S. Senate,,DEM,Kamala D. Harris,94
+Napa,315702,U.S. Senate,,DEM,Loretta L. Sanchez,57
+Napa,321671,U.S. Senate,,DEM,Kamala D. Harris,247
+Napa,321671,U.S. Senate,,DEM,Loretta L. Sanchez,152
+Napa,321672,U.S. Senate,,DEM,Kamala D. Harris,224
+Napa,321672,U.S. Senate,,DEM,Loretta L. Sanchez,133
+Napa,332601,U.S. Senate,,DEM,Kamala D. Harris,388
+Napa,332601,U.S. Senate,,DEM,Loretta L. Sanchez,173
+Napa,332602,U.S. Senate,,DEM,Kamala D. Harris,287
+Napa,332602,U.S. Senate,,DEM,Loretta L. Sanchez,91
+Napa,332603,U.S. Senate,,DEM,Kamala D. Harris,404
+Napa,332603,U.S. Senate,,DEM,Loretta L. Sanchez,113
+Napa,332604,U.S. Senate,,DEM,Kamala D. Harris,354
+Napa,332604,U.S. Senate,,DEM,Loretta L. Sanchez,166
+Napa,332605,U.S. Senate,,DEM,Kamala D. Harris,220
+Napa,332605,U.S. Senate,,DEM,Loretta L. Sanchez,92
+Napa,332606,U.S. Senate,,DEM,Kamala D. Harris,168
+Napa,332606,U.S. Senate,,DEM,Loretta L. Sanchez,36
+Napa,343701,U.S. Senate,,DEM,Kamala D. Harris,428
+Napa,343701,U.S. Senate,,DEM,Loretta L. Sanchez,238
+Napa,343702,U.S. Senate,,DEM,Kamala D. Harris,214
+Napa,343702,U.S. Senate,,DEM,Loretta L. Sanchez,79
+Napa,343703,U.S. Senate,,DEM,Kamala D. Harris,241
+Napa,343703,U.S. Senate,,DEM,Loretta L. Sanchez,68
+Napa,343704,U.S. Senate,,DEM,Kamala D. Harris,157
+Napa,343704,U.S. Senate,,DEM,Loretta L. Sanchez,90
+Napa,343705,U.S. Senate,,DEM,Kamala D. Harris,184
+Napa,343705,U.S. Senate,,DEM,Loretta L. Sanchez,69
+Napa,351611,U.S. Senate,,DEM,Kamala D. Harris,292
+Napa,351611,U.S. Senate,,DEM,Loretta L. Sanchez,124
+Napa,351612,U.S. Senate,,DEM,Kamala D. Harris,269
+Napa,351612,U.S. Senate,,DEM,Loretta L. Sanchez,86
+Napa,351613,U.S. Senate,,DEM,Kamala D. Harris,334
+Napa,351613,U.S. Senate,,DEM,Loretta L. Sanchez,109
+Napa,351614,U.S. Senate,,DEM,Kamala D. Harris,144
+Napa,351614,U.S. Senate,,DEM,Loretta L. Sanchez,49
+Napa,411221,U.S. Senate,,DEM,Kamala D. Harris,39
+Napa,411221,U.S. Senate,,DEM,Loretta L. Sanchez,26
+Napa,411411,U.S. Senate,,DEM,Kamala D. Harris,93
+Napa,411411,U.S. Senate,,DEM,Loretta L. Sanchez,40
+Napa,411412,U.S. Senate,,DEM,Kamala D. Harris,164
+Napa,411412,U.S. Senate,,DEM,Loretta L. Sanchez,83
+Napa,411413,U.S. Senate,,DEM,Kamala D. Harris,150
+Napa,411413,U.S. Senate,,DEM,Loretta L. Sanchez,74
+Napa,411414,U.S. Senate,,DEM,Kamala D. Harris,78
+Napa,411414,U.S. Senate,,DEM,Loretta L. Sanchez,30
+Napa,411415,U.S. Senate,,DEM,Kamala D. Harris,253
+Napa,411415,U.S. Senate,,DEM,Loretta L. Sanchez,139
+Napa,411416,U.S. Senate,,DEM,Kamala D. Harris,316
+Napa,411416,U.S. Senate,,DEM,Loretta L. Sanchez,165
+Napa,411417,U.S. Senate,,DEM,Kamala D. Harris,31
+Napa,411417,U.S. Senate,,DEM,Loretta L. Sanchez,15
+Napa,411418,U.S. Senate,,DEM,Kamala D. Harris,73
+Napa,411418,U.S. Senate,,DEM,Loretta L. Sanchez,61
+Napa,411419,U.S. Senate,,DEM,Kamala D. Harris,433
+Napa,411419,U.S. Senate,,DEM,Loretta L. Sanchez,222
+Napa,411711,U.S. Senate,,DEM,Kamala D. Harris,157
+Napa,411711,U.S. Senate,,DEM,Loretta L. Sanchez,109
+Napa,411712,U.S. Senate,,DEM,Kamala D. Harris,178
+Napa,411712,U.S. Senate,,DEM,Loretta L. Sanchez,93
+Napa,411713,U.S. Senate,,DEM,Kamala D. Harris,77
+Napa,411713,U.S. Senate,,DEM,Loretta L. Sanchez,25
+Napa,416801,U.S. Senate,,DEM,Kamala D. Harris,62
+Napa,416801,U.S. Senate,,DEM,Loretta L. Sanchez,54
+Napa,421221,U.S. Senate,,DEM,Kamala D. Harris,142
+Napa,421221,U.S. Senate,,DEM,Loretta L. Sanchez,131
+Napa,421222,U.S. Senate,,DEM,Kamala D. Harris,200
+Napa,421222,U.S. Senate,,DEM,Loretta L. Sanchez,127
+Napa,421223,U.S. Senate,,DEM,Kamala D. Harris,28
+Napa,421223,U.S. Senate,,DEM,Loretta L. Sanchez,30
+Napa,421224,U.S. Senate,,DEM,Kamala D. Harris,274
+Napa,421224,U.S. Senate,,DEM,Loretta L. Sanchez,148
+Napa,421225,U.S. Senate,,DEM,Kamala D. Harris,225
+Napa,421225,U.S. Senate,,DEM,Loretta L. Sanchez,89
+Napa,421226,U.S. Senate,,DEM,Kamala D. Harris,225
+Napa,421226,U.S. Senate,,DEM,Loretta L. Sanchez,95
+Napa,421227,U.S. Senate,,DEM,Kamala D. Harris,112
+Napa,421227,U.S. Senate,,DEM,Loretta L. Sanchez,59
+Napa,421421,U.S. Senate,,DEM,Kamala D. Harris,61
+Napa,421421,U.S. Senate,,DEM,Loretta L. Sanchez,26
+Napa,421422,U.S. Senate,,DEM,Kamala D. Harris,210
+Napa,421422,U.S. Senate,,DEM,Loretta L. Sanchez,169
+Napa,421423,U.S. Senate,,DEM,Kamala D. Harris,165
+Napa,421423,U.S. Senate,,DEM,Loretta L. Sanchez,131
+Napa,421424,U.S. Senate,,DEM,Kamala D. Harris,359
+Napa,421424,U.S. Senate,,DEM,Loretta L. Sanchez,200
+Napa,421425,U.S. Senate,,DEM,Kamala D. Harris,370
+Napa,421425,U.S. Senate,,DEM,Loretta L. Sanchez,168
+Napa,421426,U.S. Senate,,DEM,Kamala D. Harris,326
+Napa,421426,U.S. Senate,,DEM,Loretta L. Sanchez,173
+Napa,421427,U.S. Senate,,DEM,Kamala D. Harris,348
+Napa,421427,U.S. Senate,,DEM,Loretta L. Sanchez,158
+Napa,421471,U.S. Senate,,DEM,Kamala D. Harris,959
+Napa,421471,U.S. Senate,,DEM,Loretta L. Sanchez,437
+Napa,421521,U.S. Senate,,DEM,Kamala D. Harris,5
+Napa,421521,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Napa,421571,U.S. Senate,,DEM,Kamala D. Harris,314
+Napa,421571,U.S. Senate,,DEM,Loretta L. Sanchez,191
+Napa,421671,U.S. Senate,,DEM,Kamala D. Harris,260
+Napa,421671,U.S. Senate,,DEM,Loretta L. Sanchez,205
+Napa,511141,U.S. Senate,,DEM,Kamala D. Harris,82
+Napa,511141,U.S. Senate,,DEM,Loretta L. Sanchez,49
+Napa,511211,U.S. Senate,,DEM,Kamala D. Harris,127
+Napa,511211,U.S. Senate,,DEM,Loretta L. Sanchez,53
+Napa,511221,U.S. Senate,,DEM,Kamala D. Harris,47
+Napa,511221,U.S. Senate,,DEM,Loretta L. Sanchez,15
+Napa,511411,U.S. Senate,,DEM,Kamala D. Harris,312
+Napa,511411,U.S. Senate,,DEM,Loretta L. Sanchez,148
+Napa,511431,U.S. Senate,,DEM,Kamala D. Harris,201
+Napa,511431,U.S. Senate,,DEM,Loretta L. Sanchez,103
+Napa,511441,U.S. Senate,,DEM,Kamala D. Harris,24
+Napa,511441,U.S. Senate,,DEM,Loretta L. Sanchez,5
+Napa,521141,U.S. Senate,,DEM,Kamala D. Harris,372
+Napa,521141,U.S. Senate,,DEM,Loretta L. Sanchez,213
+Napa,521142,U.S. Senate,,DEM,Kamala D. Harris,440
+Napa,521142,U.S. Senate,,DEM,Loretta L. Sanchez,169
+Napa,521143,U.S. Senate,,DEM,Kamala D. Harris,2
+Napa,521143,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Napa,521221,U.S. Senate,,DEM,Kamala D. Harris,148
+Napa,521221,U.S. Senate,,DEM,Loretta L. Sanchez,39
+Napa,521222,U.S. Senate,,DEM,Kamala D. Harris,67
+Napa,521222,U.S. Senate,,DEM,Loretta L. Sanchez,29
+Napa,521223,U.S. Senate,,DEM,Kamala D. Harris,422
+Napa,521223,U.S. Senate,,DEM,Loretta L. Sanchez,106
+Napa,521224,U.S. Senate,,DEM,Kamala D. Harris,304
+Napa,521224,U.S. Senate,,DEM,Loretta L. Sanchez,85
+Napa,521225,U.S. Senate,,DEM,Kamala D. Harris,131
+Napa,521225,U.S. Senate,,DEM,Loretta L. Sanchez,40
+Napa,561141,U.S. Senate,,DEM,Kamala D. Harris,3
+Napa,561141,U.S. Senate,,DEM,Loretta L. Sanchez,5
+Napa,561340,U.S. Senate,,DEM,Kamala D. Harris,925
+Napa,561340,U.S. Senate,,DEM,Loretta L. Sanchez,352
+Napa,561341,U.S. Senate,,DEM,Kamala D. Harris,10
+Napa,561341,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Napa,561342,U.S. Senate,,DEM,Kamala D. Harris,588
+Napa,561342,U.S. Senate,,DEM,Loretta L. Sanchez,297
+Napa,561343,U.S. Senate,,DEM,Kamala D. Harris,797
+Napa,561343,U.S. Senate,,DEM,Loretta L. Sanchez,447
+Napa,561345,U.S. Senate,,DEM,Kamala D. Harris,938
+Napa,561345,U.S. Senate,,DEM,Loretta L. Sanchez,557
+Napa,561347,U.S. Senate,,DEM,Kamala D. Harris,1369
+Napa,561347,U.S. Senate,,DEM,Loretta L. Sanchez,613
+Napa,561348,U.S. Senate,,DEM,Kamala D. Harris,82
+Napa,561348,U.S. Senate,,DEM,Loretta L. Sanchez,42

--- a/2016/20161108__ca__general__nevada__precinct.csv
+++ b/2016/20161108__ca__general__nevada__precinct.csv
@@ -3279,167 +3279,167 @@ Nevada,MB81,Proposition 67,,N/A,Yes,45
 Nevada,MB81,Proposition 67,,N/A,No,56
 Nevada,MB82,Proposition 67,,N/A,Yes,13
 Nevada,MB82,Proposition 67,,N/A,No,22
-Nevada,CP01,U.S. Senate,,DEM,Kamala Harris,797
-Nevada,CP01,U.S. Senate,,DEM,Loretta Sanchez,352
-Nevada,CP02,U.S. Senate,,DEM,Kamala Harris,347
-Nevada,CP02,U.S. Senate,,DEM,Loretta Sanchez,171
-Nevada,CP03,U.S. Senate,,DEM,Kamala Harris,345
-Nevada,CP03,U.S. Senate,,DEM,Loretta Sanchez,157
-Nevada,CP04,U.S. Senate,,DEM,Kamala Harris,746
-Nevada,CP04,U.S. Senate,,DEM,Loretta Sanchez,291
-Nevada,CP05,U.S. Senate,,DEM,Kamala Harris,408
-Nevada,CP05,U.S. Senate,,DEM,Loretta Sanchez,149
-Nevada,CP06,U.S. Senate,,DEM,Kamala Harris,817
-Nevada,CP06,U.S. Senate,,DEM,Loretta Sanchez,295
-Nevada,CP07,U.S. Senate,,DEM,Kamala Harris,1300
-Nevada,CP07,U.S. Senate,,DEM,Loretta Sanchez,489
-Nevada,CP08,U.S. Senate,,DEM,Kamala Harris,398
-Nevada,CP08,U.S. Senate,,DEM,Loretta Sanchez,183
-Nevada,CP09,U.S. Senate,,DEM,Kamala Harris,1132
-Nevada,CP09,U.S. Senate,,DEM,Loretta Sanchez,305
-Nevada,CP10,U.S. Senate,,DEM,Kamala Harris,301
-Nevada,CP10,U.S. Senate,,DEM,Loretta Sanchez,113
-Nevada,CP11,U.S. Senate,,DEM,Kamala Harris,616
-Nevada,CP11,U.S. Senate,,DEM,Loretta Sanchez,255
-Nevada,CP12,U.S. Senate,,DEM,Kamala Harris,508
-Nevada,CP12,U.S. Senate,,DEM,Loretta Sanchez,304
-Nevada,CP13,U.S. Senate,,DEM,Kamala Harris,1147
-Nevada,CP13,U.S. Senate,,DEM,Loretta Sanchez,596
-Nevada,CP14,U.S. Senate,,DEM,Kamala Harris,175
-Nevada,CP14,U.S. Senate,,DEM,Loretta Sanchez,117
-Nevada,CP15,U.S. Senate,,DEM,Kamala Harris,541
-Nevada,CP15,U.S. Senate,,DEM,Loretta Sanchez,318
-Nevada,CP16,U.S. Senate,,DEM,Kamala Harris,51
-Nevada,CP16,U.S. Senate,,DEM,Loretta Sanchez,28
-Nevada,CP17,U.S. Senate,,DEM,Kamala Harris,868
-Nevada,CP17,U.S. Senate,,DEM,Loretta Sanchez,430
-Nevada,CP18,U.S. Senate,,DEM,Kamala Harris,636
-Nevada,CP18,U.S. Senate,,DEM,Loretta Sanchez,323
-Nevada,CP19,U.S. Senate,,DEM,Kamala Harris,675
-Nevada,CP19,U.S. Senate,,DEM,Loretta Sanchez,371
-Nevada,CP20,U.S. Senate,,DEM,Kamala Harris,144
-Nevada,CP20,U.S. Senate,,DEM,Loretta Sanchez,101
-Nevada,CP21,U.S. Senate,,DEM,Kamala Harris,208
-Nevada,CP21,U.S. Senate,,DEM,Loretta Sanchez,123
-Nevada,CP22,U.S. Senate,,DEM,Kamala Harris,113
-Nevada,CP22,U.S. Senate,,DEM,Loretta Sanchez,53
-Nevada,CP23,U.S. Senate,,DEM,Kamala Harris,349
-Nevada,CP23,U.S. Senate,,DEM,Loretta Sanchez,134
-Nevada,CP24,U.S. Senate,,DEM,Kamala Harris,747
-Nevada,CP24,U.S. Senate,,DEM,Loretta Sanchez,304
-Nevada,CP25,U.S. Senate,,DEM,Kamala Harris,689
-Nevada,CP25,U.S. Senate,,DEM,Loretta Sanchez,263
-Nevada,CP26,U.S. Senate,,DEM,Kamala Harris,853
-Nevada,CP26,U.S. Senate,,DEM,Loretta Sanchez,377
-Nevada,CP27,U.S. Senate,,DEM,Kamala Harris,503
-Nevada,CP27,U.S. Senate,,DEM,Loretta Sanchez,249
-Nevada,CP28,U.S. Senate,,DEM,Kamala Harris,870
-Nevada,CP28,U.S. Senate,,DEM,Loretta Sanchez,354
-Nevada,CP29,U.S. Senate,,DEM,Kamala Harris,740
-Nevada,CP29,U.S. Senate,,DEM,Loretta Sanchez,309
-Nevada,CP30,U.S. Senate,,DEM,Kamala Harris,420
-Nevada,CP30,U.S. Senate,,DEM,Loretta Sanchez,189
-Nevada,CP31,U.S. Senate,,DEM,Kamala Harris,987
-Nevada,CP31,U.S. Senate,,DEM,Loretta Sanchez,477
-Nevada,CP32,U.S. Senate,,DEM,Kamala Harris,683
-Nevada,CP32,U.S. Senate,,DEM,Loretta Sanchez,341
-Nevada,CP33,U.S. Senate,,DEM,Kamala Harris,85
-Nevada,CP33,U.S. Senate,,DEM,Loretta Sanchez,33
-Nevada,CP34,U.S. Senate,,DEM,Kamala Harris,204
-Nevada,CP34,U.S. Senate,,DEM,Loretta Sanchez,112
-Nevada,CP35,U.S. Senate,,DEM,Kamala Harris,447
-Nevada,CP35,U.S. Senate,,DEM,Loretta Sanchez,223
-Nevada,CP36,U.S. Senate,,DEM,Kamala Harris,216
-Nevada,CP36,U.S. Senate,,DEM,Loretta Sanchez,102
-Nevada,CP37,U.S. Senate,,DEM,Kamala Harris,942
-Nevada,CP37,U.S. Senate,,DEM,Loretta Sanchez,551
-Nevada,CP38,U.S. Senate,,DEM,Kamala Harris,253
-Nevada,CP38,U.S. Senate,,DEM,Loretta Sanchez,146
-Nevada,CP39,U.S. Senate,,DEM,Kamala Harris,308
-Nevada,CP39,U.S. Senate,,DEM,Loretta Sanchez,163
-Nevada,CP40,U.S. Senate,,DEM,Kamala Harris,444
-Nevada,CP40,U.S. Senate,,DEM,Loretta Sanchez,172
-Nevada,CP41,U.S. Senate,,DEM,Kamala Harris,384
-Nevada,CP41,U.S. Senate,,DEM,Loretta Sanchez,157
-Nevada,CP42,U.S. Senate,,DEM,Kamala Harris,393
-Nevada,CP42,U.S. Senate,,DEM,Loretta Sanchez,113
-Nevada,CP43,U.S. Senate,,DEM,Kamala Harris,393
-Nevada,CP43,U.S. Senate,,DEM,Loretta Sanchez,150
-Nevada,CP44,U.S. Senate,,DEM,Kamala Harris,379
-Nevada,CP44,U.S. Senate,,DEM,Loretta Sanchez,127
-Nevada,CP45,U.S. Senate,,DEM,Kamala Harris,742
-Nevada,CP45,U.S. Senate,,DEM,Loretta Sanchez,243
-Nevada,CP46,U.S. Senate,,DEM,Kamala Harris,778
-Nevada,CP46,U.S. Senate,,DEM,Loretta Sanchez,370
-Nevada,CP47,U.S. Senate,,DEM,Kamala Harris,862
-Nevada,CP47,U.S. Senate,,DEM,Loretta Sanchez,361
-Nevada,MB48,U.S. Senate,,DEM,Kamala Harris,3
-Nevada,MB48,U.S. Senate,,DEM,Loretta Sanchez,1
-Nevada,MB49,U.S. Senate,,DEM,Kamala Harris,4
-Nevada,MB49,U.S. Senate,,DEM,Loretta Sanchez,0
-Nevada,MB50,U.S. Senate,,DEM,Kamala Harris,3
-Nevada,MB50,U.S. Senate,,DEM,Loretta Sanchez,0
-Nevada,MB51,U.S. Senate,,DEM,Kamala Harris,0
-Nevada,MB51,U.S. Senate,,DEM,Loretta Sanchez,0
-Nevada,MB52,U.S. Senate,,DEM,Kamala Harris,239
-Nevada,MB52,U.S. Senate,,DEM,Loretta Sanchez,113
-Nevada,MB53,U.S. Senate,,DEM,Kamala Harris,0
-Nevada,MB53,U.S. Senate,,DEM,Loretta Sanchez,0
-Nevada,MB54,U.S. Senate,,DEM,Kamala Harris,98
-Nevada,MB54,U.S. Senate,,DEM,Loretta Sanchez,46
-Nevada,MB55,U.S. Senate,,DEM,Kamala Harris,0
-Nevada,MB55,U.S. Senate,,DEM,Loretta Sanchez,0
-Nevada,MB56,U.S. Senate,,DEM,Kamala Harris,98
-Nevada,MB56,U.S. Senate,,DEM,Loretta Sanchez,40
-Nevada,MB57,U.S. Senate,,DEM,Kamala Harris,471
-Nevada,MB57,U.S. Senate,,DEM,Loretta Sanchez,215
-Nevada,MB58,U.S. Senate,,DEM,Kamala Harris,216
-Nevada,MB58,U.S. Senate,,DEM,Loretta Sanchez,74
-Nevada,MB59,U.S. Senate,,DEM,Kamala Harris,1
-Nevada,MB59,U.S. Senate,,DEM,Loretta Sanchez,6
-Nevada,MB60,U.S. Senate,,DEM,Kamala Harris,107
-Nevada,MB60,U.S. Senate,,DEM,Loretta Sanchez,48
-Nevada,MB61,U.S. Senate,,DEM,Kamala Harris,58
-Nevada,MB61,U.S. Senate,,DEM,Loretta Sanchez,29
-Nevada,MB62,U.S. Senate,,DEM,Kamala Harris,397
-Nevada,MB62,U.S. Senate,,DEM,Loretta Sanchez,164
-Nevada,MB63,U.S. Senate,,DEM,Kamala Harris,27
-Nevada,MB63,U.S. Senate,,DEM,Loretta Sanchez,11
-Nevada,MB64,U.S. Senate,,DEM,Kamala Harris,343
-Nevada,MB64,U.S. Senate,,DEM,Loretta Sanchez,198
-Nevada,MB65,U.S. Senate,,DEM,Kamala Harris,65
-Nevada,MB65,U.S. Senate,,DEM,Loretta Sanchez,32
-Nevada,MB66,U.S. Senate,,DEM,Kamala Harris,95
-Nevada,MB66,U.S. Senate,,DEM,Loretta Sanchez,46
-Nevada,MB67,U.S. Senate,,DEM,Kamala Harris,23
-Nevada,MB67,U.S. Senate,,DEM,Loretta Sanchez,24
-Nevada,MB68,U.S. Senate,,DEM,Kamala Harris,55
-Nevada,MB68,U.S. Senate,,DEM,Loretta Sanchez,13
-Nevada,MB69,U.S. Senate,,DEM,Kamala Harris,70
-Nevada,MB69,U.S. Senate,,DEM,Loretta Sanchez,30
-Nevada,MB70,U.S. Senate,,DEM,Kamala Harris,50
-Nevada,MB70,U.S. Senate,,DEM,Loretta Sanchez,36
-Nevada,MB71,U.S. Senate,,DEM,Kamala Harris,324
-Nevada,MB71,U.S. Senate,,DEM,Loretta Sanchez,137
-Nevada,MB72,U.S. Senate,,DEM,Kamala Harris,54
-Nevada,MB72,U.S. Senate,,DEM,Loretta Sanchez,14
-Nevada,MB73,U.S. Senate,,DEM,Kamala Harris,14
-Nevada,MB73,U.S. Senate,,DEM,Loretta Sanchez,8
-Nevada,MB74,U.S. Senate,,DEM,Kamala Harris,259
-Nevada,MB74,U.S. Senate,,DEM,Loretta Sanchez,158
-Nevada,MB75,U.S. Senate,,DEM,Kamala Harris,130
-Nevada,MB75,U.S. Senate,,DEM,Loretta Sanchez,91
-Nevada,MB76,U.S. Senate,,DEM,Kamala Harris,0
-Nevada,MB76,U.S. Senate,,DEM,Loretta Sanchez,0
-Nevada,MB77,U.S. Senate,,DEM,Kamala Harris,45
-Nevada,MB77,U.S. Senate,,DEM,Loretta Sanchez,24
-Nevada,MB78,U.S. Senate,,DEM,Kamala Harris,262
-Nevada,MB78,U.S. Senate,,DEM,Loretta Sanchez,124
-Nevada,MB79,U.S. Senate,,DEM,Kamala Harris,104
-Nevada,MB79,U.S. Senate,,DEM,Loretta Sanchez,51
-Nevada,MB80,U.S. Senate,,DEM,Kamala Harris,16
-Nevada,MB80,U.S. Senate,,DEM,Loretta Sanchez,13
-Nevada,MB81,U.S. Senate,,DEM,Kamala Harris,54
-Nevada,MB81,U.S. Senate,,DEM,Loretta Sanchez,28
-Nevada,MB82,U.S. Senate,,DEM,Kamala Harris,10
-Nevada,MB82,U.S. Senate,,DEM,Loretta Sanchez,11
+Nevada,CP01,U.S. Senate,,DEM,Kamala D. Harris,797
+Nevada,CP01,U.S. Senate,,DEM,Loretta L. Sanchez,352
+Nevada,CP02,U.S. Senate,,DEM,Kamala D. Harris,347
+Nevada,CP02,U.S. Senate,,DEM,Loretta L. Sanchez,171
+Nevada,CP03,U.S. Senate,,DEM,Kamala D. Harris,345
+Nevada,CP03,U.S. Senate,,DEM,Loretta L. Sanchez,157
+Nevada,CP04,U.S. Senate,,DEM,Kamala D. Harris,746
+Nevada,CP04,U.S. Senate,,DEM,Loretta L. Sanchez,291
+Nevada,CP05,U.S. Senate,,DEM,Kamala D. Harris,408
+Nevada,CP05,U.S. Senate,,DEM,Loretta L. Sanchez,149
+Nevada,CP06,U.S. Senate,,DEM,Kamala D. Harris,817
+Nevada,CP06,U.S. Senate,,DEM,Loretta L. Sanchez,295
+Nevada,CP07,U.S. Senate,,DEM,Kamala D. Harris,1300
+Nevada,CP07,U.S. Senate,,DEM,Loretta L. Sanchez,489
+Nevada,CP08,U.S. Senate,,DEM,Kamala D. Harris,398
+Nevada,CP08,U.S. Senate,,DEM,Loretta L. Sanchez,183
+Nevada,CP09,U.S. Senate,,DEM,Kamala D. Harris,1132
+Nevada,CP09,U.S. Senate,,DEM,Loretta L. Sanchez,305
+Nevada,CP10,U.S. Senate,,DEM,Kamala D. Harris,301
+Nevada,CP10,U.S. Senate,,DEM,Loretta L. Sanchez,113
+Nevada,CP11,U.S. Senate,,DEM,Kamala D. Harris,616
+Nevada,CP11,U.S. Senate,,DEM,Loretta L. Sanchez,255
+Nevada,CP12,U.S. Senate,,DEM,Kamala D. Harris,508
+Nevada,CP12,U.S. Senate,,DEM,Loretta L. Sanchez,304
+Nevada,CP13,U.S. Senate,,DEM,Kamala D. Harris,1147
+Nevada,CP13,U.S. Senate,,DEM,Loretta L. Sanchez,596
+Nevada,CP14,U.S. Senate,,DEM,Kamala D. Harris,175
+Nevada,CP14,U.S. Senate,,DEM,Loretta L. Sanchez,117
+Nevada,CP15,U.S. Senate,,DEM,Kamala D. Harris,541
+Nevada,CP15,U.S. Senate,,DEM,Loretta L. Sanchez,318
+Nevada,CP16,U.S. Senate,,DEM,Kamala D. Harris,51
+Nevada,CP16,U.S. Senate,,DEM,Loretta L. Sanchez,28
+Nevada,CP17,U.S. Senate,,DEM,Kamala D. Harris,868
+Nevada,CP17,U.S. Senate,,DEM,Loretta L. Sanchez,430
+Nevada,CP18,U.S. Senate,,DEM,Kamala D. Harris,636
+Nevada,CP18,U.S. Senate,,DEM,Loretta L. Sanchez,323
+Nevada,CP19,U.S. Senate,,DEM,Kamala D. Harris,675
+Nevada,CP19,U.S. Senate,,DEM,Loretta L. Sanchez,371
+Nevada,CP20,U.S. Senate,,DEM,Kamala D. Harris,144
+Nevada,CP20,U.S. Senate,,DEM,Loretta L. Sanchez,101
+Nevada,CP21,U.S. Senate,,DEM,Kamala D. Harris,208
+Nevada,CP21,U.S. Senate,,DEM,Loretta L. Sanchez,123
+Nevada,CP22,U.S. Senate,,DEM,Kamala D. Harris,113
+Nevada,CP22,U.S. Senate,,DEM,Loretta L. Sanchez,53
+Nevada,CP23,U.S. Senate,,DEM,Kamala D. Harris,349
+Nevada,CP23,U.S. Senate,,DEM,Loretta L. Sanchez,134
+Nevada,CP24,U.S. Senate,,DEM,Kamala D. Harris,747
+Nevada,CP24,U.S. Senate,,DEM,Loretta L. Sanchez,304
+Nevada,CP25,U.S. Senate,,DEM,Kamala D. Harris,689
+Nevada,CP25,U.S. Senate,,DEM,Loretta L. Sanchez,263
+Nevada,CP26,U.S. Senate,,DEM,Kamala D. Harris,853
+Nevada,CP26,U.S. Senate,,DEM,Loretta L. Sanchez,377
+Nevada,CP27,U.S. Senate,,DEM,Kamala D. Harris,503
+Nevada,CP27,U.S. Senate,,DEM,Loretta L. Sanchez,249
+Nevada,CP28,U.S. Senate,,DEM,Kamala D. Harris,870
+Nevada,CP28,U.S. Senate,,DEM,Loretta L. Sanchez,354
+Nevada,CP29,U.S. Senate,,DEM,Kamala D. Harris,740
+Nevada,CP29,U.S. Senate,,DEM,Loretta L. Sanchez,309
+Nevada,CP30,U.S. Senate,,DEM,Kamala D. Harris,420
+Nevada,CP30,U.S. Senate,,DEM,Loretta L. Sanchez,189
+Nevada,CP31,U.S. Senate,,DEM,Kamala D. Harris,987
+Nevada,CP31,U.S. Senate,,DEM,Loretta L. Sanchez,477
+Nevada,CP32,U.S. Senate,,DEM,Kamala D. Harris,683
+Nevada,CP32,U.S. Senate,,DEM,Loretta L. Sanchez,341
+Nevada,CP33,U.S. Senate,,DEM,Kamala D. Harris,85
+Nevada,CP33,U.S. Senate,,DEM,Loretta L. Sanchez,33
+Nevada,CP34,U.S. Senate,,DEM,Kamala D. Harris,204
+Nevada,CP34,U.S. Senate,,DEM,Loretta L. Sanchez,112
+Nevada,CP35,U.S. Senate,,DEM,Kamala D. Harris,447
+Nevada,CP35,U.S. Senate,,DEM,Loretta L. Sanchez,223
+Nevada,CP36,U.S. Senate,,DEM,Kamala D. Harris,216
+Nevada,CP36,U.S. Senate,,DEM,Loretta L. Sanchez,102
+Nevada,CP37,U.S. Senate,,DEM,Kamala D. Harris,942
+Nevada,CP37,U.S. Senate,,DEM,Loretta L. Sanchez,551
+Nevada,CP38,U.S. Senate,,DEM,Kamala D. Harris,253
+Nevada,CP38,U.S. Senate,,DEM,Loretta L. Sanchez,146
+Nevada,CP39,U.S. Senate,,DEM,Kamala D. Harris,308
+Nevada,CP39,U.S. Senate,,DEM,Loretta L. Sanchez,163
+Nevada,CP40,U.S. Senate,,DEM,Kamala D. Harris,444
+Nevada,CP40,U.S. Senate,,DEM,Loretta L. Sanchez,172
+Nevada,CP41,U.S. Senate,,DEM,Kamala D. Harris,384
+Nevada,CP41,U.S. Senate,,DEM,Loretta L. Sanchez,157
+Nevada,CP42,U.S. Senate,,DEM,Kamala D. Harris,393
+Nevada,CP42,U.S. Senate,,DEM,Loretta L. Sanchez,113
+Nevada,CP43,U.S. Senate,,DEM,Kamala D. Harris,393
+Nevada,CP43,U.S. Senate,,DEM,Loretta L. Sanchez,150
+Nevada,CP44,U.S. Senate,,DEM,Kamala D. Harris,379
+Nevada,CP44,U.S. Senate,,DEM,Loretta L. Sanchez,127
+Nevada,CP45,U.S. Senate,,DEM,Kamala D. Harris,742
+Nevada,CP45,U.S. Senate,,DEM,Loretta L. Sanchez,243
+Nevada,CP46,U.S. Senate,,DEM,Kamala D. Harris,778
+Nevada,CP46,U.S. Senate,,DEM,Loretta L. Sanchez,370
+Nevada,CP47,U.S. Senate,,DEM,Kamala D. Harris,862
+Nevada,CP47,U.S. Senate,,DEM,Loretta L. Sanchez,361
+Nevada,MB48,U.S. Senate,,DEM,Kamala D. Harris,3
+Nevada,MB48,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Nevada,MB49,U.S. Senate,,DEM,Kamala D. Harris,4
+Nevada,MB49,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Nevada,MB50,U.S. Senate,,DEM,Kamala D. Harris,3
+Nevada,MB50,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Nevada,MB51,U.S. Senate,,DEM,Kamala D. Harris,0
+Nevada,MB51,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Nevada,MB52,U.S. Senate,,DEM,Kamala D. Harris,239
+Nevada,MB52,U.S. Senate,,DEM,Loretta L. Sanchez,113
+Nevada,MB53,U.S. Senate,,DEM,Kamala D. Harris,0
+Nevada,MB53,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Nevada,MB54,U.S. Senate,,DEM,Kamala D. Harris,98
+Nevada,MB54,U.S. Senate,,DEM,Loretta L. Sanchez,46
+Nevada,MB55,U.S. Senate,,DEM,Kamala D. Harris,0
+Nevada,MB55,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Nevada,MB56,U.S. Senate,,DEM,Kamala D. Harris,98
+Nevada,MB56,U.S. Senate,,DEM,Loretta L. Sanchez,40
+Nevada,MB57,U.S. Senate,,DEM,Kamala D. Harris,471
+Nevada,MB57,U.S. Senate,,DEM,Loretta L. Sanchez,215
+Nevada,MB58,U.S. Senate,,DEM,Kamala D. Harris,216
+Nevada,MB58,U.S. Senate,,DEM,Loretta L. Sanchez,74
+Nevada,MB59,U.S. Senate,,DEM,Kamala D. Harris,1
+Nevada,MB59,U.S. Senate,,DEM,Loretta L. Sanchez,6
+Nevada,MB60,U.S. Senate,,DEM,Kamala D. Harris,107
+Nevada,MB60,U.S. Senate,,DEM,Loretta L. Sanchez,48
+Nevada,MB61,U.S. Senate,,DEM,Kamala D. Harris,58
+Nevada,MB61,U.S. Senate,,DEM,Loretta L. Sanchez,29
+Nevada,MB62,U.S. Senate,,DEM,Kamala D. Harris,397
+Nevada,MB62,U.S. Senate,,DEM,Loretta L. Sanchez,164
+Nevada,MB63,U.S. Senate,,DEM,Kamala D. Harris,27
+Nevada,MB63,U.S. Senate,,DEM,Loretta L. Sanchez,11
+Nevada,MB64,U.S. Senate,,DEM,Kamala D. Harris,343
+Nevada,MB64,U.S. Senate,,DEM,Loretta L. Sanchez,198
+Nevada,MB65,U.S. Senate,,DEM,Kamala D. Harris,65
+Nevada,MB65,U.S. Senate,,DEM,Loretta L. Sanchez,32
+Nevada,MB66,U.S. Senate,,DEM,Kamala D. Harris,95
+Nevada,MB66,U.S. Senate,,DEM,Loretta L. Sanchez,46
+Nevada,MB67,U.S. Senate,,DEM,Kamala D. Harris,23
+Nevada,MB67,U.S. Senate,,DEM,Loretta L. Sanchez,24
+Nevada,MB68,U.S. Senate,,DEM,Kamala D. Harris,55
+Nevada,MB68,U.S. Senate,,DEM,Loretta L. Sanchez,13
+Nevada,MB69,U.S. Senate,,DEM,Kamala D. Harris,70
+Nevada,MB69,U.S. Senate,,DEM,Loretta L. Sanchez,30
+Nevada,MB70,U.S. Senate,,DEM,Kamala D. Harris,50
+Nevada,MB70,U.S. Senate,,DEM,Loretta L. Sanchez,36
+Nevada,MB71,U.S. Senate,,DEM,Kamala D. Harris,324
+Nevada,MB71,U.S. Senate,,DEM,Loretta L. Sanchez,137
+Nevada,MB72,U.S. Senate,,DEM,Kamala D. Harris,54
+Nevada,MB72,U.S. Senate,,DEM,Loretta L. Sanchez,14
+Nevada,MB73,U.S. Senate,,DEM,Kamala D. Harris,14
+Nevada,MB73,U.S. Senate,,DEM,Loretta L. Sanchez,8
+Nevada,MB74,U.S. Senate,,DEM,Kamala D. Harris,259
+Nevada,MB74,U.S. Senate,,DEM,Loretta L. Sanchez,158
+Nevada,MB75,U.S. Senate,,DEM,Kamala D. Harris,130
+Nevada,MB75,U.S. Senate,,DEM,Loretta L. Sanchez,91
+Nevada,MB76,U.S. Senate,,DEM,Kamala D. Harris,0
+Nevada,MB76,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Nevada,MB77,U.S. Senate,,DEM,Kamala D. Harris,45
+Nevada,MB77,U.S. Senate,,DEM,Loretta L. Sanchez,24
+Nevada,MB78,U.S. Senate,,DEM,Kamala D. Harris,262
+Nevada,MB78,U.S. Senate,,DEM,Loretta L. Sanchez,124
+Nevada,MB79,U.S. Senate,,DEM,Kamala D. Harris,104
+Nevada,MB79,U.S. Senate,,DEM,Loretta L. Sanchez,51
+Nevada,MB80,U.S. Senate,,DEM,Kamala D. Harris,16
+Nevada,MB80,U.S. Senate,,DEM,Loretta L. Sanchez,13
+Nevada,MB81,U.S. Senate,,DEM,Kamala D. Harris,54
+Nevada,MB81,U.S. Senate,,DEM,Loretta L. Sanchez,28
+Nevada,MB82,U.S. Senate,,DEM,Kamala D. Harris,10
+Nevada,MB82,U.S. Senate,,DEM,Loretta L. Sanchez,11

--- a/2016/20161108__ca__general__orange__precinct.csv
+++ b/2016/20161108__ca__general__orange__precinct.csv
@@ -66719,3339 +66719,3339 @@ Orange,75702,Proposition 67,,N/A,Yes,278
 Orange,75702,Proposition 67,,N/A,No,589
 Orange,75703,Proposition 67,,N/A,Yes,283
 Orange,75703,Proposition 67,,N/A,No,603
-Orange,2001,U.S. Senate,,DEM,Kamala Harris,169
-Orange,2001,U.S. Senate,,DEM,Loretta Sanchez,291
-Orange,2002,U.S. Senate,,DEM,Kamala Harris,60
-Orange,2002,U.S. Senate,,DEM,Loretta Sanchez,111
-Orange,2003,U.S. Senate,,DEM,Kamala Harris,211
-Orange,2003,U.S. Senate,,DEM,Loretta Sanchez,289
-Orange,2007,U.S. Senate,,DEM,Kamala Harris,260
-Orange,2007,U.S. Senate,,DEM,Loretta Sanchez,367
-Orange,2008,U.S. Senate,,DEM,Kamala Harris,324
-Orange,2008,U.S. Senate,,DEM,Loretta Sanchez,504
-Orange,2009,U.S. Senate,,DEM,Kamala Harris,112
-Orange,2009,U.S. Senate,,DEM,Loretta Sanchez,139
-Orange,2011,U.S. Senate,,DEM,Kamala Harris,388
-Orange,2011,U.S. Senate,,DEM,Loretta Sanchez,291
-Orange,2012,U.S. Senate,,DEM,Kamala Harris,212
-Orange,2012,U.S. Senate,,DEM,Loretta Sanchez,284
-Orange,2015,U.S. Senate,,DEM,Kamala Harris,166
-Orange,2015,U.S. Senate,,DEM,Loretta Sanchez,183
-Orange,2017,U.S. Senate,,DEM,Kamala Harris,691
-Orange,2017,U.S. Senate,,DEM,Loretta Sanchez,414
-Orange,2020,U.S. Senate,,DEM,Kamala Harris,375
-Orange,2020,U.S. Senate,,DEM,Loretta Sanchez,393
-Orange,2023,U.S. Senate,,DEM,Kamala Harris,337
-Orange,2023,U.S. Senate,,DEM,Loretta Sanchez,417
-Orange,2024,U.S. Senate,,DEM,Kamala Harris,415
-Orange,2024,U.S. Senate,,DEM,Loretta Sanchez,248
-Orange,2025,U.S. Senate,,DEM,Kamala Harris,307
-Orange,2025,U.S. Senate,,DEM,Loretta Sanchez,546
-Orange,2030,U.S. Senate,,DEM,Kamala Harris,355
-Orange,2030,U.S. Senate,,DEM,Loretta Sanchez,416
-Orange,2031,U.S. Senate,,DEM,Kamala Harris,144
-Orange,2031,U.S. Senate,,DEM,Loretta Sanchez,193
-Orange,2033,U.S. Senate,,DEM,Kamala Harris,343
-Orange,2033,U.S. Senate,,DEM,Loretta Sanchez,423
-Orange,2034,U.S. Senate,,DEM,Kamala Harris,2
-Orange,2034,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,2036,U.S. Senate,,DEM,Kamala Harris,267
-Orange,2036,U.S. Senate,,DEM,Loretta Sanchez,232
-Orange,2037,U.S. Senate,,DEM,Kamala Harris,233
-Orange,2037,U.S. Senate,,DEM,Loretta Sanchez,164
-Orange,2038,U.S. Senate,,DEM,Kamala Harris,300
-Orange,2038,U.S. Senate,,DEM,Loretta Sanchez,246
-Orange,2039,U.S. Senate,,DEM,Kamala Harris,358
-Orange,2039,U.S. Senate,,DEM,Loretta Sanchez,241
-Orange,2040,U.S. Senate,,DEM,Kamala Harris,384
-Orange,2040,U.S. Senate,,DEM,Loretta Sanchez,281
-Orange,2047,U.S. Senate,,DEM,Kamala Harris,673
-Orange,2047,U.S. Senate,,DEM,Loretta Sanchez,458
-Orange,2048,U.S. Senate,,DEM,Kamala Harris,783
-Orange,2048,U.S. Senate,,DEM,Loretta Sanchez,517
-Orange,2049,U.S. Senate,,DEM,Kamala Harris,279
-Orange,2049,U.S. Senate,,DEM,Loretta Sanchez,224
-Orange,2051,U.S. Senate,,DEM,Kamala Harris,706
-Orange,2051,U.S. Senate,,DEM,Loretta Sanchez,480
-Orange,2054,U.S. Senate,,DEM,Kamala Harris,412
-Orange,2054,U.S. Senate,,DEM,Loretta Sanchez,481
-Orange,2055,U.S. Senate,,DEM,Kamala Harris,320
-Orange,2055,U.S. Senate,,DEM,Loretta Sanchez,461
-Orange,2060,U.S. Senate,,DEM,Kamala Harris,238
-Orange,2060,U.S. Senate,,DEM,Loretta Sanchez,153
-Orange,2061,U.S. Senate,,DEM,Kamala Harris,2
-Orange,2061,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,2069,U.S. Senate,,DEM,Kamala Harris,401
-Orange,2069,U.S. Senate,,DEM,Loretta Sanchez,219
-Orange,2070,U.S. Senate,,DEM,Kamala Harris,371
-Orange,2070,U.S. Senate,,DEM,Loretta Sanchez,195
-Orange,2071,U.S. Senate,,DEM,Kamala Harris,325
-Orange,2071,U.S. Senate,,DEM,Loretta Sanchez,239
-Orange,2072,U.S. Senate,,DEM,Kamala Harris,333
-Orange,2072,U.S. Senate,,DEM,Loretta Sanchez,223
-Orange,2073,U.S. Senate,,DEM,Kamala Harris,201
-Orange,2073,U.S. Senate,,DEM,Loretta Sanchez,171
-Orange,2075,U.S. Senate,,DEM,Kamala Harris,280
-Orange,2075,U.S. Senate,,DEM,Loretta Sanchez,220
-Orange,2077,U.S. Senate,,DEM,Kamala Harris,303
-Orange,2077,U.S. Senate,,DEM,Loretta Sanchez,206
-Orange,2078,U.S. Senate,,DEM,Kamala Harris,513
-Orange,2078,U.S. Senate,,DEM,Loretta Sanchez,334
-Orange,2079,U.S. Senate,,DEM,Kamala Harris,425
-Orange,2079,U.S. Senate,,DEM,Loretta Sanchez,267
-Orange,2080,U.S. Senate,,DEM,Kamala Harris,360
-Orange,2080,U.S. Senate,,DEM,Loretta Sanchez,217
-Orange,2081,U.S. Senate,,DEM,Kamala Harris,455
-Orange,2081,U.S. Senate,,DEM,Loretta Sanchez,250
-Orange,2082,U.S. Senate,,DEM,Kamala Harris,298
-Orange,2082,U.S. Senate,,DEM,Loretta Sanchez,156
-Orange,2088,U.S. Senate,,DEM,Kamala Harris,446
-Orange,2088,U.S. Senate,,DEM,Loretta Sanchez,321
-Orange,2094,U.S. Senate,,DEM,Kamala Harris,391
-Orange,2094,U.S. Senate,,DEM,Loretta Sanchez,192
-Orange,2096,U.S. Senate,,DEM,Kamala Harris,0
-Orange,2096,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,2097,U.S. Senate,,DEM,Kamala Harris,0
-Orange,2097,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,2098,U.S. Senate,,DEM,Kamala Harris,147
-Orange,2098,U.S. Senate,,DEM,Loretta Sanchez,171
-Orange,2099,U.S. Senate,,DEM,Kamala Harris,64
-Orange,2099,U.S. Senate,,DEM,Loretta Sanchez,126
-Orange,2117,U.S. Senate,,DEM,Kamala Harris,316
-Orange,2117,U.S. Senate,,DEM,Loretta Sanchez,462
-Orange,2119,U.S. Senate,,DEM,Kamala Harris,325
-Orange,2119,U.S. Senate,,DEM,Loretta Sanchez,661
-Orange,2122,U.S. Senate,,DEM,Kamala Harris,9
-Orange,2122,U.S. Senate,,DEM,Loretta Sanchez,10
-Orange,2128,U.S. Senate,,DEM,Kamala Harris,482
-Orange,2128,U.S. Senate,,DEM,Loretta Sanchez,720
-Orange,2131,U.S. Senate,,DEM,Kamala Harris,265
-Orange,2131,U.S. Senate,,DEM,Loretta Sanchez,373
-Orange,2133,U.S. Senate,,DEM,Kamala Harris,0
-Orange,2133,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,2134,U.S. Senate,,DEM,Kamala Harris,284
-Orange,2134,U.S. Senate,,DEM,Loretta Sanchez,540
-Orange,2135,U.S. Senate,,DEM,Kamala Harris,294
-Orange,2135,U.S. Senate,,DEM,Loretta Sanchez,532
-Orange,2139,U.S. Senate,,DEM,Kamala Harris,270
-Orange,2139,U.S. Senate,,DEM,Loretta Sanchez,296
-Orange,2143,U.S. Senate,,DEM,Kamala Harris,672
-Orange,2143,U.S. Senate,,DEM,Loretta Sanchez,780
-Orange,2146,U.S. Senate,,DEM,Kamala Harris,155
-Orange,2146,U.S. Senate,,DEM,Loretta Sanchez,190
-Orange,2148,U.S. Senate,,DEM,Kamala Harris,367
-Orange,2148,U.S. Senate,,DEM,Loretta Sanchez,403
-Orange,2151,U.S. Senate,,DEM,Kamala Harris,198
-Orange,2151,U.S. Senate,,DEM,Loretta Sanchez,290
-Orange,2152,U.S. Senate,,DEM,Kamala Harris,299
-Orange,2152,U.S. Senate,,DEM,Loretta Sanchez,428
-Orange,2153,U.S. Senate,,DEM,Kamala Harris,50
-Orange,2153,U.S. Senate,,DEM,Loretta Sanchez,52
-Orange,2160,U.S. Senate,,DEM,Kamala Harris,502
-Orange,2160,U.S. Senate,,DEM,Loretta Sanchez,660
-Orange,2166,U.S. Senate,,DEM,Kamala Harris,290
-Orange,2166,U.S. Senate,,DEM,Loretta Sanchez,392
-Orange,2171,U.S. Senate,,DEM,Kamala Harris,410
-Orange,2171,U.S. Senate,,DEM,Loretta Sanchez,486
-Orange,2176,U.S. Senate,,DEM,Kamala Harris,205
-Orange,2176,U.S. Senate,,DEM,Loretta Sanchez,390
-Orange,2177,U.S. Senate,,DEM,Kamala Harris,262
-Orange,2177,U.S. Senate,,DEM,Loretta Sanchez,459
-Orange,2181,U.S. Senate,,DEM,Kamala Harris,658
-Orange,2181,U.S. Senate,,DEM,Loretta Sanchez,817
-Orange,2182,U.S. Senate,,DEM,Kamala Harris,272
-Orange,2182,U.S. Senate,,DEM,Loretta Sanchez,352
-Orange,2187,U.S. Senate,,DEM,Kamala Harris,354
-Orange,2187,U.S. Senate,,DEM,Loretta Sanchez,587
-Orange,2193,U.S. Senate,,DEM,Kamala Harris,297
-Orange,2193,U.S. Senate,,DEM,Loretta Sanchez,664
-Orange,2194,U.S. Senate,,DEM,Kamala Harris,271
-Orange,2194,U.S. Senate,,DEM,Loretta Sanchez,289
-Orange,2197,U.S. Senate,,DEM,Kamala Harris,346
-Orange,2197,U.S. Senate,,DEM,Loretta Sanchez,383
-Orange,2200,U.S. Senate,,DEM,Kamala Harris,270
-Orange,2200,U.S. Senate,,DEM,Loretta Sanchez,315
-Orange,2201,U.S. Senate,,DEM,Kamala Harris,297
-Orange,2201,U.S. Senate,,DEM,Loretta Sanchez,424
-Orange,2205,U.S. Senate,,DEM,Kamala Harris,269
-Orange,2205,U.S. Senate,,DEM,Loretta Sanchez,522
-Orange,2211,U.S. Senate,,DEM,Kamala Harris,500
-Orange,2211,U.S. Senate,,DEM,Loretta Sanchez,559
-Orange,2212,U.S. Senate,,DEM,Kamala Harris,295
-Orange,2212,U.S. Senate,,DEM,Loretta Sanchez,370
-Orange,2216,U.S. Senate,,DEM,Kamala Harris,504
-Orange,2216,U.S. Senate,,DEM,Loretta Sanchez,1056
-Orange,2222,U.S. Senate,,DEM,Kamala Harris,247
-Orange,2222,U.S. Senate,,DEM,Loretta Sanchez,441
-Orange,2223,U.S. Senate,,DEM,Kamala Harris,285
-Orange,2223,U.S. Senate,,DEM,Loretta Sanchez,343
-Orange,2225,U.S. Senate,,DEM,Kamala Harris,582
-Orange,2225,U.S. Senate,,DEM,Loretta Sanchez,438
-Orange,2228,U.S. Senate,,DEM,Kamala Harris,150
-Orange,2228,U.S. Senate,,DEM,Loretta Sanchez,380
-Orange,2229,U.S. Senate,,DEM,Kamala Harris,448
-Orange,2229,U.S. Senate,,DEM,Loretta Sanchez,551
-Orange,2230,U.S. Senate,,DEM,Kamala Harris,430
-Orange,2230,U.S. Senate,,DEM,Loretta Sanchez,474
-Orange,2234,U.S. Senate,,DEM,Kamala Harris,217
-Orange,2234,U.S. Senate,,DEM,Loretta Sanchez,151
-Orange,2235,U.S. Senate,,DEM,Kamala Harris,459
-Orange,2235,U.S. Senate,,DEM,Loretta Sanchez,390
-Orange,2237,U.S. Senate,,DEM,Kamala Harris,361
-Orange,2237,U.S. Senate,,DEM,Loretta Sanchez,280
-Orange,2276,U.S. Senate,,DEM,Kamala Harris,246
-Orange,2276,U.S. Senate,,DEM,Loretta Sanchez,283
-Orange,2303,U.S. Senate,,DEM,Kamala Harris,0
-Orange,2303,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,2304,U.S. Senate,,DEM,Kamala Harris,0
-Orange,2304,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,2306,U.S. Senate,,DEM,Kamala Harris,18
-Orange,2306,U.S. Senate,,DEM,Loretta Sanchez,33
-Orange,2307,U.S. Senate,,DEM,Kamala Harris,63
-Orange,2307,U.S. Senate,,DEM,Loretta Sanchez,101
-Orange,2315,U.S. Senate,,DEM,Kamala Harris,300
-Orange,2315,U.S. Senate,,DEM,Loretta Sanchez,343
-Orange,2319,U.S. Senate,,DEM,Kamala Harris,325
-Orange,2319,U.S. Senate,,DEM,Loretta Sanchez,367
-Orange,2321,U.S. Senate,,DEM,Kamala Harris,334
-Orange,2321,U.S. Senate,,DEM,Loretta Sanchez,477
-Orange,2322,U.S. Senate,,DEM,Kamala Harris,0
-Orange,2322,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,2331,U.S. Senate,,DEM,Kamala Harris,79
-Orange,2331,U.S. Senate,,DEM,Loretta Sanchez,68
-Orange,2337,U.S. Senate,,DEM,Kamala Harris,266
-Orange,2337,U.S. Senate,,DEM,Loretta Sanchez,344
-Orange,2338,U.S. Senate,,DEM,Kamala Harris,158
-Orange,2338,U.S. Senate,,DEM,Loretta Sanchez,229
-Orange,2340,U.S. Senate,,DEM,Kamala Harris,265
-Orange,2340,U.S. Senate,,DEM,Loretta Sanchez,310
-Orange,2341,U.S. Senate,,DEM,Kamala Harris,295
-Orange,2341,U.S. Senate,,DEM,Loretta Sanchez,295
-Orange,2345,U.S. Senate,,DEM,Kamala Harris,236
-Orange,2345,U.S. Senate,,DEM,Loretta Sanchez,175
-Orange,2347,U.S. Senate,,DEM,Kamala Harris,208
-Orange,2347,U.S. Senate,,DEM,Loretta Sanchez,271
-Orange,2348,U.S. Senate,,DEM,Kamala Harris,213
-Orange,2348,U.S. Senate,,DEM,Loretta Sanchez,215
-Orange,2352,U.S. Senate,,DEM,Kamala Harris,361
-Orange,2352,U.S. Senate,,DEM,Loretta Sanchez,414
-Orange,2355,U.S. Senate,,DEM,Kamala Harris,87
-Orange,2355,U.S. Senate,,DEM,Loretta Sanchez,89
-Orange,2356,U.S. Senate,,DEM,Kamala Harris,271
-Orange,2356,U.S. Senate,,DEM,Loretta Sanchez,457
-Orange,2357,U.S. Senate,,DEM,Kamala Harris,291
-Orange,2357,U.S. Senate,,DEM,Loretta Sanchez,356
-Orange,2359,U.S. Senate,,DEM,Kamala Harris,365
-Orange,2359,U.S. Senate,,DEM,Loretta Sanchez,515
-Orange,2361,U.S. Senate,,DEM,Kamala Harris,85
-Orange,2361,U.S. Senate,,DEM,Loretta Sanchez,119
-Orange,2362,U.S. Senate,,DEM,Kamala Harris,173
-Orange,2362,U.S. Senate,,DEM,Loretta Sanchez,248
-Orange,2365,U.S. Senate,,DEM,Kamala Harris,228
-Orange,2365,U.S. Senate,,DEM,Loretta Sanchez,417
-Orange,2367,U.S. Senate,,DEM,Kamala Harris,192
-Orange,2367,U.S. Senate,,DEM,Loretta Sanchez,194
-Orange,2368,U.S. Senate,,DEM,Kamala Harris,206
-Orange,2368,U.S. Senate,,DEM,Loretta Sanchez,330
-Orange,2370,U.S. Senate,,DEM,Kamala Harris,42
-Orange,2370,U.S. Senate,,DEM,Loretta Sanchez,87
-Orange,2371,U.S. Senate,,DEM,Kamala Harris,293
-Orange,2371,U.S. Senate,,DEM,Loretta Sanchez,443
-Orange,2377,U.S. Senate,,DEM,Kamala Harris,60
-Orange,2377,U.S. Senate,,DEM,Loretta Sanchez,115
-Orange,2382,U.S. Senate,,DEM,Kamala Harris,88
-Orange,2382,U.S. Senate,,DEM,Loretta Sanchez,195
-Orange,2385,U.S. Senate,,DEM,Kamala Harris,223
-Orange,2385,U.S. Senate,,DEM,Loretta Sanchez,183
-Orange,2387,U.S. Senate,,DEM,Kamala Harris,230
-Orange,2387,U.S. Senate,,DEM,Loretta Sanchez,253
-Orange,2389,U.S. Senate,,DEM,Kamala Harris,373
-Orange,2389,U.S. Senate,,DEM,Loretta Sanchez,513
-Orange,2390,U.S. Senate,,DEM,Kamala Harris,210
-Orange,2390,U.S. Senate,,DEM,Loretta Sanchez,333
-Orange,2391,U.S. Senate,,DEM,Kamala Harris,282
-Orange,2391,U.S. Senate,,DEM,Loretta Sanchez,349
-Orange,2392,U.S. Senate,,DEM,Kamala Harris,619
-Orange,2392,U.S. Senate,,DEM,Loretta Sanchez,626
-Orange,2393,U.S. Senate,,DEM,Kamala Harris,227
-Orange,2393,U.S. Senate,,DEM,Loretta Sanchez,393
-Orange,2395,U.S. Senate,,DEM,Kamala Harris,605
-Orange,2395,U.S. Senate,,DEM,Loretta Sanchez,584
-Orange,2398,U.S. Senate,,DEM,Kamala Harris,257
-Orange,2398,U.S. Senate,,DEM,Loretta Sanchez,323
-Orange,2401,U.S. Senate,,DEM,Kamala Harris,312
-Orange,2401,U.S. Senate,,DEM,Loretta Sanchez,342
-Orange,2402,U.S. Senate,,DEM,Kamala Harris,214
-Orange,2402,U.S. Senate,,DEM,Loretta Sanchez,198
-Orange,2403,U.S. Senate,,DEM,Kamala Harris,559
-Orange,2403,U.S. Senate,,DEM,Loretta Sanchez,370
-Orange,2405,U.S. Senate,,DEM,Kamala Harris,81
-Orange,2405,U.S. Senate,,DEM,Loretta Sanchez,133
-Orange,2408,U.S. Senate,,DEM,Kamala Harris,0
-Orange,2408,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,2409,U.S. Senate,,DEM,Kamala Harris,12
-Orange,2409,U.S. Senate,,DEM,Loretta Sanchez,32
-Orange,2411,U.S. Senate,,DEM,Kamala Harris,204
-Orange,2411,U.S. Senate,,DEM,Loretta Sanchez,405
-Orange,2423,U.S. Senate,,DEM,Kamala Harris,258
-Orange,2423,U.S. Senate,,DEM,Loretta Sanchez,319
-Orange,2429,U.S. Senate,,DEM,Kamala Harris,124
-Orange,2429,U.S. Senate,,DEM,Loretta Sanchez,415
-Orange,2432,U.S. Senate,,DEM,Kamala Harris,347
-Orange,2432,U.S. Senate,,DEM,Loretta Sanchez,475
-Orange,2434,U.S. Senate,,DEM,Kamala Harris,0
-Orange,2434,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,2437,U.S. Senate,,DEM,Kamala Harris,399
-Orange,2437,U.S. Senate,,DEM,Loretta Sanchez,538
-Orange,2438,U.S. Senate,,DEM,Kamala Harris,333
-Orange,2438,U.S. Senate,,DEM,Loretta Sanchez,389
-Orange,2440,U.S. Senate,,DEM,Kamala Harris,324
-Orange,2440,U.S. Senate,,DEM,Loretta Sanchez,485
-Orange,2441,U.S. Senate,,DEM,Kamala Harris,91
-Orange,2441,U.S. Senate,,DEM,Loretta Sanchez,73
-Orange,2443,U.S. Senate,,DEM,Kamala Harris,566
-Orange,2443,U.S. Senate,,DEM,Loretta Sanchez,655
-Orange,2448,U.S. Senate,,DEM,Kamala Harris,293
-Orange,2448,U.S. Senate,,DEM,Loretta Sanchez,343
-Orange,2450,U.S. Senate,,DEM,Kamala Harris,414
-Orange,2450,U.S. Senate,,DEM,Loretta Sanchez,526
-Orange,2453,U.S. Senate,,DEM,Kamala Harris,238
-Orange,2453,U.S. Senate,,DEM,Loretta Sanchez,190
-Orange,2457,U.S. Senate,,DEM,Kamala Harris,554
-Orange,2457,U.S. Senate,,DEM,Loretta Sanchez,644
-Orange,2459,U.S. Senate,,DEM,Kamala Harris,8
-Orange,2459,U.S. Senate,,DEM,Loretta Sanchez,3
-Orange,2601,U.S. Senate,,DEM,Kamala Harris,733
-Orange,2601,U.S. Senate,,DEM,Loretta Sanchez,589
-Orange,2602,U.S. Senate,,DEM,Kamala Harris,582
-Orange,2602,U.S. Senate,,DEM,Loretta Sanchez,395
-Orange,2603,U.S. Senate,,DEM,Kamala Harris,202
-Orange,2603,U.S. Senate,,DEM,Loretta Sanchez,144
-Orange,2901,U.S. Senate,,DEM,Kamala Harris,1
-Orange,2901,U.S. Senate,,DEM,Loretta Sanchez,2
-Orange,2902,U.S. Senate,,DEM,Kamala Harris,3
-Orange,2902,U.S. Senate,,DEM,Loretta Sanchez,1
-Orange,5302,U.S. Senate,,DEM,Kamala Harris,323
-Orange,5302,U.S. Senate,,DEM,Loretta Sanchez,248
-Orange,5303,U.S. Senate,,DEM,Kamala Harris,269
-Orange,5303,U.S. Senate,,DEM,Loretta Sanchez,209
-Orange,5305,U.S. Senate,,DEM,Kamala Harris,327
-Orange,5305,U.S. Senate,,DEM,Loretta Sanchez,232
-Orange,5307,U.S. Senate,,DEM,Kamala Harris,300
-Orange,5307,U.S. Senate,,DEM,Loretta Sanchez,250
-Orange,5308,U.S. Senate,,DEM,Kamala Harris,370
-Orange,5308,U.S. Senate,,DEM,Loretta Sanchez,323
-Orange,5310,U.S. Senate,,DEM,Kamala Harris,369
-Orange,5310,U.S. Senate,,DEM,Loretta Sanchez,323
-Orange,5311,U.S. Senate,,DEM,Kamala Harris,435
-Orange,5311,U.S. Senate,,DEM,Loretta Sanchez,359
-Orange,5316,U.S. Senate,,DEM,Kamala Harris,335
-Orange,5316,U.S. Senate,,DEM,Loretta Sanchez,242
-Orange,5317,U.S. Senate,,DEM,Kamala Harris,315
-Orange,5317,U.S. Senate,,DEM,Loretta Sanchez,210
-Orange,5318,U.S. Senate,,DEM,Kamala Harris,399
-Orange,5318,U.S. Senate,,DEM,Loretta Sanchez,289
-Orange,5319,U.S. Senate,,DEM,Kamala Harris,325
-Orange,5319,U.S. Senate,,DEM,Loretta Sanchez,284
-Orange,5333,U.S. Senate,,DEM,Kamala Harris,41
-Orange,5333,U.S. Senate,,DEM,Loretta Sanchez,20
-Orange,5335,U.S. Senate,,DEM,Kamala Harris,0
-Orange,5335,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,5336,U.S. Senate,,DEM,Kamala Harris,0
-Orange,5336,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,5337,U.S. Senate,,DEM,Kamala Harris,0
-Orange,5337,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,5338,U.S. Senate,,DEM,Kamala Harris,359
-Orange,5338,U.S. Senate,,DEM,Loretta Sanchez,257
-Orange,5340,U.S. Senate,,DEM,Kamala Harris,371
-Orange,5340,U.S. Senate,,DEM,Loretta Sanchez,287
-Orange,5342,U.S. Senate,,DEM,Kamala Harris,375
-Orange,5342,U.S. Senate,,DEM,Loretta Sanchez,238
-Orange,5343,U.S. Senate,,DEM,Kamala Harris,334
-Orange,5343,U.S. Senate,,DEM,Loretta Sanchez,201
-Orange,5344,U.S. Senate,,DEM,Kamala Harris,302
-Orange,5344,U.S. Senate,,DEM,Loretta Sanchez,214
-Orange,5379,U.S. Senate,,DEM,Kamala Harris,284
-Orange,5379,U.S. Senate,,DEM,Loretta Sanchez,166
-Orange,5380,U.S. Senate,,DEM,Kamala Harris,368
-Orange,5380,U.S. Senate,,DEM,Loretta Sanchez,296
-Orange,5381,U.S. Senate,,DEM,Kamala Harris,336
-Orange,5381,U.S. Senate,,DEM,Loretta Sanchez,278
-Orange,5383,U.S. Senate,,DEM,Kamala Harris,263
-Orange,5383,U.S. Senate,,DEM,Loretta Sanchez,242
-Orange,5384,U.S. Senate,,DEM,Kamala Harris,282
-Orange,5384,U.S. Senate,,DEM,Loretta Sanchez,260
-Orange,5385,U.S. Senate,,DEM,Kamala Harris,277
-Orange,5385,U.S. Senate,,DEM,Loretta Sanchez,217
-Orange,5386,U.S. Senate,,DEM,Kamala Harris,307
-Orange,5386,U.S. Senate,,DEM,Loretta Sanchez,276
-Orange,5388,U.S. Senate,,DEM,Kamala Harris,294
-Orange,5388,U.S. Senate,,DEM,Loretta Sanchez,246
-Orange,5389,U.S. Senate,,DEM,Kamala Harris,121
-Orange,5389,U.S. Senate,,DEM,Loretta Sanchez,110
-Orange,5392,U.S. Senate,,DEM,Kamala Harris,40
-Orange,5392,U.S. Senate,,DEM,Loretta Sanchez,48
-Orange,5393,U.S. Senate,,DEM,Kamala Harris,0
-Orange,5393,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,5396,U.S. Senate,,DEM,Kamala Harris,77
-Orange,5396,U.S. Senate,,DEM,Loretta Sanchez,40
-Orange,5397,U.S. Senate,,DEM,Kamala Harris,450
-Orange,5397,U.S. Senate,,DEM,Loretta Sanchez,331
-Orange,5398,U.S. Senate,,DEM,Kamala Harris,0
-Orange,5398,U.S. Senate,,DEM,Loretta Sanchez,1
-Orange,5701,U.S. Senate,,DEM,Kamala Harris,748
-Orange,5701,U.S. Senate,,DEM,Loretta Sanchez,548
-Orange,6200,U.S. Senate,,DEM,Kamala Harris,0
-Orange,6200,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,6204,U.S. Senate,,DEM,Kamala Harris,1
-Orange,6204,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,6205,U.S. Senate,,DEM,Kamala Harris,0
-Orange,6205,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,7022,U.S. Senate,,DEM,Kamala Harris,198
-Orange,7022,U.S. Senate,,DEM,Loretta Sanchez,163
-Orange,7092,U.S. Senate,,DEM,Kamala Harris,103
-Orange,7092,U.S. Senate,,DEM,Loretta Sanchez,103
-Orange,7093,U.S. Senate,,DEM,Kamala Harris,34
-Orange,7093,U.S. Senate,,DEM,Loretta Sanchez,57
-Orange,7094,U.S. Senate,,DEM,Kamala Harris,117
-Orange,7094,U.S. Senate,,DEM,Loretta Sanchez,109
-Orange,7095,U.S. Senate,,DEM,Kamala Harris,61
-Orange,7095,U.S. Senate,,DEM,Loretta Sanchez,53
-Orange,7098,U.S. Senate,,DEM,Kamala Harris,125
-Orange,7098,U.S. Senate,,DEM,Loretta Sanchez,121
-Orange,7101,U.S. Senate,,DEM,Kamala Harris,385
-Orange,7101,U.S. Senate,,DEM,Loretta Sanchez,436
-Orange,7102,U.S. Senate,,DEM,Kamala Harris,151
-Orange,7102,U.S. Senate,,DEM,Loretta Sanchez,323
-Orange,7103,U.S. Senate,,DEM,Kamala Harris,410
-Orange,7103,U.S. Senate,,DEM,Loretta Sanchez,330
-Orange,7104,U.S. Senate,,DEM,Kamala Harris,160
-Orange,7104,U.S. Senate,,DEM,Loretta Sanchez,255
-Orange,7106,U.S. Senate,,DEM,Kamala Harris,246
-Orange,7106,U.S. Senate,,DEM,Loretta Sanchez,330
-Orange,7108,U.S. Senate,,DEM,Kamala Harris,446
-Orange,7108,U.S. Senate,,DEM,Loretta Sanchez,458
-Orange,7109,U.S. Senate,,DEM,Kamala Harris,279
-Orange,7109,U.S. Senate,,DEM,Loretta Sanchez,299
-Orange,7110,U.S. Senate,,DEM,Kamala Harris,377
-Orange,7110,U.S. Senate,,DEM,Loretta Sanchez,320
-Orange,7111,U.S. Senate,,DEM,Kamala Harris,218
-Orange,7111,U.S. Senate,,DEM,Loretta Sanchez,274
-Orange,7112,U.S. Senate,,DEM,Kamala Harris,364
-Orange,7112,U.S. Senate,,DEM,Loretta Sanchez,495
-Orange,7120,U.S. Senate,,DEM,Kamala Harris,91
-Orange,7120,U.S. Senate,,DEM,Loretta Sanchez,106
-Orange,7121,U.S. Senate,,DEM,Kamala Harris,108
-Orange,7121,U.S. Senate,,DEM,Loretta Sanchez,93
-Orange,7122,U.S. Senate,,DEM,Kamala Harris,516
-Orange,7122,U.S. Senate,,DEM,Loretta Sanchez,471
-Orange,7123,U.S. Senate,,DEM,Kamala Harris,153
-Orange,7123,U.S. Senate,,DEM,Loretta Sanchez,188
-Orange,7124,U.S. Senate,,DEM,Kamala Harris,150
-Orange,7124,U.S. Senate,,DEM,Loretta Sanchez,130
-Orange,7125,U.S. Senate,,DEM,Kamala Harris,33
-Orange,7125,U.S. Senate,,DEM,Loretta Sanchez,30
-Orange,7126,U.S. Senate,,DEM,Kamala Harris,256
-Orange,7126,U.S. Senate,,DEM,Loretta Sanchez,263
-Orange,7127,U.S. Senate,,DEM,Kamala Harris,63
-Orange,7127,U.S. Senate,,DEM,Loretta Sanchez,61
-Orange,7128,U.S. Senate,,DEM,Kamala Harris,270
-Orange,7128,U.S. Senate,,DEM,Loretta Sanchez,246
-Orange,7129,U.S. Senate,,DEM,Kamala Harris,76
-Orange,7129,U.S. Senate,,DEM,Loretta Sanchez,72
-Orange,7130,U.S. Senate,,DEM,Kamala Harris,19
-Orange,7130,U.S. Senate,,DEM,Loretta Sanchez,23
-Orange,7131,U.S. Senate,,DEM,Kamala Harris,120
-Orange,7131,U.S. Senate,,DEM,Loretta Sanchez,139
-Orange,7133,U.S. Senate,,DEM,Kamala Harris,52
-Orange,7133,U.S. Senate,,DEM,Loretta Sanchez,68
-Orange,7134,U.S. Senate,,DEM,Kamala Harris,175
-Orange,7134,U.S. Senate,,DEM,Loretta Sanchez,183
-Orange,7135,U.S. Senate,,DEM,Kamala Harris,173
-Orange,7135,U.S. Senate,,DEM,Loretta Sanchez,190
-Orange,7136,U.S. Senate,,DEM,Kamala Harris,12
-Orange,7136,U.S. Senate,,DEM,Loretta Sanchez,6
-Orange,7137,U.S. Senate,,DEM,Kamala Harris,102
-Orange,7137,U.S. Senate,,DEM,Loretta Sanchez,69
-Orange,7138,U.S. Senate,,DEM,Kamala Harris,351
-Orange,7138,U.S. Senate,,DEM,Loretta Sanchez,350
-Orange,7139,U.S. Senate,,DEM,Kamala Harris,29
-Orange,7139,U.S. Senate,,DEM,Loretta Sanchez,20
-Orange,7140,U.S. Senate,,DEM,Kamala Harris,287
-Orange,7140,U.S. Senate,,DEM,Loretta Sanchez,214
-Orange,7142,U.S. Senate,,DEM,Kamala Harris,0
-Orange,7142,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,7145,U.S. Senate,,DEM,Kamala Harris,212
-Orange,7145,U.S. Senate,,DEM,Loretta Sanchez,228
-Orange,7146,U.S. Senate,,DEM,Kamala Harris,111
-Orange,7146,U.S. Senate,,DEM,Loretta Sanchez,127
-Orange,7147,U.S. Senate,,DEM,Kamala Harris,108
-Orange,7147,U.S. Senate,,DEM,Loretta Sanchez,131
-Orange,7148,U.S. Senate,,DEM,Kamala Harris,20
-Orange,7148,U.S. Senate,,DEM,Loretta Sanchez,13
-Orange,7149,U.S. Senate,,DEM,Kamala Harris,312
-Orange,7149,U.S. Senate,,DEM,Loretta Sanchez,270
-Orange,7151,U.S. Senate,,DEM,Kamala Harris,279
-Orange,7151,U.S. Senate,,DEM,Loretta Sanchez,241
-Orange,7152,U.S. Senate,,DEM,Kamala Harris,204
-Orange,7152,U.S. Senate,,DEM,Loretta Sanchez,186
-Orange,7153,U.S. Senate,,DEM,Kamala Harris,200
-Orange,7153,U.S. Senate,,DEM,Loretta Sanchez,188
-Orange,7158,U.S. Senate,,DEM,Kamala Harris,164
-Orange,7158,U.S. Senate,,DEM,Loretta Sanchez,187
-Orange,7159,U.S. Senate,,DEM,Kamala Harris,231
-Orange,7159,U.S. Senate,,DEM,Loretta Sanchez,186
-Orange,7161,U.S. Senate,,DEM,Kamala Harris,127
-Orange,7161,U.S. Senate,,DEM,Loretta Sanchez,115
-Orange,7162,U.S. Senate,,DEM,Kamala Harris,397
-Orange,7162,U.S. Senate,,DEM,Loretta Sanchez,377
-Orange,7164,U.S. Senate,,DEM,Kamala Harris,256
-Orange,7164,U.S. Senate,,DEM,Loretta Sanchez,205
-Orange,7166,U.S. Senate,,DEM,Kamala Harris,335
-Orange,7166,U.S. Senate,,DEM,Loretta Sanchez,289
-Orange,7167,U.S. Senate,,DEM,Kamala Harris,444
-Orange,7167,U.S. Senate,,DEM,Loretta Sanchez,380
-Orange,7169,U.S. Senate,,DEM,Kamala Harris,0
-Orange,7169,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,7170,U.S. Senate,,DEM,Kamala Harris,236
-Orange,7170,U.S. Senate,,DEM,Loretta Sanchez,203
-Orange,7172,U.S. Senate,,DEM,Kamala Harris,68
-Orange,7172,U.S. Senate,,DEM,Loretta Sanchez,83
-Orange,7174,U.S. Senate,,DEM,Kamala Harris,250
-Orange,7174,U.S. Senate,,DEM,Loretta Sanchez,190
-Orange,7176,U.S. Senate,,DEM,Kamala Harris,455
-Orange,7176,U.S. Senate,,DEM,Loretta Sanchez,477
-Orange,7177,U.S. Senate,,DEM,Kamala Harris,4
-Orange,7177,U.S. Senate,,DEM,Loretta Sanchez,1
-Orange,7180,U.S. Senate,,DEM,Kamala Harris,149
-Orange,7180,U.S. Senate,,DEM,Loretta Sanchez,154
-Orange,7181,U.S. Senate,,DEM,Kamala Harris,17
-Orange,7181,U.S. Senate,,DEM,Loretta Sanchez,20
-Orange,7182,U.S. Senate,,DEM,Kamala Harris,344
-Orange,7182,U.S. Senate,,DEM,Loretta Sanchez,303
-Orange,7183,U.S. Senate,,DEM,Kamala Harris,1
-Orange,7183,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,7185,U.S. Senate,,DEM,Kamala Harris,108
-Orange,7185,U.S. Senate,,DEM,Loretta Sanchez,113
-Orange,7186,U.S. Senate,,DEM,Kamala Harris,97
-Orange,7186,U.S. Senate,,DEM,Loretta Sanchez,130
-Orange,10316,U.S. Senate,,DEM,Kamala Harris,358
-Orange,10316,U.S. Senate,,DEM,Loretta Sanchez,258
-Orange,10317,U.S. Senate,,DEM,Kamala Harris,303
-Orange,10317,U.S. Senate,,DEM,Loretta Sanchez,313
-Orange,10319,U.S. Senate,,DEM,Kamala Harris,257
-Orange,10319,U.S. Senate,,DEM,Loretta Sanchez,246
-Orange,10320,U.S. Senate,,DEM,Kamala Harris,409
-Orange,10320,U.S. Senate,,DEM,Loretta Sanchez,292
-Orange,10322,U.S. Senate,,DEM,Kamala Harris,339
-Orange,10322,U.S. Senate,,DEM,Loretta Sanchez,260
-Orange,10324,U.S. Senate,,DEM,Kamala Harris,376
-Orange,10324,U.S. Senate,,DEM,Loretta Sanchez,289
-Orange,10325,U.S. Senate,,DEM,Kamala Harris,330
-Orange,10325,U.S. Senate,,DEM,Loretta Sanchez,278
-Orange,10326,U.S. Senate,,DEM,Kamala Harris,370
-Orange,10326,U.S. Senate,,DEM,Loretta Sanchez,293
-Orange,10329,U.S. Senate,,DEM,Kamala Harris,314
-Orange,10329,U.S. Senate,,DEM,Loretta Sanchez,259
-Orange,10333,U.S. Senate,,DEM,Kamala Harris,413
-Orange,10333,U.S. Senate,,DEM,Loretta Sanchez,273
-Orange,10334,U.S. Senate,,DEM,Kamala Harris,382
-Orange,10334,U.S. Senate,,DEM,Loretta Sanchez,217
-Orange,10336,U.S. Senate,,DEM,Kamala Harris,239
-Orange,10336,U.S. Senate,,DEM,Loretta Sanchez,154
-Orange,10337,U.S. Senate,,DEM,Kamala Harris,280
-Orange,10337,U.S. Senate,,DEM,Loretta Sanchez,257
-Orange,10338,U.S. Senate,,DEM,Kamala Harris,379
-Orange,10338,U.S. Senate,,DEM,Loretta Sanchez,243
-Orange,10339,U.S. Senate,,DEM,Kamala Harris,354
-Orange,10339,U.S. Senate,,DEM,Loretta Sanchez,261
-Orange,10340,U.S. Senate,,DEM,Kamala Harris,501
-Orange,10340,U.S. Senate,,DEM,Loretta Sanchez,365
-Orange,10360,U.S. Senate,,DEM,Kamala Harris,0
-Orange,10360,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,10361,U.S. Senate,,DEM,Kamala Harris,299
-Orange,10361,U.S. Senate,,DEM,Loretta Sanchez,258
-Orange,10362,U.S. Senate,,DEM,Kamala Harris,252
-Orange,10362,U.S. Senate,,DEM,Loretta Sanchez,274
-Orange,10364,U.S. Senate,,DEM,Kamala Harris,302
-Orange,10364,U.S. Senate,,DEM,Loretta Sanchez,277
-Orange,10367,U.S. Senate,,DEM,Kamala Harris,384
-Orange,10367,U.S. Senate,,DEM,Loretta Sanchez,309
-Orange,10371,U.S. Senate,,DEM,Kamala Harris,352
-Orange,10371,U.S. Senate,,DEM,Loretta Sanchez,283
-Orange,10374,U.S. Senate,,DEM,Kamala Harris,97
-Orange,10374,U.S. Senate,,DEM,Loretta Sanchez,70
-Orange,10376,U.S. Senate,,DEM,Kamala Harris,317
-Orange,10376,U.S. Senate,,DEM,Loretta Sanchez,261
-Orange,10379,U.S. Senate,,DEM,Kamala Harris,270
-Orange,10379,U.S. Senate,,DEM,Loretta Sanchez,246
-Orange,10380,U.S. Senate,,DEM,Kamala Harris,446
-Orange,10380,U.S. Senate,,DEM,Loretta Sanchez,322
-Orange,10382,U.S. Senate,,DEM,Kamala Harris,244
-Orange,10382,U.S. Senate,,DEM,Loretta Sanchez,210
-Orange,10383,U.S. Senate,,DEM,Kamala Harris,44
-Orange,10383,U.S. Senate,,DEM,Loretta Sanchez,31
-Orange,10384,U.S. Senate,,DEM,Kamala Harris,279
-Orange,10384,U.S. Senate,,DEM,Loretta Sanchez,195
-Orange,10388,U.S. Senate,,DEM,Kamala Harris,289
-Orange,10388,U.S. Senate,,DEM,Loretta Sanchez,253
-Orange,10392,U.S. Senate,,DEM,Kamala Harris,289
-Orange,10392,U.S. Senate,,DEM,Loretta Sanchez,256
-Orange,10701,U.S. Senate,,DEM,Kamala Harris,455
-Orange,10701,U.S. Senate,,DEM,Loretta Sanchez,357
-Orange,11041,U.S. Senate,,DEM,Kamala Harris,441
-Orange,11041,U.S. Senate,,DEM,Loretta Sanchez,317
-Orange,11043,U.S. Senate,,DEM,Kamala Harris,132
-Orange,11043,U.S. Senate,,DEM,Loretta Sanchez,94
-Orange,11075,U.S. Senate,,DEM,Kamala Harris,435
-Orange,11075,U.S. Senate,,DEM,Loretta Sanchez,292
-Orange,11351,U.S. Senate,,DEM,Kamala Harris,386
-Orange,11351,U.S. Senate,,DEM,Loretta Sanchez,234
-Orange,11353,U.S. Senate,,DEM,Kamala Harris,244
-Orange,11353,U.S. Senate,,DEM,Loretta Sanchez,155
-Orange,11354,U.S. Senate,,DEM,Kamala Harris,267
-Orange,11354,U.S. Senate,,DEM,Loretta Sanchez,256
-Orange,11355,U.S. Senate,,DEM,Kamala Harris,417
-Orange,11355,U.S. Senate,,DEM,Loretta Sanchez,310
-Orange,11356,U.S. Senate,,DEM,Kamala Harris,334
-Orange,11356,U.S. Senate,,DEM,Loretta Sanchez,289
-Orange,11357,U.S. Senate,,DEM,Kamala Harris,19
-Orange,11357,U.S. Senate,,DEM,Loretta Sanchez,18
-Orange,11359,U.S. Senate,,DEM,Kamala Harris,358
-Orange,11359,U.S. Senate,,DEM,Loretta Sanchez,265
-Orange,11362,U.S. Senate,,DEM,Kamala Harris,211
-Orange,11362,U.S. Senate,,DEM,Loretta Sanchez,170
-Orange,13030,U.S. Senate,,DEM,Kamala Harris,57
-Orange,13030,U.S. Senate,,DEM,Loretta Sanchez,43
-Orange,13031,U.S. Senate,,DEM,Kamala Harris,2
-Orange,13031,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,13032,U.S. Senate,,DEM,Kamala Harris,86
-Orange,13032,U.S. Senate,,DEM,Loretta Sanchez,108
-Orange,13033,U.S. Senate,,DEM,Kamala Harris,228
-Orange,13033,U.S. Senate,,DEM,Loretta Sanchez,223
-Orange,13034,U.S. Senate,,DEM,Kamala Harris,0
-Orange,13034,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,13035,U.S. Senate,,DEM,Kamala Harris,87
-Orange,13035,U.S. Senate,,DEM,Loretta Sanchez,64
-Orange,13036,U.S. Senate,,DEM,Kamala Harris,36
-Orange,13036,U.S. Senate,,DEM,Loretta Sanchez,19
-Orange,13038,U.S. Senate,,DEM,Kamala Harris,286
-Orange,13038,U.S. Senate,,DEM,Loretta Sanchez,258
-Orange,13041,U.S. Senate,,DEM,Kamala Harris,283
-Orange,13041,U.S. Senate,,DEM,Loretta Sanchez,224
-Orange,13042,U.S. Senate,,DEM,Kamala Harris,210
-Orange,13042,U.S. Senate,,DEM,Loretta Sanchez,237
-Orange,13043,U.S. Senate,,DEM,Kamala Harris,337
-Orange,13043,U.S. Senate,,DEM,Loretta Sanchez,463
-Orange,13044,U.S. Senate,,DEM,Kamala Harris,319
-Orange,13044,U.S. Senate,,DEM,Loretta Sanchez,371
-Orange,13047,U.S. Senate,,DEM,Kamala Harris,361
-Orange,13047,U.S. Senate,,DEM,Loretta Sanchez,374
-Orange,13050,U.S. Senate,,DEM,Kamala Harris,332
-Orange,13050,U.S. Senate,,DEM,Loretta Sanchez,310
-Orange,13052,U.S. Senate,,DEM,Kamala Harris,141
-Orange,13052,U.S. Senate,,DEM,Loretta Sanchez,140
-Orange,13053,U.S. Senate,,DEM,Kamala Harris,279
-Orange,13053,U.S. Senate,,DEM,Loretta Sanchez,431
-Orange,13057,U.S. Senate,,DEM,Kamala Harris,403
-Orange,13057,U.S. Senate,,DEM,Loretta Sanchez,363
-Orange,13061,U.S. Senate,,DEM,Kamala Harris,93
-Orange,13061,U.S. Senate,,DEM,Loretta Sanchez,160
-Orange,13062,U.S. Senate,,DEM,Kamala Harris,570
-Orange,13062,U.S. Senate,,DEM,Loretta Sanchez,380
-Orange,13063,U.S. Senate,,DEM,Kamala Harris,282
-Orange,13063,U.S. Senate,,DEM,Loretta Sanchez,211
-Orange,13064,U.S. Senate,,DEM,Kamala Harris,482
-Orange,13064,U.S. Senate,,DEM,Loretta Sanchez,506
-Orange,13065,U.S. Senate,,DEM,Kamala Harris,552
-Orange,13065,U.S. Senate,,DEM,Loretta Sanchez,568
-Orange,13068,U.S. Senate,,DEM,Kamala Harris,508
-Orange,13068,U.S. Senate,,DEM,Loretta Sanchez,529
-Orange,13069,U.S. Senate,,DEM,Kamala Harris,551
-Orange,13069,U.S. Senate,,DEM,Loretta Sanchez,408
-Orange,13074,U.S. Senate,,DEM,Kamala Harris,96
-Orange,13074,U.S. Senate,,DEM,Loretta Sanchez,53
-Orange,13076,U.S. Senate,,DEM,Kamala Harris,200
-Orange,13076,U.S. Senate,,DEM,Loretta Sanchez,222
-Orange,13078,U.S. Senate,,DEM,Kamala Harris,312
-Orange,13078,U.S. Senate,,DEM,Loretta Sanchez,308
-Orange,13080,U.S. Senate,,DEM,Kamala Harris,319
-Orange,13080,U.S. Senate,,DEM,Loretta Sanchez,260
-Orange,13082,U.S. Senate,,DEM,Kamala Harris,561
-Orange,13082,U.S. Senate,,DEM,Loretta Sanchez,454
-Orange,13084,U.S. Senate,,DEM,Kamala Harris,291
-Orange,13084,U.S. Senate,,DEM,Loretta Sanchez,219
-Orange,13085,U.S. Senate,,DEM,Kamala Harris,339
-Orange,13085,U.S. Senate,,DEM,Loretta Sanchez,273
-Orange,13086,U.S. Senate,,DEM,Kamala Harris,727
-Orange,13086,U.S. Senate,,DEM,Loretta Sanchez,573
-Orange,13091,U.S. Senate,,DEM,Kamala Harris,1
-Orange,13091,U.S. Senate,,DEM,Loretta Sanchez,2
-Orange,13094,U.S. Senate,,DEM,Kamala Harris,219
-Orange,13094,U.S. Senate,,DEM,Loretta Sanchez,193
-Orange,13096,U.S. Senate,,DEM,Kamala Harris,516
-Orange,13096,U.S. Senate,,DEM,Loretta Sanchez,408
-Orange,13098,U.S. Senate,,DEM,Kamala Harris,662
-Orange,13098,U.S. Senate,,DEM,Loretta Sanchez,554
-Orange,13099,U.S. Senate,,DEM,Kamala Harris,288
-Orange,13099,U.S. Senate,,DEM,Loretta Sanchez,246
-Orange,13100,U.S. Senate,,DEM,Kamala Harris,237
-Orange,13100,U.S. Senate,,DEM,Loretta Sanchez,192
-Orange,13205,U.S. Senate,,DEM,Kamala Harris,424
-Orange,13205,U.S. Senate,,DEM,Loretta Sanchez,409
-Orange,13208,U.S. Senate,,DEM,Kamala Harris,509
-Orange,13208,U.S. Senate,,DEM,Loretta Sanchez,364
-Orange,13210,U.S. Senate,,DEM,Kamala Harris,325
-Orange,13210,U.S. Senate,,DEM,Loretta Sanchez,245
-Orange,13211,U.S. Senate,,DEM,Kamala Harris,286
-Orange,13211,U.S. Senate,,DEM,Loretta Sanchez,202
-Orange,13214,U.S. Senate,,DEM,Kamala Harris,733
-Orange,13214,U.S. Senate,,DEM,Loretta Sanchez,563
-Orange,13216,U.S. Senate,,DEM,Kamala Harris,61
-Orange,13216,U.S. Senate,,DEM,Loretta Sanchez,45
-Orange,13217,U.S. Senate,,DEM,Kamala Harris,553
-Orange,13217,U.S. Senate,,DEM,Loretta Sanchez,504
-Orange,13220,U.S. Senate,,DEM,Kamala Harris,273
-Orange,13220,U.S. Senate,,DEM,Loretta Sanchez,211
-Orange,13221,U.S. Senate,,DEM,Kamala Harris,690
-Orange,13221,U.S. Senate,,DEM,Loretta Sanchez,527
-Orange,13227,U.S. Senate,,DEM,Kamala Harris,741
-Orange,13227,U.S. Senate,,DEM,Loretta Sanchez,585
-Orange,13228,U.S. Senate,,DEM,Kamala Harris,240
-Orange,13228,U.S. Senate,,DEM,Loretta Sanchez,225
-Orange,13231,U.S. Senate,,DEM,Kamala Harris,192
-Orange,13231,U.S. Senate,,DEM,Loretta Sanchez,200
-Orange,13237,U.S. Senate,,DEM,Kamala Harris,462
-Orange,13237,U.S. Senate,,DEM,Loretta Sanchez,555
-Orange,13241,U.S. Senate,,DEM,Kamala Harris,332
-Orange,13241,U.S. Senate,,DEM,Loretta Sanchez,388
-Orange,13376,U.S. Senate,,DEM,Kamala Harris,271
-Orange,13376,U.S. Senate,,DEM,Loretta Sanchez,204
-Orange,13377,U.S. Senate,,DEM,Kamala Harris,715
-Orange,13377,U.S. Senate,,DEM,Loretta Sanchez,517
-Orange,13379,U.S. Senate,,DEM,Kamala Harris,50
-Orange,13379,U.S. Senate,,DEM,Loretta Sanchez,62
-Orange,13380,U.S. Senate,,DEM,Kamala Harris,1
-Orange,13380,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,13383,U.S. Senate,,DEM,Kamala Harris,603
-Orange,13383,U.S. Senate,,DEM,Loretta Sanchez,456
-Orange,13391,U.S. Senate,,DEM,Kamala Harris,17
-Orange,13391,U.S. Senate,,DEM,Loretta Sanchez,37
-Orange,13395,U.S. Senate,,DEM,Kamala Harris,289
-Orange,13395,U.S. Senate,,DEM,Loretta Sanchez,188
-Orange,13396,U.S. Senate,,DEM,Kamala Harris,424
-Orange,13396,U.S. Senate,,DEM,Loretta Sanchez,571
-Orange,13398,U.S. Senate,,DEM,Kamala Harris,421
-Orange,13398,U.S. Senate,,DEM,Loretta Sanchez,492
-Orange,13408,U.S. Senate,,DEM,Kamala Harris,114
-Orange,13408,U.S. Senate,,DEM,Loretta Sanchez,184
-Orange,13415,U.S. Senate,,DEM,Kamala Harris,0
-Orange,13415,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,13416,U.S. Senate,,DEM,Kamala Harris,109
-Orange,13416,U.S. Senate,,DEM,Loretta Sanchez,107
-Orange,13420,U.S. Senate,,DEM,Kamala Harris,249
-Orange,13420,U.S. Senate,,DEM,Loretta Sanchez,493
-Orange,13425,U.S. Senate,,DEM,Kamala Harris,384
-Orange,13425,U.S. Senate,,DEM,Loretta Sanchez,558
-Orange,13426,U.S. Senate,,DEM,Kamala Harris,192
-Orange,13426,U.S. Senate,,DEM,Loretta Sanchez,137
-Orange,13431,U.S. Senate,,DEM,Kamala Harris,335
-Orange,13431,U.S. Senate,,DEM,Loretta Sanchez,414
-Orange,13432,U.S. Senate,,DEM,Kamala Harris,427
-Orange,13432,U.S. Senate,,DEM,Loretta Sanchez,310
-Orange,13434,U.S. Senate,,DEM,Kamala Harris,62
-Orange,13434,U.S. Senate,,DEM,Loretta Sanchez,32
-Orange,13435,U.S. Senate,,DEM,Kamala Harris,104
-Orange,13435,U.S. Senate,,DEM,Loretta Sanchez,106
-Orange,13441,U.S. Senate,,DEM,Kamala Harris,0
-Orange,13441,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,13443,U.S. Senate,,DEM,Kamala Harris,372
-Orange,13443,U.S. Senate,,DEM,Loretta Sanchez,305
-Orange,13445,U.S. Senate,,DEM,Kamala Harris,0
-Orange,13445,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,13452,U.S. Senate,,DEM,Kamala Harris,296
-Orange,13452,U.S. Senate,,DEM,Loretta Sanchez,209
-Orange,13461,U.S. Senate,,DEM,Kamala Harris,155
-Orange,13461,U.S. Senate,,DEM,Loretta Sanchez,107
-Orange,13463,U.S. Senate,,DEM,Kamala Harris,401
-Orange,13463,U.S. Senate,,DEM,Loretta Sanchez,363
-Orange,13467,U.S. Senate,,DEM,Kamala Harris,0
-Orange,13467,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,13701,U.S. Senate,,DEM,Kamala Harris,528
-Orange,13701,U.S. Senate,,DEM,Loretta Sanchez,412
-Orange,14002,U.S. Senate,,DEM,Kamala Harris,364
-Orange,14002,U.S. Senate,,DEM,Loretta Sanchez,562
-Orange,14005,U.S. Senate,,DEM,Kamala Harris,221
-Orange,14005,U.S. Senate,,DEM,Loretta Sanchez,294
-Orange,14008,U.S. Senate,,DEM,Kamala Harris,240
-Orange,14008,U.S. Senate,,DEM,Loretta Sanchez,421
-Orange,14009,U.S. Senate,,DEM,Kamala Harris,273
-Orange,14009,U.S. Senate,,DEM,Loretta Sanchez,392
-Orange,14012,U.S. Senate,,DEM,Kamala Harris,248
-Orange,14012,U.S. Senate,,DEM,Loretta Sanchez,338
-Orange,14013,U.S. Senate,,DEM,Kamala Harris,170
-Orange,14013,U.S. Senate,,DEM,Loretta Sanchez,198
-Orange,14014,U.S. Senate,,DEM,Kamala Harris,278
-Orange,14014,U.S. Senate,,DEM,Loretta Sanchez,361
-Orange,14015,U.S. Senate,,DEM,Kamala Harris,243
-Orange,14015,U.S. Senate,,DEM,Loretta Sanchez,335
-Orange,14016,U.S. Senate,,DEM,Kamala Harris,306
-Orange,14016,U.S. Senate,,DEM,Loretta Sanchez,453
-Orange,14018,U.S. Senate,,DEM,Kamala Harris,228
-Orange,14018,U.S. Senate,,DEM,Loretta Sanchez,472
-Orange,14020,U.S. Senate,,DEM,Kamala Harris,374
-Orange,14020,U.S. Senate,,DEM,Loretta Sanchez,523
-Orange,14021,U.S. Senate,,DEM,Kamala Harris,154
-Orange,14021,U.S. Senate,,DEM,Loretta Sanchez,285
-Orange,14023,U.S. Senate,,DEM,Kamala Harris,294
-Orange,14023,U.S. Senate,,DEM,Loretta Sanchez,439
-Orange,14026,U.S. Senate,,DEM,Kamala Harris,437
-Orange,14026,U.S. Senate,,DEM,Loretta Sanchez,505
-Orange,14027,U.S. Senate,,DEM,Kamala Harris,215
-Orange,14027,U.S. Senate,,DEM,Loretta Sanchez,314
-Orange,14029,U.S. Senate,,DEM,Kamala Harris,248
-Orange,14029,U.S. Senate,,DEM,Loretta Sanchez,350
-Orange,14031,U.S. Senate,,DEM,Kamala Harris,298
-Orange,14031,U.S. Senate,,DEM,Loretta Sanchez,491
-Orange,14032,U.S. Senate,,DEM,Kamala Harris,316
-Orange,14032,U.S. Senate,,DEM,Loretta Sanchez,361
-Orange,14033,U.S. Senate,,DEM,Kamala Harris,153
-Orange,14033,U.S. Senate,,DEM,Loretta Sanchez,239
-Orange,14034,U.S. Senate,,DEM,Kamala Harris,225
-Orange,14034,U.S. Senate,,DEM,Loretta Sanchez,329
-Orange,14035,U.S. Senate,,DEM,Kamala Harris,314
-Orange,14035,U.S. Senate,,DEM,Loretta Sanchez,437
-Orange,14036,U.S. Senate,,DEM,Kamala Harris,269
-Orange,14036,U.S. Senate,,DEM,Loretta Sanchez,301
-Orange,14037,U.S. Senate,,DEM,Kamala Harris,336
-Orange,14037,U.S. Senate,,DEM,Loretta Sanchez,451
-Orange,14041,U.S. Senate,,DEM,Kamala Harris,158
-Orange,14041,U.S. Senate,,DEM,Loretta Sanchez,352
-Orange,14045,U.S. Senate,,DEM,Kamala Harris,86
-Orange,14045,U.S. Senate,,DEM,Loretta Sanchez,187
-Orange,14046,U.S. Senate,,DEM,Kamala Harris,6
-Orange,14046,U.S. Senate,,DEM,Loretta Sanchez,8
-Orange,14047,U.S. Senate,,DEM,Kamala Harris,222
-Orange,14047,U.S. Senate,,DEM,Loretta Sanchez,449
-Orange,14053,U.S. Senate,,DEM,Kamala Harris,291
-Orange,14053,U.S. Senate,,DEM,Loretta Sanchez,482
-Orange,14058,U.S. Senate,,DEM,Kamala Harris,137
-Orange,14058,U.S. Senate,,DEM,Loretta Sanchez,201
-Orange,14059,U.S. Senate,,DEM,Kamala Harris,202
-Orange,14059,U.S. Senate,,DEM,Loretta Sanchez,388
-Orange,14063,U.S. Senate,,DEM,Kamala Harris,126
-Orange,14063,U.S. Senate,,DEM,Loretta Sanchez,309
-Orange,14065,U.S. Senate,,DEM,Kamala Harris,0
-Orange,14065,U.S. Senate,,DEM,Loretta Sanchez,1
-Orange,14066,U.S. Senate,,DEM,Kamala Harris,278
-Orange,14066,U.S. Senate,,DEM,Loretta Sanchez,373
-Orange,14069,U.S. Senate,,DEM,Kamala Harris,301
-Orange,14069,U.S. Senate,,DEM,Loretta Sanchez,529
-Orange,14071,U.S. Senate,,DEM,Kamala Harris,124
-Orange,14071,U.S. Senate,,DEM,Loretta Sanchez,233
-Orange,14075,U.S. Senate,,DEM,Kamala Harris,253
-Orange,14075,U.S. Senate,,DEM,Loretta Sanchez,220
-Orange,14078,U.S. Senate,,DEM,Kamala Harris,393
-Orange,14078,U.S. Senate,,DEM,Loretta Sanchez,339
-Orange,14082,U.S. Senate,,DEM,Kamala Harris,292
-Orange,14082,U.S. Senate,,DEM,Loretta Sanchez,246
-Orange,14084,U.S. Senate,,DEM,Kamala Harris,340
-Orange,14084,U.S. Senate,,DEM,Loretta Sanchez,272
-Orange,14085,U.S. Senate,,DEM,Kamala Harris,251
-Orange,14085,U.S. Senate,,DEM,Loretta Sanchez,206
-Orange,14086,U.S. Senate,,DEM,Kamala Harris,389
-Orange,14086,U.S. Senate,,DEM,Loretta Sanchez,286
-Orange,14089,U.S. Senate,,DEM,Kamala Harris,296
-Orange,14089,U.S. Senate,,DEM,Loretta Sanchez,252
-Orange,14090,U.S. Senate,,DEM,Kamala Harris,258
-Orange,14090,U.S. Senate,,DEM,Loretta Sanchez,199
-Orange,14091,U.S. Senate,,DEM,Kamala Harris,235
-Orange,14091,U.S. Senate,,DEM,Loretta Sanchez,167
-Orange,14092,U.S. Senate,,DEM,Kamala Harris,339
-Orange,14092,U.S. Senate,,DEM,Loretta Sanchez,290
-Orange,14218,U.S. Senate,,DEM,Kamala Harris,157
-Orange,14218,U.S. Senate,,DEM,Loretta Sanchez,257
-Orange,14221,U.S. Senate,,DEM,Kamala Harris,220
-Orange,14221,U.S. Senate,,DEM,Loretta Sanchez,580
-Orange,14226,U.S. Senate,,DEM,Kamala Harris,236
-Orange,14226,U.S. Senate,,DEM,Loretta Sanchez,701
-Orange,14228,U.S. Senate,,DEM,Kamala Harris,173
-Orange,14228,U.S. Senate,,DEM,Loretta Sanchez,262
-Orange,14229,U.S. Senate,,DEM,Kamala Harris,267
-Orange,14229,U.S. Senate,,DEM,Loretta Sanchez,401
-Orange,14234,U.S. Senate,,DEM,Kamala Harris,330
-Orange,14234,U.S. Senate,,DEM,Loretta Sanchez,529
-Orange,14235,U.S. Senate,,DEM,Kamala Harris,247
-Orange,14235,U.S. Senate,,DEM,Loretta Sanchez,395
-Orange,14236,U.S. Senate,,DEM,Kamala Harris,369
-Orange,14236,U.S. Senate,,DEM,Loretta Sanchez,610
-Orange,14239,U.S. Senate,,DEM,Kamala Harris,177
-Orange,14239,U.S. Senate,,DEM,Loretta Sanchez,320
-Orange,14241,U.S. Senate,,DEM,Kamala Harris,321
-Orange,14241,U.S. Senate,,DEM,Loretta Sanchez,540
-Orange,14244,U.S. Senate,,DEM,Kamala Harris,171
-Orange,14244,U.S. Senate,,DEM,Loretta Sanchez,362
-Orange,14247,U.S. Senate,,DEM,Kamala Harris,114
-Orange,14247,U.S. Senate,,DEM,Loretta Sanchez,243
-Orange,14249,U.S. Senate,,DEM,Kamala Harris,134
-Orange,14249,U.S. Senate,,DEM,Loretta Sanchez,270
-Orange,14250,U.S. Senate,,DEM,Kamala Harris,200
-Orange,14250,U.S. Senate,,DEM,Loretta Sanchez,308
-Orange,14251,U.S. Senate,,DEM,Kamala Harris,296
-Orange,14251,U.S. Senate,,DEM,Loretta Sanchez,410
-Orange,14252,U.S. Senate,,DEM,Kamala Harris,118
-Orange,14252,U.S. Senate,,DEM,Loretta Sanchez,258
-Orange,14257,U.S. Senate,,DEM,Kamala Harris,187
-Orange,14257,U.S. Senate,,DEM,Loretta Sanchez,415
-Orange,14274,U.S. Senate,,DEM,Kamala Harris,370
-Orange,14274,U.S. Senate,,DEM,Loretta Sanchez,361
-Orange,14275,U.S. Senate,,DEM,Kamala Harris,224
-Orange,14275,U.S. Senate,,DEM,Loretta Sanchez,370
-Orange,14282,U.S. Senate,,DEM,Kamala Harris,70
-Orange,14282,U.S. Senate,,DEM,Loretta Sanchez,67
-Orange,14285,U.S. Senate,,DEM,Kamala Harris,13
-Orange,14285,U.S. Senate,,DEM,Loretta Sanchez,30
-Orange,14291,U.S. Senate,,DEM,Kamala Harris,40
-Orange,14291,U.S. Senate,,DEM,Loretta Sanchez,41
-Orange,14293,U.S. Senate,,DEM,Kamala Harris,97
-Orange,14293,U.S. Senate,,DEM,Loretta Sanchez,237
-Orange,14295,U.S. Senate,,DEM,Kamala Harris,172
-Orange,14295,U.S. Senate,,DEM,Loretta Sanchez,354
-Orange,14298,U.S. Senate,,DEM,Kamala Harris,146
-Orange,14298,U.S. Senate,,DEM,Loretta Sanchez,248
-Orange,14306,U.S. Senate,,DEM,Kamala Harris,198
-Orange,14306,U.S. Senate,,DEM,Loretta Sanchez,442
-Orange,14308,U.S. Senate,,DEM,Kamala Harris,240
-Orange,14308,U.S. Senate,,DEM,Loretta Sanchez,304
-Orange,14316,U.S. Senate,,DEM,Kamala Harris,237
-Orange,14316,U.S. Senate,,DEM,Loretta Sanchez,268
-Orange,14317,U.S. Senate,,DEM,Kamala Harris,259
-Orange,14317,U.S. Senate,,DEM,Loretta Sanchez,516
-Orange,14701,U.S. Senate,,DEM,Kamala Harris,296
-Orange,14701,U.S. Senate,,DEM,Loretta Sanchez,594
-Orange,14702,U.S. Senate,,DEM,Kamala Harris,436
-Orange,14702,U.S. Senate,,DEM,Loretta Sanchez,811
-Orange,14703,U.S. Senate,,DEM,Kamala Harris,276
-Orange,14703,U.S. Senate,,DEM,Loretta Sanchez,606
-Orange,14704,U.S. Senate,,DEM,Kamala Harris,345
-Orange,14704,U.S. Senate,,DEM,Loretta Sanchez,547
-Orange,14705,U.S. Senate,,DEM,Kamala Harris,674
-Orange,14705,U.S. Senate,,DEM,Loretta Sanchez,561
-Orange,14706,U.S. Senate,,DEM,Kamala Harris,369
-Orange,14706,U.S. Senate,,DEM,Loretta Sanchez,695
-Orange,16101,U.S. Senate,,DEM,Kamala Harris,186
-Orange,16101,U.S. Senate,,DEM,Loretta Sanchez,403
-Orange,16106,U.S. Senate,,DEM,Kamala Harris,38
-Orange,16106,U.S. Senate,,DEM,Loretta Sanchez,64
-Orange,16109,U.S. Senate,,DEM,Kamala Harris,25
-Orange,16109,U.S. Senate,,DEM,Loretta Sanchez,33
-Orange,17256,U.S. Senate,,DEM,Kamala Harris,356
-Orange,17256,U.S. Senate,,DEM,Loretta Sanchez,415
-Orange,17258,U.S. Senate,,DEM,Kamala Harris,391
-Orange,17258,U.S. Senate,,DEM,Loretta Sanchez,595
-Orange,17260,U.S. Senate,,DEM,Kamala Harris,359
-Orange,17260,U.S. Senate,,DEM,Loretta Sanchez,350
-Orange,17261,U.S. Senate,,DEM,Kamala Harris,286
-Orange,17261,U.S. Senate,,DEM,Loretta Sanchez,334
-Orange,17263,U.S. Senate,,DEM,Kamala Harris,27
-Orange,17263,U.S. Senate,,DEM,Loretta Sanchez,20
-Orange,17264,U.S. Senate,,DEM,Kamala Harris,299
-Orange,17264,U.S. Senate,,DEM,Loretta Sanchez,293
-Orange,17268,U.S. Senate,,DEM,Kamala Harris,266
-Orange,17268,U.S. Senate,,DEM,Loretta Sanchez,277
-Orange,17269,U.S. Senate,,DEM,Kamala Harris,296
-Orange,17269,U.S. Senate,,DEM,Loretta Sanchez,200
-Orange,17271,U.S. Senate,,DEM,Kamala Harris,308
-Orange,17271,U.S. Senate,,DEM,Loretta Sanchez,221
-Orange,17274,U.S. Senate,,DEM,Kamala Harris,368
-Orange,17274,U.S. Senate,,DEM,Loretta Sanchez,379
-Orange,17278,U.S. Senate,,DEM,Kamala Harris,386
-Orange,17278,U.S. Senate,,DEM,Loretta Sanchez,321
-Orange,17279,U.S. Senate,,DEM,Kamala Harris,383
-Orange,17279,U.S. Senate,,DEM,Loretta Sanchez,371
-Orange,17281,U.S. Senate,,DEM,Kamala Harris,402
-Orange,17281,U.S. Senate,,DEM,Loretta Sanchez,393
-Orange,17282,U.S. Senate,,DEM,Kamala Harris,288
-Orange,17282,U.S. Senate,,DEM,Loretta Sanchez,436
-Orange,17290,U.S. Senate,,DEM,Kamala Harris,367
-Orange,17290,U.S. Senate,,DEM,Loretta Sanchez,430
-Orange,17294,U.S. Senate,,DEM,Kamala Harris,330
-Orange,17294,U.S. Senate,,DEM,Loretta Sanchez,340
-Orange,17335,U.S. Senate,,DEM,Kamala Harris,369
-Orange,17335,U.S. Senate,,DEM,Loretta Sanchez,294
-Orange,17336,U.S. Senate,,DEM,Kamala Harris,333
-Orange,17336,U.S. Senate,,DEM,Loretta Sanchez,262
-Orange,17338,U.S. Senate,,DEM,Kamala Harris,302
-Orange,17338,U.S. Senate,,DEM,Loretta Sanchez,315
-Orange,17340,U.S. Senate,,DEM,Kamala Harris,288
-Orange,17340,U.S. Senate,,DEM,Loretta Sanchez,221
-Orange,17345,U.S. Senate,,DEM,Kamala Harris,269
-Orange,17345,U.S. Senate,,DEM,Loretta Sanchez,329
-Orange,17352,U.S. Senate,,DEM,Kamala Harris,378
-Orange,17352,U.S. Senate,,DEM,Loretta Sanchez,329
-Orange,17355,U.S. Senate,,DEM,Kamala Harris,379
-Orange,17355,U.S. Senate,,DEM,Loretta Sanchez,318
-Orange,17701,U.S. Senate,,DEM,Kamala Harris,525
-Orange,17701,U.S. Senate,,DEM,Loretta Sanchez,526
-Orange,17702,U.S. Senate,,DEM,Kamala Harris,484
-Orange,17702,U.S. Senate,,DEM,Loretta Sanchez,648
-Orange,17703,U.S. Senate,,DEM,Kamala Harris,502
-Orange,17703,U.S. Senate,,DEM,Loretta Sanchez,430
-Orange,18194,U.S. Senate,,DEM,Kamala Harris,29
-Orange,18194,U.S. Senate,,DEM,Loretta Sanchez,25
-Orange,18195,U.S. Senate,,DEM,Kamala Harris,222
-Orange,18195,U.S. Senate,,DEM,Loretta Sanchez,203
-Orange,18196,U.S. Senate,,DEM,Kamala Harris,26
-Orange,18196,U.S. Senate,,DEM,Loretta Sanchez,29
-Orange,18198,U.S. Senate,,DEM,Kamala Harris,11
-Orange,18198,U.S. Senate,,DEM,Loretta Sanchez,7
-Orange,21369,U.S. Senate,,DEM,Kamala Harris,392
-Orange,21369,U.S. Senate,,DEM,Loretta Sanchez,582
-Orange,21375,U.S. Senate,,DEM,Kamala Harris,13
-Orange,21375,U.S. Senate,,DEM,Loretta Sanchez,23
-Orange,21376,U.S. Senate,,DEM,Kamala Harris,249
-Orange,21376,U.S. Senate,,DEM,Loretta Sanchez,269
-Orange,21377,U.S. Senate,,DEM,Kamala Harris,61
-Orange,21377,U.S. Senate,,DEM,Loretta Sanchez,75
-Orange,21380,U.S. Senate,,DEM,Kamala Harris,359
-Orange,21380,U.S. Senate,,DEM,Loretta Sanchez,570
-Orange,21383,U.S. Senate,,DEM,Kamala Harris,0
-Orange,21383,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,21402,U.S. Senate,,DEM,Kamala Harris,0
-Orange,21402,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,22166,U.S. Senate,,DEM,Kamala Harris,94
-Orange,22166,U.S. Senate,,DEM,Loretta Sanchez,74
-Orange,23169,U.S. Senate,,DEM,Kamala Harris,386
-Orange,23169,U.S. Senate,,DEM,Loretta Sanchez,356
-Orange,23174,U.S. Senate,,DEM,Kamala Harris,222
-Orange,23174,U.S. Senate,,DEM,Loretta Sanchez,210
-Orange,23176,U.S. Senate,,DEM,Kamala Harris,412
-Orange,23176,U.S. Senate,,DEM,Loretta Sanchez,324
-Orange,23180,U.S. Senate,,DEM,Kamala Harris,691
-Orange,23180,U.S. Senate,,DEM,Loretta Sanchez,509
-Orange,23187,U.S. Senate,,DEM,Kamala Harris,352
-Orange,23187,U.S. Senate,,DEM,Loretta Sanchez,306
-Orange,23193,U.S. Senate,,DEM,Kamala Harris,153
-Orange,23193,U.S. Senate,,DEM,Loretta Sanchez,116
-Orange,23196,U.S. Senate,,DEM,Kamala Harris,293
-Orange,23196,U.S. Senate,,DEM,Loretta Sanchez,271
-Orange,23203,U.S. Senate,,DEM,Kamala Harris,386
-Orange,23203,U.S. Senate,,DEM,Loretta Sanchez,322
-Orange,23205,U.S. Senate,,DEM,Kamala Harris,384
-Orange,23205,U.S. Senate,,DEM,Loretta Sanchez,354
-Orange,23206,U.S. Senate,,DEM,Kamala Harris,455
-Orange,23206,U.S. Senate,,DEM,Loretta Sanchez,567
-Orange,23207,U.S. Senate,,DEM,Kamala Harris,694
-Orange,23207,U.S. Senate,,DEM,Loretta Sanchez,537
-Orange,23213,U.S. Senate,,DEM,Kamala Harris,207
-Orange,23213,U.S. Senate,,DEM,Loretta Sanchez,449
-Orange,23217,U.S. Senate,,DEM,Kamala Harris,260
-Orange,23217,U.S. Senate,,DEM,Loretta Sanchez,355
-Orange,23224,U.S. Senate,,DEM,Kamala Harris,54
-Orange,23224,U.S. Senate,,DEM,Loretta Sanchez,38
-Orange,23601,U.S. Senate,,DEM,Kamala Harris,911
-Orange,23601,U.S. Senate,,DEM,Loretta Sanchez,721
-Orange,23602,U.S. Senate,,DEM,Kamala Harris,513
-Orange,23602,U.S. Senate,,DEM,Loretta Sanchez,425
-Orange,23603,U.S. Senate,,DEM,Kamala Harris,463
-Orange,23603,U.S. Senate,,DEM,Loretta Sanchez,391
-Orange,23604,U.S. Senate,,DEM,Kamala Harris,682
-Orange,23604,U.S. Senate,,DEM,Loretta Sanchez,605
-Orange,23605,U.S. Senate,,DEM,Kamala Harris,816
-Orange,23605,U.S. Senate,,DEM,Loretta Sanchez,696
-Orange,23606,U.S. Senate,,DEM,Kamala Harris,548
-Orange,23606,U.S. Senate,,DEM,Loretta Sanchez,489
-Orange,23607,U.S. Senate,,DEM,Kamala Harris,220
-Orange,23607,U.S. Senate,,DEM,Loretta Sanchez,189
-Orange,23608,U.S. Senate,,DEM,Kamala Harris,408
-Orange,23608,U.S. Senate,,DEM,Loretta Sanchez,366
-Orange,23609,U.S. Senate,,DEM,Kamala Harris,110
-Orange,23609,U.S. Senate,,DEM,Loretta Sanchez,89
-Orange,23901,U.S. Senate,,DEM,Kamala Harris,65
-Orange,23901,U.S. Senate,,DEM,Loretta Sanchez,63
-Orange,23902,U.S. Senate,,DEM,Kamala Harris,90
-Orange,23902,U.S. Senate,,DEM,Loretta Sanchez,60
-Orange,25230,U.S. Senate,,DEM,Kamala Harris,596
-Orange,25230,U.S. Senate,,DEM,Loretta Sanchez,313
-Orange,25231,U.S. Senate,,DEM,Kamala Harris,1003
-Orange,25231,U.S. Senate,,DEM,Loretta Sanchez,560
-Orange,25234,U.S. Senate,,DEM,Kamala Harris,1304
-Orange,25234,U.S. Senate,,DEM,Loretta Sanchez,683
-Orange,25237,U.S. Senate,,DEM,Kamala Harris,172
-Orange,25237,U.S. Senate,,DEM,Loretta Sanchez,52
-Orange,25282,U.S. Senate,,DEM,Kamala Harris,1419
-Orange,25282,U.S. Senate,,DEM,Loretta Sanchez,677
-Orange,25371,U.S. Senate,,DEM,Kamala Harris,25
-Orange,25371,U.S. Senate,,DEM,Loretta Sanchez,13
-Orange,25377,U.S. Senate,,DEM,Kamala Harris,63
-Orange,25377,U.S. Senate,,DEM,Loretta Sanchez,28
-Orange,25381,U.S. Senate,,DEM,Kamala Harris,0
-Orange,25381,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,25382,U.S. Senate,,DEM,Kamala Harris,320
-Orange,25382,U.S. Senate,,DEM,Loretta Sanchez,133
-Orange,25385,U.S. Senate,,DEM,Kamala Harris,1469
-Orange,25385,U.S. Senate,,DEM,Loretta Sanchez,831
-Orange,25391,U.S. Senate,,DEM,Kamala Harris,217
-Orange,25391,U.S. Senate,,DEM,Loretta Sanchez,115
-Orange,26193,U.S. Senate,,DEM,Kamala Harris,117
-Orange,26193,U.S. Senate,,DEM,Loretta Sanchez,117
-Orange,26197,U.S. Senate,,DEM,Kamala Harris,0
-Orange,26197,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,26198,U.S. Senate,,DEM,Kamala Harris,90
-Orange,26198,U.S. Senate,,DEM,Loretta Sanchez,82
-Orange,26200,U.S. Senate,,DEM,Kamala Harris,0
-Orange,26200,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,27112,U.S. Senate,,DEM,Kamala Harris,230
-Orange,27112,U.S. Senate,,DEM,Loretta Sanchez,372
-Orange,27113,U.S. Senate,,DEM,Kamala Harris,247
-Orange,27113,U.S. Senate,,DEM,Loretta Sanchez,409
-Orange,27117,U.S. Senate,,DEM,Kamala Harris,233
-Orange,27117,U.S. Senate,,DEM,Loretta Sanchez,316
-Orange,27140,U.S. Senate,,DEM,Kamala Harris,2
-Orange,27140,U.S. Senate,,DEM,Loretta Sanchez,1
-Orange,27141,U.S. Senate,,DEM,Kamala Harris,17
-Orange,27141,U.S. Senate,,DEM,Loretta Sanchez,41
-Orange,27142,U.S. Senate,,DEM,Kamala Harris,77
-Orange,27142,U.S. Senate,,DEM,Loretta Sanchez,141
-Orange,27143,U.S. Senate,,DEM,Kamala Harris,165
-Orange,27143,U.S. Senate,,DEM,Loretta Sanchez,290
-Orange,27146,U.S. Senate,,DEM,Kamala Harris,0
-Orange,27146,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,27155,U.S. Senate,,DEM,Kamala Harris,170
-Orange,27155,U.S. Senate,,DEM,Loretta Sanchez,230
-Orange,27156,U.S. Senate,,DEM,Kamala Harris,274
-Orange,27156,U.S. Senate,,DEM,Loretta Sanchez,235
-Orange,27157,U.S. Senate,,DEM,Kamala Harris,8
-Orange,27157,U.S. Senate,,DEM,Loretta Sanchez,6
-Orange,27159,U.S. Senate,,DEM,Kamala Harris,191
-Orange,27159,U.S. Senate,,DEM,Loretta Sanchez,273
-Orange,27164,U.S. Senate,,DEM,Kamala Harris,16
-Orange,27164,U.S. Senate,,DEM,Loretta Sanchez,78
-Orange,27168,U.S. Senate,,DEM,Kamala Harris,211
-Orange,27168,U.S. Senate,,DEM,Loretta Sanchez,260
-Orange,27601,U.S. Senate,,DEM,Kamala Harris,197
-Orange,27601,U.S. Senate,,DEM,Loretta Sanchez,445
-Orange,27602,U.S. Senate,,DEM,Kamala Harris,356
-Orange,27602,U.S. Senate,,DEM,Loretta Sanchez,387
-Orange,27603,U.S. Senate,,DEM,Kamala Harris,171
-Orange,27603,U.S. Senate,,DEM,Loretta Sanchez,249
-Orange,27604,U.S. Senate,,DEM,Kamala Harris,568
-Orange,27604,U.S. Senate,,DEM,Loretta Sanchez,667
-Orange,27605,U.S. Senate,,DEM,Kamala Harris,323
-Orange,27605,U.S. Senate,,DEM,Loretta Sanchez,337
-Orange,27701,U.S. Senate,,DEM,Kamala Harris,371
-Orange,27701,U.S. Senate,,DEM,Loretta Sanchez,672
-Orange,28200,U.S. Senate,,DEM,Kamala Harris,163
-Orange,28200,U.S. Senate,,DEM,Loretta Sanchez,111
-Orange,28201,U.S. Senate,,DEM,Kamala Harris,215
-Orange,28201,U.S. Senate,,DEM,Loretta Sanchez,151
-Orange,28206,U.S. Senate,,DEM,Kamala Harris,0
-Orange,28206,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,28247,U.S. Senate,,DEM,Kamala Harris,201
-Orange,28247,U.S. Senate,,DEM,Loretta Sanchez,208
-Orange,28901,U.S. Senate,,DEM,Kamala Harris,0
-Orange,28901,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,28902,U.S. Senate,,DEM,Kamala Harris,0
-Orange,28902,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,28903,U.S. Senate,,DEM,Kamala Harris,0
-Orange,28903,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,29277,U.S. Senate,,DEM,Kamala Harris,661
-Orange,29277,U.S. Senate,,DEM,Loretta Sanchez,470
-Orange,29278,U.S. Senate,,DEM,Kamala Harris,0
-Orange,29278,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,29279,U.S. Senate,,DEM,Kamala Harris,489
-Orange,29279,U.S. Senate,,DEM,Loretta Sanchez,373
-Orange,29280,U.S. Senate,,DEM,Kamala Harris,245
-Orange,29280,U.S. Senate,,DEM,Loretta Sanchez,230
-Orange,29282,U.S. Senate,,DEM,Kamala Harris,375
-Orange,29282,U.S. Senate,,DEM,Loretta Sanchez,343
-Orange,29285,U.S. Senate,,DEM,Kamala Harris,488
-Orange,29285,U.S. Senate,,DEM,Loretta Sanchez,373
-Orange,29286,U.S. Senate,,DEM,Kamala Harris,691
-Orange,29286,U.S. Senate,,DEM,Loretta Sanchez,655
-Orange,29289,U.S. Senate,,DEM,Kamala Harris,6
-Orange,29289,U.S. Senate,,DEM,Loretta Sanchez,5
-Orange,29292,U.S. Senate,,DEM,Kamala Harris,313
-Orange,29292,U.S. Senate,,DEM,Loretta Sanchez,276
-Orange,29293,U.S. Senate,,DEM,Kamala Harris,482
-Orange,29293,U.S. Senate,,DEM,Loretta Sanchez,469
-Orange,29294,U.S. Senate,,DEM,Kamala Harris,342
-Orange,29294,U.S. Senate,,DEM,Loretta Sanchez,329
-Orange,29295,U.S. Senate,,DEM,Kamala Harris,672
-Orange,29295,U.S. Senate,,DEM,Loretta Sanchez,555
-Orange,29297,U.S. Senate,,DEM,Kamala Harris,206
-Orange,29297,U.S. Senate,,DEM,Loretta Sanchez,256
-Orange,29299,U.S. Senate,,DEM,Kamala Harris,574
-Orange,29299,U.S. Senate,,DEM,Loretta Sanchez,525
-Orange,29300,U.S. Senate,,DEM,Kamala Harris,318
-Orange,29300,U.S. Senate,,DEM,Loretta Sanchez,368
-Orange,29302,U.S. Senate,,DEM,Kamala Harris,288
-Orange,29302,U.S. Senate,,DEM,Loretta Sanchez,259
-Orange,29304,U.S. Senate,,DEM,Kamala Harris,648
-Orange,29304,U.S. Senate,,DEM,Loretta Sanchez,750
-Orange,29305,U.S. Senate,,DEM,Kamala Harris,582
-Orange,29305,U.S. Senate,,DEM,Loretta Sanchez,521
-Orange,29308,U.S. Senate,,DEM,Kamala Harris,170
-Orange,29308,U.S. Senate,,DEM,Loretta Sanchez,158
-Orange,29309,U.S. Senate,,DEM,Kamala Harris,402
-Orange,29309,U.S. Senate,,DEM,Loretta Sanchez,266
-Orange,29311,U.S. Senate,,DEM,Kamala Harris,766
-Orange,29311,U.S. Senate,,DEM,Loretta Sanchez,633
-Orange,29313,U.S. Senate,,DEM,Kamala Harris,403
-Orange,29313,U.S. Senate,,DEM,Loretta Sanchez,332
-Orange,29314,U.S. Senate,,DEM,Kamala Harris,598
-Orange,29314,U.S. Senate,,DEM,Loretta Sanchez,511
-Orange,29345,U.S. Senate,,DEM,Kamala Harris,262
-Orange,29345,U.S. Senate,,DEM,Loretta Sanchez,255
-Orange,29346,U.S. Senate,,DEM,Kamala Harris,195
-Orange,29346,U.S. Senate,,DEM,Loretta Sanchez,174
-Orange,29347,U.S. Senate,,DEM,Kamala Harris,224
-Orange,29347,U.S. Senate,,DEM,Loretta Sanchez,224
-Orange,29349,U.S. Senate,,DEM,Kamala Harris,325
-Orange,29349,U.S. Senate,,DEM,Loretta Sanchez,326
-Orange,29354,U.S. Senate,,DEM,Kamala Harris,432
-Orange,29354,U.S. Senate,,DEM,Loretta Sanchez,299
-Orange,29356,U.S. Senate,,DEM,Kamala Harris,202
-Orange,29356,U.S. Senate,,DEM,Loretta Sanchez,212
-Orange,29359,U.S. Senate,,DEM,Kamala Harris,274
-Orange,29359,U.S. Senate,,DEM,Loretta Sanchez,259
-Orange,29360,U.S. Senate,,DEM,Kamala Harris,163
-Orange,29360,U.S. Senate,,DEM,Loretta Sanchez,128
-Orange,29361,U.S. Senate,,DEM,Kamala Harris,114
-Orange,29361,U.S. Senate,,DEM,Loretta Sanchez,111
-Orange,29362,U.S. Senate,,DEM,Kamala Harris,748
-Orange,29362,U.S. Senate,,DEM,Loretta Sanchez,593
-Orange,29363,U.S. Senate,,DEM,Kamala Harris,611
-Orange,29363,U.S. Senate,,DEM,Loretta Sanchez,545
-Orange,29364,U.S. Senate,,DEM,Kamala Harris,354
-Orange,29364,U.S. Senate,,DEM,Loretta Sanchez,331
-Orange,29365,U.S. Senate,,DEM,Kamala Harris,370
-Orange,29365,U.S. Senate,,DEM,Loretta Sanchez,364
-Orange,29368,U.S. Senate,,DEM,Kamala Harris,329
-Orange,29368,U.S. Senate,,DEM,Loretta Sanchez,266
-Orange,29369,U.S. Senate,,DEM,Kamala Harris,715
-Orange,29369,U.S. Senate,,DEM,Loretta Sanchez,606
-Orange,29370,U.S. Senate,,DEM,Kamala Harris,406
-Orange,29370,U.S. Senate,,DEM,Loretta Sanchez,292
-Orange,29901,U.S. Senate,,DEM,Kamala Harris,0
-Orange,29901,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,29902,U.S. Senate,,DEM,Kamala Harris,2
-Orange,29902,U.S. Senate,,DEM,Loretta Sanchez,3
-Orange,31001,U.S. Senate,,DEM,Kamala Harris,340
-Orange,31001,U.S. Senate,,DEM,Loretta Sanchez,255
-Orange,31002,U.S. Senate,,DEM,Kamala Harris,681
-Orange,31002,U.S. Senate,,DEM,Loretta Sanchez,549
-Orange,31004,U.S. Senate,,DEM,Kamala Harris,418
-Orange,31004,U.S. Senate,,DEM,Loretta Sanchez,398
-Orange,31005,U.S. Senate,,DEM,Kamala Harris,336
-Orange,31005,U.S. Senate,,DEM,Loretta Sanchez,258
-Orange,31006,U.S. Senate,,DEM,Kamala Harris,191
-Orange,31006,U.S. Senate,,DEM,Loretta Sanchez,135
-Orange,31009,U.S. Senate,,DEM,Kamala Harris,674
-Orange,31009,U.S. Senate,,DEM,Loretta Sanchez,584
-Orange,31010,U.S. Senate,,DEM,Kamala Harris,465
-Orange,31010,U.S. Senate,,DEM,Loretta Sanchez,585
-Orange,31013,U.S. Senate,,DEM,Kamala Harris,269
-Orange,31013,U.S. Senate,,DEM,Loretta Sanchez,290
-Orange,31016,U.S. Senate,,DEM,Kamala Harris,537
-Orange,31016,U.S. Senate,,DEM,Loretta Sanchez,558
-Orange,31017,U.S. Senate,,DEM,Kamala Harris,411
-Orange,31017,U.S. Senate,,DEM,Loretta Sanchez,323
-Orange,31201,U.S. Senate,,DEM,Kamala Harris,333
-Orange,31201,U.S. Senate,,DEM,Loretta Sanchez,270
-Orange,31205,U.S. Senate,,DEM,Kamala Harris,347
-Orange,31205,U.S. Senate,,DEM,Loretta Sanchez,249
-Orange,31210,U.S. Senate,,DEM,Kamala Harris,111
-Orange,31210,U.S. Senate,,DEM,Loretta Sanchez,128
-Orange,31212,U.S. Senate,,DEM,Kamala Harris,241
-Orange,31212,U.S. Senate,,DEM,Loretta Sanchez,179
-Orange,31218,U.S. Senate,,DEM,Kamala Harris,652
-Orange,31218,U.S. Senate,,DEM,Loretta Sanchez,717
-Orange,31221,U.S. Senate,,DEM,Kamala Harris,212
-Orange,31221,U.S. Senate,,DEM,Loretta Sanchez,179
-Orange,31241,U.S. Senate,,DEM,Kamala Harris,340
-Orange,31241,U.S. Senate,,DEM,Loretta Sanchez,270
-Orange,31242,U.S. Senate,,DEM,Kamala Harris,316
-Orange,31242,U.S. Senate,,DEM,Loretta Sanchez,308
-Orange,31245,U.S. Senate,,DEM,Kamala Harris,310
-Orange,31245,U.S. Senate,,DEM,Loretta Sanchez,247
-Orange,31246,U.S. Senate,,DEM,Kamala Harris,314
-Orange,31246,U.S. Senate,,DEM,Loretta Sanchez,252
-Orange,31247,U.S. Senate,,DEM,Kamala Harris,705
-Orange,31247,U.S. Senate,,DEM,Loretta Sanchez,612
-Orange,31601,U.S. Senate,,DEM,Kamala Harris,598
-Orange,31601,U.S. Senate,,DEM,Loretta Sanchez,461
-Orange,31602,U.S. Senate,,DEM,Kamala Harris,563
-Orange,31602,U.S. Senate,,DEM,Loretta Sanchez,447
-Orange,31603,U.S. Senate,,DEM,Kamala Harris,899
-Orange,31603,U.S. Senate,,DEM,Loretta Sanchez,628
-Orange,31604,U.S. Senate,,DEM,Kamala Harris,761
-Orange,31604,U.S. Senate,,DEM,Loretta Sanchez,570
-Orange,31605,U.S. Senate,,DEM,Kamala Harris,597
-Orange,31605,U.S. Senate,,DEM,Loretta Sanchez,588
-Orange,31606,U.S. Senate,,DEM,Kamala Harris,217
-Orange,31606,U.S. Senate,,DEM,Loretta Sanchez,201
-Orange,31607,U.S. Senate,,DEM,Kamala Harris,165
-Orange,31607,U.S. Senate,,DEM,Loretta Sanchez,149
-Orange,31901,U.S. Senate,,DEM,Kamala Harris,0
-Orange,31901,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,32101,U.S. Senate,,DEM,Kamala Harris,467
-Orange,32101,U.S. Senate,,DEM,Loretta Sanchez,378
-Orange,32103,U.S. Senate,,DEM,Kamala Harris,565
-Orange,32103,U.S. Senate,,DEM,Loretta Sanchez,440
-Orange,32106,U.S. Senate,,DEM,Kamala Harris,339
-Orange,32106,U.S. Senate,,DEM,Loretta Sanchez,200
-Orange,32109,U.S. Senate,,DEM,Kamala Harris,263
-Orange,32109,U.S. Senate,,DEM,Loretta Sanchez,219
-Orange,32110,U.S. Senate,,DEM,Kamala Harris,413
-Orange,32110,U.S. Senate,,DEM,Loretta Sanchez,294
-Orange,32111,U.S. Senate,,DEM,Kamala Harris,1
-Orange,32111,U.S. Senate,,DEM,Loretta Sanchez,2
-Orange,32112,U.S. Senate,,DEM,Kamala Harris,69
-Orange,32112,U.S. Senate,,DEM,Loretta Sanchez,78
-Orange,32138,U.S. Senate,,DEM,Kamala Harris,305
-Orange,32138,U.S. Senate,,DEM,Loretta Sanchez,199
-Orange,32139,U.S. Senate,,DEM,Kamala Harris,555
-Orange,32139,U.S. Senate,,DEM,Loretta Sanchez,399
-Orange,32140,U.S. Senate,,DEM,Kamala Harris,482
-Orange,32140,U.S. Senate,,DEM,Loretta Sanchez,331
-Orange,32141,U.S. Senate,,DEM,Kamala Harris,403
-Orange,32141,U.S. Senate,,DEM,Loretta Sanchez,298
-Orange,32142,U.S. Senate,,DEM,Kamala Harris,642
-Orange,32142,U.S. Senate,,DEM,Loretta Sanchez,383
-Orange,32143,U.S. Senate,,DEM,Kamala Harris,667
-Orange,32143,U.S. Senate,,DEM,Loretta Sanchez,413
-Orange,32145,U.S. Senate,,DEM,Kamala Harris,381
-Orange,32145,U.S. Senate,,DEM,Loretta Sanchez,277
-Orange,32146,U.S. Senate,,DEM,Kamala Harris,680
-Orange,32146,U.S. Senate,,DEM,Loretta Sanchez,453
-Orange,32150,U.S. Senate,,DEM,Kamala Harris,388
-Orange,32150,U.S. Senate,,DEM,Loretta Sanchez,258
-Orange,32154,U.S. Senate,,DEM,Kamala Harris,308
-Orange,32154,U.S. Senate,,DEM,Loretta Sanchez,213
-Orange,32155,U.S. Senate,,DEM,Kamala Harris,272
-Orange,32155,U.S. Senate,,DEM,Loretta Sanchez,189
-Orange,32160,U.S. Senate,,DEM,Kamala Harris,464
-Orange,32160,U.S. Senate,,DEM,Loretta Sanchez,341
-Orange,32161,U.S. Senate,,DEM,Kamala Harris,397
-Orange,32161,U.S. Senate,,DEM,Loretta Sanchez,285
-Orange,32162,U.S. Senate,,DEM,Kamala Harris,492
-Orange,32162,U.S. Senate,,DEM,Loretta Sanchez,307
-Orange,32163,U.S. Senate,,DEM,Kamala Harris,214
-Orange,32163,U.S. Senate,,DEM,Loretta Sanchez,155
-Orange,32165,U.S. Senate,,DEM,Kamala Harris,230
-Orange,32165,U.S. Senate,,DEM,Loretta Sanchez,186
-Orange,32166,U.S. Senate,,DEM,Kamala Harris,436
-Orange,32166,U.S. Senate,,DEM,Loretta Sanchez,304
-Orange,32171,U.S. Senate,,DEM,Kamala Harris,317
-Orange,32171,U.S. Senate,,DEM,Loretta Sanchez,314
-Orange,32174,U.S. Senate,,DEM,Kamala Harris,409
-Orange,32174,U.S. Senate,,DEM,Loretta Sanchez,293
-Orange,32176,U.S. Senate,,DEM,Kamala Harris,410
-Orange,32176,U.S. Senate,,DEM,Loretta Sanchez,267
-Orange,32178,U.S. Senate,,DEM,Kamala Harris,485
-Orange,32178,U.S. Senate,,DEM,Loretta Sanchez,392
-Orange,32179,U.S. Senate,,DEM,Kamala Harris,365
-Orange,32179,U.S. Senate,,DEM,Loretta Sanchez,255
-Orange,32184,U.S. Senate,,DEM,Kamala Harris,377
-Orange,32184,U.S. Senate,,DEM,Loretta Sanchez,263
-Orange,32188,U.S. Senate,,DEM,Kamala Harris,385
-Orange,32188,U.S. Senate,,DEM,Loretta Sanchez,278
-Orange,32190,U.S. Senate,,DEM,Kamala Harris,643
-Orange,32190,U.S. Senate,,DEM,Loretta Sanchez,398
-Orange,32193,U.S. Senate,,DEM,Kamala Harris,663
-Orange,32193,U.S. Senate,,DEM,Loretta Sanchez,464
-Orange,32195,U.S. Senate,,DEM,Kamala Harris,477
-Orange,32195,U.S. Senate,,DEM,Loretta Sanchez,308
-Orange,32196,U.S. Senate,,DEM,Kamala Harris,546
-Orange,32196,U.S. Senate,,DEM,Loretta Sanchez,385
-Orange,32197,U.S. Senate,,DEM,Kamala Harris,490
-Orange,32197,U.S. Senate,,DEM,Loretta Sanchez,319
-Orange,32198,U.S. Senate,,DEM,Kamala Harris,422
-Orange,32198,U.S. Senate,,DEM,Loretta Sanchez,335
-Orange,32200,U.S. Senate,,DEM,Kamala Harris,427
-Orange,32200,U.S. Senate,,DEM,Loretta Sanchez,303
-Orange,32204,U.S. Senate,,DEM,Kamala Harris,192
-Orange,32204,U.S. Senate,,DEM,Loretta Sanchez,148
-Orange,32205,U.S. Senate,,DEM,Kamala Harris,569
-Orange,32205,U.S. Senate,,DEM,Loretta Sanchez,394
-Orange,32207,U.S. Senate,,DEM,Kamala Harris,439
-Orange,32207,U.S. Senate,,DEM,Loretta Sanchez,266
-Orange,32208,U.S. Senate,,DEM,Kamala Harris,671
-Orange,32208,U.S. Senate,,DEM,Loretta Sanchez,462
-Orange,32210,U.S. Senate,,DEM,Kamala Harris,0
-Orange,32210,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,32211,U.S. Senate,,DEM,Kamala Harris,37
-Orange,32211,U.S. Senate,,DEM,Loretta Sanchez,29
-Orange,32212,U.S. Senate,,DEM,Kamala Harris,296
-Orange,32212,U.S. Senate,,DEM,Loretta Sanchez,158
-Orange,32232,U.S. Senate,,DEM,Kamala Harris,555
-Orange,32232,U.S. Senate,,DEM,Loretta Sanchez,400
-Orange,32247,U.S. Senate,,DEM,Kamala Harris,536
-Orange,32247,U.S. Senate,,DEM,Loretta Sanchez,342
-Orange,32265,U.S. Senate,,DEM,Kamala Harris,762
-Orange,32265,U.S. Senate,,DEM,Loretta Sanchez,548
-Orange,32266,U.S. Senate,,DEM,Kamala Harris,301
-Orange,32266,U.S. Senate,,DEM,Loretta Sanchez,244
-Orange,32267,U.S. Senate,,DEM,Kamala Harris,629
-Orange,32267,U.S. Senate,,DEM,Loretta Sanchez,472
-Orange,32269,U.S. Senate,,DEM,Kamala Harris,281
-Orange,32269,U.S. Senate,,DEM,Loretta Sanchez,191
-Orange,32270,U.S. Senate,,DEM,Kamala Harris,652
-Orange,32270,U.S. Senate,,DEM,Loretta Sanchez,531
-Orange,32282,U.S. Senate,,DEM,Kamala Harris,663
-Orange,32282,U.S. Senate,,DEM,Loretta Sanchez,448
-Orange,32283,U.S. Senate,,DEM,Kamala Harris,338
-Orange,32283,U.S. Senate,,DEM,Loretta Sanchez,231
-Orange,32285,U.S. Senate,,DEM,Kamala Harris,248
-Orange,32285,U.S. Senate,,DEM,Loretta Sanchez,204
-Orange,32293,U.S. Senate,,DEM,Kamala Harris,272
-Orange,32293,U.S. Senate,,DEM,Loretta Sanchez,195
-Orange,32295,U.S. Senate,,DEM,Kamala Harris,412
-Orange,32295,U.S. Senate,,DEM,Loretta Sanchez,257
-Orange,32300,U.S. Senate,,DEM,Kamala Harris,95
-Orange,32300,U.S. Senate,,DEM,Loretta Sanchez,102
-Orange,32302,U.S. Senate,,DEM,Kamala Harris,564
-Orange,32302,U.S. Senate,,DEM,Loretta Sanchez,377
-Orange,32303,U.S. Senate,,DEM,Kamala Harris,326
-Orange,32303,U.S. Senate,,DEM,Loretta Sanchez,238
-Orange,32305,U.S. Senate,,DEM,Kamala Harris,627
-Orange,32305,U.S. Senate,,DEM,Loretta Sanchez,376
-Orange,32306,U.S. Senate,,DEM,Kamala Harris,350
-Orange,32306,U.S. Senate,,DEM,Loretta Sanchez,211
-Orange,32307,U.S. Senate,,DEM,Kamala Harris,604
-Orange,32307,U.S. Senate,,DEM,Loretta Sanchez,439
-Orange,32308,U.S. Senate,,DEM,Kamala Harris,656
-Orange,32308,U.S. Senate,,DEM,Loretta Sanchez,482
-Orange,32312,U.S. Senate,,DEM,Kamala Harris,572
-Orange,32312,U.S. Senate,,DEM,Loretta Sanchez,441
-Orange,32320,U.S. Senate,,DEM,Kamala Harris,324
-Orange,32320,U.S. Senate,,DEM,Loretta Sanchez,218
-Orange,32322,U.S. Senate,,DEM,Kamala Harris,405
-Orange,32322,U.S. Senate,,DEM,Loretta Sanchez,352
-Orange,32325,U.S. Senate,,DEM,Kamala Harris,318
-Orange,32325,U.S. Senate,,DEM,Loretta Sanchez,259
-Orange,32329,U.S. Senate,,DEM,Kamala Harris,317
-Orange,32329,U.S. Senate,,DEM,Loretta Sanchez,213
-Orange,32335,U.S. Senate,,DEM,Kamala Harris,374
-Orange,32335,U.S. Senate,,DEM,Loretta Sanchez,243
-Orange,32337,U.S. Senate,,DEM,Kamala Harris,517
-Orange,32337,U.S. Senate,,DEM,Loretta Sanchez,368
-Orange,32338,U.S. Senate,,DEM,Kamala Harris,321
-Orange,32338,U.S. Senate,,DEM,Loretta Sanchez,183
-Orange,32341,U.S. Senate,,DEM,Kamala Harris,240
-Orange,32341,U.S. Senate,,DEM,Loretta Sanchez,161
-Orange,32345,U.S. Senate,,DEM,Kamala Harris,309
-Orange,32345,U.S. Senate,,DEM,Loretta Sanchez,216
-Orange,32347,U.S. Senate,,DEM,Kamala Harris,483
-Orange,32347,U.S. Senate,,DEM,Loretta Sanchez,349
-Orange,32348,U.S. Senate,,DEM,Kamala Harris,261
-Orange,32348,U.S. Senate,,DEM,Loretta Sanchez,161
-Orange,32349,U.S. Senate,,DEM,Kamala Harris,493
-Orange,32349,U.S. Senate,,DEM,Loretta Sanchez,420
-Orange,32355,U.S. Senate,,DEM,Kamala Harris,528
-Orange,32355,U.S. Senate,,DEM,Loretta Sanchez,438
-Orange,32358,U.S. Senate,,DEM,Kamala Harris,421
-Orange,32358,U.S. Senate,,DEM,Loretta Sanchez,233
-Orange,32361,U.S. Senate,,DEM,Kamala Harris,395
-Orange,32361,U.S. Senate,,DEM,Loretta Sanchez,216
-Orange,32362,U.S. Senate,,DEM,Kamala Harris,72
-Orange,32362,U.S. Senate,,DEM,Loretta Sanchez,50
-Orange,32365,U.S. Senate,,DEM,Kamala Harris,423
-Orange,32365,U.S. Senate,,DEM,Loretta Sanchez,287
-Orange,32370,U.S. Senate,,DEM,Kamala Harris,264
-Orange,32370,U.S. Senate,,DEM,Loretta Sanchez,441
-Orange,32371,U.S. Senate,,DEM,Kamala Harris,468
-Orange,32371,U.S. Senate,,DEM,Loretta Sanchez,352
-Orange,32375,U.S. Senate,,DEM,Kamala Harris,333
-Orange,32375,U.S. Senate,,DEM,Loretta Sanchez,278
-Orange,32376,U.S. Senate,,DEM,Kamala Harris,551
-Orange,32376,U.S. Senate,,DEM,Loretta Sanchez,358
-Orange,32379,U.S. Senate,,DEM,Kamala Harris,282
-Orange,32379,U.S. Senate,,DEM,Loretta Sanchez,183
-Orange,32381,U.S. Senate,,DEM,Kamala Harris,248
-Orange,32381,U.S. Senate,,DEM,Loretta Sanchez,142
-Orange,32383,U.S. Senate,,DEM,Kamala Harris,412
-Orange,32383,U.S. Senate,,DEM,Loretta Sanchez,241
-Orange,32393,U.S. Senate,,DEM,Kamala Harris,379
-Orange,32393,U.S. Senate,,DEM,Loretta Sanchez,222
-Orange,32395,U.S. Senate,,DEM,Kamala Harris,484
-Orange,32395,U.S. Senate,,DEM,Loretta Sanchez,380
-Orange,32397,U.S. Senate,,DEM,Kamala Harris,560
-Orange,32397,U.S. Senate,,DEM,Loretta Sanchez,493
-Orange,32401,U.S. Senate,,DEM,Kamala Harris,328
-Orange,32401,U.S. Senate,,DEM,Loretta Sanchez,206
-Orange,32408,U.S. Senate,,DEM,Kamala Harris,427
-Orange,32408,U.S. Senate,,DEM,Loretta Sanchez,270
-Orange,32412,U.S. Senate,,DEM,Kamala Harris,405
-Orange,32412,U.S. Senate,,DEM,Loretta Sanchez,270
-Orange,32413,U.S. Senate,,DEM,Kamala Harris,345
-Orange,32413,U.S. Senate,,DEM,Loretta Sanchez,256
-Orange,32416,U.S. Senate,,DEM,Kamala Harris,302
-Orange,32416,U.S. Senate,,DEM,Loretta Sanchez,201
-Orange,32601,U.S. Senate,,DEM,Kamala Harris,559
-Orange,32601,U.S. Senate,,DEM,Loretta Sanchez,433
-Orange,32602,U.S. Senate,,DEM,Kamala Harris,519
-Orange,32602,U.S. Senate,,DEM,Loretta Sanchez,351
-Orange,32603,U.S. Senate,,DEM,Kamala Harris,993
-Orange,32603,U.S. Senate,,DEM,Loretta Sanchez,599
-Orange,32604,U.S. Senate,,DEM,Kamala Harris,364
-Orange,32604,U.S. Senate,,DEM,Loretta Sanchez,248
-Orange,32605,U.S. Senate,,DEM,Kamala Harris,272
-Orange,32605,U.S. Senate,,DEM,Loretta Sanchez,170
-Orange,32606,U.S. Senate,,DEM,Kamala Harris,224
-Orange,32606,U.S. Senate,,DEM,Loretta Sanchez,112
-Orange,32607,U.S. Senate,,DEM,Kamala Harris,393
-Orange,32607,U.S. Senate,,DEM,Loretta Sanchez,280
-Orange,32608,U.S. Senate,,DEM,Kamala Harris,375
-Orange,32608,U.S. Senate,,DEM,Loretta Sanchez,257
-Orange,32609,U.S. Senate,,DEM,Kamala Harris,562
-Orange,32609,U.S. Senate,,DEM,Loretta Sanchez,426
-Orange,32610,U.S. Senate,,DEM,Kamala Harris,384
-Orange,32610,U.S. Senate,,DEM,Loretta Sanchez,291
-Orange,32611,U.S. Senate,,DEM,Kamala Harris,623
-Orange,32611,U.S. Senate,,DEM,Loretta Sanchez,445
-Orange,32612,U.S. Senate,,DEM,Kamala Harris,769
-Orange,32612,U.S. Senate,,DEM,Loretta Sanchez,597
-Orange,32614,U.S. Senate,,DEM,Kamala Harris,550
-Orange,32614,U.S. Senate,,DEM,Loretta Sanchez,445
-Orange,32701,U.S. Senate,,DEM,Kamala Harris,657
-Orange,32701,U.S. Senate,,DEM,Loretta Sanchez,443
-Orange,33117,U.S. Senate,,DEM,Kamala Harris,375
-Orange,33117,U.S. Senate,,DEM,Loretta Sanchez,283
-Orange,33118,U.S. Senate,,DEM,Kamala Harris,324
-Orange,33118,U.S. Senate,,DEM,Loretta Sanchez,226
-Orange,33121,U.S. Senate,,DEM,Kamala Harris,299
-Orange,33121,U.S. Senate,,DEM,Loretta Sanchez,243
-Orange,33122,U.S. Senate,,DEM,Kamala Harris,360
-Orange,33122,U.S. Senate,,DEM,Loretta Sanchez,214
-Orange,33123,U.S. Senate,,DEM,Kamala Harris,349
-Orange,33123,U.S. Senate,,DEM,Loretta Sanchez,290
-Orange,33124,U.S. Senate,,DEM,Kamala Harris,0
-Orange,33124,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,33126,U.S. Senate,,DEM,Kamala Harris,389
-Orange,33126,U.S. Senate,,DEM,Loretta Sanchez,264
-Orange,33128,U.S. Senate,,DEM,Kamala Harris,427
-Orange,33128,U.S. Senate,,DEM,Loretta Sanchez,237
-Orange,33130,U.S. Senate,,DEM,Kamala Harris,0
-Orange,33130,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,33134,U.S. Senate,,DEM,Kamala Harris,66
-Orange,33134,U.S. Senate,,DEM,Loretta Sanchez,40
-Orange,34092,U.S. Senate,,DEM,Kamala Harris,75
-Orange,34092,U.S. Senate,,DEM,Loretta Sanchez,91
-Orange,34093,U.S. Senate,,DEM,Kamala Harris,119
-Orange,34093,U.S. Senate,,DEM,Loretta Sanchez,226
-Orange,34095,U.S. Senate,,DEM,Kamala Harris,86
-Orange,34095,U.S. Senate,,DEM,Loretta Sanchez,104
-Orange,34097,U.S. Senate,,DEM,Kamala Harris,141
-Orange,34097,U.S. Senate,,DEM,Loretta Sanchez,274
-Orange,34098,U.S. Senate,,DEM,Kamala Harris,116
-Orange,34098,U.S. Senate,,DEM,Loretta Sanchez,107
-Orange,34337,U.S. Senate,,DEM,Kamala Harris,287
-Orange,34337,U.S. Senate,,DEM,Loretta Sanchez,507
-Orange,35125,U.S. Senate,,DEM,Kamala Harris,409
-Orange,35125,U.S. Senate,,DEM,Loretta Sanchez,281
-Orange,35126,U.S. Senate,,DEM,Kamala Harris,365
-Orange,35126,U.S. Senate,,DEM,Loretta Sanchez,255
-Orange,35127,U.S. Senate,,DEM,Kamala Harris,305
-Orange,35127,U.S. Senate,,DEM,Loretta Sanchez,241
-Orange,35129,U.S. Senate,,DEM,Kamala Harris,273
-Orange,35129,U.S. Senate,,DEM,Loretta Sanchez,165
-Orange,35134,U.S. Senate,,DEM,Kamala Harris,421
-Orange,35134,U.S. Senate,,DEM,Loretta Sanchez,222
-Orange,35135,U.S. Senate,,DEM,Kamala Harris,327
-Orange,35135,U.S. Senate,,DEM,Loretta Sanchez,262
-Orange,35137,U.S. Senate,,DEM,Kamala Harris,426
-Orange,35137,U.S. Senate,,DEM,Loretta Sanchez,266
-Orange,35140,U.S. Senate,,DEM,Kamala Harris,397
-Orange,35140,U.S. Senate,,DEM,Loretta Sanchez,235
-Orange,35146,U.S. Senate,,DEM,Kamala Harris,272
-Orange,35146,U.S. Senate,,DEM,Loretta Sanchez,171
-Orange,36001,U.S. Senate,,DEM,Kamala Harris,172
-Orange,36001,U.S. Senate,,DEM,Loretta Sanchez,101
-Orange,36003,U.S. Senate,,DEM,Kamala Harris,236
-Orange,36003,U.S. Senate,,DEM,Loretta Sanchez,130
-Orange,36004,U.S. Senate,,DEM,Kamala Harris,474
-Orange,36004,U.S. Senate,,DEM,Loretta Sanchez,260
-Orange,36008,U.S. Senate,,DEM,Kamala Harris,450
-Orange,36008,U.S. Senate,,DEM,Loretta Sanchez,284
-Orange,36011,U.S. Senate,,DEM,Kamala Harris,465
-Orange,36011,U.S. Senate,,DEM,Loretta Sanchez,265
-Orange,36105,U.S. Senate,,DEM,Kamala Harris,258
-Orange,36105,U.S. Senate,,DEM,Loretta Sanchez,190
-Orange,36258,U.S. Senate,,DEM,Kamala Harris,392
-Orange,36258,U.S. Senate,,DEM,Loretta Sanchez,254
-Orange,36264,U.S. Senate,,DEM,Kamala Harris,382
-Orange,36264,U.S. Senate,,DEM,Loretta Sanchez,202
-Orange,36266,U.S. Senate,,DEM,Kamala Harris,387
-Orange,36266,U.S. Senate,,DEM,Loretta Sanchez,221
-Orange,36267,U.S. Senate,,DEM,Kamala Harris,393
-Orange,36267,U.S. Senate,,DEM,Loretta Sanchez,247
-Orange,36268,U.S. Senate,,DEM,Kamala Harris,358
-Orange,36268,U.S. Senate,,DEM,Loretta Sanchez,236
-Orange,36272,U.S. Senate,,DEM,Kamala Harris,0
-Orange,36272,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,36279,U.S. Senate,,DEM,Kamala Harris,248
-Orange,36279,U.S. Senate,,DEM,Loretta Sanchez,147
-Orange,36315,U.S. Senate,,DEM,Kamala Harris,0
-Orange,36315,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,36316,U.S. Senate,,DEM,Kamala Harris,340
-Orange,36316,U.S. Senate,,DEM,Loretta Sanchez,245
-Orange,36317,U.S. Senate,,DEM,Kamala Harris,243
-Orange,36317,U.S. Senate,,DEM,Loretta Sanchez,106
-Orange,36318,U.S. Senate,,DEM,Kamala Harris,471
-Orange,36318,U.S. Senate,,DEM,Loretta Sanchez,275
-Orange,36327,U.S. Senate,,DEM,Kamala Harris,303
-Orange,36327,U.S. Senate,,DEM,Loretta Sanchez,163
-Orange,36329,U.S. Senate,,DEM,Kamala Harris,377
-Orange,36329,U.S. Senate,,DEM,Loretta Sanchez,225
-Orange,36331,U.S. Senate,,DEM,Kamala Harris,0
-Orange,36331,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,36334,U.S. Senate,,DEM,Kamala Harris,253
-Orange,36334,U.S. Senate,,DEM,Loretta Sanchez,158
-Orange,36339,U.S. Senate,,DEM,Kamala Harris,345
-Orange,36339,U.S. Senate,,DEM,Loretta Sanchez,173
-Orange,36340,U.S. Senate,,DEM,Kamala Harris,293
-Orange,36340,U.S. Senate,,DEM,Loretta Sanchez,143
-Orange,36601,U.S. Senate,,DEM,Kamala Harris,116
-Orange,36601,U.S. Senate,,DEM,Loretta Sanchez,108
-Orange,36701,U.S. Senate,,DEM,Kamala Harris,1023
-Orange,36701,U.S. Senate,,DEM,Loretta Sanchez,616
-Orange,36901,U.S. Senate,,DEM,Kamala Harris,3
-Orange,36901,U.S. Senate,,DEM,Loretta Sanchez,1
-Orange,36902,U.S. Senate,,DEM,Kamala Harris,3
-Orange,36902,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,37202,U.S. Senate,,DEM,Kamala Harris,0
-Orange,37202,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,37203,U.S. Senate,,DEM,Kamala Harris,0
-Orange,37203,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,38084,U.S. Senate,,DEM,Kamala Harris,227
-Orange,38084,U.S. Senate,,DEM,Loretta Sanchez,185
-Orange,38091,U.S. Senate,,DEM,Kamala Harris,171
-Orange,38091,U.S. Senate,,DEM,Loretta Sanchez,143
-Orange,38104,U.S. Senate,,DEM,Kamala Harris,396
-Orange,38104,U.S. Senate,,DEM,Loretta Sanchez,307
-Orange,38236,U.S. Senate,,DEM,Kamala Harris,238
-Orange,38236,U.S. Senate,,DEM,Loretta Sanchez,173
-Orange,38292,U.S. Senate,,DEM,Kamala Harris,58
-Orange,38292,U.S. Senate,,DEM,Loretta Sanchez,80
-Orange,38293,U.S. Senate,,DEM,Kamala Harris,479
-Orange,38293,U.S. Senate,,DEM,Loretta Sanchez,313
-Orange,38301,U.S. Senate,,DEM,Kamala Harris,153
-Orange,38301,U.S. Senate,,DEM,Loretta Sanchez,118
-Orange,38302,U.S. Senate,,DEM,Kamala Harris,398
-Orange,38302,U.S. Senate,,DEM,Loretta Sanchez,294
-Orange,38304,U.S. Senate,,DEM,Kamala Harris,311
-Orange,38304,U.S. Senate,,DEM,Loretta Sanchez,240
-Orange,38305,U.S. Senate,,DEM,Kamala Harris,357
-Orange,38305,U.S. Senate,,DEM,Loretta Sanchez,248
-Orange,38310,U.S. Senate,,DEM,Kamala Harris,246
-Orange,38310,U.S. Senate,,DEM,Loretta Sanchez,213
-Orange,38311,U.S. Senate,,DEM,Kamala Harris,431
-Orange,38311,U.S. Senate,,DEM,Loretta Sanchez,276
-Orange,38312,U.S. Senate,,DEM,Kamala Harris,478
-Orange,38312,U.S. Senate,,DEM,Loretta Sanchez,329
-Orange,38313,U.S. Senate,,DEM,Kamala Harris,363
-Orange,38313,U.S. Senate,,DEM,Loretta Sanchez,278
-Orange,38314,U.S. Senate,,DEM,Kamala Harris,319
-Orange,38314,U.S. Senate,,DEM,Loretta Sanchez,250
-Orange,38375,U.S. Senate,,DEM,Kamala Harris,239
-Orange,38375,U.S. Senate,,DEM,Loretta Sanchez,190
-Orange,38376,U.S. Senate,,DEM,Kamala Harris,286
-Orange,38376,U.S. Senate,,DEM,Loretta Sanchez,179
-Orange,38601,U.S. Senate,,DEM,Kamala Harris,338
-Orange,38601,U.S. Senate,,DEM,Loretta Sanchez,231
-Orange,38602,U.S. Senate,,DEM,Kamala Harris,371
-Orange,38602,U.S. Senate,,DEM,Loretta Sanchez,275
-Orange,38701,U.S. Senate,,DEM,Kamala Harris,538
-Orange,38701,U.S. Senate,,DEM,Loretta Sanchez,450
-Orange,38702,U.S. Senate,,DEM,Kamala Harris,596
-Orange,38702,U.S. Senate,,DEM,Loretta Sanchez,401
-Orange,39201,U.S. Senate,,DEM,Kamala Harris,525
-Orange,39201,U.S. Senate,,DEM,Loretta Sanchez,807
-Orange,39204,U.S. Senate,,DEM,Kamala Harris,588
-Orange,39204,U.S. Senate,,DEM,Loretta Sanchez,655
-Orange,39206,U.S. Senate,,DEM,Kamala Harris,240
-Orange,39206,U.S. Senate,,DEM,Loretta Sanchez,455
-Orange,39208,U.S. Senate,,DEM,Kamala Harris,484
-Orange,39208,U.S. Senate,,DEM,Loretta Sanchez,703
-Orange,39214,U.S. Senate,,DEM,Kamala Harris,339
-Orange,39214,U.S. Senate,,DEM,Loretta Sanchez,415
-Orange,39217,U.S. Senate,,DEM,Kamala Harris,576
-Orange,39217,U.S. Senate,,DEM,Loretta Sanchez,414
-Orange,39219,U.S. Senate,,DEM,Kamala Harris,303
-Orange,39219,U.S. Senate,,DEM,Loretta Sanchez,528
-Orange,39220,U.S. Senate,,DEM,Kamala Harris,261
-Orange,39220,U.S. Senate,,DEM,Loretta Sanchez,337
-Orange,39221,U.S. Senate,,DEM,Kamala Harris,573
-Orange,39221,U.S. Senate,,DEM,Loretta Sanchez,495
-Orange,39222,U.S. Senate,,DEM,Kamala Harris,323
-Orange,39222,U.S. Senate,,DEM,Loretta Sanchez,494
-Orange,39223,U.S. Senate,,DEM,Kamala Harris,546
-Orange,39223,U.S. Senate,,DEM,Loretta Sanchez,943
-Orange,39234,U.S. Senate,,DEM,Kamala Harris,210
-Orange,39234,U.S. Senate,,DEM,Loretta Sanchez,402
-Orange,39237,U.S. Senate,,DEM,Kamala Harris,228
-Orange,39237,U.S. Senate,,DEM,Loretta Sanchez,474
-Orange,39239,U.S. Senate,,DEM,Kamala Harris,287
-Orange,39239,U.S. Senate,,DEM,Loretta Sanchez,518
-Orange,39244,U.S. Senate,,DEM,Kamala Harris,121
-Orange,39244,U.S. Senate,,DEM,Loretta Sanchez,131
-Orange,39274,U.S. Senate,,DEM,Kamala Harris,85
-Orange,39274,U.S. Senate,,DEM,Loretta Sanchez,123
-Orange,39275,U.S. Senate,,DEM,Kamala Harris,515
-Orange,39275,U.S. Senate,,DEM,Loretta Sanchez,595
-Orange,39315,U.S. Senate,,DEM,Kamala Harris,0
-Orange,39315,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,39341,U.S. Senate,,DEM,Kamala Harris,176
-Orange,39341,U.S. Senate,,DEM,Loretta Sanchez,316
-Orange,39344,U.S. Senate,,DEM,Kamala Harris,369
-Orange,39344,U.S. Senate,,DEM,Loretta Sanchez,834
-Orange,39346,U.S. Senate,,DEM,Kamala Harris,191
-Orange,39346,U.S. Senate,,DEM,Loretta Sanchez,162
-Orange,39350,U.S. Senate,,DEM,Kamala Harris,482
-Orange,39350,U.S. Senate,,DEM,Loretta Sanchez,493
-Orange,39364,U.S. Senate,,DEM,Kamala Harris,599
-Orange,39364,U.S. Senate,,DEM,Loretta Sanchez,625
-Orange,39369,U.S. Senate,,DEM,Kamala Harris,483
-Orange,39369,U.S. Senate,,DEM,Loretta Sanchez,681
-Orange,39375,U.S. Senate,,DEM,Kamala Harris,933
-Orange,39375,U.S. Senate,,DEM,Loretta Sanchez,669
-Orange,39376,U.S. Senate,,DEM,Kamala Harris,316
-Orange,39376,U.S. Senate,,DEM,Loretta Sanchez,525
-Orange,39378,U.S. Senate,,DEM,Kamala Harris,489
-Orange,39378,U.S. Senate,,DEM,Loretta Sanchez,749
-Orange,39601,U.S. Senate,,DEM,Kamala Harris,528
-Orange,39601,U.S. Senate,,DEM,Loretta Sanchez,724
-Orange,39602,U.S. Senate,,DEM,Kamala Harris,270
-Orange,39602,U.S. Senate,,DEM,Loretta Sanchez,584
-Orange,39603,U.S. Senate,,DEM,Kamala Harris,352
-Orange,39603,U.S. Senate,,DEM,Loretta Sanchez,491
-Orange,39604,U.S. Senate,,DEM,Kamala Harris,274
-Orange,39604,U.S. Senate,,DEM,Loretta Sanchez,593
-Orange,39901,U.S. Senate,,DEM,Kamala Harris,46
-Orange,39901,U.S. Senate,,DEM,Loretta Sanchez,118
-Orange,39902,U.S. Senate,,DEM,Kamala Harris,0
-Orange,39902,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,39903,U.S. Senate,,DEM,Kamala Harris,0
-Orange,39903,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,40601,U.S. Senate,,DEM,Kamala Harris,1
-Orange,40601,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,40602,U.S. Senate,,DEM,Kamala Harris,0
-Orange,40602,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,40603,U.S. Senate,,DEM,Kamala Harris,0
-Orange,40603,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,41100,U.S. Senate,,DEM,Kamala Harris,283
-Orange,41100,U.S. Senate,,DEM,Loretta Sanchez,156
-Orange,41121,U.S. Senate,,DEM,Kamala Harris,411
-Orange,41121,U.S. Senate,,DEM,Loretta Sanchez,303
-Orange,41123,U.S. Senate,,DEM,Kamala Harris,311
-Orange,41123,U.S. Senate,,DEM,Loretta Sanchez,220
-Orange,41124,U.S. Senate,,DEM,Kamala Harris,302
-Orange,41124,U.S. Senate,,DEM,Loretta Sanchez,251
-Orange,41155,U.S. Senate,,DEM,Kamala Harris,266
-Orange,41155,U.S. Senate,,DEM,Loretta Sanchez,212
-Orange,41156,U.S. Senate,,DEM,Kamala Harris,214
-Orange,41156,U.S. Senate,,DEM,Loretta Sanchez,191
-Orange,41161,U.S. Senate,,DEM,Kamala Harris,327
-Orange,41161,U.S. Senate,,DEM,Loretta Sanchez,225
-Orange,41162,U.S. Senate,,DEM,Kamala Harris,256
-Orange,41162,U.S. Senate,,DEM,Loretta Sanchez,185
-Orange,41169,U.S. Senate,,DEM,Kamala Harris,201
-Orange,41169,U.S. Senate,,DEM,Loretta Sanchez,135
-Orange,41224,U.S. Senate,,DEM,Kamala Harris,234
-Orange,41224,U.S. Senate,,DEM,Loretta Sanchez,149
-Orange,41291,U.S. Senate,,DEM,Kamala Harris,415
-Orange,41291,U.S. Senate,,DEM,Loretta Sanchez,304
-Orange,41292,U.S. Senate,,DEM,Kamala Harris,373
-Orange,41292,U.S. Senate,,DEM,Loretta Sanchez,280
-Orange,41293,U.S. Senate,,DEM,Kamala Harris,374
-Orange,41293,U.S. Senate,,DEM,Loretta Sanchez,193
-Orange,41298,U.S. Senate,,DEM,Kamala Harris,367
-Orange,41298,U.S. Senate,,DEM,Loretta Sanchez,232
-Orange,41300,U.S. Senate,,DEM,Kamala Harris,252
-Orange,41300,U.S. Senate,,DEM,Loretta Sanchez,199
-Orange,41301,U.S. Senate,,DEM,Kamala Harris,350
-Orange,41301,U.S. Senate,,DEM,Loretta Sanchez,195
-Orange,41601,U.S. Senate,,DEM,Kamala Harris,679
-Orange,41601,U.S. Senate,,DEM,Loretta Sanchez,446
-Orange,41602,U.S. Senate,,DEM,Kamala Harris,592
-Orange,41602,U.S. Senate,,DEM,Loretta Sanchez,489
-Orange,41603,U.S. Senate,,DEM,Kamala Harris,156
-Orange,41603,U.S. Senate,,DEM,Loretta Sanchez,121
-Orange,41604,U.S. Senate,,DEM,Kamala Harris,153
-Orange,41604,U.S. Senate,,DEM,Loretta Sanchez,82
-Orange,41701,U.S. Senate,,DEM,Kamala Harris,425
-Orange,41701,U.S. Senate,,DEM,Loretta Sanchez,274
-Orange,41702,U.S. Senate,,DEM,Kamala Harris,446
-Orange,41702,U.S. Senate,,DEM,Loretta Sanchez,328
-Orange,41703,U.S. Senate,,DEM,Kamala Harris,447
-Orange,41703,U.S. Senate,,DEM,Loretta Sanchez,307
-Orange,41704,U.S. Senate,,DEM,Kamala Harris,669
-Orange,41704,U.S. Senate,,DEM,Loretta Sanchez,554
-Orange,41901,U.S. Senate,,DEM,Kamala Harris,2
-Orange,41901,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,42101,U.S. Senate,,DEM,Kamala Harris,0
-Orange,42101,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,42110,U.S. Senate,,DEM,Kamala Harris,0
-Orange,42110,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,43125,U.S. Senate,,DEM,Kamala Harris,0
-Orange,43125,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,43601,U.S. Senate,,DEM,Kamala Harris,295
-Orange,43601,U.S. Senate,,DEM,Loretta Sanchez,281
-Orange,43901,U.S. Senate,,DEM,Kamala Harris,0
-Orange,43901,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,44111,U.S. Senate,,DEM,Kamala Harris,298
-Orange,44111,U.S. Senate,,DEM,Loretta Sanchez,142
-Orange,44112,U.S. Senate,,DEM,Kamala Harris,244
-Orange,44112,U.S. Senate,,DEM,Loretta Sanchez,131
-Orange,44113,U.S. Senate,,DEM,Kamala Harris,335
-Orange,44113,U.S. Senate,,DEM,Loretta Sanchez,259
-Orange,44114,U.S. Senate,,DEM,Kamala Harris,0
-Orange,44114,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,44116,U.S. Senate,,DEM,Kamala Harris,299
-Orange,44116,U.S. Senate,,DEM,Loretta Sanchez,173
-Orange,44123,U.S. Senate,,DEM,Kamala Harris,0
-Orange,44123,U.S. Senate,,DEM,Loretta Sanchez,2
-Orange,44124,U.S. Senate,,DEM,Kamala Harris,372
-Orange,44124,U.S. Senate,,DEM,Loretta Sanchez,196
-Orange,44126,U.S. Senate,,DEM,Kamala Harris,337
-Orange,44126,U.S. Senate,,DEM,Loretta Sanchez,199
-Orange,44128,U.S. Senate,,DEM,Kamala Harris,348
-Orange,44128,U.S. Senate,,DEM,Loretta Sanchez,246
-Orange,44130,U.S. Senate,,DEM,Kamala Harris,470
-Orange,44130,U.S. Senate,,DEM,Loretta Sanchez,203
-Orange,44131,U.S. Senate,,DEM,Kamala Harris,444
-Orange,44131,U.S. Senate,,DEM,Loretta Sanchez,251
-Orange,44135,U.S. Senate,,DEM,Kamala Harris,291
-Orange,44135,U.S. Senate,,DEM,Loretta Sanchez,159
-Orange,44136,U.S. Senate,,DEM,Kamala Harris,325
-Orange,44136,U.S. Senate,,DEM,Loretta Sanchez,164
-Orange,44139,U.S. Senate,,DEM,Kamala Harris,384
-Orange,44139,U.S. Senate,,DEM,Loretta Sanchez,163
-Orange,44142,U.S. Senate,,DEM,Kamala Harris,435
-Orange,44142,U.S. Senate,,DEM,Loretta Sanchez,222
-Orange,44150,U.S. Senate,,DEM,Kamala Harris,340
-Orange,44150,U.S. Senate,,DEM,Loretta Sanchez,149
-Orange,44321,U.S. Senate,,DEM,Kamala Harris,171
-Orange,44321,U.S. Senate,,DEM,Loretta Sanchez,74
-Orange,44601,U.S. Senate,,DEM,Kamala Harris,597
-Orange,44601,U.S. Senate,,DEM,Loretta Sanchez,312
-Orange,44701,U.S. Senate,,DEM,Kamala Harris,754
-Orange,44701,U.S. Senate,,DEM,Loretta Sanchez,307
-Orange,44702,U.S. Senate,,DEM,Kamala Harris,973
-Orange,44702,U.S. Senate,,DEM,Loretta Sanchez,400
-Orange,44703,U.S. Senate,,DEM,Kamala Harris,666
-Orange,44703,U.S. Senate,,DEM,Loretta Sanchez,311
-Orange,44901,U.S. Senate,,DEM,Kamala Harris,0
-Orange,44901,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,45102,U.S. Senate,,DEM,Kamala Harris,288
-Orange,45102,U.S. Senate,,DEM,Loretta Sanchez,177
-Orange,45103,U.S. Senate,,DEM,Kamala Harris,347
-Orange,45103,U.S. Senate,,DEM,Loretta Sanchez,188
-Orange,45104,U.S. Senate,,DEM,Kamala Harris,404
-Orange,45104,U.S. Senate,,DEM,Loretta Sanchez,239
-Orange,45105,U.S. Senate,,DEM,Kamala Harris,590
-Orange,45105,U.S. Senate,,DEM,Loretta Sanchez,364
-Orange,45109,U.S. Senate,,DEM,Kamala Harris,214
-Orange,45109,U.S. Senate,,DEM,Loretta Sanchez,158
-Orange,45112,U.S. Senate,,DEM,Kamala Harris,391
-Orange,45112,U.S. Senate,,DEM,Loretta Sanchez,282
-Orange,45113,U.S. Senate,,DEM,Kamala Harris,477
-Orange,45113,U.S. Senate,,DEM,Loretta Sanchez,342
-Orange,45114,U.S. Senate,,DEM,Kamala Harris,282
-Orange,45114,U.S. Senate,,DEM,Loretta Sanchez,207
-Orange,45115,U.S. Senate,,DEM,Kamala Harris,458
-Orange,45115,U.S. Senate,,DEM,Loretta Sanchez,335
-Orange,45116,U.S. Senate,,DEM,Kamala Harris,525
-Orange,45116,U.S. Senate,,DEM,Loretta Sanchez,318
-Orange,45117,U.S. Senate,,DEM,Kamala Harris,318
-Orange,45117,U.S. Senate,,DEM,Loretta Sanchez,183
-Orange,45118,U.S. Senate,,DEM,Kamala Harris,471
-Orange,45118,U.S. Senate,,DEM,Loretta Sanchez,341
-Orange,45119,U.S. Senate,,DEM,Kamala Harris,351
-Orange,45119,U.S. Senate,,DEM,Loretta Sanchez,240
-Orange,45120,U.S. Senate,,DEM,Kamala Harris,273
-Orange,45120,U.S. Senate,,DEM,Loretta Sanchez,194
-Orange,45121,U.S. Senate,,DEM,Kamala Harris,447
-Orange,45121,U.S. Senate,,DEM,Loretta Sanchez,276
-Orange,45122,U.S. Senate,,DEM,Kamala Harris,385
-Orange,45122,U.S. Senate,,DEM,Loretta Sanchez,272
-Orange,45123,U.S. Senate,,DEM,Kamala Harris,385
-Orange,45123,U.S. Senate,,DEM,Loretta Sanchez,253
-Orange,45125,U.S. Senate,,DEM,Kamala Harris,429
-Orange,45125,U.S. Senate,,DEM,Loretta Sanchez,311
-Orange,45126,U.S. Senate,,DEM,Kamala Harris,197
-Orange,45126,U.S. Senate,,DEM,Loretta Sanchez,142
-Orange,45127,U.S. Senate,,DEM,Kamala Harris,240
-Orange,45127,U.S. Senate,,DEM,Loretta Sanchez,183
-Orange,45128,U.S. Senate,,DEM,Kamala Harris,336
-Orange,45128,U.S. Senate,,DEM,Loretta Sanchez,201
-Orange,45129,U.S. Senate,,DEM,Kamala Harris,461
-Orange,45129,U.S. Senate,,DEM,Loretta Sanchez,256
-Orange,45131,U.S. Senate,,DEM,Kamala Harris,282
-Orange,45131,U.S. Senate,,DEM,Loretta Sanchez,222
-Orange,45132,U.S. Senate,,DEM,Kamala Harris,301
-Orange,45132,U.S. Senate,,DEM,Loretta Sanchez,205
-Orange,45133,U.S. Senate,,DEM,Kamala Harris,245
-Orange,45133,U.S. Senate,,DEM,Loretta Sanchez,147
-Orange,45239,U.S. Senate,,DEM,Kamala Harris,247
-Orange,45239,U.S. Senate,,DEM,Loretta Sanchez,212
-Orange,45240,U.S. Senate,,DEM,Kamala Harris,451
-Orange,45240,U.S. Senate,,DEM,Loretta Sanchez,295
-Orange,45352,U.S. Senate,,DEM,Kamala Harris,367
-Orange,45352,U.S. Senate,,DEM,Loretta Sanchez,270
-Orange,45353,U.S. Senate,,DEM,Kamala Harris,295
-Orange,45353,U.S. Senate,,DEM,Loretta Sanchez,219
-Orange,45371,U.S. Senate,,DEM,Kamala Harris,270
-Orange,45371,U.S. Senate,,DEM,Loretta Sanchez,235
-Orange,47201,U.S. Senate,,DEM,Kamala Harris,302
-Orange,47201,U.S. Senate,,DEM,Loretta Sanchez,249
-Orange,47202,U.S. Senate,,DEM,Kamala Harris,299
-Orange,47202,U.S. Senate,,DEM,Loretta Sanchez,172
-Orange,47203,U.S. Senate,,DEM,Kamala Harris,485
-Orange,47203,U.S. Senate,,DEM,Loretta Sanchez,421
-Orange,47204,U.S. Senate,,DEM,Kamala Harris,280
-Orange,47204,U.S. Senate,,DEM,Loretta Sanchez,216
-Orange,47247,U.S. Senate,,DEM,Kamala Harris,0
-Orange,47247,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,47248,U.S. Senate,,DEM,Kamala Harris,366
-Orange,47248,U.S. Senate,,DEM,Loretta Sanchez,269
-Orange,47250,U.S. Senate,,DEM,Kamala Harris,335
-Orange,47250,U.S. Senate,,DEM,Loretta Sanchez,224
-Orange,47251,U.S. Senate,,DEM,Kamala Harris,573
-Orange,47251,U.S. Senate,,DEM,Loretta Sanchez,422
-Orange,47252,U.S. Senate,,DEM,Kamala Harris,429
-Orange,47252,U.S. Senate,,DEM,Loretta Sanchez,314
-Orange,47253,U.S. Senate,,DEM,Kamala Harris,988
-Orange,47253,U.S. Senate,,DEM,Loretta Sanchez,640
-Orange,47256,U.S. Senate,,DEM,Kamala Harris,836
-Orange,47256,U.S. Senate,,DEM,Loretta Sanchez,645
-Orange,47258,U.S. Senate,,DEM,Kamala Harris,301
-Orange,47258,U.S. Senate,,DEM,Loretta Sanchez,249
-Orange,47259,U.S. Senate,,DEM,Kamala Harris,646
-Orange,47259,U.S. Senate,,DEM,Loretta Sanchez,487
-Orange,47260,U.S. Senate,,DEM,Kamala Harris,557
-Orange,47260,U.S. Senate,,DEM,Loretta Sanchez,449
-Orange,47262,U.S. Senate,,DEM,Kamala Harris,787
-Orange,47262,U.S. Senate,,DEM,Loretta Sanchez,511
-Orange,47265,U.S. Senate,,DEM,Kamala Harris,672
-Orange,47265,U.S. Senate,,DEM,Loretta Sanchez,509
-Orange,47267,U.S. Senate,,DEM,Kamala Harris,726
-Orange,47267,U.S. Senate,,DEM,Loretta Sanchez,486
-Orange,47268,U.S. Senate,,DEM,Kamala Harris,446
-Orange,47268,U.S. Senate,,DEM,Loretta Sanchez,317
-Orange,47271,U.S. Senate,,DEM,Kamala Harris,663
-Orange,47271,U.S. Senate,,DEM,Loretta Sanchez,498
-Orange,47272,U.S. Senate,,DEM,Kamala Harris,289
-Orange,47272,U.S. Senate,,DEM,Loretta Sanchez,273
-Orange,47273,U.S. Senate,,DEM,Kamala Harris,337
-Orange,47273,U.S. Senate,,DEM,Loretta Sanchez,275
-Orange,47276,U.S. Senate,,DEM,Kamala Harris,353
-Orange,47276,U.S. Senate,,DEM,Loretta Sanchez,315
-Orange,47278,U.S. Senate,,DEM,Kamala Harris,279
-Orange,47278,U.S. Senate,,DEM,Loretta Sanchez,269
-Orange,47279,U.S. Senate,,DEM,Kamala Harris,659
-Orange,47279,U.S. Senate,,DEM,Loretta Sanchez,548
-Orange,47284,U.S. Senate,,DEM,Kamala Harris,561
-Orange,47284,U.S. Senate,,DEM,Loretta Sanchez,527
-Orange,47285,U.S. Senate,,DEM,Kamala Harris,1135
-Orange,47285,U.S. Senate,,DEM,Loretta Sanchez,819
-Orange,47287,U.S. Senate,,DEM,Kamala Harris,668
-Orange,47287,U.S. Senate,,DEM,Loretta Sanchez,605
-Orange,47288,U.S. Senate,,DEM,Kamala Harris,573
-Orange,47288,U.S. Senate,,DEM,Loretta Sanchez,467
-Orange,47289,U.S. Senate,,DEM,Kamala Harris,525
-Orange,47289,U.S. Senate,,DEM,Loretta Sanchez,439
-Orange,47290,U.S. Senate,,DEM,Kamala Harris,445
-Orange,47290,U.S. Senate,,DEM,Loretta Sanchez,284
-Orange,47293,U.S. Senate,,DEM,Kamala Harris,366
-Orange,47293,U.S. Senate,,DEM,Loretta Sanchez,325
-Orange,47294,U.S. Senate,,DEM,Kamala Harris,560
-Orange,47294,U.S. Senate,,DEM,Loretta Sanchez,510
-Orange,47295,U.S. Senate,,DEM,Kamala Harris,640
-Orange,47295,U.S. Senate,,DEM,Loretta Sanchez,494
-Orange,47296,U.S. Senate,,DEM,Kamala Harris,597
-Orange,47296,U.S. Senate,,DEM,Loretta Sanchez,442
-Orange,47301,U.S. Senate,,DEM,Kamala Harris,676
-Orange,47301,U.S. Senate,,DEM,Loretta Sanchez,618
-Orange,47305,U.S. Senate,,DEM,Kamala Harris,521
-Orange,47305,U.S. Senate,,DEM,Loretta Sanchez,456
-Orange,47308,U.S. Senate,,DEM,Kamala Harris,0
-Orange,47308,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,47316,U.S. Senate,,DEM,Kamala Harris,342
-Orange,47316,U.S. Senate,,DEM,Loretta Sanchez,310
-Orange,47336,U.S. Senate,,DEM,Kamala Harris,330
-Orange,47336,U.S. Senate,,DEM,Loretta Sanchez,271
-Orange,47344,U.S. Senate,,DEM,Kamala Harris,539
-Orange,47344,U.S. Senate,,DEM,Loretta Sanchez,442
-Orange,47345,U.S. Senate,,DEM,Kamala Harris,497
-Orange,47345,U.S. Senate,,DEM,Loretta Sanchez,420
-Orange,47346,U.S. Senate,,DEM,Kamala Harris,410
-Orange,47346,U.S. Senate,,DEM,Loretta Sanchez,285
-Orange,47348,U.S. Senate,,DEM,Kamala Harris,1
-Orange,47348,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,47601,U.S. Senate,,DEM,Kamala Harris,702
-Orange,47601,U.S. Senate,,DEM,Loretta Sanchez,555
-Orange,47602,U.S. Senate,,DEM,Kamala Harris,370
-Orange,47602,U.S. Senate,,DEM,Loretta Sanchez,352
-Orange,47701,U.S. Senate,,DEM,Kamala Harris,605
-Orange,47701,U.S. Senate,,DEM,Loretta Sanchez,465
-Orange,47901,U.S. Senate,,DEM,Kamala Harris,65
-Orange,47901,U.S. Senate,,DEM,Loretta Sanchez,48
-Orange,47902,U.S. Senate,,DEM,Kamala Harris,2
-Orange,47902,U.S. Senate,,DEM,Loretta Sanchez,2
-Orange,48141,U.S. Senate,,DEM,Kamala Harris,578
-Orange,48141,U.S. Senate,,DEM,Loretta Sanchez,419
-Orange,48142,U.S. Senate,,DEM,Kamala Harris,274
-Orange,48142,U.S. Senate,,DEM,Loretta Sanchez,207
-Orange,48144,U.S. Senate,,DEM,Kamala Harris,258
-Orange,48144,U.S. Senate,,DEM,Loretta Sanchez,176
-Orange,48146,U.S. Senate,,DEM,Kamala Harris,321
-Orange,48146,U.S. Senate,,DEM,Loretta Sanchez,238
-Orange,48148,U.S. Senate,,DEM,Kamala Harris,291
-Orange,48148,U.S. Senate,,DEM,Loretta Sanchez,217
-Orange,48151,U.S. Senate,,DEM,Kamala Harris,560
-Orange,48151,U.S. Senate,,DEM,Loretta Sanchez,431
-Orange,48152,U.S. Senate,,DEM,Kamala Harris,261
-Orange,48152,U.S. Senate,,DEM,Loretta Sanchez,227
-Orange,48155,U.S. Senate,,DEM,Kamala Harris,656
-Orange,48155,U.S. Senate,,DEM,Loretta Sanchez,499
-Orange,48156,U.S. Senate,,DEM,Kamala Harris,464
-Orange,48156,U.S. Senate,,DEM,Loretta Sanchez,354
-Orange,48157,U.S. Senate,,DEM,Kamala Harris,755
-Orange,48157,U.S. Senate,,DEM,Loretta Sanchez,585
-Orange,48165,U.S. Senate,,DEM,Kamala Harris,741
-Orange,48165,U.S. Senate,,DEM,Loretta Sanchez,569
-Orange,48166,U.S. Senate,,DEM,Kamala Harris,658
-Orange,48166,U.S. Senate,,DEM,Loretta Sanchez,507
-Orange,48167,U.S. Senate,,DEM,Kamala Harris,848
-Orange,48167,U.S. Senate,,DEM,Loretta Sanchez,633
-Orange,48169,U.S. Senate,,DEM,Kamala Harris,847
-Orange,48169,U.S. Senate,,DEM,Loretta Sanchez,633
-Orange,48171,U.S. Senate,,DEM,Kamala Harris,599
-Orange,48171,U.S. Senate,,DEM,Loretta Sanchez,425
-Orange,48173,U.S. Senate,,DEM,Kamala Harris,656
-Orange,48173,U.S. Senate,,DEM,Loretta Sanchez,543
-Orange,48175,U.S. Senate,,DEM,Kamala Harris,372
-Orange,48175,U.S. Senate,,DEM,Loretta Sanchez,321
-Orange,48239,U.S. Senate,,DEM,Kamala Harris,719
-Orange,48239,U.S. Senate,,DEM,Loretta Sanchez,437
-Orange,48240,U.S. Senate,,DEM,Kamala Harris,520
-Orange,48240,U.S. Senate,,DEM,Loretta Sanchez,338
-Orange,48241,U.S. Senate,,DEM,Kamala Harris,658
-Orange,48241,U.S. Senate,,DEM,Loretta Sanchez,377
-Orange,48242,U.S. Senate,,DEM,Kamala Harris,287
-Orange,48242,U.S. Senate,,DEM,Loretta Sanchez,239
-Orange,48249,U.S. Senate,,DEM,Kamala Harris,572
-Orange,48249,U.S. Senate,,DEM,Loretta Sanchez,452
-Orange,48256,U.S. Senate,,DEM,Kamala Harris,836
-Orange,48256,U.S. Senate,,DEM,Loretta Sanchez,550
-Orange,48601,U.S. Senate,,DEM,Kamala Harris,742
-Orange,48601,U.S. Senate,,DEM,Loretta Sanchez,600
-Orange,48602,U.S. Senate,,DEM,Kamala Harris,322
-Orange,48602,U.S. Senate,,DEM,Loretta Sanchez,231
-Orange,48603,U.S. Senate,,DEM,Kamala Harris,366
-Orange,48603,U.S. Senate,,DEM,Loretta Sanchez,347
-Orange,48604,U.S. Senate,,DEM,Kamala Harris,464
-Orange,48604,U.S. Senate,,DEM,Loretta Sanchez,266
-Orange,48605,U.S. Senate,,DEM,Kamala Harris,215
-Orange,48605,U.S. Senate,,DEM,Loretta Sanchez,119
-Orange,48606,U.S. Senate,,DEM,Kamala Harris,201
-Orange,48606,U.S. Senate,,DEM,Loretta Sanchez,136
-Orange,49116,U.S. Senate,,DEM,Kamala Harris,326
-Orange,49116,U.S. Senate,,DEM,Loretta Sanchez,245
-Orange,49118,U.S. Senate,,DEM,Kamala Harris,385
-Orange,49118,U.S. Senate,,DEM,Loretta Sanchez,303
-Orange,49122,U.S. Senate,,DEM,Kamala Harris,347
-Orange,49122,U.S. Senate,,DEM,Loretta Sanchez,259
-Orange,49125,U.S. Senate,,DEM,Kamala Harris,435
-Orange,49125,U.S. Senate,,DEM,Loretta Sanchez,382
-Orange,49126,U.S. Senate,,DEM,Kamala Harris,429
-Orange,49126,U.S. Senate,,DEM,Loretta Sanchez,344
-Orange,49128,U.S. Senate,,DEM,Kamala Harris,615
-Orange,49128,U.S. Senate,,DEM,Loretta Sanchez,422
-Orange,49129,U.S. Senate,,DEM,Kamala Harris,425
-Orange,49129,U.S. Senate,,DEM,Loretta Sanchez,419
-Orange,49132,U.S. Senate,,DEM,Kamala Harris,0
-Orange,49132,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,49133,U.S. Senate,,DEM,Kamala Harris,0
-Orange,49133,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,49134,U.S. Senate,,DEM,Kamala Harris,19
-Orange,49134,U.S. Senate,,DEM,Loretta Sanchez,3
-Orange,49332,U.S. Senate,,DEM,Kamala Harris,0
-Orange,49332,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,49333,U.S. Senate,,DEM,Kamala Harris,112
-Orange,49333,U.S. Senate,,DEM,Loretta Sanchez,211
-Orange,49335,U.S. Senate,,DEM,Kamala Harris,485
-Orange,49335,U.S. Senate,,DEM,Loretta Sanchez,422
-Orange,49338,U.S. Senate,,DEM,Kamala Harris,584
-Orange,49338,U.S. Senate,,DEM,Loretta Sanchez,440
-Orange,49339,U.S. Senate,,DEM,Kamala Harris,123
-Orange,49339,U.S. Senate,,DEM,Loretta Sanchez,109
-Orange,49341,U.S. Senate,,DEM,Kamala Harris,272
-Orange,49341,U.S. Senate,,DEM,Loretta Sanchez,323
-Orange,49346,U.S. Senate,,DEM,Kamala Harris,424
-Orange,49346,U.S. Senate,,DEM,Loretta Sanchez,614
-Orange,49349,U.S. Senate,,DEM,Kamala Harris,225
-Orange,49349,U.S. Senate,,DEM,Loretta Sanchez,200
-Orange,49601,U.S. Senate,,DEM,Kamala Harris,655
-Orange,49601,U.S. Senate,,DEM,Loretta Sanchez,609
-Orange,49602,U.S. Senate,,DEM,Kamala Harris,797
-Orange,49602,U.S. Senate,,DEM,Loretta Sanchez,612
-Orange,49603,U.S. Senate,,DEM,Kamala Harris,256
-Orange,49603,U.S. Senate,,DEM,Loretta Sanchez,276
-Orange,49604,U.S. Senate,,DEM,Kamala Harris,107
-Orange,49604,U.S. Senate,,DEM,Loretta Sanchez,84
-Orange,49901,U.S. Senate,,DEM,Kamala Harris,0
-Orange,49901,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,49902,U.S. Senate,,DEM,Kamala Harris,0
-Orange,49902,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,50070,U.S. Senate,,DEM,Kamala Harris,340
-Orange,50070,U.S. Senate,,DEM,Loretta Sanchez,321
-Orange,50071,U.S. Senate,,DEM,Kamala Harris,315
-Orange,50071,U.S. Senate,,DEM,Loretta Sanchez,318
-Orange,50076,U.S. Senate,,DEM,Kamala Harris,228
-Orange,50076,U.S. Senate,,DEM,Loretta Sanchez,227
-Orange,50077,U.S. Senate,,DEM,Kamala Harris,407
-Orange,50077,U.S. Senate,,DEM,Loretta Sanchez,338
-Orange,50080,U.S. Senate,,DEM,Kamala Harris,383
-Orange,50080,U.S. Senate,,DEM,Loretta Sanchez,340
-Orange,50088,U.S. Senate,,DEM,Kamala Harris,0
-Orange,50088,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,50090,U.S. Senate,,DEM,Kamala Harris,3
-Orange,50090,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,50092,U.S. Senate,,DEM,Kamala Harris,340
-Orange,50092,U.S. Senate,,DEM,Loretta Sanchez,349
-Orange,50094,U.S. Senate,,DEM,Kamala Harris,423
-Orange,50094,U.S. Senate,,DEM,Loretta Sanchez,348
-Orange,50096,U.S. Senate,,DEM,Kamala Harris,1
-Orange,50096,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,50098,U.S. Senate,,DEM,Kamala Harris,375
-Orange,50098,U.S. Senate,,DEM,Loretta Sanchez,305
-Orange,50105,U.S. Senate,,DEM,Kamala Harris,0
-Orange,50105,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,50601,U.S. Senate,,DEM,Kamala Harris,216
-Orange,50601,U.S. Senate,,DEM,Loretta Sanchez,198
-Orange,50602,U.S. Senate,,DEM,Kamala Harris,151
-Orange,50602,U.S. Senate,,DEM,Loretta Sanchez,158
-Orange,50901,U.S. Senate,,DEM,Kamala Harris,4
-Orange,50901,U.S. Senate,,DEM,Loretta Sanchez,2
-Orange,50902,U.S. Senate,,DEM,Kamala Harris,1
-Orange,50902,U.S. Senate,,DEM,Loretta Sanchez,5
-Orange,50903,U.S. Senate,,DEM,Kamala Harris,0
-Orange,50903,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,50904,U.S. Senate,,DEM,Kamala Harris,0
-Orange,50904,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,51063,U.S. Senate,,DEM,Kamala Harris,0
-Orange,51063,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,51066,U.S. Senate,,DEM,Kamala Harris,0
-Orange,51066,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,51069,U.S. Senate,,DEM,Kamala Harris,199
-Orange,51069,U.S. Senate,,DEM,Loretta Sanchez,142
-Orange,51165,U.S. Senate,,DEM,Kamala Harris,0
-Orange,51165,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,51213,U.S. Senate,,DEM,Kamala Harris,0
-Orange,51213,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,51215,U.S. Senate,,DEM,Kamala Harris,0
-Orange,51215,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,51901,U.S. Senate,,DEM,Kamala Harris,0
-Orange,51901,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,51902,U.S. Senate,,DEM,Kamala Harris,0
-Orange,51902,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,52002,U.S. Senate,,DEM,Kamala Harris,216
-Orange,52002,U.S. Senate,,DEM,Loretta Sanchez,132
-Orange,52003,U.S. Senate,,DEM,Kamala Harris,265
-Orange,52003,U.S. Senate,,DEM,Loretta Sanchez,159
-Orange,52004,U.S. Senate,,DEM,Kamala Harris,432
-Orange,52004,U.S. Senate,,DEM,Loretta Sanchez,318
-Orange,52006,U.S. Senate,,DEM,Kamala Harris,408
-Orange,52006,U.S. Senate,,DEM,Loretta Sanchez,268
-Orange,52007,U.S. Senate,,DEM,Kamala Harris,494
-Orange,52007,U.S. Senate,,DEM,Loretta Sanchez,280
-Orange,52009,U.S. Senate,,DEM,Kamala Harris,409
-Orange,52009,U.S. Senate,,DEM,Loretta Sanchez,269
-Orange,52010,U.S. Senate,,DEM,Kamala Harris,193
-Orange,52010,U.S. Senate,,DEM,Loretta Sanchez,205
-Orange,52011,U.S. Senate,,DEM,Kamala Harris,441
-Orange,52011,U.S. Senate,,DEM,Loretta Sanchez,316
-Orange,52016,U.S. Senate,,DEM,Kamala Harris,314
-Orange,52016,U.S. Senate,,DEM,Loretta Sanchez,280
-Orange,52020,U.S. Senate,,DEM,Kamala Harris,394
-Orange,52020,U.S. Senate,,DEM,Loretta Sanchez,265
-Orange,52022,U.S. Senate,,DEM,Kamala Harris,359
-Orange,52022,U.S. Senate,,DEM,Loretta Sanchez,294
-Orange,52023,U.S. Senate,,DEM,Kamala Harris,0
-Orange,52023,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,52024,U.S. Senate,,DEM,Kamala Harris,150
-Orange,52024,U.S. Senate,,DEM,Loretta Sanchez,119
-Orange,52026,U.S. Senate,,DEM,Kamala Harris,356
-Orange,52026,U.S. Senate,,DEM,Loretta Sanchez,201
-Orange,52027,U.S. Senate,,DEM,Kamala Harris,23
-Orange,52027,U.S. Senate,,DEM,Loretta Sanchez,16
-Orange,52028,U.S. Senate,,DEM,Kamala Harris,380
-Orange,52028,U.S. Senate,,DEM,Loretta Sanchez,278
-Orange,52031,U.S. Senate,,DEM,Kamala Harris,380
-Orange,52031,U.S. Senate,,DEM,Loretta Sanchez,194
-Orange,52032,U.S. Senate,,DEM,Kamala Harris,282
-Orange,52032,U.S. Senate,,DEM,Loretta Sanchez,240
-Orange,52033,U.S. Senate,,DEM,Kamala Harris,346
-Orange,52033,U.S. Senate,,DEM,Loretta Sanchez,228
-Orange,52035,U.S. Senate,,DEM,Kamala Harris,289
-Orange,52035,U.S. Senate,,DEM,Loretta Sanchez,214
-Orange,52037,U.S. Senate,,DEM,Kamala Harris,328
-Orange,52037,U.S. Senate,,DEM,Loretta Sanchez,296
-Orange,52038,U.S. Senate,,DEM,Kamala Harris,285
-Orange,52038,U.S. Senate,,DEM,Loretta Sanchez,165
-Orange,52041,U.S. Senate,,DEM,Kamala Harris,333
-Orange,52041,U.S. Senate,,DEM,Loretta Sanchez,255
-Orange,52042,U.S. Senate,,DEM,Kamala Harris,233
-Orange,52042,U.S. Senate,,DEM,Loretta Sanchez,168
-Orange,52043,U.S. Senate,,DEM,Kamala Harris,311
-Orange,52043,U.S. Senate,,DEM,Loretta Sanchez,226
-Orange,52045,U.S. Senate,,DEM,Kamala Harris,439
-Orange,52045,U.S. Senate,,DEM,Loretta Sanchez,337
-Orange,52047,U.S. Senate,,DEM,Kamala Harris,31
-Orange,52047,U.S. Senate,,DEM,Loretta Sanchez,18
-Orange,52048,U.S. Senate,,DEM,Kamala Harris,74
-Orange,52048,U.S. Senate,,DEM,Loretta Sanchez,35
-Orange,52049,U.S. Senate,,DEM,Kamala Harris,20
-Orange,52049,U.S. Senate,,DEM,Loretta Sanchez,14
-Orange,52051,U.S. Senate,,DEM,Kamala Harris,366
-Orange,52051,U.S. Senate,,DEM,Loretta Sanchez,266
-Orange,52056,U.S. Senate,,DEM,Kamala Harris,281
-Orange,52056,U.S. Senate,,DEM,Loretta Sanchez,168
-Orange,52059,U.S. Senate,,DEM,Kamala Harris,308
-Orange,52059,U.S. Senate,,DEM,Loretta Sanchez,218
-Orange,52061,U.S. Senate,,DEM,Kamala Harris,323
-Orange,52061,U.S. Senate,,DEM,Loretta Sanchez,187
-Orange,52166,U.S. Senate,,DEM,Kamala Harris,282
-Orange,52166,U.S. Senate,,DEM,Loretta Sanchez,235
-Orange,52167,U.S. Senate,,DEM,Kamala Harris,375
-Orange,52167,U.S. Senate,,DEM,Loretta Sanchez,300
-Orange,52173,U.S. Senate,,DEM,Kamala Harris,305
-Orange,52173,U.S. Senate,,DEM,Loretta Sanchez,157
-Orange,52177,U.S. Senate,,DEM,Kamala Harris,237
-Orange,52177,U.S. Senate,,DEM,Loretta Sanchez,187
-Orange,52179,U.S. Senate,,DEM,Kamala Harris,287
-Orange,52179,U.S. Senate,,DEM,Loretta Sanchez,221
-Orange,52181,U.S. Senate,,DEM,Kamala Harris,241
-Orange,52181,U.S. Senate,,DEM,Loretta Sanchez,197
-Orange,52182,U.S. Senate,,DEM,Kamala Harris,364
-Orange,52182,U.S. Senate,,DEM,Loretta Sanchez,278
-Orange,52183,U.S. Senate,,DEM,Kamala Harris,195
-Orange,52183,U.S. Senate,,DEM,Loretta Sanchez,151
-Orange,52184,U.S. Senate,,DEM,Kamala Harris,383
-Orange,52184,U.S. Senate,,DEM,Loretta Sanchez,251
-Orange,52186,U.S. Senate,,DEM,Kamala Harris,389
-Orange,52186,U.S. Senate,,DEM,Loretta Sanchez,203
-Orange,52192,U.S. Senate,,DEM,Kamala Harris,322
-Orange,52192,U.S. Senate,,DEM,Loretta Sanchez,187
-Orange,52194,U.S. Senate,,DEM,Kamala Harris,381
-Orange,52194,U.S. Senate,,DEM,Loretta Sanchez,295
-Orange,52195,U.S. Senate,,DEM,Kamala Harris,279
-Orange,52195,U.S. Senate,,DEM,Loretta Sanchez,212
-Orange,52196,U.S. Senate,,DEM,Kamala Harris,345
-Orange,52196,U.S. Senate,,DEM,Loretta Sanchez,208
-Orange,52201,U.S. Senate,,DEM,Kamala Harris,287
-Orange,52201,U.S. Senate,,DEM,Loretta Sanchez,202
-Orange,52203,U.S. Senate,,DEM,Kamala Harris,276
-Orange,52203,U.S. Senate,,DEM,Loretta Sanchez,189
-Orange,52209,U.S. Senate,,DEM,Kamala Harris,245
-Orange,52209,U.S. Senate,,DEM,Loretta Sanchez,157
-Orange,52213,U.S. Senate,,DEM,Kamala Harris,337
-Orange,52213,U.S. Senate,,DEM,Loretta Sanchez,257
-Orange,52219,U.S. Senate,,DEM,Kamala Harris,133
-Orange,52219,U.S. Senate,,DEM,Loretta Sanchez,114
-Orange,52224,U.S. Senate,,DEM,Kamala Harris,478
-Orange,52224,U.S. Senate,,DEM,Loretta Sanchez,261
-Orange,52225,U.S. Senate,,DEM,Kamala Harris,316
-Orange,52225,U.S. Senate,,DEM,Loretta Sanchez,205
-Orange,52601,U.S. Senate,,DEM,Kamala Harris,457
-Orange,52601,U.S. Senate,,DEM,Loretta Sanchez,537
-Orange,52602,U.S. Senate,,DEM,Kamala Harris,469
-Orange,52602,U.S. Senate,,DEM,Loretta Sanchez,536
-Orange,52603,U.S. Senate,,DEM,Kamala Harris,823
-Orange,52603,U.S. Senate,,DEM,Loretta Sanchez,619
-Orange,52604,U.S. Senate,,DEM,Kamala Harris,585
-Orange,52604,U.S. Senate,,DEM,Loretta Sanchez,433
-Orange,52605,U.S. Senate,,DEM,Kamala Harris,817
-Orange,52605,U.S. Senate,,DEM,Loretta Sanchez,581
-Orange,52701,U.S. Senate,,DEM,Kamala Harris,437
-Orange,52701,U.S. Senate,,DEM,Loretta Sanchez,408
-Orange,52702,U.S. Senate,,DEM,Kamala Harris,718
-Orange,52702,U.S. Senate,,DEM,Loretta Sanchez,595
-Orange,52703,U.S. Senate,,DEM,Kamala Harris,765
-Orange,52703,U.S. Senate,,DEM,Loretta Sanchez,559
-Orange,52901,U.S. Senate,,DEM,Kamala Harris,0
-Orange,52901,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,52902,U.S. Senate,,DEM,Kamala Harris,33
-Orange,52902,U.S. Senate,,DEM,Loretta Sanchez,22
-Orange,52903,U.S. Senate,,DEM,Kamala Harris,0
-Orange,52903,U.S. Senate,,DEM,Loretta Sanchez,1
-Orange,52904,U.S. Senate,,DEM,Kamala Harris,0
-Orange,52904,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,53064,U.S. Senate,,DEM,Kamala Harris,570
-Orange,53064,U.S. Senate,,DEM,Loretta Sanchez,389
-Orange,53066,U.S. Senate,,DEM,Kamala Harris,301
-Orange,53066,U.S. Senate,,DEM,Loretta Sanchez,171
-Orange,53068,U.S. Senate,,DEM,Kamala Harris,500
-Orange,53068,U.S. Senate,,DEM,Loretta Sanchez,390
-Orange,53069,U.S. Senate,,DEM,Kamala Harris,140
-Orange,53069,U.S. Senate,,DEM,Loretta Sanchez,149
-Orange,53073,U.S. Senate,,DEM,Kamala Harris,433
-Orange,53073,U.S. Senate,,DEM,Loretta Sanchez,281
-Orange,53075,U.S. Senate,,DEM,Kamala Harris,558
-Orange,53075,U.S. Senate,,DEM,Loretta Sanchez,447
-Orange,53081,U.S. Senate,,DEM,Kamala Harris,408
-Orange,53081,U.S. Senate,,DEM,Loretta Sanchez,251
-Orange,53082,U.S. Senate,,DEM,Kamala Harris,548
-Orange,53082,U.S. Senate,,DEM,Loretta Sanchez,449
-Orange,53091,U.S. Senate,,DEM,Kamala Harris,545
-Orange,53091,U.S. Senate,,DEM,Loretta Sanchez,416
-Orange,53097,U.S. Senate,,DEM,Kamala Harris,482
-Orange,53097,U.S. Senate,,DEM,Loretta Sanchez,346
-Orange,53098,U.S. Senate,,DEM,Kamala Harris,387
-Orange,53098,U.S. Senate,,DEM,Loretta Sanchez,300
-Orange,53101,U.S. Senate,,DEM,Kamala Harris,323
-Orange,53101,U.S. Senate,,DEM,Loretta Sanchez,222
-Orange,53140,U.S. Senate,,DEM,Kamala Harris,0
-Orange,53140,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,53145,U.S. Senate,,DEM,Kamala Harris,239
-Orange,53145,U.S. Senate,,DEM,Loretta Sanchez,136
-Orange,53146,U.S. Senate,,DEM,Kamala Harris,386
-Orange,53146,U.S. Senate,,DEM,Loretta Sanchez,256
-Orange,53147,U.S. Senate,,DEM,Kamala Harris,318
-Orange,53147,U.S. Senate,,DEM,Loretta Sanchez,164
-Orange,53355,U.S. Senate,,DEM,Kamala Harris,211
-Orange,53355,U.S. Senate,,DEM,Loretta Sanchez,155
-Orange,53360,U.S. Senate,,DEM,Kamala Harris,258
-Orange,53360,U.S. Senate,,DEM,Loretta Sanchez,181
-Orange,53362,U.S. Senate,,DEM,Kamala Harris,193
-Orange,53362,U.S. Senate,,DEM,Loretta Sanchez,113
-Orange,53375,U.S. Senate,,DEM,Kamala Harris,141
-Orange,53375,U.S. Senate,,DEM,Loretta Sanchez,110
-Orange,53381,U.S. Senate,,DEM,Kamala Harris,182
-Orange,53381,U.S. Senate,,DEM,Loretta Sanchez,104
-Orange,53601,U.S. Senate,,DEM,Kamala Harris,383
-Orange,53601,U.S. Senate,,DEM,Loretta Sanchez,269
-Orange,53602,U.S. Senate,,DEM,Kamala Harris,138
-Orange,53602,U.S. Senate,,DEM,Loretta Sanchez,91
-Orange,53603,U.S. Senate,,DEM,Kamala Harris,226
-Orange,53603,U.S. Senate,,DEM,Loretta Sanchez,199
-Orange,53604,U.S. Senate,,DEM,Kamala Harris,176
-Orange,53604,U.S. Senate,,DEM,Loretta Sanchez,90
-Orange,53605,U.S. Senate,,DEM,Kamala Harris,649
-Orange,53605,U.S. Senate,,DEM,Loretta Sanchez,557
-Orange,53606,U.S. Senate,,DEM,Kamala Harris,733
-Orange,53606,U.S. Senate,,DEM,Loretta Sanchez,638
-Orange,53607,U.S. Senate,,DEM,Kamala Harris,903
-Orange,53607,U.S. Senate,,DEM,Loretta Sanchez,848
-Orange,53608,U.S. Senate,,DEM,Kamala Harris,517
-Orange,53608,U.S. Senate,,DEM,Loretta Sanchez,360
-Orange,53609,U.S. Senate,,DEM,Kamala Harris,492
-Orange,53609,U.S. Senate,,DEM,Loretta Sanchez,408
-Orange,53610,U.S. Senate,,DEM,Kamala Harris,524
-Orange,53610,U.S. Senate,,DEM,Loretta Sanchez,287
-Orange,53611,U.S. Senate,,DEM,Kamala Harris,619
-Orange,53611,U.S. Senate,,DEM,Loretta Sanchez,388
-Orange,53612,U.S. Senate,,DEM,Kamala Harris,369
-Orange,53612,U.S. Senate,,DEM,Loretta Sanchez,269
-Orange,53613,U.S. Senate,,DEM,Kamala Harris,241
-Orange,53613,U.S. Senate,,DEM,Loretta Sanchez,178
-Orange,53614,U.S. Senate,,DEM,Kamala Harris,526
-Orange,53614,U.S. Senate,,DEM,Loretta Sanchez,349
-Orange,53615,U.S. Senate,,DEM,Kamala Harris,519
-Orange,53615,U.S. Senate,,DEM,Loretta Sanchez,515
-Orange,53616,U.S. Senate,,DEM,Kamala Harris,525
-Orange,53616,U.S. Senate,,DEM,Loretta Sanchez,385
-Orange,53617,U.S. Senate,,DEM,Kamala Harris,167
-Orange,53617,U.S. Senate,,DEM,Loretta Sanchez,114
-Orange,53618,U.S. Senate,,DEM,Kamala Harris,676
-Orange,53618,U.S. Senate,,DEM,Loretta Sanchez,447
-Orange,53619,U.S. Senate,,DEM,Kamala Harris,393
-Orange,53619,U.S. Senate,,DEM,Loretta Sanchez,255
-Orange,53620,U.S. Senate,,DEM,Kamala Harris,278
-Orange,53620,U.S. Senate,,DEM,Loretta Sanchez,210
-Orange,53621,U.S. Senate,,DEM,Kamala Harris,457
-Orange,53621,U.S. Senate,,DEM,Loretta Sanchez,305
-Orange,53622,U.S. Senate,,DEM,Kamala Harris,384
-Orange,53622,U.S. Senate,,DEM,Loretta Sanchez,319
-Orange,53623,U.S. Senate,,DEM,Kamala Harris,783
-Orange,53623,U.S. Senate,,DEM,Loretta Sanchez,553
-Orange,53624,U.S. Senate,,DEM,Kamala Harris,877
-Orange,53624,U.S. Senate,,DEM,Loretta Sanchez,611
-Orange,53625,U.S. Senate,,DEM,Kamala Harris,120
-Orange,53625,U.S. Senate,,DEM,Loretta Sanchez,94
-Orange,53626,U.S. Senate,,DEM,Kamala Harris,131
-Orange,53626,U.S. Senate,,DEM,Loretta Sanchez,65
-Orange,53701,U.S. Senate,,DEM,Kamala Harris,574
-Orange,53701,U.S. Senate,,DEM,Loretta Sanchez,388
-Orange,53702,U.S. Senate,,DEM,Kamala Harris,587
-Orange,53702,U.S. Senate,,DEM,Loretta Sanchez,421
-Orange,53703,U.S. Senate,,DEM,Kamala Harris,623
-Orange,53703,U.S. Senate,,DEM,Loretta Sanchez,445
-Orange,53704,U.S. Senate,,DEM,Kamala Harris,734
-Orange,53704,U.S. Senate,,DEM,Loretta Sanchez,530
-Orange,53901,U.S. Senate,,DEM,Kamala Harris,0
-Orange,53901,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,53902,U.S. Senate,,DEM,Kamala Harris,91
-Orange,53902,U.S. Senate,,DEM,Loretta Sanchez,43
-Orange,53903,U.S. Senate,,DEM,Kamala Harris,0
-Orange,53903,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,53904,U.S. Senate,,DEM,Kamala Harris,71
-Orange,53904,U.S. Senate,,DEM,Loretta Sanchez,55
-Orange,53905,U.S. Senate,,DEM,Kamala Harris,68
-Orange,53905,U.S. Senate,,DEM,Loretta Sanchez,34
-Orange,53906,U.S. Senate,,DEM,Kamala Harris,0
-Orange,53906,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,53907,U.S. Senate,,DEM,Kamala Harris,1
-Orange,53907,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,53908,U.S. Senate,,DEM,Kamala Harris,58
-Orange,53908,U.S. Senate,,DEM,Loretta Sanchez,39
-Orange,53909,U.S. Senate,,DEM,Kamala Harris,5
-Orange,53909,U.S. Senate,,DEM,Loretta Sanchez,1
-Orange,53910,U.S. Senate,,DEM,Kamala Harris,7
-Orange,53910,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,53911,U.S. Senate,,DEM,Kamala Harris,0
-Orange,53911,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,53912,U.S. Senate,,DEM,Kamala Harris,0
-Orange,53912,U.S. Senate,,DEM,Loretta Sanchez,1
-Orange,54101,U.S. Senate,,DEM,Kamala Harris,356
-Orange,54101,U.S. Senate,,DEM,Loretta Sanchez,313
-Orange,54102,U.S. Senate,,DEM,Kamala Harris,300
-Orange,54102,U.S. Senate,,DEM,Loretta Sanchez,236
-Orange,54103,U.S. Senate,,DEM,Kamala Harris,362
-Orange,54103,U.S. Senate,,DEM,Loretta Sanchez,275
-Orange,54104,U.S. Senate,,DEM,Kamala Harris,331
-Orange,54104,U.S. Senate,,DEM,Loretta Sanchez,274
-Orange,54105,U.S. Senate,,DEM,Kamala Harris,254
-Orange,54105,U.S. Senate,,DEM,Loretta Sanchez,209
-Orange,54106,U.S. Senate,,DEM,Kamala Harris,321
-Orange,54106,U.S. Senate,,DEM,Loretta Sanchez,259
-Orange,54107,U.S. Senate,,DEM,Kamala Harris,307
-Orange,54107,U.S. Senate,,DEM,Loretta Sanchez,251
-Orange,54108,U.S. Senate,,DEM,Kamala Harris,344
-Orange,54108,U.S. Senate,,DEM,Loretta Sanchez,247
-Orange,54109,U.S. Senate,,DEM,Kamala Harris,324
-Orange,54109,U.S. Senate,,DEM,Loretta Sanchez,255
-Orange,54110,U.S. Senate,,DEM,Kamala Harris,212
-Orange,54110,U.S. Senate,,DEM,Loretta Sanchez,171
-Orange,54111,U.S. Senate,,DEM,Kamala Harris,437
-Orange,54111,U.S. Senate,,DEM,Loretta Sanchez,314
-Orange,54112,U.S. Senate,,DEM,Kamala Harris,389
-Orange,54112,U.S. Senate,,DEM,Loretta Sanchez,353
-Orange,54113,U.S. Senate,,DEM,Kamala Harris,273
-Orange,54113,U.S. Senate,,DEM,Loretta Sanchez,182
-Orange,54114,U.S. Senate,,DEM,Kamala Harris,392
-Orange,54114,U.S. Senate,,DEM,Loretta Sanchez,330
-Orange,54115,U.S. Senate,,DEM,Kamala Harris,371
-Orange,54115,U.S. Senate,,DEM,Loretta Sanchez,264
-Orange,54120,U.S. Senate,,DEM,Kamala Harris,196
-Orange,54120,U.S. Senate,,DEM,Loretta Sanchez,160
-Orange,54121,U.S. Senate,,DEM,Kamala Harris,439
-Orange,54121,U.S. Senate,,DEM,Loretta Sanchez,361
-Orange,54122,U.S. Senate,,DEM,Kamala Harris,423
-Orange,54122,U.S. Senate,,DEM,Loretta Sanchez,340
-Orange,54123,U.S. Senate,,DEM,Kamala Harris,287
-Orange,54123,U.S. Senate,,DEM,Loretta Sanchez,240
-Orange,54141,U.S. Senate,,DEM,Kamala Harris,346
-Orange,54141,U.S. Senate,,DEM,Loretta Sanchez,299
-Orange,54142,U.S. Senate,,DEM,Kamala Harris,401
-Orange,54142,U.S. Senate,,DEM,Loretta Sanchez,316
-Orange,54143,U.S. Senate,,DEM,Kamala Harris,307
-Orange,54143,U.S. Senate,,DEM,Loretta Sanchez,245
-Orange,54144,U.S. Senate,,DEM,Kamala Harris,346
-Orange,54144,U.S. Senate,,DEM,Loretta Sanchez,281
-Orange,54160,U.S. Senate,,DEM,Kamala Harris,304
-Orange,54160,U.S. Senate,,DEM,Loretta Sanchez,228
-Orange,54161,U.S. Senate,,DEM,Kamala Harris,311
-Orange,54161,U.S. Senate,,DEM,Loretta Sanchez,235
-Orange,54180,U.S. Senate,,DEM,Kamala Harris,339
-Orange,54180,U.S. Senate,,DEM,Loretta Sanchez,291
-Orange,54181,U.S. Senate,,DEM,Kamala Harris,338
-Orange,54181,U.S. Senate,,DEM,Loretta Sanchez,288
-Orange,54182,U.S. Senate,,DEM,Kamala Harris,214
-Orange,54182,U.S. Senate,,DEM,Loretta Sanchez,222
-Orange,54183,U.S. Senate,,DEM,Kamala Harris,342
-Orange,54183,U.S. Senate,,DEM,Loretta Sanchez,280
-Orange,54184,U.S. Senate,,DEM,Kamala Harris,399
-Orange,54184,U.S. Senate,,DEM,Loretta Sanchez,364
-Orange,54185,U.S. Senate,,DEM,Kamala Harris,360
-Orange,54185,U.S. Senate,,DEM,Loretta Sanchez,268
-Orange,56065,U.S. Senate,,DEM,Kamala Harris,538
-Orange,56065,U.S. Senate,,DEM,Loretta Sanchez,381
-Orange,56069,U.S. Senate,,DEM,Kamala Harris,575
-Orange,56069,U.S. Senate,,DEM,Loretta Sanchez,392
-Orange,56070,U.S. Senate,,DEM,Kamala Harris,401
-Orange,56070,U.S. Senate,,DEM,Loretta Sanchez,288
-Orange,56072,U.S. Senate,,DEM,Kamala Harris,362
-Orange,56072,U.S. Senate,,DEM,Loretta Sanchez,211
-Orange,56073,U.S. Senate,,DEM,Kamala Harris,774
-Orange,56073,U.S. Senate,,DEM,Loretta Sanchez,507
-Orange,56079,U.S. Senate,,DEM,Kamala Harris,550
-Orange,56079,U.S. Senate,,DEM,Loretta Sanchez,418
-Orange,56080,U.S. Senate,,DEM,Kamala Harris,194
-Orange,56080,U.S. Senate,,DEM,Loretta Sanchez,209
-Orange,56090,U.S. Senate,,DEM,Kamala Harris,591
-Orange,56090,U.S. Senate,,DEM,Loretta Sanchez,486
-Orange,56095,U.S. Senate,,DEM,Kamala Harris,286
-Orange,56095,U.S. Senate,,DEM,Loretta Sanchez,232
-Orange,56096,U.S. Senate,,DEM,Kamala Harris,370
-Orange,56096,U.S. Senate,,DEM,Loretta Sanchez,355
-Orange,56098,U.S. Senate,,DEM,Kamala Harris,393
-Orange,56098,U.S. Senate,,DEM,Loretta Sanchez,326
-Orange,56101,U.S. Senate,,DEM,Kamala Harris,601
-Orange,56101,U.S. Senate,,DEM,Loretta Sanchez,474
-Orange,56105,U.S. Senate,,DEM,Kamala Harris,0
-Orange,56105,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,56109,U.S. Senate,,DEM,Kamala Harris,505
-Orange,56109,U.S. Senate,,DEM,Loretta Sanchez,385
-Orange,56110,U.S. Senate,,DEM,Kamala Harris,266
-Orange,56110,U.S. Senate,,DEM,Loretta Sanchez,178
-Orange,56277,U.S. Senate,,DEM,Kamala Harris,494
-Orange,56277,U.S. Senate,,DEM,Loretta Sanchez,324
-Orange,56278,U.S. Senate,,DEM,Kamala Harris,333
-Orange,56278,U.S. Senate,,DEM,Loretta Sanchez,267
-Orange,56290,U.S. Senate,,DEM,Kamala Harris,538
-Orange,56290,U.S. Senate,,DEM,Loretta Sanchez,449
-Orange,56292,U.S. Senate,,DEM,Kamala Harris,449
-Orange,56292,U.S. Senate,,DEM,Loretta Sanchez,406
-Orange,56293,U.S. Senate,,DEM,Kamala Harris,474
-Orange,56293,U.S. Senate,,DEM,Loretta Sanchez,355
-Orange,56295,U.S. Senate,,DEM,Kamala Harris,202
-Orange,56295,U.S. Senate,,DEM,Loretta Sanchez,154
-Orange,56296,U.S. Senate,,DEM,Kamala Harris,177
-Orange,56296,U.S. Senate,,DEM,Loretta Sanchez,122
-Orange,56301,U.S. Senate,,DEM,Kamala Harris,237
-Orange,56301,U.S. Senate,,DEM,Loretta Sanchez,209
-Orange,56308,U.S. Senate,,DEM,Kamala Harris,320
-Orange,56308,U.S. Senate,,DEM,Loretta Sanchez,225
-Orange,56315,U.S. Senate,,DEM,Kamala Harris,621
-Orange,56315,U.S. Senate,,DEM,Loretta Sanchez,515
-Orange,56383,U.S. Senate,,DEM,Kamala Harris,265
-Orange,56383,U.S. Senate,,DEM,Loretta Sanchez,191
-Orange,56601,U.S. Senate,,DEM,Kamala Harris,748
-Orange,56601,U.S. Senate,,DEM,Loretta Sanchez,572
-Orange,56602,U.S. Senate,,DEM,Kamala Harris,921
-Orange,56602,U.S. Senate,,DEM,Loretta Sanchez,650
-Orange,56603,U.S. Senate,,DEM,Kamala Harris,801
-Orange,56603,U.S. Senate,,DEM,Loretta Sanchez,521
-Orange,56604,U.S. Senate,,DEM,Kamala Harris,825
-Orange,56604,U.S. Senate,,DEM,Loretta Sanchez,626
-Orange,56605,U.S. Senate,,DEM,Kamala Harris,796
-Orange,56605,U.S. Senate,,DEM,Loretta Sanchez,653
-Orange,56606,U.S. Senate,,DEM,Kamala Harris,334
-Orange,56606,U.S. Senate,,DEM,Loretta Sanchez,236
-Orange,56608,U.S. Senate,,DEM,Kamala Harris,706
-Orange,56608,U.S. Senate,,DEM,Loretta Sanchez,529
-Orange,56609,U.S. Senate,,DEM,Kamala Harris,648
-Orange,56609,U.S. Senate,,DEM,Loretta Sanchez,468
-Orange,56610,U.S. Senate,,DEM,Kamala Harris,466
-Orange,56610,U.S. Senate,,DEM,Loretta Sanchez,378
-Orange,56611,U.S. Senate,,DEM,Kamala Harris,260
-Orange,56611,U.S. Senate,,DEM,Loretta Sanchez,188
-Orange,56901,U.S. Senate,,DEM,Kamala Harris,0
-Orange,56901,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,56902,U.S. Senate,,DEM,Kamala Harris,0
-Orange,56902,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,56903,U.S. Senate,,DEM,Kamala Harris,98
-Orange,56903,U.S. Senate,,DEM,Loretta Sanchez,60
-Orange,57002,U.S. Senate,,DEM,Kamala Harris,60
-Orange,57002,U.S. Senate,,DEM,Loretta Sanchez,98
-Orange,57004,U.S. Senate,,DEM,Kamala Harris,0
-Orange,57004,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,57007,U.S. Senate,,DEM,Kamala Harris,36
-Orange,57007,U.S. Senate,,DEM,Loretta Sanchez,51
-Orange,58105,U.S. Senate,,DEM,Kamala Harris,411
-Orange,58105,U.S. Senate,,DEM,Loretta Sanchez,309
-Orange,58106,U.S. Senate,,DEM,Kamala Harris,0
-Orange,58106,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,58107,U.S. Senate,,DEM,Kamala Harris,458
-Orange,58107,U.S. Senate,,DEM,Loretta Sanchez,267
-Orange,58108,U.S. Senate,,DEM,Kamala Harris,418
-Orange,58108,U.S. Senate,,DEM,Loretta Sanchez,334
-Orange,58109,U.S. Senate,,DEM,Kamala Harris,385
-Orange,58109,U.S. Senate,,DEM,Loretta Sanchez,220
-Orange,58114,U.S. Senate,,DEM,Kamala Harris,328
-Orange,58114,U.S. Senate,,DEM,Loretta Sanchez,287
-Orange,58117,U.S. Senate,,DEM,Kamala Harris,385
-Orange,58117,U.S. Senate,,DEM,Loretta Sanchez,263
-Orange,58118,U.S. Senate,,DEM,Kamala Harris,473
-Orange,58118,U.S. Senate,,DEM,Loretta Sanchez,272
-Orange,58120,U.S. Senate,,DEM,Kamala Harris,410
-Orange,58120,U.S. Senate,,DEM,Loretta Sanchez,249
-Orange,58127,U.S. Senate,,DEM,Kamala Harris,416
-Orange,58127,U.S. Senate,,DEM,Loretta Sanchez,303
-Orange,58299,U.S. Senate,,DEM,Kamala Harris,382
-Orange,58299,U.S. Senate,,DEM,Loretta Sanchez,282
-Orange,58300,U.S. Senate,,DEM,Kamala Harris,300
-Orange,58300,U.S. Senate,,DEM,Loretta Sanchez,190
-Orange,58314,U.S. Senate,,DEM,Kamala Harris,277
-Orange,58314,U.S. Senate,,DEM,Loretta Sanchez,180
-Orange,58316,U.S. Senate,,DEM,Kamala Harris,247
-Orange,58316,U.S. Senate,,DEM,Loretta Sanchez,169
-Orange,58317,U.S. Senate,,DEM,Kamala Harris,398
-Orange,58317,U.S. Senate,,DEM,Loretta Sanchez,286
-Orange,58318,U.S. Senate,,DEM,Kamala Harris,376
-Orange,58318,U.S. Senate,,DEM,Loretta Sanchez,260
-Orange,58319,U.S. Senate,,DEM,Kamala Harris,328
-Orange,58319,U.S. Senate,,DEM,Loretta Sanchez,190
-Orange,58320,U.S. Senate,,DEM,Kamala Harris,218
-Orange,58320,U.S. Senate,,DEM,Loretta Sanchez,192
-Orange,58325,U.S. Senate,,DEM,Kamala Harris,358
-Orange,58325,U.S. Senate,,DEM,Loretta Sanchez,271
-Orange,58328,U.S. Senate,,DEM,Kamala Harris,357
-Orange,58328,U.S. Senate,,DEM,Loretta Sanchez,293
-Orange,58329,U.S. Senate,,DEM,Kamala Harris,223
-Orange,58329,U.S. Senate,,DEM,Loretta Sanchez,209
-Orange,58330,U.S. Senate,,DEM,Kamala Harris,373
-Orange,58330,U.S. Senate,,DEM,Loretta Sanchez,257
-Orange,58331,U.S. Senate,,DEM,Kamala Harris,446
-Orange,58331,U.S. Senate,,DEM,Loretta Sanchez,288
-Orange,58332,U.S. Senate,,DEM,Kamala Harris,309
-Orange,58332,U.S. Senate,,DEM,Loretta Sanchez,207
-Orange,58333,U.S. Senate,,DEM,Kamala Harris,274
-Orange,58333,U.S. Senate,,DEM,Loretta Sanchez,251
-Orange,58334,U.S. Senate,,DEM,Kamala Harris,0
-Orange,58334,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,58335,U.S. Senate,,DEM,Kamala Harris,0
-Orange,58335,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,58348,U.S. Senate,,DEM,Kamala Harris,403
-Orange,58348,U.S. Senate,,DEM,Loretta Sanchez,273
-Orange,58350,U.S. Senate,,DEM,Kamala Harris,401
-Orange,58350,U.S. Senate,,DEM,Loretta Sanchez,290
-Orange,58351,U.S. Senate,,DEM,Kamala Harris,372
-Orange,58351,U.S. Senate,,DEM,Loretta Sanchez,233
-Orange,58353,U.S. Senate,,DEM,Kamala Harris,302
-Orange,58353,U.S. Senate,,DEM,Loretta Sanchez,148
-Orange,58354,U.S. Senate,,DEM,Kamala Harris,378
-Orange,58354,U.S. Senate,,DEM,Loretta Sanchez,212
-Orange,58355,U.S. Senate,,DEM,Kamala Harris,436
-Orange,58355,U.S. Senate,,DEM,Loretta Sanchez,366
-Orange,58356,U.S. Senate,,DEM,Kamala Harris,382
-Orange,58356,U.S. Senate,,DEM,Loretta Sanchez,305
-Orange,58357,U.S. Senate,,DEM,Kamala Harris,244
-Orange,58357,U.S. Senate,,DEM,Loretta Sanchez,166
-Orange,58371,U.S. Senate,,DEM,Kamala Harris,739
-Orange,58371,U.S. Senate,,DEM,Loretta Sanchez,520
-Orange,58373,U.S. Senate,,DEM,Kamala Harris,399
-Orange,58373,U.S. Senate,,DEM,Loretta Sanchez,246
-Orange,58374,U.S. Senate,,DEM,Kamala Harris,501
-Orange,58374,U.S. Senate,,DEM,Loretta Sanchez,299
-Orange,58376,U.S. Senate,,DEM,Kamala Harris,362
-Orange,58376,U.S. Senate,,DEM,Loretta Sanchez,217
-Orange,58378,U.S. Senate,,DEM,Kamala Harris,397
-Orange,58378,U.S. Senate,,DEM,Loretta Sanchez,268
-Orange,58380,U.S. Senate,,DEM,Kamala Harris,226
-Orange,58380,U.S. Senate,,DEM,Loretta Sanchez,121
-Orange,58601,U.S. Senate,,DEM,Kamala Harris,678
-Orange,58601,U.S. Senate,,DEM,Loretta Sanchez,462
-Orange,58701,U.S. Senate,,DEM,Kamala Harris,743
-Orange,58701,U.S. Senate,,DEM,Loretta Sanchez,465
-Orange,58702,U.S. Senate,,DEM,Kamala Harris,708
-Orange,58702,U.S. Senate,,DEM,Loretta Sanchez,443
-Orange,58901,U.S. Senate,,DEM,Kamala Harris,0
-Orange,58901,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,59001,U.S. Senate,,DEM,Kamala Harris,0
-Orange,59001,U.S. Senate,,DEM,Loretta Sanchez,1
-Orange,59002,U.S. Senate,,DEM,Kamala Harris,384
-Orange,59002,U.S. Senate,,DEM,Loretta Sanchez,219
-Orange,59003,U.S. Senate,,DEM,Kamala Harris,597
-Orange,59003,U.S. Senate,,DEM,Loretta Sanchez,405
-Orange,59005,U.S. Senate,,DEM,Kamala Harris,327
-Orange,59005,U.S. Senate,,DEM,Loretta Sanchez,180
-Orange,59006,U.S. Senate,,DEM,Kamala Harris,257
-Orange,59006,U.S. Senate,,DEM,Loretta Sanchez,143
-Orange,59007,U.S. Senate,,DEM,Kamala Harris,867
-Orange,59007,U.S. Senate,,DEM,Loretta Sanchez,421
-Orange,59009,U.S. Senate,,DEM,Kamala Harris,794
-Orange,59009,U.S. Senate,,DEM,Loretta Sanchez,459
-Orange,59011,U.S. Senate,,DEM,Kamala Harris,576
-Orange,59011,U.S. Senate,,DEM,Loretta Sanchez,320
-Orange,59014,U.S. Senate,,DEM,Kamala Harris,315
-Orange,59014,U.S. Senate,,DEM,Loretta Sanchez,122
-Orange,59015,U.S. Senate,,DEM,Kamala Harris,454
-Orange,59015,U.S. Senate,,DEM,Loretta Sanchez,206
-Orange,59016,U.S. Senate,,DEM,Kamala Harris,617
-Orange,59016,U.S. Senate,,DEM,Loretta Sanchez,334
-Orange,59018,U.S. Senate,,DEM,Kamala Harris,672
-Orange,59018,U.S. Senate,,DEM,Loretta Sanchez,387
-Orange,59019,U.S. Senate,,DEM,Kamala Harris,468
-Orange,59019,U.S. Senate,,DEM,Loretta Sanchez,402
-Orange,59020,U.S. Senate,,DEM,Kamala Harris,420
-Orange,59020,U.S. Senate,,DEM,Loretta Sanchez,234
-Orange,59021,U.S. Senate,,DEM,Kamala Harris,524
-Orange,59021,U.S. Senate,,DEM,Loretta Sanchez,299
-Orange,59022,U.S. Senate,,DEM,Kamala Harris,339
-Orange,59022,U.S. Senate,,DEM,Loretta Sanchez,203
-Orange,59026,U.S. Senate,,DEM,Kamala Harris,825
-Orange,59026,U.S. Senate,,DEM,Loretta Sanchez,479
-Orange,59027,U.S. Senate,,DEM,Kamala Harris,773
-Orange,59027,U.S. Senate,,DEM,Loretta Sanchez,389
-Orange,59030,U.S. Senate,,DEM,Kamala Harris,320
-Orange,59030,U.S. Senate,,DEM,Loretta Sanchez,222
-Orange,59032,U.S. Senate,,DEM,Kamala Harris,409
-Orange,59032,U.S. Senate,,DEM,Loretta Sanchez,232
-Orange,59033,U.S. Senate,,DEM,Kamala Harris,806
-Orange,59033,U.S. Senate,,DEM,Loretta Sanchez,447
-Orange,59034,U.S. Senate,,DEM,Kamala Harris,447
-Orange,59034,U.S. Senate,,DEM,Loretta Sanchez,298
-Orange,59036,U.S. Senate,,DEM,Kamala Harris,844
-Orange,59036,U.S. Senate,,DEM,Loretta Sanchez,476
-Orange,59037,U.S. Senate,,DEM,Kamala Harris,594
-Orange,59037,U.S. Senate,,DEM,Loretta Sanchez,303
-Orange,59038,U.S. Senate,,DEM,Kamala Harris,304
-Orange,59038,U.S. Senate,,DEM,Loretta Sanchez,193
-Orange,59039,U.S. Senate,,DEM,Kamala Harris,386
-Orange,59039,U.S. Senate,,DEM,Loretta Sanchez,212
-Orange,59041,U.S. Senate,,DEM,Kamala Harris,404
-Orange,59041,U.S. Senate,,DEM,Loretta Sanchez,195
-Orange,59042,U.S. Senate,,DEM,Kamala Harris,327
-Orange,59042,U.S. Senate,,DEM,Loretta Sanchez,185
-Orange,59043,U.S. Senate,,DEM,Kamala Harris,517
-Orange,59043,U.S. Senate,,DEM,Loretta Sanchez,379
-Orange,59044,U.S. Senate,,DEM,Kamala Harris,664
-Orange,59044,U.S. Senate,,DEM,Loretta Sanchez,411
-Orange,59045,U.S. Senate,,DEM,Kamala Harris,364
-Orange,59045,U.S. Senate,,DEM,Loretta Sanchez,275
-Orange,59047,U.S. Senate,,DEM,Kamala Harris,379
-Orange,59047,U.S. Senate,,DEM,Loretta Sanchez,253
-Orange,59048,U.S. Senate,,DEM,Kamala Harris,354
-Orange,59048,U.S. Senate,,DEM,Loretta Sanchez,175
-Orange,59054,U.S. Senate,,DEM,Kamala Harris,435
-Orange,59054,U.S. Senate,,DEM,Loretta Sanchez,248
-Orange,59055,U.S. Senate,,DEM,Kamala Harris,432
-Orange,59055,U.S. Senate,,DEM,Loretta Sanchez,218
-Orange,59058,U.S. Senate,,DEM,Kamala Harris,1397
-Orange,59058,U.S. Senate,,DEM,Loretta Sanchez,345
-Orange,59061,U.S. Senate,,DEM,Kamala Harris,487
-Orange,59061,U.S. Senate,,DEM,Loretta Sanchez,292
-Orange,59062,U.S. Senate,,DEM,Kamala Harris,457
-Orange,59062,U.S. Senate,,DEM,Loretta Sanchez,222
-Orange,59063,U.S. Senate,,DEM,Kamala Harris,391
-Orange,59063,U.S. Senate,,DEM,Loretta Sanchez,232
-Orange,59064,U.S. Senate,,DEM,Kamala Harris,324
-Orange,59064,U.S. Senate,,DEM,Loretta Sanchez,201
-Orange,59065,U.S. Senate,,DEM,Kamala Harris,325
-Orange,59065,U.S. Senate,,DEM,Loretta Sanchez,203
-Orange,59071,U.S. Senate,,DEM,Kamala Harris,425
-Orange,59071,U.S. Senate,,DEM,Loretta Sanchez,250
-Orange,59072,U.S. Senate,,DEM,Kamala Harris,719
-Orange,59072,U.S. Senate,,DEM,Loretta Sanchez,445
-Orange,59074,U.S. Senate,,DEM,Kamala Harris,252
-Orange,59074,U.S. Senate,,DEM,Loretta Sanchez,183
-Orange,59075,U.S. Senate,,DEM,Kamala Harris,678
-Orange,59075,U.S. Senate,,DEM,Loretta Sanchez,409
-Orange,59079,U.S. Senate,,DEM,Kamala Harris,429
-Orange,59079,U.S. Senate,,DEM,Loretta Sanchez,232
-Orange,59081,U.S. Senate,,DEM,Kamala Harris,298
-Orange,59081,U.S. Senate,,DEM,Loretta Sanchez,183
-Orange,59082,U.S. Senate,,DEM,Kamala Harris,436
-Orange,59082,U.S. Senate,,DEM,Loretta Sanchez,254
-Orange,59084,U.S. Senate,,DEM,Kamala Harris,1
-Orange,59084,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,59088,U.S. Senate,,DEM,Kamala Harris,758
-Orange,59088,U.S. Senate,,DEM,Loretta Sanchez,448
-Orange,59089,U.S. Senate,,DEM,Kamala Harris,485
-Orange,59089,U.S. Senate,,DEM,Loretta Sanchez,259
-Orange,59090,U.S. Senate,,DEM,Kamala Harris,811
-Orange,59090,U.S. Senate,,DEM,Loretta Sanchez,417
-Orange,59092,U.S. Senate,,DEM,Kamala Harris,716
-Orange,59092,U.S. Senate,,DEM,Loretta Sanchez,407
-Orange,59097,U.S. Senate,,DEM,Kamala Harris,413
-Orange,59097,U.S. Senate,,DEM,Loretta Sanchez,224
-Orange,59098,U.S. Senate,,DEM,Kamala Harris,605
-Orange,59098,U.S. Senate,,DEM,Loretta Sanchez,325
-Orange,59099,U.S. Senate,,DEM,Kamala Harris,568
-Orange,59099,U.S. Senate,,DEM,Loretta Sanchez,320
-Orange,59100,U.S. Senate,,DEM,Kamala Harris,705
-Orange,59100,U.S. Senate,,DEM,Loretta Sanchez,361
-Orange,59101,U.S. Senate,,DEM,Kamala Harris,352
-Orange,59101,U.S. Senate,,DEM,Loretta Sanchez,219
-Orange,59103,U.S. Senate,,DEM,Kamala Harris,318
-Orange,59103,U.S. Senate,,DEM,Loretta Sanchez,191
-Orange,59105,U.S. Senate,,DEM,Kamala Harris,438
-Orange,59105,U.S. Senate,,DEM,Loretta Sanchez,213
-Orange,59106,U.S. Senate,,DEM,Kamala Harris,626
-Orange,59106,U.S. Senate,,DEM,Loretta Sanchez,353
-Orange,59108,U.S. Senate,,DEM,Kamala Harris,89
-Orange,59108,U.S. Senate,,DEM,Loretta Sanchez,38
-Orange,59111,U.S. Senate,,DEM,Kamala Harris,491
-Orange,59111,U.S. Senate,,DEM,Loretta Sanchez,295
-Orange,59113,U.S. Senate,,DEM,Kamala Harris,523
-Orange,59113,U.S. Senate,,DEM,Loretta Sanchez,447
-Orange,59118,U.S. Senate,,DEM,Kamala Harris,623
-Orange,59118,U.S. Senate,,DEM,Loretta Sanchez,489
-Orange,59124,U.S. Senate,,DEM,Kamala Harris,750
-Orange,59124,U.S. Senate,,DEM,Loretta Sanchez,448
-Orange,59125,U.S. Senate,,DEM,Kamala Harris,406
-Orange,59125,U.S. Senate,,DEM,Loretta Sanchez,227
-Orange,59127,U.S. Senate,,DEM,Kamala Harris,500
-Orange,59127,U.S. Senate,,DEM,Loretta Sanchez,299
-Orange,59129,U.S. Senate,,DEM,Kamala Harris,689
-Orange,59129,U.S. Senate,,DEM,Loretta Sanchez,390
-Orange,59131,U.S. Senate,,DEM,Kamala Harris,833
-Orange,59131,U.S. Senate,,DEM,Loretta Sanchez,423
-Orange,59132,U.S. Senate,,DEM,Kamala Harris,566
-Orange,59132,U.S. Senate,,DEM,Loretta Sanchez,361
-Orange,59133,U.S. Senate,,DEM,Kamala Harris,534
-Orange,59133,U.S. Senate,,DEM,Loretta Sanchez,227
-Orange,59134,U.S. Senate,,DEM,Kamala Harris,0
-Orange,59134,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,59138,U.S. Senate,,DEM,Kamala Harris,0
-Orange,59138,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,59141,U.S. Senate,,DEM,Kamala Harris,732
-Orange,59141,U.S. Senate,,DEM,Loretta Sanchez,446
-Orange,59143,U.S. Senate,,DEM,Kamala Harris,330
-Orange,59143,U.S. Senate,,DEM,Loretta Sanchez,178
-Orange,59144,U.S. Senate,,DEM,Kamala Harris,720
-Orange,59144,U.S. Senate,,DEM,Loretta Sanchez,404
-Orange,59146,U.S. Senate,,DEM,Kamala Harris,828
-Orange,59146,U.S. Senate,,DEM,Loretta Sanchez,423
-Orange,59147,U.S. Senate,,DEM,Kamala Harris,300
-Orange,59147,U.S. Senate,,DEM,Loretta Sanchez,194
-Orange,59148,U.S. Senate,,DEM,Kamala Harris,283
-Orange,59148,U.S. Senate,,DEM,Loretta Sanchez,155
-Orange,59149,U.S. Senate,,DEM,Kamala Harris,1124
-Orange,59149,U.S. Senate,,DEM,Loretta Sanchez,545
-Orange,59150,U.S. Senate,,DEM,Kamala Harris,1
-Orange,59150,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,59152,U.S. Senate,,DEM,Kamala Harris,564
-Orange,59152,U.S. Senate,,DEM,Loretta Sanchez,325
-Orange,59153,U.S. Senate,,DEM,Kamala Harris,411
-Orange,59153,U.S. Senate,,DEM,Loretta Sanchez,223
-Orange,59154,U.S. Senate,,DEM,Kamala Harris,598
-Orange,59154,U.S. Senate,,DEM,Loretta Sanchez,293
-Orange,59158,U.S. Senate,,DEM,Kamala Harris,252
-Orange,59158,U.S. Senate,,DEM,Loretta Sanchez,243
-Orange,59161,U.S. Senate,,DEM,Kamala Harris,349
-Orange,59161,U.S. Senate,,DEM,Loretta Sanchez,141
-Orange,59162,U.S. Senate,,DEM,Kamala Harris,0
-Orange,59162,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,59163,U.S. Senate,,DEM,Kamala Harris,132
-Orange,59163,U.S. Senate,,DEM,Loretta Sanchez,70
-Orange,59164,U.S. Senate,,DEM,Kamala Harris,360
-Orange,59164,U.S. Senate,,DEM,Loretta Sanchez,188
-Orange,59165,U.S. Senate,,DEM,Kamala Harris,0
-Orange,59165,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,59166,U.S. Senate,,DEM,Kamala Harris,299
-Orange,59166,U.S. Senate,,DEM,Loretta Sanchez,172
-Orange,59168,U.S. Senate,,DEM,Kamala Harris,1025
-Orange,59168,U.S. Senate,,DEM,Loretta Sanchez,490
-Orange,59170,U.S. Senate,,DEM,Kamala Harris,35
-Orange,59170,U.S. Senate,,DEM,Loretta Sanchez,16
-Orange,59171,U.S. Senate,,DEM,Kamala Harris,3
-Orange,59171,U.S. Senate,,DEM,Loretta Sanchez,2
-Orange,59172,U.S. Senate,,DEM,Kamala Harris,766
-Orange,59172,U.S. Senate,,DEM,Loretta Sanchez,353
-Orange,59601,U.S. Senate,,DEM,Kamala Harris,491
-Orange,59601,U.S. Senate,,DEM,Loretta Sanchez,230
-Orange,59602,U.S. Senate,,DEM,Kamala Harris,1520
-Orange,59602,U.S. Senate,,DEM,Loretta Sanchez,785
-Orange,59603,U.S. Senate,,DEM,Kamala Harris,1040
-Orange,59603,U.S. Senate,,DEM,Loretta Sanchez,525
-Orange,59701,U.S. Senate,,DEM,Kamala Harris,824
-Orange,59701,U.S. Senate,,DEM,Loretta Sanchez,517
-Orange,59702,U.S. Senate,,DEM,Kamala Harris,1040
-Orange,59702,U.S. Senate,,DEM,Loretta Sanchez,617
-Orange,62081,U.S. Senate,,DEM,Kamala Harris,54
-Orange,62081,U.S. Senate,,DEM,Loretta Sanchez,39
-Orange,63001,U.S. Senate,,DEM,Kamala Harris,601
-Orange,63001,U.S. Senate,,DEM,Loretta Sanchez,522
-Orange,63002,U.S. Senate,,DEM,Kamala Harris,681
-Orange,63002,U.S. Senate,,DEM,Loretta Sanchez,782
-Orange,63005,U.S. Senate,,DEM,Kamala Harris,313
-Orange,63005,U.S. Senate,,DEM,Loretta Sanchez,295
-Orange,63007,U.S. Senate,,DEM,Kamala Harris,341
-Orange,63007,U.S. Senate,,DEM,Loretta Sanchez,360
-Orange,63009,U.S. Senate,,DEM,Kamala Harris,698
-Orange,63009,U.S. Senate,,DEM,Loretta Sanchez,695
-Orange,63010,U.S. Senate,,DEM,Kamala Harris,346
-Orange,63010,U.S. Senate,,DEM,Loretta Sanchez,321
-Orange,63011,U.S. Senate,,DEM,Kamala Harris,228
-Orange,63011,U.S. Senate,,DEM,Loretta Sanchez,154
-Orange,63012,U.S. Senate,,DEM,Kamala Harris,401
-Orange,63012,U.S. Senate,,DEM,Loretta Sanchez,270
-Orange,63014,U.S. Senate,,DEM,Kamala Harris,577
-Orange,63014,U.S. Senate,,DEM,Loretta Sanchez,597
-Orange,63019,U.S. Senate,,DEM,Kamala Harris,521
-Orange,63019,U.S. Senate,,DEM,Loretta Sanchez,615
-Orange,63024,U.S. Senate,,DEM,Kamala Harris,353
-Orange,63024,U.S. Senate,,DEM,Loretta Sanchez,261
-Orange,63026,U.S. Senate,,DEM,Kamala Harris,277
-Orange,63026,U.S. Senate,,DEM,Loretta Sanchez,211
-Orange,63027,U.S. Senate,,DEM,Kamala Harris,545
-Orange,63027,U.S. Senate,,DEM,Loretta Sanchez,451
-Orange,63028,U.S. Senate,,DEM,Kamala Harris,411
-Orange,63028,U.S. Senate,,DEM,Loretta Sanchez,341
-Orange,63029,U.S. Senate,,DEM,Kamala Harris,574
-Orange,63029,U.S. Senate,,DEM,Loretta Sanchez,589
-Orange,63032,U.S. Senate,,DEM,Kamala Harris,196
-Orange,63032,U.S. Senate,,DEM,Loretta Sanchez,397
-Orange,63034,U.S. Senate,,DEM,Kamala Harris,260
-Orange,63034,U.S. Senate,,DEM,Loretta Sanchez,334
-Orange,63035,U.S. Senate,,DEM,Kamala Harris,201
-Orange,63035,U.S. Senate,,DEM,Loretta Sanchez,115
-Orange,63036,U.S. Senate,,DEM,Kamala Harris,608
-Orange,63036,U.S. Senate,,DEM,Loretta Sanchez,527
-Orange,63038,U.S. Senate,,DEM,Kamala Harris,654
-Orange,63038,U.S. Senate,,DEM,Loretta Sanchez,612
-Orange,63041,U.S. Senate,,DEM,Kamala Harris,848
-Orange,63041,U.S. Senate,,DEM,Loretta Sanchez,530
-Orange,63043,U.S. Senate,,DEM,Kamala Harris,699
-Orange,63043,U.S. Senate,,DEM,Loretta Sanchez,629
-Orange,63046,U.S. Senate,,DEM,Kamala Harris,250
-Orange,63046,U.S. Senate,,DEM,Loretta Sanchez,248
-Orange,63049,U.S. Senate,,DEM,Kamala Harris,230
-Orange,63049,U.S. Senate,,DEM,Loretta Sanchez,227
-Orange,63051,U.S. Senate,,DEM,Kamala Harris,594
-Orange,63051,U.S. Senate,,DEM,Loretta Sanchez,518
-Orange,63052,U.S. Senate,,DEM,Kamala Harris,10
-Orange,63052,U.S. Senate,,DEM,Loretta Sanchez,6
-Orange,63053,U.S. Senate,,DEM,Kamala Harris,139
-Orange,63053,U.S. Senate,,DEM,Loretta Sanchez,139
-Orange,63055,U.S. Senate,,DEM,Kamala Harris,483
-Orange,63055,U.S. Senate,,DEM,Loretta Sanchez,477
-Orange,63062,U.S. Senate,,DEM,Kamala Harris,257
-Orange,63062,U.S. Senate,,DEM,Loretta Sanchez,190
-Orange,63066,U.S. Senate,,DEM,Kamala Harris,363
-Orange,63066,U.S. Senate,,DEM,Loretta Sanchez,252
-Orange,63068,U.S. Senate,,DEM,Kamala Harris,454
-Orange,63068,U.S. Senate,,DEM,Loretta Sanchez,405
-Orange,63069,U.S. Senate,,DEM,Kamala Harris,303
-Orange,63069,U.S. Senate,,DEM,Loretta Sanchez,411
-Orange,63071,U.S. Senate,,DEM,Kamala Harris,486
-Orange,63071,U.S. Senate,,DEM,Loretta Sanchez,443
-Orange,63083,U.S. Senate,,DEM,Kamala Harris,0
-Orange,63083,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,63092,U.S. Senate,,DEM,Kamala Harris,185
-Orange,63092,U.S. Senate,,DEM,Loretta Sanchez,224
-Orange,63097,U.S. Senate,,DEM,Kamala Harris,142
-Orange,63097,U.S. Senate,,DEM,Loretta Sanchez,114
-Orange,63340,U.S. Senate,,DEM,Kamala Harris,276
-Orange,63340,U.S. Senate,,DEM,Loretta Sanchez,184
-Orange,63342,U.S. Senate,,DEM,Kamala Harris,320
-Orange,63342,U.S. Senate,,DEM,Loretta Sanchez,251
-Orange,63343,U.S. Senate,,DEM,Kamala Harris,168
-Orange,63343,U.S. Senate,,DEM,Loretta Sanchez,164
-Orange,63344,U.S. Senate,,DEM,Kamala Harris,343
-Orange,63344,U.S. Senate,,DEM,Loretta Sanchez,360
-Orange,63347,U.S. Senate,,DEM,Kamala Harris,341
-Orange,63347,U.S. Senate,,DEM,Loretta Sanchez,250
-Orange,63348,U.S. Senate,,DEM,Kamala Harris,75
-Orange,63348,U.S. Senate,,DEM,Loretta Sanchez,131
-Orange,63352,U.S. Senate,,DEM,Kamala Harris,460
-Orange,63352,U.S. Senate,,DEM,Loretta Sanchez,295
-Orange,63361,U.S. Senate,,DEM,Kamala Harris,340
-Orange,63361,U.S. Senate,,DEM,Loretta Sanchez,260
-Orange,63362,U.S. Senate,,DEM,Kamala Harris,410
-Orange,63362,U.S. Senate,,DEM,Loretta Sanchez,340
-Orange,63369,U.S. Senate,,DEM,Kamala Harris,394
-Orange,63369,U.S. Senate,,DEM,Loretta Sanchez,279
-Orange,63371,U.S. Senate,,DEM,Kamala Harris,347
-Orange,63371,U.S. Senate,,DEM,Loretta Sanchez,304
-Orange,63372,U.S. Senate,,DEM,Kamala Harris,45
-Orange,63372,U.S. Senate,,DEM,Loretta Sanchez,38
-Orange,63373,U.S. Senate,,DEM,Kamala Harris,537
-Orange,63373,U.S. Senate,,DEM,Loretta Sanchez,508
-Orange,63374,U.S. Senate,,DEM,Kamala Harris,254
-Orange,63374,U.S. Senate,,DEM,Loretta Sanchez,366
-Orange,63377,U.S. Senate,,DEM,Kamala Harris,191
-Orange,63377,U.S. Senate,,DEM,Loretta Sanchez,139
-Orange,63383,U.S. Senate,,DEM,Kamala Harris,389
-Orange,63383,U.S. Senate,,DEM,Loretta Sanchez,289
-Orange,63384,U.S. Senate,,DEM,Kamala Harris,289
-Orange,63384,U.S. Senate,,DEM,Loretta Sanchez,218
-Orange,63390,U.S. Senate,,DEM,Kamala Harris,696
-Orange,63390,U.S. Senate,,DEM,Loretta Sanchez,492
-Orange,63601,U.S. Senate,,DEM,Kamala Harris,655
-Orange,63601,U.S. Senate,,DEM,Loretta Sanchez,555
-Orange,63602,U.S. Senate,,DEM,Kamala Harris,138
-Orange,63602,U.S. Senate,,DEM,Loretta Sanchez,142
-Orange,63603,U.S. Senate,,DEM,Kamala Harris,334
-Orange,63603,U.S. Senate,,DEM,Loretta Sanchez,268
-Orange,63604,U.S. Senate,,DEM,Kamala Harris,345
-Orange,63604,U.S. Senate,,DEM,Loretta Sanchez,283
-Orange,63605,U.S. Senate,,DEM,Kamala Harris,431
-Orange,63605,U.S. Senate,,DEM,Loretta Sanchez,307
-Orange,63606,U.S. Senate,,DEM,Kamala Harris,556
-Orange,63606,U.S. Senate,,DEM,Loretta Sanchez,348
-Orange,63607,U.S. Senate,,DEM,Kamala Harris,758
-Orange,63607,U.S. Senate,,DEM,Loretta Sanchez,539
-Orange,63608,U.S. Senate,,DEM,Kamala Harris,240
-Orange,63608,U.S. Senate,,DEM,Loretta Sanchez,178
-Orange,63609,U.S. Senate,,DEM,Kamala Harris,759
-Orange,63609,U.S. Senate,,DEM,Loretta Sanchez,593
-Orange,63701,U.S. Senate,,DEM,Kamala Harris,555
-Orange,63701,U.S. Senate,,DEM,Loretta Sanchez,396
-Orange,63702,U.S. Senate,,DEM,Kamala Harris,454
-Orange,63702,U.S. Senate,,DEM,Loretta Sanchez,458
-Orange,63901,U.S. Senate,,DEM,Kamala Harris,45
-Orange,63901,U.S. Senate,,DEM,Loretta Sanchez,34
-Orange,63902,U.S. Senate,,DEM,Kamala Harris,0
-Orange,63902,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,63903,U.S. Senate,,DEM,Kamala Harris,16
-Orange,63903,U.S. Senate,,DEM,Loretta Sanchez,17
-Orange,63904,U.S. Senate,,DEM,Kamala Harris,24
-Orange,63904,U.S. Senate,,DEM,Loretta Sanchez,45
-Orange,63905,U.S. Senate,,DEM,Kamala Harris,10
-Orange,63905,U.S. Senate,,DEM,Loretta Sanchez,16
-Orange,63906,U.S. Senate,,DEM,Kamala Harris,0
-Orange,63906,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,63907,U.S. Senate,,DEM,Kamala Harris,0
-Orange,63907,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,65081,U.S. Senate,,DEM,Kamala Harris,282
-Orange,65081,U.S. Senate,,DEM,Loretta Sanchez,280
-Orange,65087,U.S. Senate,,DEM,Kamala Harris,210
-Orange,65087,U.S. Senate,,DEM,Loretta Sanchez,300
-Orange,65091,U.S. Senate,,DEM,Kamala Harris,84
-Orange,65091,U.S. Senate,,DEM,Loretta Sanchez,70
-Orange,65097,U.S. Senate,,DEM,Kamala Harris,0
-Orange,65097,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,65901,U.S. Senate,,DEM,Kamala Harris,0
-Orange,65901,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,65902,U.S. Senate,,DEM,Kamala Harris,0
-Orange,65902,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,65903,U.S. Senate,,DEM,Kamala Harris,0
-Orange,65903,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,65904,U.S. Senate,,DEM,Kamala Harris,0
-Orange,65904,U.S. Senate,,DEM,Loretta Sanchez,1
-Orange,67100,U.S. Senate,,DEM,Kamala Harris,408
-Orange,67100,U.S. Senate,,DEM,Loretta Sanchez,338
-Orange,67101,U.S. Senate,,DEM,Kamala Harris,423
-Orange,67101,U.S. Senate,,DEM,Loretta Sanchez,338
-Orange,67113,U.S. Senate,,DEM,Kamala Harris,437
-Orange,67113,U.S. Senate,,DEM,Loretta Sanchez,395
-Orange,67114,U.S. Senate,,DEM,Kamala Harris,380
-Orange,67114,U.S. Senate,,DEM,Loretta Sanchez,299
-Orange,67115,U.S. Senate,,DEM,Kamala Harris,367
-Orange,67115,U.S. Senate,,DEM,Loretta Sanchez,293
-Orange,67116,U.S. Senate,,DEM,Kamala Harris,646
-Orange,67116,U.S. Senate,,DEM,Loretta Sanchez,537
-Orange,67117,U.S. Senate,,DEM,Kamala Harris,235
-Orange,67117,U.S. Senate,,DEM,Loretta Sanchez,156
-Orange,67118,U.S. Senate,,DEM,Kamala Harris,376
-Orange,67118,U.S. Senate,,DEM,Loretta Sanchez,252
-Orange,67119,U.S. Senate,,DEM,Kamala Harris,399
-Orange,67119,U.S. Senate,,DEM,Loretta Sanchez,317
-Orange,67120,U.S. Senate,,DEM,Kamala Harris,241
-Orange,67120,U.S. Senate,,DEM,Loretta Sanchez,201
-Orange,67121,U.S. Senate,,DEM,Kamala Harris,634
-Orange,67121,U.S. Senate,,DEM,Loretta Sanchez,483
-Orange,68044,U.S. Senate,,DEM,Kamala Harris,12
-Orange,68044,U.S. Senate,,DEM,Loretta Sanchez,29
-Orange,68052,U.S. Senate,,DEM,Kamala Harris,160
-Orange,68052,U.S. Senate,,DEM,Loretta Sanchez,394
-Orange,68053,U.S. Senate,,DEM,Kamala Harris,544
-Orange,68053,U.S. Senate,,DEM,Loretta Sanchez,629
-Orange,68061,U.S. Senate,,DEM,Kamala Harris,420
-Orange,68061,U.S. Senate,,DEM,Loretta Sanchez,968
-Orange,68070,U.S. Senate,,DEM,Kamala Harris,584
-Orange,68070,U.S. Senate,,DEM,Loretta Sanchez,850
-Orange,68073,U.S. Senate,,DEM,Kamala Harris,650
-Orange,68073,U.S. Senate,,DEM,Loretta Sanchez,577
-Orange,68074,U.S. Senate,,DEM,Kamala Harris,245
-Orange,68074,U.S. Senate,,DEM,Loretta Sanchez,255
-Orange,68076,U.S. Senate,,DEM,Kamala Harris,455
-Orange,68076,U.S. Senate,,DEM,Loretta Sanchez,309
-Orange,68077,U.S. Senate,,DEM,Kamala Harris,485
-Orange,68077,U.S. Senate,,DEM,Loretta Sanchez,543
-Orange,68078,U.S. Senate,,DEM,Kamala Harris,224
-Orange,68078,U.S. Senate,,DEM,Loretta Sanchez,489
-Orange,68083,U.S. Senate,,DEM,Kamala Harris,253
-Orange,68083,U.S. Senate,,DEM,Loretta Sanchez,648
-Orange,68091,U.S. Senate,,DEM,Kamala Harris,108
-Orange,68091,U.S. Senate,,DEM,Loretta Sanchez,303
-Orange,68094,U.S. Senate,,DEM,Kamala Harris,262
-Orange,68094,U.S. Senate,,DEM,Loretta Sanchez,591
-Orange,68098,U.S. Senate,,DEM,Kamala Harris,321
-Orange,68098,U.S. Senate,,DEM,Loretta Sanchez,703
-Orange,68100,U.S. Senate,,DEM,Kamala Harris,165
-Orange,68100,U.S. Senate,,DEM,Loretta Sanchez,351
-Orange,68103,U.S. Senate,,DEM,Kamala Harris,317
-Orange,68103,U.S. Senate,,DEM,Loretta Sanchez,766
-Orange,68106,U.S. Senate,,DEM,Kamala Harris,462
-Orange,68106,U.S. Senate,,DEM,Loretta Sanchez,1049
-Orange,68107,U.S. Senate,,DEM,Kamala Harris,235
-Orange,68107,U.S. Senate,,DEM,Loretta Sanchez,634
-Orange,68115,U.S. Senate,,DEM,Kamala Harris,286
-Orange,68115,U.S. Senate,,DEM,Loretta Sanchez,684
-Orange,68123,U.S. Senate,,DEM,Kamala Harris,276
-Orange,68123,U.S. Senate,,DEM,Loretta Sanchez,481
-Orange,68131,U.S. Senate,,DEM,Kamala Harris,180
-Orange,68131,U.S. Senate,,DEM,Loretta Sanchez,381
-Orange,68137,U.S. Senate,,DEM,Kamala Harris,492
-Orange,68137,U.S. Senate,,DEM,Loretta Sanchez,982
-Orange,68138,U.S. Senate,,DEM,Kamala Harris,408
-Orange,68138,U.S. Senate,,DEM,Loretta Sanchez,464
-Orange,68145,U.S. Senate,,DEM,Kamala Harris,210
-Orange,68145,U.S. Senate,,DEM,Loretta Sanchez,268
-Orange,68146,U.S. Senate,,DEM,Kamala Harris,277
-Orange,68146,U.S. Senate,,DEM,Loretta Sanchez,217
-Orange,68160,U.S. Senate,,DEM,Kamala Harris,0
-Orange,68160,U.S. Senate,,DEM,Loretta Sanchez,1
-Orange,68161,U.S. Senate,,DEM,Kamala Harris,253
-Orange,68161,U.S. Senate,,DEM,Loretta Sanchez,266
-Orange,68162,U.S. Senate,,DEM,Kamala Harris,305
-Orange,68162,U.S. Senate,,DEM,Loretta Sanchez,598
-Orange,68163,U.S. Senate,,DEM,Kamala Harris,84
-Orange,68163,U.S. Senate,,DEM,Loretta Sanchez,52
-Orange,68166,U.S. Senate,,DEM,Kamala Harris,168
-Orange,68166,U.S. Senate,,DEM,Loretta Sanchez,502
-Orange,68179,U.S. Senate,,DEM,Kamala Harris,519
-Orange,68179,U.S. Senate,,DEM,Loretta Sanchez,1211
-Orange,68180,U.S. Senate,,DEM,Kamala Harris,44
-Orange,68180,U.S. Senate,,DEM,Loretta Sanchez,122
-Orange,68181,U.S. Senate,,DEM,Kamala Harris,118
-Orange,68181,U.S. Senate,,DEM,Loretta Sanchez,336
-Orange,68183,U.S. Senate,,DEM,Kamala Harris,290
-Orange,68183,U.S. Senate,,DEM,Loretta Sanchez,689
-Orange,68185,U.S. Senate,,DEM,Kamala Harris,505
-Orange,68185,U.S. Senate,,DEM,Loretta Sanchez,1025
-Orange,68194,U.S. Senate,,DEM,Kamala Harris,441
-Orange,68194,U.S. Senate,,DEM,Loretta Sanchez,1025
-Orange,68195,U.S. Senate,,DEM,Kamala Harris,274
-Orange,68195,U.S. Senate,,DEM,Loretta Sanchez,434
-Orange,68197,U.S. Senate,,DEM,Kamala Harris,298
-Orange,68197,U.S. Senate,,DEM,Loretta Sanchez,587
-Orange,68273,U.S. Senate,,DEM,Kamala Harris,410
-Orange,68273,U.S. Senate,,DEM,Loretta Sanchez,541
-Orange,68279,U.S. Senate,,DEM,Kamala Harris,244
-Orange,68279,U.S. Senate,,DEM,Loretta Sanchez,333
-Orange,68283,U.S. Senate,,DEM,Kamala Harris,949
-Orange,68283,U.S. Senate,,DEM,Loretta Sanchez,1174
-Orange,68287,U.S. Senate,,DEM,Kamala Harris,166
-Orange,68287,U.S. Senate,,DEM,Loretta Sanchez,265
-Orange,68297,U.S. Senate,,DEM,Kamala Harris,240
-Orange,68297,U.S. Senate,,DEM,Loretta Sanchez,692
-Orange,68302,U.S. Senate,,DEM,Kamala Harris,184
-Orange,68302,U.S. Senate,,DEM,Loretta Sanchez,498
-Orange,68305,U.S. Senate,,DEM,Kamala Harris,62
-Orange,68305,U.S. Senate,,DEM,Loretta Sanchez,241
-Orange,68306,U.S. Senate,,DEM,Kamala Harris,281
-Orange,68306,U.S. Senate,,DEM,Loretta Sanchez,700
-Orange,68316,U.S. Senate,,DEM,Kamala Harris,233
-Orange,68316,U.S. Senate,,DEM,Loretta Sanchez,334
-Orange,68318,U.S. Senate,,DEM,Kamala Harris,355
-Orange,68318,U.S. Senate,,DEM,Loretta Sanchez,446
-Orange,68330,U.S. Senate,,DEM,Kamala Harris,288
-Orange,68330,U.S. Senate,,DEM,Loretta Sanchez,587
-Orange,68334,U.S. Senate,,DEM,Kamala Harris,441
-Orange,68334,U.S. Senate,,DEM,Loretta Sanchez,967
-Orange,68339,U.S. Senate,,DEM,Kamala Harris,494
-Orange,68339,U.S. Senate,,DEM,Loretta Sanchez,619
-Orange,68350,U.S. Senate,,DEM,Kamala Harris,133
-Orange,68350,U.S. Senate,,DEM,Loretta Sanchez,303
-Orange,68364,U.S. Senate,,DEM,Kamala Harris,237
-Orange,68364,U.S. Senate,,DEM,Loretta Sanchez,313
-Orange,68365,U.S. Senate,,DEM,Kamala Harris,406
-Orange,68365,U.S. Senate,,DEM,Loretta Sanchez,462
-Orange,68367,U.S. Senate,,DEM,Kamala Harris,329
-Orange,68367,U.S. Senate,,DEM,Loretta Sanchez,353
-Orange,68601,U.S. Senate,,DEM,Kamala Harris,243
-Orange,68601,U.S. Senate,,DEM,Loretta Sanchez,572
-Orange,68602,U.S. Senate,,DEM,Kamala Harris,279
-Orange,68602,U.S. Senate,,DEM,Loretta Sanchez,574
-Orange,68603,U.S. Senate,,DEM,Kamala Harris,544
-Orange,68603,U.S. Senate,,DEM,Loretta Sanchez,996
-Orange,68604,U.S. Senate,,DEM,Kamala Harris,621
-Orange,68604,U.S. Senate,,DEM,Loretta Sanchez,1348
-Orange,68605,U.S. Senate,,DEM,Kamala Harris,649
-Orange,68605,U.S. Senate,,DEM,Loretta Sanchez,1330
-Orange,68606,U.S. Senate,,DEM,Kamala Harris,736
-Orange,68606,U.S. Senate,,DEM,Loretta Sanchez,785
-Orange,68607,U.S. Senate,,DEM,Kamala Harris,542
-Orange,68607,U.S. Senate,,DEM,Loretta Sanchez,1294
-Orange,68608,U.S. Senate,,DEM,Kamala Harris,593
-Orange,68608,U.S. Senate,,DEM,Loretta Sanchez,817
-Orange,68609,U.S. Senate,,DEM,Kamala Harris,338
-Orange,68609,U.S. Senate,,DEM,Loretta Sanchez,595
-Orange,68610,U.S. Senate,,DEM,Kamala Harris,420
-Orange,68610,U.S. Senate,,DEM,Loretta Sanchez,899
-Orange,68611,U.S. Senate,,DEM,Kamala Harris,381
-Orange,68611,U.S. Senate,,DEM,Loretta Sanchez,694
-Orange,68612,U.S. Senate,,DEM,Kamala Harris,442
-Orange,68612,U.S. Senate,,DEM,Loretta Sanchez,1034
-Orange,68613,U.S. Senate,,DEM,Kamala Harris,647
-Orange,68613,U.S. Senate,,DEM,Loretta Sanchez,879
-Orange,68614,U.S. Senate,,DEM,Kamala Harris,519
-Orange,68614,U.S. Senate,,DEM,Loretta Sanchez,718
-Orange,68615,U.S. Senate,,DEM,Kamala Harris,525
-Orange,68615,U.S. Senate,,DEM,Loretta Sanchez,845
-Orange,68616,U.S. Senate,,DEM,Kamala Harris,455
-Orange,68616,U.S. Senate,,DEM,Loretta Sanchez,780
-Orange,68617,U.S. Senate,,DEM,Kamala Harris,678
-Orange,68617,U.S. Senate,,DEM,Loretta Sanchez,787
-Orange,68618,U.S. Senate,,DEM,Kamala Harris,213
-Orange,68618,U.S. Senate,,DEM,Loretta Sanchez,583
-Orange,68901,U.S. Senate,,DEM,Kamala Harris,6
-Orange,68901,U.S. Senate,,DEM,Loretta Sanchez,9
-Orange,68902,U.S. Senate,,DEM,Kamala Harris,4
-Orange,68902,U.S. Senate,,DEM,Loretta Sanchez,2
-Orange,69106,U.S. Senate,,DEM,Kamala Harris,349
-Orange,69106,U.S. Senate,,DEM,Loretta Sanchez,313
-Orange,69107,U.S. Senate,,DEM,Kamala Harris,356
-Orange,69107,U.S. Senate,,DEM,Loretta Sanchez,241
-Orange,69108,U.S. Senate,,DEM,Kamala Harris,320
-Orange,69108,U.S. Senate,,DEM,Loretta Sanchez,289
-Orange,69110,U.S. Senate,,DEM,Kamala Harris,520
-Orange,69110,U.S. Senate,,DEM,Loretta Sanchez,380
-Orange,69111,U.S. Senate,,DEM,Kamala Harris,380
-Orange,69111,U.S. Senate,,DEM,Loretta Sanchez,278
-Orange,69122,U.S. Senate,,DEM,Kamala Harris,0
-Orange,69122,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,69601,U.S. Senate,,DEM,Kamala Harris,824
-Orange,69601,U.S. Senate,,DEM,Loretta Sanchez,552
-Orange,69901,U.S. Senate,,DEM,Kamala Harris,0
-Orange,69901,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,69902,U.S. Senate,,DEM,Kamala Harris,1
-Orange,69902,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,70085,U.S. Senate,,DEM,Kamala Harris,0
-Orange,70085,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,70601,U.S. Senate,,DEM,Kamala Harris,326
-Orange,70601,U.S. Senate,,DEM,Loretta Sanchez,262
-Orange,70602,U.S. Senate,,DEM,Kamala Harris,138
-Orange,70602,U.S. Senate,,DEM,Loretta Sanchez,97
-Orange,70901,U.S. Senate,,DEM,Kamala Harris,1
-Orange,70901,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,70902,U.S. Senate,,DEM,Kamala Harris,0
-Orange,70902,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,70903,U.S. Senate,,DEM,Kamala Harris,0
-Orange,70903,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,70904,U.S. Senate,,DEM,Kamala Harris,2
-Orange,70904,U.S. Senate,,DEM,Loretta Sanchez,13
-Orange,70905,U.S. Senate,,DEM,Kamala Harris,0
-Orange,70905,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,71120,U.S. Senate,,DEM,Kamala Harris,345
-Orange,71120,U.S. Senate,,DEM,Loretta Sanchez,315
-Orange,71121,U.S. Senate,,DEM,Kamala Harris,343
-Orange,71121,U.S. Senate,,DEM,Loretta Sanchez,376
-Orange,71232,U.S. Senate,,DEM,Kamala Harris,321
-Orange,71232,U.S. Senate,,DEM,Loretta Sanchez,286
-Orange,71237,U.S. Senate,,DEM,Kamala Harris,0
-Orange,71237,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,71238,U.S. Senate,,DEM,Kamala Harris,282
-Orange,71238,U.S. Senate,,DEM,Loretta Sanchez,242
-Orange,71239,U.S. Senate,,DEM,Kamala Harris,221
-Orange,71239,U.S. Senate,,DEM,Loretta Sanchez,259
-Orange,71240,U.S. Senate,,DEM,Kamala Harris,367
-Orange,71240,U.S. Senate,,DEM,Loretta Sanchez,372
-Orange,71241,U.S. Senate,,DEM,Kamala Harris,383
-Orange,71241,U.S. Senate,,DEM,Loretta Sanchez,315
-Orange,71245,U.S. Senate,,DEM,Kamala Harris,335
-Orange,71245,U.S. Senate,,DEM,Loretta Sanchez,292
-Orange,71246,U.S. Senate,,DEM,Kamala Harris,395
-Orange,71246,U.S. Senate,,DEM,Loretta Sanchez,257
-Orange,71247,U.S. Senate,,DEM,Kamala Harris,320
-Orange,71247,U.S. Senate,,DEM,Loretta Sanchez,279
-Orange,71253,U.S. Senate,,DEM,Kamala Harris,6
-Orange,71253,U.S. Senate,,DEM,Loretta Sanchez,2
-Orange,71256,U.S. Senate,,DEM,Kamala Harris,466
-Orange,71256,U.S. Senate,,DEM,Loretta Sanchez,324
-Orange,71258,U.S. Senate,,DEM,Kamala Harris,688
-Orange,71258,U.S. Senate,,DEM,Loretta Sanchez,440
-Orange,71259,U.S. Senate,,DEM,Kamala Harris,377
-Orange,71259,U.S. Senate,,DEM,Loretta Sanchez,274
-Orange,71262,U.S. Senate,,DEM,Kamala Harris,471
-Orange,71262,U.S. Senate,,DEM,Loretta Sanchez,280
-Orange,71263,U.S. Senate,,DEM,Kamala Harris,485
-Orange,71263,U.S. Senate,,DEM,Loretta Sanchez,249
-Orange,71264,U.S. Senate,,DEM,Kamala Harris,393
-Orange,71264,U.S. Senate,,DEM,Loretta Sanchez,235
-Orange,71266,U.S. Senate,,DEM,Kamala Harris,529
-Orange,71266,U.S. Senate,,DEM,Loretta Sanchez,307
-Orange,71269,U.S. Senate,,DEM,Kamala Harris,524
-Orange,71269,U.S. Senate,,DEM,Loretta Sanchez,329
-Orange,71270,U.S. Senate,,DEM,Kamala Harris,447
-Orange,71270,U.S. Senate,,DEM,Loretta Sanchez,302
-Orange,71283,U.S. Senate,,DEM,Kamala Harris,210
-Orange,71283,U.S. Senate,,DEM,Loretta Sanchez,319
-Orange,71284,U.S. Senate,,DEM,Kamala Harris,342
-Orange,71284,U.S. Senate,,DEM,Loretta Sanchez,291
-Orange,71285,U.S. Senate,,DEM,Kamala Harris,282
-Orange,71285,U.S. Senate,,DEM,Loretta Sanchez,285
-Orange,71352,U.S. Senate,,DEM,Kamala Harris,161
-Orange,71352,U.S. Senate,,DEM,Loretta Sanchez,240
-Orange,71357,U.S. Senate,,DEM,Kamala Harris,327
-Orange,71357,U.S. Senate,,DEM,Loretta Sanchez,323
-Orange,71361,U.S. Senate,,DEM,Kamala Harris,496
-Orange,71361,U.S. Senate,,DEM,Loretta Sanchez,320
-Orange,71362,U.S. Senate,,DEM,Kamala Harris,6
-Orange,71362,U.S. Senate,,DEM,Loretta Sanchez,5
-Orange,71368,U.S. Senate,,DEM,Kamala Harris,619
-Orange,71368,U.S. Senate,,DEM,Loretta Sanchez,339
-Orange,71370,U.S. Senate,,DEM,Kamala Harris,346
-Orange,71370,U.S. Senate,,DEM,Loretta Sanchez,262
-Orange,71378,U.S. Senate,,DEM,Kamala Harris,0
-Orange,71378,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,71601,U.S. Senate,,DEM,Kamala Harris,709
-Orange,71601,U.S. Senate,,DEM,Loretta Sanchez,784
-Orange,71602,U.S. Senate,,DEM,Kamala Harris,429
-Orange,71602,U.S. Senate,,DEM,Loretta Sanchez,401
-Orange,71603,U.S. Senate,,DEM,Kamala Harris,881
-Orange,71603,U.S. Senate,,DEM,Loretta Sanchez,548
-Orange,71701,U.S. Senate,,DEM,Kamala Harris,609
-Orange,71701,U.S. Senate,,DEM,Loretta Sanchez,401
-Orange,71901,U.S. Senate,,DEM,Kamala Harris,83
-Orange,71901,U.S. Senate,,DEM,Loretta Sanchez,83
-Orange,71902,U.S. Senate,,DEM,Kamala Harris,0
-Orange,71902,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,71903,U.S. Senate,,DEM,Kamala Harris,11
-Orange,71903,U.S. Senate,,DEM,Loretta Sanchez,2
-Orange,72081,U.S. Senate,,DEM,Kamala Harris,79
-Orange,72081,U.S. Senate,,DEM,Loretta Sanchez,56
-Orange,72085,U.S. Senate,,DEM,Kamala Harris,0
-Orange,72085,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,72087,U.S. Senate,,DEM,Kamala Harris,0
-Orange,72087,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,72091,U.S. Senate,,DEM,Kamala Harris,605
-Orange,72091,U.S. Senate,,DEM,Loretta Sanchez,488
-Orange,72093,U.S. Senate,,DEM,Kamala Harris,412
-Orange,72093,U.S. Senate,,DEM,Loretta Sanchez,353
-Orange,72096,U.S. Senate,,DEM,Kamala Harris,657
-Orange,72096,U.S. Senate,,DEM,Loretta Sanchez,547
-Orange,72098,U.S. Senate,,DEM,Kamala Harris,0
-Orange,72098,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,72100,U.S. Senate,,DEM,Kamala Harris,174
-Orange,72100,U.S. Senate,,DEM,Loretta Sanchez,89
-Orange,72110,U.S. Senate,,DEM,Kamala Harris,0
-Orange,72110,U.S. Senate,,DEM,Loretta Sanchez,0
-Orange,72197,U.S. Senate,,DEM,Kamala Harris,574
-Orange,72197,U.S. Senate,,DEM,Loretta Sanchez,522
-Orange,72199,U.S. Senate,,DEM,Kamala Harris,338
-Orange,72199,U.S. Senate,,DEM,Loretta Sanchez,267
-Orange,72254,U.S. Senate,,DEM,Kamala Harris,225
-Orange,72254,U.S. Senate,,DEM,Loretta Sanchez,161
-Orange,72255,U.S. Senate,,DEM,Kamala Harris,857
-Orange,72255,U.S. Senate,,DEM,Loretta Sanchez,616
-Orange,72256,U.S. Senate,,DEM,Kamala Harris,492
-Orange,72256,U.S. Senate,,DEM,Loretta Sanchez,367
-Orange,72262,U.S. Senate,,DEM,Kamala Harris,358
-Orange,72262,U.S. Senate,,DEM,Loretta Sanchez,246
-Orange,72269,U.S. Senate,,DEM,Kamala Harris,151
-Orange,72269,U.S. Senate,,DEM,Loretta Sanchez,100
-Orange,72272,U.S. Senate,,DEM,Kamala Harris,632
-Orange,72272,U.S. Senate,,DEM,Loretta Sanchez,448
-Orange,72310,U.S. Senate,,DEM,Kamala Harris,686
-Orange,72310,U.S. Senate,,DEM,Loretta Sanchez,466
-Orange,72311,U.S. Senate,,DEM,Kamala Harris,124
-Orange,72311,U.S. Senate,,DEM,Loretta Sanchez,83
-Orange,72312,U.S. Senate,,DEM,Kamala Harris,120
-Orange,72312,U.S. Senate,,DEM,Loretta Sanchez,97
-Orange,72314,U.S. Senate,,DEM,Kamala Harris,505
-Orange,72314,U.S. Senate,,DEM,Loretta Sanchez,406
-Orange,72318,U.S. Senate,,DEM,Kamala Harris,662
-Orange,72318,U.S. Senate,,DEM,Loretta Sanchez,530
-Orange,72321,U.S. Senate,,DEM,Kamala Harris,216
-Orange,72321,U.S. Senate,,DEM,Loretta Sanchez,190
-Orange,75114,U.S. Senate,,DEM,Kamala Harris,157
-Orange,75114,U.S. Senate,,DEM,Loretta Sanchez,125
-Orange,75115,U.S. Senate,,DEM,Kamala Harris,237
-Orange,75115,U.S. Senate,,DEM,Loretta Sanchez,195
-Orange,75701,U.S. Senate,,DEM,Kamala Harris,401
-Orange,75701,U.S. Senate,,DEM,Loretta Sanchez,306
-Orange,75702,U.S. Senate,,DEM,Kamala Harris,407
-Orange,75702,U.S. Senate,,DEM,Loretta Sanchez,327
-Orange,75703,U.S. Senate,,DEM,Kamala Harris,392
-Orange,75703,U.S. Senate,,DEM,Loretta Sanchez,389
+Orange,2001,U.S. Senate,,DEM,Kamala D. Harris,169
+Orange,2001,U.S. Senate,,DEM,Loretta L. Sanchez,291
+Orange,2002,U.S. Senate,,DEM,Kamala D. Harris,60
+Orange,2002,U.S. Senate,,DEM,Loretta L. Sanchez,111
+Orange,2003,U.S. Senate,,DEM,Kamala D. Harris,211
+Orange,2003,U.S. Senate,,DEM,Loretta L. Sanchez,289
+Orange,2007,U.S. Senate,,DEM,Kamala D. Harris,260
+Orange,2007,U.S. Senate,,DEM,Loretta L. Sanchez,367
+Orange,2008,U.S. Senate,,DEM,Kamala D. Harris,324
+Orange,2008,U.S. Senate,,DEM,Loretta L. Sanchez,504
+Orange,2009,U.S. Senate,,DEM,Kamala D. Harris,112
+Orange,2009,U.S. Senate,,DEM,Loretta L. Sanchez,139
+Orange,2011,U.S. Senate,,DEM,Kamala D. Harris,388
+Orange,2011,U.S. Senate,,DEM,Loretta L. Sanchez,291
+Orange,2012,U.S. Senate,,DEM,Kamala D. Harris,212
+Orange,2012,U.S. Senate,,DEM,Loretta L. Sanchez,284
+Orange,2015,U.S. Senate,,DEM,Kamala D. Harris,166
+Orange,2015,U.S. Senate,,DEM,Loretta L. Sanchez,183
+Orange,2017,U.S. Senate,,DEM,Kamala D. Harris,691
+Orange,2017,U.S. Senate,,DEM,Loretta L. Sanchez,414
+Orange,2020,U.S. Senate,,DEM,Kamala D. Harris,375
+Orange,2020,U.S. Senate,,DEM,Loretta L. Sanchez,393
+Orange,2023,U.S. Senate,,DEM,Kamala D. Harris,337
+Orange,2023,U.S. Senate,,DEM,Loretta L. Sanchez,417
+Orange,2024,U.S. Senate,,DEM,Kamala D. Harris,415
+Orange,2024,U.S. Senate,,DEM,Loretta L. Sanchez,248
+Orange,2025,U.S. Senate,,DEM,Kamala D. Harris,307
+Orange,2025,U.S. Senate,,DEM,Loretta L. Sanchez,546
+Orange,2030,U.S. Senate,,DEM,Kamala D. Harris,355
+Orange,2030,U.S. Senate,,DEM,Loretta L. Sanchez,416
+Orange,2031,U.S. Senate,,DEM,Kamala D. Harris,144
+Orange,2031,U.S. Senate,,DEM,Loretta L. Sanchez,193
+Orange,2033,U.S. Senate,,DEM,Kamala D. Harris,343
+Orange,2033,U.S. Senate,,DEM,Loretta L. Sanchez,423
+Orange,2034,U.S. Senate,,DEM,Kamala D. Harris,2
+Orange,2034,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,2036,U.S. Senate,,DEM,Kamala D. Harris,267
+Orange,2036,U.S. Senate,,DEM,Loretta L. Sanchez,232
+Orange,2037,U.S. Senate,,DEM,Kamala D. Harris,233
+Orange,2037,U.S. Senate,,DEM,Loretta L. Sanchez,164
+Orange,2038,U.S. Senate,,DEM,Kamala D. Harris,300
+Orange,2038,U.S. Senate,,DEM,Loretta L. Sanchez,246
+Orange,2039,U.S. Senate,,DEM,Kamala D. Harris,358
+Orange,2039,U.S. Senate,,DEM,Loretta L. Sanchez,241
+Orange,2040,U.S. Senate,,DEM,Kamala D. Harris,384
+Orange,2040,U.S. Senate,,DEM,Loretta L. Sanchez,281
+Orange,2047,U.S. Senate,,DEM,Kamala D. Harris,673
+Orange,2047,U.S. Senate,,DEM,Loretta L. Sanchez,458
+Orange,2048,U.S. Senate,,DEM,Kamala D. Harris,783
+Orange,2048,U.S. Senate,,DEM,Loretta L. Sanchez,517
+Orange,2049,U.S. Senate,,DEM,Kamala D. Harris,279
+Orange,2049,U.S. Senate,,DEM,Loretta L. Sanchez,224
+Orange,2051,U.S. Senate,,DEM,Kamala D. Harris,706
+Orange,2051,U.S. Senate,,DEM,Loretta L. Sanchez,480
+Orange,2054,U.S. Senate,,DEM,Kamala D. Harris,412
+Orange,2054,U.S. Senate,,DEM,Loretta L. Sanchez,481
+Orange,2055,U.S. Senate,,DEM,Kamala D. Harris,320
+Orange,2055,U.S. Senate,,DEM,Loretta L. Sanchez,461
+Orange,2060,U.S. Senate,,DEM,Kamala D. Harris,238
+Orange,2060,U.S. Senate,,DEM,Loretta L. Sanchez,153
+Orange,2061,U.S. Senate,,DEM,Kamala D. Harris,2
+Orange,2061,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,2069,U.S. Senate,,DEM,Kamala D. Harris,401
+Orange,2069,U.S. Senate,,DEM,Loretta L. Sanchez,219
+Orange,2070,U.S. Senate,,DEM,Kamala D. Harris,371
+Orange,2070,U.S. Senate,,DEM,Loretta L. Sanchez,195
+Orange,2071,U.S. Senate,,DEM,Kamala D. Harris,325
+Orange,2071,U.S. Senate,,DEM,Loretta L. Sanchez,239
+Orange,2072,U.S. Senate,,DEM,Kamala D. Harris,333
+Orange,2072,U.S. Senate,,DEM,Loretta L. Sanchez,223
+Orange,2073,U.S. Senate,,DEM,Kamala D. Harris,201
+Orange,2073,U.S. Senate,,DEM,Loretta L. Sanchez,171
+Orange,2075,U.S. Senate,,DEM,Kamala D. Harris,280
+Orange,2075,U.S. Senate,,DEM,Loretta L. Sanchez,220
+Orange,2077,U.S. Senate,,DEM,Kamala D. Harris,303
+Orange,2077,U.S. Senate,,DEM,Loretta L. Sanchez,206
+Orange,2078,U.S. Senate,,DEM,Kamala D. Harris,513
+Orange,2078,U.S. Senate,,DEM,Loretta L. Sanchez,334
+Orange,2079,U.S. Senate,,DEM,Kamala D. Harris,425
+Orange,2079,U.S. Senate,,DEM,Loretta L. Sanchez,267
+Orange,2080,U.S. Senate,,DEM,Kamala D. Harris,360
+Orange,2080,U.S. Senate,,DEM,Loretta L. Sanchez,217
+Orange,2081,U.S. Senate,,DEM,Kamala D. Harris,455
+Orange,2081,U.S. Senate,,DEM,Loretta L. Sanchez,250
+Orange,2082,U.S. Senate,,DEM,Kamala D. Harris,298
+Orange,2082,U.S. Senate,,DEM,Loretta L. Sanchez,156
+Orange,2088,U.S. Senate,,DEM,Kamala D. Harris,446
+Orange,2088,U.S. Senate,,DEM,Loretta L. Sanchez,321
+Orange,2094,U.S. Senate,,DEM,Kamala D. Harris,391
+Orange,2094,U.S. Senate,,DEM,Loretta L. Sanchez,192
+Orange,2096,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,2096,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,2097,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,2097,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,2098,U.S. Senate,,DEM,Kamala D. Harris,147
+Orange,2098,U.S. Senate,,DEM,Loretta L. Sanchez,171
+Orange,2099,U.S. Senate,,DEM,Kamala D. Harris,64
+Orange,2099,U.S. Senate,,DEM,Loretta L. Sanchez,126
+Orange,2117,U.S. Senate,,DEM,Kamala D. Harris,316
+Orange,2117,U.S. Senate,,DEM,Loretta L. Sanchez,462
+Orange,2119,U.S. Senate,,DEM,Kamala D. Harris,325
+Orange,2119,U.S. Senate,,DEM,Loretta L. Sanchez,661
+Orange,2122,U.S. Senate,,DEM,Kamala D. Harris,9
+Orange,2122,U.S. Senate,,DEM,Loretta L. Sanchez,10
+Orange,2128,U.S. Senate,,DEM,Kamala D. Harris,482
+Orange,2128,U.S. Senate,,DEM,Loretta L. Sanchez,720
+Orange,2131,U.S. Senate,,DEM,Kamala D. Harris,265
+Orange,2131,U.S. Senate,,DEM,Loretta L. Sanchez,373
+Orange,2133,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,2133,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,2134,U.S. Senate,,DEM,Kamala D. Harris,284
+Orange,2134,U.S. Senate,,DEM,Loretta L. Sanchez,540
+Orange,2135,U.S. Senate,,DEM,Kamala D. Harris,294
+Orange,2135,U.S. Senate,,DEM,Loretta L. Sanchez,532
+Orange,2139,U.S. Senate,,DEM,Kamala D. Harris,270
+Orange,2139,U.S. Senate,,DEM,Loretta L. Sanchez,296
+Orange,2143,U.S. Senate,,DEM,Kamala D. Harris,672
+Orange,2143,U.S. Senate,,DEM,Loretta L. Sanchez,780
+Orange,2146,U.S. Senate,,DEM,Kamala D. Harris,155
+Orange,2146,U.S. Senate,,DEM,Loretta L. Sanchez,190
+Orange,2148,U.S. Senate,,DEM,Kamala D. Harris,367
+Orange,2148,U.S. Senate,,DEM,Loretta L. Sanchez,403
+Orange,2151,U.S. Senate,,DEM,Kamala D. Harris,198
+Orange,2151,U.S. Senate,,DEM,Loretta L. Sanchez,290
+Orange,2152,U.S. Senate,,DEM,Kamala D. Harris,299
+Orange,2152,U.S. Senate,,DEM,Loretta L. Sanchez,428
+Orange,2153,U.S. Senate,,DEM,Kamala D. Harris,50
+Orange,2153,U.S. Senate,,DEM,Loretta L. Sanchez,52
+Orange,2160,U.S. Senate,,DEM,Kamala D. Harris,502
+Orange,2160,U.S. Senate,,DEM,Loretta L. Sanchez,660
+Orange,2166,U.S. Senate,,DEM,Kamala D. Harris,290
+Orange,2166,U.S. Senate,,DEM,Loretta L. Sanchez,392
+Orange,2171,U.S. Senate,,DEM,Kamala D. Harris,410
+Orange,2171,U.S. Senate,,DEM,Loretta L. Sanchez,486
+Orange,2176,U.S. Senate,,DEM,Kamala D. Harris,205
+Orange,2176,U.S. Senate,,DEM,Loretta L. Sanchez,390
+Orange,2177,U.S. Senate,,DEM,Kamala D. Harris,262
+Orange,2177,U.S. Senate,,DEM,Loretta L. Sanchez,459
+Orange,2181,U.S. Senate,,DEM,Kamala D. Harris,658
+Orange,2181,U.S. Senate,,DEM,Loretta L. Sanchez,817
+Orange,2182,U.S. Senate,,DEM,Kamala D. Harris,272
+Orange,2182,U.S. Senate,,DEM,Loretta L. Sanchez,352
+Orange,2187,U.S. Senate,,DEM,Kamala D. Harris,354
+Orange,2187,U.S. Senate,,DEM,Loretta L. Sanchez,587
+Orange,2193,U.S. Senate,,DEM,Kamala D. Harris,297
+Orange,2193,U.S. Senate,,DEM,Loretta L. Sanchez,664
+Orange,2194,U.S. Senate,,DEM,Kamala D. Harris,271
+Orange,2194,U.S. Senate,,DEM,Loretta L. Sanchez,289
+Orange,2197,U.S. Senate,,DEM,Kamala D. Harris,346
+Orange,2197,U.S. Senate,,DEM,Loretta L. Sanchez,383
+Orange,2200,U.S. Senate,,DEM,Kamala D. Harris,270
+Orange,2200,U.S. Senate,,DEM,Loretta L. Sanchez,315
+Orange,2201,U.S. Senate,,DEM,Kamala D. Harris,297
+Orange,2201,U.S. Senate,,DEM,Loretta L. Sanchez,424
+Orange,2205,U.S. Senate,,DEM,Kamala D. Harris,269
+Orange,2205,U.S. Senate,,DEM,Loretta L. Sanchez,522
+Orange,2211,U.S. Senate,,DEM,Kamala D. Harris,500
+Orange,2211,U.S. Senate,,DEM,Loretta L. Sanchez,559
+Orange,2212,U.S. Senate,,DEM,Kamala D. Harris,295
+Orange,2212,U.S. Senate,,DEM,Loretta L. Sanchez,370
+Orange,2216,U.S. Senate,,DEM,Kamala D. Harris,504
+Orange,2216,U.S. Senate,,DEM,Loretta L. Sanchez,1056
+Orange,2222,U.S. Senate,,DEM,Kamala D. Harris,247
+Orange,2222,U.S. Senate,,DEM,Loretta L. Sanchez,441
+Orange,2223,U.S. Senate,,DEM,Kamala D. Harris,285
+Orange,2223,U.S. Senate,,DEM,Loretta L. Sanchez,343
+Orange,2225,U.S. Senate,,DEM,Kamala D. Harris,582
+Orange,2225,U.S. Senate,,DEM,Loretta L. Sanchez,438
+Orange,2228,U.S. Senate,,DEM,Kamala D. Harris,150
+Orange,2228,U.S. Senate,,DEM,Loretta L. Sanchez,380
+Orange,2229,U.S. Senate,,DEM,Kamala D. Harris,448
+Orange,2229,U.S. Senate,,DEM,Loretta L. Sanchez,551
+Orange,2230,U.S. Senate,,DEM,Kamala D. Harris,430
+Orange,2230,U.S. Senate,,DEM,Loretta L. Sanchez,474
+Orange,2234,U.S. Senate,,DEM,Kamala D. Harris,217
+Orange,2234,U.S. Senate,,DEM,Loretta L. Sanchez,151
+Orange,2235,U.S. Senate,,DEM,Kamala D. Harris,459
+Orange,2235,U.S. Senate,,DEM,Loretta L. Sanchez,390
+Orange,2237,U.S. Senate,,DEM,Kamala D. Harris,361
+Orange,2237,U.S. Senate,,DEM,Loretta L. Sanchez,280
+Orange,2276,U.S. Senate,,DEM,Kamala D. Harris,246
+Orange,2276,U.S. Senate,,DEM,Loretta L. Sanchez,283
+Orange,2303,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,2303,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,2304,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,2304,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,2306,U.S. Senate,,DEM,Kamala D. Harris,18
+Orange,2306,U.S. Senate,,DEM,Loretta L. Sanchez,33
+Orange,2307,U.S. Senate,,DEM,Kamala D. Harris,63
+Orange,2307,U.S. Senate,,DEM,Loretta L. Sanchez,101
+Orange,2315,U.S. Senate,,DEM,Kamala D. Harris,300
+Orange,2315,U.S. Senate,,DEM,Loretta L. Sanchez,343
+Orange,2319,U.S. Senate,,DEM,Kamala D. Harris,325
+Orange,2319,U.S. Senate,,DEM,Loretta L. Sanchez,367
+Orange,2321,U.S. Senate,,DEM,Kamala D. Harris,334
+Orange,2321,U.S. Senate,,DEM,Loretta L. Sanchez,477
+Orange,2322,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,2322,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,2331,U.S. Senate,,DEM,Kamala D. Harris,79
+Orange,2331,U.S. Senate,,DEM,Loretta L. Sanchez,68
+Orange,2337,U.S. Senate,,DEM,Kamala D. Harris,266
+Orange,2337,U.S. Senate,,DEM,Loretta L. Sanchez,344
+Orange,2338,U.S. Senate,,DEM,Kamala D. Harris,158
+Orange,2338,U.S. Senate,,DEM,Loretta L. Sanchez,229
+Orange,2340,U.S. Senate,,DEM,Kamala D. Harris,265
+Orange,2340,U.S. Senate,,DEM,Loretta L. Sanchez,310
+Orange,2341,U.S. Senate,,DEM,Kamala D. Harris,295
+Orange,2341,U.S. Senate,,DEM,Loretta L. Sanchez,295
+Orange,2345,U.S. Senate,,DEM,Kamala D. Harris,236
+Orange,2345,U.S. Senate,,DEM,Loretta L. Sanchez,175
+Orange,2347,U.S. Senate,,DEM,Kamala D. Harris,208
+Orange,2347,U.S. Senate,,DEM,Loretta L. Sanchez,271
+Orange,2348,U.S. Senate,,DEM,Kamala D. Harris,213
+Orange,2348,U.S. Senate,,DEM,Loretta L. Sanchez,215
+Orange,2352,U.S. Senate,,DEM,Kamala D. Harris,361
+Orange,2352,U.S. Senate,,DEM,Loretta L. Sanchez,414
+Orange,2355,U.S. Senate,,DEM,Kamala D. Harris,87
+Orange,2355,U.S. Senate,,DEM,Loretta L. Sanchez,89
+Orange,2356,U.S. Senate,,DEM,Kamala D. Harris,271
+Orange,2356,U.S. Senate,,DEM,Loretta L. Sanchez,457
+Orange,2357,U.S. Senate,,DEM,Kamala D. Harris,291
+Orange,2357,U.S. Senate,,DEM,Loretta L. Sanchez,356
+Orange,2359,U.S. Senate,,DEM,Kamala D. Harris,365
+Orange,2359,U.S. Senate,,DEM,Loretta L. Sanchez,515
+Orange,2361,U.S. Senate,,DEM,Kamala D. Harris,85
+Orange,2361,U.S. Senate,,DEM,Loretta L. Sanchez,119
+Orange,2362,U.S. Senate,,DEM,Kamala D. Harris,173
+Orange,2362,U.S. Senate,,DEM,Loretta L. Sanchez,248
+Orange,2365,U.S. Senate,,DEM,Kamala D. Harris,228
+Orange,2365,U.S. Senate,,DEM,Loretta L. Sanchez,417
+Orange,2367,U.S. Senate,,DEM,Kamala D. Harris,192
+Orange,2367,U.S. Senate,,DEM,Loretta L. Sanchez,194
+Orange,2368,U.S. Senate,,DEM,Kamala D. Harris,206
+Orange,2368,U.S. Senate,,DEM,Loretta L. Sanchez,330
+Orange,2370,U.S. Senate,,DEM,Kamala D. Harris,42
+Orange,2370,U.S. Senate,,DEM,Loretta L. Sanchez,87
+Orange,2371,U.S. Senate,,DEM,Kamala D. Harris,293
+Orange,2371,U.S. Senate,,DEM,Loretta L. Sanchez,443
+Orange,2377,U.S. Senate,,DEM,Kamala D. Harris,60
+Orange,2377,U.S. Senate,,DEM,Loretta L. Sanchez,115
+Orange,2382,U.S. Senate,,DEM,Kamala D. Harris,88
+Orange,2382,U.S. Senate,,DEM,Loretta L. Sanchez,195
+Orange,2385,U.S. Senate,,DEM,Kamala D. Harris,223
+Orange,2385,U.S. Senate,,DEM,Loretta L. Sanchez,183
+Orange,2387,U.S. Senate,,DEM,Kamala D. Harris,230
+Orange,2387,U.S. Senate,,DEM,Loretta L. Sanchez,253
+Orange,2389,U.S. Senate,,DEM,Kamala D. Harris,373
+Orange,2389,U.S. Senate,,DEM,Loretta L. Sanchez,513
+Orange,2390,U.S. Senate,,DEM,Kamala D. Harris,210
+Orange,2390,U.S. Senate,,DEM,Loretta L. Sanchez,333
+Orange,2391,U.S. Senate,,DEM,Kamala D. Harris,282
+Orange,2391,U.S. Senate,,DEM,Loretta L. Sanchez,349
+Orange,2392,U.S. Senate,,DEM,Kamala D. Harris,619
+Orange,2392,U.S. Senate,,DEM,Loretta L. Sanchez,626
+Orange,2393,U.S. Senate,,DEM,Kamala D. Harris,227
+Orange,2393,U.S. Senate,,DEM,Loretta L. Sanchez,393
+Orange,2395,U.S. Senate,,DEM,Kamala D. Harris,605
+Orange,2395,U.S. Senate,,DEM,Loretta L. Sanchez,584
+Orange,2398,U.S. Senate,,DEM,Kamala D. Harris,257
+Orange,2398,U.S. Senate,,DEM,Loretta L. Sanchez,323
+Orange,2401,U.S. Senate,,DEM,Kamala D. Harris,312
+Orange,2401,U.S. Senate,,DEM,Loretta L. Sanchez,342
+Orange,2402,U.S. Senate,,DEM,Kamala D. Harris,214
+Orange,2402,U.S. Senate,,DEM,Loretta L. Sanchez,198
+Orange,2403,U.S. Senate,,DEM,Kamala D. Harris,559
+Orange,2403,U.S. Senate,,DEM,Loretta L. Sanchez,370
+Orange,2405,U.S. Senate,,DEM,Kamala D. Harris,81
+Orange,2405,U.S. Senate,,DEM,Loretta L. Sanchez,133
+Orange,2408,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,2408,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,2409,U.S. Senate,,DEM,Kamala D. Harris,12
+Orange,2409,U.S. Senate,,DEM,Loretta L. Sanchez,32
+Orange,2411,U.S. Senate,,DEM,Kamala D. Harris,204
+Orange,2411,U.S. Senate,,DEM,Loretta L. Sanchez,405
+Orange,2423,U.S. Senate,,DEM,Kamala D. Harris,258
+Orange,2423,U.S. Senate,,DEM,Loretta L. Sanchez,319
+Orange,2429,U.S. Senate,,DEM,Kamala D. Harris,124
+Orange,2429,U.S. Senate,,DEM,Loretta L. Sanchez,415
+Orange,2432,U.S. Senate,,DEM,Kamala D. Harris,347
+Orange,2432,U.S. Senate,,DEM,Loretta L. Sanchez,475
+Orange,2434,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,2434,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,2437,U.S. Senate,,DEM,Kamala D. Harris,399
+Orange,2437,U.S. Senate,,DEM,Loretta L. Sanchez,538
+Orange,2438,U.S. Senate,,DEM,Kamala D. Harris,333
+Orange,2438,U.S. Senate,,DEM,Loretta L. Sanchez,389
+Orange,2440,U.S. Senate,,DEM,Kamala D. Harris,324
+Orange,2440,U.S. Senate,,DEM,Loretta L. Sanchez,485
+Orange,2441,U.S. Senate,,DEM,Kamala D. Harris,91
+Orange,2441,U.S. Senate,,DEM,Loretta L. Sanchez,73
+Orange,2443,U.S. Senate,,DEM,Kamala D. Harris,566
+Orange,2443,U.S. Senate,,DEM,Loretta L. Sanchez,655
+Orange,2448,U.S. Senate,,DEM,Kamala D. Harris,293
+Orange,2448,U.S. Senate,,DEM,Loretta L. Sanchez,343
+Orange,2450,U.S. Senate,,DEM,Kamala D. Harris,414
+Orange,2450,U.S. Senate,,DEM,Loretta L. Sanchez,526
+Orange,2453,U.S. Senate,,DEM,Kamala D. Harris,238
+Orange,2453,U.S. Senate,,DEM,Loretta L. Sanchez,190
+Orange,2457,U.S. Senate,,DEM,Kamala D. Harris,554
+Orange,2457,U.S. Senate,,DEM,Loretta L. Sanchez,644
+Orange,2459,U.S. Senate,,DEM,Kamala D. Harris,8
+Orange,2459,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Orange,2601,U.S. Senate,,DEM,Kamala D. Harris,733
+Orange,2601,U.S. Senate,,DEM,Loretta L. Sanchez,589
+Orange,2602,U.S. Senate,,DEM,Kamala D. Harris,582
+Orange,2602,U.S. Senate,,DEM,Loretta L. Sanchez,395
+Orange,2603,U.S. Senate,,DEM,Kamala D. Harris,202
+Orange,2603,U.S. Senate,,DEM,Loretta L. Sanchez,144
+Orange,2901,U.S. Senate,,DEM,Kamala D. Harris,1
+Orange,2901,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Orange,2902,U.S. Senate,,DEM,Kamala D. Harris,3
+Orange,2902,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Orange,5302,U.S. Senate,,DEM,Kamala D. Harris,323
+Orange,5302,U.S. Senate,,DEM,Loretta L. Sanchez,248
+Orange,5303,U.S. Senate,,DEM,Kamala D. Harris,269
+Orange,5303,U.S. Senate,,DEM,Loretta L. Sanchez,209
+Orange,5305,U.S. Senate,,DEM,Kamala D. Harris,327
+Orange,5305,U.S. Senate,,DEM,Loretta L. Sanchez,232
+Orange,5307,U.S. Senate,,DEM,Kamala D. Harris,300
+Orange,5307,U.S. Senate,,DEM,Loretta L. Sanchez,250
+Orange,5308,U.S. Senate,,DEM,Kamala D. Harris,370
+Orange,5308,U.S. Senate,,DEM,Loretta L. Sanchez,323
+Orange,5310,U.S. Senate,,DEM,Kamala D. Harris,369
+Orange,5310,U.S. Senate,,DEM,Loretta L. Sanchez,323
+Orange,5311,U.S. Senate,,DEM,Kamala D. Harris,435
+Orange,5311,U.S. Senate,,DEM,Loretta L. Sanchez,359
+Orange,5316,U.S. Senate,,DEM,Kamala D. Harris,335
+Orange,5316,U.S. Senate,,DEM,Loretta L. Sanchez,242
+Orange,5317,U.S. Senate,,DEM,Kamala D. Harris,315
+Orange,5317,U.S. Senate,,DEM,Loretta L. Sanchez,210
+Orange,5318,U.S. Senate,,DEM,Kamala D. Harris,399
+Orange,5318,U.S. Senate,,DEM,Loretta L. Sanchez,289
+Orange,5319,U.S. Senate,,DEM,Kamala D. Harris,325
+Orange,5319,U.S. Senate,,DEM,Loretta L. Sanchez,284
+Orange,5333,U.S. Senate,,DEM,Kamala D. Harris,41
+Orange,5333,U.S. Senate,,DEM,Loretta L. Sanchez,20
+Orange,5335,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,5335,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,5336,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,5336,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,5337,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,5337,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,5338,U.S. Senate,,DEM,Kamala D. Harris,359
+Orange,5338,U.S. Senate,,DEM,Loretta L. Sanchez,257
+Orange,5340,U.S. Senate,,DEM,Kamala D. Harris,371
+Orange,5340,U.S. Senate,,DEM,Loretta L. Sanchez,287
+Orange,5342,U.S. Senate,,DEM,Kamala D. Harris,375
+Orange,5342,U.S. Senate,,DEM,Loretta L. Sanchez,238
+Orange,5343,U.S. Senate,,DEM,Kamala D. Harris,334
+Orange,5343,U.S. Senate,,DEM,Loretta L. Sanchez,201
+Orange,5344,U.S. Senate,,DEM,Kamala D. Harris,302
+Orange,5344,U.S. Senate,,DEM,Loretta L. Sanchez,214
+Orange,5379,U.S. Senate,,DEM,Kamala D. Harris,284
+Orange,5379,U.S. Senate,,DEM,Loretta L. Sanchez,166
+Orange,5380,U.S. Senate,,DEM,Kamala D. Harris,368
+Orange,5380,U.S. Senate,,DEM,Loretta L. Sanchez,296
+Orange,5381,U.S. Senate,,DEM,Kamala D. Harris,336
+Orange,5381,U.S. Senate,,DEM,Loretta L. Sanchez,278
+Orange,5383,U.S. Senate,,DEM,Kamala D. Harris,263
+Orange,5383,U.S. Senate,,DEM,Loretta L. Sanchez,242
+Orange,5384,U.S. Senate,,DEM,Kamala D. Harris,282
+Orange,5384,U.S. Senate,,DEM,Loretta L. Sanchez,260
+Orange,5385,U.S. Senate,,DEM,Kamala D. Harris,277
+Orange,5385,U.S. Senate,,DEM,Loretta L. Sanchez,217
+Orange,5386,U.S. Senate,,DEM,Kamala D. Harris,307
+Orange,5386,U.S. Senate,,DEM,Loretta L. Sanchez,276
+Orange,5388,U.S. Senate,,DEM,Kamala D. Harris,294
+Orange,5388,U.S. Senate,,DEM,Loretta L. Sanchez,246
+Orange,5389,U.S. Senate,,DEM,Kamala D. Harris,121
+Orange,5389,U.S. Senate,,DEM,Loretta L. Sanchez,110
+Orange,5392,U.S. Senate,,DEM,Kamala D. Harris,40
+Orange,5392,U.S. Senate,,DEM,Loretta L. Sanchez,48
+Orange,5393,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,5393,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,5396,U.S. Senate,,DEM,Kamala D. Harris,77
+Orange,5396,U.S. Senate,,DEM,Loretta L. Sanchez,40
+Orange,5397,U.S. Senate,,DEM,Kamala D. Harris,450
+Orange,5397,U.S. Senate,,DEM,Loretta L. Sanchez,331
+Orange,5398,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,5398,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Orange,5701,U.S. Senate,,DEM,Kamala D. Harris,748
+Orange,5701,U.S. Senate,,DEM,Loretta L. Sanchez,548
+Orange,6200,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,6200,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,6204,U.S. Senate,,DEM,Kamala D. Harris,1
+Orange,6204,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,6205,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,6205,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,7022,U.S. Senate,,DEM,Kamala D. Harris,198
+Orange,7022,U.S. Senate,,DEM,Loretta L. Sanchez,163
+Orange,7092,U.S. Senate,,DEM,Kamala D. Harris,103
+Orange,7092,U.S. Senate,,DEM,Loretta L. Sanchez,103
+Orange,7093,U.S. Senate,,DEM,Kamala D. Harris,34
+Orange,7093,U.S. Senate,,DEM,Loretta L. Sanchez,57
+Orange,7094,U.S. Senate,,DEM,Kamala D. Harris,117
+Orange,7094,U.S. Senate,,DEM,Loretta L. Sanchez,109
+Orange,7095,U.S. Senate,,DEM,Kamala D. Harris,61
+Orange,7095,U.S. Senate,,DEM,Loretta L. Sanchez,53
+Orange,7098,U.S. Senate,,DEM,Kamala D. Harris,125
+Orange,7098,U.S. Senate,,DEM,Loretta L. Sanchez,121
+Orange,7101,U.S. Senate,,DEM,Kamala D. Harris,385
+Orange,7101,U.S. Senate,,DEM,Loretta L. Sanchez,436
+Orange,7102,U.S. Senate,,DEM,Kamala D. Harris,151
+Orange,7102,U.S. Senate,,DEM,Loretta L. Sanchez,323
+Orange,7103,U.S. Senate,,DEM,Kamala D. Harris,410
+Orange,7103,U.S. Senate,,DEM,Loretta L. Sanchez,330
+Orange,7104,U.S. Senate,,DEM,Kamala D. Harris,160
+Orange,7104,U.S. Senate,,DEM,Loretta L. Sanchez,255
+Orange,7106,U.S. Senate,,DEM,Kamala D. Harris,246
+Orange,7106,U.S. Senate,,DEM,Loretta L. Sanchez,330
+Orange,7108,U.S. Senate,,DEM,Kamala D. Harris,446
+Orange,7108,U.S. Senate,,DEM,Loretta L. Sanchez,458
+Orange,7109,U.S. Senate,,DEM,Kamala D. Harris,279
+Orange,7109,U.S. Senate,,DEM,Loretta L. Sanchez,299
+Orange,7110,U.S. Senate,,DEM,Kamala D. Harris,377
+Orange,7110,U.S. Senate,,DEM,Loretta L. Sanchez,320
+Orange,7111,U.S. Senate,,DEM,Kamala D. Harris,218
+Orange,7111,U.S. Senate,,DEM,Loretta L. Sanchez,274
+Orange,7112,U.S. Senate,,DEM,Kamala D. Harris,364
+Orange,7112,U.S. Senate,,DEM,Loretta L. Sanchez,495
+Orange,7120,U.S. Senate,,DEM,Kamala D. Harris,91
+Orange,7120,U.S. Senate,,DEM,Loretta L. Sanchez,106
+Orange,7121,U.S. Senate,,DEM,Kamala D. Harris,108
+Orange,7121,U.S. Senate,,DEM,Loretta L. Sanchez,93
+Orange,7122,U.S. Senate,,DEM,Kamala D. Harris,516
+Orange,7122,U.S. Senate,,DEM,Loretta L. Sanchez,471
+Orange,7123,U.S. Senate,,DEM,Kamala D. Harris,153
+Orange,7123,U.S. Senate,,DEM,Loretta L. Sanchez,188
+Orange,7124,U.S. Senate,,DEM,Kamala D. Harris,150
+Orange,7124,U.S. Senate,,DEM,Loretta L. Sanchez,130
+Orange,7125,U.S. Senate,,DEM,Kamala D. Harris,33
+Orange,7125,U.S. Senate,,DEM,Loretta L. Sanchez,30
+Orange,7126,U.S. Senate,,DEM,Kamala D. Harris,256
+Orange,7126,U.S. Senate,,DEM,Loretta L. Sanchez,263
+Orange,7127,U.S. Senate,,DEM,Kamala D. Harris,63
+Orange,7127,U.S. Senate,,DEM,Loretta L. Sanchez,61
+Orange,7128,U.S. Senate,,DEM,Kamala D. Harris,270
+Orange,7128,U.S. Senate,,DEM,Loretta L. Sanchez,246
+Orange,7129,U.S. Senate,,DEM,Kamala D. Harris,76
+Orange,7129,U.S. Senate,,DEM,Loretta L. Sanchez,72
+Orange,7130,U.S. Senate,,DEM,Kamala D. Harris,19
+Orange,7130,U.S. Senate,,DEM,Loretta L. Sanchez,23
+Orange,7131,U.S. Senate,,DEM,Kamala D. Harris,120
+Orange,7131,U.S. Senate,,DEM,Loretta L. Sanchez,139
+Orange,7133,U.S. Senate,,DEM,Kamala D. Harris,52
+Orange,7133,U.S. Senate,,DEM,Loretta L. Sanchez,68
+Orange,7134,U.S. Senate,,DEM,Kamala D. Harris,175
+Orange,7134,U.S. Senate,,DEM,Loretta L. Sanchez,183
+Orange,7135,U.S. Senate,,DEM,Kamala D. Harris,173
+Orange,7135,U.S. Senate,,DEM,Loretta L. Sanchez,190
+Orange,7136,U.S. Senate,,DEM,Kamala D. Harris,12
+Orange,7136,U.S. Senate,,DEM,Loretta L. Sanchez,6
+Orange,7137,U.S. Senate,,DEM,Kamala D. Harris,102
+Orange,7137,U.S. Senate,,DEM,Loretta L. Sanchez,69
+Orange,7138,U.S. Senate,,DEM,Kamala D. Harris,351
+Orange,7138,U.S. Senate,,DEM,Loretta L. Sanchez,350
+Orange,7139,U.S. Senate,,DEM,Kamala D. Harris,29
+Orange,7139,U.S. Senate,,DEM,Loretta L. Sanchez,20
+Orange,7140,U.S. Senate,,DEM,Kamala D. Harris,287
+Orange,7140,U.S. Senate,,DEM,Loretta L. Sanchez,214
+Orange,7142,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,7142,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,7145,U.S. Senate,,DEM,Kamala D. Harris,212
+Orange,7145,U.S. Senate,,DEM,Loretta L. Sanchez,228
+Orange,7146,U.S. Senate,,DEM,Kamala D. Harris,111
+Orange,7146,U.S. Senate,,DEM,Loretta L. Sanchez,127
+Orange,7147,U.S. Senate,,DEM,Kamala D. Harris,108
+Orange,7147,U.S. Senate,,DEM,Loretta L. Sanchez,131
+Orange,7148,U.S. Senate,,DEM,Kamala D. Harris,20
+Orange,7148,U.S. Senate,,DEM,Loretta L. Sanchez,13
+Orange,7149,U.S. Senate,,DEM,Kamala D. Harris,312
+Orange,7149,U.S. Senate,,DEM,Loretta L. Sanchez,270
+Orange,7151,U.S. Senate,,DEM,Kamala D. Harris,279
+Orange,7151,U.S. Senate,,DEM,Loretta L. Sanchez,241
+Orange,7152,U.S. Senate,,DEM,Kamala D. Harris,204
+Orange,7152,U.S. Senate,,DEM,Loretta L. Sanchez,186
+Orange,7153,U.S. Senate,,DEM,Kamala D. Harris,200
+Orange,7153,U.S. Senate,,DEM,Loretta L. Sanchez,188
+Orange,7158,U.S. Senate,,DEM,Kamala D. Harris,164
+Orange,7158,U.S. Senate,,DEM,Loretta L. Sanchez,187
+Orange,7159,U.S. Senate,,DEM,Kamala D. Harris,231
+Orange,7159,U.S. Senate,,DEM,Loretta L. Sanchez,186
+Orange,7161,U.S. Senate,,DEM,Kamala D. Harris,127
+Orange,7161,U.S. Senate,,DEM,Loretta L. Sanchez,115
+Orange,7162,U.S. Senate,,DEM,Kamala D. Harris,397
+Orange,7162,U.S. Senate,,DEM,Loretta L. Sanchez,377
+Orange,7164,U.S. Senate,,DEM,Kamala D. Harris,256
+Orange,7164,U.S. Senate,,DEM,Loretta L. Sanchez,205
+Orange,7166,U.S. Senate,,DEM,Kamala D. Harris,335
+Orange,7166,U.S. Senate,,DEM,Loretta L. Sanchez,289
+Orange,7167,U.S. Senate,,DEM,Kamala D. Harris,444
+Orange,7167,U.S. Senate,,DEM,Loretta L. Sanchez,380
+Orange,7169,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,7169,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,7170,U.S. Senate,,DEM,Kamala D. Harris,236
+Orange,7170,U.S. Senate,,DEM,Loretta L. Sanchez,203
+Orange,7172,U.S. Senate,,DEM,Kamala D. Harris,68
+Orange,7172,U.S. Senate,,DEM,Loretta L. Sanchez,83
+Orange,7174,U.S. Senate,,DEM,Kamala D. Harris,250
+Orange,7174,U.S. Senate,,DEM,Loretta L. Sanchez,190
+Orange,7176,U.S. Senate,,DEM,Kamala D. Harris,455
+Orange,7176,U.S. Senate,,DEM,Loretta L. Sanchez,477
+Orange,7177,U.S. Senate,,DEM,Kamala D. Harris,4
+Orange,7177,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Orange,7180,U.S. Senate,,DEM,Kamala D. Harris,149
+Orange,7180,U.S. Senate,,DEM,Loretta L. Sanchez,154
+Orange,7181,U.S. Senate,,DEM,Kamala D. Harris,17
+Orange,7181,U.S. Senate,,DEM,Loretta L. Sanchez,20
+Orange,7182,U.S. Senate,,DEM,Kamala D. Harris,344
+Orange,7182,U.S. Senate,,DEM,Loretta L. Sanchez,303
+Orange,7183,U.S. Senate,,DEM,Kamala D. Harris,1
+Orange,7183,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,7185,U.S. Senate,,DEM,Kamala D. Harris,108
+Orange,7185,U.S. Senate,,DEM,Loretta L. Sanchez,113
+Orange,7186,U.S. Senate,,DEM,Kamala D. Harris,97
+Orange,7186,U.S. Senate,,DEM,Loretta L. Sanchez,130
+Orange,10316,U.S. Senate,,DEM,Kamala D. Harris,358
+Orange,10316,U.S. Senate,,DEM,Loretta L. Sanchez,258
+Orange,10317,U.S. Senate,,DEM,Kamala D. Harris,303
+Orange,10317,U.S. Senate,,DEM,Loretta L. Sanchez,313
+Orange,10319,U.S. Senate,,DEM,Kamala D. Harris,257
+Orange,10319,U.S. Senate,,DEM,Loretta L. Sanchez,246
+Orange,10320,U.S. Senate,,DEM,Kamala D. Harris,409
+Orange,10320,U.S. Senate,,DEM,Loretta L. Sanchez,292
+Orange,10322,U.S. Senate,,DEM,Kamala D. Harris,339
+Orange,10322,U.S. Senate,,DEM,Loretta L. Sanchez,260
+Orange,10324,U.S. Senate,,DEM,Kamala D. Harris,376
+Orange,10324,U.S. Senate,,DEM,Loretta L. Sanchez,289
+Orange,10325,U.S. Senate,,DEM,Kamala D. Harris,330
+Orange,10325,U.S. Senate,,DEM,Loretta L. Sanchez,278
+Orange,10326,U.S. Senate,,DEM,Kamala D. Harris,370
+Orange,10326,U.S. Senate,,DEM,Loretta L. Sanchez,293
+Orange,10329,U.S. Senate,,DEM,Kamala D. Harris,314
+Orange,10329,U.S. Senate,,DEM,Loretta L. Sanchez,259
+Orange,10333,U.S. Senate,,DEM,Kamala D. Harris,413
+Orange,10333,U.S. Senate,,DEM,Loretta L. Sanchez,273
+Orange,10334,U.S. Senate,,DEM,Kamala D. Harris,382
+Orange,10334,U.S. Senate,,DEM,Loretta L. Sanchez,217
+Orange,10336,U.S. Senate,,DEM,Kamala D. Harris,239
+Orange,10336,U.S. Senate,,DEM,Loretta L. Sanchez,154
+Orange,10337,U.S. Senate,,DEM,Kamala D. Harris,280
+Orange,10337,U.S. Senate,,DEM,Loretta L. Sanchez,257
+Orange,10338,U.S. Senate,,DEM,Kamala D. Harris,379
+Orange,10338,U.S. Senate,,DEM,Loretta L. Sanchez,243
+Orange,10339,U.S. Senate,,DEM,Kamala D. Harris,354
+Orange,10339,U.S. Senate,,DEM,Loretta L. Sanchez,261
+Orange,10340,U.S. Senate,,DEM,Kamala D. Harris,501
+Orange,10340,U.S. Senate,,DEM,Loretta L. Sanchez,365
+Orange,10360,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,10360,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,10361,U.S. Senate,,DEM,Kamala D. Harris,299
+Orange,10361,U.S. Senate,,DEM,Loretta L. Sanchez,258
+Orange,10362,U.S. Senate,,DEM,Kamala D. Harris,252
+Orange,10362,U.S. Senate,,DEM,Loretta L. Sanchez,274
+Orange,10364,U.S. Senate,,DEM,Kamala D. Harris,302
+Orange,10364,U.S. Senate,,DEM,Loretta L. Sanchez,277
+Orange,10367,U.S. Senate,,DEM,Kamala D. Harris,384
+Orange,10367,U.S. Senate,,DEM,Loretta L. Sanchez,309
+Orange,10371,U.S. Senate,,DEM,Kamala D. Harris,352
+Orange,10371,U.S. Senate,,DEM,Loretta L. Sanchez,283
+Orange,10374,U.S. Senate,,DEM,Kamala D. Harris,97
+Orange,10374,U.S. Senate,,DEM,Loretta L. Sanchez,70
+Orange,10376,U.S. Senate,,DEM,Kamala D. Harris,317
+Orange,10376,U.S. Senate,,DEM,Loretta L. Sanchez,261
+Orange,10379,U.S. Senate,,DEM,Kamala D. Harris,270
+Orange,10379,U.S. Senate,,DEM,Loretta L. Sanchez,246
+Orange,10380,U.S. Senate,,DEM,Kamala D. Harris,446
+Orange,10380,U.S. Senate,,DEM,Loretta L. Sanchez,322
+Orange,10382,U.S. Senate,,DEM,Kamala D. Harris,244
+Orange,10382,U.S. Senate,,DEM,Loretta L. Sanchez,210
+Orange,10383,U.S. Senate,,DEM,Kamala D. Harris,44
+Orange,10383,U.S. Senate,,DEM,Loretta L. Sanchez,31
+Orange,10384,U.S. Senate,,DEM,Kamala D. Harris,279
+Orange,10384,U.S. Senate,,DEM,Loretta L. Sanchez,195
+Orange,10388,U.S. Senate,,DEM,Kamala D. Harris,289
+Orange,10388,U.S. Senate,,DEM,Loretta L. Sanchez,253
+Orange,10392,U.S. Senate,,DEM,Kamala D. Harris,289
+Orange,10392,U.S. Senate,,DEM,Loretta L. Sanchez,256
+Orange,10701,U.S. Senate,,DEM,Kamala D. Harris,455
+Orange,10701,U.S. Senate,,DEM,Loretta L. Sanchez,357
+Orange,11041,U.S. Senate,,DEM,Kamala D. Harris,441
+Orange,11041,U.S. Senate,,DEM,Loretta L. Sanchez,317
+Orange,11043,U.S. Senate,,DEM,Kamala D. Harris,132
+Orange,11043,U.S. Senate,,DEM,Loretta L. Sanchez,94
+Orange,11075,U.S. Senate,,DEM,Kamala D. Harris,435
+Orange,11075,U.S. Senate,,DEM,Loretta L. Sanchez,292
+Orange,11351,U.S. Senate,,DEM,Kamala D. Harris,386
+Orange,11351,U.S. Senate,,DEM,Loretta L. Sanchez,234
+Orange,11353,U.S. Senate,,DEM,Kamala D. Harris,244
+Orange,11353,U.S. Senate,,DEM,Loretta L. Sanchez,155
+Orange,11354,U.S. Senate,,DEM,Kamala D. Harris,267
+Orange,11354,U.S. Senate,,DEM,Loretta L. Sanchez,256
+Orange,11355,U.S. Senate,,DEM,Kamala D. Harris,417
+Orange,11355,U.S. Senate,,DEM,Loretta L. Sanchez,310
+Orange,11356,U.S. Senate,,DEM,Kamala D. Harris,334
+Orange,11356,U.S. Senate,,DEM,Loretta L. Sanchez,289
+Orange,11357,U.S. Senate,,DEM,Kamala D. Harris,19
+Orange,11357,U.S. Senate,,DEM,Loretta L. Sanchez,18
+Orange,11359,U.S. Senate,,DEM,Kamala D. Harris,358
+Orange,11359,U.S. Senate,,DEM,Loretta L. Sanchez,265
+Orange,11362,U.S. Senate,,DEM,Kamala D. Harris,211
+Orange,11362,U.S. Senate,,DEM,Loretta L. Sanchez,170
+Orange,13030,U.S. Senate,,DEM,Kamala D. Harris,57
+Orange,13030,U.S. Senate,,DEM,Loretta L. Sanchez,43
+Orange,13031,U.S. Senate,,DEM,Kamala D. Harris,2
+Orange,13031,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,13032,U.S. Senate,,DEM,Kamala D. Harris,86
+Orange,13032,U.S. Senate,,DEM,Loretta L. Sanchez,108
+Orange,13033,U.S. Senate,,DEM,Kamala D. Harris,228
+Orange,13033,U.S. Senate,,DEM,Loretta L. Sanchez,223
+Orange,13034,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,13034,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,13035,U.S. Senate,,DEM,Kamala D. Harris,87
+Orange,13035,U.S. Senate,,DEM,Loretta L. Sanchez,64
+Orange,13036,U.S. Senate,,DEM,Kamala D. Harris,36
+Orange,13036,U.S. Senate,,DEM,Loretta L. Sanchez,19
+Orange,13038,U.S. Senate,,DEM,Kamala D. Harris,286
+Orange,13038,U.S. Senate,,DEM,Loretta L. Sanchez,258
+Orange,13041,U.S. Senate,,DEM,Kamala D. Harris,283
+Orange,13041,U.S. Senate,,DEM,Loretta L. Sanchez,224
+Orange,13042,U.S. Senate,,DEM,Kamala D. Harris,210
+Orange,13042,U.S. Senate,,DEM,Loretta L. Sanchez,237
+Orange,13043,U.S. Senate,,DEM,Kamala D. Harris,337
+Orange,13043,U.S. Senate,,DEM,Loretta L. Sanchez,463
+Orange,13044,U.S. Senate,,DEM,Kamala D. Harris,319
+Orange,13044,U.S. Senate,,DEM,Loretta L. Sanchez,371
+Orange,13047,U.S. Senate,,DEM,Kamala D. Harris,361
+Orange,13047,U.S. Senate,,DEM,Loretta L. Sanchez,374
+Orange,13050,U.S. Senate,,DEM,Kamala D. Harris,332
+Orange,13050,U.S. Senate,,DEM,Loretta L. Sanchez,310
+Orange,13052,U.S. Senate,,DEM,Kamala D. Harris,141
+Orange,13052,U.S. Senate,,DEM,Loretta L. Sanchez,140
+Orange,13053,U.S. Senate,,DEM,Kamala D. Harris,279
+Orange,13053,U.S. Senate,,DEM,Loretta L. Sanchez,431
+Orange,13057,U.S. Senate,,DEM,Kamala D. Harris,403
+Orange,13057,U.S. Senate,,DEM,Loretta L. Sanchez,363
+Orange,13061,U.S. Senate,,DEM,Kamala D. Harris,93
+Orange,13061,U.S. Senate,,DEM,Loretta L. Sanchez,160
+Orange,13062,U.S. Senate,,DEM,Kamala D. Harris,570
+Orange,13062,U.S. Senate,,DEM,Loretta L. Sanchez,380
+Orange,13063,U.S. Senate,,DEM,Kamala D. Harris,282
+Orange,13063,U.S. Senate,,DEM,Loretta L. Sanchez,211
+Orange,13064,U.S. Senate,,DEM,Kamala D. Harris,482
+Orange,13064,U.S. Senate,,DEM,Loretta L. Sanchez,506
+Orange,13065,U.S. Senate,,DEM,Kamala D. Harris,552
+Orange,13065,U.S. Senate,,DEM,Loretta L. Sanchez,568
+Orange,13068,U.S. Senate,,DEM,Kamala D. Harris,508
+Orange,13068,U.S. Senate,,DEM,Loretta L. Sanchez,529
+Orange,13069,U.S. Senate,,DEM,Kamala D. Harris,551
+Orange,13069,U.S. Senate,,DEM,Loretta L. Sanchez,408
+Orange,13074,U.S. Senate,,DEM,Kamala D. Harris,96
+Orange,13074,U.S. Senate,,DEM,Loretta L. Sanchez,53
+Orange,13076,U.S. Senate,,DEM,Kamala D. Harris,200
+Orange,13076,U.S. Senate,,DEM,Loretta L. Sanchez,222
+Orange,13078,U.S. Senate,,DEM,Kamala D. Harris,312
+Orange,13078,U.S. Senate,,DEM,Loretta L. Sanchez,308
+Orange,13080,U.S. Senate,,DEM,Kamala D. Harris,319
+Orange,13080,U.S. Senate,,DEM,Loretta L. Sanchez,260
+Orange,13082,U.S. Senate,,DEM,Kamala D. Harris,561
+Orange,13082,U.S. Senate,,DEM,Loretta L. Sanchez,454
+Orange,13084,U.S. Senate,,DEM,Kamala D. Harris,291
+Orange,13084,U.S. Senate,,DEM,Loretta L. Sanchez,219
+Orange,13085,U.S. Senate,,DEM,Kamala D. Harris,339
+Orange,13085,U.S. Senate,,DEM,Loretta L. Sanchez,273
+Orange,13086,U.S. Senate,,DEM,Kamala D. Harris,727
+Orange,13086,U.S. Senate,,DEM,Loretta L. Sanchez,573
+Orange,13091,U.S. Senate,,DEM,Kamala D. Harris,1
+Orange,13091,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Orange,13094,U.S. Senate,,DEM,Kamala D. Harris,219
+Orange,13094,U.S. Senate,,DEM,Loretta L. Sanchez,193
+Orange,13096,U.S. Senate,,DEM,Kamala D. Harris,516
+Orange,13096,U.S. Senate,,DEM,Loretta L. Sanchez,408
+Orange,13098,U.S. Senate,,DEM,Kamala D. Harris,662
+Orange,13098,U.S. Senate,,DEM,Loretta L. Sanchez,554
+Orange,13099,U.S. Senate,,DEM,Kamala D. Harris,288
+Orange,13099,U.S. Senate,,DEM,Loretta L. Sanchez,246
+Orange,13100,U.S. Senate,,DEM,Kamala D. Harris,237
+Orange,13100,U.S. Senate,,DEM,Loretta L. Sanchez,192
+Orange,13205,U.S. Senate,,DEM,Kamala D. Harris,424
+Orange,13205,U.S. Senate,,DEM,Loretta L. Sanchez,409
+Orange,13208,U.S. Senate,,DEM,Kamala D. Harris,509
+Orange,13208,U.S. Senate,,DEM,Loretta L. Sanchez,364
+Orange,13210,U.S. Senate,,DEM,Kamala D. Harris,325
+Orange,13210,U.S. Senate,,DEM,Loretta L. Sanchez,245
+Orange,13211,U.S. Senate,,DEM,Kamala D. Harris,286
+Orange,13211,U.S. Senate,,DEM,Loretta L. Sanchez,202
+Orange,13214,U.S. Senate,,DEM,Kamala D. Harris,733
+Orange,13214,U.S. Senate,,DEM,Loretta L. Sanchez,563
+Orange,13216,U.S. Senate,,DEM,Kamala D. Harris,61
+Orange,13216,U.S. Senate,,DEM,Loretta L. Sanchez,45
+Orange,13217,U.S. Senate,,DEM,Kamala D. Harris,553
+Orange,13217,U.S. Senate,,DEM,Loretta L. Sanchez,504
+Orange,13220,U.S. Senate,,DEM,Kamala D. Harris,273
+Orange,13220,U.S. Senate,,DEM,Loretta L. Sanchez,211
+Orange,13221,U.S. Senate,,DEM,Kamala D. Harris,690
+Orange,13221,U.S. Senate,,DEM,Loretta L. Sanchez,527
+Orange,13227,U.S. Senate,,DEM,Kamala D. Harris,741
+Orange,13227,U.S. Senate,,DEM,Loretta L. Sanchez,585
+Orange,13228,U.S. Senate,,DEM,Kamala D. Harris,240
+Orange,13228,U.S. Senate,,DEM,Loretta L. Sanchez,225
+Orange,13231,U.S. Senate,,DEM,Kamala D. Harris,192
+Orange,13231,U.S. Senate,,DEM,Loretta L. Sanchez,200
+Orange,13237,U.S. Senate,,DEM,Kamala D. Harris,462
+Orange,13237,U.S. Senate,,DEM,Loretta L. Sanchez,555
+Orange,13241,U.S. Senate,,DEM,Kamala D. Harris,332
+Orange,13241,U.S. Senate,,DEM,Loretta L. Sanchez,388
+Orange,13376,U.S. Senate,,DEM,Kamala D. Harris,271
+Orange,13376,U.S. Senate,,DEM,Loretta L. Sanchez,204
+Orange,13377,U.S. Senate,,DEM,Kamala D. Harris,715
+Orange,13377,U.S. Senate,,DEM,Loretta L. Sanchez,517
+Orange,13379,U.S. Senate,,DEM,Kamala D. Harris,50
+Orange,13379,U.S. Senate,,DEM,Loretta L. Sanchez,62
+Orange,13380,U.S. Senate,,DEM,Kamala D. Harris,1
+Orange,13380,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,13383,U.S. Senate,,DEM,Kamala D. Harris,603
+Orange,13383,U.S. Senate,,DEM,Loretta L. Sanchez,456
+Orange,13391,U.S. Senate,,DEM,Kamala D. Harris,17
+Orange,13391,U.S. Senate,,DEM,Loretta L. Sanchez,37
+Orange,13395,U.S. Senate,,DEM,Kamala D. Harris,289
+Orange,13395,U.S. Senate,,DEM,Loretta L. Sanchez,188
+Orange,13396,U.S. Senate,,DEM,Kamala D. Harris,424
+Orange,13396,U.S. Senate,,DEM,Loretta L. Sanchez,571
+Orange,13398,U.S. Senate,,DEM,Kamala D. Harris,421
+Orange,13398,U.S. Senate,,DEM,Loretta L. Sanchez,492
+Orange,13408,U.S. Senate,,DEM,Kamala D. Harris,114
+Orange,13408,U.S. Senate,,DEM,Loretta L. Sanchez,184
+Orange,13415,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,13415,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,13416,U.S. Senate,,DEM,Kamala D. Harris,109
+Orange,13416,U.S. Senate,,DEM,Loretta L. Sanchez,107
+Orange,13420,U.S. Senate,,DEM,Kamala D. Harris,249
+Orange,13420,U.S. Senate,,DEM,Loretta L. Sanchez,493
+Orange,13425,U.S. Senate,,DEM,Kamala D. Harris,384
+Orange,13425,U.S. Senate,,DEM,Loretta L. Sanchez,558
+Orange,13426,U.S. Senate,,DEM,Kamala D. Harris,192
+Orange,13426,U.S. Senate,,DEM,Loretta L. Sanchez,137
+Orange,13431,U.S. Senate,,DEM,Kamala D. Harris,335
+Orange,13431,U.S. Senate,,DEM,Loretta L. Sanchez,414
+Orange,13432,U.S. Senate,,DEM,Kamala D. Harris,427
+Orange,13432,U.S. Senate,,DEM,Loretta L. Sanchez,310
+Orange,13434,U.S. Senate,,DEM,Kamala D. Harris,62
+Orange,13434,U.S. Senate,,DEM,Loretta L. Sanchez,32
+Orange,13435,U.S. Senate,,DEM,Kamala D. Harris,104
+Orange,13435,U.S. Senate,,DEM,Loretta L. Sanchez,106
+Orange,13441,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,13441,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,13443,U.S. Senate,,DEM,Kamala D. Harris,372
+Orange,13443,U.S. Senate,,DEM,Loretta L. Sanchez,305
+Orange,13445,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,13445,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,13452,U.S. Senate,,DEM,Kamala D. Harris,296
+Orange,13452,U.S. Senate,,DEM,Loretta L. Sanchez,209
+Orange,13461,U.S. Senate,,DEM,Kamala D. Harris,155
+Orange,13461,U.S. Senate,,DEM,Loretta L. Sanchez,107
+Orange,13463,U.S. Senate,,DEM,Kamala D. Harris,401
+Orange,13463,U.S. Senate,,DEM,Loretta L. Sanchez,363
+Orange,13467,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,13467,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,13701,U.S. Senate,,DEM,Kamala D. Harris,528
+Orange,13701,U.S. Senate,,DEM,Loretta L. Sanchez,412
+Orange,14002,U.S. Senate,,DEM,Kamala D. Harris,364
+Orange,14002,U.S. Senate,,DEM,Loretta L. Sanchez,562
+Orange,14005,U.S. Senate,,DEM,Kamala D. Harris,221
+Orange,14005,U.S. Senate,,DEM,Loretta L. Sanchez,294
+Orange,14008,U.S. Senate,,DEM,Kamala D. Harris,240
+Orange,14008,U.S. Senate,,DEM,Loretta L. Sanchez,421
+Orange,14009,U.S. Senate,,DEM,Kamala D. Harris,273
+Orange,14009,U.S. Senate,,DEM,Loretta L. Sanchez,392
+Orange,14012,U.S. Senate,,DEM,Kamala D. Harris,248
+Orange,14012,U.S. Senate,,DEM,Loretta L. Sanchez,338
+Orange,14013,U.S. Senate,,DEM,Kamala D. Harris,170
+Orange,14013,U.S. Senate,,DEM,Loretta L. Sanchez,198
+Orange,14014,U.S. Senate,,DEM,Kamala D. Harris,278
+Orange,14014,U.S. Senate,,DEM,Loretta L. Sanchez,361
+Orange,14015,U.S. Senate,,DEM,Kamala D. Harris,243
+Orange,14015,U.S. Senate,,DEM,Loretta L. Sanchez,335
+Orange,14016,U.S. Senate,,DEM,Kamala D. Harris,306
+Orange,14016,U.S. Senate,,DEM,Loretta L. Sanchez,453
+Orange,14018,U.S. Senate,,DEM,Kamala D. Harris,228
+Orange,14018,U.S. Senate,,DEM,Loretta L. Sanchez,472
+Orange,14020,U.S. Senate,,DEM,Kamala D. Harris,374
+Orange,14020,U.S. Senate,,DEM,Loretta L. Sanchez,523
+Orange,14021,U.S. Senate,,DEM,Kamala D. Harris,154
+Orange,14021,U.S. Senate,,DEM,Loretta L. Sanchez,285
+Orange,14023,U.S. Senate,,DEM,Kamala D. Harris,294
+Orange,14023,U.S. Senate,,DEM,Loretta L. Sanchez,439
+Orange,14026,U.S. Senate,,DEM,Kamala D. Harris,437
+Orange,14026,U.S. Senate,,DEM,Loretta L. Sanchez,505
+Orange,14027,U.S. Senate,,DEM,Kamala D. Harris,215
+Orange,14027,U.S. Senate,,DEM,Loretta L. Sanchez,314
+Orange,14029,U.S. Senate,,DEM,Kamala D. Harris,248
+Orange,14029,U.S. Senate,,DEM,Loretta L. Sanchez,350
+Orange,14031,U.S. Senate,,DEM,Kamala D. Harris,298
+Orange,14031,U.S. Senate,,DEM,Loretta L. Sanchez,491
+Orange,14032,U.S. Senate,,DEM,Kamala D. Harris,316
+Orange,14032,U.S. Senate,,DEM,Loretta L. Sanchez,361
+Orange,14033,U.S. Senate,,DEM,Kamala D. Harris,153
+Orange,14033,U.S. Senate,,DEM,Loretta L. Sanchez,239
+Orange,14034,U.S. Senate,,DEM,Kamala D. Harris,225
+Orange,14034,U.S. Senate,,DEM,Loretta L. Sanchez,329
+Orange,14035,U.S. Senate,,DEM,Kamala D. Harris,314
+Orange,14035,U.S. Senate,,DEM,Loretta L. Sanchez,437
+Orange,14036,U.S. Senate,,DEM,Kamala D. Harris,269
+Orange,14036,U.S. Senate,,DEM,Loretta L. Sanchez,301
+Orange,14037,U.S. Senate,,DEM,Kamala D. Harris,336
+Orange,14037,U.S. Senate,,DEM,Loretta L. Sanchez,451
+Orange,14041,U.S. Senate,,DEM,Kamala D. Harris,158
+Orange,14041,U.S. Senate,,DEM,Loretta L. Sanchez,352
+Orange,14045,U.S. Senate,,DEM,Kamala D. Harris,86
+Orange,14045,U.S. Senate,,DEM,Loretta L. Sanchez,187
+Orange,14046,U.S. Senate,,DEM,Kamala D. Harris,6
+Orange,14046,U.S. Senate,,DEM,Loretta L. Sanchez,8
+Orange,14047,U.S. Senate,,DEM,Kamala D. Harris,222
+Orange,14047,U.S. Senate,,DEM,Loretta L. Sanchez,449
+Orange,14053,U.S. Senate,,DEM,Kamala D. Harris,291
+Orange,14053,U.S. Senate,,DEM,Loretta L. Sanchez,482
+Orange,14058,U.S. Senate,,DEM,Kamala D. Harris,137
+Orange,14058,U.S. Senate,,DEM,Loretta L. Sanchez,201
+Orange,14059,U.S. Senate,,DEM,Kamala D. Harris,202
+Orange,14059,U.S. Senate,,DEM,Loretta L. Sanchez,388
+Orange,14063,U.S. Senate,,DEM,Kamala D. Harris,126
+Orange,14063,U.S. Senate,,DEM,Loretta L. Sanchez,309
+Orange,14065,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,14065,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Orange,14066,U.S. Senate,,DEM,Kamala D. Harris,278
+Orange,14066,U.S. Senate,,DEM,Loretta L. Sanchez,373
+Orange,14069,U.S. Senate,,DEM,Kamala D. Harris,301
+Orange,14069,U.S. Senate,,DEM,Loretta L. Sanchez,529
+Orange,14071,U.S. Senate,,DEM,Kamala D. Harris,124
+Orange,14071,U.S. Senate,,DEM,Loretta L. Sanchez,233
+Orange,14075,U.S. Senate,,DEM,Kamala D. Harris,253
+Orange,14075,U.S. Senate,,DEM,Loretta L. Sanchez,220
+Orange,14078,U.S. Senate,,DEM,Kamala D. Harris,393
+Orange,14078,U.S. Senate,,DEM,Loretta L. Sanchez,339
+Orange,14082,U.S. Senate,,DEM,Kamala D. Harris,292
+Orange,14082,U.S. Senate,,DEM,Loretta L. Sanchez,246
+Orange,14084,U.S. Senate,,DEM,Kamala D. Harris,340
+Orange,14084,U.S. Senate,,DEM,Loretta L. Sanchez,272
+Orange,14085,U.S. Senate,,DEM,Kamala D. Harris,251
+Orange,14085,U.S. Senate,,DEM,Loretta L. Sanchez,206
+Orange,14086,U.S. Senate,,DEM,Kamala D. Harris,389
+Orange,14086,U.S. Senate,,DEM,Loretta L. Sanchez,286
+Orange,14089,U.S. Senate,,DEM,Kamala D. Harris,296
+Orange,14089,U.S. Senate,,DEM,Loretta L. Sanchez,252
+Orange,14090,U.S. Senate,,DEM,Kamala D. Harris,258
+Orange,14090,U.S. Senate,,DEM,Loretta L. Sanchez,199
+Orange,14091,U.S. Senate,,DEM,Kamala D. Harris,235
+Orange,14091,U.S. Senate,,DEM,Loretta L. Sanchez,167
+Orange,14092,U.S. Senate,,DEM,Kamala D. Harris,339
+Orange,14092,U.S. Senate,,DEM,Loretta L. Sanchez,290
+Orange,14218,U.S. Senate,,DEM,Kamala D. Harris,157
+Orange,14218,U.S. Senate,,DEM,Loretta L. Sanchez,257
+Orange,14221,U.S. Senate,,DEM,Kamala D. Harris,220
+Orange,14221,U.S. Senate,,DEM,Loretta L. Sanchez,580
+Orange,14226,U.S. Senate,,DEM,Kamala D. Harris,236
+Orange,14226,U.S. Senate,,DEM,Loretta L. Sanchez,701
+Orange,14228,U.S. Senate,,DEM,Kamala D. Harris,173
+Orange,14228,U.S. Senate,,DEM,Loretta L. Sanchez,262
+Orange,14229,U.S. Senate,,DEM,Kamala D. Harris,267
+Orange,14229,U.S. Senate,,DEM,Loretta L. Sanchez,401
+Orange,14234,U.S. Senate,,DEM,Kamala D. Harris,330
+Orange,14234,U.S. Senate,,DEM,Loretta L. Sanchez,529
+Orange,14235,U.S. Senate,,DEM,Kamala D. Harris,247
+Orange,14235,U.S. Senate,,DEM,Loretta L. Sanchez,395
+Orange,14236,U.S. Senate,,DEM,Kamala D. Harris,369
+Orange,14236,U.S. Senate,,DEM,Loretta L. Sanchez,610
+Orange,14239,U.S. Senate,,DEM,Kamala D. Harris,177
+Orange,14239,U.S. Senate,,DEM,Loretta L. Sanchez,320
+Orange,14241,U.S. Senate,,DEM,Kamala D. Harris,321
+Orange,14241,U.S. Senate,,DEM,Loretta L. Sanchez,540
+Orange,14244,U.S. Senate,,DEM,Kamala D. Harris,171
+Orange,14244,U.S. Senate,,DEM,Loretta L. Sanchez,362
+Orange,14247,U.S. Senate,,DEM,Kamala D. Harris,114
+Orange,14247,U.S. Senate,,DEM,Loretta L. Sanchez,243
+Orange,14249,U.S. Senate,,DEM,Kamala D. Harris,134
+Orange,14249,U.S. Senate,,DEM,Loretta L. Sanchez,270
+Orange,14250,U.S. Senate,,DEM,Kamala D. Harris,200
+Orange,14250,U.S. Senate,,DEM,Loretta L. Sanchez,308
+Orange,14251,U.S. Senate,,DEM,Kamala D. Harris,296
+Orange,14251,U.S. Senate,,DEM,Loretta L. Sanchez,410
+Orange,14252,U.S. Senate,,DEM,Kamala D. Harris,118
+Orange,14252,U.S. Senate,,DEM,Loretta L. Sanchez,258
+Orange,14257,U.S. Senate,,DEM,Kamala D. Harris,187
+Orange,14257,U.S. Senate,,DEM,Loretta L. Sanchez,415
+Orange,14274,U.S. Senate,,DEM,Kamala D. Harris,370
+Orange,14274,U.S. Senate,,DEM,Loretta L. Sanchez,361
+Orange,14275,U.S. Senate,,DEM,Kamala D. Harris,224
+Orange,14275,U.S. Senate,,DEM,Loretta L. Sanchez,370
+Orange,14282,U.S. Senate,,DEM,Kamala D. Harris,70
+Orange,14282,U.S. Senate,,DEM,Loretta L. Sanchez,67
+Orange,14285,U.S. Senate,,DEM,Kamala D. Harris,13
+Orange,14285,U.S. Senate,,DEM,Loretta L. Sanchez,30
+Orange,14291,U.S. Senate,,DEM,Kamala D. Harris,40
+Orange,14291,U.S. Senate,,DEM,Loretta L. Sanchez,41
+Orange,14293,U.S. Senate,,DEM,Kamala D. Harris,97
+Orange,14293,U.S. Senate,,DEM,Loretta L. Sanchez,237
+Orange,14295,U.S. Senate,,DEM,Kamala D. Harris,172
+Orange,14295,U.S. Senate,,DEM,Loretta L. Sanchez,354
+Orange,14298,U.S. Senate,,DEM,Kamala D. Harris,146
+Orange,14298,U.S. Senate,,DEM,Loretta L. Sanchez,248
+Orange,14306,U.S. Senate,,DEM,Kamala D. Harris,198
+Orange,14306,U.S. Senate,,DEM,Loretta L. Sanchez,442
+Orange,14308,U.S. Senate,,DEM,Kamala D. Harris,240
+Orange,14308,U.S. Senate,,DEM,Loretta L. Sanchez,304
+Orange,14316,U.S. Senate,,DEM,Kamala D. Harris,237
+Orange,14316,U.S. Senate,,DEM,Loretta L. Sanchez,268
+Orange,14317,U.S. Senate,,DEM,Kamala D. Harris,259
+Orange,14317,U.S. Senate,,DEM,Loretta L. Sanchez,516
+Orange,14701,U.S. Senate,,DEM,Kamala D. Harris,296
+Orange,14701,U.S. Senate,,DEM,Loretta L. Sanchez,594
+Orange,14702,U.S. Senate,,DEM,Kamala D. Harris,436
+Orange,14702,U.S. Senate,,DEM,Loretta L. Sanchez,811
+Orange,14703,U.S. Senate,,DEM,Kamala D. Harris,276
+Orange,14703,U.S. Senate,,DEM,Loretta L. Sanchez,606
+Orange,14704,U.S. Senate,,DEM,Kamala D. Harris,345
+Orange,14704,U.S. Senate,,DEM,Loretta L. Sanchez,547
+Orange,14705,U.S. Senate,,DEM,Kamala D. Harris,674
+Orange,14705,U.S. Senate,,DEM,Loretta L. Sanchez,561
+Orange,14706,U.S. Senate,,DEM,Kamala D. Harris,369
+Orange,14706,U.S. Senate,,DEM,Loretta L. Sanchez,695
+Orange,16101,U.S. Senate,,DEM,Kamala D. Harris,186
+Orange,16101,U.S. Senate,,DEM,Loretta L. Sanchez,403
+Orange,16106,U.S. Senate,,DEM,Kamala D. Harris,38
+Orange,16106,U.S. Senate,,DEM,Loretta L. Sanchez,64
+Orange,16109,U.S. Senate,,DEM,Kamala D. Harris,25
+Orange,16109,U.S. Senate,,DEM,Loretta L. Sanchez,33
+Orange,17256,U.S. Senate,,DEM,Kamala D. Harris,356
+Orange,17256,U.S. Senate,,DEM,Loretta L. Sanchez,415
+Orange,17258,U.S. Senate,,DEM,Kamala D. Harris,391
+Orange,17258,U.S. Senate,,DEM,Loretta L. Sanchez,595
+Orange,17260,U.S. Senate,,DEM,Kamala D. Harris,359
+Orange,17260,U.S. Senate,,DEM,Loretta L. Sanchez,350
+Orange,17261,U.S. Senate,,DEM,Kamala D. Harris,286
+Orange,17261,U.S. Senate,,DEM,Loretta L. Sanchez,334
+Orange,17263,U.S. Senate,,DEM,Kamala D. Harris,27
+Orange,17263,U.S. Senate,,DEM,Loretta L. Sanchez,20
+Orange,17264,U.S. Senate,,DEM,Kamala D. Harris,299
+Orange,17264,U.S. Senate,,DEM,Loretta L. Sanchez,293
+Orange,17268,U.S. Senate,,DEM,Kamala D. Harris,266
+Orange,17268,U.S. Senate,,DEM,Loretta L. Sanchez,277
+Orange,17269,U.S. Senate,,DEM,Kamala D. Harris,296
+Orange,17269,U.S. Senate,,DEM,Loretta L. Sanchez,200
+Orange,17271,U.S. Senate,,DEM,Kamala D. Harris,308
+Orange,17271,U.S. Senate,,DEM,Loretta L. Sanchez,221
+Orange,17274,U.S. Senate,,DEM,Kamala D. Harris,368
+Orange,17274,U.S. Senate,,DEM,Loretta L. Sanchez,379
+Orange,17278,U.S. Senate,,DEM,Kamala D. Harris,386
+Orange,17278,U.S. Senate,,DEM,Loretta L. Sanchez,321
+Orange,17279,U.S. Senate,,DEM,Kamala D. Harris,383
+Orange,17279,U.S. Senate,,DEM,Loretta L. Sanchez,371
+Orange,17281,U.S. Senate,,DEM,Kamala D. Harris,402
+Orange,17281,U.S. Senate,,DEM,Loretta L. Sanchez,393
+Orange,17282,U.S. Senate,,DEM,Kamala D. Harris,288
+Orange,17282,U.S. Senate,,DEM,Loretta L. Sanchez,436
+Orange,17290,U.S. Senate,,DEM,Kamala D. Harris,367
+Orange,17290,U.S. Senate,,DEM,Loretta L. Sanchez,430
+Orange,17294,U.S. Senate,,DEM,Kamala D. Harris,330
+Orange,17294,U.S. Senate,,DEM,Loretta L. Sanchez,340
+Orange,17335,U.S. Senate,,DEM,Kamala D. Harris,369
+Orange,17335,U.S. Senate,,DEM,Loretta L. Sanchez,294
+Orange,17336,U.S. Senate,,DEM,Kamala D. Harris,333
+Orange,17336,U.S. Senate,,DEM,Loretta L. Sanchez,262
+Orange,17338,U.S. Senate,,DEM,Kamala D. Harris,302
+Orange,17338,U.S. Senate,,DEM,Loretta L. Sanchez,315
+Orange,17340,U.S. Senate,,DEM,Kamala D. Harris,288
+Orange,17340,U.S. Senate,,DEM,Loretta L. Sanchez,221
+Orange,17345,U.S. Senate,,DEM,Kamala D. Harris,269
+Orange,17345,U.S. Senate,,DEM,Loretta L. Sanchez,329
+Orange,17352,U.S. Senate,,DEM,Kamala D. Harris,378
+Orange,17352,U.S. Senate,,DEM,Loretta L. Sanchez,329
+Orange,17355,U.S. Senate,,DEM,Kamala D. Harris,379
+Orange,17355,U.S. Senate,,DEM,Loretta L. Sanchez,318
+Orange,17701,U.S. Senate,,DEM,Kamala D. Harris,525
+Orange,17701,U.S. Senate,,DEM,Loretta L. Sanchez,526
+Orange,17702,U.S. Senate,,DEM,Kamala D. Harris,484
+Orange,17702,U.S. Senate,,DEM,Loretta L. Sanchez,648
+Orange,17703,U.S. Senate,,DEM,Kamala D. Harris,502
+Orange,17703,U.S. Senate,,DEM,Loretta L. Sanchez,430
+Orange,18194,U.S. Senate,,DEM,Kamala D. Harris,29
+Orange,18194,U.S. Senate,,DEM,Loretta L. Sanchez,25
+Orange,18195,U.S. Senate,,DEM,Kamala D. Harris,222
+Orange,18195,U.S. Senate,,DEM,Loretta L. Sanchez,203
+Orange,18196,U.S. Senate,,DEM,Kamala D. Harris,26
+Orange,18196,U.S. Senate,,DEM,Loretta L. Sanchez,29
+Orange,18198,U.S. Senate,,DEM,Kamala D. Harris,11
+Orange,18198,U.S. Senate,,DEM,Loretta L. Sanchez,7
+Orange,21369,U.S. Senate,,DEM,Kamala D. Harris,392
+Orange,21369,U.S. Senate,,DEM,Loretta L. Sanchez,582
+Orange,21375,U.S. Senate,,DEM,Kamala D. Harris,13
+Orange,21375,U.S. Senate,,DEM,Loretta L. Sanchez,23
+Orange,21376,U.S. Senate,,DEM,Kamala D. Harris,249
+Orange,21376,U.S. Senate,,DEM,Loretta L. Sanchez,269
+Orange,21377,U.S. Senate,,DEM,Kamala D. Harris,61
+Orange,21377,U.S. Senate,,DEM,Loretta L. Sanchez,75
+Orange,21380,U.S. Senate,,DEM,Kamala D. Harris,359
+Orange,21380,U.S. Senate,,DEM,Loretta L. Sanchez,570
+Orange,21383,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,21383,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,21402,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,21402,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,22166,U.S. Senate,,DEM,Kamala D. Harris,94
+Orange,22166,U.S. Senate,,DEM,Loretta L. Sanchez,74
+Orange,23169,U.S. Senate,,DEM,Kamala D. Harris,386
+Orange,23169,U.S. Senate,,DEM,Loretta L. Sanchez,356
+Orange,23174,U.S. Senate,,DEM,Kamala D. Harris,222
+Orange,23174,U.S. Senate,,DEM,Loretta L. Sanchez,210
+Orange,23176,U.S. Senate,,DEM,Kamala D. Harris,412
+Orange,23176,U.S. Senate,,DEM,Loretta L. Sanchez,324
+Orange,23180,U.S. Senate,,DEM,Kamala D. Harris,691
+Orange,23180,U.S. Senate,,DEM,Loretta L. Sanchez,509
+Orange,23187,U.S. Senate,,DEM,Kamala D. Harris,352
+Orange,23187,U.S. Senate,,DEM,Loretta L. Sanchez,306
+Orange,23193,U.S. Senate,,DEM,Kamala D. Harris,153
+Orange,23193,U.S. Senate,,DEM,Loretta L. Sanchez,116
+Orange,23196,U.S. Senate,,DEM,Kamala D. Harris,293
+Orange,23196,U.S. Senate,,DEM,Loretta L. Sanchez,271
+Orange,23203,U.S. Senate,,DEM,Kamala D. Harris,386
+Orange,23203,U.S. Senate,,DEM,Loretta L. Sanchez,322
+Orange,23205,U.S. Senate,,DEM,Kamala D. Harris,384
+Orange,23205,U.S. Senate,,DEM,Loretta L. Sanchez,354
+Orange,23206,U.S. Senate,,DEM,Kamala D. Harris,455
+Orange,23206,U.S. Senate,,DEM,Loretta L. Sanchez,567
+Orange,23207,U.S. Senate,,DEM,Kamala D. Harris,694
+Orange,23207,U.S. Senate,,DEM,Loretta L. Sanchez,537
+Orange,23213,U.S. Senate,,DEM,Kamala D. Harris,207
+Orange,23213,U.S. Senate,,DEM,Loretta L. Sanchez,449
+Orange,23217,U.S. Senate,,DEM,Kamala D. Harris,260
+Orange,23217,U.S. Senate,,DEM,Loretta L. Sanchez,355
+Orange,23224,U.S. Senate,,DEM,Kamala D. Harris,54
+Orange,23224,U.S. Senate,,DEM,Loretta L. Sanchez,38
+Orange,23601,U.S. Senate,,DEM,Kamala D. Harris,911
+Orange,23601,U.S. Senate,,DEM,Loretta L. Sanchez,721
+Orange,23602,U.S. Senate,,DEM,Kamala D. Harris,513
+Orange,23602,U.S. Senate,,DEM,Loretta L. Sanchez,425
+Orange,23603,U.S. Senate,,DEM,Kamala D. Harris,463
+Orange,23603,U.S. Senate,,DEM,Loretta L. Sanchez,391
+Orange,23604,U.S. Senate,,DEM,Kamala D. Harris,682
+Orange,23604,U.S. Senate,,DEM,Loretta L. Sanchez,605
+Orange,23605,U.S. Senate,,DEM,Kamala D. Harris,816
+Orange,23605,U.S. Senate,,DEM,Loretta L. Sanchez,696
+Orange,23606,U.S. Senate,,DEM,Kamala D. Harris,548
+Orange,23606,U.S. Senate,,DEM,Loretta L. Sanchez,489
+Orange,23607,U.S. Senate,,DEM,Kamala D. Harris,220
+Orange,23607,U.S. Senate,,DEM,Loretta L. Sanchez,189
+Orange,23608,U.S. Senate,,DEM,Kamala D. Harris,408
+Orange,23608,U.S. Senate,,DEM,Loretta L. Sanchez,366
+Orange,23609,U.S. Senate,,DEM,Kamala D. Harris,110
+Orange,23609,U.S. Senate,,DEM,Loretta L. Sanchez,89
+Orange,23901,U.S. Senate,,DEM,Kamala D. Harris,65
+Orange,23901,U.S. Senate,,DEM,Loretta L. Sanchez,63
+Orange,23902,U.S. Senate,,DEM,Kamala D. Harris,90
+Orange,23902,U.S. Senate,,DEM,Loretta L. Sanchez,60
+Orange,25230,U.S. Senate,,DEM,Kamala D. Harris,596
+Orange,25230,U.S. Senate,,DEM,Loretta L. Sanchez,313
+Orange,25231,U.S. Senate,,DEM,Kamala D. Harris,1003
+Orange,25231,U.S. Senate,,DEM,Loretta L. Sanchez,560
+Orange,25234,U.S. Senate,,DEM,Kamala D. Harris,1304
+Orange,25234,U.S. Senate,,DEM,Loretta L. Sanchez,683
+Orange,25237,U.S. Senate,,DEM,Kamala D. Harris,172
+Orange,25237,U.S. Senate,,DEM,Loretta L. Sanchez,52
+Orange,25282,U.S. Senate,,DEM,Kamala D. Harris,1419
+Orange,25282,U.S. Senate,,DEM,Loretta L. Sanchez,677
+Orange,25371,U.S. Senate,,DEM,Kamala D. Harris,25
+Orange,25371,U.S. Senate,,DEM,Loretta L. Sanchez,13
+Orange,25377,U.S. Senate,,DEM,Kamala D. Harris,63
+Orange,25377,U.S. Senate,,DEM,Loretta L. Sanchez,28
+Orange,25381,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,25381,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,25382,U.S. Senate,,DEM,Kamala D. Harris,320
+Orange,25382,U.S. Senate,,DEM,Loretta L. Sanchez,133
+Orange,25385,U.S. Senate,,DEM,Kamala D. Harris,1469
+Orange,25385,U.S. Senate,,DEM,Loretta L. Sanchez,831
+Orange,25391,U.S. Senate,,DEM,Kamala D. Harris,217
+Orange,25391,U.S. Senate,,DEM,Loretta L. Sanchez,115
+Orange,26193,U.S. Senate,,DEM,Kamala D. Harris,117
+Orange,26193,U.S. Senate,,DEM,Loretta L. Sanchez,117
+Orange,26197,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,26197,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,26198,U.S. Senate,,DEM,Kamala D. Harris,90
+Orange,26198,U.S. Senate,,DEM,Loretta L. Sanchez,82
+Orange,26200,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,26200,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,27112,U.S. Senate,,DEM,Kamala D. Harris,230
+Orange,27112,U.S. Senate,,DEM,Loretta L. Sanchez,372
+Orange,27113,U.S. Senate,,DEM,Kamala D. Harris,247
+Orange,27113,U.S. Senate,,DEM,Loretta L. Sanchez,409
+Orange,27117,U.S. Senate,,DEM,Kamala D. Harris,233
+Orange,27117,U.S. Senate,,DEM,Loretta L. Sanchez,316
+Orange,27140,U.S. Senate,,DEM,Kamala D. Harris,2
+Orange,27140,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Orange,27141,U.S. Senate,,DEM,Kamala D. Harris,17
+Orange,27141,U.S. Senate,,DEM,Loretta L. Sanchez,41
+Orange,27142,U.S. Senate,,DEM,Kamala D. Harris,77
+Orange,27142,U.S. Senate,,DEM,Loretta L. Sanchez,141
+Orange,27143,U.S. Senate,,DEM,Kamala D. Harris,165
+Orange,27143,U.S. Senate,,DEM,Loretta L. Sanchez,290
+Orange,27146,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,27146,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,27155,U.S. Senate,,DEM,Kamala D. Harris,170
+Orange,27155,U.S. Senate,,DEM,Loretta L. Sanchez,230
+Orange,27156,U.S. Senate,,DEM,Kamala D. Harris,274
+Orange,27156,U.S. Senate,,DEM,Loretta L. Sanchez,235
+Orange,27157,U.S. Senate,,DEM,Kamala D. Harris,8
+Orange,27157,U.S. Senate,,DEM,Loretta L. Sanchez,6
+Orange,27159,U.S. Senate,,DEM,Kamala D. Harris,191
+Orange,27159,U.S. Senate,,DEM,Loretta L. Sanchez,273
+Orange,27164,U.S. Senate,,DEM,Kamala D. Harris,16
+Orange,27164,U.S. Senate,,DEM,Loretta L. Sanchez,78
+Orange,27168,U.S. Senate,,DEM,Kamala D. Harris,211
+Orange,27168,U.S. Senate,,DEM,Loretta L. Sanchez,260
+Orange,27601,U.S. Senate,,DEM,Kamala D. Harris,197
+Orange,27601,U.S. Senate,,DEM,Loretta L. Sanchez,445
+Orange,27602,U.S. Senate,,DEM,Kamala D. Harris,356
+Orange,27602,U.S. Senate,,DEM,Loretta L. Sanchez,387
+Orange,27603,U.S. Senate,,DEM,Kamala D. Harris,171
+Orange,27603,U.S. Senate,,DEM,Loretta L. Sanchez,249
+Orange,27604,U.S. Senate,,DEM,Kamala D. Harris,568
+Orange,27604,U.S. Senate,,DEM,Loretta L. Sanchez,667
+Orange,27605,U.S. Senate,,DEM,Kamala D. Harris,323
+Orange,27605,U.S. Senate,,DEM,Loretta L. Sanchez,337
+Orange,27701,U.S. Senate,,DEM,Kamala D. Harris,371
+Orange,27701,U.S. Senate,,DEM,Loretta L. Sanchez,672
+Orange,28200,U.S. Senate,,DEM,Kamala D. Harris,163
+Orange,28200,U.S. Senate,,DEM,Loretta L. Sanchez,111
+Orange,28201,U.S. Senate,,DEM,Kamala D. Harris,215
+Orange,28201,U.S. Senate,,DEM,Loretta L. Sanchez,151
+Orange,28206,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,28206,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,28247,U.S. Senate,,DEM,Kamala D. Harris,201
+Orange,28247,U.S. Senate,,DEM,Loretta L. Sanchez,208
+Orange,28901,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,28901,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,28902,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,28902,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,28903,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,28903,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,29277,U.S. Senate,,DEM,Kamala D. Harris,661
+Orange,29277,U.S. Senate,,DEM,Loretta L. Sanchez,470
+Orange,29278,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,29278,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,29279,U.S. Senate,,DEM,Kamala D. Harris,489
+Orange,29279,U.S. Senate,,DEM,Loretta L. Sanchez,373
+Orange,29280,U.S. Senate,,DEM,Kamala D. Harris,245
+Orange,29280,U.S. Senate,,DEM,Loretta L. Sanchez,230
+Orange,29282,U.S. Senate,,DEM,Kamala D. Harris,375
+Orange,29282,U.S. Senate,,DEM,Loretta L. Sanchez,343
+Orange,29285,U.S. Senate,,DEM,Kamala D. Harris,488
+Orange,29285,U.S. Senate,,DEM,Loretta L. Sanchez,373
+Orange,29286,U.S. Senate,,DEM,Kamala D. Harris,691
+Orange,29286,U.S. Senate,,DEM,Loretta L. Sanchez,655
+Orange,29289,U.S. Senate,,DEM,Kamala D. Harris,6
+Orange,29289,U.S. Senate,,DEM,Loretta L. Sanchez,5
+Orange,29292,U.S. Senate,,DEM,Kamala D. Harris,313
+Orange,29292,U.S. Senate,,DEM,Loretta L. Sanchez,276
+Orange,29293,U.S. Senate,,DEM,Kamala D. Harris,482
+Orange,29293,U.S. Senate,,DEM,Loretta L. Sanchez,469
+Orange,29294,U.S. Senate,,DEM,Kamala D. Harris,342
+Orange,29294,U.S. Senate,,DEM,Loretta L. Sanchez,329
+Orange,29295,U.S. Senate,,DEM,Kamala D. Harris,672
+Orange,29295,U.S. Senate,,DEM,Loretta L. Sanchez,555
+Orange,29297,U.S. Senate,,DEM,Kamala D. Harris,206
+Orange,29297,U.S. Senate,,DEM,Loretta L. Sanchez,256
+Orange,29299,U.S. Senate,,DEM,Kamala D. Harris,574
+Orange,29299,U.S. Senate,,DEM,Loretta L. Sanchez,525
+Orange,29300,U.S. Senate,,DEM,Kamala D. Harris,318
+Orange,29300,U.S. Senate,,DEM,Loretta L. Sanchez,368
+Orange,29302,U.S. Senate,,DEM,Kamala D. Harris,288
+Orange,29302,U.S. Senate,,DEM,Loretta L. Sanchez,259
+Orange,29304,U.S. Senate,,DEM,Kamala D. Harris,648
+Orange,29304,U.S. Senate,,DEM,Loretta L. Sanchez,750
+Orange,29305,U.S. Senate,,DEM,Kamala D. Harris,582
+Orange,29305,U.S. Senate,,DEM,Loretta L. Sanchez,521
+Orange,29308,U.S. Senate,,DEM,Kamala D. Harris,170
+Orange,29308,U.S. Senate,,DEM,Loretta L. Sanchez,158
+Orange,29309,U.S. Senate,,DEM,Kamala D. Harris,402
+Orange,29309,U.S. Senate,,DEM,Loretta L. Sanchez,266
+Orange,29311,U.S. Senate,,DEM,Kamala D. Harris,766
+Orange,29311,U.S. Senate,,DEM,Loretta L. Sanchez,633
+Orange,29313,U.S. Senate,,DEM,Kamala D. Harris,403
+Orange,29313,U.S. Senate,,DEM,Loretta L. Sanchez,332
+Orange,29314,U.S. Senate,,DEM,Kamala D. Harris,598
+Orange,29314,U.S. Senate,,DEM,Loretta L. Sanchez,511
+Orange,29345,U.S. Senate,,DEM,Kamala D. Harris,262
+Orange,29345,U.S. Senate,,DEM,Loretta L. Sanchez,255
+Orange,29346,U.S. Senate,,DEM,Kamala D. Harris,195
+Orange,29346,U.S. Senate,,DEM,Loretta L. Sanchez,174
+Orange,29347,U.S. Senate,,DEM,Kamala D. Harris,224
+Orange,29347,U.S. Senate,,DEM,Loretta L. Sanchez,224
+Orange,29349,U.S. Senate,,DEM,Kamala D. Harris,325
+Orange,29349,U.S. Senate,,DEM,Loretta L. Sanchez,326
+Orange,29354,U.S. Senate,,DEM,Kamala D. Harris,432
+Orange,29354,U.S. Senate,,DEM,Loretta L. Sanchez,299
+Orange,29356,U.S. Senate,,DEM,Kamala D. Harris,202
+Orange,29356,U.S. Senate,,DEM,Loretta L. Sanchez,212
+Orange,29359,U.S. Senate,,DEM,Kamala D. Harris,274
+Orange,29359,U.S. Senate,,DEM,Loretta L. Sanchez,259
+Orange,29360,U.S. Senate,,DEM,Kamala D. Harris,163
+Orange,29360,U.S. Senate,,DEM,Loretta L. Sanchez,128
+Orange,29361,U.S. Senate,,DEM,Kamala D. Harris,114
+Orange,29361,U.S. Senate,,DEM,Loretta L. Sanchez,111
+Orange,29362,U.S. Senate,,DEM,Kamala D. Harris,748
+Orange,29362,U.S. Senate,,DEM,Loretta L. Sanchez,593
+Orange,29363,U.S. Senate,,DEM,Kamala D. Harris,611
+Orange,29363,U.S. Senate,,DEM,Loretta L. Sanchez,545
+Orange,29364,U.S. Senate,,DEM,Kamala D. Harris,354
+Orange,29364,U.S. Senate,,DEM,Loretta L. Sanchez,331
+Orange,29365,U.S. Senate,,DEM,Kamala D. Harris,370
+Orange,29365,U.S. Senate,,DEM,Loretta L. Sanchez,364
+Orange,29368,U.S. Senate,,DEM,Kamala D. Harris,329
+Orange,29368,U.S. Senate,,DEM,Loretta L. Sanchez,266
+Orange,29369,U.S. Senate,,DEM,Kamala D. Harris,715
+Orange,29369,U.S. Senate,,DEM,Loretta L. Sanchez,606
+Orange,29370,U.S. Senate,,DEM,Kamala D. Harris,406
+Orange,29370,U.S. Senate,,DEM,Loretta L. Sanchez,292
+Orange,29901,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,29901,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,29902,U.S. Senate,,DEM,Kamala D. Harris,2
+Orange,29902,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Orange,31001,U.S. Senate,,DEM,Kamala D. Harris,340
+Orange,31001,U.S. Senate,,DEM,Loretta L. Sanchez,255
+Orange,31002,U.S. Senate,,DEM,Kamala D. Harris,681
+Orange,31002,U.S. Senate,,DEM,Loretta L. Sanchez,549
+Orange,31004,U.S. Senate,,DEM,Kamala D. Harris,418
+Orange,31004,U.S. Senate,,DEM,Loretta L. Sanchez,398
+Orange,31005,U.S. Senate,,DEM,Kamala D. Harris,336
+Orange,31005,U.S. Senate,,DEM,Loretta L. Sanchez,258
+Orange,31006,U.S. Senate,,DEM,Kamala D. Harris,191
+Orange,31006,U.S. Senate,,DEM,Loretta L. Sanchez,135
+Orange,31009,U.S. Senate,,DEM,Kamala D. Harris,674
+Orange,31009,U.S. Senate,,DEM,Loretta L. Sanchez,584
+Orange,31010,U.S. Senate,,DEM,Kamala D. Harris,465
+Orange,31010,U.S. Senate,,DEM,Loretta L. Sanchez,585
+Orange,31013,U.S. Senate,,DEM,Kamala D. Harris,269
+Orange,31013,U.S. Senate,,DEM,Loretta L. Sanchez,290
+Orange,31016,U.S. Senate,,DEM,Kamala D. Harris,537
+Orange,31016,U.S. Senate,,DEM,Loretta L. Sanchez,558
+Orange,31017,U.S. Senate,,DEM,Kamala D. Harris,411
+Orange,31017,U.S. Senate,,DEM,Loretta L. Sanchez,323
+Orange,31201,U.S. Senate,,DEM,Kamala D. Harris,333
+Orange,31201,U.S. Senate,,DEM,Loretta L. Sanchez,270
+Orange,31205,U.S. Senate,,DEM,Kamala D. Harris,347
+Orange,31205,U.S. Senate,,DEM,Loretta L. Sanchez,249
+Orange,31210,U.S. Senate,,DEM,Kamala D. Harris,111
+Orange,31210,U.S. Senate,,DEM,Loretta L. Sanchez,128
+Orange,31212,U.S. Senate,,DEM,Kamala D. Harris,241
+Orange,31212,U.S. Senate,,DEM,Loretta L. Sanchez,179
+Orange,31218,U.S. Senate,,DEM,Kamala D. Harris,652
+Orange,31218,U.S. Senate,,DEM,Loretta L. Sanchez,717
+Orange,31221,U.S. Senate,,DEM,Kamala D. Harris,212
+Orange,31221,U.S. Senate,,DEM,Loretta L. Sanchez,179
+Orange,31241,U.S. Senate,,DEM,Kamala D. Harris,340
+Orange,31241,U.S. Senate,,DEM,Loretta L. Sanchez,270
+Orange,31242,U.S. Senate,,DEM,Kamala D. Harris,316
+Orange,31242,U.S. Senate,,DEM,Loretta L. Sanchez,308
+Orange,31245,U.S. Senate,,DEM,Kamala D. Harris,310
+Orange,31245,U.S. Senate,,DEM,Loretta L. Sanchez,247
+Orange,31246,U.S. Senate,,DEM,Kamala D. Harris,314
+Orange,31246,U.S. Senate,,DEM,Loretta L. Sanchez,252
+Orange,31247,U.S. Senate,,DEM,Kamala D. Harris,705
+Orange,31247,U.S. Senate,,DEM,Loretta L. Sanchez,612
+Orange,31601,U.S. Senate,,DEM,Kamala D. Harris,598
+Orange,31601,U.S. Senate,,DEM,Loretta L. Sanchez,461
+Orange,31602,U.S. Senate,,DEM,Kamala D. Harris,563
+Orange,31602,U.S. Senate,,DEM,Loretta L. Sanchez,447
+Orange,31603,U.S. Senate,,DEM,Kamala D. Harris,899
+Orange,31603,U.S. Senate,,DEM,Loretta L. Sanchez,628
+Orange,31604,U.S. Senate,,DEM,Kamala D. Harris,761
+Orange,31604,U.S. Senate,,DEM,Loretta L. Sanchez,570
+Orange,31605,U.S. Senate,,DEM,Kamala D. Harris,597
+Orange,31605,U.S. Senate,,DEM,Loretta L. Sanchez,588
+Orange,31606,U.S. Senate,,DEM,Kamala D. Harris,217
+Orange,31606,U.S. Senate,,DEM,Loretta L. Sanchez,201
+Orange,31607,U.S. Senate,,DEM,Kamala D. Harris,165
+Orange,31607,U.S. Senate,,DEM,Loretta L. Sanchez,149
+Orange,31901,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,31901,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,32101,U.S. Senate,,DEM,Kamala D. Harris,467
+Orange,32101,U.S. Senate,,DEM,Loretta L. Sanchez,378
+Orange,32103,U.S. Senate,,DEM,Kamala D. Harris,565
+Orange,32103,U.S. Senate,,DEM,Loretta L. Sanchez,440
+Orange,32106,U.S. Senate,,DEM,Kamala D. Harris,339
+Orange,32106,U.S. Senate,,DEM,Loretta L. Sanchez,200
+Orange,32109,U.S. Senate,,DEM,Kamala D. Harris,263
+Orange,32109,U.S. Senate,,DEM,Loretta L. Sanchez,219
+Orange,32110,U.S. Senate,,DEM,Kamala D. Harris,413
+Orange,32110,U.S. Senate,,DEM,Loretta L. Sanchez,294
+Orange,32111,U.S. Senate,,DEM,Kamala D. Harris,1
+Orange,32111,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Orange,32112,U.S. Senate,,DEM,Kamala D. Harris,69
+Orange,32112,U.S. Senate,,DEM,Loretta L. Sanchez,78
+Orange,32138,U.S. Senate,,DEM,Kamala D. Harris,305
+Orange,32138,U.S. Senate,,DEM,Loretta L. Sanchez,199
+Orange,32139,U.S. Senate,,DEM,Kamala D. Harris,555
+Orange,32139,U.S. Senate,,DEM,Loretta L. Sanchez,399
+Orange,32140,U.S. Senate,,DEM,Kamala D. Harris,482
+Orange,32140,U.S. Senate,,DEM,Loretta L. Sanchez,331
+Orange,32141,U.S. Senate,,DEM,Kamala D. Harris,403
+Orange,32141,U.S. Senate,,DEM,Loretta L. Sanchez,298
+Orange,32142,U.S. Senate,,DEM,Kamala D. Harris,642
+Orange,32142,U.S. Senate,,DEM,Loretta L. Sanchez,383
+Orange,32143,U.S. Senate,,DEM,Kamala D. Harris,667
+Orange,32143,U.S. Senate,,DEM,Loretta L. Sanchez,413
+Orange,32145,U.S. Senate,,DEM,Kamala D. Harris,381
+Orange,32145,U.S. Senate,,DEM,Loretta L. Sanchez,277
+Orange,32146,U.S. Senate,,DEM,Kamala D. Harris,680
+Orange,32146,U.S. Senate,,DEM,Loretta L. Sanchez,453
+Orange,32150,U.S. Senate,,DEM,Kamala D. Harris,388
+Orange,32150,U.S. Senate,,DEM,Loretta L. Sanchez,258
+Orange,32154,U.S. Senate,,DEM,Kamala D. Harris,308
+Orange,32154,U.S. Senate,,DEM,Loretta L. Sanchez,213
+Orange,32155,U.S. Senate,,DEM,Kamala D. Harris,272
+Orange,32155,U.S. Senate,,DEM,Loretta L. Sanchez,189
+Orange,32160,U.S. Senate,,DEM,Kamala D. Harris,464
+Orange,32160,U.S. Senate,,DEM,Loretta L. Sanchez,341
+Orange,32161,U.S. Senate,,DEM,Kamala D. Harris,397
+Orange,32161,U.S. Senate,,DEM,Loretta L. Sanchez,285
+Orange,32162,U.S. Senate,,DEM,Kamala D. Harris,492
+Orange,32162,U.S. Senate,,DEM,Loretta L. Sanchez,307
+Orange,32163,U.S. Senate,,DEM,Kamala D. Harris,214
+Orange,32163,U.S. Senate,,DEM,Loretta L. Sanchez,155
+Orange,32165,U.S. Senate,,DEM,Kamala D. Harris,230
+Orange,32165,U.S. Senate,,DEM,Loretta L. Sanchez,186
+Orange,32166,U.S. Senate,,DEM,Kamala D. Harris,436
+Orange,32166,U.S. Senate,,DEM,Loretta L. Sanchez,304
+Orange,32171,U.S. Senate,,DEM,Kamala D. Harris,317
+Orange,32171,U.S. Senate,,DEM,Loretta L. Sanchez,314
+Orange,32174,U.S. Senate,,DEM,Kamala D. Harris,409
+Orange,32174,U.S. Senate,,DEM,Loretta L. Sanchez,293
+Orange,32176,U.S. Senate,,DEM,Kamala D. Harris,410
+Orange,32176,U.S. Senate,,DEM,Loretta L. Sanchez,267
+Orange,32178,U.S. Senate,,DEM,Kamala D. Harris,485
+Orange,32178,U.S. Senate,,DEM,Loretta L. Sanchez,392
+Orange,32179,U.S. Senate,,DEM,Kamala D. Harris,365
+Orange,32179,U.S. Senate,,DEM,Loretta L. Sanchez,255
+Orange,32184,U.S. Senate,,DEM,Kamala D. Harris,377
+Orange,32184,U.S. Senate,,DEM,Loretta L. Sanchez,263
+Orange,32188,U.S. Senate,,DEM,Kamala D. Harris,385
+Orange,32188,U.S. Senate,,DEM,Loretta L. Sanchez,278
+Orange,32190,U.S. Senate,,DEM,Kamala D. Harris,643
+Orange,32190,U.S. Senate,,DEM,Loretta L. Sanchez,398
+Orange,32193,U.S. Senate,,DEM,Kamala D. Harris,663
+Orange,32193,U.S. Senate,,DEM,Loretta L. Sanchez,464
+Orange,32195,U.S. Senate,,DEM,Kamala D. Harris,477
+Orange,32195,U.S. Senate,,DEM,Loretta L. Sanchez,308
+Orange,32196,U.S. Senate,,DEM,Kamala D. Harris,546
+Orange,32196,U.S. Senate,,DEM,Loretta L. Sanchez,385
+Orange,32197,U.S. Senate,,DEM,Kamala D. Harris,490
+Orange,32197,U.S. Senate,,DEM,Loretta L. Sanchez,319
+Orange,32198,U.S. Senate,,DEM,Kamala D. Harris,422
+Orange,32198,U.S. Senate,,DEM,Loretta L. Sanchez,335
+Orange,32200,U.S. Senate,,DEM,Kamala D. Harris,427
+Orange,32200,U.S. Senate,,DEM,Loretta L. Sanchez,303
+Orange,32204,U.S. Senate,,DEM,Kamala D. Harris,192
+Orange,32204,U.S. Senate,,DEM,Loretta L. Sanchez,148
+Orange,32205,U.S. Senate,,DEM,Kamala D. Harris,569
+Orange,32205,U.S. Senate,,DEM,Loretta L. Sanchez,394
+Orange,32207,U.S. Senate,,DEM,Kamala D. Harris,439
+Orange,32207,U.S. Senate,,DEM,Loretta L. Sanchez,266
+Orange,32208,U.S. Senate,,DEM,Kamala D. Harris,671
+Orange,32208,U.S. Senate,,DEM,Loretta L. Sanchez,462
+Orange,32210,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,32210,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,32211,U.S. Senate,,DEM,Kamala D. Harris,37
+Orange,32211,U.S. Senate,,DEM,Loretta L. Sanchez,29
+Orange,32212,U.S. Senate,,DEM,Kamala D. Harris,296
+Orange,32212,U.S. Senate,,DEM,Loretta L. Sanchez,158
+Orange,32232,U.S. Senate,,DEM,Kamala D. Harris,555
+Orange,32232,U.S. Senate,,DEM,Loretta L. Sanchez,400
+Orange,32247,U.S. Senate,,DEM,Kamala D. Harris,536
+Orange,32247,U.S. Senate,,DEM,Loretta L. Sanchez,342
+Orange,32265,U.S. Senate,,DEM,Kamala D. Harris,762
+Orange,32265,U.S. Senate,,DEM,Loretta L. Sanchez,548
+Orange,32266,U.S. Senate,,DEM,Kamala D. Harris,301
+Orange,32266,U.S. Senate,,DEM,Loretta L. Sanchez,244
+Orange,32267,U.S. Senate,,DEM,Kamala D. Harris,629
+Orange,32267,U.S. Senate,,DEM,Loretta L. Sanchez,472
+Orange,32269,U.S. Senate,,DEM,Kamala D. Harris,281
+Orange,32269,U.S. Senate,,DEM,Loretta L. Sanchez,191
+Orange,32270,U.S. Senate,,DEM,Kamala D. Harris,652
+Orange,32270,U.S. Senate,,DEM,Loretta L. Sanchez,531
+Orange,32282,U.S. Senate,,DEM,Kamala D. Harris,663
+Orange,32282,U.S. Senate,,DEM,Loretta L. Sanchez,448
+Orange,32283,U.S. Senate,,DEM,Kamala D. Harris,338
+Orange,32283,U.S. Senate,,DEM,Loretta L. Sanchez,231
+Orange,32285,U.S. Senate,,DEM,Kamala D. Harris,248
+Orange,32285,U.S. Senate,,DEM,Loretta L. Sanchez,204
+Orange,32293,U.S. Senate,,DEM,Kamala D. Harris,272
+Orange,32293,U.S. Senate,,DEM,Loretta L. Sanchez,195
+Orange,32295,U.S. Senate,,DEM,Kamala D. Harris,412
+Orange,32295,U.S. Senate,,DEM,Loretta L. Sanchez,257
+Orange,32300,U.S. Senate,,DEM,Kamala D. Harris,95
+Orange,32300,U.S. Senate,,DEM,Loretta L. Sanchez,102
+Orange,32302,U.S. Senate,,DEM,Kamala D. Harris,564
+Orange,32302,U.S. Senate,,DEM,Loretta L. Sanchez,377
+Orange,32303,U.S. Senate,,DEM,Kamala D. Harris,326
+Orange,32303,U.S. Senate,,DEM,Loretta L. Sanchez,238
+Orange,32305,U.S. Senate,,DEM,Kamala D. Harris,627
+Orange,32305,U.S. Senate,,DEM,Loretta L. Sanchez,376
+Orange,32306,U.S. Senate,,DEM,Kamala D. Harris,350
+Orange,32306,U.S. Senate,,DEM,Loretta L. Sanchez,211
+Orange,32307,U.S. Senate,,DEM,Kamala D. Harris,604
+Orange,32307,U.S. Senate,,DEM,Loretta L. Sanchez,439
+Orange,32308,U.S. Senate,,DEM,Kamala D. Harris,656
+Orange,32308,U.S. Senate,,DEM,Loretta L. Sanchez,482
+Orange,32312,U.S. Senate,,DEM,Kamala D. Harris,572
+Orange,32312,U.S. Senate,,DEM,Loretta L. Sanchez,441
+Orange,32320,U.S. Senate,,DEM,Kamala D. Harris,324
+Orange,32320,U.S. Senate,,DEM,Loretta L. Sanchez,218
+Orange,32322,U.S. Senate,,DEM,Kamala D. Harris,405
+Orange,32322,U.S. Senate,,DEM,Loretta L. Sanchez,352
+Orange,32325,U.S. Senate,,DEM,Kamala D. Harris,318
+Orange,32325,U.S. Senate,,DEM,Loretta L. Sanchez,259
+Orange,32329,U.S. Senate,,DEM,Kamala D. Harris,317
+Orange,32329,U.S. Senate,,DEM,Loretta L. Sanchez,213
+Orange,32335,U.S. Senate,,DEM,Kamala D. Harris,374
+Orange,32335,U.S. Senate,,DEM,Loretta L. Sanchez,243
+Orange,32337,U.S. Senate,,DEM,Kamala D. Harris,517
+Orange,32337,U.S. Senate,,DEM,Loretta L. Sanchez,368
+Orange,32338,U.S. Senate,,DEM,Kamala D. Harris,321
+Orange,32338,U.S. Senate,,DEM,Loretta L. Sanchez,183
+Orange,32341,U.S. Senate,,DEM,Kamala D. Harris,240
+Orange,32341,U.S. Senate,,DEM,Loretta L. Sanchez,161
+Orange,32345,U.S. Senate,,DEM,Kamala D. Harris,309
+Orange,32345,U.S. Senate,,DEM,Loretta L. Sanchez,216
+Orange,32347,U.S. Senate,,DEM,Kamala D. Harris,483
+Orange,32347,U.S. Senate,,DEM,Loretta L. Sanchez,349
+Orange,32348,U.S. Senate,,DEM,Kamala D. Harris,261
+Orange,32348,U.S. Senate,,DEM,Loretta L. Sanchez,161
+Orange,32349,U.S. Senate,,DEM,Kamala D. Harris,493
+Orange,32349,U.S. Senate,,DEM,Loretta L. Sanchez,420
+Orange,32355,U.S. Senate,,DEM,Kamala D. Harris,528
+Orange,32355,U.S. Senate,,DEM,Loretta L. Sanchez,438
+Orange,32358,U.S. Senate,,DEM,Kamala D. Harris,421
+Orange,32358,U.S. Senate,,DEM,Loretta L. Sanchez,233
+Orange,32361,U.S. Senate,,DEM,Kamala D. Harris,395
+Orange,32361,U.S. Senate,,DEM,Loretta L. Sanchez,216
+Orange,32362,U.S. Senate,,DEM,Kamala D. Harris,72
+Orange,32362,U.S. Senate,,DEM,Loretta L. Sanchez,50
+Orange,32365,U.S. Senate,,DEM,Kamala D. Harris,423
+Orange,32365,U.S. Senate,,DEM,Loretta L. Sanchez,287
+Orange,32370,U.S. Senate,,DEM,Kamala D. Harris,264
+Orange,32370,U.S. Senate,,DEM,Loretta L. Sanchez,441
+Orange,32371,U.S. Senate,,DEM,Kamala D. Harris,468
+Orange,32371,U.S. Senate,,DEM,Loretta L. Sanchez,352
+Orange,32375,U.S. Senate,,DEM,Kamala D. Harris,333
+Orange,32375,U.S. Senate,,DEM,Loretta L. Sanchez,278
+Orange,32376,U.S. Senate,,DEM,Kamala D. Harris,551
+Orange,32376,U.S. Senate,,DEM,Loretta L. Sanchez,358
+Orange,32379,U.S. Senate,,DEM,Kamala D. Harris,282
+Orange,32379,U.S. Senate,,DEM,Loretta L. Sanchez,183
+Orange,32381,U.S. Senate,,DEM,Kamala D. Harris,248
+Orange,32381,U.S. Senate,,DEM,Loretta L. Sanchez,142
+Orange,32383,U.S. Senate,,DEM,Kamala D. Harris,412
+Orange,32383,U.S. Senate,,DEM,Loretta L. Sanchez,241
+Orange,32393,U.S. Senate,,DEM,Kamala D. Harris,379
+Orange,32393,U.S. Senate,,DEM,Loretta L. Sanchez,222
+Orange,32395,U.S. Senate,,DEM,Kamala D. Harris,484
+Orange,32395,U.S. Senate,,DEM,Loretta L. Sanchez,380
+Orange,32397,U.S. Senate,,DEM,Kamala D. Harris,560
+Orange,32397,U.S. Senate,,DEM,Loretta L. Sanchez,493
+Orange,32401,U.S. Senate,,DEM,Kamala D. Harris,328
+Orange,32401,U.S. Senate,,DEM,Loretta L. Sanchez,206
+Orange,32408,U.S. Senate,,DEM,Kamala D. Harris,427
+Orange,32408,U.S. Senate,,DEM,Loretta L. Sanchez,270
+Orange,32412,U.S. Senate,,DEM,Kamala D. Harris,405
+Orange,32412,U.S. Senate,,DEM,Loretta L. Sanchez,270
+Orange,32413,U.S. Senate,,DEM,Kamala D. Harris,345
+Orange,32413,U.S. Senate,,DEM,Loretta L. Sanchez,256
+Orange,32416,U.S. Senate,,DEM,Kamala D. Harris,302
+Orange,32416,U.S. Senate,,DEM,Loretta L. Sanchez,201
+Orange,32601,U.S. Senate,,DEM,Kamala D. Harris,559
+Orange,32601,U.S. Senate,,DEM,Loretta L. Sanchez,433
+Orange,32602,U.S. Senate,,DEM,Kamala D. Harris,519
+Orange,32602,U.S. Senate,,DEM,Loretta L. Sanchez,351
+Orange,32603,U.S. Senate,,DEM,Kamala D. Harris,993
+Orange,32603,U.S. Senate,,DEM,Loretta L. Sanchez,599
+Orange,32604,U.S. Senate,,DEM,Kamala D. Harris,364
+Orange,32604,U.S. Senate,,DEM,Loretta L. Sanchez,248
+Orange,32605,U.S. Senate,,DEM,Kamala D. Harris,272
+Orange,32605,U.S. Senate,,DEM,Loretta L. Sanchez,170
+Orange,32606,U.S. Senate,,DEM,Kamala D. Harris,224
+Orange,32606,U.S. Senate,,DEM,Loretta L. Sanchez,112
+Orange,32607,U.S. Senate,,DEM,Kamala D. Harris,393
+Orange,32607,U.S. Senate,,DEM,Loretta L. Sanchez,280
+Orange,32608,U.S. Senate,,DEM,Kamala D. Harris,375
+Orange,32608,U.S. Senate,,DEM,Loretta L. Sanchez,257
+Orange,32609,U.S. Senate,,DEM,Kamala D. Harris,562
+Orange,32609,U.S. Senate,,DEM,Loretta L. Sanchez,426
+Orange,32610,U.S. Senate,,DEM,Kamala D. Harris,384
+Orange,32610,U.S. Senate,,DEM,Loretta L. Sanchez,291
+Orange,32611,U.S. Senate,,DEM,Kamala D. Harris,623
+Orange,32611,U.S. Senate,,DEM,Loretta L. Sanchez,445
+Orange,32612,U.S. Senate,,DEM,Kamala D. Harris,769
+Orange,32612,U.S. Senate,,DEM,Loretta L. Sanchez,597
+Orange,32614,U.S. Senate,,DEM,Kamala D. Harris,550
+Orange,32614,U.S. Senate,,DEM,Loretta L. Sanchez,445
+Orange,32701,U.S. Senate,,DEM,Kamala D. Harris,657
+Orange,32701,U.S. Senate,,DEM,Loretta L. Sanchez,443
+Orange,33117,U.S. Senate,,DEM,Kamala D. Harris,375
+Orange,33117,U.S. Senate,,DEM,Loretta L. Sanchez,283
+Orange,33118,U.S. Senate,,DEM,Kamala D. Harris,324
+Orange,33118,U.S. Senate,,DEM,Loretta L. Sanchez,226
+Orange,33121,U.S. Senate,,DEM,Kamala D. Harris,299
+Orange,33121,U.S. Senate,,DEM,Loretta L. Sanchez,243
+Orange,33122,U.S. Senate,,DEM,Kamala D. Harris,360
+Orange,33122,U.S. Senate,,DEM,Loretta L. Sanchez,214
+Orange,33123,U.S. Senate,,DEM,Kamala D. Harris,349
+Orange,33123,U.S. Senate,,DEM,Loretta L. Sanchez,290
+Orange,33124,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,33124,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,33126,U.S. Senate,,DEM,Kamala D. Harris,389
+Orange,33126,U.S. Senate,,DEM,Loretta L. Sanchez,264
+Orange,33128,U.S. Senate,,DEM,Kamala D. Harris,427
+Orange,33128,U.S. Senate,,DEM,Loretta L. Sanchez,237
+Orange,33130,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,33130,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,33134,U.S. Senate,,DEM,Kamala D. Harris,66
+Orange,33134,U.S. Senate,,DEM,Loretta L. Sanchez,40
+Orange,34092,U.S. Senate,,DEM,Kamala D. Harris,75
+Orange,34092,U.S. Senate,,DEM,Loretta L. Sanchez,91
+Orange,34093,U.S. Senate,,DEM,Kamala D. Harris,119
+Orange,34093,U.S. Senate,,DEM,Loretta L. Sanchez,226
+Orange,34095,U.S. Senate,,DEM,Kamala D. Harris,86
+Orange,34095,U.S. Senate,,DEM,Loretta L. Sanchez,104
+Orange,34097,U.S. Senate,,DEM,Kamala D. Harris,141
+Orange,34097,U.S. Senate,,DEM,Loretta L. Sanchez,274
+Orange,34098,U.S. Senate,,DEM,Kamala D. Harris,116
+Orange,34098,U.S. Senate,,DEM,Loretta L. Sanchez,107
+Orange,34337,U.S. Senate,,DEM,Kamala D. Harris,287
+Orange,34337,U.S. Senate,,DEM,Loretta L. Sanchez,507
+Orange,35125,U.S. Senate,,DEM,Kamala D. Harris,409
+Orange,35125,U.S. Senate,,DEM,Loretta L. Sanchez,281
+Orange,35126,U.S. Senate,,DEM,Kamala D. Harris,365
+Orange,35126,U.S. Senate,,DEM,Loretta L. Sanchez,255
+Orange,35127,U.S. Senate,,DEM,Kamala D. Harris,305
+Orange,35127,U.S. Senate,,DEM,Loretta L. Sanchez,241
+Orange,35129,U.S. Senate,,DEM,Kamala D. Harris,273
+Orange,35129,U.S. Senate,,DEM,Loretta L. Sanchez,165
+Orange,35134,U.S. Senate,,DEM,Kamala D. Harris,421
+Orange,35134,U.S. Senate,,DEM,Loretta L. Sanchez,222
+Orange,35135,U.S. Senate,,DEM,Kamala D. Harris,327
+Orange,35135,U.S. Senate,,DEM,Loretta L. Sanchez,262
+Orange,35137,U.S. Senate,,DEM,Kamala D. Harris,426
+Orange,35137,U.S. Senate,,DEM,Loretta L. Sanchez,266
+Orange,35140,U.S. Senate,,DEM,Kamala D. Harris,397
+Orange,35140,U.S. Senate,,DEM,Loretta L. Sanchez,235
+Orange,35146,U.S. Senate,,DEM,Kamala D. Harris,272
+Orange,35146,U.S. Senate,,DEM,Loretta L. Sanchez,171
+Orange,36001,U.S. Senate,,DEM,Kamala D. Harris,172
+Orange,36001,U.S. Senate,,DEM,Loretta L. Sanchez,101
+Orange,36003,U.S. Senate,,DEM,Kamala D. Harris,236
+Orange,36003,U.S. Senate,,DEM,Loretta L. Sanchez,130
+Orange,36004,U.S. Senate,,DEM,Kamala D. Harris,474
+Orange,36004,U.S. Senate,,DEM,Loretta L. Sanchez,260
+Orange,36008,U.S. Senate,,DEM,Kamala D. Harris,450
+Orange,36008,U.S. Senate,,DEM,Loretta L. Sanchez,284
+Orange,36011,U.S. Senate,,DEM,Kamala D. Harris,465
+Orange,36011,U.S. Senate,,DEM,Loretta L. Sanchez,265
+Orange,36105,U.S. Senate,,DEM,Kamala D. Harris,258
+Orange,36105,U.S. Senate,,DEM,Loretta L. Sanchez,190
+Orange,36258,U.S. Senate,,DEM,Kamala D. Harris,392
+Orange,36258,U.S. Senate,,DEM,Loretta L. Sanchez,254
+Orange,36264,U.S. Senate,,DEM,Kamala D. Harris,382
+Orange,36264,U.S. Senate,,DEM,Loretta L. Sanchez,202
+Orange,36266,U.S. Senate,,DEM,Kamala D. Harris,387
+Orange,36266,U.S. Senate,,DEM,Loretta L. Sanchez,221
+Orange,36267,U.S. Senate,,DEM,Kamala D. Harris,393
+Orange,36267,U.S. Senate,,DEM,Loretta L. Sanchez,247
+Orange,36268,U.S. Senate,,DEM,Kamala D. Harris,358
+Orange,36268,U.S. Senate,,DEM,Loretta L. Sanchez,236
+Orange,36272,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,36272,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,36279,U.S. Senate,,DEM,Kamala D. Harris,248
+Orange,36279,U.S. Senate,,DEM,Loretta L. Sanchez,147
+Orange,36315,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,36315,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,36316,U.S. Senate,,DEM,Kamala D. Harris,340
+Orange,36316,U.S. Senate,,DEM,Loretta L. Sanchez,245
+Orange,36317,U.S. Senate,,DEM,Kamala D. Harris,243
+Orange,36317,U.S. Senate,,DEM,Loretta L. Sanchez,106
+Orange,36318,U.S. Senate,,DEM,Kamala D. Harris,471
+Orange,36318,U.S. Senate,,DEM,Loretta L. Sanchez,275
+Orange,36327,U.S. Senate,,DEM,Kamala D. Harris,303
+Orange,36327,U.S. Senate,,DEM,Loretta L. Sanchez,163
+Orange,36329,U.S. Senate,,DEM,Kamala D. Harris,377
+Orange,36329,U.S. Senate,,DEM,Loretta L. Sanchez,225
+Orange,36331,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,36331,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,36334,U.S. Senate,,DEM,Kamala D. Harris,253
+Orange,36334,U.S. Senate,,DEM,Loretta L. Sanchez,158
+Orange,36339,U.S. Senate,,DEM,Kamala D. Harris,345
+Orange,36339,U.S. Senate,,DEM,Loretta L. Sanchez,173
+Orange,36340,U.S. Senate,,DEM,Kamala D. Harris,293
+Orange,36340,U.S. Senate,,DEM,Loretta L. Sanchez,143
+Orange,36601,U.S. Senate,,DEM,Kamala D. Harris,116
+Orange,36601,U.S. Senate,,DEM,Loretta L. Sanchez,108
+Orange,36701,U.S. Senate,,DEM,Kamala D. Harris,1023
+Orange,36701,U.S. Senate,,DEM,Loretta L. Sanchez,616
+Orange,36901,U.S. Senate,,DEM,Kamala D. Harris,3
+Orange,36901,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Orange,36902,U.S. Senate,,DEM,Kamala D. Harris,3
+Orange,36902,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,37202,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,37202,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,37203,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,37203,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,38084,U.S. Senate,,DEM,Kamala D. Harris,227
+Orange,38084,U.S. Senate,,DEM,Loretta L. Sanchez,185
+Orange,38091,U.S. Senate,,DEM,Kamala D. Harris,171
+Orange,38091,U.S. Senate,,DEM,Loretta L. Sanchez,143
+Orange,38104,U.S. Senate,,DEM,Kamala D. Harris,396
+Orange,38104,U.S. Senate,,DEM,Loretta L. Sanchez,307
+Orange,38236,U.S. Senate,,DEM,Kamala D. Harris,238
+Orange,38236,U.S. Senate,,DEM,Loretta L. Sanchez,173
+Orange,38292,U.S. Senate,,DEM,Kamala D. Harris,58
+Orange,38292,U.S. Senate,,DEM,Loretta L. Sanchez,80
+Orange,38293,U.S. Senate,,DEM,Kamala D. Harris,479
+Orange,38293,U.S. Senate,,DEM,Loretta L. Sanchez,313
+Orange,38301,U.S. Senate,,DEM,Kamala D. Harris,153
+Orange,38301,U.S. Senate,,DEM,Loretta L. Sanchez,118
+Orange,38302,U.S. Senate,,DEM,Kamala D. Harris,398
+Orange,38302,U.S. Senate,,DEM,Loretta L. Sanchez,294
+Orange,38304,U.S. Senate,,DEM,Kamala D. Harris,311
+Orange,38304,U.S. Senate,,DEM,Loretta L. Sanchez,240
+Orange,38305,U.S. Senate,,DEM,Kamala D. Harris,357
+Orange,38305,U.S. Senate,,DEM,Loretta L. Sanchez,248
+Orange,38310,U.S. Senate,,DEM,Kamala D. Harris,246
+Orange,38310,U.S. Senate,,DEM,Loretta L. Sanchez,213
+Orange,38311,U.S. Senate,,DEM,Kamala D. Harris,431
+Orange,38311,U.S. Senate,,DEM,Loretta L. Sanchez,276
+Orange,38312,U.S. Senate,,DEM,Kamala D. Harris,478
+Orange,38312,U.S. Senate,,DEM,Loretta L. Sanchez,329
+Orange,38313,U.S. Senate,,DEM,Kamala D. Harris,363
+Orange,38313,U.S. Senate,,DEM,Loretta L. Sanchez,278
+Orange,38314,U.S. Senate,,DEM,Kamala D. Harris,319
+Orange,38314,U.S. Senate,,DEM,Loretta L. Sanchez,250
+Orange,38375,U.S. Senate,,DEM,Kamala D. Harris,239
+Orange,38375,U.S. Senate,,DEM,Loretta L. Sanchez,190
+Orange,38376,U.S. Senate,,DEM,Kamala D. Harris,286
+Orange,38376,U.S. Senate,,DEM,Loretta L. Sanchez,179
+Orange,38601,U.S. Senate,,DEM,Kamala D. Harris,338
+Orange,38601,U.S. Senate,,DEM,Loretta L. Sanchez,231
+Orange,38602,U.S. Senate,,DEM,Kamala D. Harris,371
+Orange,38602,U.S. Senate,,DEM,Loretta L. Sanchez,275
+Orange,38701,U.S. Senate,,DEM,Kamala D. Harris,538
+Orange,38701,U.S. Senate,,DEM,Loretta L. Sanchez,450
+Orange,38702,U.S. Senate,,DEM,Kamala D. Harris,596
+Orange,38702,U.S. Senate,,DEM,Loretta L. Sanchez,401
+Orange,39201,U.S. Senate,,DEM,Kamala D. Harris,525
+Orange,39201,U.S. Senate,,DEM,Loretta L. Sanchez,807
+Orange,39204,U.S. Senate,,DEM,Kamala D. Harris,588
+Orange,39204,U.S. Senate,,DEM,Loretta L. Sanchez,655
+Orange,39206,U.S. Senate,,DEM,Kamala D. Harris,240
+Orange,39206,U.S. Senate,,DEM,Loretta L. Sanchez,455
+Orange,39208,U.S. Senate,,DEM,Kamala D. Harris,484
+Orange,39208,U.S. Senate,,DEM,Loretta L. Sanchez,703
+Orange,39214,U.S. Senate,,DEM,Kamala D. Harris,339
+Orange,39214,U.S. Senate,,DEM,Loretta L. Sanchez,415
+Orange,39217,U.S. Senate,,DEM,Kamala D. Harris,576
+Orange,39217,U.S. Senate,,DEM,Loretta L. Sanchez,414
+Orange,39219,U.S. Senate,,DEM,Kamala D. Harris,303
+Orange,39219,U.S. Senate,,DEM,Loretta L. Sanchez,528
+Orange,39220,U.S. Senate,,DEM,Kamala D. Harris,261
+Orange,39220,U.S. Senate,,DEM,Loretta L. Sanchez,337
+Orange,39221,U.S. Senate,,DEM,Kamala D. Harris,573
+Orange,39221,U.S. Senate,,DEM,Loretta L. Sanchez,495
+Orange,39222,U.S. Senate,,DEM,Kamala D. Harris,323
+Orange,39222,U.S. Senate,,DEM,Loretta L. Sanchez,494
+Orange,39223,U.S. Senate,,DEM,Kamala D. Harris,546
+Orange,39223,U.S. Senate,,DEM,Loretta L. Sanchez,943
+Orange,39234,U.S. Senate,,DEM,Kamala D. Harris,210
+Orange,39234,U.S. Senate,,DEM,Loretta L. Sanchez,402
+Orange,39237,U.S. Senate,,DEM,Kamala D. Harris,228
+Orange,39237,U.S. Senate,,DEM,Loretta L. Sanchez,474
+Orange,39239,U.S. Senate,,DEM,Kamala D. Harris,287
+Orange,39239,U.S. Senate,,DEM,Loretta L. Sanchez,518
+Orange,39244,U.S. Senate,,DEM,Kamala D. Harris,121
+Orange,39244,U.S. Senate,,DEM,Loretta L. Sanchez,131
+Orange,39274,U.S. Senate,,DEM,Kamala D. Harris,85
+Orange,39274,U.S. Senate,,DEM,Loretta L. Sanchez,123
+Orange,39275,U.S. Senate,,DEM,Kamala D. Harris,515
+Orange,39275,U.S. Senate,,DEM,Loretta L. Sanchez,595
+Orange,39315,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,39315,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,39341,U.S. Senate,,DEM,Kamala D. Harris,176
+Orange,39341,U.S. Senate,,DEM,Loretta L. Sanchez,316
+Orange,39344,U.S. Senate,,DEM,Kamala D. Harris,369
+Orange,39344,U.S. Senate,,DEM,Loretta L. Sanchez,834
+Orange,39346,U.S. Senate,,DEM,Kamala D. Harris,191
+Orange,39346,U.S. Senate,,DEM,Loretta L. Sanchez,162
+Orange,39350,U.S. Senate,,DEM,Kamala D. Harris,482
+Orange,39350,U.S. Senate,,DEM,Loretta L. Sanchez,493
+Orange,39364,U.S. Senate,,DEM,Kamala D. Harris,599
+Orange,39364,U.S. Senate,,DEM,Loretta L. Sanchez,625
+Orange,39369,U.S. Senate,,DEM,Kamala D. Harris,483
+Orange,39369,U.S. Senate,,DEM,Loretta L. Sanchez,681
+Orange,39375,U.S. Senate,,DEM,Kamala D. Harris,933
+Orange,39375,U.S. Senate,,DEM,Loretta L. Sanchez,669
+Orange,39376,U.S. Senate,,DEM,Kamala D. Harris,316
+Orange,39376,U.S. Senate,,DEM,Loretta L. Sanchez,525
+Orange,39378,U.S. Senate,,DEM,Kamala D. Harris,489
+Orange,39378,U.S. Senate,,DEM,Loretta L. Sanchez,749
+Orange,39601,U.S. Senate,,DEM,Kamala D. Harris,528
+Orange,39601,U.S. Senate,,DEM,Loretta L. Sanchez,724
+Orange,39602,U.S. Senate,,DEM,Kamala D. Harris,270
+Orange,39602,U.S. Senate,,DEM,Loretta L. Sanchez,584
+Orange,39603,U.S. Senate,,DEM,Kamala D. Harris,352
+Orange,39603,U.S. Senate,,DEM,Loretta L. Sanchez,491
+Orange,39604,U.S. Senate,,DEM,Kamala D. Harris,274
+Orange,39604,U.S. Senate,,DEM,Loretta L. Sanchez,593
+Orange,39901,U.S. Senate,,DEM,Kamala D. Harris,46
+Orange,39901,U.S. Senate,,DEM,Loretta L. Sanchez,118
+Orange,39902,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,39902,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,39903,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,39903,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,40601,U.S. Senate,,DEM,Kamala D. Harris,1
+Orange,40601,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,40602,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,40602,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,40603,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,40603,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,41100,U.S. Senate,,DEM,Kamala D. Harris,283
+Orange,41100,U.S. Senate,,DEM,Loretta L. Sanchez,156
+Orange,41121,U.S. Senate,,DEM,Kamala D. Harris,411
+Orange,41121,U.S. Senate,,DEM,Loretta L. Sanchez,303
+Orange,41123,U.S. Senate,,DEM,Kamala D. Harris,311
+Orange,41123,U.S. Senate,,DEM,Loretta L. Sanchez,220
+Orange,41124,U.S. Senate,,DEM,Kamala D. Harris,302
+Orange,41124,U.S. Senate,,DEM,Loretta L. Sanchez,251
+Orange,41155,U.S. Senate,,DEM,Kamala D. Harris,266
+Orange,41155,U.S. Senate,,DEM,Loretta L. Sanchez,212
+Orange,41156,U.S. Senate,,DEM,Kamala D. Harris,214
+Orange,41156,U.S. Senate,,DEM,Loretta L. Sanchez,191
+Orange,41161,U.S. Senate,,DEM,Kamala D. Harris,327
+Orange,41161,U.S. Senate,,DEM,Loretta L. Sanchez,225
+Orange,41162,U.S. Senate,,DEM,Kamala D. Harris,256
+Orange,41162,U.S. Senate,,DEM,Loretta L. Sanchez,185
+Orange,41169,U.S. Senate,,DEM,Kamala D. Harris,201
+Orange,41169,U.S. Senate,,DEM,Loretta L. Sanchez,135
+Orange,41224,U.S. Senate,,DEM,Kamala D. Harris,234
+Orange,41224,U.S. Senate,,DEM,Loretta L. Sanchez,149
+Orange,41291,U.S. Senate,,DEM,Kamala D. Harris,415
+Orange,41291,U.S. Senate,,DEM,Loretta L. Sanchez,304
+Orange,41292,U.S. Senate,,DEM,Kamala D. Harris,373
+Orange,41292,U.S. Senate,,DEM,Loretta L. Sanchez,280
+Orange,41293,U.S. Senate,,DEM,Kamala D. Harris,374
+Orange,41293,U.S. Senate,,DEM,Loretta L. Sanchez,193
+Orange,41298,U.S. Senate,,DEM,Kamala D. Harris,367
+Orange,41298,U.S. Senate,,DEM,Loretta L. Sanchez,232
+Orange,41300,U.S. Senate,,DEM,Kamala D. Harris,252
+Orange,41300,U.S. Senate,,DEM,Loretta L. Sanchez,199
+Orange,41301,U.S. Senate,,DEM,Kamala D. Harris,350
+Orange,41301,U.S. Senate,,DEM,Loretta L. Sanchez,195
+Orange,41601,U.S. Senate,,DEM,Kamala D. Harris,679
+Orange,41601,U.S. Senate,,DEM,Loretta L. Sanchez,446
+Orange,41602,U.S. Senate,,DEM,Kamala D. Harris,592
+Orange,41602,U.S. Senate,,DEM,Loretta L. Sanchez,489
+Orange,41603,U.S. Senate,,DEM,Kamala D. Harris,156
+Orange,41603,U.S. Senate,,DEM,Loretta L. Sanchez,121
+Orange,41604,U.S. Senate,,DEM,Kamala D. Harris,153
+Orange,41604,U.S. Senate,,DEM,Loretta L. Sanchez,82
+Orange,41701,U.S. Senate,,DEM,Kamala D. Harris,425
+Orange,41701,U.S. Senate,,DEM,Loretta L. Sanchez,274
+Orange,41702,U.S. Senate,,DEM,Kamala D. Harris,446
+Orange,41702,U.S. Senate,,DEM,Loretta L. Sanchez,328
+Orange,41703,U.S. Senate,,DEM,Kamala D. Harris,447
+Orange,41703,U.S. Senate,,DEM,Loretta L. Sanchez,307
+Orange,41704,U.S. Senate,,DEM,Kamala D. Harris,669
+Orange,41704,U.S. Senate,,DEM,Loretta L. Sanchez,554
+Orange,41901,U.S. Senate,,DEM,Kamala D. Harris,2
+Orange,41901,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,42101,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,42101,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,42110,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,42110,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,43125,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,43125,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,43601,U.S. Senate,,DEM,Kamala D. Harris,295
+Orange,43601,U.S. Senate,,DEM,Loretta L. Sanchez,281
+Orange,43901,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,43901,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,44111,U.S. Senate,,DEM,Kamala D. Harris,298
+Orange,44111,U.S. Senate,,DEM,Loretta L. Sanchez,142
+Orange,44112,U.S. Senate,,DEM,Kamala D. Harris,244
+Orange,44112,U.S. Senate,,DEM,Loretta L. Sanchez,131
+Orange,44113,U.S. Senate,,DEM,Kamala D. Harris,335
+Orange,44113,U.S. Senate,,DEM,Loretta L. Sanchez,259
+Orange,44114,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,44114,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,44116,U.S. Senate,,DEM,Kamala D. Harris,299
+Orange,44116,U.S. Senate,,DEM,Loretta L. Sanchez,173
+Orange,44123,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,44123,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Orange,44124,U.S. Senate,,DEM,Kamala D. Harris,372
+Orange,44124,U.S. Senate,,DEM,Loretta L. Sanchez,196
+Orange,44126,U.S. Senate,,DEM,Kamala D. Harris,337
+Orange,44126,U.S. Senate,,DEM,Loretta L. Sanchez,199
+Orange,44128,U.S. Senate,,DEM,Kamala D. Harris,348
+Orange,44128,U.S. Senate,,DEM,Loretta L. Sanchez,246
+Orange,44130,U.S. Senate,,DEM,Kamala D. Harris,470
+Orange,44130,U.S. Senate,,DEM,Loretta L. Sanchez,203
+Orange,44131,U.S. Senate,,DEM,Kamala D. Harris,444
+Orange,44131,U.S. Senate,,DEM,Loretta L. Sanchez,251
+Orange,44135,U.S. Senate,,DEM,Kamala D. Harris,291
+Orange,44135,U.S. Senate,,DEM,Loretta L. Sanchez,159
+Orange,44136,U.S. Senate,,DEM,Kamala D. Harris,325
+Orange,44136,U.S. Senate,,DEM,Loretta L. Sanchez,164
+Orange,44139,U.S. Senate,,DEM,Kamala D. Harris,384
+Orange,44139,U.S. Senate,,DEM,Loretta L. Sanchez,163
+Orange,44142,U.S. Senate,,DEM,Kamala D. Harris,435
+Orange,44142,U.S. Senate,,DEM,Loretta L. Sanchez,222
+Orange,44150,U.S. Senate,,DEM,Kamala D. Harris,340
+Orange,44150,U.S. Senate,,DEM,Loretta L. Sanchez,149
+Orange,44321,U.S. Senate,,DEM,Kamala D. Harris,171
+Orange,44321,U.S. Senate,,DEM,Loretta L. Sanchez,74
+Orange,44601,U.S. Senate,,DEM,Kamala D. Harris,597
+Orange,44601,U.S. Senate,,DEM,Loretta L. Sanchez,312
+Orange,44701,U.S. Senate,,DEM,Kamala D. Harris,754
+Orange,44701,U.S. Senate,,DEM,Loretta L. Sanchez,307
+Orange,44702,U.S. Senate,,DEM,Kamala D. Harris,973
+Orange,44702,U.S. Senate,,DEM,Loretta L. Sanchez,400
+Orange,44703,U.S. Senate,,DEM,Kamala D. Harris,666
+Orange,44703,U.S. Senate,,DEM,Loretta L. Sanchez,311
+Orange,44901,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,44901,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,45102,U.S. Senate,,DEM,Kamala D. Harris,288
+Orange,45102,U.S. Senate,,DEM,Loretta L. Sanchez,177
+Orange,45103,U.S. Senate,,DEM,Kamala D. Harris,347
+Orange,45103,U.S. Senate,,DEM,Loretta L. Sanchez,188
+Orange,45104,U.S. Senate,,DEM,Kamala D. Harris,404
+Orange,45104,U.S. Senate,,DEM,Loretta L. Sanchez,239
+Orange,45105,U.S. Senate,,DEM,Kamala D. Harris,590
+Orange,45105,U.S. Senate,,DEM,Loretta L. Sanchez,364
+Orange,45109,U.S. Senate,,DEM,Kamala D. Harris,214
+Orange,45109,U.S. Senate,,DEM,Loretta L. Sanchez,158
+Orange,45112,U.S. Senate,,DEM,Kamala D. Harris,391
+Orange,45112,U.S. Senate,,DEM,Loretta L. Sanchez,282
+Orange,45113,U.S. Senate,,DEM,Kamala D. Harris,477
+Orange,45113,U.S. Senate,,DEM,Loretta L. Sanchez,342
+Orange,45114,U.S. Senate,,DEM,Kamala D. Harris,282
+Orange,45114,U.S. Senate,,DEM,Loretta L. Sanchez,207
+Orange,45115,U.S. Senate,,DEM,Kamala D. Harris,458
+Orange,45115,U.S. Senate,,DEM,Loretta L. Sanchez,335
+Orange,45116,U.S. Senate,,DEM,Kamala D. Harris,525
+Orange,45116,U.S. Senate,,DEM,Loretta L. Sanchez,318
+Orange,45117,U.S. Senate,,DEM,Kamala D. Harris,318
+Orange,45117,U.S. Senate,,DEM,Loretta L. Sanchez,183
+Orange,45118,U.S. Senate,,DEM,Kamala D. Harris,471
+Orange,45118,U.S. Senate,,DEM,Loretta L. Sanchez,341
+Orange,45119,U.S. Senate,,DEM,Kamala D. Harris,351
+Orange,45119,U.S. Senate,,DEM,Loretta L. Sanchez,240
+Orange,45120,U.S. Senate,,DEM,Kamala D. Harris,273
+Orange,45120,U.S. Senate,,DEM,Loretta L. Sanchez,194
+Orange,45121,U.S. Senate,,DEM,Kamala D. Harris,447
+Orange,45121,U.S. Senate,,DEM,Loretta L. Sanchez,276
+Orange,45122,U.S. Senate,,DEM,Kamala D. Harris,385
+Orange,45122,U.S. Senate,,DEM,Loretta L. Sanchez,272
+Orange,45123,U.S. Senate,,DEM,Kamala D. Harris,385
+Orange,45123,U.S. Senate,,DEM,Loretta L. Sanchez,253
+Orange,45125,U.S. Senate,,DEM,Kamala D. Harris,429
+Orange,45125,U.S. Senate,,DEM,Loretta L. Sanchez,311
+Orange,45126,U.S. Senate,,DEM,Kamala D. Harris,197
+Orange,45126,U.S. Senate,,DEM,Loretta L. Sanchez,142
+Orange,45127,U.S. Senate,,DEM,Kamala D. Harris,240
+Orange,45127,U.S. Senate,,DEM,Loretta L. Sanchez,183
+Orange,45128,U.S. Senate,,DEM,Kamala D. Harris,336
+Orange,45128,U.S. Senate,,DEM,Loretta L. Sanchez,201
+Orange,45129,U.S. Senate,,DEM,Kamala D. Harris,461
+Orange,45129,U.S. Senate,,DEM,Loretta L. Sanchez,256
+Orange,45131,U.S. Senate,,DEM,Kamala D. Harris,282
+Orange,45131,U.S. Senate,,DEM,Loretta L. Sanchez,222
+Orange,45132,U.S. Senate,,DEM,Kamala D. Harris,301
+Orange,45132,U.S. Senate,,DEM,Loretta L. Sanchez,205
+Orange,45133,U.S. Senate,,DEM,Kamala D. Harris,245
+Orange,45133,U.S. Senate,,DEM,Loretta L. Sanchez,147
+Orange,45239,U.S. Senate,,DEM,Kamala D. Harris,247
+Orange,45239,U.S. Senate,,DEM,Loretta L. Sanchez,212
+Orange,45240,U.S. Senate,,DEM,Kamala D. Harris,451
+Orange,45240,U.S. Senate,,DEM,Loretta L. Sanchez,295
+Orange,45352,U.S. Senate,,DEM,Kamala D. Harris,367
+Orange,45352,U.S. Senate,,DEM,Loretta L. Sanchez,270
+Orange,45353,U.S. Senate,,DEM,Kamala D. Harris,295
+Orange,45353,U.S. Senate,,DEM,Loretta L. Sanchez,219
+Orange,45371,U.S. Senate,,DEM,Kamala D. Harris,270
+Orange,45371,U.S. Senate,,DEM,Loretta L. Sanchez,235
+Orange,47201,U.S. Senate,,DEM,Kamala D. Harris,302
+Orange,47201,U.S. Senate,,DEM,Loretta L. Sanchez,249
+Orange,47202,U.S. Senate,,DEM,Kamala D. Harris,299
+Orange,47202,U.S. Senate,,DEM,Loretta L. Sanchez,172
+Orange,47203,U.S. Senate,,DEM,Kamala D. Harris,485
+Orange,47203,U.S. Senate,,DEM,Loretta L. Sanchez,421
+Orange,47204,U.S. Senate,,DEM,Kamala D. Harris,280
+Orange,47204,U.S. Senate,,DEM,Loretta L. Sanchez,216
+Orange,47247,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,47247,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,47248,U.S. Senate,,DEM,Kamala D. Harris,366
+Orange,47248,U.S. Senate,,DEM,Loretta L. Sanchez,269
+Orange,47250,U.S. Senate,,DEM,Kamala D. Harris,335
+Orange,47250,U.S. Senate,,DEM,Loretta L. Sanchez,224
+Orange,47251,U.S. Senate,,DEM,Kamala D. Harris,573
+Orange,47251,U.S. Senate,,DEM,Loretta L. Sanchez,422
+Orange,47252,U.S. Senate,,DEM,Kamala D. Harris,429
+Orange,47252,U.S. Senate,,DEM,Loretta L. Sanchez,314
+Orange,47253,U.S. Senate,,DEM,Kamala D. Harris,988
+Orange,47253,U.S. Senate,,DEM,Loretta L. Sanchez,640
+Orange,47256,U.S. Senate,,DEM,Kamala D. Harris,836
+Orange,47256,U.S. Senate,,DEM,Loretta L. Sanchez,645
+Orange,47258,U.S. Senate,,DEM,Kamala D. Harris,301
+Orange,47258,U.S. Senate,,DEM,Loretta L. Sanchez,249
+Orange,47259,U.S. Senate,,DEM,Kamala D. Harris,646
+Orange,47259,U.S. Senate,,DEM,Loretta L. Sanchez,487
+Orange,47260,U.S. Senate,,DEM,Kamala D. Harris,557
+Orange,47260,U.S. Senate,,DEM,Loretta L. Sanchez,449
+Orange,47262,U.S. Senate,,DEM,Kamala D. Harris,787
+Orange,47262,U.S. Senate,,DEM,Loretta L. Sanchez,511
+Orange,47265,U.S. Senate,,DEM,Kamala D. Harris,672
+Orange,47265,U.S. Senate,,DEM,Loretta L. Sanchez,509
+Orange,47267,U.S. Senate,,DEM,Kamala D. Harris,726
+Orange,47267,U.S. Senate,,DEM,Loretta L. Sanchez,486
+Orange,47268,U.S. Senate,,DEM,Kamala D. Harris,446
+Orange,47268,U.S. Senate,,DEM,Loretta L. Sanchez,317
+Orange,47271,U.S. Senate,,DEM,Kamala D. Harris,663
+Orange,47271,U.S. Senate,,DEM,Loretta L. Sanchez,498
+Orange,47272,U.S. Senate,,DEM,Kamala D. Harris,289
+Orange,47272,U.S. Senate,,DEM,Loretta L. Sanchez,273
+Orange,47273,U.S. Senate,,DEM,Kamala D. Harris,337
+Orange,47273,U.S. Senate,,DEM,Loretta L. Sanchez,275
+Orange,47276,U.S. Senate,,DEM,Kamala D. Harris,353
+Orange,47276,U.S. Senate,,DEM,Loretta L. Sanchez,315
+Orange,47278,U.S. Senate,,DEM,Kamala D. Harris,279
+Orange,47278,U.S. Senate,,DEM,Loretta L. Sanchez,269
+Orange,47279,U.S. Senate,,DEM,Kamala D. Harris,659
+Orange,47279,U.S. Senate,,DEM,Loretta L. Sanchez,548
+Orange,47284,U.S. Senate,,DEM,Kamala D. Harris,561
+Orange,47284,U.S. Senate,,DEM,Loretta L. Sanchez,527
+Orange,47285,U.S. Senate,,DEM,Kamala D. Harris,1135
+Orange,47285,U.S. Senate,,DEM,Loretta L. Sanchez,819
+Orange,47287,U.S. Senate,,DEM,Kamala D. Harris,668
+Orange,47287,U.S. Senate,,DEM,Loretta L. Sanchez,605
+Orange,47288,U.S. Senate,,DEM,Kamala D. Harris,573
+Orange,47288,U.S. Senate,,DEM,Loretta L. Sanchez,467
+Orange,47289,U.S. Senate,,DEM,Kamala D. Harris,525
+Orange,47289,U.S. Senate,,DEM,Loretta L. Sanchez,439
+Orange,47290,U.S. Senate,,DEM,Kamala D. Harris,445
+Orange,47290,U.S. Senate,,DEM,Loretta L. Sanchez,284
+Orange,47293,U.S. Senate,,DEM,Kamala D. Harris,366
+Orange,47293,U.S. Senate,,DEM,Loretta L. Sanchez,325
+Orange,47294,U.S. Senate,,DEM,Kamala D. Harris,560
+Orange,47294,U.S. Senate,,DEM,Loretta L. Sanchez,510
+Orange,47295,U.S. Senate,,DEM,Kamala D. Harris,640
+Orange,47295,U.S. Senate,,DEM,Loretta L. Sanchez,494
+Orange,47296,U.S. Senate,,DEM,Kamala D. Harris,597
+Orange,47296,U.S. Senate,,DEM,Loretta L. Sanchez,442
+Orange,47301,U.S. Senate,,DEM,Kamala D. Harris,676
+Orange,47301,U.S. Senate,,DEM,Loretta L. Sanchez,618
+Orange,47305,U.S. Senate,,DEM,Kamala D. Harris,521
+Orange,47305,U.S. Senate,,DEM,Loretta L. Sanchez,456
+Orange,47308,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,47308,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,47316,U.S. Senate,,DEM,Kamala D. Harris,342
+Orange,47316,U.S. Senate,,DEM,Loretta L. Sanchez,310
+Orange,47336,U.S. Senate,,DEM,Kamala D. Harris,330
+Orange,47336,U.S. Senate,,DEM,Loretta L. Sanchez,271
+Orange,47344,U.S. Senate,,DEM,Kamala D. Harris,539
+Orange,47344,U.S. Senate,,DEM,Loretta L. Sanchez,442
+Orange,47345,U.S. Senate,,DEM,Kamala D. Harris,497
+Orange,47345,U.S. Senate,,DEM,Loretta L. Sanchez,420
+Orange,47346,U.S. Senate,,DEM,Kamala D. Harris,410
+Orange,47346,U.S. Senate,,DEM,Loretta L. Sanchez,285
+Orange,47348,U.S. Senate,,DEM,Kamala D. Harris,1
+Orange,47348,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,47601,U.S. Senate,,DEM,Kamala D. Harris,702
+Orange,47601,U.S. Senate,,DEM,Loretta L. Sanchez,555
+Orange,47602,U.S. Senate,,DEM,Kamala D. Harris,370
+Orange,47602,U.S. Senate,,DEM,Loretta L. Sanchez,352
+Orange,47701,U.S. Senate,,DEM,Kamala D. Harris,605
+Orange,47701,U.S. Senate,,DEM,Loretta L. Sanchez,465
+Orange,47901,U.S. Senate,,DEM,Kamala D. Harris,65
+Orange,47901,U.S. Senate,,DEM,Loretta L. Sanchez,48
+Orange,47902,U.S. Senate,,DEM,Kamala D. Harris,2
+Orange,47902,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Orange,48141,U.S. Senate,,DEM,Kamala D. Harris,578
+Orange,48141,U.S. Senate,,DEM,Loretta L. Sanchez,419
+Orange,48142,U.S. Senate,,DEM,Kamala D. Harris,274
+Orange,48142,U.S. Senate,,DEM,Loretta L. Sanchez,207
+Orange,48144,U.S. Senate,,DEM,Kamala D. Harris,258
+Orange,48144,U.S. Senate,,DEM,Loretta L. Sanchez,176
+Orange,48146,U.S. Senate,,DEM,Kamala D. Harris,321
+Orange,48146,U.S. Senate,,DEM,Loretta L. Sanchez,238
+Orange,48148,U.S. Senate,,DEM,Kamala D. Harris,291
+Orange,48148,U.S. Senate,,DEM,Loretta L. Sanchez,217
+Orange,48151,U.S. Senate,,DEM,Kamala D. Harris,560
+Orange,48151,U.S. Senate,,DEM,Loretta L. Sanchez,431
+Orange,48152,U.S. Senate,,DEM,Kamala D. Harris,261
+Orange,48152,U.S. Senate,,DEM,Loretta L. Sanchez,227
+Orange,48155,U.S. Senate,,DEM,Kamala D. Harris,656
+Orange,48155,U.S. Senate,,DEM,Loretta L. Sanchez,499
+Orange,48156,U.S. Senate,,DEM,Kamala D. Harris,464
+Orange,48156,U.S. Senate,,DEM,Loretta L. Sanchez,354
+Orange,48157,U.S. Senate,,DEM,Kamala D. Harris,755
+Orange,48157,U.S. Senate,,DEM,Loretta L. Sanchez,585
+Orange,48165,U.S. Senate,,DEM,Kamala D. Harris,741
+Orange,48165,U.S. Senate,,DEM,Loretta L. Sanchez,569
+Orange,48166,U.S. Senate,,DEM,Kamala D. Harris,658
+Orange,48166,U.S. Senate,,DEM,Loretta L. Sanchez,507
+Orange,48167,U.S. Senate,,DEM,Kamala D. Harris,848
+Orange,48167,U.S. Senate,,DEM,Loretta L. Sanchez,633
+Orange,48169,U.S. Senate,,DEM,Kamala D. Harris,847
+Orange,48169,U.S. Senate,,DEM,Loretta L. Sanchez,633
+Orange,48171,U.S. Senate,,DEM,Kamala D. Harris,599
+Orange,48171,U.S. Senate,,DEM,Loretta L. Sanchez,425
+Orange,48173,U.S. Senate,,DEM,Kamala D. Harris,656
+Orange,48173,U.S. Senate,,DEM,Loretta L. Sanchez,543
+Orange,48175,U.S. Senate,,DEM,Kamala D. Harris,372
+Orange,48175,U.S. Senate,,DEM,Loretta L. Sanchez,321
+Orange,48239,U.S. Senate,,DEM,Kamala D. Harris,719
+Orange,48239,U.S. Senate,,DEM,Loretta L. Sanchez,437
+Orange,48240,U.S. Senate,,DEM,Kamala D. Harris,520
+Orange,48240,U.S. Senate,,DEM,Loretta L. Sanchez,338
+Orange,48241,U.S. Senate,,DEM,Kamala D. Harris,658
+Orange,48241,U.S. Senate,,DEM,Loretta L. Sanchez,377
+Orange,48242,U.S. Senate,,DEM,Kamala D. Harris,287
+Orange,48242,U.S. Senate,,DEM,Loretta L. Sanchez,239
+Orange,48249,U.S. Senate,,DEM,Kamala D. Harris,572
+Orange,48249,U.S. Senate,,DEM,Loretta L. Sanchez,452
+Orange,48256,U.S. Senate,,DEM,Kamala D. Harris,836
+Orange,48256,U.S. Senate,,DEM,Loretta L. Sanchez,550
+Orange,48601,U.S. Senate,,DEM,Kamala D. Harris,742
+Orange,48601,U.S. Senate,,DEM,Loretta L. Sanchez,600
+Orange,48602,U.S. Senate,,DEM,Kamala D. Harris,322
+Orange,48602,U.S. Senate,,DEM,Loretta L. Sanchez,231
+Orange,48603,U.S. Senate,,DEM,Kamala D. Harris,366
+Orange,48603,U.S. Senate,,DEM,Loretta L. Sanchez,347
+Orange,48604,U.S. Senate,,DEM,Kamala D. Harris,464
+Orange,48604,U.S. Senate,,DEM,Loretta L. Sanchez,266
+Orange,48605,U.S. Senate,,DEM,Kamala D. Harris,215
+Orange,48605,U.S. Senate,,DEM,Loretta L. Sanchez,119
+Orange,48606,U.S. Senate,,DEM,Kamala D. Harris,201
+Orange,48606,U.S. Senate,,DEM,Loretta L. Sanchez,136
+Orange,49116,U.S. Senate,,DEM,Kamala D. Harris,326
+Orange,49116,U.S. Senate,,DEM,Loretta L. Sanchez,245
+Orange,49118,U.S. Senate,,DEM,Kamala D. Harris,385
+Orange,49118,U.S. Senate,,DEM,Loretta L. Sanchez,303
+Orange,49122,U.S. Senate,,DEM,Kamala D. Harris,347
+Orange,49122,U.S. Senate,,DEM,Loretta L. Sanchez,259
+Orange,49125,U.S. Senate,,DEM,Kamala D. Harris,435
+Orange,49125,U.S. Senate,,DEM,Loretta L. Sanchez,382
+Orange,49126,U.S. Senate,,DEM,Kamala D. Harris,429
+Orange,49126,U.S. Senate,,DEM,Loretta L. Sanchez,344
+Orange,49128,U.S. Senate,,DEM,Kamala D. Harris,615
+Orange,49128,U.S. Senate,,DEM,Loretta L. Sanchez,422
+Orange,49129,U.S. Senate,,DEM,Kamala D. Harris,425
+Orange,49129,U.S. Senate,,DEM,Loretta L. Sanchez,419
+Orange,49132,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,49132,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,49133,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,49133,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,49134,U.S. Senate,,DEM,Kamala D. Harris,19
+Orange,49134,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Orange,49332,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,49332,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,49333,U.S. Senate,,DEM,Kamala D. Harris,112
+Orange,49333,U.S. Senate,,DEM,Loretta L. Sanchez,211
+Orange,49335,U.S. Senate,,DEM,Kamala D. Harris,485
+Orange,49335,U.S. Senate,,DEM,Loretta L. Sanchez,422
+Orange,49338,U.S. Senate,,DEM,Kamala D. Harris,584
+Orange,49338,U.S. Senate,,DEM,Loretta L. Sanchez,440
+Orange,49339,U.S. Senate,,DEM,Kamala D. Harris,123
+Orange,49339,U.S. Senate,,DEM,Loretta L. Sanchez,109
+Orange,49341,U.S. Senate,,DEM,Kamala D. Harris,272
+Orange,49341,U.S. Senate,,DEM,Loretta L. Sanchez,323
+Orange,49346,U.S. Senate,,DEM,Kamala D. Harris,424
+Orange,49346,U.S. Senate,,DEM,Loretta L. Sanchez,614
+Orange,49349,U.S. Senate,,DEM,Kamala D. Harris,225
+Orange,49349,U.S. Senate,,DEM,Loretta L. Sanchez,200
+Orange,49601,U.S. Senate,,DEM,Kamala D. Harris,655
+Orange,49601,U.S. Senate,,DEM,Loretta L. Sanchez,609
+Orange,49602,U.S. Senate,,DEM,Kamala D. Harris,797
+Orange,49602,U.S. Senate,,DEM,Loretta L. Sanchez,612
+Orange,49603,U.S. Senate,,DEM,Kamala D. Harris,256
+Orange,49603,U.S. Senate,,DEM,Loretta L. Sanchez,276
+Orange,49604,U.S. Senate,,DEM,Kamala D. Harris,107
+Orange,49604,U.S. Senate,,DEM,Loretta L. Sanchez,84
+Orange,49901,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,49901,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,49902,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,49902,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,50070,U.S. Senate,,DEM,Kamala D. Harris,340
+Orange,50070,U.S. Senate,,DEM,Loretta L. Sanchez,321
+Orange,50071,U.S. Senate,,DEM,Kamala D. Harris,315
+Orange,50071,U.S. Senate,,DEM,Loretta L. Sanchez,318
+Orange,50076,U.S. Senate,,DEM,Kamala D. Harris,228
+Orange,50076,U.S. Senate,,DEM,Loretta L. Sanchez,227
+Orange,50077,U.S. Senate,,DEM,Kamala D. Harris,407
+Orange,50077,U.S. Senate,,DEM,Loretta L. Sanchez,338
+Orange,50080,U.S. Senate,,DEM,Kamala D. Harris,383
+Orange,50080,U.S. Senate,,DEM,Loretta L. Sanchez,340
+Orange,50088,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,50088,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,50090,U.S. Senate,,DEM,Kamala D. Harris,3
+Orange,50090,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,50092,U.S. Senate,,DEM,Kamala D. Harris,340
+Orange,50092,U.S. Senate,,DEM,Loretta L. Sanchez,349
+Orange,50094,U.S. Senate,,DEM,Kamala D. Harris,423
+Orange,50094,U.S. Senate,,DEM,Loretta L. Sanchez,348
+Orange,50096,U.S. Senate,,DEM,Kamala D. Harris,1
+Orange,50096,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,50098,U.S. Senate,,DEM,Kamala D. Harris,375
+Orange,50098,U.S. Senate,,DEM,Loretta L. Sanchez,305
+Orange,50105,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,50105,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,50601,U.S. Senate,,DEM,Kamala D. Harris,216
+Orange,50601,U.S. Senate,,DEM,Loretta L. Sanchez,198
+Orange,50602,U.S. Senate,,DEM,Kamala D. Harris,151
+Orange,50602,U.S. Senate,,DEM,Loretta L. Sanchez,158
+Orange,50901,U.S. Senate,,DEM,Kamala D. Harris,4
+Orange,50901,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Orange,50902,U.S. Senate,,DEM,Kamala D. Harris,1
+Orange,50902,U.S. Senate,,DEM,Loretta L. Sanchez,5
+Orange,50903,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,50903,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,50904,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,50904,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,51063,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,51063,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,51066,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,51066,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,51069,U.S. Senate,,DEM,Kamala D. Harris,199
+Orange,51069,U.S. Senate,,DEM,Loretta L. Sanchez,142
+Orange,51165,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,51165,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,51213,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,51213,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,51215,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,51215,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,51901,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,51901,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,51902,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,51902,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,52002,U.S. Senate,,DEM,Kamala D. Harris,216
+Orange,52002,U.S. Senate,,DEM,Loretta L. Sanchez,132
+Orange,52003,U.S. Senate,,DEM,Kamala D. Harris,265
+Orange,52003,U.S. Senate,,DEM,Loretta L. Sanchez,159
+Orange,52004,U.S. Senate,,DEM,Kamala D. Harris,432
+Orange,52004,U.S. Senate,,DEM,Loretta L. Sanchez,318
+Orange,52006,U.S. Senate,,DEM,Kamala D. Harris,408
+Orange,52006,U.S. Senate,,DEM,Loretta L. Sanchez,268
+Orange,52007,U.S. Senate,,DEM,Kamala D. Harris,494
+Orange,52007,U.S. Senate,,DEM,Loretta L. Sanchez,280
+Orange,52009,U.S. Senate,,DEM,Kamala D. Harris,409
+Orange,52009,U.S. Senate,,DEM,Loretta L. Sanchez,269
+Orange,52010,U.S. Senate,,DEM,Kamala D. Harris,193
+Orange,52010,U.S. Senate,,DEM,Loretta L. Sanchez,205
+Orange,52011,U.S. Senate,,DEM,Kamala D. Harris,441
+Orange,52011,U.S. Senate,,DEM,Loretta L. Sanchez,316
+Orange,52016,U.S. Senate,,DEM,Kamala D. Harris,314
+Orange,52016,U.S. Senate,,DEM,Loretta L. Sanchez,280
+Orange,52020,U.S. Senate,,DEM,Kamala D. Harris,394
+Orange,52020,U.S. Senate,,DEM,Loretta L. Sanchez,265
+Orange,52022,U.S. Senate,,DEM,Kamala D. Harris,359
+Orange,52022,U.S. Senate,,DEM,Loretta L. Sanchez,294
+Orange,52023,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,52023,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,52024,U.S. Senate,,DEM,Kamala D. Harris,150
+Orange,52024,U.S. Senate,,DEM,Loretta L. Sanchez,119
+Orange,52026,U.S. Senate,,DEM,Kamala D. Harris,356
+Orange,52026,U.S. Senate,,DEM,Loretta L. Sanchez,201
+Orange,52027,U.S. Senate,,DEM,Kamala D. Harris,23
+Orange,52027,U.S. Senate,,DEM,Loretta L. Sanchez,16
+Orange,52028,U.S. Senate,,DEM,Kamala D. Harris,380
+Orange,52028,U.S. Senate,,DEM,Loretta L. Sanchez,278
+Orange,52031,U.S. Senate,,DEM,Kamala D. Harris,380
+Orange,52031,U.S. Senate,,DEM,Loretta L. Sanchez,194
+Orange,52032,U.S. Senate,,DEM,Kamala D. Harris,282
+Orange,52032,U.S. Senate,,DEM,Loretta L. Sanchez,240
+Orange,52033,U.S. Senate,,DEM,Kamala D. Harris,346
+Orange,52033,U.S. Senate,,DEM,Loretta L. Sanchez,228
+Orange,52035,U.S. Senate,,DEM,Kamala D. Harris,289
+Orange,52035,U.S. Senate,,DEM,Loretta L. Sanchez,214
+Orange,52037,U.S. Senate,,DEM,Kamala D. Harris,328
+Orange,52037,U.S. Senate,,DEM,Loretta L. Sanchez,296
+Orange,52038,U.S. Senate,,DEM,Kamala D. Harris,285
+Orange,52038,U.S. Senate,,DEM,Loretta L. Sanchez,165
+Orange,52041,U.S. Senate,,DEM,Kamala D. Harris,333
+Orange,52041,U.S. Senate,,DEM,Loretta L. Sanchez,255
+Orange,52042,U.S. Senate,,DEM,Kamala D. Harris,233
+Orange,52042,U.S. Senate,,DEM,Loretta L. Sanchez,168
+Orange,52043,U.S. Senate,,DEM,Kamala D. Harris,311
+Orange,52043,U.S. Senate,,DEM,Loretta L. Sanchez,226
+Orange,52045,U.S. Senate,,DEM,Kamala D. Harris,439
+Orange,52045,U.S. Senate,,DEM,Loretta L. Sanchez,337
+Orange,52047,U.S. Senate,,DEM,Kamala D. Harris,31
+Orange,52047,U.S. Senate,,DEM,Loretta L. Sanchez,18
+Orange,52048,U.S. Senate,,DEM,Kamala D. Harris,74
+Orange,52048,U.S. Senate,,DEM,Loretta L. Sanchez,35
+Orange,52049,U.S. Senate,,DEM,Kamala D. Harris,20
+Orange,52049,U.S. Senate,,DEM,Loretta L. Sanchez,14
+Orange,52051,U.S. Senate,,DEM,Kamala D. Harris,366
+Orange,52051,U.S. Senate,,DEM,Loretta L. Sanchez,266
+Orange,52056,U.S. Senate,,DEM,Kamala D. Harris,281
+Orange,52056,U.S. Senate,,DEM,Loretta L. Sanchez,168
+Orange,52059,U.S. Senate,,DEM,Kamala D. Harris,308
+Orange,52059,U.S. Senate,,DEM,Loretta L. Sanchez,218
+Orange,52061,U.S. Senate,,DEM,Kamala D. Harris,323
+Orange,52061,U.S. Senate,,DEM,Loretta L. Sanchez,187
+Orange,52166,U.S. Senate,,DEM,Kamala D. Harris,282
+Orange,52166,U.S. Senate,,DEM,Loretta L. Sanchez,235
+Orange,52167,U.S. Senate,,DEM,Kamala D. Harris,375
+Orange,52167,U.S. Senate,,DEM,Loretta L. Sanchez,300
+Orange,52173,U.S. Senate,,DEM,Kamala D. Harris,305
+Orange,52173,U.S. Senate,,DEM,Loretta L. Sanchez,157
+Orange,52177,U.S. Senate,,DEM,Kamala D. Harris,237
+Orange,52177,U.S. Senate,,DEM,Loretta L. Sanchez,187
+Orange,52179,U.S. Senate,,DEM,Kamala D. Harris,287
+Orange,52179,U.S. Senate,,DEM,Loretta L. Sanchez,221
+Orange,52181,U.S. Senate,,DEM,Kamala D. Harris,241
+Orange,52181,U.S. Senate,,DEM,Loretta L. Sanchez,197
+Orange,52182,U.S. Senate,,DEM,Kamala D. Harris,364
+Orange,52182,U.S. Senate,,DEM,Loretta L. Sanchez,278
+Orange,52183,U.S. Senate,,DEM,Kamala D. Harris,195
+Orange,52183,U.S. Senate,,DEM,Loretta L. Sanchez,151
+Orange,52184,U.S. Senate,,DEM,Kamala D. Harris,383
+Orange,52184,U.S. Senate,,DEM,Loretta L. Sanchez,251
+Orange,52186,U.S. Senate,,DEM,Kamala D. Harris,389
+Orange,52186,U.S. Senate,,DEM,Loretta L. Sanchez,203
+Orange,52192,U.S. Senate,,DEM,Kamala D. Harris,322
+Orange,52192,U.S. Senate,,DEM,Loretta L. Sanchez,187
+Orange,52194,U.S. Senate,,DEM,Kamala D. Harris,381
+Orange,52194,U.S. Senate,,DEM,Loretta L. Sanchez,295
+Orange,52195,U.S. Senate,,DEM,Kamala D. Harris,279
+Orange,52195,U.S. Senate,,DEM,Loretta L. Sanchez,212
+Orange,52196,U.S. Senate,,DEM,Kamala D. Harris,345
+Orange,52196,U.S. Senate,,DEM,Loretta L. Sanchez,208
+Orange,52201,U.S. Senate,,DEM,Kamala D. Harris,287
+Orange,52201,U.S. Senate,,DEM,Loretta L. Sanchez,202
+Orange,52203,U.S. Senate,,DEM,Kamala D. Harris,276
+Orange,52203,U.S. Senate,,DEM,Loretta L. Sanchez,189
+Orange,52209,U.S. Senate,,DEM,Kamala D. Harris,245
+Orange,52209,U.S. Senate,,DEM,Loretta L. Sanchez,157
+Orange,52213,U.S. Senate,,DEM,Kamala D. Harris,337
+Orange,52213,U.S. Senate,,DEM,Loretta L. Sanchez,257
+Orange,52219,U.S. Senate,,DEM,Kamala D. Harris,133
+Orange,52219,U.S. Senate,,DEM,Loretta L. Sanchez,114
+Orange,52224,U.S. Senate,,DEM,Kamala D. Harris,478
+Orange,52224,U.S. Senate,,DEM,Loretta L. Sanchez,261
+Orange,52225,U.S. Senate,,DEM,Kamala D. Harris,316
+Orange,52225,U.S. Senate,,DEM,Loretta L. Sanchez,205
+Orange,52601,U.S. Senate,,DEM,Kamala D. Harris,457
+Orange,52601,U.S. Senate,,DEM,Loretta L. Sanchez,537
+Orange,52602,U.S. Senate,,DEM,Kamala D. Harris,469
+Orange,52602,U.S. Senate,,DEM,Loretta L. Sanchez,536
+Orange,52603,U.S. Senate,,DEM,Kamala D. Harris,823
+Orange,52603,U.S. Senate,,DEM,Loretta L. Sanchez,619
+Orange,52604,U.S. Senate,,DEM,Kamala D. Harris,585
+Orange,52604,U.S. Senate,,DEM,Loretta L. Sanchez,433
+Orange,52605,U.S. Senate,,DEM,Kamala D. Harris,817
+Orange,52605,U.S. Senate,,DEM,Loretta L. Sanchez,581
+Orange,52701,U.S. Senate,,DEM,Kamala D. Harris,437
+Orange,52701,U.S. Senate,,DEM,Loretta L. Sanchez,408
+Orange,52702,U.S. Senate,,DEM,Kamala D. Harris,718
+Orange,52702,U.S. Senate,,DEM,Loretta L. Sanchez,595
+Orange,52703,U.S. Senate,,DEM,Kamala D. Harris,765
+Orange,52703,U.S. Senate,,DEM,Loretta L. Sanchez,559
+Orange,52901,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,52901,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,52902,U.S. Senate,,DEM,Kamala D. Harris,33
+Orange,52902,U.S. Senate,,DEM,Loretta L. Sanchez,22
+Orange,52903,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,52903,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Orange,52904,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,52904,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,53064,U.S. Senate,,DEM,Kamala D. Harris,570
+Orange,53064,U.S. Senate,,DEM,Loretta L. Sanchez,389
+Orange,53066,U.S. Senate,,DEM,Kamala D. Harris,301
+Orange,53066,U.S. Senate,,DEM,Loretta L. Sanchez,171
+Orange,53068,U.S. Senate,,DEM,Kamala D. Harris,500
+Orange,53068,U.S. Senate,,DEM,Loretta L. Sanchez,390
+Orange,53069,U.S. Senate,,DEM,Kamala D. Harris,140
+Orange,53069,U.S. Senate,,DEM,Loretta L. Sanchez,149
+Orange,53073,U.S. Senate,,DEM,Kamala D. Harris,433
+Orange,53073,U.S. Senate,,DEM,Loretta L. Sanchez,281
+Orange,53075,U.S. Senate,,DEM,Kamala D. Harris,558
+Orange,53075,U.S. Senate,,DEM,Loretta L. Sanchez,447
+Orange,53081,U.S. Senate,,DEM,Kamala D. Harris,408
+Orange,53081,U.S. Senate,,DEM,Loretta L. Sanchez,251
+Orange,53082,U.S. Senate,,DEM,Kamala D. Harris,548
+Orange,53082,U.S. Senate,,DEM,Loretta L. Sanchez,449
+Orange,53091,U.S. Senate,,DEM,Kamala D. Harris,545
+Orange,53091,U.S. Senate,,DEM,Loretta L. Sanchez,416
+Orange,53097,U.S. Senate,,DEM,Kamala D. Harris,482
+Orange,53097,U.S. Senate,,DEM,Loretta L. Sanchez,346
+Orange,53098,U.S. Senate,,DEM,Kamala D. Harris,387
+Orange,53098,U.S. Senate,,DEM,Loretta L. Sanchez,300
+Orange,53101,U.S. Senate,,DEM,Kamala D. Harris,323
+Orange,53101,U.S. Senate,,DEM,Loretta L. Sanchez,222
+Orange,53140,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,53140,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,53145,U.S. Senate,,DEM,Kamala D. Harris,239
+Orange,53145,U.S. Senate,,DEM,Loretta L. Sanchez,136
+Orange,53146,U.S. Senate,,DEM,Kamala D. Harris,386
+Orange,53146,U.S. Senate,,DEM,Loretta L. Sanchez,256
+Orange,53147,U.S. Senate,,DEM,Kamala D. Harris,318
+Orange,53147,U.S. Senate,,DEM,Loretta L. Sanchez,164
+Orange,53355,U.S. Senate,,DEM,Kamala D. Harris,211
+Orange,53355,U.S. Senate,,DEM,Loretta L. Sanchez,155
+Orange,53360,U.S. Senate,,DEM,Kamala D. Harris,258
+Orange,53360,U.S. Senate,,DEM,Loretta L. Sanchez,181
+Orange,53362,U.S. Senate,,DEM,Kamala D. Harris,193
+Orange,53362,U.S. Senate,,DEM,Loretta L. Sanchez,113
+Orange,53375,U.S. Senate,,DEM,Kamala D. Harris,141
+Orange,53375,U.S. Senate,,DEM,Loretta L. Sanchez,110
+Orange,53381,U.S. Senate,,DEM,Kamala D. Harris,182
+Orange,53381,U.S. Senate,,DEM,Loretta L. Sanchez,104
+Orange,53601,U.S. Senate,,DEM,Kamala D. Harris,383
+Orange,53601,U.S. Senate,,DEM,Loretta L. Sanchez,269
+Orange,53602,U.S. Senate,,DEM,Kamala D. Harris,138
+Orange,53602,U.S. Senate,,DEM,Loretta L. Sanchez,91
+Orange,53603,U.S. Senate,,DEM,Kamala D. Harris,226
+Orange,53603,U.S. Senate,,DEM,Loretta L. Sanchez,199
+Orange,53604,U.S. Senate,,DEM,Kamala D. Harris,176
+Orange,53604,U.S. Senate,,DEM,Loretta L. Sanchez,90
+Orange,53605,U.S. Senate,,DEM,Kamala D. Harris,649
+Orange,53605,U.S. Senate,,DEM,Loretta L. Sanchez,557
+Orange,53606,U.S. Senate,,DEM,Kamala D. Harris,733
+Orange,53606,U.S. Senate,,DEM,Loretta L. Sanchez,638
+Orange,53607,U.S. Senate,,DEM,Kamala D. Harris,903
+Orange,53607,U.S. Senate,,DEM,Loretta L. Sanchez,848
+Orange,53608,U.S. Senate,,DEM,Kamala D. Harris,517
+Orange,53608,U.S. Senate,,DEM,Loretta L. Sanchez,360
+Orange,53609,U.S. Senate,,DEM,Kamala D. Harris,492
+Orange,53609,U.S. Senate,,DEM,Loretta L. Sanchez,408
+Orange,53610,U.S. Senate,,DEM,Kamala D. Harris,524
+Orange,53610,U.S. Senate,,DEM,Loretta L. Sanchez,287
+Orange,53611,U.S. Senate,,DEM,Kamala D. Harris,619
+Orange,53611,U.S. Senate,,DEM,Loretta L. Sanchez,388
+Orange,53612,U.S. Senate,,DEM,Kamala D. Harris,369
+Orange,53612,U.S. Senate,,DEM,Loretta L. Sanchez,269
+Orange,53613,U.S. Senate,,DEM,Kamala D. Harris,241
+Orange,53613,U.S. Senate,,DEM,Loretta L. Sanchez,178
+Orange,53614,U.S. Senate,,DEM,Kamala D. Harris,526
+Orange,53614,U.S. Senate,,DEM,Loretta L. Sanchez,349
+Orange,53615,U.S. Senate,,DEM,Kamala D. Harris,519
+Orange,53615,U.S. Senate,,DEM,Loretta L. Sanchez,515
+Orange,53616,U.S. Senate,,DEM,Kamala D. Harris,525
+Orange,53616,U.S. Senate,,DEM,Loretta L. Sanchez,385
+Orange,53617,U.S. Senate,,DEM,Kamala D. Harris,167
+Orange,53617,U.S. Senate,,DEM,Loretta L. Sanchez,114
+Orange,53618,U.S. Senate,,DEM,Kamala D. Harris,676
+Orange,53618,U.S. Senate,,DEM,Loretta L. Sanchez,447
+Orange,53619,U.S. Senate,,DEM,Kamala D. Harris,393
+Orange,53619,U.S. Senate,,DEM,Loretta L. Sanchez,255
+Orange,53620,U.S. Senate,,DEM,Kamala D. Harris,278
+Orange,53620,U.S. Senate,,DEM,Loretta L. Sanchez,210
+Orange,53621,U.S. Senate,,DEM,Kamala D. Harris,457
+Orange,53621,U.S. Senate,,DEM,Loretta L. Sanchez,305
+Orange,53622,U.S. Senate,,DEM,Kamala D. Harris,384
+Orange,53622,U.S. Senate,,DEM,Loretta L. Sanchez,319
+Orange,53623,U.S. Senate,,DEM,Kamala D. Harris,783
+Orange,53623,U.S. Senate,,DEM,Loretta L. Sanchez,553
+Orange,53624,U.S. Senate,,DEM,Kamala D. Harris,877
+Orange,53624,U.S. Senate,,DEM,Loretta L. Sanchez,611
+Orange,53625,U.S. Senate,,DEM,Kamala D. Harris,120
+Orange,53625,U.S. Senate,,DEM,Loretta L. Sanchez,94
+Orange,53626,U.S. Senate,,DEM,Kamala D. Harris,131
+Orange,53626,U.S. Senate,,DEM,Loretta L. Sanchez,65
+Orange,53701,U.S. Senate,,DEM,Kamala D. Harris,574
+Orange,53701,U.S. Senate,,DEM,Loretta L. Sanchez,388
+Orange,53702,U.S. Senate,,DEM,Kamala D. Harris,587
+Orange,53702,U.S. Senate,,DEM,Loretta L. Sanchez,421
+Orange,53703,U.S. Senate,,DEM,Kamala D. Harris,623
+Orange,53703,U.S. Senate,,DEM,Loretta L. Sanchez,445
+Orange,53704,U.S. Senate,,DEM,Kamala D. Harris,734
+Orange,53704,U.S. Senate,,DEM,Loretta L. Sanchez,530
+Orange,53901,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,53901,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,53902,U.S. Senate,,DEM,Kamala D. Harris,91
+Orange,53902,U.S. Senate,,DEM,Loretta L. Sanchez,43
+Orange,53903,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,53903,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,53904,U.S. Senate,,DEM,Kamala D. Harris,71
+Orange,53904,U.S. Senate,,DEM,Loretta L. Sanchez,55
+Orange,53905,U.S. Senate,,DEM,Kamala D. Harris,68
+Orange,53905,U.S. Senate,,DEM,Loretta L. Sanchez,34
+Orange,53906,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,53906,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,53907,U.S. Senate,,DEM,Kamala D. Harris,1
+Orange,53907,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,53908,U.S. Senate,,DEM,Kamala D. Harris,58
+Orange,53908,U.S. Senate,,DEM,Loretta L. Sanchez,39
+Orange,53909,U.S. Senate,,DEM,Kamala D. Harris,5
+Orange,53909,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Orange,53910,U.S. Senate,,DEM,Kamala D. Harris,7
+Orange,53910,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,53911,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,53911,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,53912,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,53912,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Orange,54101,U.S. Senate,,DEM,Kamala D. Harris,356
+Orange,54101,U.S. Senate,,DEM,Loretta L. Sanchez,313
+Orange,54102,U.S. Senate,,DEM,Kamala D. Harris,300
+Orange,54102,U.S. Senate,,DEM,Loretta L. Sanchez,236
+Orange,54103,U.S. Senate,,DEM,Kamala D. Harris,362
+Orange,54103,U.S. Senate,,DEM,Loretta L. Sanchez,275
+Orange,54104,U.S. Senate,,DEM,Kamala D. Harris,331
+Orange,54104,U.S. Senate,,DEM,Loretta L. Sanchez,274
+Orange,54105,U.S. Senate,,DEM,Kamala D. Harris,254
+Orange,54105,U.S. Senate,,DEM,Loretta L. Sanchez,209
+Orange,54106,U.S. Senate,,DEM,Kamala D. Harris,321
+Orange,54106,U.S. Senate,,DEM,Loretta L. Sanchez,259
+Orange,54107,U.S. Senate,,DEM,Kamala D. Harris,307
+Orange,54107,U.S. Senate,,DEM,Loretta L. Sanchez,251
+Orange,54108,U.S. Senate,,DEM,Kamala D. Harris,344
+Orange,54108,U.S. Senate,,DEM,Loretta L. Sanchez,247
+Orange,54109,U.S. Senate,,DEM,Kamala D. Harris,324
+Orange,54109,U.S. Senate,,DEM,Loretta L. Sanchez,255
+Orange,54110,U.S. Senate,,DEM,Kamala D. Harris,212
+Orange,54110,U.S. Senate,,DEM,Loretta L. Sanchez,171
+Orange,54111,U.S. Senate,,DEM,Kamala D. Harris,437
+Orange,54111,U.S. Senate,,DEM,Loretta L. Sanchez,314
+Orange,54112,U.S. Senate,,DEM,Kamala D. Harris,389
+Orange,54112,U.S. Senate,,DEM,Loretta L. Sanchez,353
+Orange,54113,U.S. Senate,,DEM,Kamala D. Harris,273
+Orange,54113,U.S. Senate,,DEM,Loretta L. Sanchez,182
+Orange,54114,U.S. Senate,,DEM,Kamala D. Harris,392
+Orange,54114,U.S. Senate,,DEM,Loretta L. Sanchez,330
+Orange,54115,U.S. Senate,,DEM,Kamala D. Harris,371
+Orange,54115,U.S. Senate,,DEM,Loretta L. Sanchez,264
+Orange,54120,U.S. Senate,,DEM,Kamala D. Harris,196
+Orange,54120,U.S. Senate,,DEM,Loretta L. Sanchez,160
+Orange,54121,U.S. Senate,,DEM,Kamala D. Harris,439
+Orange,54121,U.S. Senate,,DEM,Loretta L. Sanchez,361
+Orange,54122,U.S. Senate,,DEM,Kamala D. Harris,423
+Orange,54122,U.S. Senate,,DEM,Loretta L. Sanchez,340
+Orange,54123,U.S. Senate,,DEM,Kamala D. Harris,287
+Orange,54123,U.S. Senate,,DEM,Loretta L. Sanchez,240
+Orange,54141,U.S. Senate,,DEM,Kamala D. Harris,346
+Orange,54141,U.S. Senate,,DEM,Loretta L. Sanchez,299
+Orange,54142,U.S. Senate,,DEM,Kamala D. Harris,401
+Orange,54142,U.S. Senate,,DEM,Loretta L. Sanchez,316
+Orange,54143,U.S. Senate,,DEM,Kamala D. Harris,307
+Orange,54143,U.S. Senate,,DEM,Loretta L. Sanchez,245
+Orange,54144,U.S. Senate,,DEM,Kamala D. Harris,346
+Orange,54144,U.S. Senate,,DEM,Loretta L. Sanchez,281
+Orange,54160,U.S. Senate,,DEM,Kamala D. Harris,304
+Orange,54160,U.S. Senate,,DEM,Loretta L. Sanchez,228
+Orange,54161,U.S. Senate,,DEM,Kamala D. Harris,311
+Orange,54161,U.S. Senate,,DEM,Loretta L. Sanchez,235
+Orange,54180,U.S. Senate,,DEM,Kamala D. Harris,339
+Orange,54180,U.S. Senate,,DEM,Loretta L. Sanchez,291
+Orange,54181,U.S. Senate,,DEM,Kamala D. Harris,338
+Orange,54181,U.S. Senate,,DEM,Loretta L. Sanchez,288
+Orange,54182,U.S. Senate,,DEM,Kamala D. Harris,214
+Orange,54182,U.S. Senate,,DEM,Loretta L. Sanchez,222
+Orange,54183,U.S. Senate,,DEM,Kamala D. Harris,342
+Orange,54183,U.S. Senate,,DEM,Loretta L. Sanchez,280
+Orange,54184,U.S. Senate,,DEM,Kamala D. Harris,399
+Orange,54184,U.S. Senate,,DEM,Loretta L. Sanchez,364
+Orange,54185,U.S. Senate,,DEM,Kamala D. Harris,360
+Orange,54185,U.S. Senate,,DEM,Loretta L. Sanchez,268
+Orange,56065,U.S. Senate,,DEM,Kamala D. Harris,538
+Orange,56065,U.S. Senate,,DEM,Loretta L. Sanchez,381
+Orange,56069,U.S. Senate,,DEM,Kamala D. Harris,575
+Orange,56069,U.S. Senate,,DEM,Loretta L. Sanchez,392
+Orange,56070,U.S. Senate,,DEM,Kamala D. Harris,401
+Orange,56070,U.S. Senate,,DEM,Loretta L. Sanchez,288
+Orange,56072,U.S. Senate,,DEM,Kamala D. Harris,362
+Orange,56072,U.S. Senate,,DEM,Loretta L. Sanchez,211
+Orange,56073,U.S. Senate,,DEM,Kamala D. Harris,774
+Orange,56073,U.S. Senate,,DEM,Loretta L. Sanchez,507
+Orange,56079,U.S. Senate,,DEM,Kamala D. Harris,550
+Orange,56079,U.S. Senate,,DEM,Loretta L. Sanchez,418
+Orange,56080,U.S. Senate,,DEM,Kamala D. Harris,194
+Orange,56080,U.S. Senate,,DEM,Loretta L. Sanchez,209
+Orange,56090,U.S. Senate,,DEM,Kamala D. Harris,591
+Orange,56090,U.S. Senate,,DEM,Loretta L. Sanchez,486
+Orange,56095,U.S. Senate,,DEM,Kamala D. Harris,286
+Orange,56095,U.S. Senate,,DEM,Loretta L. Sanchez,232
+Orange,56096,U.S. Senate,,DEM,Kamala D. Harris,370
+Orange,56096,U.S. Senate,,DEM,Loretta L. Sanchez,355
+Orange,56098,U.S. Senate,,DEM,Kamala D. Harris,393
+Orange,56098,U.S. Senate,,DEM,Loretta L. Sanchez,326
+Orange,56101,U.S. Senate,,DEM,Kamala D. Harris,601
+Orange,56101,U.S. Senate,,DEM,Loretta L. Sanchez,474
+Orange,56105,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,56105,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,56109,U.S. Senate,,DEM,Kamala D. Harris,505
+Orange,56109,U.S. Senate,,DEM,Loretta L. Sanchez,385
+Orange,56110,U.S. Senate,,DEM,Kamala D. Harris,266
+Orange,56110,U.S. Senate,,DEM,Loretta L. Sanchez,178
+Orange,56277,U.S. Senate,,DEM,Kamala D. Harris,494
+Orange,56277,U.S. Senate,,DEM,Loretta L. Sanchez,324
+Orange,56278,U.S. Senate,,DEM,Kamala D. Harris,333
+Orange,56278,U.S. Senate,,DEM,Loretta L. Sanchez,267
+Orange,56290,U.S. Senate,,DEM,Kamala D. Harris,538
+Orange,56290,U.S. Senate,,DEM,Loretta L. Sanchez,449
+Orange,56292,U.S. Senate,,DEM,Kamala D. Harris,449
+Orange,56292,U.S. Senate,,DEM,Loretta L. Sanchez,406
+Orange,56293,U.S. Senate,,DEM,Kamala D. Harris,474
+Orange,56293,U.S. Senate,,DEM,Loretta L. Sanchez,355
+Orange,56295,U.S. Senate,,DEM,Kamala D. Harris,202
+Orange,56295,U.S. Senate,,DEM,Loretta L. Sanchez,154
+Orange,56296,U.S. Senate,,DEM,Kamala D. Harris,177
+Orange,56296,U.S. Senate,,DEM,Loretta L. Sanchez,122
+Orange,56301,U.S. Senate,,DEM,Kamala D. Harris,237
+Orange,56301,U.S. Senate,,DEM,Loretta L. Sanchez,209
+Orange,56308,U.S. Senate,,DEM,Kamala D. Harris,320
+Orange,56308,U.S. Senate,,DEM,Loretta L. Sanchez,225
+Orange,56315,U.S. Senate,,DEM,Kamala D. Harris,621
+Orange,56315,U.S. Senate,,DEM,Loretta L. Sanchez,515
+Orange,56383,U.S. Senate,,DEM,Kamala D. Harris,265
+Orange,56383,U.S. Senate,,DEM,Loretta L. Sanchez,191
+Orange,56601,U.S. Senate,,DEM,Kamala D. Harris,748
+Orange,56601,U.S. Senate,,DEM,Loretta L. Sanchez,572
+Orange,56602,U.S. Senate,,DEM,Kamala D. Harris,921
+Orange,56602,U.S. Senate,,DEM,Loretta L. Sanchez,650
+Orange,56603,U.S. Senate,,DEM,Kamala D. Harris,801
+Orange,56603,U.S. Senate,,DEM,Loretta L. Sanchez,521
+Orange,56604,U.S. Senate,,DEM,Kamala D. Harris,825
+Orange,56604,U.S. Senate,,DEM,Loretta L. Sanchez,626
+Orange,56605,U.S. Senate,,DEM,Kamala D. Harris,796
+Orange,56605,U.S. Senate,,DEM,Loretta L. Sanchez,653
+Orange,56606,U.S. Senate,,DEM,Kamala D. Harris,334
+Orange,56606,U.S. Senate,,DEM,Loretta L. Sanchez,236
+Orange,56608,U.S. Senate,,DEM,Kamala D. Harris,706
+Orange,56608,U.S. Senate,,DEM,Loretta L. Sanchez,529
+Orange,56609,U.S. Senate,,DEM,Kamala D. Harris,648
+Orange,56609,U.S. Senate,,DEM,Loretta L. Sanchez,468
+Orange,56610,U.S. Senate,,DEM,Kamala D. Harris,466
+Orange,56610,U.S. Senate,,DEM,Loretta L. Sanchez,378
+Orange,56611,U.S. Senate,,DEM,Kamala D. Harris,260
+Orange,56611,U.S. Senate,,DEM,Loretta L. Sanchez,188
+Orange,56901,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,56901,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,56902,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,56902,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,56903,U.S. Senate,,DEM,Kamala D. Harris,98
+Orange,56903,U.S. Senate,,DEM,Loretta L. Sanchez,60
+Orange,57002,U.S. Senate,,DEM,Kamala D. Harris,60
+Orange,57002,U.S. Senate,,DEM,Loretta L. Sanchez,98
+Orange,57004,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,57004,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,57007,U.S. Senate,,DEM,Kamala D. Harris,36
+Orange,57007,U.S. Senate,,DEM,Loretta L. Sanchez,51
+Orange,58105,U.S. Senate,,DEM,Kamala D. Harris,411
+Orange,58105,U.S. Senate,,DEM,Loretta L. Sanchez,309
+Orange,58106,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,58106,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,58107,U.S. Senate,,DEM,Kamala D. Harris,458
+Orange,58107,U.S. Senate,,DEM,Loretta L. Sanchez,267
+Orange,58108,U.S. Senate,,DEM,Kamala D. Harris,418
+Orange,58108,U.S. Senate,,DEM,Loretta L. Sanchez,334
+Orange,58109,U.S. Senate,,DEM,Kamala D. Harris,385
+Orange,58109,U.S. Senate,,DEM,Loretta L. Sanchez,220
+Orange,58114,U.S. Senate,,DEM,Kamala D. Harris,328
+Orange,58114,U.S. Senate,,DEM,Loretta L. Sanchez,287
+Orange,58117,U.S. Senate,,DEM,Kamala D. Harris,385
+Orange,58117,U.S. Senate,,DEM,Loretta L. Sanchez,263
+Orange,58118,U.S. Senate,,DEM,Kamala D. Harris,473
+Orange,58118,U.S. Senate,,DEM,Loretta L. Sanchez,272
+Orange,58120,U.S. Senate,,DEM,Kamala D. Harris,410
+Orange,58120,U.S. Senate,,DEM,Loretta L. Sanchez,249
+Orange,58127,U.S. Senate,,DEM,Kamala D. Harris,416
+Orange,58127,U.S. Senate,,DEM,Loretta L. Sanchez,303
+Orange,58299,U.S. Senate,,DEM,Kamala D. Harris,382
+Orange,58299,U.S. Senate,,DEM,Loretta L. Sanchez,282
+Orange,58300,U.S. Senate,,DEM,Kamala D. Harris,300
+Orange,58300,U.S. Senate,,DEM,Loretta L. Sanchez,190
+Orange,58314,U.S. Senate,,DEM,Kamala D. Harris,277
+Orange,58314,U.S. Senate,,DEM,Loretta L. Sanchez,180
+Orange,58316,U.S. Senate,,DEM,Kamala D. Harris,247
+Orange,58316,U.S. Senate,,DEM,Loretta L. Sanchez,169
+Orange,58317,U.S. Senate,,DEM,Kamala D. Harris,398
+Orange,58317,U.S. Senate,,DEM,Loretta L. Sanchez,286
+Orange,58318,U.S. Senate,,DEM,Kamala D. Harris,376
+Orange,58318,U.S. Senate,,DEM,Loretta L. Sanchez,260
+Orange,58319,U.S. Senate,,DEM,Kamala D. Harris,328
+Orange,58319,U.S. Senate,,DEM,Loretta L. Sanchez,190
+Orange,58320,U.S. Senate,,DEM,Kamala D. Harris,218
+Orange,58320,U.S. Senate,,DEM,Loretta L. Sanchez,192
+Orange,58325,U.S. Senate,,DEM,Kamala D. Harris,358
+Orange,58325,U.S. Senate,,DEM,Loretta L. Sanchez,271
+Orange,58328,U.S. Senate,,DEM,Kamala D. Harris,357
+Orange,58328,U.S. Senate,,DEM,Loretta L. Sanchez,293
+Orange,58329,U.S. Senate,,DEM,Kamala D. Harris,223
+Orange,58329,U.S. Senate,,DEM,Loretta L. Sanchez,209
+Orange,58330,U.S. Senate,,DEM,Kamala D. Harris,373
+Orange,58330,U.S. Senate,,DEM,Loretta L. Sanchez,257
+Orange,58331,U.S. Senate,,DEM,Kamala D. Harris,446
+Orange,58331,U.S. Senate,,DEM,Loretta L. Sanchez,288
+Orange,58332,U.S. Senate,,DEM,Kamala D. Harris,309
+Orange,58332,U.S. Senate,,DEM,Loretta L. Sanchez,207
+Orange,58333,U.S. Senate,,DEM,Kamala D. Harris,274
+Orange,58333,U.S. Senate,,DEM,Loretta L. Sanchez,251
+Orange,58334,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,58334,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,58335,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,58335,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,58348,U.S. Senate,,DEM,Kamala D. Harris,403
+Orange,58348,U.S. Senate,,DEM,Loretta L. Sanchez,273
+Orange,58350,U.S. Senate,,DEM,Kamala D. Harris,401
+Orange,58350,U.S. Senate,,DEM,Loretta L. Sanchez,290
+Orange,58351,U.S. Senate,,DEM,Kamala D. Harris,372
+Orange,58351,U.S. Senate,,DEM,Loretta L. Sanchez,233
+Orange,58353,U.S. Senate,,DEM,Kamala D. Harris,302
+Orange,58353,U.S. Senate,,DEM,Loretta L. Sanchez,148
+Orange,58354,U.S. Senate,,DEM,Kamala D. Harris,378
+Orange,58354,U.S. Senate,,DEM,Loretta L. Sanchez,212
+Orange,58355,U.S. Senate,,DEM,Kamala D. Harris,436
+Orange,58355,U.S. Senate,,DEM,Loretta L. Sanchez,366
+Orange,58356,U.S. Senate,,DEM,Kamala D. Harris,382
+Orange,58356,U.S. Senate,,DEM,Loretta L. Sanchez,305
+Orange,58357,U.S. Senate,,DEM,Kamala D. Harris,244
+Orange,58357,U.S. Senate,,DEM,Loretta L. Sanchez,166
+Orange,58371,U.S. Senate,,DEM,Kamala D. Harris,739
+Orange,58371,U.S. Senate,,DEM,Loretta L. Sanchez,520
+Orange,58373,U.S. Senate,,DEM,Kamala D. Harris,399
+Orange,58373,U.S. Senate,,DEM,Loretta L. Sanchez,246
+Orange,58374,U.S. Senate,,DEM,Kamala D. Harris,501
+Orange,58374,U.S. Senate,,DEM,Loretta L. Sanchez,299
+Orange,58376,U.S. Senate,,DEM,Kamala D. Harris,362
+Orange,58376,U.S. Senate,,DEM,Loretta L. Sanchez,217
+Orange,58378,U.S. Senate,,DEM,Kamala D. Harris,397
+Orange,58378,U.S. Senate,,DEM,Loretta L. Sanchez,268
+Orange,58380,U.S. Senate,,DEM,Kamala D. Harris,226
+Orange,58380,U.S. Senate,,DEM,Loretta L. Sanchez,121
+Orange,58601,U.S. Senate,,DEM,Kamala D. Harris,678
+Orange,58601,U.S. Senate,,DEM,Loretta L. Sanchez,462
+Orange,58701,U.S. Senate,,DEM,Kamala D. Harris,743
+Orange,58701,U.S. Senate,,DEM,Loretta L. Sanchez,465
+Orange,58702,U.S. Senate,,DEM,Kamala D. Harris,708
+Orange,58702,U.S. Senate,,DEM,Loretta L. Sanchez,443
+Orange,58901,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,58901,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,59001,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,59001,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Orange,59002,U.S. Senate,,DEM,Kamala D. Harris,384
+Orange,59002,U.S. Senate,,DEM,Loretta L. Sanchez,219
+Orange,59003,U.S. Senate,,DEM,Kamala D. Harris,597
+Orange,59003,U.S. Senate,,DEM,Loretta L. Sanchez,405
+Orange,59005,U.S. Senate,,DEM,Kamala D. Harris,327
+Orange,59005,U.S. Senate,,DEM,Loretta L. Sanchez,180
+Orange,59006,U.S. Senate,,DEM,Kamala D. Harris,257
+Orange,59006,U.S. Senate,,DEM,Loretta L. Sanchez,143
+Orange,59007,U.S. Senate,,DEM,Kamala D. Harris,867
+Orange,59007,U.S. Senate,,DEM,Loretta L. Sanchez,421
+Orange,59009,U.S. Senate,,DEM,Kamala D. Harris,794
+Orange,59009,U.S. Senate,,DEM,Loretta L. Sanchez,459
+Orange,59011,U.S. Senate,,DEM,Kamala D. Harris,576
+Orange,59011,U.S. Senate,,DEM,Loretta L. Sanchez,320
+Orange,59014,U.S. Senate,,DEM,Kamala D. Harris,315
+Orange,59014,U.S. Senate,,DEM,Loretta L. Sanchez,122
+Orange,59015,U.S. Senate,,DEM,Kamala D. Harris,454
+Orange,59015,U.S. Senate,,DEM,Loretta L. Sanchez,206
+Orange,59016,U.S. Senate,,DEM,Kamala D. Harris,617
+Orange,59016,U.S. Senate,,DEM,Loretta L. Sanchez,334
+Orange,59018,U.S. Senate,,DEM,Kamala D. Harris,672
+Orange,59018,U.S. Senate,,DEM,Loretta L. Sanchez,387
+Orange,59019,U.S. Senate,,DEM,Kamala D. Harris,468
+Orange,59019,U.S. Senate,,DEM,Loretta L. Sanchez,402
+Orange,59020,U.S. Senate,,DEM,Kamala D. Harris,420
+Orange,59020,U.S. Senate,,DEM,Loretta L. Sanchez,234
+Orange,59021,U.S. Senate,,DEM,Kamala D. Harris,524
+Orange,59021,U.S. Senate,,DEM,Loretta L. Sanchez,299
+Orange,59022,U.S. Senate,,DEM,Kamala D. Harris,339
+Orange,59022,U.S. Senate,,DEM,Loretta L. Sanchez,203
+Orange,59026,U.S. Senate,,DEM,Kamala D. Harris,825
+Orange,59026,U.S. Senate,,DEM,Loretta L. Sanchez,479
+Orange,59027,U.S. Senate,,DEM,Kamala D. Harris,773
+Orange,59027,U.S. Senate,,DEM,Loretta L. Sanchez,389
+Orange,59030,U.S. Senate,,DEM,Kamala D. Harris,320
+Orange,59030,U.S. Senate,,DEM,Loretta L. Sanchez,222
+Orange,59032,U.S. Senate,,DEM,Kamala D. Harris,409
+Orange,59032,U.S. Senate,,DEM,Loretta L. Sanchez,232
+Orange,59033,U.S. Senate,,DEM,Kamala D. Harris,806
+Orange,59033,U.S. Senate,,DEM,Loretta L. Sanchez,447
+Orange,59034,U.S. Senate,,DEM,Kamala D. Harris,447
+Orange,59034,U.S. Senate,,DEM,Loretta L. Sanchez,298
+Orange,59036,U.S. Senate,,DEM,Kamala D. Harris,844
+Orange,59036,U.S. Senate,,DEM,Loretta L. Sanchez,476
+Orange,59037,U.S. Senate,,DEM,Kamala D. Harris,594
+Orange,59037,U.S. Senate,,DEM,Loretta L. Sanchez,303
+Orange,59038,U.S. Senate,,DEM,Kamala D. Harris,304
+Orange,59038,U.S. Senate,,DEM,Loretta L. Sanchez,193
+Orange,59039,U.S. Senate,,DEM,Kamala D. Harris,386
+Orange,59039,U.S. Senate,,DEM,Loretta L. Sanchez,212
+Orange,59041,U.S. Senate,,DEM,Kamala D. Harris,404
+Orange,59041,U.S. Senate,,DEM,Loretta L. Sanchez,195
+Orange,59042,U.S. Senate,,DEM,Kamala D. Harris,327
+Orange,59042,U.S. Senate,,DEM,Loretta L. Sanchez,185
+Orange,59043,U.S. Senate,,DEM,Kamala D. Harris,517
+Orange,59043,U.S. Senate,,DEM,Loretta L. Sanchez,379
+Orange,59044,U.S. Senate,,DEM,Kamala D. Harris,664
+Orange,59044,U.S. Senate,,DEM,Loretta L. Sanchez,411
+Orange,59045,U.S. Senate,,DEM,Kamala D. Harris,364
+Orange,59045,U.S. Senate,,DEM,Loretta L. Sanchez,275
+Orange,59047,U.S. Senate,,DEM,Kamala D. Harris,379
+Orange,59047,U.S. Senate,,DEM,Loretta L. Sanchez,253
+Orange,59048,U.S. Senate,,DEM,Kamala D. Harris,354
+Orange,59048,U.S. Senate,,DEM,Loretta L. Sanchez,175
+Orange,59054,U.S. Senate,,DEM,Kamala D. Harris,435
+Orange,59054,U.S. Senate,,DEM,Loretta L. Sanchez,248
+Orange,59055,U.S. Senate,,DEM,Kamala D. Harris,432
+Orange,59055,U.S. Senate,,DEM,Loretta L. Sanchez,218
+Orange,59058,U.S. Senate,,DEM,Kamala D. Harris,1397
+Orange,59058,U.S. Senate,,DEM,Loretta L. Sanchez,345
+Orange,59061,U.S. Senate,,DEM,Kamala D. Harris,487
+Orange,59061,U.S. Senate,,DEM,Loretta L. Sanchez,292
+Orange,59062,U.S. Senate,,DEM,Kamala D. Harris,457
+Orange,59062,U.S. Senate,,DEM,Loretta L. Sanchez,222
+Orange,59063,U.S. Senate,,DEM,Kamala D. Harris,391
+Orange,59063,U.S. Senate,,DEM,Loretta L. Sanchez,232
+Orange,59064,U.S. Senate,,DEM,Kamala D. Harris,324
+Orange,59064,U.S. Senate,,DEM,Loretta L. Sanchez,201
+Orange,59065,U.S. Senate,,DEM,Kamala D. Harris,325
+Orange,59065,U.S. Senate,,DEM,Loretta L. Sanchez,203
+Orange,59071,U.S. Senate,,DEM,Kamala D. Harris,425
+Orange,59071,U.S. Senate,,DEM,Loretta L. Sanchez,250
+Orange,59072,U.S. Senate,,DEM,Kamala D. Harris,719
+Orange,59072,U.S. Senate,,DEM,Loretta L. Sanchez,445
+Orange,59074,U.S. Senate,,DEM,Kamala D. Harris,252
+Orange,59074,U.S. Senate,,DEM,Loretta L. Sanchez,183
+Orange,59075,U.S. Senate,,DEM,Kamala D. Harris,678
+Orange,59075,U.S. Senate,,DEM,Loretta L. Sanchez,409
+Orange,59079,U.S. Senate,,DEM,Kamala D. Harris,429
+Orange,59079,U.S. Senate,,DEM,Loretta L. Sanchez,232
+Orange,59081,U.S. Senate,,DEM,Kamala D. Harris,298
+Orange,59081,U.S. Senate,,DEM,Loretta L. Sanchez,183
+Orange,59082,U.S. Senate,,DEM,Kamala D. Harris,436
+Orange,59082,U.S. Senate,,DEM,Loretta L. Sanchez,254
+Orange,59084,U.S. Senate,,DEM,Kamala D. Harris,1
+Orange,59084,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,59088,U.S. Senate,,DEM,Kamala D. Harris,758
+Orange,59088,U.S. Senate,,DEM,Loretta L. Sanchez,448
+Orange,59089,U.S. Senate,,DEM,Kamala D. Harris,485
+Orange,59089,U.S. Senate,,DEM,Loretta L. Sanchez,259
+Orange,59090,U.S. Senate,,DEM,Kamala D. Harris,811
+Orange,59090,U.S. Senate,,DEM,Loretta L. Sanchez,417
+Orange,59092,U.S. Senate,,DEM,Kamala D. Harris,716
+Orange,59092,U.S. Senate,,DEM,Loretta L. Sanchez,407
+Orange,59097,U.S. Senate,,DEM,Kamala D. Harris,413
+Orange,59097,U.S. Senate,,DEM,Loretta L. Sanchez,224
+Orange,59098,U.S. Senate,,DEM,Kamala D. Harris,605
+Orange,59098,U.S. Senate,,DEM,Loretta L. Sanchez,325
+Orange,59099,U.S. Senate,,DEM,Kamala D. Harris,568
+Orange,59099,U.S. Senate,,DEM,Loretta L. Sanchez,320
+Orange,59100,U.S. Senate,,DEM,Kamala D. Harris,705
+Orange,59100,U.S. Senate,,DEM,Loretta L. Sanchez,361
+Orange,59101,U.S. Senate,,DEM,Kamala D. Harris,352
+Orange,59101,U.S. Senate,,DEM,Loretta L. Sanchez,219
+Orange,59103,U.S. Senate,,DEM,Kamala D. Harris,318
+Orange,59103,U.S. Senate,,DEM,Loretta L. Sanchez,191
+Orange,59105,U.S. Senate,,DEM,Kamala D. Harris,438
+Orange,59105,U.S. Senate,,DEM,Loretta L. Sanchez,213
+Orange,59106,U.S. Senate,,DEM,Kamala D. Harris,626
+Orange,59106,U.S. Senate,,DEM,Loretta L. Sanchez,353
+Orange,59108,U.S. Senate,,DEM,Kamala D. Harris,89
+Orange,59108,U.S. Senate,,DEM,Loretta L. Sanchez,38
+Orange,59111,U.S. Senate,,DEM,Kamala D. Harris,491
+Orange,59111,U.S. Senate,,DEM,Loretta L. Sanchez,295
+Orange,59113,U.S. Senate,,DEM,Kamala D. Harris,523
+Orange,59113,U.S. Senate,,DEM,Loretta L. Sanchez,447
+Orange,59118,U.S. Senate,,DEM,Kamala D. Harris,623
+Orange,59118,U.S. Senate,,DEM,Loretta L. Sanchez,489
+Orange,59124,U.S. Senate,,DEM,Kamala D. Harris,750
+Orange,59124,U.S. Senate,,DEM,Loretta L. Sanchez,448
+Orange,59125,U.S. Senate,,DEM,Kamala D. Harris,406
+Orange,59125,U.S. Senate,,DEM,Loretta L. Sanchez,227
+Orange,59127,U.S. Senate,,DEM,Kamala D. Harris,500
+Orange,59127,U.S. Senate,,DEM,Loretta L. Sanchez,299
+Orange,59129,U.S. Senate,,DEM,Kamala D. Harris,689
+Orange,59129,U.S. Senate,,DEM,Loretta L. Sanchez,390
+Orange,59131,U.S. Senate,,DEM,Kamala D. Harris,833
+Orange,59131,U.S. Senate,,DEM,Loretta L. Sanchez,423
+Orange,59132,U.S. Senate,,DEM,Kamala D. Harris,566
+Orange,59132,U.S. Senate,,DEM,Loretta L. Sanchez,361
+Orange,59133,U.S. Senate,,DEM,Kamala D. Harris,534
+Orange,59133,U.S. Senate,,DEM,Loretta L. Sanchez,227
+Orange,59134,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,59134,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,59138,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,59138,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,59141,U.S. Senate,,DEM,Kamala D. Harris,732
+Orange,59141,U.S. Senate,,DEM,Loretta L. Sanchez,446
+Orange,59143,U.S. Senate,,DEM,Kamala D. Harris,330
+Orange,59143,U.S. Senate,,DEM,Loretta L. Sanchez,178
+Orange,59144,U.S. Senate,,DEM,Kamala D. Harris,720
+Orange,59144,U.S. Senate,,DEM,Loretta L. Sanchez,404
+Orange,59146,U.S. Senate,,DEM,Kamala D. Harris,828
+Orange,59146,U.S. Senate,,DEM,Loretta L. Sanchez,423
+Orange,59147,U.S. Senate,,DEM,Kamala D. Harris,300
+Orange,59147,U.S. Senate,,DEM,Loretta L. Sanchez,194
+Orange,59148,U.S. Senate,,DEM,Kamala D. Harris,283
+Orange,59148,U.S. Senate,,DEM,Loretta L. Sanchez,155
+Orange,59149,U.S. Senate,,DEM,Kamala D. Harris,1124
+Orange,59149,U.S. Senate,,DEM,Loretta L. Sanchez,545
+Orange,59150,U.S. Senate,,DEM,Kamala D. Harris,1
+Orange,59150,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,59152,U.S. Senate,,DEM,Kamala D. Harris,564
+Orange,59152,U.S. Senate,,DEM,Loretta L. Sanchez,325
+Orange,59153,U.S. Senate,,DEM,Kamala D. Harris,411
+Orange,59153,U.S. Senate,,DEM,Loretta L. Sanchez,223
+Orange,59154,U.S. Senate,,DEM,Kamala D. Harris,598
+Orange,59154,U.S. Senate,,DEM,Loretta L. Sanchez,293
+Orange,59158,U.S. Senate,,DEM,Kamala D. Harris,252
+Orange,59158,U.S. Senate,,DEM,Loretta L. Sanchez,243
+Orange,59161,U.S. Senate,,DEM,Kamala D. Harris,349
+Orange,59161,U.S. Senate,,DEM,Loretta L. Sanchez,141
+Orange,59162,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,59162,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,59163,U.S. Senate,,DEM,Kamala D. Harris,132
+Orange,59163,U.S. Senate,,DEM,Loretta L. Sanchez,70
+Orange,59164,U.S. Senate,,DEM,Kamala D. Harris,360
+Orange,59164,U.S. Senate,,DEM,Loretta L. Sanchez,188
+Orange,59165,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,59165,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,59166,U.S. Senate,,DEM,Kamala D. Harris,299
+Orange,59166,U.S. Senate,,DEM,Loretta L. Sanchez,172
+Orange,59168,U.S. Senate,,DEM,Kamala D. Harris,1025
+Orange,59168,U.S. Senate,,DEM,Loretta L. Sanchez,490
+Orange,59170,U.S. Senate,,DEM,Kamala D. Harris,35
+Orange,59170,U.S. Senate,,DEM,Loretta L. Sanchez,16
+Orange,59171,U.S. Senate,,DEM,Kamala D. Harris,3
+Orange,59171,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Orange,59172,U.S. Senate,,DEM,Kamala D. Harris,766
+Orange,59172,U.S. Senate,,DEM,Loretta L. Sanchez,353
+Orange,59601,U.S. Senate,,DEM,Kamala D. Harris,491
+Orange,59601,U.S. Senate,,DEM,Loretta L. Sanchez,230
+Orange,59602,U.S. Senate,,DEM,Kamala D. Harris,1520
+Orange,59602,U.S. Senate,,DEM,Loretta L. Sanchez,785
+Orange,59603,U.S. Senate,,DEM,Kamala D. Harris,1040
+Orange,59603,U.S. Senate,,DEM,Loretta L. Sanchez,525
+Orange,59701,U.S. Senate,,DEM,Kamala D. Harris,824
+Orange,59701,U.S. Senate,,DEM,Loretta L. Sanchez,517
+Orange,59702,U.S. Senate,,DEM,Kamala D. Harris,1040
+Orange,59702,U.S. Senate,,DEM,Loretta L. Sanchez,617
+Orange,62081,U.S. Senate,,DEM,Kamala D. Harris,54
+Orange,62081,U.S. Senate,,DEM,Loretta L. Sanchez,39
+Orange,63001,U.S. Senate,,DEM,Kamala D. Harris,601
+Orange,63001,U.S. Senate,,DEM,Loretta L. Sanchez,522
+Orange,63002,U.S. Senate,,DEM,Kamala D. Harris,681
+Orange,63002,U.S. Senate,,DEM,Loretta L. Sanchez,782
+Orange,63005,U.S. Senate,,DEM,Kamala D. Harris,313
+Orange,63005,U.S. Senate,,DEM,Loretta L. Sanchez,295
+Orange,63007,U.S. Senate,,DEM,Kamala D. Harris,341
+Orange,63007,U.S. Senate,,DEM,Loretta L. Sanchez,360
+Orange,63009,U.S. Senate,,DEM,Kamala D. Harris,698
+Orange,63009,U.S. Senate,,DEM,Loretta L. Sanchez,695
+Orange,63010,U.S. Senate,,DEM,Kamala D. Harris,346
+Orange,63010,U.S. Senate,,DEM,Loretta L. Sanchez,321
+Orange,63011,U.S. Senate,,DEM,Kamala D. Harris,228
+Orange,63011,U.S. Senate,,DEM,Loretta L. Sanchez,154
+Orange,63012,U.S. Senate,,DEM,Kamala D. Harris,401
+Orange,63012,U.S. Senate,,DEM,Loretta L. Sanchez,270
+Orange,63014,U.S. Senate,,DEM,Kamala D. Harris,577
+Orange,63014,U.S. Senate,,DEM,Loretta L. Sanchez,597
+Orange,63019,U.S. Senate,,DEM,Kamala D. Harris,521
+Orange,63019,U.S. Senate,,DEM,Loretta L. Sanchez,615
+Orange,63024,U.S. Senate,,DEM,Kamala D. Harris,353
+Orange,63024,U.S. Senate,,DEM,Loretta L. Sanchez,261
+Orange,63026,U.S. Senate,,DEM,Kamala D. Harris,277
+Orange,63026,U.S. Senate,,DEM,Loretta L. Sanchez,211
+Orange,63027,U.S. Senate,,DEM,Kamala D. Harris,545
+Orange,63027,U.S. Senate,,DEM,Loretta L. Sanchez,451
+Orange,63028,U.S. Senate,,DEM,Kamala D. Harris,411
+Orange,63028,U.S. Senate,,DEM,Loretta L. Sanchez,341
+Orange,63029,U.S. Senate,,DEM,Kamala D. Harris,574
+Orange,63029,U.S. Senate,,DEM,Loretta L. Sanchez,589
+Orange,63032,U.S. Senate,,DEM,Kamala D. Harris,196
+Orange,63032,U.S. Senate,,DEM,Loretta L. Sanchez,397
+Orange,63034,U.S. Senate,,DEM,Kamala D. Harris,260
+Orange,63034,U.S. Senate,,DEM,Loretta L. Sanchez,334
+Orange,63035,U.S. Senate,,DEM,Kamala D. Harris,201
+Orange,63035,U.S. Senate,,DEM,Loretta L. Sanchez,115
+Orange,63036,U.S. Senate,,DEM,Kamala D. Harris,608
+Orange,63036,U.S. Senate,,DEM,Loretta L. Sanchez,527
+Orange,63038,U.S. Senate,,DEM,Kamala D. Harris,654
+Orange,63038,U.S. Senate,,DEM,Loretta L. Sanchez,612
+Orange,63041,U.S. Senate,,DEM,Kamala D. Harris,848
+Orange,63041,U.S. Senate,,DEM,Loretta L. Sanchez,530
+Orange,63043,U.S. Senate,,DEM,Kamala D. Harris,699
+Orange,63043,U.S. Senate,,DEM,Loretta L. Sanchez,629
+Orange,63046,U.S. Senate,,DEM,Kamala D. Harris,250
+Orange,63046,U.S. Senate,,DEM,Loretta L. Sanchez,248
+Orange,63049,U.S. Senate,,DEM,Kamala D. Harris,230
+Orange,63049,U.S. Senate,,DEM,Loretta L. Sanchez,227
+Orange,63051,U.S. Senate,,DEM,Kamala D. Harris,594
+Orange,63051,U.S. Senate,,DEM,Loretta L. Sanchez,518
+Orange,63052,U.S. Senate,,DEM,Kamala D. Harris,10
+Orange,63052,U.S. Senate,,DEM,Loretta L. Sanchez,6
+Orange,63053,U.S. Senate,,DEM,Kamala D. Harris,139
+Orange,63053,U.S. Senate,,DEM,Loretta L. Sanchez,139
+Orange,63055,U.S. Senate,,DEM,Kamala D. Harris,483
+Orange,63055,U.S. Senate,,DEM,Loretta L. Sanchez,477
+Orange,63062,U.S. Senate,,DEM,Kamala D. Harris,257
+Orange,63062,U.S. Senate,,DEM,Loretta L. Sanchez,190
+Orange,63066,U.S. Senate,,DEM,Kamala D. Harris,363
+Orange,63066,U.S. Senate,,DEM,Loretta L. Sanchez,252
+Orange,63068,U.S. Senate,,DEM,Kamala D. Harris,454
+Orange,63068,U.S. Senate,,DEM,Loretta L. Sanchez,405
+Orange,63069,U.S. Senate,,DEM,Kamala D. Harris,303
+Orange,63069,U.S. Senate,,DEM,Loretta L. Sanchez,411
+Orange,63071,U.S. Senate,,DEM,Kamala D. Harris,486
+Orange,63071,U.S. Senate,,DEM,Loretta L. Sanchez,443
+Orange,63083,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,63083,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,63092,U.S. Senate,,DEM,Kamala D. Harris,185
+Orange,63092,U.S. Senate,,DEM,Loretta L. Sanchez,224
+Orange,63097,U.S. Senate,,DEM,Kamala D. Harris,142
+Orange,63097,U.S. Senate,,DEM,Loretta L. Sanchez,114
+Orange,63340,U.S. Senate,,DEM,Kamala D. Harris,276
+Orange,63340,U.S. Senate,,DEM,Loretta L. Sanchez,184
+Orange,63342,U.S. Senate,,DEM,Kamala D. Harris,320
+Orange,63342,U.S. Senate,,DEM,Loretta L. Sanchez,251
+Orange,63343,U.S. Senate,,DEM,Kamala D. Harris,168
+Orange,63343,U.S. Senate,,DEM,Loretta L. Sanchez,164
+Orange,63344,U.S. Senate,,DEM,Kamala D. Harris,343
+Orange,63344,U.S. Senate,,DEM,Loretta L. Sanchez,360
+Orange,63347,U.S. Senate,,DEM,Kamala D. Harris,341
+Orange,63347,U.S. Senate,,DEM,Loretta L. Sanchez,250
+Orange,63348,U.S. Senate,,DEM,Kamala D. Harris,75
+Orange,63348,U.S. Senate,,DEM,Loretta L. Sanchez,131
+Orange,63352,U.S. Senate,,DEM,Kamala D. Harris,460
+Orange,63352,U.S. Senate,,DEM,Loretta L. Sanchez,295
+Orange,63361,U.S. Senate,,DEM,Kamala D. Harris,340
+Orange,63361,U.S. Senate,,DEM,Loretta L. Sanchez,260
+Orange,63362,U.S. Senate,,DEM,Kamala D. Harris,410
+Orange,63362,U.S. Senate,,DEM,Loretta L. Sanchez,340
+Orange,63369,U.S. Senate,,DEM,Kamala D. Harris,394
+Orange,63369,U.S. Senate,,DEM,Loretta L. Sanchez,279
+Orange,63371,U.S. Senate,,DEM,Kamala D. Harris,347
+Orange,63371,U.S. Senate,,DEM,Loretta L. Sanchez,304
+Orange,63372,U.S. Senate,,DEM,Kamala D. Harris,45
+Orange,63372,U.S. Senate,,DEM,Loretta L. Sanchez,38
+Orange,63373,U.S. Senate,,DEM,Kamala D. Harris,537
+Orange,63373,U.S. Senate,,DEM,Loretta L. Sanchez,508
+Orange,63374,U.S. Senate,,DEM,Kamala D. Harris,254
+Orange,63374,U.S. Senate,,DEM,Loretta L. Sanchez,366
+Orange,63377,U.S. Senate,,DEM,Kamala D. Harris,191
+Orange,63377,U.S. Senate,,DEM,Loretta L. Sanchez,139
+Orange,63383,U.S. Senate,,DEM,Kamala D. Harris,389
+Orange,63383,U.S. Senate,,DEM,Loretta L. Sanchez,289
+Orange,63384,U.S. Senate,,DEM,Kamala D. Harris,289
+Orange,63384,U.S. Senate,,DEM,Loretta L. Sanchez,218
+Orange,63390,U.S. Senate,,DEM,Kamala D. Harris,696
+Orange,63390,U.S. Senate,,DEM,Loretta L. Sanchez,492
+Orange,63601,U.S. Senate,,DEM,Kamala D. Harris,655
+Orange,63601,U.S. Senate,,DEM,Loretta L. Sanchez,555
+Orange,63602,U.S. Senate,,DEM,Kamala D. Harris,138
+Orange,63602,U.S. Senate,,DEM,Loretta L. Sanchez,142
+Orange,63603,U.S. Senate,,DEM,Kamala D. Harris,334
+Orange,63603,U.S. Senate,,DEM,Loretta L. Sanchez,268
+Orange,63604,U.S. Senate,,DEM,Kamala D. Harris,345
+Orange,63604,U.S. Senate,,DEM,Loretta L. Sanchez,283
+Orange,63605,U.S. Senate,,DEM,Kamala D. Harris,431
+Orange,63605,U.S. Senate,,DEM,Loretta L. Sanchez,307
+Orange,63606,U.S. Senate,,DEM,Kamala D. Harris,556
+Orange,63606,U.S. Senate,,DEM,Loretta L. Sanchez,348
+Orange,63607,U.S. Senate,,DEM,Kamala D. Harris,758
+Orange,63607,U.S. Senate,,DEM,Loretta L. Sanchez,539
+Orange,63608,U.S. Senate,,DEM,Kamala D. Harris,240
+Orange,63608,U.S. Senate,,DEM,Loretta L. Sanchez,178
+Orange,63609,U.S. Senate,,DEM,Kamala D. Harris,759
+Orange,63609,U.S. Senate,,DEM,Loretta L. Sanchez,593
+Orange,63701,U.S. Senate,,DEM,Kamala D. Harris,555
+Orange,63701,U.S. Senate,,DEM,Loretta L. Sanchez,396
+Orange,63702,U.S. Senate,,DEM,Kamala D. Harris,454
+Orange,63702,U.S. Senate,,DEM,Loretta L. Sanchez,458
+Orange,63901,U.S. Senate,,DEM,Kamala D. Harris,45
+Orange,63901,U.S. Senate,,DEM,Loretta L. Sanchez,34
+Orange,63902,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,63902,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,63903,U.S. Senate,,DEM,Kamala D. Harris,16
+Orange,63903,U.S. Senate,,DEM,Loretta L. Sanchez,17
+Orange,63904,U.S. Senate,,DEM,Kamala D. Harris,24
+Orange,63904,U.S. Senate,,DEM,Loretta L. Sanchez,45
+Orange,63905,U.S. Senate,,DEM,Kamala D. Harris,10
+Orange,63905,U.S. Senate,,DEM,Loretta L. Sanchez,16
+Orange,63906,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,63906,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,63907,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,63907,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,65081,U.S. Senate,,DEM,Kamala D. Harris,282
+Orange,65081,U.S. Senate,,DEM,Loretta L. Sanchez,280
+Orange,65087,U.S. Senate,,DEM,Kamala D. Harris,210
+Orange,65087,U.S. Senate,,DEM,Loretta L. Sanchez,300
+Orange,65091,U.S. Senate,,DEM,Kamala D. Harris,84
+Orange,65091,U.S. Senate,,DEM,Loretta L. Sanchez,70
+Orange,65097,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,65097,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,65901,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,65901,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,65902,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,65902,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,65903,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,65903,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,65904,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,65904,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Orange,67100,U.S. Senate,,DEM,Kamala D. Harris,408
+Orange,67100,U.S. Senate,,DEM,Loretta L. Sanchez,338
+Orange,67101,U.S. Senate,,DEM,Kamala D. Harris,423
+Orange,67101,U.S. Senate,,DEM,Loretta L. Sanchez,338
+Orange,67113,U.S. Senate,,DEM,Kamala D. Harris,437
+Orange,67113,U.S. Senate,,DEM,Loretta L. Sanchez,395
+Orange,67114,U.S. Senate,,DEM,Kamala D. Harris,380
+Orange,67114,U.S. Senate,,DEM,Loretta L. Sanchez,299
+Orange,67115,U.S. Senate,,DEM,Kamala D. Harris,367
+Orange,67115,U.S. Senate,,DEM,Loretta L. Sanchez,293
+Orange,67116,U.S. Senate,,DEM,Kamala D. Harris,646
+Orange,67116,U.S. Senate,,DEM,Loretta L. Sanchez,537
+Orange,67117,U.S. Senate,,DEM,Kamala D. Harris,235
+Orange,67117,U.S. Senate,,DEM,Loretta L. Sanchez,156
+Orange,67118,U.S. Senate,,DEM,Kamala D. Harris,376
+Orange,67118,U.S. Senate,,DEM,Loretta L. Sanchez,252
+Orange,67119,U.S. Senate,,DEM,Kamala D. Harris,399
+Orange,67119,U.S. Senate,,DEM,Loretta L. Sanchez,317
+Orange,67120,U.S. Senate,,DEM,Kamala D. Harris,241
+Orange,67120,U.S. Senate,,DEM,Loretta L. Sanchez,201
+Orange,67121,U.S. Senate,,DEM,Kamala D. Harris,634
+Orange,67121,U.S. Senate,,DEM,Loretta L. Sanchez,483
+Orange,68044,U.S. Senate,,DEM,Kamala D. Harris,12
+Orange,68044,U.S. Senate,,DEM,Loretta L. Sanchez,29
+Orange,68052,U.S. Senate,,DEM,Kamala D. Harris,160
+Orange,68052,U.S. Senate,,DEM,Loretta L. Sanchez,394
+Orange,68053,U.S. Senate,,DEM,Kamala D. Harris,544
+Orange,68053,U.S. Senate,,DEM,Loretta L. Sanchez,629
+Orange,68061,U.S. Senate,,DEM,Kamala D. Harris,420
+Orange,68061,U.S. Senate,,DEM,Loretta L. Sanchez,968
+Orange,68070,U.S. Senate,,DEM,Kamala D. Harris,584
+Orange,68070,U.S. Senate,,DEM,Loretta L. Sanchez,850
+Orange,68073,U.S. Senate,,DEM,Kamala D. Harris,650
+Orange,68073,U.S. Senate,,DEM,Loretta L. Sanchez,577
+Orange,68074,U.S. Senate,,DEM,Kamala D. Harris,245
+Orange,68074,U.S. Senate,,DEM,Loretta L. Sanchez,255
+Orange,68076,U.S. Senate,,DEM,Kamala D. Harris,455
+Orange,68076,U.S. Senate,,DEM,Loretta L. Sanchez,309
+Orange,68077,U.S. Senate,,DEM,Kamala D. Harris,485
+Orange,68077,U.S. Senate,,DEM,Loretta L. Sanchez,543
+Orange,68078,U.S. Senate,,DEM,Kamala D. Harris,224
+Orange,68078,U.S. Senate,,DEM,Loretta L. Sanchez,489
+Orange,68083,U.S. Senate,,DEM,Kamala D. Harris,253
+Orange,68083,U.S. Senate,,DEM,Loretta L. Sanchez,648
+Orange,68091,U.S. Senate,,DEM,Kamala D. Harris,108
+Orange,68091,U.S. Senate,,DEM,Loretta L. Sanchez,303
+Orange,68094,U.S. Senate,,DEM,Kamala D. Harris,262
+Orange,68094,U.S. Senate,,DEM,Loretta L. Sanchez,591
+Orange,68098,U.S. Senate,,DEM,Kamala D. Harris,321
+Orange,68098,U.S. Senate,,DEM,Loretta L. Sanchez,703
+Orange,68100,U.S. Senate,,DEM,Kamala D. Harris,165
+Orange,68100,U.S. Senate,,DEM,Loretta L. Sanchez,351
+Orange,68103,U.S. Senate,,DEM,Kamala D. Harris,317
+Orange,68103,U.S. Senate,,DEM,Loretta L. Sanchez,766
+Orange,68106,U.S. Senate,,DEM,Kamala D. Harris,462
+Orange,68106,U.S. Senate,,DEM,Loretta L. Sanchez,1049
+Orange,68107,U.S. Senate,,DEM,Kamala D. Harris,235
+Orange,68107,U.S. Senate,,DEM,Loretta L. Sanchez,634
+Orange,68115,U.S. Senate,,DEM,Kamala D. Harris,286
+Orange,68115,U.S. Senate,,DEM,Loretta L. Sanchez,684
+Orange,68123,U.S. Senate,,DEM,Kamala D. Harris,276
+Orange,68123,U.S. Senate,,DEM,Loretta L. Sanchez,481
+Orange,68131,U.S. Senate,,DEM,Kamala D. Harris,180
+Orange,68131,U.S. Senate,,DEM,Loretta L. Sanchez,381
+Orange,68137,U.S. Senate,,DEM,Kamala D. Harris,492
+Orange,68137,U.S. Senate,,DEM,Loretta L. Sanchez,982
+Orange,68138,U.S. Senate,,DEM,Kamala D. Harris,408
+Orange,68138,U.S. Senate,,DEM,Loretta L. Sanchez,464
+Orange,68145,U.S. Senate,,DEM,Kamala D. Harris,210
+Orange,68145,U.S. Senate,,DEM,Loretta L. Sanchez,268
+Orange,68146,U.S. Senate,,DEM,Kamala D. Harris,277
+Orange,68146,U.S. Senate,,DEM,Loretta L. Sanchez,217
+Orange,68160,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,68160,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Orange,68161,U.S. Senate,,DEM,Kamala D. Harris,253
+Orange,68161,U.S. Senate,,DEM,Loretta L. Sanchez,266
+Orange,68162,U.S. Senate,,DEM,Kamala D. Harris,305
+Orange,68162,U.S. Senate,,DEM,Loretta L. Sanchez,598
+Orange,68163,U.S. Senate,,DEM,Kamala D. Harris,84
+Orange,68163,U.S. Senate,,DEM,Loretta L. Sanchez,52
+Orange,68166,U.S. Senate,,DEM,Kamala D. Harris,168
+Orange,68166,U.S. Senate,,DEM,Loretta L. Sanchez,502
+Orange,68179,U.S. Senate,,DEM,Kamala D. Harris,519
+Orange,68179,U.S. Senate,,DEM,Loretta L. Sanchez,1211
+Orange,68180,U.S. Senate,,DEM,Kamala D. Harris,44
+Orange,68180,U.S. Senate,,DEM,Loretta L. Sanchez,122
+Orange,68181,U.S. Senate,,DEM,Kamala D. Harris,118
+Orange,68181,U.S. Senate,,DEM,Loretta L. Sanchez,336
+Orange,68183,U.S. Senate,,DEM,Kamala D. Harris,290
+Orange,68183,U.S. Senate,,DEM,Loretta L. Sanchez,689
+Orange,68185,U.S. Senate,,DEM,Kamala D. Harris,505
+Orange,68185,U.S. Senate,,DEM,Loretta L. Sanchez,1025
+Orange,68194,U.S. Senate,,DEM,Kamala D. Harris,441
+Orange,68194,U.S. Senate,,DEM,Loretta L. Sanchez,1025
+Orange,68195,U.S. Senate,,DEM,Kamala D. Harris,274
+Orange,68195,U.S. Senate,,DEM,Loretta L. Sanchez,434
+Orange,68197,U.S. Senate,,DEM,Kamala D. Harris,298
+Orange,68197,U.S. Senate,,DEM,Loretta L. Sanchez,587
+Orange,68273,U.S. Senate,,DEM,Kamala D. Harris,410
+Orange,68273,U.S. Senate,,DEM,Loretta L. Sanchez,541
+Orange,68279,U.S. Senate,,DEM,Kamala D. Harris,244
+Orange,68279,U.S. Senate,,DEM,Loretta L. Sanchez,333
+Orange,68283,U.S. Senate,,DEM,Kamala D. Harris,949
+Orange,68283,U.S. Senate,,DEM,Loretta L. Sanchez,1174
+Orange,68287,U.S. Senate,,DEM,Kamala D. Harris,166
+Orange,68287,U.S. Senate,,DEM,Loretta L. Sanchez,265
+Orange,68297,U.S. Senate,,DEM,Kamala D. Harris,240
+Orange,68297,U.S. Senate,,DEM,Loretta L. Sanchez,692
+Orange,68302,U.S. Senate,,DEM,Kamala D. Harris,184
+Orange,68302,U.S. Senate,,DEM,Loretta L. Sanchez,498
+Orange,68305,U.S. Senate,,DEM,Kamala D. Harris,62
+Orange,68305,U.S. Senate,,DEM,Loretta L. Sanchez,241
+Orange,68306,U.S. Senate,,DEM,Kamala D. Harris,281
+Orange,68306,U.S. Senate,,DEM,Loretta L. Sanchez,700
+Orange,68316,U.S. Senate,,DEM,Kamala D. Harris,233
+Orange,68316,U.S. Senate,,DEM,Loretta L. Sanchez,334
+Orange,68318,U.S. Senate,,DEM,Kamala D. Harris,355
+Orange,68318,U.S. Senate,,DEM,Loretta L. Sanchez,446
+Orange,68330,U.S. Senate,,DEM,Kamala D. Harris,288
+Orange,68330,U.S. Senate,,DEM,Loretta L. Sanchez,587
+Orange,68334,U.S. Senate,,DEM,Kamala D. Harris,441
+Orange,68334,U.S. Senate,,DEM,Loretta L. Sanchez,967
+Orange,68339,U.S. Senate,,DEM,Kamala D. Harris,494
+Orange,68339,U.S. Senate,,DEM,Loretta L. Sanchez,619
+Orange,68350,U.S. Senate,,DEM,Kamala D. Harris,133
+Orange,68350,U.S. Senate,,DEM,Loretta L. Sanchez,303
+Orange,68364,U.S. Senate,,DEM,Kamala D. Harris,237
+Orange,68364,U.S. Senate,,DEM,Loretta L. Sanchez,313
+Orange,68365,U.S. Senate,,DEM,Kamala D. Harris,406
+Orange,68365,U.S. Senate,,DEM,Loretta L. Sanchez,462
+Orange,68367,U.S. Senate,,DEM,Kamala D. Harris,329
+Orange,68367,U.S. Senate,,DEM,Loretta L. Sanchez,353
+Orange,68601,U.S. Senate,,DEM,Kamala D. Harris,243
+Orange,68601,U.S. Senate,,DEM,Loretta L. Sanchez,572
+Orange,68602,U.S. Senate,,DEM,Kamala D. Harris,279
+Orange,68602,U.S. Senate,,DEM,Loretta L. Sanchez,574
+Orange,68603,U.S. Senate,,DEM,Kamala D. Harris,544
+Orange,68603,U.S. Senate,,DEM,Loretta L. Sanchez,996
+Orange,68604,U.S. Senate,,DEM,Kamala D. Harris,621
+Orange,68604,U.S. Senate,,DEM,Loretta L. Sanchez,1348
+Orange,68605,U.S. Senate,,DEM,Kamala D. Harris,649
+Orange,68605,U.S. Senate,,DEM,Loretta L. Sanchez,1330
+Orange,68606,U.S. Senate,,DEM,Kamala D. Harris,736
+Orange,68606,U.S. Senate,,DEM,Loretta L. Sanchez,785
+Orange,68607,U.S. Senate,,DEM,Kamala D. Harris,542
+Orange,68607,U.S. Senate,,DEM,Loretta L. Sanchez,1294
+Orange,68608,U.S. Senate,,DEM,Kamala D. Harris,593
+Orange,68608,U.S. Senate,,DEM,Loretta L. Sanchez,817
+Orange,68609,U.S. Senate,,DEM,Kamala D. Harris,338
+Orange,68609,U.S. Senate,,DEM,Loretta L. Sanchez,595
+Orange,68610,U.S. Senate,,DEM,Kamala D. Harris,420
+Orange,68610,U.S. Senate,,DEM,Loretta L. Sanchez,899
+Orange,68611,U.S. Senate,,DEM,Kamala D. Harris,381
+Orange,68611,U.S. Senate,,DEM,Loretta L. Sanchez,694
+Orange,68612,U.S. Senate,,DEM,Kamala D. Harris,442
+Orange,68612,U.S. Senate,,DEM,Loretta L. Sanchez,1034
+Orange,68613,U.S. Senate,,DEM,Kamala D. Harris,647
+Orange,68613,U.S. Senate,,DEM,Loretta L. Sanchez,879
+Orange,68614,U.S. Senate,,DEM,Kamala D. Harris,519
+Orange,68614,U.S. Senate,,DEM,Loretta L. Sanchez,718
+Orange,68615,U.S. Senate,,DEM,Kamala D. Harris,525
+Orange,68615,U.S. Senate,,DEM,Loretta L. Sanchez,845
+Orange,68616,U.S. Senate,,DEM,Kamala D. Harris,455
+Orange,68616,U.S. Senate,,DEM,Loretta L. Sanchez,780
+Orange,68617,U.S. Senate,,DEM,Kamala D. Harris,678
+Orange,68617,U.S. Senate,,DEM,Loretta L. Sanchez,787
+Orange,68618,U.S. Senate,,DEM,Kamala D. Harris,213
+Orange,68618,U.S. Senate,,DEM,Loretta L. Sanchez,583
+Orange,68901,U.S. Senate,,DEM,Kamala D. Harris,6
+Orange,68901,U.S. Senate,,DEM,Loretta L. Sanchez,9
+Orange,68902,U.S. Senate,,DEM,Kamala D. Harris,4
+Orange,68902,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Orange,69106,U.S. Senate,,DEM,Kamala D. Harris,349
+Orange,69106,U.S. Senate,,DEM,Loretta L. Sanchez,313
+Orange,69107,U.S. Senate,,DEM,Kamala D. Harris,356
+Orange,69107,U.S. Senate,,DEM,Loretta L. Sanchez,241
+Orange,69108,U.S. Senate,,DEM,Kamala D. Harris,320
+Orange,69108,U.S. Senate,,DEM,Loretta L. Sanchez,289
+Orange,69110,U.S. Senate,,DEM,Kamala D. Harris,520
+Orange,69110,U.S. Senate,,DEM,Loretta L. Sanchez,380
+Orange,69111,U.S. Senate,,DEM,Kamala D. Harris,380
+Orange,69111,U.S. Senate,,DEM,Loretta L. Sanchez,278
+Orange,69122,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,69122,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,69601,U.S. Senate,,DEM,Kamala D. Harris,824
+Orange,69601,U.S. Senate,,DEM,Loretta L. Sanchez,552
+Orange,69901,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,69901,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,69902,U.S. Senate,,DEM,Kamala D. Harris,1
+Orange,69902,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,70085,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,70085,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,70601,U.S. Senate,,DEM,Kamala D. Harris,326
+Orange,70601,U.S. Senate,,DEM,Loretta L. Sanchez,262
+Orange,70602,U.S. Senate,,DEM,Kamala D. Harris,138
+Orange,70602,U.S. Senate,,DEM,Loretta L. Sanchez,97
+Orange,70901,U.S. Senate,,DEM,Kamala D. Harris,1
+Orange,70901,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,70902,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,70902,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,70903,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,70903,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,70904,U.S. Senate,,DEM,Kamala D. Harris,2
+Orange,70904,U.S. Senate,,DEM,Loretta L. Sanchez,13
+Orange,70905,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,70905,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,71120,U.S. Senate,,DEM,Kamala D. Harris,345
+Orange,71120,U.S. Senate,,DEM,Loretta L. Sanchez,315
+Orange,71121,U.S. Senate,,DEM,Kamala D. Harris,343
+Orange,71121,U.S. Senate,,DEM,Loretta L. Sanchez,376
+Orange,71232,U.S. Senate,,DEM,Kamala D. Harris,321
+Orange,71232,U.S. Senate,,DEM,Loretta L. Sanchez,286
+Orange,71237,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,71237,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,71238,U.S. Senate,,DEM,Kamala D. Harris,282
+Orange,71238,U.S. Senate,,DEM,Loretta L. Sanchez,242
+Orange,71239,U.S. Senate,,DEM,Kamala D. Harris,221
+Orange,71239,U.S. Senate,,DEM,Loretta L. Sanchez,259
+Orange,71240,U.S. Senate,,DEM,Kamala D. Harris,367
+Orange,71240,U.S. Senate,,DEM,Loretta L. Sanchez,372
+Orange,71241,U.S. Senate,,DEM,Kamala D. Harris,383
+Orange,71241,U.S. Senate,,DEM,Loretta L. Sanchez,315
+Orange,71245,U.S. Senate,,DEM,Kamala D. Harris,335
+Orange,71245,U.S. Senate,,DEM,Loretta L. Sanchez,292
+Orange,71246,U.S. Senate,,DEM,Kamala D. Harris,395
+Orange,71246,U.S. Senate,,DEM,Loretta L. Sanchez,257
+Orange,71247,U.S. Senate,,DEM,Kamala D. Harris,320
+Orange,71247,U.S. Senate,,DEM,Loretta L. Sanchez,279
+Orange,71253,U.S. Senate,,DEM,Kamala D. Harris,6
+Orange,71253,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Orange,71256,U.S. Senate,,DEM,Kamala D. Harris,466
+Orange,71256,U.S. Senate,,DEM,Loretta L. Sanchez,324
+Orange,71258,U.S. Senate,,DEM,Kamala D. Harris,688
+Orange,71258,U.S. Senate,,DEM,Loretta L. Sanchez,440
+Orange,71259,U.S. Senate,,DEM,Kamala D. Harris,377
+Orange,71259,U.S. Senate,,DEM,Loretta L. Sanchez,274
+Orange,71262,U.S. Senate,,DEM,Kamala D. Harris,471
+Orange,71262,U.S. Senate,,DEM,Loretta L. Sanchez,280
+Orange,71263,U.S. Senate,,DEM,Kamala D. Harris,485
+Orange,71263,U.S. Senate,,DEM,Loretta L. Sanchez,249
+Orange,71264,U.S. Senate,,DEM,Kamala D. Harris,393
+Orange,71264,U.S. Senate,,DEM,Loretta L. Sanchez,235
+Orange,71266,U.S. Senate,,DEM,Kamala D. Harris,529
+Orange,71266,U.S. Senate,,DEM,Loretta L. Sanchez,307
+Orange,71269,U.S. Senate,,DEM,Kamala D. Harris,524
+Orange,71269,U.S. Senate,,DEM,Loretta L. Sanchez,329
+Orange,71270,U.S. Senate,,DEM,Kamala D. Harris,447
+Orange,71270,U.S. Senate,,DEM,Loretta L. Sanchez,302
+Orange,71283,U.S. Senate,,DEM,Kamala D. Harris,210
+Orange,71283,U.S. Senate,,DEM,Loretta L. Sanchez,319
+Orange,71284,U.S. Senate,,DEM,Kamala D. Harris,342
+Orange,71284,U.S. Senate,,DEM,Loretta L. Sanchez,291
+Orange,71285,U.S. Senate,,DEM,Kamala D. Harris,282
+Orange,71285,U.S. Senate,,DEM,Loretta L. Sanchez,285
+Orange,71352,U.S. Senate,,DEM,Kamala D. Harris,161
+Orange,71352,U.S. Senate,,DEM,Loretta L. Sanchez,240
+Orange,71357,U.S. Senate,,DEM,Kamala D. Harris,327
+Orange,71357,U.S. Senate,,DEM,Loretta L. Sanchez,323
+Orange,71361,U.S. Senate,,DEM,Kamala D. Harris,496
+Orange,71361,U.S. Senate,,DEM,Loretta L. Sanchez,320
+Orange,71362,U.S. Senate,,DEM,Kamala D. Harris,6
+Orange,71362,U.S. Senate,,DEM,Loretta L. Sanchez,5
+Orange,71368,U.S. Senate,,DEM,Kamala D. Harris,619
+Orange,71368,U.S. Senate,,DEM,Loretta L. Sanchez,339
+Orange,71370,U.S. Senate,,DEM,Kamala D. Harris,346
+Orange,71370,U.S. Senate,,DEM,Loretta L. Sanchez,262
+Orange,71378,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,71378,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,71601,U.S. Senate,,DEM,Kamala D. Harris,709
+Orange,71601,U.S. Senate,,DEM,Loretta L. Sanchez,784
+Orange,71602,U.S. Senate,,DEM,Kamala D. Harris,429
+Orange,71602,U.S. Senate,,DEM,Loretta L. Sanchez,401
+Orange,71603,U.S. Senate,,DEM,Kamala D. Harris,881
+Orange,71603,U.S. Senate,,DEM,Loretta L. Sanchez,548
+Orange,71701,U.S. Senate,,DEM,Kamala D. Harris,609
+Orange,71701,U.S. Senate,,DEM,Loretta L. Sanchez,401
+Orange,71901,U.S. Senate,,DEM,Kamala D. Harris,83
+Orange,71901,U.S. Senate,,DEM,Loretta L. Sanchez,83
+Orange,71902,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,71902,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,71903,U.S. Senate,,DEM,Kamala D. Harris,11
+Orange,71903,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Orange,72081,U.S. Senate,,DEM,Kamala D. Harris,79
+Orange,72081,U.S. Senate,,DEM,Loretta L. Sanchez,56
+Orange,72085,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,72085,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,72087,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,72087,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,72091,U.S. Senate,,DEM,Kamala D. Harris,605
+Orange,72091,U.S. Senate,,DEM,Loretta L. Sanchez,488
+Orange,72093,U.S. Senate,,DEM,Kamala D. Harris,412
+Orange,72093,U.S. Senate,,DEM,Loretta L. Sanchez,353
+Orange,72096,U.S. Senate,,DEM,Kamala D. Harris,657
+Orange,72096,U.S. Senate,,DEM,Loretta L. Sanchez,547
+Orange,72098,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,72098,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,72100,U.S. Senate,,DEM,Kamala D. Harris,174
+Orange,72100,U.S. Senate,,DEM,Loretta L. Sanchez,89
+Orange,72110,U.S. Senate,,DEM,Kamala D. Harris,0
+Orange,72110,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Orange,72197,U.S. Senate,,DEM,Kamala D. Harris,574
+Orange,72197,U.S. Senate,,DEM,Loretta L. Sanchez,522
+Orange,72199,U.S. Senate,,DEM,Kamala D. Harris,338
+Orange,72199,U.S. Senate,,DEM,Loretta L. Sanchez,267
+Orange,72254,U.S. Senate,,DEM,Kamala D. Harris,225
+Orange,72254,U.S. Senate,,DEM,Loretta L. Sanchez,161
+Orange,72255,U.S. Senate,,DEM,Kamala D. Harris,857
+Orange,72255,U.S. Senate,,DEM,Loretta L. Sanchez,616
+Orange,72256,U.S. Senate,,DEM,Kamala D. Harris,492
+Orange,72256,U.S. Senate,,DEM,Loretta L. Sanchez,367
+Orange,72262,U.S. Senate,,DEM,Kamala D. Harris,358
+Orange,72262,U.S. Senate,,DEM,Loretta L. Sanchez,246
+Orange,72269,U.S. Senate,,DEM,Kamala D. Harris,151
+Orange,72269,U.S. Senate,,DEM,Loretta L. Sanchez,100
+Orange,72272,U.S. Senate,,DEM,Kamala D. Harris,632
+Orange,72272,U.S. Senate,,DEM,Loretta L. Sanchez,448
+Orange,72310,U.S. Senate,,DEM,Kamala D. Harris,686
+Orange,72310,U.S. Senate,,DEM,Loretta L. Sanchez,466
+Orange,72311,U.S. Senate,,DEM,Kamala D. Harris,124
+Orange,72311,U.S. Senate,,DEM,Loretta L. Sanchez,83
+Orange,72312,U.S. Senate,,DEM,Kamala D. Harris,120
+Orange,72312,U.S. Senate,,DEM,Loretta L. Sanchez,97
+Orange,72314,U.S. Senate,,DEM,Kamala D. Harris,505
+Orange,72314,U.S. Senate,,DEM,Loretta L. Sanchez,406
+Orange,72318,U.S. Senate,,DEM,Kamala D. Harris,662
+Orange,72318,U.S. Senate,,DEM,Loretta L. Sanchez,530
+Orange,72321,U.S. Senate,,DEM,Kamala D. Harris,216
+Orange,72321,U.S. Senate,,DEM,Loretta L. Sanchez,190
+Orange,75114,U.S. Senate,,DEM,Kamala D. Harris,157
+Orange,75114,U.S. Senate,,DEM,Loretta L. Sanchez,125
+Orange,75115,U.S. Senate,,DEM,Kamala D. Harris,237
+Orange,75115,U.S. Senate,,DEM,Loretta L. Sanchez,195
+Orange,75701,U.S. Senate,,DEM,Kamala D. Harris,401
+Orange,75701,U.S. Senate,,DEM,Loretta L. Sanchez,306
+Orange,75702,U.S. Senate,,DEM,Kamala D. Harris,407
+Orange,75702,U.S. Senate,,DEM,Loretta L. Sanchez,327
+Orange,75703,U.S. Senate,,DEM,Kamala D. Harris,392
+Orange,75703,U.S. Senate,,DEM,Loretta L. Sanchez,389

--- a/2016/20161108__ca__general__placer__precinct.csv
+++ b/2016/20161108__ca__general__placer__precinct.csv
@@ -14519,729 +14519,729 @@ Placer,6562501,Proposition 67,,N/A,Yes,0
 Placer,6562501,Proposition 67,,N/A,No,0
 Placer,6562505,Proposition 67,,N/A,Yes,23
 Placer,6562505,Proposition 67,,N/A,No,37
-Placer,160603,U.S. Senate,,DEM,Kamala Harris,483
-Placer,160603,U.S. Senate,,DEM,Loretta Sanchez,323
-Placer,160605,U.S. Senate,,DEM,Kamala Harris,461
-Placer,160605,U.S. Senate,,DEM,Loretta Sanchez,321
-Placer,160606,U.S. Senate,,DEM,Kamala Harris,369
-Placer,160606,U.S. Senate,,DEM,Loretta Sanchez,256
-Placer,160607,U.S. Senate,,DEM,Kamala Harris,515
-Placer,160607,U.S. Senate,,DEM,Loretta Sanchez,326
-Placer,160608,U.S. Senate,,DEM,Kamala Harris,467
-Placer,160608,U.S. Senate,,DEM,Loretta Sanchez,314
-Placer,160609,U.S. Senate,,DEM,Kamala Harris,491
-Placer,160609,U.S. Senate,,DEM,Loretta Sanchez,306
-Placer,160610,U.S. Senate,,DEM,Kamala Harris,439
-Placer,160610,U.S. Senate,,DEM,Loretta Sanchez,270
-Placer,160611,U.S. Senate,,DEM,Kamala Harris,380
-Placer,160611,U.S. Senate,,DEM,Loretta Sanchez,191
-Placer,160612,U.S. Senate,,DEM,Kamala Harris,424
-Placer,160612,U.S. Senate,,DEM,Loretta Sanchez,247
-Placer,160613,U.S. Senate,,DEM,Kamala Harris,426
-Placer,160613,U.S. Senate,,DEM,Loretta Sanchez,241
-Placer,160614,U.S. Senate,,DEM,Kamala Harris,363
-Placer,160614,U.S. Senate,,DEM,Loretta Sanchez,206
-Placer,160615,U.S. Senate,,DEM,Kamala Harris,318
-Placer,160615,U.S. Senate,,DEM,Loretta Sanchez,189
-Placer,160616,U.S. Senate,,DEM,Kamala Harris,473
-Placer,160616,U.S. Senate,,DEM,Loretta Sanchez,273
-Placer,160617,U.S. Senate,,DEM,Kamala Harris,437
-Placer,160617,U.S. Senate,,DEM,Loretta Sanchez,225
-Placer,160618,U.S. Senate,,DEM,Kamala Harris,372
-Placer,160618,U.S. Senate,,DEM,Loretta Sanchez,178
-Placer,160619,U.S. Senate,,DEM,Kamala Harris,323
-Placer,160619,U.S. Senate,,DEM,Loretta Sanchez,226
-Placer,160620,U.S. Senate,,DEM,Kamala Harris,412
-Placer,160620,U.S. Senate,,DEM,Loretta Sanchez,283
-Placer,160621,U.S. Senate,,DEM,Kamala Harris,651
-Placer,160621,U.S. Senate,,DEM,Loretta Sanchez,251
-Placer,160622,U.S. Senate,,DEM,Kamala Harris,738
-Placer,160622,U.S. Senate,,DEM,Loretta Sanchez,385
-Placer,160624,U.S. Senate,,DEM,Kamala Harris,531
-Placer,160624,U.S. Senate,,DEM,Loretta Sanchez,279
-Placer,160625,U.S. Senate,,DEM,Kamala Harris,614
-Placer,160625,U.S. Senate,,DEM,Loretta Sanchez,318
-Placer,160626,U.S. Senate,,DEM,Kamala Harris,373
-Placer,160626,U.S. Senate,,DEM,Loretta Sanchez,191
-Placer,160627,U.S. Senate,,DEM,Kamala Harris,375
-Placer,160627,U.S. Senate,,DEM,Loretta Sanchez,245
-Placer,160628,U.S. Senate,,DEM,Kamala Harris,311
-Placer,160628,U.S. Senate,,DEM,Loretta Sanchez,219
-Placer,160629,U.S. Senate,,DEM,Kamala Harris,337
-Placer,160629,U.S. Senate,,DEM,Loretta Sanchez,210
-Placer,160630,U.S. Senate,,DEM,Kamala Harris,372
-Placer,160630,U.S. Senate,,DEM,Loretta Sanchez,263
-Placer,160631,U.S. Senate,,DEM,Kamala Harris,285
-Placer,160631,U.S. Senate,,DEM,Loretta Sanchez,219
-Placer,160632,U.S. Senate,,DEM,Kamala Harris,344
-Placer,160632,U.S. Senate,,DEM,Loretta Sanchez,226
-Placer,160633,U.S. Senate,,DEM,Kamala Harris,476
-Placer,160633,U.S. Senate,,DEM,Loretta Sanchez,216
-Placer,160634,U.S. Senate,,DEM,Kamala Harris,538
-Placer,160634,U.S. Senate,,DEM,Loretta Sanchez,269
-Placer,160635,U.S. Senate,,DEM,Kamala Harris,388
-Placer,160635,U.S. Senate,,DEM,Loretta Sanchez,247
-Placer,160636,U.S. Senate,,DEM,Kamala Harris,780
-Placer,160636,U.S. Senate,,DEM,Loretta Sanchez,365
-Placer,160637,U.S. Senate,,DEM,Kamala Harris,648
-Placer,160637,U.S. Senate,,DEM,Loretta Sanchez,327
-Placer,160638,U.S. Senate,,DEM,Kamala Harris,502
-Placer,160638,U.S. Senate,,DEM,Loretta Sanchez,300
-Placer,160639,U.S. Senate,,DEM,Kamala Harris,317
-Placer,160639,U.S. Senate,,DEM,Loretta Sanchez,163
-Placer,160640,U.S. Senate,,DEM,Kamala Harris,549
-Placer,160640,U.S. Senate,,DEM,Loretta Sanchez,280
-Placer,160643,U.S. Senate,,DEM,Kamala Harris,493
-Placer,160643,U.S. Senate,,DEM,Loretta Sanchez,231
-Placer,160644,U.S. Senate,,DEM,Kamala Harris,617
-Placer,160644,U.S. Senate,,DEM,Loretta Sanchez,324
-Placer,160647,U.S. Senate,,DEM,Kamala Harris,262
-Placer,160647,U.S. Senate,,DEM,Loretta Sanchez,170
-Placer,160648,U.S. Senate,,DEM,Kamala Harris,285
-Placer,160648,U.S. Senate,,DEM,Loretta Sanchez,157
-Placer,161004,U.S. Senate,,DEM,Kamala Harris,179
-Placer,161004,U.S. Senate,,DEM,Loretta Sanchez,93
-Placer,161005,U.S. Senate,,DEM,Kamala Harris,366
-Placer,161005,U.S. Senate,,DEM,Loretta Sanchez,215
-Placer,161006,U.S. Senate,,DEM,Kamala Harris,250
-Placer,161006,U.S. Senate,,DEM,Loretta Sanchez,161
-Placer,161011,U.S. Senate,,DEM,Kamala Harris,387
-Placer,161011,U.S. Senate,,DEM,Loretta Sanchez,205
-Placer,260302,U.S. Senate,,DEM,Kamala Harris,403
-Placer,260302,U.S. Senate,,DEM,Loretta Sanchez,243
-Placer,260303,U.S. Senate,,DEM,Kamala Harris,361
-Placer,260303,U.S. Senate,,DEM,Loretta Sanchez,214
-Placer,260304,U.S. Senate,,DEM,Kamala Harris,584
-Placer,260304,U.S. Senate,,DEM,Loretta Sanchez,401
-Placer,260305,U.S. Senate,,DEM,Kamala Harris,677
-Placer,260305,U.S. Senate,,DEM,Loretta Sanchez,301
-Placer,260307,U.S. Senate,,DEM,Kamala Harris,590
-Placer,260307,U.S. Senate,,DEM,Loretta Sanchez,228
-Placer,260308,U.S. Senate,,DEM,Kamala Harris,465
-Placer,260308,U.S. Senate,,DEM,Loretta Sanchez,219
-Placer,260310,U.S. Senate,,DEM,Kamala Harris,692
-Placer,260310,U.S. Senate,,DEM,Loretta Sanchez,331
-Placer,260312,U.S. Senate,,DEM,Kamala Harris,528
-Placer,260312,U.S. Senate,,DEM,Loretta Sanchez,251
-Placer,260313,U.S. Senate,,DEM,Kamala Harris,375
-Placer,260313,U.S. Senate,,DEM,Loretta Sanchez,183
-Placer,260314,U.S. Senate,,DEM,Kamala Harris,445
-Placer,260314,U.S. Senate,,DEM,Loretta Sanchez,220
-Placer,260315,U.S. Senate,,DEM,Kamala Harris,586
-Placer,260315,U.S. Senate,,DEM,Loretta Sanchez,326
-Placer,260316,U.S. Senate,,DEM,Kamala Harris,329
-Placer,260316,U.S. Senate,,DEM,Loretta Sanchez,179
-Placer,260317,U.S. Senate,,DEM,Kamala Harris,588
-Placer,260317,U.S. Senate,,DEM,Loretta Sanchez,281
-Placer,260318,U.S. Senate,,DEM,Kamala Harris,610
-Placer,260318,U.S. Senate,,DEM,Loretta Sanchez,220
-Placer,260319,U.S. Senate,,DEM,Kamala Harris,421
-Placer,260319,U.S. Senate,,DEM,Loretta Sanchez,162
-Placer,260320,U.S. Senate,,DEM,Kamala Harris,504
-Placer,260320,U.S. Senate,,DEM,Loretta Sanchez,205
-Placer,260321,U.S. Senate,,DEM,Kamala Harris,443
-Placer,260321,U.S. Senate,,DEM,Loretta Sanchez,291
-Placer,260322,U.S. Senate,,DEM,Kamala Harris,308
-Placer,260322,U.S. Senate,,DEM,Loretta Sanchez,190
-Placer,260323,U.S. Senate,,DEM,Kamala Harris,267
-Placer,260323,U.S. Senate,,DEM,Loretta Sanchez,290
-Placer,260324,U.S. Senate,,DEM,Kamala Harris,226
-Placer,260324,U.S. Senate,,DEM,Loretta Sanchez,167
-Placer,260325,U.S. Senate,,DEM,Kamala Harris,520
-Placer,260325,U.S. Senate,,DEM,Loretta Sanchez,436
-Placer,260326,U.S. Senate,,DEM,Kamala Harris,350
-Placer,260326,U.S. Senate,,DEM,Loretta Sanchez,250
-Placer,260327,U.S. Senate,,DEM,Kamala Harris,321
-Placer,260327,U.S. Senate,,DEM,Loretta Sanchez,283
-Placer,260328,U.S. Senate,,DEM,Kamala Harris,470
-Placer,260328,U.S. Senate,,DEM,Loretta Sanchez,352
-Placer,260329,U.S. Senate,,DEM,Kamala Harris,498
-Placer,260329,U.S. Senate,,DEM,Loretta Sanchez,316
-Placer,260330,U.S. Senate,,DEM,Kamala Harris,139
-Placer,260330,U.S. Senate,,DEM,Loretta Sanchez,78
-Placer,260501,U.S. Senate,,DEM,Kamala Harris,278
-Placer,260501,U.S. Senate,,DEM,Loretta Sanchez,202
-Placer,260502,U.S. Senate,,DEM,Kamala Harris,305
-Placer,260502,U.S. Senate,,DEM,Loretta Sanchez,150
-Placer,260503,U.S. Senate,,DEM,Kamala Harris,495
-Placer,260503,U.S. Senate,,DEM,Loretta Sanchez,292
-Placer,260504,U.S. Senate,,DEM,Kamala Harris,490
-Placer,260504,U.S. Senate,,DEM,Loretta Sanchez,277
-Placer,260505,U.S. Senate,,DEM,Kamala Harris,456
-Placer,260505,U.S. Senate,,DEM,Loretta Sanchez,257
-Placer,260506,U.S. Senate,,DEM,Kamala Harris,587
-Placer,260506,U.S. Senate,,DEM,Loretta Sanchez,277
-Placer,260507,U.S. Senate,,DEM,Kamala Harris,257
-Placer,260507,U.S. Senate,,DEM,Loretta Sanchez,156
-Placer,260508,U.S. Senate,,DEM,Kamala Harris,437
-Placer,260508,U.S. Senate,,DEM,Loretta Sanchez,266
-Placer,260509,U.S. Senate,,DEM,Kamala Harris,424
-Placer,260509,U.S. Senate,,DEM,Loretta Sanchez,244
-Placer,260510,U.S. Senate,,DEM,Kamala Harris,346
-Placer,260510,U.S. Senate,,DEM,Loretta Sanchez,183
-Placer,260511,U.S. Senate,,DEM,Kamala Harris,312
-Placer,260511,U.S. Senate,,DEM,Loretta Sanchez,153
-Placer,261102,U.S. Senate,,DEM,Kamala Harris,136
-Placer,261102,U.S. Senate,,DEM,Loretta Sanchez,116
-Placer,261201,U.S. Senate,,DEM,Kamala Harris,192
-Placer,261201,U.S. Senate,,DEM,Loretta Sanchez,184
-Placer,261302,U.S. Senate,,DEM,Kamala Harris,232
-Placer,261302,U.S. Senate,,DEM,Loretta Sanchez,160
-Placer,261310,U.S. Senate,,DEM,Kamala Harris,221
-Placer,261310,U.S. Senate,,DEM,Loretta Sanchez,179
-Placer,261318,U.S. Senate,,DEM,Kamala Harris,125
-Placer,261318,U.S. Senate,,DEM,Loretta Sanchez,89
-Placer,261334,U.S. Senate,,DEM,Kamala Harris,168
-Placer,261334,U.S. Senate,,DEM,Loretta Sanchez,130
-Placer,261402,U.S. Senate,,DEM,Kamala Harris,113
-Placer,261402,U.S. Senate,,DEM,Loretta Sanchez,64
-Placer,312202,U.S. Senate,,DEM,Kamala Harris,388
-Placer,312202,U.S. Senate,,DEM,Loretta Sanchez,196
-Placer,312211,U.S. Senate,,DEM,Kamala Harris,393
-Placer,312211,U.S. Senate,,DEM,Loretta Sanchez,220
-Placer,312212,U.S. Senate,,DEM,Kamala Harris,261
-Placer,312212,U.S. Senate,,DEM,Loretta Sanchez,158
-Placer,351801,U.S. Senate,,DEM,Kamala Harris,279
-Placer,351801,U.S. Senate,,DEM,Loretta Sanchez,161
-Placer,351802,U.S. Senate,,DEM,Kamala Harris,195
-Placer,351802,U.S. Senate,,DEM,Loretta Sanchez,121
-Placer,351803,U.S. Senate,,DEM,Kamala Harris,109
-Placer,351803,U.S. Senate,,DEM,Loretta Sanchez,77
-Placer,351903,U.S. Senate,,DEM,Kamala Harris,400
-Placer,351903,U.S. Senate,,DEM,Loretta Sanchez,214
-Placer,352109,U.S. Senate,,DEM,Kamala Harris,174
-Placer,352109,U.S. Senate,,DEM,Loretta Sanchez,112
-Placer,352110,U.S. Senate,,DEM,Kamala Harris,222
-Placer,352110,U.S. Senate,,DEM,Loretta Sanchez,131
-Placer,360403,U.S. Senate,,DEM,Kamala Harris,398
-Placer,360403,U.S. Senate,,DEM,Loretta Sanchez,233
-Placer,360406,U.S. Senate,,DEM,Kamala Harris,214
-Placer,360406,U.S. Senate,,DEM,Loretta Sanchez,124
-Placer,360408,U.S. Senate,,DEM,Kamala Harris,324
-Placer,360408,U.S. Senate,,DEM,Loretta Sanchez,188
-Placer,360409,U.S. Senate,,DEM,Kamala Harris,274
-Placer,360409,U.S. Senate,,DEM,Loretta Sanchez,163
-Placer,360412,U.S. Senate,,DEM,Kamala Harris,233
-Placer,360412,U.S. Senate,,DEM,Loretta Sanchez,140
-Placer,360501,U.S. Senate,,DEM,Kamala Harris,375
-Placer,360501,U.S. Senate,,DEM,Loretta Sanchez,222
-Placer,360502,U.S. Senate,,DEM,Kamala Harris,420
-Placer,360502,U.S. Senate,,DEM,Loretta Sanchez,245
-Placer,360503,U.S. Senate,,DEM,Kamala Harris,373
-Placer,360503,U.S. Senate,,DEM,Loretta Sanchez,203
-Placer,360504,U.S. Senate,,DEM,Kamala Harris,380
-Placer,360504,U.S. Senate,,DEM,Loretta Sanchez,239
-Placer,360505,U.S. Senate,,DEM,Kamala Harris,125
-Placer,360505,U.S. Senate,,DEM,Loretta Sanchez,80
-Placer,360507,U.S. Senate,,DEM,Kamala Harris,431
-Placer,360507,U.S. Senate,,DEM,Loretta Sanchez,276
-Placer,360508,U.S. Senate,,DEM,Kamala Harris,439
-Placer,360508,U.S. Senate,,DEM,Loretta Sanchez,269
-Placer,360509,U.S. Senate,,DEM,Kamala Harris,455
-Placer,360509,U.S. Senate,,DEM,Loretta Sanchez,238
-Placer,360511,U.S. Senate,,DEM,Kamala Harris,410
-Placer,360511,U.S. Senate,,DEM,Loretta Sanchez,266
-Placer,360512,U.S. Senate,,DEM,Kamala Harris,508
-Placer,360512,U.S. Senate,,DEM,Loretta Sanchez,308
-Placer,360513,U.S. Senate,,DEM,Kamala Harris,258
-Placer,360513,U.S. Senate,,DEM,Loretta Sanchez,185
-Placer,360514,U.S. Senate,,DEM,Kamala Harris,455
-Placer,360514,U.S. Senate,,DEM,Loretta Sanchez,313
-Placer,360517,U.S. Senate,,DEM,Kamala Harris,393
-Placer,360517,U.S. Senate,,DEM,Loretta Sanchez,219
-Placer,360518,U.S. Senate,,DEM,Kamala Harris,372
-Placer,360518,U.S. Senate,,DEM,Loretta Sanchez,231
-Placer,360519,U.S. Senate,,DEM,Kamala Harris,378
-Placer,360519,U.S. Senate,,DEM,Loretta Sanchez,199
-Placer,360520,U.S. Senate,,DEM,Kamala Harris,424
-Placer,360520,U.S. Senate,,DEM,Loretta Sanchez,273
-Placer,360521,U.S. Senate,,DEM,Kamala Harris,412
-Placer,360521,U.S. Senate,,DEM,Loretta Sanchez,229
-Placer,360522,U.S. Senate,,DEM,Kamala Harris,285
-Placer,360522,U.S. Senate,,DEM,Loretta Sanchez,174
-Placer,360523,U.S. Senate,,DEM,Kamala Harris,341
-Placer,360523,U.S. Senate,,DEM,Loretta Sanchez,189
-Placer,360524,U.S. Senate,,DEM,Kamala Harris,423
-Placer,360524,U.S. Senate,,DEM,Loretta Sanchez,238
-Placer,360525,U.S. Senate,,DEM,Kamala Harris,399
-Placer,360525,U.S. Senate,,DEM,Loretta Sanchez,213
-Placer,360526,U.S. Senate,,DEM,Kamala Harris,526
-Placer,360526,U.S. Senate,,DEM,Loretta Sanchez,285
-Placer,360527,U.S. Senate,,DEM,Kamala Harris,534
-Placer,360527,U.S. Senate,,DEM,Loretta Sanchez,277
-Placer,360533,U.S. Senate,,DEM,Kamala Harris,335
-Placer,360533,U.S. Senate,,DEM,Loretta Sanchez,184
-Placer,361501,U.S. Senate,,DEM,Kamala Harris,249
-Placer,361501,U.S. Senate,,DEM,Loretta Sanchez,130
-Placer,361502,U.S. Senate,,DEM,Kamala Harris,370
-Placer,361502,U.S. Senate,,DEM,Loretta Sanchez,254
-Placer,361503,U.S. Senate,,DEM,Kamala Harris,442
-Placer,361503,U.S. Senate,,DEM,Loretta Sanchez,277
-Placer,361508,U.S. Senate,,DEM,Kamala Harris,184
-Placer,361508,U.S. Senate,,DEM,Loretta Sanchez,118
-Placer,361511,U.S. Senate,,DEM,Kamala Harris,226
-Placer,361511,U.S. Senate,,DEM,Loretta Sanchez,142
-Placer,361601,U.S. Senate,,DEM,Kamala Harris,103
-Placer,361601,U.S. Senate,,DEM,Loretta Sanchez,83
-Placer,361704,U.S. Senate,,DEM,Kamala Harris,500
-Placer,361704,U.S. Senate,,DEM,Loretta Sanchez,310
-Placer,460601,U.S. Senate,,DEM,Kamala Harris,433
-Placer,460601,U.S. Senate,,DEM,Loretta Sanchez,290
-Placer,460602,U.S. Senate,,DEM,Kamala Harris,344
-Placer,460602,U.S. Senate,,DEM,Loretta Sanchez,205
-Placer,460603,U.S. Senate,,DEM,Kamala Harris,343
-Placer,460603,U.S. Senate,,DEM,Loretta Sanchez,238
-Placer,460607,U.S. Senate,,DEM,Kamala Harris,275
-Placer,460607,U.S. Senate,,DEM,Loretta Sanchez,222
-Placer,460608,U.S. Senate,,DEM,Kamala Harris,306
-Placer,460608,U.S. Senate,,DEM,Loretta Sanchez,199
-Placer,460611,U.S. Senate,,DEM,Kamala Harris,500
-Placer,460611,U.S. Senate,,DEM,Loretta Sanchez,253
-Placer,460612,U.S. Senate,,DEM,Kamala Harris,286
-Placer,460612,U.S. Senate,,DEM,Loretta Sanchez,201
-Placer,460613,U.S. Senate,,DEM,Kamala Harris,354
-Placer,460613,U.S. Senate,,DEM,Loretta Sanchez,220
-Placer,460614,U.S. Senate,,DEM,Kamala Harris,318
-Placer,460614,U.S. Senate,,DEM,Loretta Sanchez,192
-Placer,460615,U.S. Senate,,DEM,Kamala Harris,330
-Placer,460615,U.S. Senate,,DEM,Loretta Sanchez,211
-Placer,460616,U.S. Senate,,DEM,Kamala Harris,371
-Placer,460616,U.S. Senate,,DEM,Loretta Sanchez,183
-Placer,460617,U.S. Senate,,DEM,Kamala Harris,381
-Placer,460617,U.S. Senate,,DEM,Loretta Sanchez,174
-Placer,460618,U.S. Senate,,DEM,Kamala Harris,326
-Placer,460618,U.S. Senate,,DEM,Loretta Sanchez,236
-Placer,460619,U.S. Senate,,DEM,Kamala Harris,452
-Placer,460619,U.S. Senate,,DEM,Loretta Sanchez,234
-Placer,460620,U.S. Senate,,DEM,Kamala Harris,264
-Placer,460620,U.S. Senate,,DEM,Loretta Sanchez,176
-Placer,460621,U.S. Senate,,DEM,Kamala Harris,296
-Placer,460621,U.S. Senate,,DEM,Loretta Sanchez,170
-Placer,460622,U.S. Senate,,DEM,Kamala Harris,351
-Placer,460622,U.S. Senate,,DEM,Loretta Sanchez,191
-Placer,460623,U.S. Senate,,DEM,Kamala Harris,334
-Placer,460623,U.S. Senate,,DEM,Loretta Sanchez,142
-Placer,460624,U.S. Senate,,DEM,Kamala Harris,427
-Placer,460624,U.S. Senate,,DEM,Loretta Sanchez,235
-Placer,460625,U.S. Senate,,DEM,Kamala Harris,683
-Placer,460625,U.S. Senate,,DEM,Loretta Sanchez,329
-Placer,460626,U.S. Senate,,DEM,Kamala Harris,528
-Placer,460626,U.S. Senate,,DEM,Loretta Sanchez,271
-Placer,460627,U.S. Senate,,DEM,Kamala Harris,493
-Placer,460627,U.S. Senate,,DEM,Loretta Sanchez,339
-Placer,460628,U.S. Senate,,DEM,Kamala Harris,323
-Placer,460628,U.S. Senate,,DEM,Loretta Sanchez,190
-Placer,460629,U.S. Senate,,DEM,Kamala Harris,496
-Placer,460629,U.S. Senate,,DEM,Loretta Sanchez,337
-Placer,460630,U.S. Senate,,DEM,Kamala Harris,486
-Placer,460630,U.S. Senate,,DEM,Loretta Sanchez,265
-Placer,460634,U.S. Senate,,DEM,Kamala Harris,500
-Placer,460634,U.S. Senate,,DEM,Loretta Sanchez,254
-Placer,460635,U.S. Senate,,DEM,Kamala Harris,259
-Placer,460635,U.S. Senate,,DEM,Loretta Sanchez,165
-Placer,460636,U.S. Senate,,DEM,Kamala Harris,333
-Placer,460636,U.S. Senate,,DEM,Loretta Sanchez,195
-Placer,460637,U.S. Senate,,DEM,Kamala Harris,349
-Placer,460637,U.S. Senate,,DEM,Loretta Sanchez,192
-Placer,460638,U.S. Senate,,DEM,Kamala Harris,577
-Placer,460638,U.S. Senate,,DEM,Loretta Sanchez,334
-Placer,460639,U.S. Senate,,DEM,Kamala Harris,384
-Placer,460639,U.S. Senate,,DEM,Loretta Sanchez,244
-Placer,462401,U.S. Senate,,DEM,Kamala Harris,393
-Placer,462401,U.S. Senate,,DEM,Loretta Sanchez,253
-Placer,462402,U.S. Senate,,DEM,Kamala Harris,236
-Placer,462402,U.S. Senate,,DEM,Loretta Sanchez,155
-Placer,462403,U.S. Senate,,DEM,Kamala Harris,363
-Placer,462403,U.S. Senate,,DEM,Loretta Sanchez,234
-Placer,462404,U.S. Senate,,DEM,Kamala Harris,346
-Placer,462404,U.S. Senate,,DEM,Loretta Sanchez,202
-Placer,462405,U.S. Senate,,DEM,Kamala Harris,288
-Placer,462405,U.S. Senate,,DEM,Loretta Sanchez,163
-Placer,462406,U.S. Senate,,DEM,Kamala Harris,408
-Placer,462406,U.S. Senate,,DEM,Loretta Sanchez,199
-Placer,462407,U.S. Senate,,DEM,Kamala Harris,452
-Placer,462407,U.S. Senate,,DEM,Loretta Sanchez,306
-Placer,462410,U.S. Senate,,DEM,Kamala Harris,283
-Placer,462410,U.S. Senate,,DEM,Loretta Sanchez,201
-Placer,462411,U.S. Senate,,DEM,Kamala Harris,393
-Placer,462411,U.S. Senate,,DEM,Loretta Sanchez,249
-Placer,462412,U.S. Senate,,DEM,Kamala Harris,363
-Placer,462412,U.S. Senate,,DEM,Loretta Sanchez,223
-Placer,462413,U.S. Senate,,DEM,Kamala Harris,410
-Placer,462413,U.S. Senate,,DEM,Loretta Sanchez,263
-Placer,462416,U.S. Senate,,DEM,Kamala Harris,255
-Placer,462416,U.S. Senate,,DEM,Loretta Sanchez,197
-Placer,462417,U.S. Senate,,DEM,Kamala Harris,257
-Placer,462417,U.S. Senate,,DEM,Loretta Sanchez,162
-Placer,462418,U.S. Senate,,DEM,Kamala Harris,277
-Placer,462418,U.S. Senate,,DEM,Loretta Sanchez,155
-Placer,462420,U.S. Senate,,DEM,Kamala Harris,323
-Placer,462420,U.S. Senate,,DEM,Loretta Sanchez,220
-Placer,462433,U.S. Senate,,DEM,Kamala Harris,206
-Placer,462433,U.S. Senate,,DEM,Loretta Sanchez,136
-Placer,510201,U.S. Senate,,DEM,Kamala Harris,392
-Placer,510201,U.S. Senate,,DEM,Loretta Sanchez,223
-Placer,512501,U.S. Senate,,DEM,Kamala Harris,249
-Placer,512501,U.S. Senate,,DEM,Loretta Sanchez,101
-Placer,512502,U.S. Senate,,DEM,Kamala Harris,205
-Placer,512502,U.S. Senate,,DEM,Loretta Sanchez,171
-Placer,512505,U.S. Senate,,DEM,Kamala Harris,422
-Placer,512505,U.S. Senate,,DEM,Loretta Sanchez,198
-Placer,512506,U.S. Senate,,DEM,Kamala Harris,388
-Placer,512506,U.S. Senate,,DEM,Loretta Sanchez,253
-Placer,512509,U.S. Senate,,DEM,Kamala Harris,333
-Placer,512509,U.S. Senate,,DEM,Loretta Sanchez,171
-Placer,512510,U.S. Senate,,DEM,Kamala Harris,292
-Placer,512510,U.S. Senate,,DEM,Loretta Sanchez,179
-Placer,512513,U.S. Senate,,DEM,Kamala Harris,293
-Placer,512513,U.S. Senate,,DEM,Loretta Sanchez,189
-Placer,512514,U.S. Senate,,DEM,Kamala Harris,197
-Placer,512514,U.S. Senate,,DEM,Loretta Sanchez,146
-Placer,512520,U.S. Senate,,DEM,Kamala Harris,232
-Placer,512520,U.S. Senate,,DEM,Loretta Sanchez,149
-Placer,512524,U.S. Senate,,DEM,Kamala Harris,114
-Placer,512524,U.S. Senate,,DEM,Loretta Sanchez,76
-Placer,512527,U.S. Senate,,DEM,Kamala Harris,185
-Placer,512527,U.S. Senate,,DEM,Loretta Sanchez,114
-Placer,512529,U.S. Senate,,DEM,Kamala Harris,321
-Placer,512529,U.S. Senate,,DEM,Loretta Sanchez,224
-Placer,512602,U.S. Senate,,DEM,Kamala Harris,114
-Placer,512602,U.S. Senate,,DEM,Loretta Sanchez,91
-Placer,512603,U.S. Senate,,DEM,Kamala Harris,332
-Placer,512603,U.S. Senate,,DEM,Loretta Sanchez,216
-Placer,512604,U.S. Senate,,DEM,Kamala Harris,326
-Placer,512604,U.S. Senate,,DEM,Loretta Sanchez,256
-Placer,512605,U.S. Senate,,DEM,Kamala Harris,360
-Placer,512605,U.S. Senate,,DEM,Loretta Sanchez,228
-Placer,512606,U.S. Senate,,DEM,Kamala Harris,326
-Placer,512606,U.S. Senate,,DEM,Loretta Sanchez,239
-Placer,512702,U.S. Senate,,DEM,Kamala Harris,152
-Placer,512702,U.S. Senate,,DEM,Loretta Sanchez,96
-Placer,512705,U.S. Senate,,DEM,Kamala Harris,398
-Placer,512705,U.S. Senate,,DEM,Loretta Sanchez,218
-Placer,512706,U.S. Senate,,DEM,Kamala Harris,482
-Placer,512706,U.S. Senate,,DEM,Loretta Sanchez,268
-Placer,512717,U.S. Senate,,DEM,Kamala Harris,370
-Placer,512717,U.S. Senate,,DEM,Loretta Sanchez,255
-Placer,512803,U.S. Senate,,DEM,Kamala Harris,400
-Placer,512803,U.S. Senate,,DEM,Loretta Sanchez,238
-Placer,512806,U.S. Senate,,DEM,Kamala Harris,396
-Placer,512806,U.S. Senate,,DEM,Loretta Sanchez,267
-Placer,512807,U.S. Senate,,DEM,Kamala Harris,444
-Placer,512807,U.S. Senate,,DEM,Loretta Sanchez,303
-Placer,512901,U.S. Senate,,DEM,Kamala Harris,281
-Placer,512901,U.S. Senate,,DEM,Loretta Sanchez,119
-Placer,512903,U.S. Senate,,DEM,Kamala Harris,510
-Placer,512903,U.S. Senate,,DEM,Loretta Sanchez,347
-Placer,513101,U.S. Senate,,DEM,Kamala Harris,268
-Placer,513101,U.S. Senate,,DEM,Loretta Sanchez,126
-Placer,513102,U.S. Senate,,DEM,Kamala Harris,174
-Placer,513102,U.S. Senate,,DEM,Loretta Sanchez,98
-Placer,513203,U.S. Senate,,DEM,Kamala Harris,290
-Placer,513203,U.S. Senate,,DEM,Loretta Sanchez,80
-Placer,513302,U.S. Senate,,DEM,Kamala Harris,268
-Placer,513302,U.S. Senate,,DEM,Loretta Sanchez,94
-Placer,513403,U.S. Senate,,DEM,Kamala Harris,142
-Placer,513403,U.S. Senate,,DEM,Loretta Sanchez,59
-Placer,513607,U.S. Senate,,DEM,Kamala Harris,480
-Placer,513607,U.S. Senate,,DEM,Loretta Sanchez,214
-Placer,513609,U.S. Senate,,DEM,Kamala Harris,493
-Placer,513609,U.S. Senate,,DEM,Loretta Sanchez,210
-Placer,513613,U.S. Senate,,DEM,Kamala Harris,148
-Placer,513613,U.S. Senate,,DEM,Loretta Sanchez,61
-Placer,513615,U.S. Senate,,DEM,Kamala Harris,297
-Placer,513615,U.S. Senate,,DEM,Loretta Sanchez,111
-Placer,513702,U.S. Senate,,DEM,Kamala Harris,609
-Placer,513702,U.S. Senate,,DEM,Loretta Sanchez,281
-Placer,513706,U.S. Senate,,DEM,Kamala Harris,459
-Placer,513706,U.S. Senate,,DEM,Loretta Sanchez,312
-Placer,550101,U.S. Senate,,DEM,Kamala Harris,269
-Placer,550101,U.S. Senate,,DEM,Loretta Sanchez,137
-Placer,550102,U.S. Senate,,DEM,Kamala Harris,338
-Placer,550102,U.S. Senate,,DEM,Loretta Sanchez,213
-Placer,550103,U.S. Senate,,DEM,Kamala Harris,413
-Placer,550103,U.S. Senate,,DEM,Loretta Sanchez,189
-Placer,550104,U.S. Senate,,DEM,Kamala Harris,411
-Placer,550104,U.S. Senate,,DEM,Loretta Sanchez,208
-Placer,550106,U.S. Senate,,DEM,Kamala Harris,395
-Placer,550106,U.S. Senate,,DEM,Loretta Sanchez,199
-Placer,550107,U.S. Senate,,DEM,Kamala Harris,309
-Placer,550107,U.S. Senate,,DEM,Loretta Sanchez,190
-Placer,550109,U.S. Senate,,DEM,Kamala Harris,587
-Placer,550109,U.S. Senate,,DEM,Loretta Sanchez,283
-Placer,550110,U.S. Senate,,DEM,Kamala Harris,279
-Placer,550110,U.S. Senate,,DEM,Loretta Sanchez,158
-Placer,550111,U.S. Senate,,DEM,Kamala Harris,368
-Placer,550111,U.S. Senate,,DEM,Loretta Sanchez,188
-Placer,550114,U.S. Senate,,DEM,Kamala Harris,231
-Placer,550114,U.S. Senate,,DEM,Loretta Sanchez,146
-Placer,550116,U.S. Senate,,DEM,Kamala Harris,136
-Placer,550116,U.S. Senate,,DEM,Loretta Sanchez,69
-Placer,562204,U.S. Senate,,DEM,Kamala Harris,129
-Placer,562204,U.S. Senate,,DEM,Loretta Sanchez,85
-Placer,562206,U.S. Senate,,DEM,Kamala Harris,204
-Placer,562206,U.S. Senate,,DEM,Loretta Sanchez,160
-Placer,562503,U.S. Senate,,DEM,Kamala Harris,147
-Placer,562503,U.S. Senate,,DEM,Loretta Sanchez,77
-Placer,6160601,U.S. Senate,,DEM,Kamala Harris,28
-Placer,6160601,U.S. Senate,,DEM,Loretta Sanchez,20
-Placer,6160602,U.S. Senate,,DEM,Kamala Harris,74
-Placer,6160602,U.S. Senate,,DEM,Loretta Sanchez,42
-Placer,6160623,U.S. Senate,,DEM,Kamala Harris,0
-Placer,6160623,U.S. Senate,,DEM,Loretta Sanchez,0
-Placer,6160641,U.S. Senate,,DEM,Kamala Harris,0
-Placer,6160641,U.S. Senate,,DEM,Loretta Sanchez,1
-Placer,6161001,U.S. Senate,,DEM,Kamala Harris,69
-Placer,6161001,U.S. Senate,,DEM,Loretta Sanchez,53
-Placer,6161002,U.S. Senate,,DEM,Kamala Harris,21
-Placer,6161002,U.S. Senate,,DEM,Loretta Sanchez,8
-Placer,6161009,U.S. Senate,,DEM,Kamala Harris,0
-Placer,6161009,U.S. Senate,,DEM,Loretta Sanchez,0
-Placer,6251401,U.S. Senate,,DEM,Kamala Harris,0
-Placer,6251401,U.S. Senate,,DEM,Loretta Sanchez,1
-Placer,6260301,U.S. Senate,,DEM,Kamala Harris,0
-Placer,6260301,U.S. Senate,,DEM,Loretta Sanchez,2
-Placer,6260601,U.S. Senate,,DEM,Kamala Harris,0
-Placer,6260601,U.S. Senate,,DEM,Loretta Sanchez,0
-Placer,6261001,U.S. Senate,,DEM,Kamala Harris,18
-Placer,6261001,U.S. Senate,,DEM,Loretta Sanchez,16
-Placer,6261003,U.S. Senate,,DEM,Kamala Harris,5
-Placer,6261003,U.S. Senate,,DEM,Loretta Sanchez,5
-Placer,6261101,U.S. Senate,,DEM,Kamala Harris,25
-Placer,6261101,U.S. Senate,,DEM,Loretta Sanchez,11
-Placer,6261103,U.S. Senate,,DEM,Kamala Harris,59
-Placer,6261103,U.S. Senate,,DEM,Loretta Sanchez,60
-Placer,6261106,U.S. Senate,,DEM,Kamala Harris,21
-Placer,6261106,U.S. Senate,,DEM,Loretta Sanchez,11
-Placer,6261207,U.S. Senate,,DEM,Kamala Harris,10
-Placer,6261207,U.S. Senate,,DEM,Loretta Sanchez,2
-Placer,6261309,U.S. Senate,,DEM,Kamala Harris,79
-Placer,6261309,U.S. Senate,,DEM,Loretta Sanchez,42
-Placer,6261311,U.S. Senate,,DEM,Kamala Harris,37
-Placer,6261311,U.S. Senate,,DEM,Loretta Sanchez,46
-Placer,6261314,U.S. Senate,,DEM,Kamala Harris,16
-Placer,6261314,U.S. Senate,,DEM,Loretta Sanchez,16
-Placer,6261323,U.S. Senate,,DEM,Kamala Harris,99
-Placer,6261323,U.S. Senate,,DEM,Loretta Sanchez,71
-Placer,6261324,U.S. Senate,,DEM,Kamala Harris,7
-Placer,6261324,U.S. Senate,,DEM,Loretta Sanchez,7
-Placer,6261328,U.S. Senate,,DEM,Kamala Harris,22
-Placer,6261328,U.S. Senate,,DEM,Loretta Sanchez,21
-Placer,6261331,U.S. Senate,,DEM,Kamala Harris,0
-Placer,6261331,U.S. Senate,,DEM,Loretta Sanchez,0
-Placer,6261344,U.S. Senate,,DEM,Kamala Harris,10
-Placer,6261344,U.S. Senate,,DEM,Loretta Sanchez,16
-Placer,6261405,U.S. Senate,,DEM,Kamala Harris,4
-Placer,6261405,U.S. Senate,,DEM,Loretta Sanchez,2
-Placer,6261406,U.S. Senate,,DEM,Kamala Harris,1
-Placer,6261406,U.S. Senate,,DEM,Loretta Sanchez,0
-Placer,6312201,U.S. Senate,,DEM,Kamala Harris,7
-Placer,6312201,U.S. Senate,,DEM,Loretta Sanchez,10
-Placer,6312205,U.S. Senate,,DEM,Kamala Harris,15
-Placer,6312205,U.S. Senate,,DEM,Loretta Sanchez,3
-Placer,6312208,U.S. Senate,,DEM,Kamala Harris,40
-Placer,6312208,U.S. Senate,,DEM,Loretta Sanchez,28
-Placer,6312209,U.S. Senate,,DEM,Kamala Harris,82
-Placer,6312209,U.S. Senate,,DEM,Loretta Sanchez,48
-Placer,6312214,U.S. Senate,,DEM,Kamala Harris,11
-Placer,6312214,U.S. Senate,,DEM,Loretta Sanchez,5
-Placer,6350101,U.S. Senate,,DEM,Kamala Harris,0
-Placer,6350101,U.S. Senate,,DEM,Loretta Sanchez,0
-Placer,6351701,U.S. Senate,,DEM,Kamala Harris,47
-Placer,6351701,U.S. Senate,,DEM,Loretta Sanchez,29
-Placer,6351703,U.S. Senate,,DEM,Kamala Harris,37
-Placer,6351703,U.S. Senate,,DEM,Loretta Sanchez,6
-Placer,6351804,U.S. Senate,,DEM,Kamala Harris,14
-Placer,6351804,U.S. Senate,,DEM,Loretta Sanchez,14
-Placer,6351808,U.S. Senate,,DEM,Kamala Harris,42
-Placer,6351808,U.S. Senate,,DEM,Loretta Sanchez,28
-Placer,6351814,U.S. Senate,,DEM,Kamala Harris,68
-Placer,6351814,U.S. Senate,,DEM,Loretta Sanchez,34
-Placer,6351815,U.S. Senate,,DEM,Kamala Harris,17
-Placer,6351815,U.S. Senate,,DEM,Loretta Sanchez,16
-Placer,6351817,U.S. Senate,,DEM,Kamala Harris,4
-Placer,6351817,U.S. Senate,,DEM,Loretta Sanchez,4
-Placer,6351818,U.S. Senate,,DEM,Kamala Harris,0
-Placer,6351818,U.S. Senate,,DEM,Loretta Sanchez,0
-Placer,6351824,U.S. Senate,,DEM,Kamala Harris,13
-Placer,6351824,U.S. Senate,,DEM,Loretta Sanchez,3
-Placer,6351901,U.S. Senate,,DEM,Kamala Harris,48
-Placer,6351901,U.S. Senate,,DEM,Loretta Sanchez,30
-Placer,6352105,U.S. Senate,,DEM,Kamala Harris,74
-Placer,6352105,U.S. Senate,,DEM,Loretta Sanchez,48
-Placer,6352106,U.S. Senate,,DEM,Kamala Harris,33
-Placer,6352106,U.S. Senate,,DEM,Loretta Sanchez,16
-Placer,6352120,U.S. Senate,,DEM,Kamala Harris,29
-Placer,6352120,U.S. Senate,,DEM,Loretta Sanchez,27
-Placer,6352125,U.S. Senate,,DEM,Kamala Harris,53
-Placer,6352125,U.S. Senate,,DEM,Loretta Sanchez,37
-Placer,6352129,U.S. Senate,,DEM,Kamala Harris,37
-Placer,6352129,U.S. Senate,,DEM,Loretta Sanchez,19
-Placer,6352130,U.S. Senate,,DEM,Kamala Harris,11
-Placer,6352130,U.S. Senate,,DEM,Loretta Sanchez,0
-Placer,6360401,U.S. Senate,,DEM,Kamala Harris,43
-Placer,6360401,U.S. Senate,,DEM,Loretta Sanchez,41
-Placer,6360402,U.S. Senate,,DEM,Kamala Harris,49
-Placer,6360402,U.S. Senate,,DEM,Loretta Sanchez,38
-Placer,6360404,U.S. Senate,,DEM,Kamala Harris,7
-Placer,6360404,U.S. Senate,,DEM,Loretta Sanchez,4
-Placer,6360410,U.S. Senate,,DEM,Kamala Harris,74
-Placer,6360410,U.S. Senate,,DEM,Loretta Sanchez,26
-Placer,6360506,U.S. Senate,,DEM,Kamala Harris,28
-Placer,6360506,U.S. Senate,,DEM,Loretta Sanchez,22
-Placer,6360510,U.S. Senate,,DEM,Kamala Harris,0
-Placer,6360510,U.S. Senate,,DEM,Loretta Sanchez,0
-Placer,6360515,U.S. Senate,,DEM,Kamala Harris,53
-Placer,6360515,U.S. Senate,,DEM,Loretta Sanchez,42
-Placer,6361301,U.S. Senate,,DEM,Kamala Harris,11
-Placer,6361301,U.S. Senate,,DEM,Loretta Sanchez,4
-Placer,6361302,U.S. Senate,,DEM,Kamala Harris,1
-Placer,6361302,U.S. Senate,,DEM,Loretta Sanchez,1
-Placer,6361504,U.S. Senate,,DEM,Kamala Harris,65
-Placer,6361504,U.S. Senate,,DEM,Loretta Sanchez,27
-Placer,6361505,U.S. Senate,,DEM,Kamala Harris,65
-Placer,6361505,U.S. Senate,,DEM,Loretta Sanchez,48
-Placer,6361506,U.S. Senate,,DEM,Kamala Harris,73
-Placer,6361506,U.S. Senate,,DEM,Loretta Sanchez,54
-Placer,6361510,U.S. Senate,,DEM,Kamala Harris,52
-Placer,6361510,U.S. Senate,,DEM,Loretta Sanchez,40
-Placer,6361515,U.S. Senate,,DEM,Kamala Harris,45
-Placer,6361515,U.S. Senate,,DEM,Loretta Sanchez,34
-Placer,6361701,U.S. Senate,,DEM,Kamala Harris,63
-Placer,6361701,U.S. Senate,,DEM,Loretta Sanchez,31
-Placer,6361712,U.S. Senate,,DEM,Kamala Harris,3
-Placer,6361712,U.S. Senate,,DEM,Loretta Sanchez,0
-Placer,6361713,U.S. Senate,,DEM,Kamala Harris,30
-Placer,6361713,U.S. Senate,,DEM,Loretta Sanchez,35
-Placer,6361715,U.S. Senate,,DEM,Kamala Harris,105
-Placer,6361715,U.S. Senate,,DEM,Loretta Sanchez,61
-Placer,6361716,U.S. Senate,,DEM,Kamala Harris,2
-Placer,6361716,U.S. Senate,,DEM,Loretta Sanchez,2
-Placer,6361717,U.S. Senate,,DEM,Kamala Harris,15
-Placer,6361717,U.S. Senate,,DEM,Loretta Sanchez,4
-Placer,6361719,U.S. Senate,,DEM,Kamala Harris,1
-Placer,6361719,U.S. Senate,,DEM,Loretta Sanchez,1
-Placer,6361801,U.S. Senate,,DEM,Kamala Harris,53
-Placer,6361801,U.S. Senate,,DEM,Loretta Sanchez,29
-Placer,6361802,U.S. Senate,,DEM,Kamala Harris,0
-Placer,6361802,U.S. Senate,,DEM,Loretta Sanchez,0
-Placer,6460604,U.S. Senate,,DEM,Kamala Harris,0
-Placer,6460604,U.S. Senate,,DEM,Loretta Sanchez,0
-Placer,6460605,U.S. Senate,,DEM,Kamala Harris,0
-Placer,6460605,U.S. Senate,,DEM,Loretta Sanchez,0
-Placer,6460606,U.S. Senate,,DEM,Kamala Harris,0
-Placer,6460606,U.S. Senate,,DEM,Loretta Sanchez,0
-Placer,6460609,U.S. Senate,,DEM,Kamala Harris,110
-Placer,6460609,U.S. Senate,,DEM,Loretta Sanchez,53
-Placer,6460631,U.S. Senate,,DEM,Kamala Harris,0
-Placer,6460631,U.S. Senate,,DEM,Loretta Sanchez,0
-Placer,6460633,U.S. Senate,,DEM,Kamala Harris,0
-Placer,6460633,U.S. Senate,,DEM,Loretta Sanchez,0
-Placer,6462301,U.S. Senate,,DEM,Kamala Harris,46
-Placer,6462301,U.S. Senate,,DEM,Loretta Sanchez,28
-Placer,6462302,U.S. Senate,,DEM,Kamala Harris,101
-Placer,6462302,U.S. Senate,,DEM,Loretta Sanchez,66
-Placer,6462305,U.S. Senate,,DEM,Kamala Harris,58
-Placer,6462305,U.S. Senate,,DEM,Loretta Sanchez,33
-Placer,6462308,U.S. Senate,,DEM,Kamala Harris,95
-Placer,6462308,U.S. Senate,,DEM,Loretta Sanchez,65
-Placer,6462309,U.S. Senate,,DEM,Kamala Harris,79
-Placer,6462309,U.S. Senate,,DEM,Loretta Sanchez,42
-Placer,6462408,U.S. Senate,,DEM,Kamala Harris,2
-Placer,6462408,U.S. Senate,,DEM,Loretta Sanchez,0
-Placer,6462409,U.S. Senate,,DEM,Kamala Harris,0
-Placer,6462409,U.S. Senate,,DEM,Loretta Sanchez,0
-Placer,6462415,U.S. Senate,,DEM,Kamala Harris,54
-Placer,6462415,U.S. Senate,,DEM,Loretta Sanchez,28
-Placer,6462421,U.S. Senate,,DEM,Kamala Harris,49
-Placer,6462421,U.S. Senate,,DEM,Loretta Sanchez,28
-Placer,6462427,U.S. Senate,,DEM,Kamala Harris,82
-Placer,6462427,U.S. Senate,,DEM,Loretta Sanchez,28
-Placer,6510101,U.S. Senate,,DEM,Kamala Harris,2
-Placer,6510101,U.S. Senate,,DEM,Loretta Sanchez,2
-Placer,6510102,U.S. Senate,,DEM,Kamala Harris,2
-Placer,6510102,U.S. Senate,,DEM,Loretta Sanchez,0
-Placer,6510202,U.S. Senate,,DEM,Kamala Harris,0
-Placer,6510202,U.S. Senate,,DEM,Loretta Sanchez,0
-Placer,6512201,U.S. Senate,,DEM,Kamala Harris,58
-Placer,6512201,U.S. Senate,,DEM,Loretta Sanchez,38
-Placer,6512503,U.S. Senate,,DEM,Kamala Harris,90
-Placer,6512503,U.S. Senate,,DEM,Loretta Sanchez,37
-Placer,6512511,U.S. Senate,,DEM,Kamala Harris,69
-Placer,6512511,U.S. Senate,,DEM,Loretta Sanchez,46
-Placer,6512518,U.S. Senate,,DEM,Kamala Harris,7
-Placer,6512518,U.S. Senate,,DEM,Loretta Sanchez,7
-Placer,6512521,U.S. Senate,,DEM,Kamala Harris,97
-Placer,6512521,U.S. Senate,,DEM,Loretta Sanchez,48
-Placer,6512533,U.S. Senate,,DEM,Kamala Harris,6
-Placer,6512533,U.S. Senate,,DEM,Loretta Sanchez,6
-Placer,6512537,U.S. Senate,,DEM,Kamala Harris,45
-Placer,6512537,U.S. Senate,,DEM,Loretta Sanchez,27
-Placer,6512540,U.S. Senate,,DEM,Kamala Harris,79
-Placer,6512540,U.S. Senate,,DEM,Loretta Sanchez,60
-Placer,6512608,U.S. Senate,,DEM,Kamala Harris,3
-Placer,6512608,U.S. Senate,,DEM,Loretta Sanchez,0
-Placer,6512612,U.S. Senate,,DEM,Kamala Harris,0
-Placer,6512612,U.S. Senate,,DEM,Loretta Sanchez,0
-Placer,6512709,U.S. Senate,,DEM,Kamala Harris,86
-Placer,6512709,U.S. Senate,,DEM,Loretta Sanchez,67
-Placer,6512716,U.S. Senate,,DEM,Kamala Harris,73
-Placer,6512716,U.S. Senate,,DEM,Loretta Sanchez,61
-Placer,6512719,U.S. Senate,,DEM,Kamala Harris,76
-Placer,6512719,U.S. Senate,,DEM,Loretta Sanchez,29
-Placer,6512722,U.S. Senate,,DEM,Kamala Harris,51
-Placer,6512722,U.S. Senate,,DEM,Loretta Sanchez,28
-Placer,6512804,U.S. Senate,,DEM,Kamala Harris,0
-Placer,6512804,U.S. Senate,,DEM,Loretta Sanchez,0
-Placer,6512902,U.S. Senate,,DEM,Kamala Harris,26
-Placer,6512902,U.S. Senate,,DEM,Loretta Sanchez,12
-Placer,6513001,U.S. Senate,,DEM,Kamala Harris,23
-Placer,6513001,U.S. Senate,,DEM,Loretta Sanchez,6
-Placer,6513201,U.S. Senate,,DEM,Kamala Harris,20
-Placer,6513201,U.S. Senate,,DEM,Loretta Sanchez,10
-Placer,6513202,U.S. Senate,,DEM,Kamala Harris,70
-Placer,6513202,U.S. Senate,,DEM,Loretta Sanchez,21
-Placer,6513206,U.S. Senate,,DEM,Kamala Harris,9
-Placer,6513206,U.S. Senate,,DEM,Loretta Sanchez,7
-Placer,6513301,U.S. Senate,,DEM,Kamala Harris,94
-Placer,6513301,U.S. Senate,,DEM,Loretta Sanchez,41
-Placer,6513401,U.S. Senate,,DEM,Kamala Harris,0
-Placer,6513401,U.S. Senate,,DEM,Loretta Sanchez,0
-Placer,6513406,U.S. Senate,,DEM,Kamala Harris,80
-Placer,6513406,U.S. Senate,,DEM,Loretta Sanchez,24
-Placer,6513410,U.S. Senate,,DEM,Kamala Harris,0
-Placer,6513410,U.S. Senate,,DEM,Loretta Sanchez,0
-Placer,6513413,U.S. Senate,,DEM,Kamala Harris,0
-Placer,6513413,U.S. Senate,,DEM,Loretta Sanchez,0
-Placer,6513614,U.S. Senate,,DEM,Kamala Harris,8
-Placer,6513614,U.S. Senate,,DEM,Loretta Sanchez,2
-Placer,6513801,U.S. Senate,,DEM,Kamala Harris,81
-Placer,6513801,U.S. Senate,,DEM,Loretta Sanchez,25
-Placer,6513902,U.S. Senate,,DEM,Kamala Harris,0
-Placer,6513902,U.S. Senate,,DEM,Loretta Sanchez,0
-Placer,6513903,U.S. Senate,,DEM,Kamala Harris,2
-Placer,6513903,U.S. Senate,,DEM,Loretta Sanchez,0
-Placer,6513908,U.S. Senate,,DEM,Kamala Harris,0
-Placer,6513908,U.S. Senate,,DEM,Loretta Sanchez,0
-Placer,6513913,U.S. Senate,,DEM,Kamala Harris,8
-Placer,6513913,U.S. Senate,,DEM,Loretta Sanchez,2
-Placer,6513914,U.S. Senate,,DEM,Kamala Harris,36
-Placer,6513914,U.S. Senate,,DEM,Loretta Sanchez,5
-Placer,6550105,U.S. Senate,,DEM,Kamala Harris,57
-Placer,6550105,U.S. Senate,,DEM,Loretta Sanchez,38
-Placer,6551901,U.S. Senate,,DEM,Kamala Harris,0
-Placer,6551901,U.S. Senate,,DEM,Loretta Sanchez,0
-Placer,6552001,U.S. Senate,,DEM,Kamala Harris,0
-Placer,6552001,U.S. Senate,,DEM,Loretta Sanchez,3
-Placer,6552201,U.S. Senate,,DEM,Kamala Harris,1
-Placer,6552201,U.S. Senate,,DEM,Loretta Sanchez,0
-Placer,6552202,U.S. Senate,,DEM,Kamala Harris,4
-Placer,6552202,U.S. Senate,,DEM,Loretta Sanchez,2
-Placer,6562201,U.S. Senate,,DEM,Kamala Harris,2
-Placer,6562201,U.S. Senate,,DEM,Loretta Sanchez,0
-Placer,6562202,U.S. Senate,,DEM,Kamala Harris,96
-Placer,6562202,U.S. Senate,,DEM,Loretta Sanchez,49
-Placer,6562501,U.S. Senate,,DEM,Kamala Harris,0
-Placer,6562501,U.S. Senate,,DEM,Loretta Sanchez,0
-Placer,6562505,U.S. Senate,,DEM,Kamala Harris,28
-Placer,6562505,U.S. Senate,,DEM,Loretta Sanchez,21
+Placer,160603,U.S. Senate,,DEM,Kamala D. Harris,483
+Placer,160603,U.S. Senate,,DEM,Loretta L. Sanchez,323
+Placer,160605,U.S. Senate,,DEM,Kamala D. Harris,461
+Placer,160605,U.S. Senate,,DEM,Loretta L. Sanchez,321
+Placer,160606,U.S. Senate,,DEM,Kamala D. Harris,369
+Placer,160606,U.S. Senate,,DEM,Loretta L. Sanchez,256
+Placer,160607,U.S. Senate,,DEM,Kamala D. Harris,515
+Placer,160607,U.S. Senate,,DEM,Loretta L. Sanchez,326
+Placer,160608,U.S. Senate,,DEM,Kamala D. Harris,467
+Placer,160608,U.S. Senate,,DEM,Loretta L. Sanchez,314
+Placer,160609,U.S. Senate,,DEM,Kamala D. Harris,491
+Placer,160609,U.S. Senate,,DEM,Loretta L. Sanchez,306
+Placer,160610,U.S. Senate,,DEM,Kamala D. Harris,439
+Placer,160610,U.S. Senate,,DEM,Loretta L. Sanchez,270
+Placer,160611,U.S. Senate,,DEM,Kamala D. Harris,380
+Placer,160611,U.S. Senate,,DEM,Loretta L. Sanchez,191
+Placer,160612,U.S. Senate,,DEM,Kamala D. Harris,424
+Placer,160612,U.S. Senate,,DEM,Loretta L. Sanchez,247
+Placer,160613,U.S. Senate,,DEM,Kamala D. Harris,426
+Placer,160613,U.S. Senate,,DEM,Loretta L. Sanchez,241
+Placer,160614,U.S. Senate,,DEM,Kamala D. Harris,363
+Placer,160614,U.S. Senate,,DEM,Loretta L. Sanchez,206
+Placer,160615,U.S. Senate,,DEM,Kamala D. Harris,318
+Placer,160615,U.S. Senate,,DEM,Loretta L. Sanchez,189
+Placer,160616,U.S. Senate,,DEM,Kamala D. Harris,473
+Placer,160616,U.S. Senate,,DEM,Loretta L. Sanchez,273
+Placer,160617,U.S. Senate,,DEM,Kamala D. Harris,437
+Placer,160617,U.S. Senate,,DEM,Loretta L. Sanchez,225
+Placer,160618,U.S. Senate,,DEM,Kamala D. Harris,372
+Placer,160618,U.S. Senate,,DEM,Loretta L. Sanchez,178
+Placer,160619,U.S. Senate,,DEM,Kamala D. Harris,323
+Placer,160619,U.S. Senate,,DEM,Loretta L. Sanchez,226
+Placer,160620,U.S. Senate,,DEM,Kamala D. Harris,412
+Placer,160620,U.S. Senate,,DEM,Loretta L. Sanchez,283
+Placer,160621,U.S. Senate,,DEM,Kamala D. Harris,651
+Placer,160621,U.S. Senate,,DEM,Loretta L. Sanchez,251
+Placer,160622,U.S. Senate,,DEM,Kamala D. Harris,738
+Placer,160622,U.S. Senate,,DEM,Loretta L. Sanchez,385
+Placer,160624,U.S. Senate,,DEM,Kamala D. Harris,531
+Placer,160624,U.S. Senate,,DEM,Loretta L. Sanchez,279
+Placer,160625,U.S. Senate,,DEM,Kamala D. Harris,614
+Placer,160625,U.S. Senate,,DEM,Loretta L. Sanchez,318
+Placer,160626,U.S. Senate,,DEM,Kamala D. Harris,373
+Placer,160626,U.S. Senate,,DEM,Loretta L. Sanchez,191
+Placer,160627,U.S. Senate,,DEM,Kamala D. Harris,375
+Placer,160627,U.S. Senate,,DEM,Loretta L. Sanchez,245
+Placer,160628,U.S. Senate,,DEM,Kamala D. Harris,311
+Placer,160628,U.S. Senate,,DEM,Loretta L. Sanchez,219
+Placer,160629,U.S. Senate,,DEM,Kamala D. Harris,337
+Placer,160629,U.S. Senate,,DEM,Loretta L. Sanchez,210
+Placer,160630,U.S. Senate,,DEM,Kamala D. Harris,372
+Placer,160630,U.S. Senate,,DEM,Loretta L. Sanchez,263
+Placer,160631,U.S. Senate,,DEM,Kamala D. Harris,285
+Placer,160631,U.S. Senate,,DEM,Loretta L. Sanchez,219
+Placer,160632,U.S. Senate,,DEM,Kamala D. Harris,344
+Placer,160632,U.S. Senate,,DEM,Loretta L. Sanchez,226
+Placer,160633,U.S. Senate,,DEM,Kamala D. Harris,476
+Placer,160633,U.S. Senate,,DEM,Loretta L. Sanchez,216
+Placer,160634,U.S. Senate,,DEM,Kamala D. Harris,538
+Placer,160634,U.S. Senate,,DEM,Loretta L. Sanchez,269
+Placer,160635,U.S. Senate,,DEM,Kamala D. Harris,388
+Placer,160635,U.S. Senate,,DEM,Loretta L. Sanchez,247
+Placer,160636,U.S. Senate,,DEM,Kamala D. Harris,780
+Placer,160636,U.S. Senate,,DEM,Loretta L. Sanchez,365
+Placer,160637,U.S. Senate,,DEM,Kamala D. Harris,648
+Placer,160637,U.S. Senate,,DEM,Loretta L. Sanchez,327
+Placer,160638,U.S. Senate,,DEM,Kamala D. Harris,502
+Placer,160638,U.S. Senate,,DEM,Loretta L. Sanchez,300
+Placer,160639,U.S. Senate,,DEM,Kamala D. Harris,317
+Placer,160639,U.S. Senate,,DEM,Loretta L. Sanchez,163
+Placer,160640,U.S. Senate,,DEM,Kamala D. Harris,549
+Placer,160640,U.S. Senate,,DEM,Loretta L. Sanchez,280
+Placer,160643,U.S. Senate,,DEM,Kamala D. Harris,493
+Placer,160643,U.S. Senate,,DEM,Loretta L. Sanchez,231
+Placer,160644,U.S. Senate,,DEM,Kamala D. Harris,617
+Placer,160644,U.S. Senate,,DEM,Loretta L. Sanchez,324
+Placer,160647,U.S. Senate,,DEM,Kamala D. Harris,262
+Placer,160647,U.S. Senate,,DEM,Loretta L. Sanchez,170
+Placer,160648,U.S. Senate,,DEM,Kamala D. Harris,285
+Placer,160648,U.S. Senate,,DEM,Loretta L. Sanchez,157
+Placer,161004,U.S. Senate,,DEM,Kamala D. Harris,179
+Placer,161004,U.S. Senate,,DEM,Loretta L. Sanchez,93
+Placer,161005,U.S. Senate,,DEM,Kamala D. Harris,366
+Placer,161005,U.S. Senate,,DEM,Loretta L. Sanchez,215
+Placer,161006,U.S. Senate,,DEM,Kamala D. Harris,250
+Placer,161006,U.S. Senate,,DEM,Loretta L. Sanchez,161
+Placer,161011,U.S. Senate,,DEM,Kamala D. Harris,387
+Placer,161011,U.S. Senate,,DEM,Loretta L. Sanchez,205
+Placer,260302,U.S. Senate,,DEM,Kamala D. Harris,403
+Placer,260302,U.S. Senate,,DEM,Loretta L. Sanchez,243
+Placer,260303,U.S. Senate,,DEM,Kamala D. Harris,361
+Placer,260303,U.S. Senate,,DEM,Loretta L. Sanchez,214
+Placer,260304,U.S. Senate,,DEM,Kamala D. Harris,584
+Placer,260304,U.S. Senate,,DEM,Loretta L. Sanchez,401
+Placer,260305,U.S. Senate,,DEM,Kamala D. Harris,677
+Placer,260305,U.S. Senate,,DEM,Loretta L. Sanchez,301
+Placer,260307,U.S. Senate,,DEM,Kamala D. Harris,590
+Placer,260307,U.S. Senate,,DEM,Loretta L. Sanchez,228
+Placer,260308,U.S. Senate,,DEM,Kamala D. Harris,465
+Placer,260308,U.S. Senate,,DEM,Loretta L. Sanchez,219
+Placer,260310,U.S. Senate,,DEM,Kamala D. Harris,692
+Placer,260310,U.S. Senate,,DEM,Loretta L. Sanchez,331
+Placer,260312,U.S. Senate,,DEM,Kamala D. Harris,528
+Placer,260312,U.S. Senate,,DEM,Loretta L. Sanchez,251
+Placer,260313,U.S. Senate,,DEM,Kamala D. Harris,375
+Placer,260313,U.S. Senate,,DEM,Loretta L. Sanchez,183
+Placer,260314,U.S. Senate,,DEM,Kamala D. Harris,445
+Placer,260314,U.S. Senate,,DEM,Loretta L. Sanchez,220
+Placer,260315,U.S. Senate,,DEM,Kamala D. Harris,586
+Placer,260315,U.S. Senate,,DEM,Loretta L. Sanchez,326
+Placer,260316,U.S. Senate,,DEM,Kamala D. Harris,329
+Placer,260316,U.S. Senate,,DEM,Loretta L. Sanchez,179
+Placer,260317,U.S. Senate,,DEM,Kamala D. Harris,588
+Placer,260317,U.S. Senate,,DEM,Loretta L. Sanchez,281
+Placer,260318,U.S. Senate,,DEM,Kamala D. Harris,610
+Placer,260318,U.S. Senate,,DEM,Loretta L. Sanchez,220
+Placer,260319,U.S. Senate,,DEM,Kamala D. Harris,421
+Placer,260319,U.S. Senate,,DEM,Loretta L. Sanchez,162
+Placer,260320,U.S. Senate,,DEM,Kamala D. Harris,504
+Placer,260320,U.S. Senate,,DEM,Loretta L. Sanchez,205
+Placer,260321,U.S. Senate,,DEM,Kamala D. Harris,443
+Placer,260321,U.S. Senate,,DEM,Loretta L. Sanchez,291
+Placer,260322,U.S. Senate,,DEM,Kamala D. Harris,308
+Placer,260322,U.S. Senate,,DEM,Loretta L. Sanchez,190
+Placer,260323,U.S. Senate,,DEM,Kamala D. Harris,267
+Placer,260323,U.S. Senate,,DEM,Loretta L. Sanchez,290
+Placer,260324,U.S. Senate,,DEM,Kamala D. Harris,226
+Placer,260324,U.S. Senate,,DEM,Loretta L. Sanchez,167
+Placer,260325,U.S. Senate,,DEM,Kamala D. Harris,520
+Placer,260325,U.S. Senate,,DEM,Loretta L. Sanchez,436
+Placer,260326,U.S. Senate,,DEM,Kamala D. Harris,350
+Placer,260326,U.S. Senate,,DEM,Loretta L. Sanchez,250
+Placer,260327,U.S. Senate,,DEM,Kamala D. Harris,321
+Placer,260327,U.S. Senate,,DEM,Loretta L. Sanchez,283
+Placer,260328,U.S. Senate,,DEM,Kamala D. Harris,470
+Placer,260328,U.S. Senate,,DEM,Loretta L. Sanchez,352
+Placer,260329,U.S. Senate,,DEM,Kamala D. Harris,498
+Placer,260329,U.S. Senate,,DEM,Loretta L. Sanchez,316
+Placer,260330,U.S. Senate,,DEM,Kamala D. Harris,139
+Placer,260330,U.S. Senate,,DEM,Loretta L. Sanchez,78
+Placer,260501,U.S. Senate,,DEM,Kamala D. Harris,278
+Placer,260501,U.S. Senate,,DEM,Loretta L. Sanchez,202
+Placer,260502,U.S. Senate,,DEM,Kamala D. Harris,305
+Placer,260502,U.S. Senate,,DEM,Loretta L. Sanchez,150
+Placer,260503,U.S. Senate,,DEM,Kamala D. Harris,495
+Placer,260503,U.S. Senate,,DEM,Loretta L. Sanchez,292
+Placer,260504,U.S. Senate,,DEM,Kamala D. Harris,490
+Placer,260504,U.S. Senate,,DEM,Loretta L. Sanchez,277
+Placer,260505,U.S. Senate,,DEM,Kamala D. Harris,456
+Placer,260505,U.S. Senate,,DEM,Loretta L. Sanchez,257
+Placer,260506,U.S. Senate,,DEM,Kamala D. Harris,587
+Placer,260506,U.S. Senate,,DEM,Loretta L. Sanchez,277
+Placer,260507,U.S. Senate,,DEM,Kamala D. Harris,257
+Placer,260507,U.S. Senate,,DEM,Loretta L. Sanchez,156
+Placer,260508,U.S. Senate,,DEM,Kamala D. Harris,437
+Placer,260508,U.S. Senate,,DEM,Loretta L. Sanchez,266
+Placer,260509,U.S. Senate,,DEM,Kamala D. Harris,424
+Placer,260509,U.S. Senate,,DEM,Loretta L. Sanchez,244
+Placer,260510,U.S. Senate,,DEM,Kamala D. Harris,346
+Placer,260510,U.S. Senate,,DEM,Loretta L. Sanchez,183
+Placer,260511,U.S. Senate,,DEM,Kamala D. Harris,312
+Placer,260511,U.S. Senate,,DEM,Loretta L. Sanchez,153
+Placer,261102,U.S. Senate,,DEM,Kamala D. Harris,136
+Placer,261102,U.S. Senate,,DEM,Loretta L. Sanchez,116
+Placer,261201,U.S. Senate,,DEM,Kamala D. Harris,192
+Placer,261201,U.S. Senate,,DEM,Loretta L. Sanchez,184
+Placer,261302,U.S. Senate,,DEM,Kamala D. Harris,232
+Placer,261302,U.S. Senate,,DEM,Loretta L. Sanchez,160
+Placer,261310,U.S. Senate,,DEM,Kamala D. Harris,221
+Placer,261310,U.S. Senate,,DEM,Loretta L. Sanchez,179
+Placer,261318,U.S. Senate,,DEM,Kamala D. Harris,125
+Placer,261318,U.S. Senate,,DEM,Loretta L. Sanchez,89
+Placer,261334,U.S. Senate,,DEM,Kamala D. Harris,168
+Placer,261334,U.S. Senate,,DEM,Loretta L. Sanchez,130
+Placer,261402,U.S. Senate,,DEM,Kamala D. Harris,113
+Placer,261402,U.S. Senate,,DEM,Loretta L. Sanchez,64
+Placer,312202,U.S. Senate,,DEM,Kamala D. Harris,388
+Placer,312202,U.S. Senate,,DEM,Loretta L. Sanchez,196
+Placer,312211,U.S. Senate,,DEM,Kamala D. Harris,393
+Placer,312211,U.S. Senate,,DEM,Loretta L. Sanchez,220
+Placer,312212,U.S. Senate,,DEM,Kamala D. Harris,261
+Placer,312212,U.S. Senate,,DEM,Loretta L. Sanchez,158
+Placer,351801,U.S. Senate,,DEM,Kamala D. Harris,279
+Placer,351801,U.S. Senate,,DEM,Loretta L. Sanchez,161
+Placer,351802,U.S. Senate,,DEM,Kamala D. Harris,195
+Placer,351802,U.S. Senate,,DEM,Loretta L. Sanchez,121
+Placer,351803,U.S. Senate,,DEM,Kamala D. Harris,109
+Placer,351803,U.S. Senate,,DEM,Loretta L. Sanchez,77
+Placer,351903,U.S. Senate,,DEM,Kamala D. Harris,400
+Placer,351903,U.S. Senate,,DEM,Loretta L. Sanchez,214
+Placer,352109,U.S. Senate,,DEM,Kamala D. Harris,174
+Placer,352109,U.S. Senate,,DEM,Loretta L. Sanchez,112
+Placer,352110,U.S. Senate,,DEM,Kamala D. Harris,222
+Placer,352110,U.S. Senate,,DEM,Loretta L. Sanchez,131
+Placer,360403,U.S. Senate,,DEM,Kamala D. Harris,398
+Placer,360403,U.S. Senate,,DEM,Loretta L. Sanchez,233
+Placer,360406,U.S. Senate,,DEM,Kamala D. Harris,214
+Placer,360406,U.S. Senate,,DEM,Loretta L. Sanchez,124
+Placer,360408,U.S. Senate,,DEM,Kamala D. Harris,324
+Placer,360408,U.S. Senate,,DEM,Loretta L. Sanchez,188
+Placer,360409,U.S. Senate,,DEM,Kamala D. Harris,274
+Placer,360409,U.S. Senate,,DEM,Loretta L. Sanchez,163
+Placer,360412,U.S. Senate,,DEM,Kamala D. Harris,233
+Placer,360412,U.S. Senate,,DEM,Loretta L. Sanchez,140
+Placer,360501,U.S. Senate,,DEM,Kamala D. Harris,375
+Placer,360501,U.S. Senate,,DEM,Loretta L. Sanchez,222
+Placer,360502,U.S. Senate,,DEM,Kamala D. Harris,420
+Placer,360502,U.S. Senate,,DEM,Loretta L. Sanchez,245
+Placer,360503,U.S. Senate,,DEM,Kamala D. Harris,373
+Placer,360503,U.S. Senate,,DEM,Loretta L. Sanchez,203
+Placer,360504,U.S. Senate,,DEM,Kamala D. Harris,380
+Placer,360504,U.S. Senate,,DEM,Loretta L. Sanchez,239
+Placer,360505,U.S. Senate,,DEM,Kamala D. Harris,125
+Placer,360505,U.S. Senate,,DEM,Loretta L. Sanchez,80
+Placer,360507,U.S. Senate,,DEM,Kamala D. Harris,431
+Placer,360507,U.S. Senate,,DEM,Loretta L. Sanchez,276
+Placer,360508,U.S. Senate,,DEM,Kamala D. Harris,439
+Placer,360508,U.S. Senate,,DEM,Loretta L. Sanchez,269
+Placer,360509,U.S. Senate,,DEM,Kamala D. Harris,455
+Placer,360509,U.S. Senate,,DEM,Loretta L. Sanchez,238
+Placer,360511,U.S. Senate,,DEM,Kamala D. Harris,410
+Placer,360511,U.S. Senate,,DEM,Loretta L. Sanchez,266
+Placer,360512,U.S. Senate,,DEM,Kamala D. Harris,508
+Placer,360512,U.S. Senate,,DEM,Loretta L. Sanchez,308
+Placer,360513,U.S. Senate,,DEM,Kamala D. Harris,258
+Placer,360513,U.S. Senate,,DEM,Loretta L. Sanchez,185
+Placer,360514,U.S. Senate,,DEM,Kamala D. Harris,455
+Placer,360514,U.S. Senate,,DEM,Loretta L. Sanchez,313
+Placer,360517,U.S. Senate,,DEM,Kamala D. Harris,393
+Placer,360517,U.S. Senate,,DEM,Loretta L. Sanchez,219
+Placer,360518,U.S. Senate,,DEM,Kamala D. Harris,372
+Placer,360518,U.S. Senate,,DEM,Loretta L. Sanchez,231
+Placer,360519,U.S. Senate,,DEM,Kamala D. Harris,378
+Placer,360519,U.S. Senate,,DEM,Loretta L. Sanchez,199
+Placer,360520,U.S. Senate,,DEM,Kamala D. Harris,424
+Placer,360520,U.S. Senate,,DEM,Loretta L. Sanchez,273
+Placer,360521,U.S. Senate,,DEM,Kamala D. Harris,412
+Placer,360521,U.S. Senate,,DEM,Loretta L. Sanchez,229
+Placer,360522,U.S. Senate,,DEM,Kamala D. Harris,285
+Placer,360522,U.S. Senate,,DEM,Loretta L. Sanchez,174
+Placer,360523,U.S. Senate,,DEM,Kamala D. Harris,341
+Placer,360523,U.S. Senate,,DEM,Loretta L. Sanchez,189
+Placer,360524,U.S. Senate,,DEM,Kamala D. Harris,423
+Placer,360524,U.S. Senate,,DEM,Loretta L. Sanchez,238
+Placer,360525,U.S. Senate,,DEM,Kamala D. Harris,399
+Placer,360525,U.S. Senate,,DEM,Loretta L. Sanchez,213
+Placer,360526,U.S. Senate,,DEM,Kamala D. Harris,526
+Placer,360526,U.S. Senate,,DEM,Loretta L. Sanchez,285
+Placer,360527,U.S. Senate,,DEM,Kamala D. Harris,534
+Placer,360527,U.S. Senate,,DEM,Loretta L. Sanchez,277
+Placer,360533,U.S. Senate,,DEM,Kamala D. Harris,335
+Placer,360533,U.S. Senate,,DEM,Loretta L. Sanchez,184
+Placer,361501,U.S. Senate,,DEM,Kamala D. Harris,249
+Placer,361501,U.S. Senate,,DEM,Loretta L. Sanchez,130
+Placer,361502,U.S. Senate,,DEM,Kamala D. Harris,370
+Placer,361502,U.S. Senate,,DEM,Loretta L. Sanchez,254
+Placer,361503,U.S. Senate,,DEM,Kamala D. Harris,442
+Placer,361503,U.S. Senate,,DEM,Loretta L. Sanchez,277
+Placer,361508,U.S. Senate,,DEM,Kamala D. Harris,184
+Placer,361508,U.S. Senate,,DEM,Loretta L. Sanchez,118
+Placer,361511,U.S. Senate,,DEM,Kamala D. Harris,226
+Placer,361511,U.S. Senate,,DEM,Loretta L. Sanchez,142
+Placer,361601,U.S. Senate,,DEM,Kamala D. Harris,103
+Placer,361601,U.S. Senate,,DEM,Loretta L. Sanchez,83
+Placer,361704,U.S. Senate,,DEM,Kamala D. Harris,500
+Placer,361704,U.S. Senate,,DEM,Loretta L. Sanchez,310
+Placer,460601,U.S. Senate,,DEM,Kamala D. Harris,433
+Placer,460601,U.S. Senate,,DEM,Loretta L. Sanchez,290
+Placer,460602,U.S. Senate,,DEM,Kamala D. Harris,344
+Placer,460602,U.S. Senate,,DEM,Loretta L. Sanchez,205
+Placer,460603,U.S. Senate,,DEM,Kamala D. Harris,343
+Placer,460603,U.S. Senate,,DEM,Loretta L. Sanchez,238
+Placer,460607,U.S. Senate,,DEM,Kamala D. Harris,275
+Placer,460607,U.S. Senate,,DEM,Loretta L. Sanchez,222
+Placer,460608,U.S. Senate,,DEM,Kamala D. Harris,306
+Placer,460608,U.S. Senate,,DEM,Loretta L. Sanchez,199
+Placer,460611,U.S. Senate,,DEM,Kamala D. Harris,500
+Placer,460611,U.S. Senate,,DEM,Loretta L. Sanchez,253
+Placer,460612,U.S. Senate,,DEM,Kamala D. Harris,286
+Placer,460612,U.S. Senate,,DEM,Loretta L. Sanchez,201
+Placer,460613,U.S. Senate,,DEM,Kamala D. Harris,354
+Placer,460613,U.S. Senate,,DEM,Loretta L. Sanchez,220
+Placer,460614,U.S. Senate,,DEM,Kamala D. Harris,318
+Placer,460614,U.S. Senate,,DEM,Loretta L. Sanchez,192
+Placer,460615,U.S. Senate,,DEM,Kamala D. Harris,330
+Placer,460615,U.S. Senate,,DEM,Loretta L. Sanchez,211
+Placer,460616,U.S. Senate,,DEM,Kamala D. Harris,371
+Placer,460616,U.S. Senate,,DEM,Loretta L. Sanchez,183
+Placer,460617,U.S. Senate,,DEM,Kamala D. Harris,381
+Placer,460617,U.S. Senate,,DEM,Loretta L. Sanchez,174
+Placer,460618,U.S. Senate,,DEM,Kamala D. Harris,326
+Placer,460618,U.S. Senate,,DEM,Loretta L. Sanchez,236
+Placer,460619,U.S. Senate,,DEM,Kamala D. Harris,452
+Placer,460619,U.S. Senate,,DEM,Loretta L. Sanchez,234
+Placer,460620,U.S. Senate,,DEM,Kamala D. Harris,264
+Placer,460620,U.S. Senate,,DEM,Loretta L. Sanchez,176
+Placer,460621,U.S. Senate,,DEM,Kamala D. Harris,296
+Placer,460621,U.S. Senate,,DEM,Loretta L. Sanchez,170
+Placer,460622,U.S. Senate,,DEM,Kamala D. Harris,351
+Placer,460622,U.S. Senate,,DEM,Loretta L. Sanchez,191
+Placer,460623,U.S. Senate,,DEM,Kamala D. Harris,334
+Placer,460623,U.S. Senate,,DEM,Loretta L. Sanchez,142
+Placer,460624,U.S. Senate,,DEM,Kamala D. Harris,427
+Placer,460624,U.S. Senate,,DEM,Loretta L. Sanchez,235
+Placer,460625,U.S. Senate,,DEM,Kamala D. Harris,683
+Placer,460625,U.S. Senate,,DEM,Loretta L. Sanchez,329
+Placer,460626,U.S. Senate,,DEM,Kamala D. Harris,528
+Placer,460626,U.S. Senate,,DEM,Loretta L. Sanchez,271
+Placer,460627,U.S. Senate,,DEM,Kamala D. Harris,493
+Placer,460627,U.S. Senate,,DEM,Loretta L. Sanchez,339
+Placer,460628,U.S. Senate,,DEM,Kamala D. Harris,323
+Placer,460628,U.S. Senate,,DEM,Loretta L. Sanchez,190
+Placer,460629,U.S. Senate,,DEM,Kamala D. Harris,496
+Placer,460629,U.S. Senate,,DEM,Loretta L. Sanchez,337
+Placer,460630,U.S. Senate,,DEM,Kamala D. Harris,486
+Placer,460630,U.S. Senate,,DEM,Loretta L. Sanchez,265
+Placer,460634,U.S. Senate,,DEM,Kamala D. Harris,500
+Placer,460634,U.S. Senate,,DEM,Loretta L. Sanchez,254
+Placer,460635,U.S. Senate,,DEM,Kamala D. Harris,259
+Placer,460635,U.S. Senate,,DEM,Loretta L. Sanchez,165
+Placer,460636,U.S. Senate,,DEM,Kamala D. Harris,333
+Placer,460636,U.S. Senate,,DEM,Loretta L. Sanchez,195
+Placer,460637,U.S. Senate,,DEM,Kamala D. Harris,349
+Placer,460637,U.S. Senate,,DEM,Loretta L. Sanchez,192
+Placer,460638,U.S. Senate,,DEM,Kamala D. Harris,577
+Placer,460638,U.S. Senate,,DEM,Loretta L. Sanchez,334
+Placer,460639,U.S. Senate,,DEM,Kamala D. Harris,384
+Placer,460639,U.S. Senate,,DEM,Loretta L. Sanchez,244
+Placer,462401,U.S. Senate,,DEM,Kamala D. Harris,393
+Placer,462401,U.S. Senate,,DEM,Loretta L. Sanchez,253
+Placer,462402,U.S. Senate,,DEM,Kamala D. Harris,236
+Placer,462402,U.S. Senate,,DEM,Loretta L. Sanchez,155
+Placer,462403,U.S. Senate,,DEM,Kamala D. Harris,363
+Placer,462403,U.S. Senate,,DEM,Loretta L. Sanchez,234
+Placer,462404,U.S. Senate,,DEM,Kamala D. Harris,346
+Placer,462404,U.S. Senate,,DEM,Loretta L. Sanchez,202
+Placer,462405,U.S. Senate,,DEM,Kamala D. Harris,288
+Placer,462405,U.S. Senate,,DEM,Loretta L. Sanchez,163
+Placer,462406,U.S. Senate,,DEM,Kamala D. Harris,408
+Placer,462406,U.S. Senate,,DEM,Loretta L. Sanchez,199
+Placer,462407,U.S. Senate,,DEM,Kamala D. Harris,452
+Placer,462407,U.S. Senate,,DEM,Loretta L. Sanchez,306
+Placer,462410,U.S. Senate,,DEM,Kamala D. Harris,283
+Placer,462410,U.S. Senate,,DEM,Loretta L. Sanchez,201
+Placer,462411,U.S. Senate,,DEM,Kamala D. Harris,393
+Placer,462411,U.S. Senate,,DEM,Loretta L. Sanchez,249
+Placer,462412,U.S. Senate,,DEM,Kamala D. Harris,363
+Placer,462412,U.S. Senate,,DEM,Loretta L. Sanchez,223
+Placer,462413,U.S. Senate,,DEM,Kamala D. Harris,410
+Placer,462413,U.S. Senate,,DEM,Loretta L. Sanchez,263
+Placer,462416,U.S. Senate,,DEM,Kamala D. Harris,255
+Placer,462416,U.S. Senate,,DEM,Loretta L. Sanchez,197
+Placer,462417,U.S. Senate,,DEM,Kamala D. Harris,257
+Placer,462417,U.S. Senate,,DEM,Loretta L. Sanchez,162
+Placer,462418,U.S. Senate,,DEM,Kamala D. Harris,277
+Placer,462418,U.S. Senate,,DEM,Loretta L. Sanchez,155
+Placer,462420,U.S. Senate,,DEM,Kamala D. Harris,323
+Placer,462420,U.S. Senate,,DEM,Loretta L. Sanchez,220
+Placer,462433,U.S. Senate,,DEM,Kamala D. Harris,206
+Placer,462433,U.S. Senate,,DEM,Loretta L. Sanchez,136
+Placer,510201,U.S. Senate,,DEM,Kamala D. Harris,392
+Placer,510201,U.S. Senate,,DEM,Loretta L. Sanchez,223
+Placer,512501,U.S. Senate,,DEM,Kamala D. Harris,249
+Placer,512501,U.S. Senate,,DEM,Loretta L. Sanchez,101
+Placer,512502,U.S. Senate,,DEM,Kamala D. Harris,205
+Placer,512502,U.S. Senate,,DEM,Loretta L. Sanchez,171
+Placer,512505,U.S. Senate,,DEM,Kamala D. Harris,422
+Placer,512505,U.S. Senate,,DEM,Loretta L. Sanchez,198
+Placer,512506,U.S. Senate,,DEM,Kamala D. Harris,388
+Placer,512506,U.S. Senate,,DEM,Loretta L. Sanchez,253
+Placer,512509,U.S. Senate,,DEM,Kamala D. Harris,333
+Placer,512509,U.S. Senate,,DEM,Loretta L. Sanchez,171
+Placer,512510,U.S. Senate,,DEM,Kamala D. Harris,292
+Placer,512510,U.S. Senate,,DEM,Loretta L. Sanchez,179
+Placer,512513,U.S. Senate,,DEM,Kamala D. Harris,293
+Placer,512513,U.S. Senate,,DEM,Loretta L. Sanchez,189
+Placer,512514,U.S. Senate,,DEM,Kamala D. Harris,197
+Placer,512514,U.S. Senate,,DEM,Loretta L. Sanchez,146
+Placer,512520,U.S. Senate,,DEM,Kamala D. Harris,232
+Placer,512520,U.S. Senate,,DEM,Loretta L. Sanchez,149
+Placer,512524,U.S. Senate,,DEM,Kamala D. Harris,114
+Placer,512524,U.S. Senate,,DEM,Loretta L. Sanchez,76
+Placer,512527,U.S. Senate,,DEM,Kamala D. Harris,185
+Placer,512527,U.S. Senate,,DEM,Loretta L. Sanchez,114
+Placer,512529,U.S. Senate,,DEM,Kamala D. Harris,321
+Placer,512529,U.S. Senate,,DEM,Loretta L. Sanchez,224
+Placer,512602,U.S. Senate,,DEM,Kamala D. Harris,114
+Placer,512602,U.S. Senate,,DEM,Loretta L. Sanchez,91
+Placer,512603,U.S. Senate,,DEM,Kamala D. Harris,332
+Placer,512603,U.S. Senate,,DEM,Loretta L. Sanchez,216
+Placer,512604,U.S. Senate,,DEM,Kamala D. Harris,326
+Placer,512604,U.S. Senate,,DEM,Loretta L. Sanchez,256
+Placer,512605,U.S. Senate,,DEM,Kamala D. Harris,360
+Placer,512605,U.S. Senate,,DEM,Loretta L. Sanchez,228
+Placer,512606,U.S. Senate,,DEM,Kamala D. Harris,326
+Placer,512606,U.S. Senate,,DEM,Loretta L. Sanchez,239
+Placer,512702,U.S. Senate,,DEM,Kamala D. Harris,152
+Placer,512702,U.S. Senate,,DEM,Loretta L. Sanchez,96
+Placer,512705,U.S. Senate,,DEM,Kamala D. Harris,398
+Placer,512705,U.S. Senate,,DEM,Loretta L. Sanchez,218
+Placer,512706,U.S. Senate,,DEM,Kamala D. Harris,482
+Placer,512706,U.S. Senate,,DEM,Loretta L. Sanchez,268
+Placer,512717,U.S. Senate,,DEM,Kamala D. Harris,370
+Placer,512717,U.S. Senate,,DEM,Loretta L. Sanchez,255
+Placer,512803,U.S. Senate,,DEM,Kamala D. Harris,400
+Placer,512803,U.S. Senate,,DEM,Loretta L. Sanchez,238
+Placer,512806,U.S. Senate,,DEM,Kamala D. Harris,396
+Placer,512806,U.S. Senate,,DEM,Loretta L. Sanchez,267
+Placer,512807,U.S. Senate,,DEM,Kamala D. Harris,444
+Placer,512807,U.S. Senate,,DEM,Loretta L. Sanchez,303
+Placer,512901,U.S. Senate,,DEM,Kamala D. Harris,281
+Placer,512901,U.S. Senate,,DEM,Loretta L. Sanchez,119
+Placer,512903,U.S. Senate,,DEM,Kamala D. Harris,510
+Placer,512903,U.S. Senate,,DEM,Loretta L. Sanchez,347
+Placer,513101,U.S. Senate,,DEM,Kamala D. Harris,268
+Placer,513101,U.S. Senate,,DEM,Loretta L. Sanchez,126
+Placer,513102,U.S. Senate,,DEM,Kamala D. Harris,174
+Placer,513102,U.S. Senate,,DEM,Loretta L. Sanchez,98
+Placer,513203,U.S. Senate,,DEM,Kamala D. Harris,290
+Placer,513203,U.S. Senate,,DEM,Loretta L. Sanchez,80
+Placer,513302,U.S. Senate,,DEM,Kamala D. Harris,268
+Placer,513302,U.S. Senate,,DEM,Loretta L. Sanchez,94
+Placer,513403,U.S. Senate,,DEM,Kamala D. Harris,142
+Placer,513403,U.S. Senate,,DEM,Loretta L. Sanchez,59
+Placer,513607,U.S. Senate,,DEM,Kamala D. Harris,480
+Placer,513607,U.S. Senate,,DEM,Loretta L. Sanchez,214
+Placer,513609,U.S. Senate,,DEM,Kamala D. Harris,493
+Placer,513609,U.S. Senate,,DEM,Loretta L. Sanchez,210
+Placer,513613,U.S. Senate,,DEM,Kamala D. Harris,148
+Placer,513613,U.S. Senate,,DEM,Loretta L. Sanchez,61
+Placer,513615,U.S. Senate,,DEM,Kamala D. Harris,297
+Placer,513615,U.S. Senate,,DEM,Loretta L. Sanchez,111
+Placer,513702,U.S. Senate,,DEM,Kamala D. Harris,609
+Placer,513702,U.S. Senate,,DEM,Loretta L. Sanchez,281
+Placer,513706,U.S. Senate,,DEM,Kamala D. Harris,459
+Placer,513706,U.S. Senate,,DEM,Loretta L. Sanchez,312
+Placer,550101,U.S. Senate,,DEM,Kamala D. Harris,269
+Placer,550101,U.S. Senate,,DEM,Loretta L. Sanchez,137
+Placer,550102,U.S. Senate,,DEM,Kamala D. Harris,338
+Placer,550102,U.S. Senate,,DEM,Loretta L. Sanchez,213
+Placer,550103,U.S. Senate,,DEM,Kamala D. Harris,413
+Placer,550103,U.S. Senate,,DEM,Loretta L. Sanchez,189
+Placer,550104,U.S. Senate,,DEM,Kamala D. Harris,411
+Placer,550104,U.S. Senate,,DEM,Loretta L. Sanchez,208
+Placer,550106,U.S. Senate,,DEM,Kamala D. Harris,395
+Placer,550106,U.S. Senate,,DEM,Loretta L. Sanchez,199
+Placer,550107,U.S. Senate,,DEM,Kamala D. Harris,309
+Placer,550107,U.S. Senate,,DEM,Loretta L. Sanchez,190
+Placer,550109,U.S. Senate,,DEM,Kamala D. Harris,587
+Placer,550109,U.S. Senate,,DEM,Loretta L. Sanchez,283
+Placer,550110,U.S. Senate,,DEM,Kamala D. Harris,279
+Placer,550110,U.S. Senate,,DEM,Loretta L. Sanchez,158
+Placer,550111,U.S. Senate,,DEM,Kamala D. Harris,368
+Placer,550111,U.S. Senate,,DEM,Loretta L. Sanchez,188
+Placer,550114,U.S. Senate,,DEM,Kamala D. Harris,231
+Placer,550114,U.S. Senate,,DEM,Loretta L. Sanchez,146
+Placer,550116,U.S. Senate,,DEM,Kamala D. Harris,136
+Placer,550116,U.S. Senate,,DEM,Loretta L. Sanchez,69
+Placer,562204,U.S. Senate,,DEM,Kamala D. Harris,129
+Placer,562204,U.S. Senate,,DEM,Loretta L. Sanchez,85
+Placer,562206,U.S. Senate,,DEM,Kamala D. Harris,204
+Placer,562206,U.S. Senate,,DEM,Loretta L. Sanchez,160
+Placer,562503,U.S. Senate,,DEM,Kamala D. Harris,147
+Placer,562503,U.S. Senate,,DEM,Loretta L. Sanchez,77
+Placer,6160601,U.S. Senate,,DEM,Kamala D. Harris,28
+Placer,6160601,U.S. Senate,,DEM,Loretta L. Sanchez,20
+Placer,6160602,U.S. Senate,,DEM,Kamala D. Harris,74
+Placer,6160602,U.S. Senate,,DEM,Loretta L. Sanchez,42
+Placer,6160623,U.S. Senate,,DEM,Kamala D. Harris,0
+Placer,6160623,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Placer,6160641,U.S. Senate,,DEM,Kamala D. Harris,0
+Placer,6160641,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Placer,6161001,U.S. Senate,,DEM,Kamala D. Harris,69
+Placer,6161001,U.S. Senate,,DEM,Loretta L. Sanchez,53
+Placer,6161002,U.S. Senate,,DEM,Kamala D. Harris,21
+Placer,6161002,U.S. Senate,,DEM,Loretta L. Sanchez,8
+Placer,6161009,U.S. Senate,,DEM,Kamala D. Harris,0
+Placer,6161009,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Placer,6251401,U.S. Senate,,DEM,Kamala D. Harris,0
+Placer,6251401,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Placer,6260301,U.S. Senate,,DEM,Kamala D. Harris,0
+Placer,6260301,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Placer,6260601,U.S. Senate,,DEM,Kamala D. Harris,0
+Placer,6260601,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Placer,6261001,U.S. Senate,,DEM,Kamala D. Harris,18
+Placer,6261001,U.S. Senate,,DEM,Loretta L. Sanchez,16
+Placer,6261003,U.S. Senate,,DEM,Kamala D. Harris,5
+Placer,6261003,U.S. Senate,,DEM,Loretta L. Sanchez,5
+Placer,6261101,U.S. Senate,,DEM,Kamala D. Harris,25
+Placer,6261101,U.S. Senate,,DEM,Loretta L. Sanchez,11
+Placer,6261103,U.S. Senate,,DEM,Kamala D. Harris,59
+Placer,6261103,U.S. Senate,,DEM,Loretta L. Sanchez,60
+Placer,6261106,U.S. Senate,,DEM,Kamala D. Harris,21
+Placer,6261106,U.S. Senate,,DEM,Loretta L. Sanchez,11
+Placer,6261207,U.S. Senate,,DEM,Kamala D. Harris,10
+Placer,6261207,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Placer,6261309,U.S. Senate,,DEM,Kamala D. Harris,79
+Placer,6261309,U.S. Senate,,DEM,Loretta L. Sanchez,42
+Placer,6261311,U.S. Senate,,DEM,Kamala D. Harris,37
+Placer,6261311,U.S. Senate,,DEM,Loretta L. Sanchez,46
+Placer,6261314,U.S. Senate,,DEM,Kamala D. Harris,16
+Placer,6261314,U.S. Senate,,DEM,Loretta L. Sanchez,16
+Placer,6261323,U.S. Senate,,DEM,Kamala D. Harris,99
+Placer,6261323,U.S. Senate,,DEM,Loretta L. Sanchez,71
+Placer,6261324,U.S. Senate,,DEM,Kamala D. Harris,7
+Placer,6261324,U.S. Senate,,DEM,Loretta L. Sanchez,7
+Placer,6261328,U.S. Senate,,DEM,Kamala D. Harris,22
+Placer,6261328,U.S. Senate,,DEM,Loretta L. Sanchez,21
+Placer,6261331,U.S. Senate,,DEM,Kamala D. Harris,0
+Placer,6261331,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Placer,6261344,U.S. Senate,,DEM,Kamala D. Harris,10
+Placer,6261344,U.S. Senate,,DEM,Loretta L. Sanchez,16
+Placer,6261405,U.S. Senate,,DEM,Kamala D. Harris,4
+Placer,6261405,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Placer,6261406,U.S. Senate,,DEM,Kamala D. Harris,1
+Placer,6261406,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Placer,6312201,U.S. Senate,,DEM,Kamala D. Harris,7
+Placer,6312201,U.S. Senate,,DEM,Loretta L. Sanchez,10
+Placer,6312205,U.S. Senate,,DEM,Kamala D. Harris,15
+Placer,6312205,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Placer,6312208,U.S. Senate,,DEM,Kamala D. Harris,40
+Placer,6312208,U.S. Senate,,DEM,Loretta L. Sanchez,28
+Placer,6312209,U.S. Senate,,DEM,Kamala D. Harris,82
+Placer,6312209,U.S. Senate,,DEM,Loretta L. Sanchez,48
+Placer,6312214,U.S. Senate,,DEM,Kamala D. Harris,11
+Placer,6312214,U.S. Senate,,DEM,Loretta L. Sanchez,5
+Placer,6350101,U.S. Senate,,DEM,Kamala D. Harris,0
+Placer,6350101,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Placer,6351701,U.S. Senate,,DEM,Kamala D. Harris,47
+Placer,6351701,U.S. Senate,,DEM,Loretta L. Sanchez,29
+Placer,6351703,U.S. Senate,,DEM,Kamala D. Harris,37
+Placer,6351703,U.S. Senate,,DEM,Loretta L. Sanchez,6
+Placer,6351804,U.S. Senate,,DEM,Kamala D. Harris,14
+Placer,6351804,U.S. Senate,,DEM,Loretta L. Sanchez,14
+Placer,6351808,U.S. Senate,,DEM,Kamala D. Harris,42
+Placer,6351808,U.S. Senate,,DEM,Loretta L. Sanchez,28
+Placer,6351814,U.S. Senate,,DEM,Kamala D. Harris,68
+Placer,6351814,U.S. Senate,,DEM,Loretta L. Sanchez,34
+Placer,6351815,U.S. Senate,,DEM,Kamala D. Harris,17
+Placer,6351815,U.S. Senate,,DEM,Loretta L. Sanchez,16
+Placer,6351817,U.S. Senate,,DEM,Kamala D. Harris,4
+Placer,6351817,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Placer,6351818,U.S. Senate,,DEM,Kamala D. Harris,0
+Placer,6351818,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Placer,6351824,U.S. Senate,,DEM,Kamala D. Harris,13
+Placer,6351824,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Placer,6351901,U.S. Senate,,DEM,Kamala D. Harris,48
+Placer,6351901,U.S. Senate,,DEM,Loretta L. Sanchez,30
+Placer,6352105,U.S. Senate,,DEM,Kamala D. Harris,74
+Placer,6352105,U.S. Senate,,DEM,Loretta L. Sanchez,48
+Placer,6352106,U.S. Senate,,DEM,Kamala D. Harris,33
+Placer,6352106,U.S. Senate,,DEM,Loretta L. Sanchez,16
+Placer,6352120,U.S. Senate,,DEM,Kamala D. Harris,29
+Placer,6352120,U.S. Senate,,DEM,Loretta L. Sanchez,27
+Placer,6352125,U.S. Senate,,DEM,Kamala D. Harris,53
+Placer,6352125,U.S. Senate,,DEM,Loretta L. Sanchez,37
+Placer,6352129,U.S. Senate,,DEM,Kamala D. Harris,37
+Placer,6352129,U.S. Senate,,DEM,Loretta L. Sanchez,19
+Placer,6352130,U.S. Senate,,DEM,Kamala D. Harris,11
+Placer,6352130,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Placer,6360401,U.S. Senate,,DEM,Kamala D. Harris,43
+Placer,6360401,U.S. Senate,,DEM,Loretta L. Sanchez,41
+Placer,6360402,U.S. Senate,,DEM,Kamala D. Harris,49
+Placer,6360402,U.S. Senate,,DEM,Loretta L. Sanchez,38
+Placer,6360404,U.S. Senate,,DEM,Kamala D. Harris,7
+Placer,6360404,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Placer,6360410,U.S. Senate,,DEM,Kamala D. Harris,74
+Placer,6360410,U.S. Senate,,DEM,Loretta L. Sanchez,26
+Placer,6360506,U.S. Senate,,DEM,Kamala D. Harris,28
+Placer,6360506,U.S. Senate,,DEM,Loretta L. Sanchez,22
+Placer,6360510,U.S. Senate,,DEM,Kamala D. Harris,0
+Placer,6360510,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Placer,6360515,U.S. Senate,,DEM,Kamala D. Harris,53
+Placer,6360515,U.S. Senate,,DEM,Loretta L. Sanchez,42
+Placer,6361301,U.S. Senate,,DEM,Kamala D. Harris,11
+Placer,6361301,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Placer,6361302,U.S. Senate,,DEM,Kamala D. Harris,1
+Placer,6361302,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Placer,6361504,U.S. Senate,,DEM,Kamala D. Harris,65
+Placer,6361504,U.S. Senate,,DEM,Loretta L. Sanchez,27
+Placer,6361505,U.S. Senate,,DEM,Kamala D. Harris,65
+Placer,6361505,U.S. Senate,,DEM,Loretta L. Sanchez,48
+Placer,6361506,U.S. Senate,,DEM,Kamala D. Harris,73
+Placer,6361506,U.S. Senate,,DEM,Loretta L. Sanchez,54
+Placer,6361510,U.S. Senate,,DEM,Kamala D. Harris,52
+Placer,6361510,U.S. Senate,,DEM,Loretta L. Sanchez,40
+Placer,6361515,U.S. Senate,,DEM,Kamala D. Harris,45
+Placer,6361515,U.S. Senate,,DEM,Loretta L. Sanchez,34
+Placer,6361701,U.S. Senate,,DEM,Kamala D. Harris,63
+Placer,6361701,U.S. Senate,,DEM,Loretta L. Sanchez,31
+Placer,6361712,U.S. Senate,,DEM,Kamala D. Harris,3
+Placer,6361712,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Placer,6361713,U.S. Senate,,DEM,Kamala D. Harris,30
+Placer,6361713,U.S. Senate,,DEM,Loretta L. Sanchez,35
+Placer,6361715,U.S. Senate,,DEM,Kamala D. Harris,105
+Placer,6361715,U.S. Senate,,DEM,Loretta L. Sanchez,61
+Placer,6361716,U.S. Senate,,DEM,Kamala D. Harris,2
+Placer,6361716,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Placer,6361717,U.S. Senate,,DEM,Kamala D. Harris,15
+Placer,6361717,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Placer,6361719,U.S. Senate,,DEM,Kamala D. Harris,1
+Placer,6361719,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Placer,6361801,U.S. Senate,,DEM,Kamala D. Harris,53
+Placer,6361801,U.S. Senate,,DEM,Loretta L. Sanchez,29
+Placer,6361802,U.S. Senate,,DEM,Kamala D. Harris,0
+Placer,6361802,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Placer,6460604,U.S. Senate,,DEM,Kamala D. Harris,0
+Placer,6460604,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Placer,6460605,U.S. Senate,,DEM,Kamala D. Harris,0
+Placer,6460605,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Placer,6460606,U.S. Senate,,DEM,Kamala D. Harris,0
+Placer,6460606,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Placer,6460609,U.S. Senate,,DEM,Kamala D. Harris,110
+Placer,6460609,U.S. Senate,,DEM,Loretta L. Sanchez,53
+Placer,6460631,U.S. Senate,,DEM,Kamala D. Harris,0
+Placer,6460631,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Placer,6460633,U.S. Senate,,DEM,Kamala D. Harris,0
+Placer,6460633,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Placer,6462301,U.S. Senate,,DEM,Kamala D. Harris,46
+Placer,6462301,U.S. Senate,,DEM,Loretta L. Sanchez,28
+Placer,6462302,U.S. Senate,,DEM,Kamala D. Harris,101
+Placer,6462302,U.S. Senate,,DEM,Loretta L. Sanchez,66
+Placer,6462305,U.S. Senate,,DEM,Kamala D. Harris,58
+Placer,6462305,U.S. Senate,,DEM,Loretta L. Sanchez,33
+Placer,6462308,U.S. Senate,,DEM,Kamala D. Harris,95
+Placer,6462308,U.S. Senate,,DEM,Loretta L. Sanchez,65
+Placer,6462309,U.S. Senate,,DEM,Kamala D. Harris,79
+Placer,6462309,U.S. Senate,,DEM,Loretta L. Sanchez,42
+Placer,6462408,U.S. Senate,,DEM,Kamala D. Harris,2
+Placer,6462408,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Placer,6462409,U.S. Senate,,DEM,Kamala D. Harris,0
+Placer,6462409,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Placer,6462415,U.S. Senate,,DEM,Kamala D. Harris,54
+Placer,6462415,U.S. Senate,,DEM,Loretta L. Sanchez,28
+Placer,6462421,U.S. Senate,,DEM,Kamala D. Harris,49
+Placer,6462421,U.S. Senate,,DEM,Loretta L. Sanchez,28
+Placer,6462427,U.S. Senate,,DEM,Kamala D. Harris,82
+Placer,6462427,U.S. Senate,,DEM,Loretta L. Sanchez,28
+Placer,6510101,U.S. Senate,,DEM,Kamala D. Harris,2
+Placer,6510101,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Placer,6510102,U.S. Senate,,DEM,Kamala D. Harris,2
+Placer,6510102,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Placer,6510202,U.S. Senate,,DEM,Kamala D. Harris,0
+Placer,6510202,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Placer,6512201,U.S. Senate,,DEM,Kamala D. Harris,58
+Placer,6512201,U.S. Senate,,DEM,Loretta L. Sanchez,38
+Placer,6512503,U.S. Senate,,DEM,Kamala D. Harris,90
+Placer,6512503,U.S. Senate,,DEM,Loretta L. Sanchez,37
+Placer,6512511,U.S. Senate,,DEM,Kamala D. Harris,69
+Placer,6512511,U.S. Senate,,DEM,Loretta L. Sanchez,46
+Placer,6512518,U.S. Senate,,DEM,Kamala D. Harris,7
+Placer,6512518,U.S. Senate,,DEM,Loretta L. Sanchez,7
+Placer,6512521,U.S. Senate,,DEM,Kamala D. Harris,97
+Placer,6512521,U.S. Senate,,DEM,Loretta L. Sanchez,48
+Placer,6512533,U.S. Senate,,DEM,Kamala D. Harris,6
+Placer,6512533,U.S. Senate,,DEM,Loretta L. Sanchez,6
+Placer,6512537,U.S. Senate,,DEM,Kamala D. Harris,45
+Placer,6512537,U.S. Senate,,DEM,Loretta L. Sanchez,27
+Placer,6512540,U.S. Senate,,DEM,Kamala D. Harris,79
+Placer,6512540,U.S. Senate,,DEM,Loretta L. Sanchez,60
+Placer,6512608,U.S. Senate,,DEM,Kamala D. Harris,3
+Placer,6512608,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Placer,6512612,U.S. Senate,,DEM,Kamala D. Harris,0
+Placer,6512612,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Placer,6512709,U.S. Senate,,DEM,Kamala D. Harris,86
+Placer,6512709,U.S. Senate,,DEM,Loretta L. Sanchez,67
+Placer,6512716,U.S. Senate,,DEM,Kamala D. Harris,73
+Placer,6512716,U.S. Senate,,DEM,Loretta L. Sanchez,61
+Placer,6512719,U.S. Senate,,DEM,Kamala D. Harris,76
+Placer,6512719,U.S. Senate,,DEM,Loretta L. Sanchez,29
+Placer,6512722,U.S. Senate,,DEM,Kamala D. Harris,51
+Placer,6512722,U.S. Senate,,DEM,Loretta L. Sanchez,28
+Placer,6512804,U.S. Senate,,DEM,Kamala D. Harris,0
+Placer,6512804,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Placer,6512902,U.S. Senate,,DEM,Kamala D. Harris,26
+Placer,6512902,U.S. Senate,,DEM,Loretta L. Sanchez,12
+Placer,6513001,U.S. Senate,,DEM,Kamala D. Harris,23
+Placer,6513001,U.S. Senate,,DEM,Loretta L. Sanchez,6
+Placer,6513201,U.S. Senate,,DEM,Kamala D. Harris,20
+Placer,6513201,U.S. Senate,,DEM,Loretta L. Sanchez,10
+Placer,6513202,U.S. Senate,,DEM,Kamala D. Harris,70
+Placer,6513202,U.S. Senate,,DEM,Loretta L. Sanchez,21
+Placer,6513206,U.S. Senate,,DEM,Kamala D. Harris,9
+Placer,6513206,U.S. Senate,,DEM,Loretta L. Sanchez,7
+Placer,6513301,U.S. Senate,,DEM,Kamala D. Harris,94
+Placer,6513301,U.S. Senate,,DEM,Loretta L. Sanchez,41
+Placer,6513401,U.S. Senate,,DEM,Kamala D. Harris,0
+Placer,6513401,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Placer,6513406,U.S. Senate,,DEM,Kamala D. Harris,80
+Placer,6513406,U.S. Senate,,DEM,Loretta L. Sanchez,24
+Placer,6513410,U.S. Senate,,DEM,Kamala D. Harris,0
+Placer,6513410,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Placer,6513413,U.S. Senate,,DEM,Kamala D. Harris,0
+Placer,6513413,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Placer,6513614,U.S. Senate,,DEM,Kamala D. Harris,8
+Placer,6513614,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Placer,6513801,U.S. Senate,,DEM,Kamala D. Harris,81
+Placer,6513801,U.S. Senate,,DEM,Loretta L. Sanchez,25
+Placer,6513902,U.S. Senate,,DEM,Kamala D. Harris,0
+Placer,6513902,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Placer,6513903,U.S. Senate,,DEM,Kamala D. Harris,2
+Placer,6513903,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Placer,6513908,U.S. Senate,,DEM,Kamala D. Harris,0
+Placer,6513908,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Placer,6513913,U.S. Senate,,DEM,Kamala D. Harris,8
+Placer,6513913,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Placer,6513914,U.S. Senate,,DEM,Kamala D. Harris,36
+Placer,6513914,U.S. Senate,,DEM,Loretta L. Sanchez,5
+Placer,6550105,U.S. Senate,,DEM,Kamala D. Harris,57
+Placer,6550105,U.S. Senate,,DEM,Loretta L. Sanchez,38
+Placer,6551901,U.S. Senate,,DEM,Kamala D. Harris,0
+Placer,6551901,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Placer,6552001,U.S. Senate,,DEM,Kamala D. Harris,0
+Placer,6552001,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Placer,6552201,U.S. Senate,,DEM,Kamala D. Harris,1
+Placer,6552201,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Placer,6552202,U.S. Senate,,DEM,Kamala D. Harris,4
+Placer,6552202,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Placer,6562201,U.S. Senate,,DEM,Kamala D. Harris,2
+Placer,6562201,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Placer,6562202,U.S. Senate,,DEM,Kamala D. Harris,96
+Placer,6562202,U.S. Senate,,DEM,Loretta L. Sanchez,49
+Placer,6562501,U.S. Senate,,DEM,Kamala D. Harris,0
+Placer,6562501,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Placer,6562505,U.S. Senate,,DEM,Kamala D. Harris,28
+Placer,6562505,U.S. Senate,,DEM,Loretta L. Sanchez,21

--- a/2016/20161108__ca__general__plumas__precinct.csv
+++ b/2016/20161108__ca__general__plumas__precinct.csv
@@ -1159,61 +1159,61 @@ Plumas,28,Proposition 67,,N/A,Yes,191
 Plumas,28,Proposition 67,,N/A,No,368
 Plumas,29,Proposition 67,,N/A,Yes,172
 Plumas,29,Proposition 67,,N/A,No,318
-Plumas,1,U.S. Senate,,DEM,Kamala Harris,64
-Plumas,1,U.S. Senate,,DEM,Loretta Sanchez,72
-Plumas,2,U.S. Senate,,DEM,Kamala Harris,88
-Plumas,2,U.S. Senate,,DEM,Loretta Sanchez,133
-Plumas,3,U.S. Senate,,DEM,Kamala Harris,27
-Plumas,3,U.S. Senate,,DEM,Loretta Sanchez,86
-Plumas,4,U.S. Senate,,DEM,Kamala Harris,5
-Plumas,4,U.S. Senate,,DEM,Loretta Sanchez,10
-Plumas,5,U.S. Senate,,DEM,Kamala Harris,54
-Plumas,5,U.S. Senate,,DEM,Loretta Sanchez,84
-Plumas,6,U.S. Senate,,DEM,Kamala Harris,12
-Plumas,6,U.S. Senate,,DEM,Loretta Sanchez,40
-Plumas,7,U.S. Senate,,DEM,Kamala Harris,24
-Plumas,7,U.S. Senate,,DEM,Loretta Sanchez,41
-Plumas,8,U.S. Senate,,DEM,Kamala Harris,12
-Plumas,8,U.S. Senate,,DEM,Loretta Sanchez,18
-Plumas,9,U.S. Senate,,DEM,Kamala Harris,8
-Plumas,9,U.S. Senate,,DEM,Loretta Sanchez,7
-Plumas,10,U.S. Senate,,DEM,Kamala Harris,100
-Plumas,10,U.S. Senate,,DEM,Loretta Sanchez,151
-Plumas,11,U.S. Senate,,DEM,Kamala Harris,107
-Plumas,11,U.S. Senate,,DEM,Loretta Sanchez,237
-Plumas,12,U.S. Senate,,DEM,Kamala Harris,100
-Plumas,12,U.S. Senate,,DEM,Loretta Sanchez,155
-Plumas,13,U.S. Senate,,DEM,Kamala Harris,139
-Plumas,13,U.S. Senate,,DEM,Loretta Sanchez,357
-Plumas,14,U.S. Senate,,DEM,Kamala Harris,167
-Plumas,14,U.S. Senate,,DEM,Loretta Sanchez,338
-Plumas,15,U.S. Senate,,DEM,Kamala Harris,69
-Plumas,15,U.S. Senate,,DEM,Loretta Sanchez,160
-Plumas,16,U.S. Senate,,DEM,Kamala Harris,109
-Plumas,16,U.S. Senate,,DEM,Loretta Sanchez,251
-Plumas,17,U.S. Senate,,DEM,Kamala Harris,159
-Plumas,17,U.S. Senate,,DEM,Loretta Sanchez,332
-Plumas,18,U.S. Senate,,DEM,Kamala Harris,93
-Plumas,18,U.S. Senate,,DEM,Loretta Sanchez,194
-Plumas,19,U.S. Senate,,DEM,Kamala Harris,53
-Plumas,19,U.S. Senate,,DEM,Loretta Sanchez,145
-Plumas,20,U.S. Senate,,DEM,Kamala Harris,98
-Plumas,20,U.S. Senate,,DEM,Loretta Sanchez,185
-Plumas,21,U.S. Senate,,DEM,Kamala Harris,103
-Plumas,21,U.S. Senate,,DEM,Loretta Sanchez,208
-Plumas,22,U.S. Senate,,DEM,Kamala Harris,32
-Plumas,22,U.S. Senate,,DEM,Loretta Sanchez,68
-Plumas,23,U.S. Senate,,DEM,Kamala Harris,114
-Plumas,23,U.S. Senate,,DEM,Loretta Sanchez,185
-Plumas,24,U.S. Senate,,DEM,Kamala Harris,39
-Plumas,24,U.S. Senate,,DEM,Loretta Sanchez,77
-Plumas,25,U.S. Senate,,DEM,Kamala Harris,123
-Plumas,25,U.S. Senate,,DEM,Loretta Sanchez,248
-Plumas,26,U.S. Senate,,DEM,Kamala Harris,93
-Plumas,26,U.S. Senate,,DEM,Loretta Sanchez,150
-Plumas,27,U.S. Senate,,DEM,Kamala Harris,140
-Plumas,27,U.S. Senate,,DEM,Loretta Sanchez,230
-Plumas,28,U.S. Senate,,DEM,Kamala Harris,171
-Plumas,28,U.S. Senate,,DEM,Loretta Sanchez,218
-Plumas,29,U.S. Senate,,DEM,Kamala Harris,115
-Plumas,29,U.S. Senate,,DEM,Loretta Sanchez,226
+Plumas,1,U.S. Senate,,DEM,Kamala D. Harris,64
+Plumas,1,U.S. Senate,,DEM,Loretta L. Sanchez,72
+Plumas,2,U.S. Senate,,DEM,Kamala D. Harris,88
+Plumas,2,U.S. Senate,,DEM,Loretta L. Sanchez,133
+Plumas,3,U.S. Senate,,DEM,Kamala D. Harris,27
+Plumas,3,U.S. Senate,,DEM,Loretta L. Sanchez,86
+Plumas,4,U.S. Senate,,DEM,Kamala D. Harris,5
+Plumas,4,U.S. Senate,,DEM,Loretta L. Sanchez,10
+Plumas,5,U.S. Senate,,DEM,Kamala D. Harris,54
+Plumas,5,U.S. Senate,,DEM,Loretta L. Sanchez,84
+Plumas,6,U.S. Senate,,DEM,Kamala D. Harris,12
+Plumas,6,U.S. Senate,,DEM,Loretta L. Sanchez,40
+Plumas,7,U.S. Senate,,DEM,Kamala D. Harris,24
+Plumas,7,U.S. Senate,,DEM,Loretta L. Sanchez,41
+Plumas,8,U.S. Senate,,DEM,Kamala D. Harris,12
+Plumas,8,U.S. Senate,,DEM,Loretta L. Sanchez,18
+Plumas,9,U.S. Senate,,DEM,Kamala D. Harris,8
+Plumas,9,U.S. Senate,,DEM,Loretta L. Sanchez,7
+Plumas,10,U.S. Senate,,DEM,Kamala D. Harris,100
+Plumas,10,U.S. Senate,,DEM,Loretta L. Sanchez,151
+Plumas,11,U.S. Senate,,DEM,Kamala D. Harris,107
+Plumas,11,U.S. Senate,,DEM,Loretta L. Sanchez,237
+Plumas,12,U.S. Senate,,DEM,Kamala D. Harris,100
+Plumas,12,U.S. Senate,,DEM,Loretta L. Sanchez,155
+Plumas,13,U.S. Senate,,DEM,Kamala D. Harris,139
+Plumas,13,U.S. Senate,,DEM,Loretta L. Sanchez,357
+Plumas,14,U.S. Senate,,DEM,Kamala D. Harris,167
+Plumas,14,U.S. Senate,,DEM,Loretta L. Sanchez,338
+Plumas,15,U.S. Senate,,DEM,Kamala D. Harris,69
+Plumas,15,U.S. Senate,,DEM,Loretta L. Sanchez,160
+Plumas,16,U.S. Senate,,DEM,Kamala D. Harris,109
+Plumas,16,U.S. Senate,,DEM,Loretta L. Sanchez,251
+Plumas,17,U.S. Senate,,DEM,Kamala D. Harris,159
+Plumas,17,U.S. Senate,,DEM,Loretta L. Sanchez,332
+Plumas,18,U.S. Senate,,DEM,Kamala D. Harris,93
+Plumas,18,U.S. Senate,,DEM,Loretta L. Sanchez,194
+Plumas,19,U.S. Senate,,DEM,Kamala D. Harris,53
+Plumas,19,U.S. Senate,,DEM,Loretta L. Sanchez,145
+Plumas,20,U.S. Senate,,DEM,Kamala D. Harris,98
+Plumas,20,U.S. Senate,,DEM,Loretta L. Sanchez,185
+Plumas,21,U.S. Senate,,DEM,Kamala D. Harris,103
+Plumas,21,U.S. Senate,,DEM,Loretta L. Sanchez,208
+Plumas,22,U.S. Senate,,DEM,Kamala D. Harris,32
+Plumas,22,U.S. Senate,,DEM,Loretta L. Sanchez,68
+Plumas,23,U.S. Senate,,DEM,Kamala D. Harris,114
+Plumas,23,U.S. Senate,,DEM,Loretta L. Sanchez,185
+Plumas,24,U.S. Senate,,DEM,Kamala D. Harris,39
+Plumas,24,U.S. Senate,,DEM,Loretta L. Sanchez,77
+Plumas,25,U.S. Senate,,DEM,Kamala D. Harris,123
+Plumas,25,U.S. Senate,,DEM,Loretta L. Sanchez,248
+Plumas,26,U.S. Senate,,DEM,Kamala D. Harris,93
+Plumas,26,U.S. Senate,,DEM,Loretta L. Sanchez,150
+Plumas,27,U.S. Senate,,DEM,Kamala D. Harris,140
+Plumas,27,U.S. Senate,,DEM,Loretta L. Sanchez,230
+Plumas,28,U.S. Senate,,DEM,Kamala D. Harris,171
+Plumas,28,U.S. Senate,,DEM,Loretta L. Sanchez,218
+Plumas,29,U.S. Senate,,DEM,Kamala D. Harris,115
+Plumas,29,U.S. Senate,,DEM,Loretta L. Sanchez,226

--- a/2016/20161108__ca__general__riverside__precinct.csv
+++ b/2016/20161108__ca__general__riverside__precinct.csv
@@ -45039,2255 +45039,2255 @@ Riverside,59803,Proposition 67,,N/A,Yes,32
 Riverside,59803,Proposition 67,,N/A,No,28
 Riverside,59804,Proposition 67,,N/A,Yes,77
 Riverside,59804,Proposition 67,,N/A,No,75
-Riverside,11103,U.S. Senate,,DEM,Kamala Harris,673
-Riverside,11103,U.S. Senate,,DEM,Loretta Sanchez,519
-Riverside,11105,U.S. Senate,,DEM,Kamala Harris,32
-Riverside,11105,U.S. Senate,,DEM,Loretta Sanchez,35
-Riverside,11108,U.S. Senate,,DEM,Kamala Harris,763
-Riverside,11108,U.S. Senate,,DEM,Loretta Sanchez,632
-Riverside,11113,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,11113,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,11200,U.S. Senate,,DEM,Kamala Harris,578
-Riverside,11200,U.S. Senate,,DEM,Loretta Sanchez,697
-Riverside,11205,U.S. Senate,,DEM,Kamala Harris,504
-Riverside,11205,U.S. Senate,,DEM,Loretta Sanchez,664
-Riverside,11206,U.S. Senate,,DEM,Kamala Harris,508
-Riverside,11206,U.S. Senate,,DEM,Loretta Sanchez,414
-Riverside,11208,U.S. Senate,,DEM,Kamala Harris,256
-Riverside,11208,U.S. Senate,,DEM,Loretta Sanchez,203
-Riverside,11212,U.S. Senate,,DEM,Kamala Harris,939
-Riverside,11212,U.S. Senate,,DEM,Loretta Sanchez,608
-Riverside,11216,U.S. Senate,,DEM,Kamala Harris,232
-Riverside,11216,U.S. Senate,,DEM,Loretta Sanchez,283
-Riverside,11217,U.S. Senate,,DEM,Kamala Harris,317
-Riverside,11217,U.S. Senate,,DEM,Loretta Sanchez,165
-Riverside,11221,U.S. Senate,,DEM,Kamala Harris,894
-Riverside,11221,U.S. Senate,,DEM,Loretta Sanchez,489
-Riverside,11224,U.S. Senate,,DEM,Kamala Harris,896
-Riverside,11224,U.S. Senate,,DEM,Loretta Sanchez,504
-Riverside,11226,U.S. Senate,,DEM,Kamala Harris,747
-Riverside,11226,U.S. Senate,,DEM,Loretta Sanchez,445
-Riverside,11227,U.S. Senate,,DEM,Kamala Harris,1266
-Riverside,11227,U.S. Senate,,DEM,Loretta Sanchez,770
-Riverside,11233,U.S. Senate,,DEM,Kamala Harris,1
-Riverside,11233,U.S. Senate,,DEM,Loretta Sanchez,2
-Riverside,11239,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,11239,U.S. Senate,,DEM,Loretta Sanchez,1
-Riverside,11302,U.S. Senate,,DEM,Kamala Harris,846
-Riverside,11302,U.S. Senate,,DEM,Loretta Sanchez,523
-Riverside,11305,U.S. Senate,,DEM,Kamala Harris,762
-Riverside,11305,U.S. Senate,,DEM,Loretta Sanchez,478
-Riverside,11310,U.S. Senate,,DEM,Kamala Harris,868
-Riverside,11310,U.S. Senate,,DEM,Loretta Sanchez,771
-Riverside,11312,U.S. Senate,,DEM,Kamala Harris,698
-Riverside,11312,U.S. Senate,,DEM,Loretta Sanchez,522
-Riverside,11314,U.S. Senate,,DEM,Kamala Harris,585
-Riverside,11314,U.S. Senate,,DEM,Loretta Sanchez,354
-Riverside,11402,U.S. Senate,,DEM,Kamala Harris,700
-Riverside,11402,U.S. Senate,,DEM,Loretta Sanchez,783
-Riverside,11406,U.S. Senate,,DEM,Kamala Harris,792
-Riverside,11406,U.S. Senate,,DEM,Loretta Sanchez,629
-Riverside,11411,U.S. Senate,,DEM,Kamala Harris,1005
-Riverside,11411,U.S. Senate,,DEM,Loretta Sanchez,678
-Riverside,11413,U.S. Senate,,DEM,Kamala Harris,993
-Riverside,11413,U.S. Senate,,DEM,Loretta Sanchez,602
-Riverside,11416,U.S. Senate,,DEM,Kamala Harris,883
-Riverside,11416,U.S. Senate,,DEM,Loretta Sanchez,646
-Riverside,11419,U.S. Senate,,DEM,Kamala Harris,792
-Riverside,11419,U.S. Senate,,DEM,Loretta Sanchez,509
-Riverside,11421,U.S. Senate,,DEM,Kamala Harris,856
-Riverside,11421,U.S. Senate,,DEM,Loretta Sanchez,628
-Riverside,11424,U.S. Senate,,DEM,Kamala Harris,661
-Riverside,11424,U.S. Senate,,DEM,Loretta Sanchez,490
-Riverside,11427,U.S. Senate,,DEM,Kamala Harris,746
-Riverside,11427,U.S. Senate,,DEM,Loretta Sanchez,527
-Riverside,11432,U.S. Senate,,DEM,Kamala Harris,809
-Riverside,11432,U.S. Senate,,DEM,Loretta Sanchez,573
-Riverside,11434,U.S. Senate,,DEM,Kamala Harris,724
-Riverside,11434,U.S. Senate,,DEM,Loretta Sanchez,483
-Riverside,11435,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,11435,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,11500,U.S. Senate,,DEM,Kamala Harris,556
-Riverside,11500,U.S. Senate,,DEM,Loretta Sanchez,426
-Riverside,11501,U.S. Senate,,DEM,Kamala Harris,766
-Riverside,11501,U.S. Senate,,DEM,Loretta Sanchez,618
-Riverside,11508,U.S. Senate,,DEM,Kamala Harris,679
-Riverside,11508,U.S. Senate,,DEM,Loretta Sanchez,650
-Riverside,11511,U.S. Senate,,DEM,Kamala Harris,418
-Riverside,11511,U.S. Senate,,DEM,Loretta Sanchez,450
-Riverside,11517,U.S. Senate,,DEM,Kamala Harris,119
-Riverside,11517,U.S. Senate,,DEM,Loretta Sanchez,79
-Riverside,11518,U.S. Senate,,DEM,Kamala Harris,556
-Riverside,11518,U.S. Senate,,DEM,Loretta Sanchez,476
-Riverside,11521,U.S. Senate,,DEM,Kamala Harris,544
-Riverside,11521,U.S. Senate,,DEM,Loretta Sanchez,487
-Riverside,11525,U.S. Senate,,DEM,Kamala Harris,676
-Riverside,11525,U.S. Senate,,DEM,Loretta Sanchez,600
-Riverside,11528,U.S. Senate,,DEM,Kamala Harris,889
-Riverside,11528,U.S. Senate,,DEM,Loretta Sanchez,821
-Riverside,11602,U.S. Senate,,DEM,Kamala Harris,516
-Riverside,11602,U.S. Senate,,DEM,Loretta Sanchez,456
-Riverside,11605,U.S. Senate,,DEM,Kamala Harris,580
-Riverside,11605,U.S. Senate,,DEM,Loretta Sanchez,913
-Riverside,11607,U.S. Senate,,DEM,Kamala Harris,550
-Riverside,11607,U.S. Senate,,DEM,Loretta Sanchez,683
-Riverside,11608,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,11608,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,11610,U.S. Senate,,DEM,Kamala Harris,599
-Riverside,11610,U.S. Senate,,DEM,Loretta Sanchez,659
-Riverside,11611,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,11611,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,11613,U.S. Senate,,DEM,Kamala Harris,538
-Riverside,11613,U.S. Senate,,DEM,Loretta Sanchez,521
-Riverside,11617,U.S. Senate,,DEM,Kamala Harris,681
-Riverside,11617,U.S. Senate,,DEM,Loretta Sanchez,575
-Riverside,11618,U.S. Senate,,DEM,Kamala Harris,400
-Riverside,11618,U.S. Senate,,DEM,Loretta Sanchez,341
-Riverside,11620,U.S. Senate,,DEM,Kamala Harris,81
-Riverside,11620,U.S. Senate,,DEM,Loretta Sanchez,83
-Riverside,11625,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,11625,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,11627,U.S. Senate,,DEM,Kamala Harris,509
-Riverside,11627,U.S. Senate,,DEM,Loretta Sanchez,453
-Riverside,11629,U.S. Senate,,DEM,Kamala Harris,636
-Riverside,11629,U.S. Senate,,DEM,Loretta Sanchez,644
-Riverside,11700,U.S. Senate,,DEM,Kamala Harris,514
-Riverside,11700,U.S. Senate,,DEM,Loretta Sanchez,574
-Riverside,11701,U.S. Senate,,DEM,Kamala Harris,536
-Riverside,11701,U.S. Senate,,DEM,Loretta Sanchez,745
-Riverside,11709,U.S. Senate,,DEM,Kamala Harris,750
-Riverside,11709,U.S. Senate,,DEM,Loretta Sanchez,679
-Riverside,11711,U.S. Senate,,DEM,Kamala Harris,227
-Riverside,11711,U.S. Senate,,DEM,Loretta Sanchez,374
-Riverside,11712,U.S. Senate,,DEM,Kamala Harris,857
-Riverside,11712,U.S. Senate,,DEM,Loretta Sanchez,494
-Riverside,11715,U.S. Senate,,DEM,Kamala Harris,563
-Riverside,11715,U.S. Senate,,DEM,Loretta Sanchez,371
-Riverside,11717,U.S. Senate,,DEM,Kamala Harris,625
-Riverside,11717,U.S. Senate,,DEM,Loretta Sanchez,472
-Riverside,11802,U.S. Senate,,DEM,Kamala Harris,28
-Riverside,11802,U.S. Senate,,DEM,Loretta Sanchez,62
-Riverside,11803,U.S. Senate,,DEM,Kamala Harris,8
-Riverside,11803,U.S. Senate,,DEM,Loretta Sanchez,2
-Riverside,11807,U.S. Senate,,DEM,Kamala Harris,6
-Riverside,11807,U.S. Senate,,DEM,Loretta Sanchez,7
-Riverside,11820,U.S. Senate,,DEM,Kamala Harris,74
-Riverside,11820,U.S. Senate,,DEM,Loretta Sanchez,58
-Riverside,11821,U.S. Senate,,DEM,Kamala Harris,28
-Riverside,11821,U.S. Senate,,DEM,Loretta Sanchez,20
-Riverside,11861,U.S. Senate,,DEM,Kamala Harris,518
-Riverside,11861,U.S. Senate,,DEM,Loretta Sanchez,441
-Riverside,11863,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,11863,U.S. Senate,,DEM,Loretta Sanchez,3
-Riverside,11865,U.S. Senate,,DEM,Kamala Harris,382
-Riverside,11865,U.S. Senate,,DEM,Loretta Sanchez,330
-Riverside,11872,U.S. Senate,,DEM,Kamala Harris,358
-Riverside,11872,U.S. Senate,,DEM,Loretta Sanchez,326
-Riverside,11874,U.S. Senate,,DEM,Kamala Harris,470
-Riverside,11874,U.S. Senate,,DEM,Loretta Sanchez,505
-Riverside,11901,U.S. Senate,,DEM,Kamala Harris,811
-Riverside,11901,U.S. Senate,,DEM,Loretta Sanchez,676
-Riverside,11903,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,11903,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,11907,U.S. Senate,,DEM,Kamala Harris,361
-Riverside,11907,U.S. Senate,,DEM,Loretta Sanchez,311
-Riverside,11908,U.S. Senate,,DEM,Kamala Harris,4
-Riverside,11908,U.S. Senate,,DEM,Loretta Sanchez,1
-Riverside,11911,U.S. Senate,,DEM,Kamala Harris,11
-Riverside,11911,U.S. Senate,,DEM,Loretta Sanchez,1
-Riverside,11914,U.S. Senate,,DEM,Kamala Harris,83
-Riverside,11914,U.S. Senate,,DEM,Loretta Sanchez,62
-Riverside,11915,U.S. Senate,,DEM,Kamala Harris,270
-Riverside,11915,U.S. Senate,,DEM,Loretta Sanchez,236
-Riverside,11920,U.S. Senate,,DEM,Kamala Harris,518
-Riverside,11920,U.S. Senate,,DEM,Loretta Sanchez,351
-Riverside,11929,U.S. Senate,,DEM,Kamala Harris,699
-Riverside,11929,U.S. Senate,,DEM,Loretta Sanchez,608
-Riverside,11930,U.S. Senate,,DEM,Kamala Harris,608
-Riverside,11930,U.S. Senate,,DEM,Loretta Sanchez,531
-Riverside,11932,U.S. Senate,,DEM,Kamala Harris,329
-Riverside,11932,U.S. Senate,,DEM,Loretta Sanchez,300
-Riverside,11943,U.S. Senate,,DEM,Kamala Harris,191
-Riverside,11943,U.S. Senate,,DEM,Loretta Sanchez,139
-Riverside,11945,U.S. Senate,,DEM,Kamala Harris,136
-Riverside,11945,U.S. Senate,,DEM,Loretta Sanchez,120
-Riverside,11948,U.S. Senate,,DEM,Kamala Harris,296
-Riverside,11948,U.S. Senate,,DEM,Loretta Sanchez,269
-Riverside,11953,U.S. Senate,,DEM,Kamala Harris,712
-Riverside,11953,U.S. Senate,,DEM,Loretta Sanchez,689
-Riverside,11954,U.S. Senate,,DEM,Kamala Harris,348
-Riverside,11954,U.S. Senate,,DEM,Loretta Sanchez,476
-Riverside,11959,U.S. Senate,,DEM,Kamala Harris,384
-Riverside,11959,U.S. Senate,,DEM,Loretta Sanchez,496
-Riverside,11960,U.S. Senate,,DEM,Kamala Harris,3
-Riverside,11960,U.S. Senate,,DEM,Loretta Sanchez,4
-Riverside,11963,U.S. Senate,,DEM,Kamala Harris,118
-Riverside,11963,U.S. Senate,,DEM,Loretta Sanchez,141
-Riverside,11967,U.S. Senate,,DEM,Kamala Harris,21
-Riverside,11967,U.S. Senate,,DEM,Loretta Sanchez,41
-Riverside,11970,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,11970,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,11971,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,11971,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,11972,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,11972,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,11975,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,11975,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,11980,U.S. Senate,,DEM,Kamala Harris,124
-Riverside,11980,U.S. Senate,,DEM,Loretta Sanchez,97
-Riverside,12008,U.S. Senate,,DEM,Kamala Harris,758
-Riverside,12008,U.S. Senate,,DEM,Loretta Sanchez,715
-Riverside,12012,U.S. Senate,,DEM,Kamala Harris,625
-Riverside,12012,U.S. Senate,,DEM,Loretta Sanchez,531
-Riverside,12014,U.S. Senate,,DEM,Kamala Harris,516
-Riverside,12014,U.S. Senate,,DEM,Loretta Sanchez,536
-Riverside,12016,U.S. Senate,,DEM,Kamala Harris,554
-Riverside,12016,U.S. Senate,,DEM,Loretta Sanchez,546
-Riverside,12024,U.S. Senate,,DEM,Kamala Harris,414
-Riverside,12024,U.S. Senate,,DEM,Loretta Sanchez,415
-Riverside,12026,U.S. Senate,,DEM,Kamala Harris,641
-Riverside,12026,U.S. Senate,,DEM,Loretta Sanchez,601
-Riverside,12028,U.S. Senate,,DEM,Kamala Harris,445
-Riverside,12028,U.S. Senate,,DEM,Loretta Sanchez,400
-Riverside,12029,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,12029,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,12033,U.S. Senate,,DEM,Kamala Harris,686
-Riverside,12033,U.S. Senate,,DEM,Loretta Sanchez,619
-Riverside,12043,U.S. Senate,,DEM,Kamala Harris,669
-Riverside,12043,U.S. Senate,,DEM,Loretta Sanchez,486
-Riverside,12045,U.S. Senate,,DEM,Kamala Harris,270
-Riverside,12045,U.S. Senate,,DEM,Loretta Sanchez,228
-Riverside,12048,U.S. Senate,,DEM,Kamala Harris,912
-Riverside,12048,U.S. Senate,,DEM,Loretta Sanchez,728
-Riverside,12055,U.S. Senate,,DEM,Kamala Harris,739
-Riverside,12055,U.S. Senate,,DEM,Loretta Sanchez,471
-Riverside,12057,U.S. Senate,,DEM,Kamala Harris,188
-Riverside,12057,U.S. Senate,,DEM,Loretta Sanchez,209
-Riverside,12066,U.S. Senate,,DEM,Kamala Harris,388
-Riverside,12066,U.S. Senate,,DEM,Loretta Sanchez,463
-Riverside,12602,U.S. Senate,,DEM,Kamala Harris,540
-Riverside,12602,U.S. Senate,,DEM,Loretta Sanchez,432
-Riverside,12603,U.S. Senate,,DEM,Kamala Harris,290
-Riverside,12603,U.S. Senate,,DEM,Loretta Sanchez,253
-Riverside,12604,U.S. Senate,,DEM,Kamala Harris,493
-Riverside,12604,U.S. Senate,,DEM,Loretta Sanchez,362
-Riverside,12649,U.S. Senate,,DEM,Kamala Harris,11
-Riverside,12649,U.S. Senate,,DEM,Loretta Sanchez,4
-Riverside,12650,U.S. Senate,,DEM,Kamala Harris,58
-Riverside,12650,U.S. Senate,,DEM,Loretta Sanchez,38
-Riverside,12651,U.S. Senate,,DEM,Kamala Harris,1196
-Riverside,12651,U.S. Senate,,DEM,Loretta Sanchez,754
-Riverside,12660,U.S. Senate,,DEM,Kamala Harris,80
-Riverside,12660,U.S. Senate,,DEM,Loretta Sanchez,42
-Riverside,12664,U.S. Senate,,DEM,Kamala Harris,812
-Riverside,12664,U.S. Senate,,DEM,Loretta Sanchez,582
-Riverside,12703,U.S. Senate,,DEM,Kamala Harris,2
-Riverside,12703,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,12704,U.S. Senate,,DEM,Kamala Harris,605
-Riverside,12704,U.S. Senate,,DEM,Loretta Sanchez,460
-Riverside,12710,U.S. Senate,,DEM,Kamala Harris,571
-Riverside,12710,U.S. Senate,,DEM,Loretta Sanchez,498
-Riverside,12750,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,12750,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,12756,U.S. Senate,,DEM,Kamala Harris,60
-Riverside,12756,U.S. Senate,,DEM,Loretta Sanchez,57
-Riverside,12757,U.S. Senate,,DEM,Kamala Harris,10
-Riverside,12757,U.S. Senate,,DEM,Loretta Sanchez,8
-Riverside,12758,U.S. Senate,,DEM,Kamala Harris,46
-Riverside,12758,U.S. Senate,,DEM,Loretta Sanchez,43
-Riverside,12849,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,12849,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,12850,U.S. Senate,,DEM,Kamala Harris,6
-Riverside,12850,U.S. Senate,,DEM,Loretta Sanchez,2
-Riverside,12851,U.S. Senate,,DEM,Kamala Harris,367
-Riverside,12851,U.S. Senate,,DEM,Loretta Sanchez,268
-Riverside,12900,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,12900,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,12901,U.S. Senate,,DEM,Kamala Harris,114
-Riverside,12901,U.S. Senate,,DEM,Loretta Sanchez,80
-Riverside,12920,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,12920,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,12921,U.S. Senate,,DEM,Kamala Harris,3
-Riverside,12921,U.S. Senate,,DEM,Loretta Sanchez,4
-Riverside,12922,U.S. Senate,,DEM,Kamala Harris,45
-Riverside,12922,U.S. Senate,,DEM,Loretta Sanchez,55
-Riverside,13005,U.S. Senate,,DEM,Kamala Harris,724
-Riverside,13005,U.S. Senate,,DEM,Loretta Sanchez,684
-Riverside,13006,U.S. Senate,,DEM,Kamala Harris,792
-Riverside,13006,U.S. Senate,,DEM,Loretta Sanchez,667
-Riverside,13020,U.S. Senate,,DEM,Kamala Harris,545
-Riverside,13020,U.S. Senate,,DEM,Loretta Sanchez,449
-Riverside,14105,U.S. Senate,,DEM,Kamala Harris,484
-Riverside,14105,U.S. Senate,,DEM,Loretta Sanchez,459
-Riverside,14108,U.S. Senate,,DEM,Kamala Harris,319
-Riverside,14108,U.S. Senate,,DEM,Loretta Sanchez,388
-Riverside,14200,U.S. Senate,,DEM,Kamala Harris,8
-Riverside,14200,U.S. Senate,,DEM,Loretta Sanchez,3
-Riverside,14201,U.S. Senate,,DEM,Kamala Harris,59
-Riverside,14201,U.S. Senate,,DEM,Loretta Sanchez,78
-Riverside,14207,U.S. Senate,,DEM,Kamala Harris,639
-Riverside,14207,U.S. Senate,,DEM,Loretta Sanchez,503
-Riverside,14211,U.S. Senate,,DEM,Kamala Harris,328
-Riverside,14211,U.S. Senate,,DEM,Loretta Sanchez,289
-Riverside,14303,U.S. Senate,,DEM,Kamala Harris,655
-Riverside,14303,U.S. Senate,,DEM,Loretta Sanchez,619
-Riverside,14307,U.S. Senate,,DEM,Kamala Harris,523
-Riverside,14307,U.S. Senate,,DEM,Loretta Sanchez,460
-Riverside,14401,U.S. Senate,,DEM,Kamala Harris,651
-Riverside,14401,U.S. Senate,,DEM,Loretta Sanchez,589
-Riverside,14403,U.S. Senate,,DEM,Kamala Harris,309
-Riverside,14403,U.S. Senate,,DEM,Loretta Sanchez,382
-Riverside,14504,U.S. Senate,,DEM,Kamala Harris,895
-Riverside,14504,U.S. Senate,,DEM,Loretta Sanchez,742
-Riverside,14506,U.S. Senate,,DEM,Kamala Harris,302
-Riverside,14506,U.S. Senate,,DEM,Loretta Sanchez,248
-Riverside,14802,U.S. Senate,,DEM,Kamala Harris,458
-Riverside,14802,U.S. Senate,,DEM,Loretta Sanchez,479
-Riverside,14804,U.S. Senate,,DEM,Kamala Harris,440
-Riverside,14804,U.S. Senate,,DEM,Loretta Sanchez,437
-Riverside,14850,U.S. Senate,,DEM,Kamala Harris,40
-Riverside,14850,U.S. Senate,,DEM,Loretta Sanchez,21
-Riverside,14901,U.S. Senate,,DEM,Kamala Harris,194
-Riverside,14901,U.S. Senate,,DEM,Loretta Sanchez,225
-Riverside,14902,U.S. Senate,,DEM,Kamala Harris,390
-Riverside,14902,U.S. Senate,,DEM,Loretta Sanchez,362
-Riverside,14904,U.S. Senate,,DEM,Kamala Harris,6
-Riverside,14904,U.S. Senate,,DEM,Loretta Sanchez,4
-Riverside,14908,U.S. Senate,,DEM,Kamala Harris,47
-Riverside,14908,U.S. Senate,,DEM,Loretta Sanchez,51
-Riverside,14909,U.S. Senate,,DEM,Kamala Harris,54
-Riverside,14909,U.S. Senate,,DEM,Loretta Sanchez,61
-Riverside,14910,U.S. Senate,,DEM,Kamala Harris,12
-Riverside,14910,U.S. Senate,,DEM,Loretta Sanchez,8
-Riverside,15810,U.S. Senate,,DEM,Kamala Harris,210
-Riverside,15810,U.S. Senate,,DEM,Loretta Sanchez,183
-Riverside,15815,U.S. Senate,,DEM,Kamala Harris,38
-Riverside,15815,U.S. Senate,,DEM,Loretta Sanchez,12
-Riverside,15843,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,15843,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,15844,U.S. Senate,,DEM,Kamala Harris,7
-Riverside,15844,U.S. Senate,,DEM,Loretta Sanchez,6
-Riverside,15846,U.S. Senate,,DEM,Kamala Harris,229
-Riverside,15846,U.S. Senate,,DEM,Loretta Sanchez,381
-Riverside,15852,U.S. Senate,,DEM,Kamala Harris,129
-Riverside,15852,U.S. Senate,,DEM,Loretta Sanchez,144
-Riverside,15855,U.S. Senate,,DEM,Kamala Harris,19
-Riverside,15855,U.S. Senate,,DEM,Loretta Sanchez,44
-Riverside,15856,U.S. Senate,,DEM,Kamala Harris,19
-Riverside,15856,U.S. Senate,,DEM,Loretta Sanchez,17
-Riverside,15863,U.S. Senate,,DEM,Kamala Harris,285
-Riverside,15863,U.S. Senate,,DEM,Loretta Sanchez,455
-Riverside,15874,U.S. Senate,,DEM,Kamala Harris,2
-Riverside,15874,U.S. Senate,,DEM,Loretta Sanchez,1
-Riverside,15877,U.S. Senate,,DEM,Kamala Harris,112
-Riverside,15877,U.S. Senate,,DEM,Loretta Sanchez,133
-Riverside,15880,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,15880,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,15885,U.S. Senate,,DEM,Kamala Harris,92
-Riverside,15885,U.S. Senate,,DEM,Loretta Sanchez,92
-Riverside,18603,U.S. Senate,,DEM,Kamala Harris,541
-Riverside,18603,U.S. Senate,,DEM,Loretta Sanchez,513
-Riverside,18612,U.S. Senate,,DEM,Kamala Harris,404
-Riverside,18612,U.S. Senate,,DEM,Loretta Sanchez,302
-Riverside,18614,U.S. Senate,,DEM,Kamala Harris,38
-Riverside,18614,U.S. Senate,,DEM,Loretta Sanchez,30
-Riverside,20005,U.S. Senate,,DEM,Kamala Harris,874
-Riverside,20005,U.S. Senate,,DEM,Loretta Sanchez,643
-Riverside,20014,U.S. Senate,,DEM,Kamala Harris,516
-Riverside,20014,U.S. Senate,,DEM,Loretta Sanchez,545
-Riverside,20020,U.S. Senate,,DEM,Kamala Harris,518
-Riverside,20020,U.S. Senate,,DEM,Loretta Sanchez,682
-Riverside,20022,U.S. Senate,,DEM,Kamala Harris,680
-Riverside,20022,U.S. Senate,,DEM,Loretta Sanchez,647
-Riverside,20023,U.S. Senate,,DEM,Kamala Harris,609
-Riverside,20023,U.S. Senate,,DEM,Loretta Sanchez,707
-Riverside,20026,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,20026,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,20027,U.S. Senate,,DEM,Kamala Harris,40
-Riverside,20027,U.S. Senate,,DEM,Loretta Sanchez,48
-Riverside,20029,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,20029,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,20031,U.S. Senate,,DEM,Kamala Harris,1
-Riverside,20031,U.S. Senate,,DEM,Loretta Sanchez,4
-Riverside,20033,U.S. Senate,,DEM,Kamala Harris,290
-Riverside,20033,U.S. Senate,,DEM,Loretta Sanchez,293
-Riverside,20034,U.S. Senate,,DEM,Kamala Harris,1
-Riverside,20034,U.S. Senate,,DEM,Loretta Sanchez,1
-Riverside,20035,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,20035,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,20037,U.S. Senate,,DEM,Kamala Harris,268
-Riverside,20037,U.S. Senate,,DEM,Loretta Sanchez,144
-Riverside,20038,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,20038,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,20039,U.S. Senate,,DEM,Kamala Harris,557
-Riverside,20039,U.S. Senate,,DEM,Loretta Sanchez,500
-Riverside,20042,U.S. Senate,,DEM,Kamala Harris,662
-Riverside,20042,U.S. Senate,,DEM,Loretta Sanchez,691
-Riverside,20044,U.S. Senate,,DEM,Kamala Harris,190
-Riverside,20044,U.S. Senate,,DEM,Loretta Sanchez,221
-Riverside,20045,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,20045,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,20048,U.S. Senate,,DEM,Kamala Harris,472
-Riverside,20048,U.S. Senate,,DEM,Loretta Sanchez,729
-Riverside,20050,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,20050,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,20052,U.S. Senate,,DEM,Kamala Harris,602
-Riverside,20052,U.S. Senate,,DEM,Loretta Sanchez,713
-Riverside,20054,U.S. Senate,,DEM,Kamala Harris,361
-Riverside,20054,U.S. Senate,,DEM,Loretta Sanchez,442
-Riverside,20055,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,20055,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,20056,U.S. Senate,,DEM,Kamala Harris,623
-Riverside,20056,U.S. Senate,,DEM,Loretta Sanchez,563
-Riverside,20062,U.S. Senate,,DEM,Kamala Harris,846
-Riverside,20062,U.S. Senate,,DEM,Loretta Sanchez,672
-Riverside,20064,U.S. Senate,,DEM,Kamala Harris,233
-Riverside,20064,U.S. Senate,,DEM,Loretta Sanchez,256
-Riverside,20066,U.S. Senate,,DEM,Kamala Harris,400
-Riverside,20066,U.S. Senate,,DEM,Loretta Sanchez,410
-Riverside,20068,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,20068,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,20069,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,20069,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,20071,U.S. Senate,,DEM,Kamala Harris,380
-Riverside,20071,U.S. Senate,,DEM,Loretta Sanchez,309
-Riverside,20073,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,20073,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,20075,U.S. Senate,,DEM,Kamala Harris,23
-Riverside,20075,U.S. Senate,,DEM,Loretta Sanchez,27
-Riverside,20077,U.S. Senate,,DEM,Kamala Harris,1
-Riverside,20077,U.S. Senate,,DEM,Loretta Sanchez,4
-Riverside,20080,U.S. Senate,,DEM,Kamala Harris,483
-Riverside,20080,U.S. Senate,,DEM,Loretta Sanchez,628
-Riverside,20081,U.S. Senate,,DEM,Kamala Harris,511
-Riverside,20081,U.S. Senate,,DEM,Loretta Sanchez,518
-Riverside,20084,U.S. Senate,,DEM,Kamala Harris,552
-Riverside,20084,U.S. Senate,,DEM,Loretta Sanchez,565
-Riverside,20085,U.S. Senate,,DEM,Kamala Harris,12
-Riverside,20085,U.S. Senate,,DEM,Loretta Sanchez,14
-Riverside,20086,U.S. Senate,,DEM,Kamala Harris,42
-Riverside,20086,U.S. Senate,,DEM,Loretta Sanchez,34
-Riverside,20087,U.S. Senate,,DEM,Kamala Harris,12
-Riverside,20087,U.S. Senate,,DEM,Loretta Sanchez,10
-Riverside,20088,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,20088,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,20091,U.S. Senate,,DEM,Kamala Harris,541
-Riverside,20091,U.S. Senate,,DEM,Loretta Sanchez,673
-Riverside,20093,U.S. Senate,,DEM,Kamala Harris,4
-Riverside,20093,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,20096,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,20096,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,20800,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,20800,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,20801,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,20801,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,20802,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,20802,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,20803,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,20803,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,20804,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,20804,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,20806,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,20806,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,20807,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,20807,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,20808,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,20808,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,21103,U.S. Senate,,DEM,Kamala Harris,507
-Riverside,21103,U.S. Senate,,DEM,Loretta Sanchez,457
-Riverside,21105,U.S. Senate,,DEM,Kamala Harris,567
-Riverside,21105,U.S. Senate,,DEM,Loretta Sanchez,342
-Riverside,21107,U.S. Senate,,DEM,Kamala Harris,797
-Riverside,21107,U.S. Senate,,DEM,Loretta Sanchez,472
-Riverside,21109,U.S. Senate,,DEM,Kamala Harris,728
-Riverside,21109,U.S. Senate,,DEM,Loretta Sanchez,508
-Riverside,21114,U.S. Senate,,DEM,Kamala Harris,765
-Riverside,21114,U.S. Senate,,DEM,Loretta Sanchez,537
-Riverside,21117,U.S. Senate,,DEM,Kamala Harris,719
-Riverside,21117,U.S. Senate,,DEM,Loretta Sanchez,511
-Riverside,21120,U.S. Senate,,DEM,Kamala Harris,639
-Riverside,21120,U.S. Senate,,DEM,Loretta Sanchez,623
-Riverside,21124,U.S. Senate,,DEM,Kamala Harris,478
-Riverside,21124,U.S. Senate,,DEM,Loretta Sanchez,458
-Riverside,21131,U.S. Senate,,DEM,Kamala Harris,25
-Riverside,21131,U.S. Senate,,DEM,Loretta Sanchez,29
-Riverside,21300,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,21300,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,21301,U.S. Senate,,DEM,Kamala Harris,606
-Riverside,21301,U.S. Senate,,DEM,Loretta Sanchez,649
-Riverside,21304,U.S. Senate,,DEM,Kamala Harris,408
-Riverside,21304,U.S. Senate,,DEM,Loretta Sanchez,485
-Riverside,21306,U.S. Senate,,DEM,Kamala Harris,770
-Riverside,21306,U.S. Senate,,DEM,Loretta Sanchez,638
-Riverside,21313,U.S. Senate,,DEM,Kamala Harris,813
-Riverside,21313,U.S. Senate,,DEM,Loretta Sanchez,584
-Riverside,21314,U.S. Senate,,DEM,Kamala Harris,715
-Riverside,21314,U.S. Senate,,DEM,Loretta Sanchez,529
-Riverside,21316,U.S. Senate,,DEM,Kamala Harris,693
-Riverside,21316,U.S. Senate,,DEM,Loretta Sanchez,566
-Riverside,21317,U.S. Senate,,DEM,Kamala Harris,295
-Riverside,21317,U.S. Senate,,DEM,Loretta Sanchez,294
-Riverside,21500,U.S. Senate,,DEM,Kamala Harris,152
-Riverside,21500,U.S. Senate,,DEM,Loretta Sanchez,194
-Riverside,21503,U.S. Senate,,DEM,Kamala Harris,677
-Riverside,21503,U.S. Senate,,DEM,Loretta Sanchez,563
-Riverside,21700,U.S. Senate,,DEM,Kamala Harris,435
-Riverside,21700,U.S. Senate,,DEM,Loretta Sanchez,462
-Riverside,21702,U.S. Senate,,DEM,Kamala Harris,363
-Riverside,21702,U.S. Senate,,DEM,Loretta Sanchez,384
-Riverside,21704,U.S. Senate,,DEM,Kamala Harris,618
-Riverside,21704,U.S. Senate,,DEM,Loretta Sanchez,756
-Riverside,21800,U.S. Senate,,DEM,Kamala Harris,4
-Riverside,21800,U.S. Senate,,DEM,Loretta Sanchez,10
-Riverside,21986,U.S. Senate,,DEM,Kamala Harris,639
-Riverside,21986,U.S. Senate,,DEM,Loretta Sanchez,773
-Riverside,21987,U.S. Senate,,DEM,Kamala Harris,2
-Riverside,21987,U.S. Senate,,DEM,Loretta Sanchez,2
-Riverside,22100,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,22100,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,22104,U.S. Senate,,DEM,Kamala Harris,884
-Riverside,22104,U.S. Senate,,DEM,Loretta Sanchez,652
-Riverside,22107,U.S. Senate,,DEM,Kamala Harris,102
-Riverside,22107,U.S. Senate,,DEM,Loretta Sanchez,124
-Riverside,22108,U.S. Senate,,DEM,Kamala Harris,366
-Riverside,22108,U.S. Senate,,DEM,Loretta Sanchez,275
-Riverside,22109,U.S. Senate,,DEM,Kamala Harris,232
-Riverside,22109,U.S. Senate,,DEM,Loretta Sanchez,167
-Riverside,22202,U.S. Senate,,DEM,Kamala Harris,1117
-Riverside,22202,U.S. Senate,,DEM,Loretta Sanchez,764
-Riverside,22205,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,22205,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,22206,U.S. Senate,,DEM,Kamala Harris,993
-Riverside,22206,U.S. Senate,,DEM,Loretta Sanchez,682
-Riverside,22302,U.S. Senate,,DEM,Kamala Harris,430
-Riverside,22302,U.S. Senate,,DEM,Loretta Sanchez,324
-Riverside,22303,U.S. Senate,,DEM,Kamala Harris,739
-Riverside,22303,U.S. Senate,,DEM,Loretta Sanchez,488
-Riverside,22306,U.S. Senate,,DEM,Kamala Harris,556
-Riverside,22306,U.S. Senate,,DEM,Loretta Sanchez,466
-Riverside,22401,U.S. Senate,,DEM,Kamala Harris,949
-Riverside,22401,U.S. Senate,,DEM,Loretta Sanchez,729
-Riverside,22406,U.S. Senate,,DEM,Kamala Harris,997
-Riverside,22406,U.S. Senate,,DEM,Loretta Sanchez,732
-Riverside,22502,U.S. Senate,,DEM,Kamala Harris,908
-Riverside,22502,U.S. Senate,,DEM,Loretta Sanchez,686
-Riverside,22505,U.S. Senate,,DEM,Kamala Harris,885
-Riverside,22505,U.S. Senate,,DEM,Loretta Sanchez,703
-Riverside,22507,U.S. Senate,,DEM,Kamala Harris,607
-Riverside,22507,U.S. Senate,,DEM,Loretta Sanchez,417
-Riverside,22857,U.S. Senate,,DEM,Kamala Harris,285
-Riverside,22857,U.S. Senate,,DEM,Loretta Sanchez,446
-Riverside,22858,U.S. Senate,,DEM,Kamala Harris,676
-Riverside,22858,U.S. Senate,,DEM,Loretta Sanchez,664
-Riverside,22868,U.S. Senate,,DEM,Kamala Harris,184
-Riverside,22868,U.S. Senate,,DEM,Loretta Sanchez,303
-Riverside,22870,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,22870,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,22872,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,22872,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,22873,U.S. Senate,,DEM,Kamala Harris,1
-Riverside,22873,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,22921,U.S. Senate,,DEM,Kamala Harris,485
-Riverside,22921,U.S. Senate,,DEM,Loretta Sanchez,572
-Riverside,22925,U.S. Senate,,DEM,Kamala Harris,77
-Riverside,22925,U.S. Senate,,DEM,Loretta Sanchez,55
-Riverside,22930,U.S. Senate,,DEM,Kamala Harris,180
-Riverside,22930,U.S. Senate,,DEM,Loretta Sanchez,206
-Riverside,23001,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,23001,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,23002,U.S. Senate,,DEM,Kamala Harris,442
-Riverside,23002,U.S. Senate,,DEM,Loretta Sanchez,416
-Riverside,23004,U.S. Senate,,DEM,Kamala Harris,474
-Riverside,23004,U.S. Senate,,DEM,Loretta Sanchez,485
-Riverside,23006,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,23006,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,23014,U.S. Senate,,DEM,Kamala Harris,611
-Riverside,23014,U.S. Senate,,DEM,Loretta Sanchez,433
-Riverside,23016,U.S. Senate,,DEM,Kamala Harris,515
-Riverside,23016,U.S. Senate,,DEM,Loretta Sanchez,419
-Riverside,23018,U.S. Senate,,DEM,Kamala Harris,613
-Riverside,23018,U.S. Senate,,DEM,Loretta Sanchez,569
-Riverside,23019,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,23019,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,23020,U.S. Senate,,DEM,Kamala Harris,432
-Riverside,23020,U.S. Senate,,DEM,Loretta Sanchez,490
-Riverside,23023,U.S. Senate,,DEM,Kamala Harris,562
-Riverside,23023,U.S. Senate,,DEM,Loretta Sanchez,516
-Riverside,23024,U.S. Senate,,DEM,Kamala Harris,434
-Riverside,23024,U.S. Senate,,DEM,Loretta Sanchez,370
-Riverside,23026,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,23026,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,24000,U.S. Senate,,DEM,Kamala Harris,685
-Riverside,24000,U.S. Senate,,DEM,Loretta Sanchez,656
-Riverside,24003,U.S. Senate,,DEM,Kamala Harris,492
-Riverside,24003,U.S. Senate,,DEM,Loretta Sanchez,513
-Riverside,24005,U.S. Senate,,DEM,Kamala Harris,511
-Riverside,24005,U.S. Senate,,DEM,Loretta Sanchez,454
-Riverside,24010,U.S. Senate,,DEM,Kamala Harris,507
-Riverside,24010,U.S. Senate,,DEM,Loretta Sanchez,450
-Riverside,24013,U.S. Senate,,DEM,Kamala Harris,705
-Riverside,24013,U.S. Senate,,DEM,Loretta Sanchez,470
-Riverside,24014,U.S. Senate,,DEM,Kamala Harris,699
-Riverside,24014,U.S. Senate,,DEM,Loretta Sanchez,493
-Riverside,24015,U.S. Senate,,DEM,Kamala Harris,901
-Riverside,24015,U.S. Senate,,DEM,Loretta Sanchez,673
-Riverside,24019,U.S. Senate,,DEM,Kamala Harris,524
-Riverside,24019,U.S. Senate,,DEM,Loretta Sanchez,350
-Riverside,24020,U.S. Senate,,DEM,Kamala Harris,690
-Riverside,24020,U.S. Senate,,DEM,Loretta Sanchez,494
-Riverside,24026,U.S. Senate,,DEM,Kamala Harris,678
-Riverside,24026,U.S. Senate,,DEM,Loretta Sanchez,581
-Riverside,24027,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,24027,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,24029,U.S. Senate,,DEM,Kamala Harris,549
-Riverside,24029,U.S. Senate,,DEM,Loretta Sanchez,403
-Riverside,24031,U.S. Senate,,DEM,Kamala Harris,682
-Riverside,24031,U.S. Senate,,DEM,Loretta Sanchez,491
-Riverside,24033,U.S. Senate,,DEM,Kamala Harris,841
-Riverside,24033,U.S. Senate,,DEM,Loretta Sanchez,686
-Riverside,24035,U.S. Senate,,DEM,Kamala Harris,379
-Riverside,24035,U.S. Senate,,DEM,Loretta Sanchez,420
-Riverside,24037,U.S. Senate,,DEM,Kamala Harris,522
-Riverside,24037,U.S. Senate,,DEM,Loretta Sanchez,531
-Riverside,24039,U.S. Senate,,DEM,Kamala Harris,499
-Riverside,24039,U.S. Senate,,DEM,Loretta Sanchez,582
-Riverside,24042,U.S. Senate,,DEM,Kamala Harris,442
-Riverside,24042,U.S. Senate,,DEM,Loretta Sanchez,644
-Riverside,24044,U.S. Senate,,DEM,Kamala Harris,297
-Riverside,24044,U.S. Senate,,DEM,Loretta Sanchez,414
-Riverside,24045,U.S. Senate,,DEM,Kamala Harris,312
-Riverside,24045,U.S. Senate,,DEM,Loretta Sanchez,451
-Riverside,24046,U.S. Senate,,DEM,Kamala Harris,582
-Riverside,24046,U.S. Senate,,DEM,Loretta Sanchez,439
-Riverside,24048,U.S. Senate,,DEM,Kamala Harris,493
-Riverside,24048,U.S. Senate,,DEM,Loretta Sanchez,476
-Riverside,24052,U.S. Senate,,DEM,Kamala Harris,407
-Riverside,24052,U.S. Senate,,DEM,Loretta Sanchez,399
-Riverside,24053,U.S. Senate,,DEM,Kamala Harris,789
-Riverside,24053,U.S. Senate,,DEM,Loretta Sanchez,713
-Riverside,24056,U.S. Senate,,DEM,Kamala Harris,385
-Riverside,24056,U.S. Senate,,DEM,Loretta Sanchez,396
-Riverside,24057,U.S. Senate,,DEM,Kamala Harris,347
-Riverside,24057,U.S. Senate,,DEM,Loretta Sanchez,287
-Riverside,24060,U.S. Senate,,DEM,Kamala Harris,436
-Riverside,24060,U.S. Senate,,DEM,Loretta Sanchez,382
-Riverside,24063,U.S. Senate,,DEM,Kamala Harris,401
-Riverside,24063,U.S. Senate,,DEM,Loretta Sanchez,342
-Riverside,24066,U.S. Senate,,DEM,Kamala Harris,492
-Riverside,24066,U.S. Senate,,DEM,Loretta Sanchez,346
-Riverside,24069,U.S. Senate,,DEM,Kamala Harris,785
-Riverside,24069,U.S. Senate,,DEM,Loretta Sanchez,576
-Riverside,24071,U.S. Senate,,DEM,Kamala Harris,695
-Riverside,24071,U.S. Senate,,DEM,Loretta Sanchez,412
-Riverside,24072,U.S. Senate,,DEM,Kamala Harris,992
-Riverside,24072,U.S. Senate,,DEM,Loretta Sanchez,672
-Riverside,24075,U.S. Senate,,DEM,Kamala Harris,848
-Riverside,24075,U.S. Senate,,DEM,Loretta Sanchez,544
-Riverside,24077,U.S. Senate,,DEM,Kamala Harris,520
-Riverside,24077,U.S. Senate,,DEM,Loretta Sanchez,361
-Riverside,24078,U.S. Senate,,DEM,Kamala Harris,651
-Riverside,24078,U.S. Senate,,DEM,Loretta Sanchez,469
-Riverside,24079,U.S. Senate,,DEM,Kamala Harris,856
-Riverside,24079,U.S. Senate,,DEM,Loretta Sanchez,611
-Riverside,24082,U.S. Senate,,DEM,Kamala Harris,630
-Riverside,24082,U.S. Senate,,DEM,Loretta Sanchez,442
-Riverside,24083,U.S. Senate,,DEM,Kamala Harris,393
-Riverside,24083,U.S. Senate,,DEM,Loretta Sanchez,317
-Riverside,24085,U.S. Senate,,DEM,Kamala Harris,570
-Riverside,24085,U.S. Senate,,DEM,Loretta Sanchez,478
-Riverside,24086,U.S. Senate,,DEM,Kamala Harris,486
-Riverside,24086,U.S. Senate,,DEM,Loretta Sanchez,343
-Riverside,24090,U.S. Senate,,DEM,Kamala Harris,761
-Riverside,24090,U.S. Senate,,DEM,Loretta Sanchez,545
-Riverside,24092,U.S. Senate,,DEM,Kamala Harris,641
-Riverside,24092,U.S. Senate,,DEM,Loretta Sanchez,466
-Riverside,24093,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,24093,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,24108,U.S. Senate,,DEM,Kamala Harris,69
-Riverside,24108,U.S. Senate,,DEM,Loretta Sanchez,80
-Riverside,24804,U.S. Senate,,DEM,Kamala Harris,2
-Riverside,24804,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,24805,U.S. Senate,,DEM,Kamala Harris,12
-Riverside,24805,U.S. Senate,,DEM,Loretta Sanchez,13
-Riverside,24806,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,24806,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,24820,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,24820,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,24825,U.S. Senate,,DEM,Kamala Harris,320
-Riverside,24825,U.S. Senate,,DEM,Loretta Sanchez,269
-Riverside,24826,U.S. Senate,,DEM,Kamala Harris,93
-Riverside,24826,U.S. Senate,,DEM,Loretta Sanchez,93
-Riverside,24829,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,24829,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,24830,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,24830,U.S. Senate,,DEM,Loretta Sanchez,3
-Riverside,24831,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,24831,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,24832,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,24832,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,24833,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,24833,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,24834,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,24834,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,24835,U.S. Senate,,DEM,Kamala Harris,3
-Riverside,24835,U.S. Senate,,DEM,Loretta Sanchez,3
-Riverside,24836,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,24836,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,30000,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,30000,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,30002,U.S. Senate,,DEM,Kamala Harris,476
-Riverside,30002,U.S. Senate,,DEM,Loretta Sanchez,446
-Riverside,30004,U.S. Senate,,DEM,Kamala Harris,440
-Riverside,30004,U.S. Senate,,DEM,Loretta Sanchez,311
-Riverside,30008,U.S. Senate,,DEM,Kamala Harris,398
-Riverside,30008,U.S. Senate,,DEM,Loretta Sanchez,435
-Riverside,30009,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,30009,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,30020,U.S. Senate,,DEM,Kamala Harris,544
-Riverside,30020,U.S. Senate,,DEM,Loretta Sanchez,519
-Riverside,30023,U.S. Senate,,DEM,Kamala Harris,355
-Riverside,30023,U.S. Senate,,DEM,Loretta Sanchez,322
-Riverside,30025,U.S. Senate,,DEM,Kamala Harris,250
-Riverside,30025,U.S. Senate,,DEM,Loretta Sanchez,225
-Riverside,30030,U.S. Senate,,DEM,Kamala Harris,469
-Riverside,30030,U.S. Senate,,DEM,Loretta Sanchez,495
-Riverside,30034,U.S. Senate,,DEM,Kamala Harris,438
-Riverside,30034,U.S. Senate,,DEM,Loretta Sanchez,518
-Riverside,30036,U.S. Senate,,DEM,Kamala Harris,676
-Riverside,30036,U.S. Senate,,DEM,Loretta Sanchez,531
-Riverside,30042,U.S. Senate,,DEM,Kamala Harris,608
-Riverside,30042,U.S. Senate,,DEM,Loretta Sanchez,569
-Riverside,30045,U.S. Senate,,DEM,Kamala Harris,80
-Riverside,30045,U.S. Senate,,DEM,Loretta Sanchez,53
-Riverside,30048,U.S. Senate,,DEM,Kamala Harris,70
-Riverside,30048,U.S. Senate,,DEM,Loretta Sanchez,49
-Riverside,30051,U.S. Senate,,DEM,Kamala Harris,128
-Riverside,30051,U.S. Senate,,DEM,Loretta Sanchez,47
-Riverside,30057,U.S. Senate,,DEM,Kamala Harris,145
-Riverside,30057,U.S. Senate,,DEM,Loretta Sanchez,109
-Riverside,30060,U.S. Senate,,DEM,Kamala Harris,399
-Riverside,30060,U.S. Senate,,DEM,Loretta Sanchez,351
-Riverside,30062,U.S. Senate,,DEM,Kamala Harris,1
-Riverside,30062,U.S. Senate,,DEM,Loretta Sanchez,1
-Riverside,30904,U.S. Senate,,DEM,Kamala Harris,172
-Riverside,30904,U.S. Senate,,DEM,Loretta Sanchez,141
-Riverside,30909,U.S. Senate,,DEM,Kamala Harris,5
-Riverside,30909,U.S. Senate,,DEM,Loretta Sanchez,1
-Riverside,30910,U.S. Senate,,DEM,Kamala Harris,28
-Riverside,30910,U.S. Senate,,DEM,Loretta Sanchez,35
-Riverside,30913,U.S. Senate,,DEM,Kamala Harris,73
-Riverside,30913,U.S. Senate,,DEM,Loretta Sanchez,71
-Riverside,30920,U.S. Senate,,DEM,Kamala Harris,10
-Riverside,30920,U.S. Senate,,DEM,Loretta Sanchez,8
-Riverside,30922,U.S. Senate,,DEM,Kamala Harris,11
-Riverside,30922,U.S. Senate,,DEM,Loretta Sanchez,10
-Riverside,30924,U.S. Senate,,DEM,Kamala Harris,12
-Riverside,30924,U.S. Senate,,DEM,Loretta Sanchez,10
-Riverside,30925,U.S. Senate,,DEM,Kamala Harris,14
-Riverside,30925,U.S. Senate,,DEM,Loretta Sanchez,5
-Riverside,30927,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,30927,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,30928,U.S. Senate,,DEM,Kamala Harris,1
-Riverside,30928,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,30929,U.S. Senate,,DEM,Kamala Harris,1
-Riverside,30929,U.S. Senate,,DEM,Loretta Sanchez,6
-Riverside,30930,U.S. Senate,,DEM,Kamala Harris,5
-Riverside,30930,U.S. Senate,,DEM,Loretta Sanchez,1
-Riverside,30931,U.S. Senate,,DEM,Kamala Harris,7
-Riverside,30931,U.S. Senate,,DEM,Loretta Sanchez,14
-Riverside,30935,U.S. Senate,,DEM,Kamala Harris,5
-Riverside,30935,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,30937,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,30937,U.S. Senate,,DEM,Loretta Sanchez,4
-Riverside,30938,U.S. Senate,,DEM,Kamala Harris,4
-Riverside,30938,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,30940,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,30940,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,30941,U.S. Senate,,DEM,Kamala Harris,3
-Riverside,30941,U.S. Senate,,DEM,Loretta Sanchez,4
-Riverside,30943,U.S. Senate,,DEM,Kamala Harris,148
-Riverside,30943,U.S. Senate,,DEM,Loretta Sanchez,96
-Riverside,30946,U.S. Senate,,DEM,Kamala Harris,2
-Riverside,30946,U.S. Senate,,DEM,Loretta Sanchez,3
-Riverside,30947,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,30947,U.S. Senate,,DEM,Loretta Sanchez,1
-Riverside,30948,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,30948,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,30949,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,30949,U.S. Senate,,DEM,Loretta Sanchez,4
-Riverside,30951,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,30951,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,30952,U.S. Senate,,DEM,Kamala Harris,680
-Riverside,30952,U.S. Senate,,DEM,Loretta Sanchez,602
-Riverside,30955,U.S. Senate,,DEM,Kamala Harris,28
-Riverside,30955,U.S. Senate,,DEM,Loretta Sanchez,29
-Riverside,30956,U.S. Senate,,DEM,Kamala Harris,3
-Riverside,30956,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,30957,U.S. Senate,,DEM,Kamala Harris,191
-Riverside,30957,U.S. Senate,,DEM,Loretta Sanchez,186
-Riverside,30958,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,30958,U.S. Senate,,DEM,Loretta Sanchez,3
-Riverside,30965,U.S. Senate,,DEM,Kamala Harris,9
-Riverside,30965,U.S. Senate,,DEM,Loretta Sanchez,2
-Riverside,30968,U.S. Senate,,DEM,Kamala Harris,1
-Riverside,30968,U.S. Senate,,DEM,Loretta Sanchez,6
-Riverside,30972,U.S. Senate,,DEM,Kamala Harris,8
-Riverside,30972,U.S. Senate,,DEM,Loretta Sanchez,26
-Riverside,30977,U.S. Senate,,DEM,Kamala Harris,29
-Riverside,30977,U.S. Senate,,DEM,Loretta Sanchez,21
-Riverside,30979,U.S. Senate,,DEM,Kamala Harris,990
-Riverside,30979,U.S. Senate,,DEM,Loretta Sanchez,753
-Riverside,30984,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,30984,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,30985,U.S. Senate,,DEM,Kamala Harris,4
-Riverside,30985,U.S. Senate,,DEM,Loretta Sanchez,6
-Riverside,30986,U.S. Senate,,DEM,Kamala Harris,1
-Riverside,30986,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,30990,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,30990,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,30992,U.S. Senate,,DEM,Kamala Harris,283
-Riverside,30992,U.S. Senate,,DEM,Loretta Sanchez,221
-Riverside,30994,U.S. Senate,,DEM,Kamala Harris,332
-Riverside,30994,U.S. Senate,,DEM,Loretta Sanchez,270
-Riverside,30996,U.S. Senate,,DEM,Kamala Harris,733
-Riverside,30996,U.S. Senate,,DEM,Loretta Sanchez,510
-Riverside,31100,U.S. Senate,,DEM,Kamala Harris,829
-Riverside,31100,U.S. Senate,,DEM,Loretta Sanchez,559
-Riverside,31105,U.S. Senate,,DEM,Kamala Harris,51
-Riverside,31105,U.S. Senate,,DEM,Loretta Sanchez,36
-Riverside,31110,U.S. Senate,,DEM,Kamala Harris,441
-Riverside,31110,U.S. Senate,,DEM,Loretta Sanchez,421
-Riverside,31112,U.S. Senate,,DEM,Kamala Harris,39
-Riverside,31112,U.S. Senate,,DEM,Loretta Sanchez,24
-Riverside,31113,U.S. Senate,,DEM,Kamala Harris,796
-Riverside,31113,U.S. Senate,,DEM,Loretta Sanchez,612
-Riverside,31118,U.S. Senate,,DEM,Kamala Harris,8
-Riverside,31118,U.S. Senate,,DEM,Loretta Sanchez,3
-Riverside,31200,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,31200,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,31201,U.S. Senate,,DEM,Kamala Harris,1190
-Riverside,31201,U.S. Senate,,DEM,Loretta Sanchez,741
-Riverside,31206,U.S. Senate,,DEM,Kamala Harris,262
-Riverside,31206,U.S. Senate,,DEM,Loretta Sanchez,275
-Riverside,31208,U.S. Senate,,DEM,Kamala Harris,1147
-Riverside,31208,U.S. Senate,,DEM,Loretta Sanchez,771
-Riverside,31212,U.S. Senate,,DEM,Kamala Harris,233
-Riverside,31212,U.S. Senate,,DEM,Loretta Sanchez,230
-Riverside,31300,U.S. Senate,,DEM,Kamala Harris,306
-Riverside,31300,U.S. Senate,,DEM,Loretta Sanchez,302
-Riverside,31302,U.S. Senate,,DEM,Kamala Harris,1003
-Riverside,31302,U.S. Senate,,DEM,Loretta Sanchez,545
-Riverside,31305,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,31305,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,31307,U.S. Senate,,DEM,Kamala Harris,682
-Riverside,31307,U.S. Senate,,DEM,Loretta Sanchez,480
-Riverside,31313,U.S. Senate,,DEM,Kamala Harris,935
-Riverside,31313,U.S. Senate,,DEM,Loretta Sanchez,580
-Riverside,31400,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,31400,U.S. Senate,,DEM,Loretta Sanchez,2
-Riverside,31405,U.S. Senate,,DEM,Kamala Harris,813
-Riverside,31405,U.S. Senate,,DEM,Loretta Sanchez,587
-Riverside,31407,U.S. Senate,,DEM,Kamala Harris,586
-Riverside,31407,U.S. Senate,,DEM,Loretta Sanchez,463
-Riverside,31408,U.S. Senate,,DEM,Kamala Harris,197
-Riverside,31408,U.S. Senate,,DEM,Loretta Sanchez,115
-Riverside,31413,U.S. Senate,,DEM,Kamala Harris,1162
-Riverside,31413,U.S. Senate,,DEM,Loretta Sanchez,854
-Riverside,31500,U.S. Senate,,DEM,Kamala Harris,609
-Riverside,31500,U.S. Senate,,DEM,Loretta Sanchez,405
-Riverside,31505,U.S. Senate,,DEM,Kamala Harris,132
-Riverside,31505,U.S. Senate,,DEM,Loretta Sanchez,82
-Riverside,31506,U.S. Senate,,DEM,Kamala Harris,515
-Riverside,31506,U.S. Senate,,DEM,Loretta Sanchez,378
-Riverside,31511,U.S. Senate,,DEM,Kamala Harris,371
-Riverside,31511,U.S. Senate,,DEM,Loretta Sanchez,378
-Riverside,31520,U.S. Senate,,DEM,Kamala Harris,405
-Riverside,31520,U.S. Senate,,DEM,Loretta Sanchez,272
-Riverside,31846,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,31846,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,31847,U.S. Senate,,DEM,Kamala Harris,1
-Riverside,31847,U.S. Senate,,DEM,Loretta Sanchez,1
-Riverside,31850,U.S. Senate,,DEM,Kamala Harris,20
-Riverside,31850,U.S. Senate,,DEM,Loretta Sanchez,10
-Riverside,31853,U.S. Senate,,DEM,Kamala Harris,26
-Riverside,31853,U.S. Senate,,DEM,Loretta Sanchez,6
-Riverside,32003,U.S. Senate,,DEM,Kamala Harris,693
-Riverside,32003,U.S. Senate,,DEM,Loretta Sanchez,586
-Riverside,32007,U.S. Senate,,DEM,Kamala Harris,675
-Riverside,32007,U.S. Senate,,DEM,Loretta Sanchez,578
-Riverside,32009,U.S. Senate,,DEM,Kamala Harris,599
-Riverside,32009,U.S. Senate,,DEM,Loretta Sanchez,500
-Riverside,32011,U.S. Senate,,DEM,Kamala Harris,559
-Riverside,32011,U.S. Senate,,DEM,Loretta Sanchez,441
-Riverside,32017,U.S. Senate,,DEM,Kamala Harris,727
-Riverside,32017,U.S. Senate,,DEM,Loretta Sanchez,566
-Riverside,32021,U.S. Senate,,DEM,Kamala Harris,403
-Riverside,32021,U.S. Senate,,DEM,Loretta Sanchez,382
-Riverside,32022,U.S. Senate,,DEM,Kamala Harris,147
-Riverside,32022,U.S. Senate,,DEM,Loretta Sanchez,127
-Riverside,32049,U.S. Senate,,DEM,Kamala Harris,5
-Riverside,32049,U.S. Senate,,DEM,Loretta Sanchez,3
-Riverside,32052,U.S. Senate,,DEM,Kamala Harris,420
-Riverside,32052,U.S. Senate,,DEM,Loretta Sanchez,338
-Riverside,32061,U.S. Senate,,DEM,Kamala Harris,684
-Riverside,32061,U.S. Senate,,DEM,Loretta Sanchez,526
-Riverside,32062,U.S. Senate,,DEM,Kamala Harris,680
-Riverside,32062,U.S. Senate,,DEM,Loretta Sanchez,517
-Riverside,32068,U.S. Senate,,DEM,Kamala Harris,638
-Riverside,32068,U.S. Senate,,DEM,Loretta Sanchez,474
-Riverside,32072,U.S. Senate,,DEM,Kamala Harris,714
-Riverside,32072,U.S. Senate,,DEM,Loretta Sanchez,559
-Riverside,32073,U.S. Senate,,DEM,Kamala Harris,994
-Riverside,32073,U.S. Senate,,DEM,Loretta Sanchez,663
-Riverside,32076,U.S. Senate,,DEM,Kamala Harris,497
-Riverside,32076,U.S. Senate,,DEM,Loretta Sanchez,351
-Riverside,32078,U.S. Senate,,DEM,Kamala Harris,346
-Riverside,32078,U.S. Senate,,DEM,Loretta Sanchez,342
-Riverside,32079,U.S. Senate,,DEM,Kamala Harris,554
-Riverside,32079,U.S. Senate,,DEM,Loretta Sanchez,462
-Riverside,32083,U.S. Senate,,DEM,Kamala Harris,602
-Riverside,32083,U.S. Senate,,DEM,Loretta Sanchez,494
-Riverside,32087,U.S. Senate,,DEM,Kamala Harris,577
-Riverside,32087,U.S. Senate,,DEM,Loretta Sanchez,451
-Riverside,32090,U.S. Senate,,DEM,Kamala Harris,386
-Riverside,32090,U.S. Senate,,DEM,Loretta Sanchez,332
-Riverside,32099,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,32099,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,32102,U.S. Senate,,DEM,Kamala Harris,516
-Riverside,32102,U.S. Senate,,DEM,Loretta Sanchez,499
-Riverside,32105,U.S. Senate,,DEM,Kamala Harris,526
-Riverside,32105,U.S. Senate,,DEM,Loretta Sanchez,437
-Riverside,32107,U.S. Senate,,DEM,Kamala Harris,394
-Riverside,32107,U.S. Senate,,DEM,Loretta Sanchez,380
-Riverside,32111,U.S. Senate,,DEM,Kamala Harris,723
-Riverside,32111,U.S. Senate,,DEM,Loretta Sanchez,544
-Riverside,32114,U.S. Senate,,DEM,Kamala Harris,772
-Riverside,32114,U.S. Senate,,DEM,Loretta Sanchez,663
-Riverside,32118,U.S. Senate,,DEM,Kamala Harris,752
-Riverside,32118,U.S. Senate,,DEM,Loretta Sanchez,526
-Riverside,32121,U.S. Senate,,DEM,Kamala Harris,857
-Riverside,32121,U.S. Senate,,DEM,Loretta Sanchez,651
-Riverside,32123,U.S. Senate,,DEM,Kamala Harris,662
-Riverside,32123,U.S. Senate,,DEM,Loretta Sanchez,533
-Riverside,32126,U.S. Senate,,DEM,Kamala Harris,462
-Riverside,32126,U.S. Senate,,DEM,Loretta Sanchez,361
-Riverside,32127,U.S. Senate,,DEM,Kamala Harris,791
-Riverside,32127,U.S. Senate,,DEM,Loretta Sanchez,637
-Riverside,32900,U.S. Senate,,DEM,Kamala Harris,3
-Riverside,32900,U.S. Senate,,DEM,Loretta Sanchez,5
-Riverside,32904,U.S. Senate,,DEM,Kamala Harris,158
-Riverside,32904,U.S. Senate,,DEM,Loretta Sanchez,236
-Riverside,33001,U.S. Senate,,DEM,Kamala Harris,211
-Riverside,33001,U.S. Senate,,DEM,Loretta Sanchez,202
-Riverside,33012,U.S. Senate,,DEM,Kamala Harris,692
-Riverside,33012,U.S. Senate,,DEM,Loretta Sanchez,429
-Riverside,33013,U.S. Senate,,DEM,Kamala Harris,1010
-Riverside,33013,U.S. Senate,,DEM,Loretta Sanchez,719
-Riverside,33023,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,33023,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,33024,U.S. Senate,,DEM,Kamala Harris,720
-Riverside,33024,U.S. Senate,,DEM,Loretta Sanchez,596
-Riverside,33027,U.S. Senate,,DEM,Kamala Harris,905
-Riverside,33027,U.S. Senate,,DEM,Loretta Sanchez,672
-Riverside,33028,U.S. Senate,,DEM,Kamala Harris,327
-Riverside,33028,U.S. Senate,,DEM,Loretta Sanchez,276
-Riverside,33029,U.S. Senate,,DEM,Kamala Harris,139
-Riverside,33029,U.S. Senate,,DEM,Loretta Sanchez,79
-Riverside,33032,U.S. Senate,,DEM,Kamala Harris,417
-Riverside,33032,U.S. Senate,,DEM,Loretta Sanchez,342
-Riverside,33036,U.S. Senate,,DEM,Kamala Harris,535
-Riverside,33036,U.S. Senate,,DEM,Loretta Sanchez,446
-Riverside,33038,U.S. Senate,,DEM,Kamala Harris,923
-Riverside,33038,U.S. Senate,,DEM,Loretta Sanchez,601
-Riverside,33040,U.S. Senate,,DEM,Kamala Harris,494
-Riverside,33040,U.S. Senate,,DEM,Loretta Sanchez,407
-Riverside,33044,U.S. Senate,,DEM,Kamala Harris,869
-Riverside,33044,U.S. Senate,,DEM,Loretta Sanchez,747
-Riverside,33045,U.S. Senate,,DEM,Kamala Harris,541
-Riverside,33045,U.S. Senate,,DEM,Loretta Sanchez,436
-Riverside,33049,U.S. Senate,,DEM,Kamala Harris,604
-Riverside,33049,U.S. Senate,,DEM,Loretta Sanchez,458
-Riverside,33054,U.S. Senate,,DEM,Kamala Harris,531
-Riverside,33054,U.S. Senate,,DEM,Loretta Sanchez,363
-Riverside,33058,U.S. Senate,,DEM,Kamala Harris,682
-Riverside,33058,U.S. Senate,,DEM,Loretta Sanchez,552
-Riverside,33059,U.S. Senate,,DEM,Kamala Harris,962
-Riverside,33059,U.S. Senate,,DEM,Loretta Sanchez,656
-Riverside,33061,U.S. Senate,,DEM,Kamala Harris,433
-Riverside,33061,U.S. Senate,,DEM,Loretta Sanchez,303
-Riverside,33062,U.S. Senate,,DEM,Kamala Harris,682
-Riverside,33062,U.S. Senate,,DEM,Loretta Sanchez,471
-Riverside,33067,U.S. Senate,,DEM,Kamala Harris,810
-Riverside,33067,U.S. Senate,,DEM,Loretta Sanchez,664
-Riverside,33069,U.S. Senate,,DEM,Kamala Harris,729
-Riverside,33069,U.S. Senate,,DEM,Loretta Sanchez,664
-Riverside,33073,U.S. Senate,,DEM,Kamala Harris,457
-Riverside,33073,U.S. Senate,,DEM,Loretta Sanchez,287
-Riverside,33077,U.S. Senate,,DEM,Kamala Harris,622
-Riverside,33077,U.S. Senate,,DEM,Loretta Sanchez,438
-Riverside,33078,U.S. Senate,,DEM,Kamala Harris,723
-Riverside,33078,U.S. Senate,,DEM,Loretta Sanchez,483
-Riverside,33082,U.S. Senate,,DEM,Kamala Harris,415
-Riverside,33082,U.S. Senate,,DEM,Loretta Sanchez,370
-Riverside,33083,U.S. Senate,,DEM,Kamala Harris,433
-Riverside,33083,U.S. Senate,,DEM,Loretta Sanchez,296
-Riverside,33087,U.S. Senate,,DEM,Kamala Harris,384
-Riverside,33087,U.S. Senate,,DEM,Loretta Sanchez,313
-Riverside,33090,U.S. Senate,,DEM,Kamala Harris,592
-Riverside,33090,U.S. Senate,,DEM,Loretta Sanchez,522
-Riverside,33092,U.S. Senate,,DEM,Kamala Harris,1016
-Riverside,33092,U.S. Senate,,DEM,Loretta Sanchez,709
-Riverside,33097,U.S. Senate,,DEM,Kamala Harris,558
-Riverside,33097,U.S. Senate,,DEM,Loretta Sanchez,466
-Riverside,33099,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,33099,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,35600,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,35600,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,35605,U.S. Senate,,DEM,Kamala Harris,111
-Riverside,35605,U.S. Senate,,DEM,Loretta Sanchez,71
-Riverside,35607,U.S. Senate,,DEM,Kamala Harris,78
-Riverside,35607,U.S. Senate,,DEM,Loretta Sanchez,70
-Riverside,35609,U.S. Senate,,DEM,Kamala Harris,256
-Riverside,35609,U.S. Senate,,DEM,Loretta Sanchez,252
-Riverside,35612,U.S. Senate,,DEM,Kamala Harris,21
-Riverside,35612,U.S. Senate,,DEM,Loretta Sanchez,24
-Riverside,35616,U.S. Senate,,DEM,Kamala Harris,1
-Riverside,35616,U.S. Senate,,DEM,Loretta Sanchez,2
-Riverside,35617,U.S. Senate,,DEM,Kamala Harris,12
-Riverside,35617,U.S. Senate,,DEM,Loretta Sanchez,7
-Riverside,35618,U.S. Senate,,DEM,Kamala Harris,11
-Riverside,35618,U.S. Senate,,DEM,Loretta Sanchez,12
-Riverside,35619,U.S. Senate,,DEM,Kamala Harris,472
-Riverside,35619,U.S. Senate,,DEM,Loretta Sanchez,328
-Riverside,35620,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,35620,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,35622,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,35622,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,35625,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,35625,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,35626,U.S. Senate,,DEM,Kamala Harris,8
-Riverside,35626,U.S. Senate,,DEM,Loretta Sanchez,3
-Riverside,35632,U.S. Senate,,DEM,Kamala Harris,731
-Riverside,35632,U.S. Senate,,DEM,Loretta Sanchez,533
-Riverside,36802,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,36802,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,36803,U.S. Senate,,DEM,Kamala Harris,24
-Riverside,36803,U.S. Senate,,DEM,Loretta Sanchez,25
-Riverside,36807,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,36807,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,36808,U.S. Senate,,DEM,Kamala Harris,18
-Riverside,36808,U.S. Senate,,DEM,Loretta Sanchez,19
-Riverside,36850,U.S. Senate,,DEM,Kamala Harris,49
-Riverside,36850,U.S. Senate,,DEM,Loretta Sanchez,41
-Riverside,36851,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,36851,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,36852,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,36852,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,36931,U.S. Senate,,DEM,Kamala Harris,62
-Riverside,36931,U.S. Senate,,DEM,Loretta Sanchez,74
-Riverside,36932,U.S. Senate,,DEM,Kamala Harris,1
-Riverside,36932,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,36933,U.S. Senate,,DEM,Kamala Harris,1
-Riverside,36933,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,37609,U.S. Senate,,DEM,Kamala Harris,1
-Riverside,37609,U.S. Senate,,DEM,Loretta Sanchez,2
-Riverside,37610,U.S. Senate,,DEM,Kamala Harris,44
-Riverside,37610,U.S. Senate,,DEM,Loretta Sanchez,47
-Riverside,37612,U.S. Senate,,DEM,Kamala Harris,112
-Riverside,37612,U.S. Senate,,DEM,Loretta Sanchez,136
-Riverside,37621,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,37621,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,37622,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,37622,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,37623,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,37623,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,37624,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,37624,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,37625,U.S. Senate,,DEM,Kamala Harris,244
-Riverside,37625,U.S. Senate,,DEM,Loretta Sanchez,269
-Riverside,37626,U.S. Senate,,DEM,Kamala Harris,3
-Riverside,37626,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,37627,U.S. Senate,,DEM,Kamala Harris,9
-Riverside,37627,U.S. Senate,,DEM,Loretta Sanchez,9
-Riverside,37630,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,37630,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,37631,U.S. Senate,,DEM,Kamala Harris,11
-Riverside,37631,U.S. Senate,,DEM,Loretta Sanchez,8
-Riverside,37632,U.S. Senate,,DEM,Kamala Harris,389
-Riverside,37632,U.S. Senate,,DEM,Loretta Sanchez,358
-Riverside,37634,U.S. Senate,,DEM,Kamala Harris,71
-Riverside,37634,U.S. Senate,,DEM,Loretta Sanchez,30
-Riverside,37638,U.S. Senate,,DEM,Kamala Harris,43
-Riverside,37638,U.S. Senate,,DEM,Loretta Sanchez,40
-Riverside,37640,U.S. Senate,,DEM,Kamala Harris,7
-Riverside,37640,U.S. Senate,,DEM,Loretta Sanchez,4
-Riverside,37651,U.S. Senate,,DEM,Kamala Harris,212
-Riverside,37651,U.S. Senate,,DEM,Loretta Sanchez,267
-Riverside,37654,U.S. Senate,,DEM,Kamala Harris,713
-Riverside,37654,U.S. Senate,,DEM,Loretta Sanchez,626
-Riverside,37659,U.S. Senate,,DEM,Kamala Harris,3
-Riverside,37659,U.S. Senate,,DEM,Loretta Sanchez,5
-Riverside,37660,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,37660,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,37664,U.S. Senate,,DEM,Kamala Harris,291
-Riverside,37664,U.S. Senate,,DEM,Loretta Sanchez,202
-Riverside,37665,U.S. Senate,,DEM,Kamala Harris,43
-Riverside,37665,U.S. Senate,,DEM,Loretta Sanchez,17
-Riverside,37666,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,37666,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,37671,U.S. Senate,,DEM,Kamala Harris,671
-Riverside,37671,U.S. Senate,,DEM,Loretta Sanchez,569
-Riverside,37672,U.S. Senate,,DEM,Kamala Harris,631
-Riverside,37672,U.S. Senate,,DEM,Loretta Sanchez,518
-Riverside,37684,U.S. Senate,,DEM,Kamala Harris,17
-Riverside,37684,U.S. Senate,,DEM,Loretta Sanchez,12
-Riverside,37685,U.S. Senate,,DEM,Kamala Harris,677
-Riverside,37685,U.S. Senate,,DEM,Loretta Sanchez,563
-Riverside,37689,U.S. Senate,,DEM,Kamala Harris,931
-Riverside,37689,U.S. Senate,,DEM,Loretta Sanchez,817
-Riverside,37691,U.S. Senate,,DEM,Kamala Harris,18
-Riverside,37691,U.S. Senate,,DEM,Loretta Sanchez,24
-Riverside,37701,U.S. Senate,,DEM,Kamala Harris,564
-Riverside,37701,U.S. Senate,,DEM,Loretta Sanchez,507
-Riverside,37704,U.S. Senate,,DEM,Kamala Harris,374
-Riverside,37704,U.S. Senate,,DEM,Loretta Sanchez,350
-Riverside,37709,U.S. Senate,,DEM,Kamala Harris,806
-Riverside,37709,U.S. Senate,,DEM,Loretta Sanchez,736
-Riverside,37712,U.S. Senate,,DEM,Kamala Harris,552
-Riverside,37712,U.S. Senate,,DEM,Loretta Sanchez,548
-Riverside,37717,U.S. Senate,,DEM,Kamala Harris,120
-Riverside,37717,U.S. Senate,,DEM,Loretta Sanchez,94
-Riverside,37718,U.S. Senate,,DEM,Kamala Harris,6
-Riverside,37718,U.S. Senate,,DEM,Loretta Sanchez,4
-Riverside,37720,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,37720,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,37722,U.S. Senate,,DEM,Kamala Harris,66
-Riverside,37722,U.S. Senate,,DEM,Loretta Sanchez,40
-Riverside,37723,U.S. Senate,,DEM,Kamala Harris,107
-Riverside,37723,U.S. Senate,,DEM,Loretta Sanchez,111
-Riverside,37724,U.S. Senate,,DEM,Kamala Harris,696
-Riverside,37724,U.S. Senate,,DEM,Loretta Sanchez,504
-Riverside,37725,U.S. Senate,,DEM,Kamala Harris,323
-Riverside,37725,U.S. Senate,,DEM,Loretta Sanchez,271
-Riverside,37726,U.S. Senate,,DEM,Kamala Harris,765
-Riverside,37726,U.S. Senate,,DEM,Loretta Sanchez,659
-Riverside,37733,U.S. Senate,,DEM,Kamala Harris,52
-Riverside,37733,U.S. Senate,,DEM,Loretta Sanchez,60
-Riverside,37735,U.S. Senate,,DEM,Kamala Harris,338
-Riverside,37735,U.S. Senate,,DEM,Loretta Sanchez,279
-Riverside,37745,U.S. Senate,,DEM,Kamala Harris,16
-Riverside,37745,U.S. Senate,,DEM,Loretta Sanchez,13
-Riverside,37748,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,37748,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,37749,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,37749,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,37750,U.S. Senate,,DEM,Kamala Harris,55
-Riverside,37750,U.S. Senate,,DEM,Loretta Sanchez,37
-Riverside,37753,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,37753,U.S. Senate,,DEM,Loretta Sanchez,4
-Riverside,37755,U.S. Senate,,DEM,Kamala Harris,1
-Riverside,37755,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,37758,U.S. Senate,,DEM,Kamala Harris,33
-Riverside,37758,U.S. Senate,,DEM,Loretta Sanchez,31
-Riverside,37763,U.S. Senate,,DEM,Kamala Harris,3
-Riverside,37763,U.S. Senate,,DEM,Loretta Sanchez,1
-Riverside,37767,U.S. Senate,,DEM,Kamala Harris,45
-Riverside,37767,U.S. Senate,,DEM,Loretta Sanchez,33
-Riverside,37768,U.S. Senate,,DEM,Kamala Harris,1
-Riverside,37768,U.S. Senate,,DEM,Loretta Sanchez,4
-Riverside,37801,U.S. Senate,,DEM,Kamala Harris,10
-Riverside,37801,U.S. Senate,,DEM,Loretta Sanchez,11
-Riverside,37802,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,37802,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,37803,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,37803,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,37804,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,37804,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,37807,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,37807,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,37811,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,37811,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,37813,U.S. Senate,,DEM,Kamala Harris,17
-Riverside,37813,U.S. Senate,,DEM,Loretta Sanchez,5
-Riverside,37820,U.S. Senate,,DEM,Kamala Harris,3
-Riverside,37820,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,37825,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,37825,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,37831,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,37831,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,37833,U.S. Senate,,DEM,Kamala Harris,15
-Riverside,37833,U.S. Senate,,DEM,Loretta Sanchez,15
-Riverside,37850,U.S. Senate,,DEM,Kamala Harris,2
-Riverside,37850,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,37853,U.S. Senate,,DEM,Kamala Harris,33
-Riverside,37853,U.S. Senate,,DEM,Loretta Sanchez,17
-Riverside,37856,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,37856,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,37857,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,37857,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,37858,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,37858,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,37880,U.S. Senate,,DEM,Kamala Harris,240
-Riverside,37880,U.S. Senate,,DEM,Loretta Sanchez,155
-Riverside,37882,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,37882,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,37884,U.S. Senate,,DEM,Kamala Harris,8
-Riverside,37884,U.S. Senate,,DEM,Loretta Sanchez,5
-Riverside,37890,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,37890,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,37896,U.S. Senate,,DEM,Kamala Harris,819
-Riverside,37896,U.S. Senate,,DEM,Loretta Sanchez,413
-Riverside,37901,U.S. Senate,,DEM,Kamala Harris,34
-Riverside,37901,U.S. Senate,,DEM,Loretta Sanchez,24
-Riverside,37919,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,37919,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,37923,U.S. Senate,,DEM,Kamala Harris,51
-Riverside,37923,U.S. Senate,,DEM,Loretta Sanchez,59
-Riverside,37925,U.S. Senate,,DEM,Kamala Harris,7
-Riverside,37925,U.S. Senate,,DEM,Loretta Sanchez,9
-Riverside,37927,U.S. Senate,,DEM,Kamala Harris,294
-Riverside,37927,U.S. Senate,,DEM,Loretta Sanchez,227
-Riverside,37931,U.S. Senate,,DEM,Kamala Harris,8
-Riverside,37931,U.S. Senate,,DEM,Loretta Sanchez,2
-Riverside,37937,U.S. Senate,,DEM,Kamala Harris,22
-Riverside,37937,U.S. Senate,,DEM,Loretta Sanchez,27
-Riverside,37939,U.S. Senate,,DEM,Kamala Harris,38
-Riverside,37939,U.S. Senate,,DEM,Loretta Sanchez,35
-Riverside,37942,U.S. Senate,,DEM,Kamala Harris,58
-Riverside,37942,U.S. Senate,,DEM,Loretta Sanchez,55
-Riverside,37944,U.S. Senate,,DEM,Kamala Harris,119
-Riverside,37944,U.S. Senate,,DEM,Loretta Sanchez,75
-Riverside,37948,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,37948,U.S. Senate,,DEM,Loretta Sanchez,4
-Riverside,37953,U.S. Senate,,DEM,Kamala Harris,35
-Riverside,37953,U.S. Senate,,DEM,Loretta Sanchez,28
-Riverside,37955,U.S. Senate,,DEM,Kamala Harris,82
-Riverside,37955,U.S. Senate,,DEM,Loretta Sanchez,32
-Riverside,37956,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,37956,U.S. Senate,,DEM,Loretta Sanchez,1
-Riverside,37957,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,37957,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,37960,U.S. Senate,,DEM,Kamala Harris,201
-Riverside,37960,U.S. Senate,,DEM,Loretta Sanchez,192
-Riverside,37971,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,37971,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,37973,U.S. Senate,,DEM,Kamala Harris,116
-Riverside,37973,U.S. Senate,,DEM,Loretta Sanchez,94
-Riverside,37974,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,37974,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,37981,U.S. Senate,,DEM,Kamala Harris,1
-Riverside,37981,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,37982,U.S. Senate,,DEM,Kamala Harris,711
-Riverside,37982,U.S. Senate,,DEM,Loretta Sanchez,586
-Riverside,37990,U.S. Senate,,DEM,Kamala Harris,11
-Riverside,37990,U.S. Senate,,DEM,Loretta Sanchez,5
-Riverside,37997,U.S. Senate,,DEM,Kamala Harris,124
-Riverside,37997,U.S. Senate,,DEM,Loretta Sanchez,66
-Riverside,38603,U.S. Senate,,DEM,Kamala Harris,5
-Riverside,38603,U.S. Senate,,DEM,Loretta Sanchez,8
-Riverside,38901,U.S. Senate,,DEM,Kamala Harris,24
-Riverside,38901,U.S. Senate,,DEM,Loretta Sanchez,21
-Riverside,38902,U.S. Senate,,DEM,Kamala Harris,86
-Riverside,38902,U.S. Senate,,DEM,Loretta Sanchez,86
-Riverside,38905,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,38905,U.S. Senate,,DEM,Loretta Sanchez,14
-Riverside,38915,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,38915,U.S. Senate,,DEM,Loretta Sanchez,6
-Riverside,39823,U.S. Senate,,DEM,Kamala Harris,51
-Riverside,39823,U.S. Senate,,DEM,Loretta Sanchez,26
-Riverside,39827,U.S. Senate,,DEM,Kamala Harris,129
-Riverside,39827,U.S. Senate,,DEM,Loretta Sanchez,58
-Riverside,39900,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,39900,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,40000,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,40000,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,40004,U.S. Senate,,DEM,Kamala Harris,781
-Riverside,40004,U.S. Senate,,DEM,Loretta Sanchez,655
-Riverside,40007,U.S. Senate,,DEM,Kamala Harris,698
-Riverside,40007,U.S. Senate,,DEM,Loretta Sanchez,668
-Riverside,40014,U.S. Senate,,DEM,Kamala Harris,599
-Riverside,40014,U.S. Senate,,DEM,Loretta Sanchez,557
-Riverside,40017,U.S. Senate,,DEM,Kamala Harris,702
-Riverside,40017,U.S. Senate,,DEM,Loretta Sanchez,1013
-Riverside,40022,U.S. Senate,,DEM,Kamala Harris,6
-Riverside,40022,U.S. Senate,,DEM,Loretta Sanchez,8
-Riverside,40023,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,40023,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,40831,U.S. Senate,,DEM,Kamala Harris,204
-Riverside,40831,U.S. Senate,,DEM,Loretta Sanchez,478
-Riverside,40836,U.S. Senate,,DEM,Kamala Harris,145
-Riverside,40836,U.S. Senate,,DEM,Loretta Sanchez,150
-Riverside,40842,U.S. Senate,,DEM,Kamala Harris,27
-Riverside,40842,U.S. Senate,,DEM,Loretta Sanchez,28
-Riverside,40843,U.S. Senate,,DEM,Kamala Harris,1
-Riverside,40843,U.S. Senate,,DEM,Loretta Sanchez,2
-Riverside,40862,U.S. Senate,,DEM,Kamala Harris,99
-Riverside,40862,U.S. Senate,,DEM,Loretta Sanchez,150
-Riverside,40870,U.S. Senate,,DEM,Kamala Harris,3
-Riverside,40870,U.S. Senate,,DEM,Loretta Sanchez,5
-Riverside,40880,U.S. Senate,,DEM,Kamala Harris,16
-Riverside,40880,U.S. Senate,,DEM,Loretta Sanchez,10
-Riverside,41000,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,41000,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,41002,U.S. Senate,,DEM,Kamala Harris,1
-Riverside,41002,U.S. Senate,,DEM,Loretta Sanchez,1
-Riverside,41005,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,41005,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,41008,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,41008,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,41011,U.S. Senate,,DEM,Kamala Harris,1036
-Riverside,41011,U.S. Senate,,DEM,Loretta Sanchez,546
-Riverside,41020,U.S. Senate,,DEM,Kamala Harris,994
-Riverside,41020,U.S. Senate,,DEM,Loretta Sanchez,369
-Riverside,41021,U.S. Senate,,DEM,Kamala Harris,867
-Riverside,41021,U.S. Senate,,DEM,Loretta Sanchez,308
-Riverside,41024,U.S. Senate,,DEM,Kamala Harris,1268
-Riverside,41024,U.S. Senate,,DEM,Loretta Sanchez,420
-Riverside,41027,U.S. Senate,,DEM,Kamala Harris,268
-Riverside,41027,U.S. Senate,,DEM,Loretta Sanchez,89
-Riverside,41031,U.S. Senate,,DEM,Kamala Harris,1455
-Riverside,41031,U.S. Senate,,DEM,Loretta Sanchez,552
-Riverside,41037,U.S. Senate,,DEM,Kamala Harris,1527
-Riverside,41037,U.S. Senate,,DEM,Loretta Sanchez,701
-Riverside,41038,U.S. Senate,,DEM,Kamala Harris,2000
-Riverside,41038,U.S. Senate,,DEM,Loretta Sanchez,650
-Riverside,41045,U.S. Senate,,DEM,Kamala Harris,1305
-Riverside,41045,U.S. Senate,,DEM,Loretta Sanchez,462
-Riverside,41047,U.S. Senate,,DEM,Kamala Harris,1438
-Riverside,41047,U.S. Senate,,DEM,Loretta Sanchez,407
-Riverside,41054,U.S. Senate,,DEM,Kamala Harris,2
-Riverside,41054,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,41061,U.S. Senate,,DEM,Kamala Harris,746
-Riverside,41061,U.S. Senate,,DEM,Loretta Sanchez,351
-Riverside,41063,U.S. Senate,,DEM,Kamala Harris,8
-Riverside,41063,U.S. Senate,,DEM,Loretta Sanchez,4
-Riverside,42000,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,42000,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,42006,U.S. Senate,,DEM,Kamala Harris,725
-Riverside,42006,U.S. Senate,,DEM,Loretta Sanchez,536
-Riverside,42009,U.S. Senate,,DEM,Kamala Harris,642
-Riverside,42009,U.S. Senate,,DEM,Loretta Sanchez,667
-Riverside,42011,U.S. Senate,,DEM,Kamala Harris,499
-Riverside,42011,U.S. Senate,,DEM,Loretta Sanchez,490
-Riverside,42014,U.S. Senate,,DEM,Kamala Harris,560
-Riverside,42014,U.S. Senate,,DEM,Loretta Sanchez,732
-Riverside,42015,U.S. Senate,,DEM,Kamala Harris,492
-Riverside,42015,U.S. Senate,,DEM,Loretta Sanchez,622
-Riverside,42019,U.S. Senate,,DEM,Kamala Harris,372
-Riverside,42019,U.S. Senate,,DEM,Loretta Sanchez,412
-Riverside,42022,U.S. Senate,,DEM,Kamala Harris,405
-Riverside,42022,U.S. Senate,,DEM,Loretta Sanchez,936
-Riverside,42024,U.S. Senate,,DEM,Kamala Harris,692
-Riverside,42024,U.S. Senate,,DEM,Loretta Sanchez,559
-Riverside,42029,U.S. Senate,,DEM,Kamala Harris,597
-Riverside,42029,U.S. Senate,,DEM,Loretta Sanchez,210
-Riverside,42030,U.S. Senate,,DEM,Kamala Harris,868
-Riverside,42030,U.S. Senate,,DEM,Loretta Sanchez,411
-Riverside,42040,U.S. Senate,,DEM,Kamala Harris,762
-Riverside,42040,U.S. Senate,,DEM,Loretta Sanchez,377
-Riverside,42047,U.S. Senate,,DEM,Kamala Harris,73
-Riverside,42047,U.S. Senate,,DEM,Loretta Sanchez,46
-Riverside,42048,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,42048,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,42801,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,42801,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,42802,U.S. Senate,,DEM,Kamala Harris,296
-Riverside,42802,U.S. Senate,,DEM,Loretta Sanchez,540
-Riverside,42803,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,42803,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,42804,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,42804,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,42808,U.S. Senate,,DEM,Kamala Harris,554
-Riverside,42808,U.S. Senate,,DEM,Loretta Sanchez,438
-Riverside,42813,U.S. Senate,,DEM,Kamala Harris,1
-Riverside,42813,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,42821,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,42821,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,42851,U.S. Senate,,DEM,Kamala Harris,340
-Riverside,42851,U.S. Senate,,DEM,Loretta Sanchez,285
-Riverside,42861,U.S. Senate,,DEM,Kamala Harris,293
-Riverside,42861,U.S. Senate,,DEM,Loretta Sanchez,247
-Riverside,42863,U.S. Senate,,DEM,Kamala Harris,2
-Riverside,42863,U.S. Senate,,DEM,Loretta Sanchez,2
-Riverside,42866,U.S. Senate,,DEM,Kamala Harris,86
-Riverside,42866,U.S. Senate,,DEM,Loretta Sanchez,68
-Riverside,42870,U.S. Senate,,DEM,Kamala Harris,562
-Riverside,42870,U.S. Senate,,DEM,Loretta Sanchez,356
-Riverside,42900,U.S. Senate,,DEM,Kamala Harris,1282
-Riverside,42900,U.S. Senate,,DEM,Loretta Sanchez,589
-Riverside,42904,U.S. Senate,,DEM,Kamala Harris,1183
-Riverside,42904,U.S. Senate,,DEM,Loretta Sanchez,575
-Riverside,42910,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,42910,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,42950,U.S. Senate,,DEM,Kamala Harris,51
-Riverside,42950,U.S. Senate,,DEM,Loretta Sanchez,16
-Riverside,42974,U.S. Senate,,DEM,Kamala Harris,1
-Riverside,42974,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,42976,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,42976,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,43001,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,43001,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,43003,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,43003,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,43006,U.S. Senate,,DEM,Kamala Harris,1144
-Riverside,43006,U.S. Senate,,DEM,Loretta Sanchez,527
-Riverside,43009,U.S. Senate,,DEM,Kamala Harris,218
-Riverside,43009,U.S. Senate,,DEM,Loretta Sanchez,105
-Riverside,43012,U.S. Senate,,DEM,Kamala Harris,1041
-Riverside,43012,U.S. Senate,,DEM,Loretta Sanchez,422
-Riverside,43018,U.S. Senate,,DEM,Kamala Harris,2
-Riverside,43018,U.S. Senate,,DEM,Loretta Sanchez,9
-Riverside,43026,U.S. Senate,,DEM,Kamala Harris,1431
-Riverside,43026,U.S. Senate,,DEM,Loretta Sanchez,645
-Riverside,43031,U.S. Senate,,DEM,Kamala Harris,716
-Riverside,43031,U.S. Senate,,DEM,Loretta Sanchez,353
-Riverside,43035,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,43035,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,44000,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,44000,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,44003,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,44003,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,44005,U.S. Senate,,DEM,Kamala Harris,644
-Riverside,44005,U.S. Senate,,DEM,Loretta Sanchez,413
-Riverside,44011,U.S. Senate,,DEM,Kamala Harris,938
-Riverside,44011,U.S. Senate,,DEM,Loretta Sanchez,438
-Riverside,44015,U.S. Senate,,DEM,Kamala Harris,963
-Riverside,44015,U.S. Senate,,DEM,Loretta Sanchez,615
-Riverside,44019,U.S. Senate,,DEM,Kamala Harris,747
-Riverside,44019,U.S. Senate,,DEM,Loretta Sanchez,397
-Riverside,44022,U.S. Senate,,DEM,Kamala Harris,1143
-Riverside,44022,U.S. Senate,,DEM,Loretta Sanchez,667
-Riverside,44024,U.S. Senate,,DEM,Kamala Harris,1129
-Riverside,44024,U.S. Senate,,DEM,Loretta Sanchez,725
-Riverside,44029,U.S. Senate,,DEM,Kamala Harris,521
-Riverside,44029,U.S. Senate,,DEM,Loretta Sanchez,448
-Riverside,44030,U.S. Senate,,DEM,Kamala Harris,678
-Riverside,44030,U.S. Senate,,DEM,Loretta Sanchez,499
-Riverside,44031,U.S. Senate,,DEM,Kamala Harris,887
-Riverside,44031,U.S. Senate,,DEM,Loretta Sanchez,436
-Riverside,44032,U.S. Senate,,DEM,Kamala Harris,162
-Riverside,44032,U.S. Senate,,DEM,Loretta Sanchez,106
-Riverside,44039,U.S. Senate,,DEM,Kamala Harris,967
-Riverside,44039,U.S. Senate,,DEM,Loretta Sanchez,534
-Riverside,44041,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,44041,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,44043,U.S. Senate,,DEM,Kamala Harris,756
-Riverside,44043,U.S. Senate,,DEM,Loretta Sanchez,364
-Riverside,44046,U.S. Senate,,DEM,Kamala Harris,670
-Riverside,44046,U.S. Senate,,DEM,Loretta Sanchez,361
-Riverside,44047,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,44047,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,44048,U.S. Senate,,DEM,Kamala Harris,11
-Riverside,44048,U.S. Senate,,DEM,Loretta Sanchez,17
-Riverside,44900,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,44900,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,45001,U.S. Senate,,DEM,Kamala Harris,152
-Riverside,45001,U.S. Senate,,DEM,Loretta Sanchez,87
-Riverside,45002,U.S. Senate,,DEM,Kamala Harris,25
-Riverside,45002,U.S. Senate,,DEM,Loretta Sanchez,15
-Riverside,45003,U.S. Senate,,DEM,Kamala Harris,16
-Riverside,45003,U.S. Senate,,DEM,Loretta Sanchez,6
-Riverside,45004,U.S. Senate,,DEM,Kamala Harris,859
-Riverside,45004,U.S. Senate,,DEM,Loretta Sanchez,504
-Riverside,45905,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,45905,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,45907,U.S. Senate,,DEM,Kamala Harris,85
-Riverside,45907,U.S. Senate,,DEM,Loretta Sanchez,145
-Riverside,45908,U.S. Senate,,DEM,Kamala Harris,1
-Riverside,45908,U.S. Senate,,DEM,Loretta Sanchez,4
-Riverside,45910,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,45910,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,45922,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,45922,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,45925,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,45925,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,45990,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,45990,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,45991,U.S. Senate,,DEM,Kamala Harris,21
-Riverside,45991,U.S. Senate,,DEM,Loretta Sanchez,63
-Riverside,45992,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,45992,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,46002,U.S. Senate,,DEM,Kamala Harris,284
-Riverside,46002,U.S. Senate,,DEM,Loretta Sanchez,189
-Riverside,46005,U.S. Senate,,DEM,Kamala Harris,444
-Riverside,46005,U.S. Senate,,DEM,Loretta Sanchez,282
-Riverside,46007,U.S. Senate,,DEM,Kamala Harris,740
-Riverside,46007,U.S. Senate,,DEM,Loretta Sanchez,554
-Riverside,46009,U.S. Senate,,DEM,Kamala Harris,900
-Riverside,46009,U.S. Senate,,DEM,Loretta Sanchez,787
-Riverside,46016,U.S. Senate,,DEM,Kamala Harris,867
-Riverside,46016,U.S. Senate,,DEM,Loretta Sanchez,505
-Riverside,46018,U.S. Senate,,DEM,Kamala Harris,779
-Riverside,46018,U.S. Senate,,DEM,Loretta Sanchez,693
-Riverside,46019,U.S. Senate,,DEM,Kamala Harris,715
-Riverside,46019,U.S. Senate,,DEM,Loretta Sanchez,531
-Riverside,46026,U.S. Senate,,DEM,Kamala Harris,646
-Riverside,46026,U.S. Senate,,DEM,Loretta Sanchez,611
-Riverside,46028,U.S. Senate,,DEM,Kamala Harris,514
-Riverside,46028,U.S. Senate,,DEM,Loretta Sanchez,434
-Riverside,46039,U.S. Senate,,DEM,Kamala Harris,718
-Riverside,46039,U.S. Senate,,DEM,Loretta Sanchez,433
-Riverside,46044,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,46044,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,46047,U.S. Senate,,DEM,Kamala Harris,612
-Riverside,46047,U.S. Senate,,DEM,Loretta Sanchez,251
-Riverside,46600,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,46600,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,46610,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,46610,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,46612,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,46612,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,46653,U.S. Senate,,DEM,Kamala Harris,10
-Riverside,46653,U.S. Senate,,DEM,Loretta Sanchez,63
-Riverside,46661,U.S. Senate,,DEM,Kamala Harris,2
-Riverside,46661,U.S. Senate,,DEM,Loretta Sanchez,6
-Riverside,46688,U.S. Senate,,DEM,Kamala Harris,43
-Riverside,46688,U.S. Senate,,DEM,Loretta Sanchez,103
-Riverside,46693,U.S. Senate,,DEM,Kamala Harris,5
-Riverside,46693,U.S. Senate,,DEM,Loretta Sanchez,12
-Riverside,46704,U.S. Senate,,DEM,Kamala Harris,177
-Riverside,46704,U.S. Senate,,DEM,Loretta Sanchez,387
-Riverside,46710,U.S. Senate,,DEM,Kamala Harris,85
-Riverside,46710,U.S. Senate,,DEM,Loretta Sanchez,209
-Riverside,46712,U.S. Senate,,DEM,Kamala Harris,42
-Riverside,46712,U.S. Senate,,DEM,Loretta Sanchez,92
-Riverside,46715,U.S. Senate,,DEM,Kamala Harris,2
-Riverside,46715,U.S. Senate,,DEM,Loretta Sanchez,3
-Riverside,46757,U.S. Senate,,DEM,Kamala Harris,226
-Riverside,46757,U.S. Senate,,DEM,Loretta Sanchez,768
-Riverside,46758,U.S. Senate,,DEM,Kamala Harris,2
-Riverside,46758,U.S. Senate,,DEM,Loretta Sanchez,6
-Riverside,46762,U.S. Senate,,DEM,Kamala Harris,15
-Riverside,46762,U.S. Senate,,DEM,Loretta Sanchez,15
-Riverside,46800,U.S. Senate,,DEM,Kamala Harris,9
-Riverside,46800,U.S. Senate,,DEM,Loretta Sanchez,10
-Riverside,46813,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,46813,U.S. Senate,,DEM,Loretta Sanchez,2
-Riverside,46823,U.S. Senate,,DEM,Kamala Harris,107
-Riverside,46823,U.S. Senate,,DEM,Loretta Sanchez,280
-Riverside,46828,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,46828,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,46901,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,46901,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,46902,U.S. Senate,,DEM,Kamala Harris,9
-Riverside,46902,U.S. Senate,,DEM,Loretta Sanchez,3
-Riverside,46903,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,46903,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,46911,U.S. Senate,,DEM,Kamala Harris,26
-Riverside,46911,U.S. Senate,,DEM,Loretta Sanchez,25
-Riverside,46920,U.S. Senate,,DEM,Kamala Harris,2
-Riverside,46920,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,46931,U.S. Senate,,DEM,Kamala Harris,1
-Riverside,46931,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,47003,U.S. Senate,,DEM,Kamala Harris,1774
-Riverside,47003,U.S. Senate,,DEM,Loretta Sanchez,900
-Riverside,47011,U.S. Senate,,DEM,Kamala Harris,350
-Riverside,47011,U.S. Senate,,DEM,Loretta Sanchez,438
-Riverside,47013,U.S. Senate,,DEM,Kamala Harris,759
-Riverside,47013,U.S. Senate,,DEM,Loretta Sanchez,742
-Riverside,47016,U.S. Senate,,DEM,Kamala Harris,856
-Riverside,47016,U.S. Senate,,DEM,Loretta Sanchez,612
-Riverside,47019,U.S. Senate,,DEM,Kamala Harris,346
-Riverside,47019,U.S. Senate,,DEM,Loretta Sanchez,915
-Riverside,47022,U.S. Senate,,DEM,Kamala Harris,551
-Riverside,47022,U.S. Senate,,DEM,Loretta Sanchez,1045
-Riverside,47036,U.S. Senate,,DEM,Kamala Harris,532
-Riverside,47036,U.S. Senate,,DEM,Loretta Sanchez,1197
-Riverside,47037,U.S. Senate,,DEM,Kamala Harris,532
-Riverside,47037,U.S. Senate,,DEM,Loretta Sanchez,741
-Riverside,47039,U.S. Senate,,DEM,Kamala Harris,289
-Riverside,47039,U.S. Senate,,DEM,Loretta Sanchez,689
-Riverside,47041,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,47041,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,47042,U.S. Senate,,DEM,Kamala Harris,283
-Riverside,47042,U.S. Senate,,DEM,Loretta Sanchez,436
-Riverside,47044,U.S. Senate,,DEM,Kamala Harris,499
-Riverside,47044,U.S. Senate,,DEM,Loretta Sanchez,951
-Riverside,47048,U.S. Senate,,DEM,Kamala Harris,6
-Riverside,47048,U.S. Senate,,DEM,Loretta Sanchez,6
-Riverside,47049,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,47049,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,47053,U.S. Senate,,DEM,Kamala Harris,821
-Riverside,47053,U.S. Senate,,DEM,Loretta Sanchez,760
-Riverside,47055,U.S. Senate,,DEM,Kamala Harris,577
-Riverside,47055,U.S. Senate,,DEM,Loretta Sanchez,360
-Riverside,47058,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,47058,U.S. Senate,,DEM,Loretta Sanchez,10
-Riverside,47061,U.S. Senate,,DEM,Kamala Harris,462
-Riverside,47061,U.S. Senate,,DEM,Loretta Sanchez,491
-Riverside,47064,U.S. Senate,,DEM,Kamala Harris,329
-Riverside,47064,U.S. Senate,,DEM,Loretta Sanchez,349
-Riverside,47065,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,47065,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,48000,U.S. Senate,,DEM,Kamala Harris,25
-Riverside,48000,U.S. Senate,,DEM,Loretta Sanchez,22
-Riverside,48005,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,48005,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,48010,U.S. Senate,,DEM,Kamala Harris,365
-Riverside,48010,U.S. Senate,,DEM,Loretta Sanchez,999
-Riverside,48011,U.S. Senate,,DEM,Kamala Harris,355
-Riverside,48011,U.S. Senate,,DEM,Loretta Sanchez,1132
-Riverside,48012,U.S. Senate,,DEM,Kamala Harris,338
-Riverside,48012,U.S. Senate,,DEM,Loretta Sanchez,1032
-Riverside,48025,U.S. Senate,,DEM,Kamala Harris,336
-Riverside,48025,U.S. Senate,,DEM,Loretta Sanchez,1253
-Riverside,48032,U.S. Senate,,DEM,Kamala Harris,299
-Riverside,48032,U.S. Senate,,DEM,Loretta Sanchez,894
-Riverside,48036,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,48036,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,48800,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,48800,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,48806,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,48806,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,48851,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,48851,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,48852,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,48852,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,48853,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,48853,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,48870,U.S. Senate,,DEM,Kamala Harris,473
-Riverside,48870,U.S. Senate,,DEM,Loretta Sanchez,310
-Riverside,48900,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,48900,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,48902,U.S. Senate,,DEM,Kamala Harris,312
-Riverside,48902,U.S. Senate,,DEM,Loretta Sanchez,273
-Riverside,49000,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,49000,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,49007,U.S. Senate,,DEM,Kamala Harris,380
-Riverside,49007,U.S. Senate,,DEM,Loretta Sanchez,334
-Riverside,49009,U.S. Senate,,DEM,Kamala Harris,421
-Riverside,49009,U.S. Senate,,DEM,Loretta Sanchez,409
-Riverside,49011,U.S. Senate,,DEM,Kamala Harris,564
-Riverside,49011,U.S. Senate,,DEM,Loretta Sanchez,439
-Riverside,49800,U.S. Senate,,DEM,Kamala Harris,51
-Riverside,49800,U.S. Senate,,DEM,Loretta Sanchez,29
-Riverside,49812,U.S. Senate,,DEM,Kamala Harris,88
-Riverside,49812,U.S. Senate,,DEM,Loretta Sanchez,29
-Riverside,49813,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,49813,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,49820,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,49820,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,49821,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,49821,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,49826,U.S. Senate,,DEM,Kamala Harris,97
-Riverside,49826,U.S. Senate,,DEM,Loretta Sanchez,49
-Riverside,49830,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,49830,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,49841,U.S. Senate,,DEM,Kamala Harris,24
-Riverside,49841,U.S. Senate,,DEM,Loretta Sanchez,16
-Riverside,49843,U.S. Senate,,DEM,Kamala Harris,23
-Riverside,49843,U.S. Senate,,DEM,Loretta Sanchez,17
-Riverside,49852,U.S. Senate,,DEM,Kamala Harris,49
-Riverside,49852,U.S. Senate,,DEM,Loretta Sanchez,73
-Riverside,49854,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,49854,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,49860,U.S. Senate,,DEM,Kamala Harris,1
-Riverside,49860,U.S. Senate,,DEM,Loretta Sanchez,5
-Riverside,49870,U.S. Senate,,DEM,Kamala Harris,28
-Riverside,49870,U.S. Senate,,DEM,Loretta Sanchez,19
-Riverside,49880,U.S. Senate,,DEM,Kamala Harris,26
-Riverside,49880,U.S. Senate,,DEM,Loretta Sanchez,58
-Riverside,49900,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,49900,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,49901,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,49901,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,49903,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,49903,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,49907,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,49907,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,49908,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,49908,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,50100,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,50100,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,50102,U.S. Senate,,DEM,Kamala Harris,680
-Riverside,50102,U.S. Senate,,DEM,Loretta Sanchez,536
-Riverside,50110,U.S. Senate,,DEM,Kamala Harris,431
-Riverside,50110,U.S. Senate,,DEM,Loretta Sanchez,323
-Riverside,50111,U.S. Senate,,DEM,Kamala Harris,583
-Riverside,50111,U.S. Senate,,DEM,Loretta Sanchez,635
-Riverside,50116,U.S. Senate,,DEM,Kamala Harris,391
-Riverside,50116,U.S. Senate,,DEM,Loretta Sanchez,200
-Riverside,50117,U.S. Senate,,DEM,Kamala Harris,488
-Riverside,50117,U.S. Senate,,DEM,Loretta Sanchez,429
-Riverside,50119,U.S. Senate,,DEM,Kamala Harris,822
-Riverside,50119,U.S. Senate,,DEM,Loretta Sanchez,722
-Riverside,50121,U.S. Senate,,DEM,Kamala Harris,340
-Riverside,50121,U.S. Senate,,DEM,Loretta Sanchez,404
-Riverside,50126,U.S. Senate,,DEM,Kamala Harris,103
-Riverside,50126,U.S. Senate,,DEM,Loretta Sanchez,112
-Riverside,50127,U.S. Senate,,DEM,Kamala Harris,381
-Riverside,50127,U.S. Senate,,DEM,Loretta Sanchez,439
-Riverside,50130,U.S. Senate,,DEM,Kamala Harris,591
-Riverside,50130,U.S. Senate,,DEM,Loretta Sanchez,588
-Riverside,50203,U.S. Senate,,DEM,Kamala Harris,859
-Riverside,50203,U.S. Senate,,DEM,Loretta Sanchez,551
-Riverside,50205,U.S. Senate,,DEM,Kamala Harris,744
-Riverside,50205,U.S. Senate,,DEM,Loretta Sanchez,453
-Riverside,50209,U.S. Senate,,DEM,Kamala Harris,726
-Riverside,50209,U.S. Senate,,DEM,Loretta Sanchez,464
-Riverside,50213,U.S. Senate,,DEM,Kamala Harris,778
-Riverside,50213,U.S. Senate,,DEM,Loretta Sanchez,540
-Riverside,50216,U.S. Senate,,DEM,Kamala Harris,714
-Riverside,50216,U.S. Senate,,DEM,Loretta Sanchez,492
-Riverside,50221,U.S. Senate,,DEM,Kamala Harris,646
-Riverside,50221,U.S. Senate,,DEM,Loretta Sanchez,471
-Riverside,50223,U.S. Senate,,DEM,Kamala Harris,767
-Riverside,50223,U.S. Senate,,DEM,Loretta Sanchez,660
-Riverside,50226,U.S. Senate,,DEM,Kamala Harris,428
-Riverside,50226,U.S. Senate,,DEM,Loretta Sanchez,419
-Riverside,50227,U.S. Senate,,DEM,Kamala Harris,370
-Riverside,50227,U.S. Senate,,DEM,Loretta Sanchez,289
-Riverside,50228,U.S. Senate,,DEM,Kamala Harris,441
-Riverside,50228,U.S. Senate,,DEM,Loretta Sanchez,439
-Riverside,50235,U.S. Senate,,DEM,Kamala Harris,911
-Riverside,50235,U.S. Senate,,DEM,Loretta Sanchez,708
-Riverside,50237,U.S. Senate,,DEM,Kamala Harris,646
-Riverside,50237,U.S. Senate,,DEM,Loretta Sanchez,497
-Riverside,50240,U.S. Senate,,DEM,Kamala Harris,518
-Riverside,50240,U.S. Senate,,DEM,Loretta Sanchez,391
-Riverside,50241,U.S. Senate,,DEM,Kamala Harris,347
-Riverside,50241,U.S. Senate,,DEM,Loretta Sanchez,259
-Riverside,50300,U.S. Senate,,DEM,Kamala Harris,589
-Riverside,50300,U.S. Senate,,DEM,Loretta Sanchez,766
-Riverside,50304,U.S. Senate,,DEM,Kamala Harris,498
-Riverside,50304,U.S. Senate,,DEM,Loretta Sanchez,478
-Riverside,50306,U.S. Senate,,DEM,Kamala Harris,803
-Riverside,50306,U.S. Senate,,DEM,Loretta Sanchez,670
-Riverside,50307,U.S. Senate,,DEM,Kamala Harris,378
-Riverside,50307,U.S. Senate,,DEM,Loretta Sanchez,337
-Riverside,50309,U.S. Senate,,DEM,Kamala Harris,572
-Riverside,50309,U.S. Senate,,DEM,Loretta Sanchez,329
-Riverside,50313,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,50313,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,50314,U.S. Senate,,DEM,Kamala Harris,389
-Riverside,50314,U.S. Senate,,DEM,Loretta Sanchez,554
-Riverside,50317,U.S. Senate,,DEM,Kamala Harris,822
-Riverside,50317,U.S. Senate,,DEM,Loretta Sanchez,606
-Riverside,50323,U.S. Senate,,DEM,Kamala Harris,613
-Riverside,50323,U.S. Senate,,DEM,Loretta Sanchez,493
-Riverside,50324,U.S. Senate,,DEM,Kamala Harris,363
-Riverside,50324,U.S. Senate,,DEM,Loretta Sanchez,299
-Riverside,50327,U.S. Senate,,DEM,Kamala Harris,370
-Riverside,50327,U.S. Senate,,DEM,Loretta Sanchez,353
-Riverside,50328,U.S. Senate,,DEM,Kamala Harris,568
-Riverside,50328,U.S. Senate,,DEM,Loretta Sanchez,576
-Riverside,50331,U.S. Senate,,DEM,Kamala Harris,538
-Riverside,50331,U.S. Senate,,DEM,Loretta Sanchez,468
-Riverside,50402,U.S. Senate,,DEM,Kamala Harris,516
-Riverside,50402,U.S. Senate,,DEM,Loretta Sanchez,556
-Riverside,50403,U.S. Senate,,DEM,Kamala Harris,464
-Riverside,50403,U.S. Senate,,DEM,Loretta Sanchez,443
-Riverside,50404,U.S. Senate,,DEM,Kamala Harris,586
-Riverside,50404,U.S. Senate,,DEM,Loretta Sanchez,516
-Riverside,50405,U.S. Senate,,DEM,Kamala Harris,251
-Riverside,50405,U.S. Senate,,DEM,Loretta Sanchez,348
-Riverside,50408,U.S. Senate,,DEM,Kamala Harris,478
-Riverside,50408,U.S. Senate,,DEM,Loretta Sanchez,461
-Riverside,50412,U.S. Senate,,DEM,Kamala Harris,352
-Riverside,50412,U.S. Senate,,DEM,Loretta Sanchez,298
-Riverside,50413,U.S. Senate,,DEM,Kamala Harris,803
-Riverside,50413,U.S. Senate,,DEM,Loretta Sanchez,514
-Riverside,50417,U.S. Senate,,DEM,Kamala Harris,1078
-Riverside,50417,U.S. Senate,,DEM,Loretta Sanchez,700
-Riverside,50419,U.S. Senate,,DEM,Kamala Harris,844
-Riverside,50419,U.S. Senate,,DEM,Loretta Sanchez,531
-Riverside,50424,U.S. Senate,,DEM,Kamala Harris,836
-Riverside,50424,U.S. Senate,,DEM,Loretta Sanchez,475
-Riverside,50427,U.S. Senate,,DEM,Kamala Harris,516
-Riverside,50427,U.S. Senate,,DEM,Loretta Sanchez,250
-Riverside,50433,U.S. Senate,,DEM,Kamala Harris,1136
-Riverside,50433,U.S. Senate,,DEM,Loretta Sanchez,633
-Riverside,50435,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,50435,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,50436,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,50436,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,50789,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,50789,U.S. Senate,,DEM,Loretta Sanchez,3
-Riverside,50791,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,50791,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,50792,U.S. Senate,,DEM,Kamala Harris,2
-Riverside,50792,U.S. Senate,,DEM,Loretta Sanchez,4
-Riverside,50793,U.S. Senate,,DEM,Kamala Harris,4
-Riverside,50793,U.S. Senate,,DEM,Loretta Sanchez,3
-Riverside,50794,U.S. Senate,,DEM,Kamala Harris,3
-Riverside,50794,U.S. Senate,,DEM,Loretta Sanchez,1
-Riverside,50801,U.S. Senate,,DEM,Kamala Harris,130
-Riverside,50801,U.S. Senate,,DEM,Loretta Sanchez,108
-Riverside,50802,U.S. Senate,,DEM,Kamala Harris,66
-Riverside,50802,U.S. Senate,,DEM,Loretta Sanchez,33
-Riverside,50803,U.S. Senate,,DEM,Kamala Harris,10
-Riverside,50803,U.S. Senate,,DEM,Loretta Sanchez,6
-Riverside,50804,U.S. Senate,,DEM,Kamala Harris,15
-Riverside,50804,U.S. Senate,,DEM,Loretta Sanchez,12
-Riverside,50805,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,50805,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,50806,U.S. Senate,,DEM,Kamala Harris,2
-Riverside,50806,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,50807,U.S. Senate,,DEM,Kamala Harris,2
-Riverside,50807,U.S. Senate,,DEM,Loretta Sanchez,3
-Riverside,50808,U.S. Senate,,DEM,Kamala Harris,2
-Riverside,50808,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,50809,U.S. Senate,,DEM,Kamala Harris,116
-Riverside,50809,U.S. Senate,,DEM,Loretta Sanchez,80
-Riverside,50811,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,50811,U.S. Senate,,DEM,Loretta Sanchez,3
-Riverside,50812,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,50812,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,50813,U.S. Senate,,DEM,Kamala Harris,5
-Riverside,50813,U.S. Senate,,DEM,Loretta Sanchez,2
-Riverside,50814,U.S. Senate,,DEM,Kamala Harris,4
-Riverside,50814,U.S. Senate,,DEM,Loretta Sanchez,10
-Riverside,50815,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,50815,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,50816,U.S. Senate,,DEM,Kamala Harris,24
-Riverside,50816,U.S. Senate,,DEM,Loretta Sanchez,19
-Riverside,50817,U.S. Senate,,DEM,Kamala Harris,1
-Riverside,50817,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,50818,U.S. Senate,,DEM,Kamala Harris,854
-Riverside,50818,U.S. Senate,,DEM,Loretta Sanchez,731
-Riverside,50819,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,50819,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,50821,U.S. Senate,,DEM,Kamala Harris,6
-Riverside,50821,U.S. Senate,,DEM,Loretta Sanchez,2
-Riverside,50822,U.S. Senate,,DEM,Kamala Harris,4
-Riverside,50822,U.S. Senate,,DEM,Loretta Sanchez,3
-Riverside,50825,U.S. Senate,,DEM,Kamala Harris,236
-Riverside,50825,U.S. Senate,,DEM,Loretta Sanchez,134
-Riverside,50826,U.S. Senate,,DEM,Kamala Harris,4
-Riverside,50826,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,50827,U.S. Senate,,DEM,Kamala Harris,5
-Riverside,50827,U.S. Senate,,DEM,Loretta Sanchez,1
-Riverside,50828,U.S. Senate,,DEM,Kamala Harris,4
-Riverside,50828,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,50830,U.S. Senate,,DEM,Kamala Harris,89
-Riverside,50830,U.S. Senate,,DEM,Loretta Sanchez,77
-Riverside,50833,U.S. Senate,,DEM,Kamala Harris,54
-Riverside,50833,U.S. Senate,,DEM,Loretta Sanchez,72
-Riverside,50900,U.S. Senate,,DEM,Kamala Harris,3
-Riverside,50900,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,50901,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,50901,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,50906,U.S. Senate,,DEM,Kamala Harris,21
-Riverside,50906,U.S. Senate,,DEM,Loretta Sanchez,10
-Riverside,50916,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,50916,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,51000,U.S. Senate,,DEM,Kamala Harris,43
-Riverside,51000,U.S. Senate,,DEM,Loretta Sanchez,62
-Riverside,51001,U.S. Senate,,DEM,Kamala Harris,502
-Riverside,51001,U.S. Senate,,DEM,Loretta Sanchez,689
-Riverside,51003,U.S. Senate,,DEM,Kamala Harris,793
-Riverside,51003,U.S. Senate,,DEM,Loretta Sanchez,839
-Riverside,51005,U.S. Senate,,DEM,Kamala Harris,491
-Riverside,51005,U.S. Senate,,DEM,Loretta Sanchez,507
-Riverside,51009,U.S. Senate,,DEM,Kamala Harris,452
-Riverside,51009,U.S. Senate,,DEM,Loretta Sanchez,725
-Riverside,51011,U.S. Senate,,DEM,Kamala Harris,476
-Riverside,51011,U.S. Senate,,DEM,Loretta Sanchez,616
-Riverside,51019,U.S. Senate,,DEM,Kamala Harris,411
-Riverside,51019,U.S. Senate,,DEM,Loretta Sanchez,588
-Riverside,51021,U.S. Senate,,DEM,Kamala Harris,349
-Riverside,51021,U.S. Senate,,DEM,Loretta Sanchez,506
-Riverside,51022,U.S. Senate,,DEM,Kamala Harris,737
-Riverside,51022,U.S. Senate,,DEM,Loretta Sanchez,944
-Riverside,51026,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,51026,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,51027,U.S. Senate,,DEM,Kamala Harris,480
-Riverside,51027,U.S. Senate,,DEM,Loretta Sanchez,586
-Riverside,51035,U.S. Senate,,DEM,Kamala Harris,5
-Riverside,51035,U.S. Senate,,DEM,Loretta Sanchez,2
-Riverside,51041,U.S. Senate,,DEM,Kamala Harris,428
-Riverside,51041,U.S. Senate,,DEM,Loretta Sanchez,448
-Riverside,51044,U.S. Senate,,DEM,Kamala Harris,826
-Riverside,51044,U.S. Senate,,DEM,Loretta Sanchez,743
-Riverside,51047,U.S. Senate,,DEM,Kamala Harris,381
-Riverside,51047,U.S. Senate,,DEM,Loretta Sanchez,585
-Riverside,51052,U.S. Senate,,DEM,Kamala Harris,201
-Riverside,51052,U.S. Senate,,DEM,Loretta Sanchez,249
-Riverside,51056,U.S. Senate,,DEM,Kamala Harris,520
-Riverside,51056,U.S. Senate,,DEM,Loretta Sanchez,653
-Riverside,51700,U.S. Senate,,DEM,Kamala Harris,15
-Riverside,51700,U.S. Senate,,DEM,Loretta Sanchez,17
-Riverside,51701,U.S. Senate,,DEM,Kamala Harris,82
-Riverside,51701,U.S. Senate,,DEM,Loretta Sanchez,40
-Riverside,51817,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,51817,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,51819,U.S. Senate,,DEM,Kamala Harris,8
-Riverside,51819,U.S. Senate,,DEM,Loretta Sanchez,4
-Riverside,51827,U.S. Senate,,DEM,Kamala Harris,135
-Riverside,51827,U.S. Senate,,DEM,Loretta Sanchez,143
-Riverside,51830,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,51830,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,51833,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,51833,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,51836,U.S. Senate,,DEM,Kamala Harris,45
-Riverside,51836,U.S. Senate,,DEM,Loretta Sanchez,26
-Riverside,51837,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,51837,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,51838,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,51838,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,51839,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,51839,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,51840,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,51840,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,51841,U.S. Senate,,DEM,Kamala Harris,4
-Riverside,51841,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,51842,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,51842,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,51845,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,51845,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,51846,U.S. Senate,,DEM,Kamala Harris,31
-Riverside,51846,U.S. Senate,,DEM,Loretta Sanchez,28
-Riverside,51849,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,51849,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,51859,U.S. Senate,,DEM,Kamala Harris,268
-Riverside,51859,U.S. Senate,,DEM,Loretta Sanchez,229
-Riverside,51861,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,51861,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,51870,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,51870,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,51871,U.S. Senate,,DEM,Kamala Harris,22
-Riverside,51871,U.S. Senate,,DEM,Loretta Sanchez,18
-Riverside,51873,U.S. Senate,,DEM,Kamala Harris,11
-Riverside,51873,U.S. Senate,,DEM,Loretta Sanchez,18
-Riverside,51874,U.S. Senate,,DEM,Kamala Harris,67
-Riverside,51874,U.S. Senate,,DEM,Loretta Sanchez,60
-Riverside,51877,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,51877,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,51970,U.S. Senate,,DEM,Kamala Harris,75
-Riverside,51970,U.S. Senate,,DEM,Loretta Sanchez,31
-Riverside,51971,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,51971,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,51980,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,51980,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,52103,U.S. Senate,,DEM,Kamala Harris,145
-Riverside,52103,U.S. Senate,,DEM,Loretta Sanchez,97
-Riverside,52106,U.S. Senate,,DEM,Kamala Harris,1519
-Riverside,52106,U.S. Senate,,DEM,Loretta Sanchez,1022
-Riverside,52110,U.S. Senate,,DEM,Kamala Harris,570
-Riverside,52110,U.S. Senate,,DEM,Loretta Sanchez,441
-Riverside,52115,U.S. Senate,,DEM,Kamala Harris,1113
-Riverside,52115,U.S. Senate,,DEM,Loretta Sanchez,710
-Riverside,52116,U.S. Senate,,DEM,Kamala Harris,496
-Riverside,52116,U.S. Senate,,DEM,Loretta Sanchez,444
-Riverside,52123,U.S. Senate,,DEM,Kamala Harris,734
-Riverside,52123,U.S. Senate,,DEM,Loretta Sanchez,566
-Riverside,52124,U.S. Senate,,DEM,Kamala Harris,24
-Riverside,52124,U.S. Senate,,DEM,Loretta Sanchez,40
-Riverside,52201,U.S. Senate,,DEM,Kamala Harris,588
-Riverside,52201,U.S. Senate,,DEM,Loretta Sanchez,657
-Riverside,52203,U.S. Senate,,DEM,Kamala Harris,658
-Riverside,52203,U.S. Senate,,DEM,Loretta Sanchez,615
-Riverside,52209,U.S. Senate,,DEM,Kamala Harris,286
-Riverside,52209,U.S. Senate,,DEM,Loretta Sanchez,354
-Riverside,52210,U.S. Senate,,DEM,Kamala Harris,737
-Riverside,52210,U.S. Senate,,DEM,Loretta Sanchez,521
-Riverside,52216,U.S. Senate,,DEM,Kamala Harris,832
-Riverside,52216,U.S. Senate,,DEM,Loretta Sanchez,739
-Riverside,52222,U.S. Senate,,DEM,Kamala Harris,1
-Riverside,52222,U.S. Senate,,DEM,Loretta Sanchez,1
-Riverside,52301,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,52301,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,52302,U.S. Senate,,DEM,Kamala Harris,78
-Riverside,52302,U.S. Senate,,DEM,Loretta Sanchez,74
-Riverside,52303,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,52303,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,52305,U.S. Senate,,DEM,Kamala Harris,875
-Riverside,52305,U.S. Senate,,DEM,Loretta Sanchez,703
-Riverside,52312,U.S. Senate,,DEM,Kamala Harris,487
-Riverside,52312,U.S. Senate,,DEM,Loretta Sanchez,418
-Riverside,52313,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,52313,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,52315,U.S. Senate,,DEM,Kamala Harris,72
-Riverside,52315,U.S. Senate,,DEM,Loretta Sanchez,55
-Riverside,52317,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,52317,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,52318,U.S. Senate,,DEM,Kamala Harris,572
-Riverside,52318,U.S. Senate,,DEM,Loretta Sanchez,505
-Riverside,52319,U.S. Senate,,DEM,Kamala Harris,13
-Riverside,52319,U.S. Senate,,DEM,Loretta Sanchez,12
-Riverside,52322,U.S. Senate,,DEM,Kamala Harris,450
-Riverside,52322,U.S. Senate,,DEM,Loretta Sanchez,351
-Riverside,52323,U.S. Senate,,DEM,Kamala Harris,38
-Riverside,52323,U.S. Senate,,DEM,Loretta Sanchez,60
-Riverside,52326,U.S. Senate,,DEM,Kamala Harris,607
-Riverside,52326,U.S. Senate,,DEM,Loretta Sanchez,416
-Riverside,52332,U.S. Senate,,DEM,Kamala Harris,5
-Riverside,52332,U.S. Senate,,DEM,Loretta Sanchez,12
-Riverside,52333,U.S. Senate,,DEM,Kamala Harris,202
-Riverside,52333,U.S. Senate,,DEM,Loretta Sanchez,180
-Riverside,52336,U.S. Senate,,DEM,Kamala Harris,52
-Riverside,52336,U.S. Senate,,DEM,Loretta Sanchez,24
-Riverside,52337,U.S. Senate,,DEM,Kamala Harris,73
-Riverside,52337,U.S. Senate,,DEM,Loretta Sanchez,82
-Riverside,52339,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,52339,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,52404,U.S. Senate,,DEM,Kamala Harris,78
-Riverside,52404,U.S. Senate,,DEM,Loretta Sanchez,129
-Riverside,52405,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,52405,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,52407,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,52407,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,52410,U.S. Senate,,DEM,Kamala Harris,1
-Riverside,52410,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,52411,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,52411,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,52412,U.S. Senate,,DEM,Kamala Harris,49
-Riverside,52412,U.S. Senate,,DEM,Loretta Sanchez,39
-Riverside,52413,U.S. Senate,,DEM,Kamala Harris,39
-Riverside,52413,U.S. Senate,,DEM,Loretta Sanchez,26
-Riverside,52419,U.S. Senate,,DEM,Kamala Harris,675
-Riverside,52419,U.S. Senate,,DEM,Loretta Sanchez,522
-Riverside,52420,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,52420,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,52423,U.S. Senate,,DEM,Kamala Harris,9
-Riverside,52423,U.S. Senate,,DEM,Loretta Sanchez,14
-Riverside,52424,U.S. Senate,,DEM,Kamala Harris,74
-Riverside,52424,U.S. Senate,,DEM,Loretta Sanchez,53
-Riverside,52425,U.S. Senate,,DEM,Kamala Harris,609
-Riverside,52425,U.S. Senate,,DEM,Loretta Sanchez,464
-Riverside,52427,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,52427,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,52428,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,52428,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,52431,U.S. Senate,,DEM,Kamala Harris,1152
-Riverside,52431,U.S. Senate,,DEM,Loretta Sanchez,872
-Riverside,52432,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,52432,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,52434,U.S. Senate,,DEM,Kamala Harris,17
-Riverside,52434,U.S. Senate,,DEM,Loretta Sanchez,9
-Riverside,52435,U.S. Senate,,DEM,Kamala Harris,222
-Riverside,52435,U.S. Senate,,DEM,Loretta Sanchez,145
-Riverside,52436,U.S. Senate,,DEM,Kamala Harris,32
-Riverside,52436,U.S. Senate,,DEM,Loretta Sanchez,17
-Riverside,52437,U.S. Senate,,DEM,Kamala Harris,45
-Riverside,52437,U.S. Senate,,DEM,Loretta Sanchez,27
-Riverside,52438,U.S. Senate,,DEM,Kamala Harris,323
-Riverside,52438,U.S. Senate,,DEM,Loretta Sanchez,412
-Riverside,52439,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,52439,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,52440,U.S. Senate,,DEM,Kamala Harris,88
-Riverside,52440,U.S. Senate,,DEM,Loretta Sanchez,52
-Riverside,52441,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,52441,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,52442,U.S. Senate,,DEM,Kamala Harris,808
-Riverside,52442,U.S. Senate,,DEM,Loretta Sanchez,554
-Riverside,52839,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,52839,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,52840,U.S. Senate,,DEM,Kamala Harris,66
-Riverside,52840,U.S. Senate,,DEM,Loretta Sanchez,46
-Riverside,52841,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,52841,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,52845,U.S. Senate,,DEM,Kamala Harris,19
-Riverside,52845,U.S. Senate,,DEM,Loretta Sanchez,27
-Riverside,52847,U.S. Senate,,DEM,Kamala Harris,89
-Riverside,52847,U.S. Senate,,DEM,Loretta Sanchez,57
-Riverside,52849,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,52849,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,52858,U.S. Senate,,DEM,Kamala Harris,2
-Riverside,52858,U.S. Senate,,DEM,Loretta Sanchez,2
-Riverside,52863,U.S. Senate,,DEM,Kamala Harris,11
-Riverside,52863,U.S. Senate,,DEM,Loretta Sanchez,10
-Riverside,52864,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,52864,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,52867,U.S. Senate,,DEM,Kamala Harris,9
-Riverside,52867,U.S. Senate,,DEM,Loretta Sanchez,3
-Riverside,52870,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,52870,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,52872,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,52872,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,52873,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,52873,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,52876,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,52876,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,52877,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,52877,U.S. Senate,,DEM,Loretta Sanchez,2
-Riverside,52881,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,52881,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,52883,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,52883,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,52884,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,52884,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,52885,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,52885,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,52886,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,52886,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,52887,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,52887,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,52890,U.S. Senate,,DEM,Kamala Harris,2
-Riverside,52890,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,52894,U.S. Senate,,DEM,Kamala Harris,67
-Riverside,52894,U.S. Senate,,DEM,Loretta Sanchez,37
-Riverside,52895,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,52895,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,52897,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,52897,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,52900,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,52900,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,52901,U.S. Senate,,DEM,Kamala Harris,3
-Riverside,52901,U.S. Senate,,DEM,Loretta Sanchez,7
-Riverside,52903,U.S. Senate,,DEM,Kamala Harris,2
-Riverside,52903,U.S. Senate,,DEM,Loretta Sanchez,4
-Riverside,52904,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,52904,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,52905,U.S. Senate,,DEM,Kamala Harris,1
-Riverside,52905,U.S. Senate,,DEM,Loretta Sanchez,4
-Riverside,52907,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,52907,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,52919,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,52919,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,52920,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,52920,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,52921,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,52921,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,53000,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,53000,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,53002,U.S. Senate,,DEM,Kamala Harris,25
-Riverside,53002,U.S. Senate,,DEM,Loretta Sanchez,16
-Riverside,53003,U.S. Senate,,DEM,Kamala Harris,720
-Riverside,53003,U.S. Senate,,DEM,Loretta Sanchez,549
-Riverside,53010,U.S. Senate,,DEM,Kamala Harris,55
-Riverside,53010,U.S. Senate,,DEM,Loretta Sanchez,37
-Riverside,53011,U.S. Senate,,DEM,Kamala Harris,267
-Riverside,53011,U.S. Senate,,DEM,Loretta Sanchez,157
-Riverside,53017,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,53017,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,53018,U.S. Senate,,DEM,Kamala Harris,291
-Riverside,53018,U.S. Senate,,DEM,Loretta Sanchez,153
-Riverside,53020,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,53020,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,53025,U.S. Senate,,DEM,Kamala Harris,339
-Riverside,53025,U.S. Senate,,DEM,Loretta Sanchez,268
-Riverside,53038,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,53038,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,53042,U.S. Senate,,DEM,Kamala Harris,2
-Riverside,53042,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,54000,U.S. Senate,,DEM,Kamala Harris,1174
-Riverside,54000,U.S. Senate,,DEM,Loretta Sanchez,751
-Riverside,54005,U.S. Senate,,DEM,Kamala Harris,245
-Riverside,54005,U.S. Senate,,DEM,Loretta Sanchez,156
-Riverside,54007,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,54007,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,54008,U.S. Senate,,DEM,Kamala Harris,10
-Riverside,54008,U.S. Senate,,DEM,Loretta Sanchez,5
-Riverside,54010,U.S. Senate,,DEM,Kamala Harris,374
-Riverside,54010,U.S. Senate,,DEM,Loretta Sanchez,219
-Riverside,54012,U.S. Senate,,DEM,Kamala Harris,793
-Riverside,54012,U.S. Senate,,DEM,Loretta Sanchez,384
-Riverside,54016,U.S. Senate,,DEM,Kamala Harris,579
-Riverside,54016,U.S. Senate,,DEM,Loretta Sanchez,495
-Riverside,54019,U.S. Senate,,DEM,Kamala Harris,186
-Riverside,54019,U.S. Senate,,DEM,Loretta Sanchez,90
-Riverside,54022,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,54022,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,54024,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,54024,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,54025,U.S. Senate,,DEM,Kamala Harris,4
-Riverside,54025,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,54026,U.S. Senate,,DEM,Kamala Harris,463
-Riverside,54026,U.S. Senate,,DEM,Loretta Sanchez,413
-Riverside,54029,U.S. Senate,,DEM,Kamala Harris,376
-Riverside,54029,U.S. Senate,,DEM,Loretta Sanchez,352
-Riverside,54032,U.S. Senate,,DEM,Kamala Harris,1165
-Riverside,54032,U.S. Senate,,DEM,Loretta Sanchez,770
-Riverside,54035,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,54035,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,54036,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,54036,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,54037,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,54037,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,54046,U.S. Senate,,DEM,Kamala Harris,9
-Riverside,54046,U.S. Senate,,DEM,Loretta Sanchez,17
-Riverside,54050,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,54050,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,54052,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,54052,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,54054,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,54054,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,54055,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,54055,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,54058,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,54058,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,54059,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,54059,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,54064,U.S. Senate,,DEM,Kamala Harris,305
-Riverside,54064,U.S. Senate,,DEM,Loretta Sanchez,293
-Riverside,54067,U.S. Senate,,DEM,Kamala Harris,420
-Riverside,54067,U.S. Senate,,DEM,Loretta Sanchez,349
-Riverside,54069,U.S. Senate,,DEM,Kamala Harris,1638
-Riverside,54069,U.S. Senate,,DEM,Loretta Sanchez,851
-Riverside,54072,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,54072,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,54075,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,54075,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,54079,U.S. Senate,,DEM,Kamala Harris,12
-Riverside,54079,U.S. Senate,,DEM,Loretta Sanchez,10
-Riverside,54080,U.S. Senate,,DEM,Kamala Harris,2
-Riverside,54080,U.S. Senate,,DEM,Loretta Sanchez,1
-Riverside,54081,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,54081,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,55100,U.S. Senate,,DEM,Kamala Harris,566
-Riverside,55100,U.S. Senate,,DEM,Loretta Sanchez,432
-Riverside,55103,U.S. Senate,,DEM,Kamala Harris,22
-Riverside,55103,U.S. Senate,,DEM,Loretta Sanchez,15
-Riverside,55200,U.S. Senate,,DEM,Kamala Harris,479
-Riverside,55200,U.S. Senate,,DEM,Loretta Sanchez,383
-Riverside,55201,U.S. Senate,,DEM,Kamala Harris,130
-Riverside,55201,U.S. Senate,,DEM,Loretta Sanchez,96
-Riverside,55300,U.S. Senate,,DEM,Kamala Harris,171
-Riverside,55300,U.S. Senate,,DEM,Loretta Sanchez,93
-Riverside,55301,U.S. Senate,,DEM,Kamala Harris,867
-Riverside,55301,U.S. Senate,,DEM,Loretta Sanchez,444
-Riverside,55306,U.S. Senate,,DEM,Kamala Harris,1165
-Riverside,55306,U.S. Senate,,DEM,Loretta Sanchez,516
-Riverside,55308,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,55308,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,55400,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,55400,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,55401,U.S. Senate,,DEM,Kamala Harris,16
-Riverside,55401,U.S. Senate,,DEM,Loretta Sanchez,25
-Riverside,55406,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,55406,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,55407,U.S. Senate,,DEM,Kamala Harris,111
-Riverside,55407,U.S. Senate,,DEM,Loretta Sanchez,76
-Riverside,55408,U.S. Senate,,DEM,Kamala Harris,229
-Riverside,55408,U.S. Senate,,DEM,Loretta Sanchez,188
-Riverside,55410,U.S. Senate,,DEM,Kamala Harris,622
-Riverside,55410,U.S. Senate,,DEM,Loretta Sanchez,468
-Riverside,55504,U.S. Senate,,DEM,Kamala Harris,729
-Riverside,55504,U.S. Senate,,DEM,Loretta Sanchez,550
-Riverside,55751,U.S. Senate,,DEM,Kamala Harris,1
-Riverside,55751,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,55790,U.S. Senate,,DEM,Kamala Harris,58
-Riverside,55790,U.S. Senate,,DEM,Loretta Sanchez,54
-Riverside,56900,U.S. Senate,,DEM,Kamala Harris,3
-Riverside,56900,U.S. Senate,,DEM,Loretta Sanchez,2
-Riverside,56910,U.S. Senate,,DEM,Kamala Harris,64
-Riverside,56910,U.S. Senate,,DEM,Loretta Sanchez,97
-Riverside,56912,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,56912,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,56913,U.S. Senate,,DEM,Kamala Harris,443
-Riverside,56913,U.S. Senate,,DEM,Loretta Sanchez,488
-Riverside,56915,U.S. Senate,,DEM,Kamala Harris,19
-Riverside,56915,U.S. Senate,,DEM,Loretta Sanchez,24
-Riverside,56919,U.S. Senate,,DEM,Kamala Harris,597
-Riverside,56919,U.S. Senate,,DEM,Loretta Sanchez,761
-Riverside,56920,U.S. Senate,,DEM,Kamala Harris,44
-Riverside,56920,U.S. Senate,,DEM,Loretta Sanchez,25
-Riverside,56926,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,56926,U.S. Senate,,DEM,Loretta Sanchez,3
-Riverside,56930,U.S. Senate,,DEM,Kamala Harris,327
-Riverside,56930,U.S. Senate,,DEM,Loretta Sanchez,344
-Riverside,56935,U.S. Senate,,DEM,Kamala Harris,3
-Riverside,56935,U.S. Senate,,DEM,Loretta Sanchez,6
-Riverside,58825,U.S. Senate,,DEM,Kamala Harris,5
-Riverside,58825,U.S. Senate,,DEM,Loretta Sanchez,1
-Riverside,58830,U.S. Senate,,DEM,Kamala Harris,336
-Riverside,58830,U.S. Senate,,DEM,Loretta Sanchez,225
-Riverside,59800,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,59800,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,59802,U.S. Senate,,DEM,Kamala Harris,0
-Riverside,59802,U.S. Senate,,DEM,Loretta Sanchez,0
-Riverside,59803,U.S. Senate,,DEM,Kamala Harris,21
-Riverside,59803,U.S. Senate,,DEM,Loretta Sanchez,26
-Riverside,59804,U.S. Senate,,DEM,Kamala Harris,73
-Riverside,59804,U.S. Senate,,DEM,Loretta Sanchez,73
+Riverside,11103,U.S. Senate,,DEM,Kamala D. Harris,673
+Riverside,11103,U.S. Senate,,DEM,Loretta L. Sanchez,519
+Riverside,11105,U.S. Senate,,DEM,Kamala D. Harris,32
+Riverside,11105,U.S. Senate,,DEM,Loretta L. Sanchez,35
+Riverside,11108,U.S. Senate,,DEM,Kamala D. Harris,763
+Riverside,11108,U.S. Senate,,DEM,Loretta L. Sanchez,632
+Riverside,11113,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,11113,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,11200,U.S. Senate,,DEM,Kamala D. Harris,578
+Riverside,11200,U.S. Senate,,DEM,Loretta L. Sanchez,697
+Riverside,11205,U.S. Senate,,DEM,Kamala D. Harris,504
+Riverside,11205,U.S. Senate,,DEM,Loretta L. Sanchez,664
+Riverside,11206,U.S. Senate,,DEM,Kamala D. Harris,508
+Riverside,11206,U.S. Senate,,DEM,Loretta L. Sanchez,414
+Riverside,11208,U.S. Senate,,DEM,Kamala D. Harris,256
+Riverside,11208,U.S. Senate,,DEM,Loretta L. Sanchez,203
+Riverside,11212,U.S. Senate,,DEM,Kamala D. Harris,939
+Riverside,11212,U.S. Senate,,DEM,Loretta L. Sanchez,608
+Riverside,11216,U.S. Senate,,DEM,Kamala D. Harris,232
+Riverside,11216,U.S. Senate,,DEM,Loretta L. Sanchez,283
+Riverside,11217,U.S. Senate,,DEM,Kamala D. Harris,317
+Riverside,11217,U.S. Senate,,DEM,Loretta L. Sanchez,165
+Riverside,11221,U.S. Senate,,DEM,Kamala D. Harris,894
+Riverside,11221,U.S. Senate,,DEM,Loretta L. Sanchez,489
+Riverside,11224,U.S. Senate,,DEM,Kamala D. Harris,896
+Riverside,11224,U.S. Senate,,DEM,Loretta L. Sanchez,504
+Riverside,11226,U.S. Senate,,DEM,Kamala D. Harris,747
+Riverside,11226,U.S. Senate,,DEM,Loretta L. Sanchez,445
+Riverside,11227,U.S. Senate,,DEM,Kamala D. Harris,1266
+Riverside,11227,U.S. Senate,,DEM,Loretta L. Sanchez,770
+Riverside,11233,U.S. Senate,,DEM,Kamala D. Harris,1
+Riverside,11233,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Riverside,11239,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,11239,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Riverside,11302,U.S. Senate,,DEM,Kamala D. Harris,846
+Riverside,11302,U.S. Senate,,DEM,Loretta L. Sanchez,523
+Riverside,11305,U.S. Senate,,DEM,Kamala D. Harris,762
+Riverside,11305,U.S. Senate,,DEM,Loretta L. Sanchez,478
+Riverside,11310,U.S. Senate,,DEM,Kamala D. Harris,868
+Riverside,11310,U.S. Senate,,DEM,Loretta L. Sanchez,771
+Riverside,11312,U.S. Senate,,DEM,Kamala D. Harris,698
+Riverside,11312,U.S. Senate,,DEM,Loretta L. Sanchez,522
+Riverside,11314,U.S. Senate,,DEM,Kamala D. Harris,585
+Riverside,11314,U.S. Senate,,DEM,Loretta L. Sanchez,354
+Riverside,11402,U.S. Senate,,DEM,Kamala D. Harris,700
+Riverside,11402,U.S. Senate,,DEM,Loretta L. Sanchez,783
+Riverside,11406,U.S. Senate,,DEM,Kamala D. Harris,792
+Riverside,11406,U.S. Senate,,DEM,Loretta L. Sanchez,629
+Riverside,11411,U.S. Senate,,DEM,Kamala D. Harris,1005
+Riverside,11411,U.S. Senate,,DEM,Loretta L. Sanchez,678
+Riverside,11413,U.S. Senate,,DEM,Kamala D. Harris,993
+Riverside,11413,U.S. Senate,,DEM,Loretta L. Sanchez,602
+Riverside,11416,U.S. Senate,,DEM,Kamala D. Harris,883
+Riverside,11416,U.S. Senate,,DEM,Loretta L. Sanchez,646
+Riverside,11419,U.S. Senate,,DEM,Kamala D. Harris,792
+Riverside,11419,U.S. Senate,,DEM,Loretta L. Sanchez,509
+Riverside,11421,U.S. Senate,,DEM,Kamala D. Harris,856
+Riverside,11421,U.S. Senate,,DEM,Loretta L. Sanchez,628
+Riverside,11424,U.S. Senate,,DEM,Kamala D. Harris,661
+Riverside,11424,U.S. Senate,,DEM,Loretta L. Sanchez,490
+Riverside,11427,U.S. Senate,,DEM,Kamala D. Harris,746
+Riverside,11427,U.S. Senate,,DEM,Loretta L. Sanchez,527
+Riverside,11432,U.S. Senate,,DEM,Kamala D. Harris,809
+Riverside,11432,U.S. Senate,,DEM,Loretta L. Sanchez,573
+Riverside,11434,U.S. Senate,,DEM,Kamala D. Harris,724
+Riverside,11434,U.S. Senate,,DEM,Loretta L. Sanchez,483
+Riverside,11435,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,11435,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,11500,U.S. Senate,,DEM,Kamala D. Harris,556
+Riverside,11500,U.S. Senate,,DEM,Loretta L. Sanchez,426
+Riverside,11501,U.S. Senate,,DEM,Kamala D. Harris,766
+Riverside,11501,U.S. Senate,,DEM,Loretta L. Sanchez,618
+Riverside,11508,U.S. Senate,,DEM,Kamala D. Harris,679
+Riverside,11508,U.S. Senate,,DEM,Loretta L. Sanchez,650
+Riverside,11511,U.S. Senate,,DEM,Kamala D. Harris,418
+Riverside,11511,U.S. Senate,,DEM,Loretta L. Sanchez,450
+Riverside,11517,U.S. Senate,,DEM,Kamala D. Harris,119
+Riverside,11517,U.S. Senate,,DEM,Loretta L. Sanchez,79
+Riverside,11518,U.S. Senate,,DEM,Kamala D. Harris,556
+Riverside,11518,U.S. Senate,,DEM,Loretta L. Sanchez,476
+Riverside,11521,U.S. Senate,,DEM,Kamala D. Harris,544
+Riverside,11521,U.S. Senate,,DEM,Loretta L. Sanchez,487
+Riverside,11525,U.S. Senate,,DEM,Kamala D. Harris,676
+Riverside,11525,U.S. Senate,,DEM,Loretta L. Sanchez,600
+Riverside,11528,U.S. Senate,,DEM,Kamala D. Harris,889
+Riverside,11528,U.S. Senate,,DEM,Loretta L. Sanchez,821
+Riverside,11602,U.S. Senate,,DEM,Kamala D. Harris,516
+Riverside,11602,U.S. Senate,,DEM,Loretta L. Sanchez,456
+Riverside,11605,U.S. Senate,,DEM,Kamala D. Harris,580
+Riverside,11605,U.S. Senate,,DEM,Loretta L. Sanchez,913
+Riverside,11607,U.S. Senate,,DEM,Kamala D. Harris,550
+Riverside,11607,U.S. Senate,,DEM,Loretta L. Sanchez,683
+Riverside,11608,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,11608,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,11610,U.S. Senate,,DEM,Kamala D. Harris,599
+Riverside,11610,U.S. Senate,,DEM,Loretta L. Sanchez,659
+Riverside,11611,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,11611,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,11613,U.S. Senate,,DEM,Kamala D. Harris,538
+Riverside,11613,U.S. Senate,,DEM,Loretta L. Sanchez,521
+Riverside,11617,U.S. Senate,,DEM,Kamala D. Harris,681
+Riverside,11617,U.S. Senate,,DEM,Loretta L. Sanchez,575
+Riverside,11618,U.S. Senate,,DEM,Kamala D. Harris,400
+Riverside,11618,U.S. Senate,,DEM,Loretta L. Sanchez,341
+Riverside,11620,U.S. Senate,,DEM,Kamala D. Harris,81
+Riverside,11620,U.S. Senate,,DEM,Loretta L. Sanchez,83
+Riverside,11625,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,11625,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,11627,U.S. Senate,,DEM,Kamala D. Harris,509
+Riverside,11627,U.S. Senate,,DEM,Loretta L. Sanchez,453
+Riverside,11629,U.S. Senate,,DEM,Kamala D. Harris,636
+Riverside,11629,U.S. Senate,,DEM,Loretta L. Sanchez,644
+Riverside,11700,U.S. Senate,,DEM,Kamala D. Harris,514
+Riverside,11700,U.S. Senate,,DEM,Loretta L. Sanchez,574
+Riverside,11701,U.S. Senate,,DEM,Kamala D. Harris,536
+Riverside,11701,U.S. Senate,,DEM,Loretta L. Sanchez,745
+Riverside,11709,U.S. Senate,,DEM,Kamala D. Harris,750
+Riverside,11709,U.S. Senate,,DEM,Loretta L. Sanchez,679
+Riverside,11711,U.S. Senate,,DEM,Kamala D. Harris,227
+Riverside,11711,U.S. Senate,,DEM,Loretta L. Sanchez,374
+Riverside,11712,U.S. Senate,,DEM,Kamala D. Harris,857
+Riverside,11712,U.S. Senate,,DEM,Loretta L. Sanchez,494
+Riverside,11715,U.S. Senate,,DEM,Kamala D. Harris,563
+Riverside,11715,U.S. Senate,,DEM,Loretta L. Sanchez,371
+Riverside,11717,U.S. Senate,,DEM,Kamala D. Harris,625
+Riverside,11717,U.S. Senate,,DEM,Loretta L. Sanchez,472
+Riverside,11802,U.S. Senate,,DEM,Kamala D. Harris,28
+Riverside,11802,U.S. Senate,,DEM,Loretta L. Sanchez,62
+Riverside,11803,U.S. Senate,,DEM,Kamala D. Harris,8
+Riverside,11803,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Riverside,11807,U.S. Senate,,DEM,Kamala D. Harris,6
+Riverside,11807,U.S. Senate,,DEM,Loretta L. Sanchez,7
+Riverside,11820,U.S. Senate,,DEM,Kamala D. Harris,74
+Riverside,11820,U.S. Senate,,DEM,Loretta L. Sanchez,58
+Riverside,11821,U.S. Senate,,DEM,Kamala D. Harris,28
+Riverside,11821,U.S. Senate,,DEM,Loretta L. Sanchez,20
+Riverside,11861,U.S. Senate,,DEM,Kamala D. Harris,518
+Riverside,11861,U.S. Senate,,DEM,Loretta L. Sanchez,441
+Riverside,11863,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,11863,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Riverside,11865,U.S. Senate,,DEM,Kamala D. Harris,382
+Riverside,11865,U.S. Senate,,DEM,Loretta L. Sanchez,330
+Riverside,11872,U.S. Senate,,DEM,Kamala D. Harris,358
+Riverside,11872,U.S. Senate,,DEM,Loretta L. Sanchez,326
+Riverside,11874,U.S. Senate,,DEM,Kamala D. Harris,470
+Riverside,11874,U.S. Senate,,DEM,Loretta L. Sanchez,505
+Riverside,11901,U.S. Senate,,DEM,Kamala D. Harris,811
+Riverside,11901,U.S. Senate,,DEM,Loretta L. Sanchez,676
+Riverside,11903,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,11903,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,11907,U.S. Senate,,DEM,Kamala D. Harris,361
+Riverside,11907,U.S. Senate,,DEM,Loretta L. Sanchez,311
+Riverside,11908,U.S. Senate,,DEM,Kamala D. Harris,4
+Riverside,11908,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Riverside,11911,U.S. Senate,,DEM,Kamala D. Harris,11
+Riverside,11911,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Riverside,11914,U.S. Senate,,DEM,Kamala D. Harris,83
+Riverside,11914,U.S. Senate,,DEM,Loretta L. Sanchez,62
+Riverside,11915,U.S. Senate,,DEM,Kamala D. Harris,270
+Riverside,11915,U.S. Senate,,DEM,Loretta L. Sanchez,236
+Riverside,11920,U.S. Senate,,DEM,Kamala D. Harris,518
+Riverside,11920,U.S. Senate,,DEM,Loretta L. Sanchez,351
+Riverside,11929,U.S. Senate,,DEM,Kamala D. Harris,699
+Riverside,11929,U.S. Senate,,DEM,Loretta L. Sanchez,608
+Riverside,11930,U.S. Senate,,DEM,Kamala D. Harris,608
+Riverside,11930,U.S. Senate,,DEM,Loretta L. Sanchez,531
+Riverside,11932,U.S. Senate,,DEM,Kamala D. Harris,329
+Riverside,11932,U.S. Senate,,DEM,Loretta L. Sanchez,300
+Riverside,11943,U.S. Senate,,DEM,Kamala D. Harris,191
+Riverside,11943,U.S. Senate,,DEM,Loretta L. Sanchez,139
+Riverside,11945,U.S. Senate,,DEM,Kamala D. Harris,136
+Riverside,11945,U.S. Senate,,DEM,Loretta L. Sanchez,120
+Riverside,11948,U.S. Senate,,DEM,Kamala D. Harris,296
+Riverside,11948,U.S. Senate,,DEM,Loretta L. Sanchez,269
+Riverside,11953,U.S. Senate,,DEM,Kamala D. Harris,712
+Riverside,11953,U.S. Senate,,DEM,Loretta L. Sanchez,689
+Riverside,11954,U.S. Senate,,DEM,Kamala D. Harris,348
+Riverside,11954,U.S. Senate,,DEM,Loretta L. Sanchez,476
+Riverside,11959,U.S. Senate,,DEM,Kamala D. Harris,384
+Riverside,11959,U.S. Senate,,DEM,Loretta L. Sanchez,496
+Riverside,11960,U.S. Senate,,DEM,Kamala D. Harris,3
+Riverside,11960,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Riverside,11963,U.S. Senate,,DEM,Kamala D. Harris,118
+Riverside,11963,U.S. Senate,,DEM,Loretta L. Sanchez,141
+Riverside,11967,U.S. Senate,,DEM,Kamala D. Harris,21
+Riverside,11967,U.S. Senate,,DEM,Loretta L. Sanchez,41
+Riverside,11970,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,11970,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,11971,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,11971,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,11972,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,11972,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,11975,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,11975,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,11980,U.S. Senate,,DEM,Kamala D. Harris,124
+Riverside,11980,U.S. Senate,,DEM,Loretta L. Sanchez,97
+Riverside,12008,U.S. Senate,,DEM,Kamala D. Harris,758
+Riverside,12008,U.S. Senate,,DEM,Loretta L. Sanchez,715
+Riverside,12012,U.S. Senate,,DEM,Kamala D. Harris,625
+Riverside,12012,U.S. Senate,,DEM,Loretta L. Sanchez,531
+Riverside,12014,U.S. Senate,,DEM,Kamala D. Harris,516
+Riverside,12014,U.S. Senate,,DEM,Loretta L. Sanchez,536
+Riverside,12016,U.S. Senate,,DEM,Kamala D. Harris,554
+Riverside,12016,U.S. Senate,,DEM,Loretta L. Sanchez,546
+Riverside,12024,U.S. Senate,,DEM,Kamala D. Harris,414
+Riverside,12024,U.S. Senate,,DEM,Loretta L. Sanchez,415
+Riverside,12026,U.S. Senate,,DEM,Kamala D. Harris,641
+Riverside,12026,U.S. Senate,,DEM,Loretta L. Sanchez,601
+Riverside,12028,U.S. Senate,,DEM,Kamala D. Harris,445
+Riverside,12028,U.S. Senate,,DEM,Loretta L. Sanchez,400
+Riverside,12029,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,12029,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,12033,U.S. Senate,,DEM,Kamala D. Harris,686
+Riverside,12033,U.S. Senate,,DEM,Loretta L. Sanchez,619
+Riverside,12043,U.S. Senate,,DEM,Kamala D. Harris,669
+Riverside,12043,U.S. Senate,,DEM,Loretta L. Sanchez,486
+Riverside,12045,U.S. Senate,,DEM,Kamala D. Harris,270
+Riverside,12045,U.S. Senate,,DEM,Loretta L. Sanchez,228
+Riverside,12048,U.S. Senate,,DEM,Kamala D. Harris,912
+Riverside,12048,U.S. Senate,,DEM,Loretta L. Sanchez,728
+Riverside,12055,U.S. Senate,,DEM,Kamala D. Harris,739
+Riverside,12055,U.S. Senate,,DEM,Loretta L. Sanchez,471
+Riverside,12057,U.S. Senate,,DEM,Kamala D. Harris,188
+Riverside,12057,U.S. Senate,,DEM,Loretta L. Sanchez,209
+Riverside,12066,U.S. Senate,,DEM,Kamala D. Harris,388
+Riverside,12066,U.S. Senate,,DEM,Loretta L. Sanchez,463
+Riverside,12602,U.S. Senate,,DEM,Kamala D. Harris,540
+Riverside,12602,U.S. Senate,,DEM,Loretta L. Sanchez,432
+Riverside,12603,U.S. Senate,,DEM,Kamala D. Harris,290
+Riverside,12603,U.S. Senate,,DEM,Loretta L. Sanchez,253
+Riverside,12604,U.S. Senate,,DEM,Kamala D. Harris,493
+Riverside,12604,U.S. Senate,,DEM,Loretta L. Sanchez,362
+Riverside,12649,U.S. Senate,,DEM,Kamala D. Harris,11
+Riverside,12649,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Riverside,12650,U.S. Senate,,DEM,Kamala D. Harris,58
+Riverside,12650,U.S. Senate,,DEM,Loretta L. Sanchez,38
+Riverside,12651,U.S. Senate,,DEM,Kamala D. Harris,1196
+Riverside,12651,U.S. Senate,,DEM,Loretta L. Sanchez,754
+Riverside,12660,U.S. Senate,,DEM,Kamala D. Harris,80
+Riverside,12660,U.S. Senate,,DEM,Loretta L. Sanchez,42
+Riverside,12664,U.S. Senate,,DEM,Kamala D. Harris,812
+Riverside,12664,U.S. Senate,,DEM,Loretta L. Sanchez,582
+Riverside,12703,U.S. Senate,,DEM,Kamala D. Harris,2
+Riverside,12703,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,12704,U.S. Senate,,DEM,Kamala D. Harris,605
+Riverside,12704,U.S. Senate,,DEM,Loretta L. Sanchez,460
+Riverside,12710,U.S. Senate,,DEM,Kamala D. Harris,571
+Riverside,12710,U.S. Senate,,DEM,Loretta L. Sanchez,498
+Riverside,12750,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,12750,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,12756,U.S. Senate,,DEM,Kamala D. Harris,60
+Riverside,12756,U.S. Senate,,DEM,Loretta L. Sanchez,57
+Riverside,12757,U.S. Senate,,DEM,Kamala D. Harris,10
+Riverside,12757,U.S. Senate,,DEM,Loretta L. Sanchez,8
+Riverside,12758,U.S. Senate,,DEM,Kamala D. Harris,46
+Riverside,12758,U.S. Senate,,DEM,Loretta L. Sanchez,43
+Riverside,12849,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,12849,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,12850,U.S. Senate,,DEM,Kamala D. Harris,6
+Riverside,12850,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Riverside,12851,U.S. Senate,,DEM,Kamala D. Harris,367
+Riverside,12851,U.S. Senate,,DEM,Loretta L. Sanchez,268
+Riverside,12900,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,12900,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,12901,U.S. Senate,,DEM,Kamala D. Harris,114
+Riverside,12901,U.S. Senate,,DEM,Loretta L. Sanchez,80
+Riverside,12920,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,12920,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,12921,U.S. Senate,,DEM,Kamala D. Harris,3
+Riverside,12921,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Riverside,12922,U.S. Senate,,DEM,Kamala D. Harris,45
+Riverside,12922,U.S. Senate,,DEM,Loretta L. Sanchez,55
+Riverside,13005,U.S. Senate,,DEM,Kamala D. Harris,724
+Riverside,13005,U.S. Senate,,DEM,Loretta L. Sanchez,684
+Riverside,13006,U.S. Senate,,DEM,Kamala D. Harris,792
+Riverside,13006,U.S. Senate,,DEM,Loretta L. Sanchez,667
+Riverside,13020,U.S. Senate,,DEM,Kamala D. Harris,545
+Riverside,13020,U.S. Senate,,DEM,Loretta L. Sanchez,449
+Riverside,14105,U.S. Senate,,DEM,Kamala D. Harris,484
+Riverside,14105,U.S. Senate,,DEM,Loretta L. Sanchez,459
+Riverside,14108,U.S. Senate,,DEM,Kamala D. Harris,319
+Riverside,14108,U.S. Senate,,DEM,Loretta L. Sanchez,388
+Riverside,14200,U.S. Senate,,DEM,Kamala D. Harris,8
+Riverside,14200,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Riverside,14201,U.S. Senate,,DEM,Kamala D. Harris,59
+Riverside,14201,U.S. Senate,,DEM,Loretta L. Sanchez,78
+Riverside,14207,U.S. Senate,,DEM,Kamala D. Harris,639
+Riverside,14207,U.S. Senate,,DEM,Loretta L. Sanchez,503
+Riverside,14211,U.S. Senate,,DEM,Kamala D. Harris,328
+Riverside,14211,U.S. Senate,,DEM,Loretta L. Sanchez,289
+Riverside,14303,U.S. Senate,,DEM,Kamala D. Harris,655
+Riverside,14303,U.S. Senate,,DEM,Loretta L. Sanchez,619
+Riverside,14307,U.S. Senate,,DEM,Kamala D. Harris,523
+Riverside,14307,U.S. Senate,,DEM,Loretta L. Sanchez,460
+Riverside,14401,U.S. Senate,,DEM,Kamala D. Harris,651
+Riverside,14401,U.S. Senate,,DEM,Loretta L. Sanchez,589
+Riverside,14403,U.S. Senate,,DEM,Kamala D. Harris,309
+Riverside,14403,U.S. Senate,,DEM,Loretta L. Sanchez,382
+Riverside,14504,U.S. Senate,,DEM,Kamala D. Harris,895
+Riverside,14504,U.S. Senate,,DEM,Loretta L. Sanchez,742
+Riverside,14506,U.S. Senate,,DEM,Kamala D. Harris,302
+Riverside,14506,U.S. Senate,,DEM,Loretta L. Sanchez,248
+Riverside,14802,U.S. Senate,,DEM,Kamala D. Harris,458
+Riverside,14802,U.S. Senate,,DEM,Loretta L. Sanchez,479
+Riverside,14804,U.S. Senate,,DEM,Kamala D. Harris,440
+Riverside,14804,U.S. Senate,,DEM,Loretta L. Sanchez,437
+Riverside,14850,U.S. Senate,,DEM,Kamala D. Harris,40
+Riverside,14850,U.S. Senate,,DEM,Loretta L. Sanchez,21
+Riverside,14901,U.S. Senate,,DEM,Kamala D. Harris,194
+Riverside,14901,U.S. Senate,,DEM,Loretta L. Sanchez,225
+Riverside,14902,U.S. Senate,,DEM,Kamala D. Harris,390
+Riverside,14902,U.S. Senate,,DEM,Loretta L. Sanchez,362
+Riverside,14904,U.S. Senate,,DEM,Kamala D. Harris,6
+Riverside,14904,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Riverside,14908,U.S. Senate,,DEM,Kamala D. Harris,47
+Riverside,14908,U.S. Senate,,DEM,Loretta L. Sanchez,51
+Riverside,14909,U.S. Senate,,DEM,Kamala D. Harris,54
+Riverside,14909,U.S. Senate,,DEM,Loretta L. Sanchez,61
+Riverside,14910,U.S. Senate,,DEM,Kamala D. Harris,12
+Riverside,14910,U.S. Senate,,DEM,Loretta L. Sanchez,8
+Riverside,15810,U.S. Senate,,DEM,Kamala D. Harris,210
+Riverside,15810,U.S. Senate,,DEM,Loretta L. Sanchez,183
+Riverside,15815,U.S. Senate,,DEM,Kamala D. Harris,38
+Riverside,15815,U.S. Senate,,DEM,Loretta L. Sanchez,12
+Riverside,15843,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,15843,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,15844,U.S. Senate,,DEM,Kamala D. Harris,7
+Riverside,15844,U.S. Senate,,DEM,Loretta L. Sanchez,6
+Riverside,15846,U.S. Senate,,DEM,Kamala D. Harris,229
+Riverside,15846,U.S. Senate,,DEM,Loretta L. Sanchez,381
+Riverside,15852,U.S. Senate,,DEM,Kamala D. Harris,129
+Riverside,15852,U.S. Senate,,DEM,Loretta L. Sanchez,144
+Riverside,15855,U.S. Senate,,DEM,Kamala D. Harris,19
+Riverside,15855,U.S. Senate,,DEM,Loretta L. Sanchez,44
+Riverside,15856,U.S. Senate,,DEM,Kamala D. Harris,19
+Riverside,15856,U.S. Senate,,DEM,Loretta L. Sanchez,17
+Riverside,15863,U.S. Senate,,DEM,Kamala D. Harris,285
+Riverside,15863,U.S. Senate,,DEM,Loretta L. Sanchez,455
+Riverside,15874,U.S. Senate,,DEM,Kamala D. Harris,2
+Riverside,15874,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Riverside,15877,U.S. Senate,,DEM,Kamala D. Harris,112
+Riverside,15877,U.S. Senate,,DEM,Loretta L. Sanchez,133
+Riverside,15880,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,15880,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,15885,U.S. Senate,,DEM,Kamala D. Harris,92
+Riverside,15885,U.S. Senate,,DEM,Loretta L. Sanchez,92
+Riverside,18603,U.S. Senate,,DEM,Kamala D. Harris,541
+Riverside,18603,U.S. Senate,,DEM,Loretta L. Sanchez,513
+Riverside,18612,U.S. Senate,,DEM,Kamala D. Harris,404
+Riverside,18612,U.S. Senate,,DEM,Loretta L. Sanchez,302
+Riverside,18614,U.S. Senate,,DEM,Kamala D. Harris,38
+Riverside,18614,U.S. Senate,,DEM,Loretta L. Sanchez,30
+Riverside,20005,U.S. Senate,,DEM,Kamala D. Harris,874
+Riverside,20005,U.S. Senate,,DEM,Loretta L. Sanchez,643
+Riverside,20014,U.S. Senate,,DEM,Kamala D. Harris,516
+Riverside,20014,U.S. Senate,,DEM,Loretta L. Sanchez,545
+Riverside,20020,U.S. Senate,,DEM,Kamala D. Harris,518
+Riverside,20020,U.S. Senate,,DEM,Loretta L. Sanchez,682
+Riverside,20022,U.S. Senate,,DEM,Kamala D. Harris,680
+Riverside,20022,U.S. Senate,,DEM,Loretta L. Sanchez,647
+Riverside,20023,U.S. Senate,,DEM,Kamala D. Harris,609
+Riverside,20023,U.S. Senate,,DEM,Loretta L. Sanchez,707
+Riverside,20026,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,20026,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,20027,U.S. Senate,,DEM,Kamala D. Harris,40
+Riverside,20027,U.S. Senate,,DEM,Loretta L. Sanchez,48
+Riverside,20029,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,20029,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,20031,U.S. Senate,,DEM,Kamala D. Harris,1
+Riverside,20031,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Riverside,20033,U.S. Senate,,DEM,Kamala D. Harris,290
+Riverside,20033,U.S. Senate,,DEM,Loretta L. Sanchez,293
+Riverside,20034,U.S. Senate,,DEM,Kamala D. Harris,1
+Riverside,20034,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Riverside,20035,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,20035,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,20037,U.S. Senate,,DEM,Kamala D. Harris,268
+Riverside,20037,U.S. Senate,,DEM,Loretta L. Sanchez,144
+Riverside,20038,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,20038,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,20039,U.S. Senate,,DEM,Kamala D. Harris,557
+Riverside,20039,U.S. Senate,,DEM,Loretta L. Sanchez,500
+Riverside,20042,U.S. Senate,,DEM,Kamala D. Harris,662
+Riverside,20042,U.S. Senate,,DEM,Loretta L. Sanchez,691
+Riverside,20044,U.S. Senate,,DEM,Kamala D. Harris,190
+Riverside,20044,U.S. Senate,,DEM,Loretta L. Sanchez,221
+Riverside,20045,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,20045,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,20048,U.S. Senate,,DEM,Kamala D. Harris,472
+Riverside,20048,U.S. Senate,,DEM,Loretta L. Sanchez,729
+Riverside,20050,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,20050,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,20052,U.S. Senate,,DEM,Kamala D. Harris,602
+Riverside,20052,U.S. Senate,,DEM,Loretta L. Sanchez,713
+Riverside,20054,U.S. Senate,,DEM,Kamala D. Harris,361
+Riverside,20054,U.S. Senate,,DEM,Loretta L. Sanchez,442
+Riverside,20055,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,20055,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,20056,U.S. Senate,,DEM,Kamala D. Harris,623
+Riverside,20056,U.S. Senate,,DEM,Loretta L. Sanchez,563
+Riverside,20062,U.S. Senate,,DEM,Kamala D. Harris,846
+Riverside,20062,U.S. Senate,,DEM,Loretta L. Sanchez,672
+Riverside,20064,U.S. Senate,,DEM,Kamala D. Harris,233
+Riverside,20064,U.S. Senate,,DEM,Loretta L. Sanchez,256
+Riverside,20066,U.S. Senate,,DEM,Kamala D. Harris,400
+Riverside,20066,U.S. Senate,,DEM,Loretta L. Sanchez,410
+Riverside,20068,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,20068,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,20069,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,20069,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,20071,U.S. Senate,,DEM,Kamala D. Harris,380
+Riverside,20071,U.S. Senate,,DEM,Loretta L. Sanchez,309
+Riverside,20073,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,20073,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,20075,U.S. Senate,,DEM,Kamala D. Harris,23
+Riverside,20075,U.S. Senate,,DEM,Loretta L. Sanchez,27
+Riverside,20077,U.S. Senate,,DEM,Kamala D. Harris,1
+Riverside,20077,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Riverside,20080,U.S. Senate,,DEM,Kamala D. Harris,483
+Riverside,20080,U.S. Senate,,DEM,Loretta L. Sanchez,628
+Riverside,20081,U.S. Senate,,DEM,Kamala D. Harris,511
+Riverside,20081,U.S. Senate,,DEM,Loretta L. Sanchez,518
+Riverside,20084,U.S. Senate,,DEM,Kamala D. Harris,552
+Riverside,20084,U.S. Senate,,DEM,Loretta L. Sanchez,565
+Riverside,20085,U.S. Senate,,DEM,Kamala D. Harris,12
+Riverside,20085,U.S. Senate,,DEM,Loretta L. Sanchez,14
+Riverside,20086,U.S. Senate,,DEM,Kamala D. Harris,42
+Riverside,20086,U.S. Senate,,DEM,Loretta L. Sanchez,34
+Riverside,20087,U.S. Senate,,DEM,Kamala D. Harris,12
+Riverside,20087,U.S. Senate,,DEM,Loretta L. Sanchez,10
+Riverside,20088,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,20088,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,20091,U.S. Senate,,DEM,Kamala D. Harris,541
+Riverside,20091,U.S. Senate,,DEM,Loretta L. Sanchez,673
+Riverside,20093,U.S. Senate,,DEM,Kamala D. Harris,4
+Riverside,20093,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,20096,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,20096,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,20800,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,20800,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,20801,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,20801,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,20802,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,20802,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,20803,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,20803,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,20804,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,20804,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,20806,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,20806,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,20807,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,20807,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,20808,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,20808,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,21103,U.S. Senate,,DEM,Kamala D. Harris,507
+Riverside,21103,U.S. Senate,,DEM,Loretta L. Sanchez,457
+Riverside,21105,U.S. Senate,,DEM,Kamala D. Harris,567
+Riverside,21105,U.S. Senate,,DEM,Loretta L. Sanchez,342
+Riverside,21107,U.S. Senate,,DEM,Kamala D. Harris,797
+Riverside,21107,U.S. Senate,,DEM,Loretta L. Sanchez,472
+Riverside,21109,U.S. Senate,,DEM,Kamala D. Harris,728
+Riverside,21109,U.S. Senate,,DEM,Loretta L. Sanchez,508
+Riverside,21114,U.S. Senate,,DEM,Kamala D. Harris,765
+Riverside,21114,U.S. Senate,,DEM,Loretta L. Sanchez,537
+Riverside,21117,U.S. Senate,,DEM,Kamala D. Harris,719
+Riverside,21117,U.S. Senate,,DEM,Loretta L. Sanchez,511
+Riverside,21120,U.S. Senate,,DEM,Kamala D. Harris,639
+Riverside,21120,U.S. Senate,,DEM,Loretta L. Sanchez,623
+Riverside,21124,U.S. Senate,,DEM,Kamala D. Harris,478
+Riverside,21124,U.S. Senate,,DEM,Loretta L. Sanchez,458
+Riverside,21131,U.S. Senate,,DEM,Kamala D. Harris,25
+Riverside,21131,U.S. Senate,,DEM,Loretta L. Sanchez,29
+Riverside,21300,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,21300,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,21301,U.S. Senate,,DEM,Kamala D. Harris,606
+Riverside,21301,U.S. Senate,,DEM,Loretta L. Sanchez,649
+Riverside,21304,U.S. Senate,,DEM,Kamala D. Harris,408
+Riverside,21304,U.S. Senate,,DEM,Loretta L. Sanchez,485
+Riverside,21306,U.S. Senate,,DEM,Kamala D. Harris,770
+Riverside,21306,U.S. Senate,,DEM,Loretta L. Sanchez,638
+Riverside,21313,U.S. Senate,,DEM,Kamala D. Harris,813
+Riverside,21313,U.S. Senate,,DEM,Loretta L. Sanchez,584
+Riverside,21314,U.S. Senate,,DEM,Kamala D. Harris,715
+Riverside,21314,U.S. Senate,,DEM,Loretta L. Sanchez,529
+Riverside,21316,U.S. Senate,,DEM,Kamala D. Harris,693
+Riverside,21316,U.S. Senate,,DEM,Loretta L. Sanchez,566
+Riverside,21317,U.S. Senate,,DEM,Kamala D. Harris,295
+Riverside,21317,U.S. Senate,,DEM,Loretta L. Sanchez,294
+Riverside,21500,U.S. Senate,,DEM,Kamala D. Harris,152
+Riverside,21500,U.S. Senate,,DEM,Loretta L. Sanchez,194
+Riverside,21503,U.S. Senate,,DEM,Kamala D. Harris,677
+Riverside,21503,U.S. Senate,,DEM,Loretta L. Sanchez,563
+Riverside,21700,U.S. Senate,,DEM,Kamala D. Harris,435
+Riverside,21700,U.S. Senate,,DEM,Loretta L. Sanchez,462
+Riverside,21702,U.S. Senate,,DEM,Kamala D. Harris,363
+Riverside,21702,U.S. Senate,,DEM,Loretta L. Sanchez,384
+Riverside,21704,U.S. Senate,,DEM,Kamala D. Harris,618
+Riverside,21704,U.S. Senate,,DEM,Loretta L. Sanchez,756
+Riverside,21800,U.S. Senate,,DEM,Kamala D. Harris,4
+Riverside,21800,U.S. Senate,,DEM,Loretta L. Sanchez,10
+Riverside,21986,U.S. Senate,,DEM,Kamala D. Harris,639
+Riverside,21986,U.S. Senate,,DEM,Loretta L. Sanchez,773
+Riverside,21987,U.S. Senate,,DEM,Kamala D. Harris,2
+Riverside,21987,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Riverside,22100,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,22100,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,22104,U.S. Senate,,DEM,Kamala D. Harris,884
+Riverside,22104,U.S. Senate,,DEM,Loretta L. Sanchez,652
+Riverside,22107,U.S. Senate,,DEM,Kamala D. Harris,102
+Riverside,22107,U.S. Senate,,DEM,Loretta L. Sanchez,124
+Riverside,22108,U.S. Senate,,DEM,Kamala D. Harris,366
+Riverside,22108,U.S. Senate,,DEM,Loretta L. Sanchez,275
+Riverside,22109,U.S. Senate,,DEM,Kamala D. Harris,232
+Riverside,22109,U.S. Senate,,DEM,Loretta L. Sanchez,167
+Riverside,22202,U.S. Senate,,DEM,Kamala D. Harris,1117
+Riverside,22202,U.S. Senate,,DEM,Loretta L. Sanchez,764
+Riverside,22205,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,22205,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,22206,U.S. Senate,,DEM,Kamala D. Harris,993
+Riverside,22206,U.S. Senate,,DEM,Loretta L. Sanchez,682
+Riverside,22302,U.S. Senate,,DEM,Kamala D. Harris,430
+Riverside,22302,U.S. Senate,,DEM,Loretta L. Sanchez,324
+Riverside,22303,U.S. Senate,,DEM,Kamala D. Harris,739
+Riverside,22303,U.S. Senate,,DEM,Loretta L. Sanchez,488
+Riverside,22306,U.S. Senate,,DEM,Kamala D. Harris,556
+Riverside,22306,U.S. Senate,,DEM,Loretta L. Sanchez,466
+Riverside,22401,U.S. Senate,,DEM,Kamala D. Harris,949
+Riverside,22401,U.S. Senate,,DEM,Loretta L. Sanchez,729
+Riverside,22406,U.S. Senate,,DEM,Kamala D. Harris,997
+Riverside,22406,U.S. Senate,,DEM,Loretta L. Sanchez,732
+Riverside,22502,U.S. Senate,,DEM,Kamala D. Harris,908
+Riverside,22502,U.S. Senate,,DEM,Loretta L. Sanchez,686
+Riverside,22505,U.S. Senate,,DEM,Kamala D. Harris,885
+Riverside,22505,U.S. Senate,,DEM,Loretta L. Sanchez,703
+Riverside,22507,U.S. Senate,,DEM,Kamala D. Harris,607
+Riverside,22507,U.S. Senate,,DEM,Loretta L. Sanchez,417
+Riverside,22857,U.S. Senate,,DEM,Kamala D. Harris,285
+Riverside,22857,U.S. Senate,,DEM,Loretta L. Sanchez,446
+Riverside,22858,U.S. Senate,,DEM,Kamala D. Harris,676
+Riverside,22858,U.S. Senate,,DEM,Loretta L. Sanchez,664
+Riverside,22868,U.S. Senate,,DEM,Kamala D. Harris,184
+Riverside,22868,U.S. Senate,,DEM,Loretta L. Sanchez,303
+Riverside,22870,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,22870,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,22872,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,22872,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,22873,U.S. Senate,,DEM,Kamala D. Harris,1
+Riverside,22873,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,22921,U.S. Senate,,DEM,Kamala D. Harris,485
+Riverside,22921,U.S. Senate,,DEM,Loretta L. Sanchez,572
+Riverside,22925,U.S. Senate,,DEM,Kamala D. Harris,77
+Riverside,22925,U.S. Senate,,DEM,Loretta L. Sanchez,55
+Riverside,22930,U.S. Senate,,DEM,Kamala D. Harris,180
+Riverside,22930,U.S. Senate,,DEM,Loretta L. Sanchez,206
+Riverside,23001,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,23001,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,23002,U.S. Senate,,DEM,Kamala D. Harris,442
+Riverside,23002,U.S. Senate,,DEM,Loretta L. Sanchez,416
+Riverside,23004,U.S. Senate,,DEM,Kamala D. Harris,474
+Riverside,23004,U.S. Senate,,DEM,Loretta L. Sanchez,485
+Riverside,23006,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,23006,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,23014,U.S. Senate,,DEM,Kamala D. Harris,611
+Riverside,23014,U.S. Senate,,DEM,Loretta L. Sanchez,433
+Riverside,23016,U.S. Senate,,DEM,Kamala D. Harris,515
+Riverside,23016,U.S. Senate,,DEM,Loretta L. Sanchez,419
+Riverside,23018,U.S. Senate,,DEM,Kamala D. Harris,613
+Riverside,23018,U.S. Senate,,DEM,Loretta L. Sanchez,569
+Riverside,23019,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,23019,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,23020,U.S. Senate,,DEM,Kamala D. Harris,432
+Riverside,23020,U.S. Senate,,DEM,Loretta L. Sanchez,490
+Riverside,23023,U.S. Senate,,DEM,Kamala D. Harris,562
+Riverside,23023,U.S. Senate,,DEM,Loretta L. Sanchez,516
+Riverside,23024,U.S. Senate,,DEM,Kamala D. Harris,434
+Riverside,23024,U.S. Senate,,DEM,Loretta L. Sanchez,370
+Riverside,23026,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,23026,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,24000,U.S. Senate,,DEM,Kamala D. Harris,685
+Riverside,24000,U.S. Senate,,DEM,Loretta L. Sanchez,656
+Riverside,24003,U.S. Senate,,DEM,Kamala D. Harris,492
+Riverside,24003,U.S. Senate,,DEM,Loretta L. Sanchez,513
+Riverside,24005,U.S. Senate,,DEM,Kamala D. Harris,511
+Riverside,24005,U.S. Senate,,DEM,Loretta L. Sanchez,454
+Riverside,24010,U.S. Senate,,DEM,Kamala D. Harris,507
+Riverside,24010,U.S. Senate,,DEM,Loretta L. Sanchez,450
+Riverside,24013,U.S. Senate,,DEM,Kamala D. Harris,705
+Riverside,24013,U.S. Senate,,DEM,Loretta L. Sanchez,470
+Riverside,24014,U.S. Senate,,DEM,Kamala D. Harris,699
+Riverside,24014,U.S. Senate,,DEM,Loretta L. Sanchez,493
+Riverside,24015,U.S. Senate,,DEM,Kamala D. Harris,901
+Riverside,24015,U.S. Senate,,DEM,Loretta L. Sanchez,673
+Riverside,24019,U.S. Senate,,DEM,Kamala D. Harris,524
+Riverside,24019,U.S. Senate,,DEM,Loretta L. Sanchez,350
+Riverside,24020,U.S. Senate,,DEM,Kamala D. Harris,690
+Riverside,24020,U.S. Senate,,DEM,Loretta L. Sanchez,494
+Riverside,24026,U.S. Senate,,DEM,Kamala D. Harris,678
+Riverside,24026,U.S. Senate,,DEM,Loretta L. Sanchez,581
+Riverside,24027,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,24027,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,24029,U.S. Senate,,DEM,Kamala D. Harris,549
+Riverside,24029,U.S. Senate,,DEM,Loretta L. Sanchez,403
+Riverside,24031,U.S. Senate,,DEM,Kamala D. Harris,682
+Riverside,24031,U.S. Senate,,DEM,Loretta L. Sanchez,491
+Riverside,24033,U.S. Senate,,DEM,Kamala D. Harris,841
+Riverside,24033,U.S. Senate,,DEM,Loretta L. Sanchez,686
+Riverside,24035,U.S. Senate,,DEM,Kamala D. Harris,379
+Riverside,24035,U.S. Senate,,DEM,Loretta L. Sanchez,420
+Riverside,24037,U.S. Senate,,DEM,Kamala D. Harris,522
+Riverside,24037,U.S. Senate,,DEM,Loretta L. Sanchez,531
+Riverside,24039,U.S. Senate,,DEM,Kamala D. Harris,499
+Riverside,24039,U.S. Senate,,DEM,Loretta L. Sanchez,582
+Riverside,24042,U.S. Senate,,DEM,Kamala D. Harris,442
+Riverside,24042,U.S. Senate,,DEM,Loretta L. Sanchez,644
+Riverside,24044,U.S. Senate,,DEM,Kamala D. Harris,297
+Riverside,24044,U.S. Senate,,DEM,Loretta L. Sanchez,414
+Riverside,24045,U.S. Senate,,DEM,Kamala D. Harris,312
+Riverside,24045,U.S. Senate,,DEM,Loretta L. Sanchez,451
+Riverside,24046,U.S. Senate,,DEM,Kamala D. Harris,582
+Riverside,24046,U.S. Senate,,DEM,Loretta L. Sanchez,439
+Riverside,24048,U.S. Senate,,DEM,Kamala D. Harris,493
+Riverside,24048,U.S. Senate,,DEM,Loretta L. Sanchez,476
+Riverside,24052,U.S. Senate,,DEM,Kamala D. Harris,407
+Riverside,24052,U.S. Senate,,DEM,Loretta L. Sanchez,399
+Riverside,24053,U.S. Senate,,DEM,Kamala D. Harris,789
+Riverside,24053,U.S. Senate,,DEM,Loretta L. Sanchez,713
+Riverside,24056,U.S. Senate,,DEM,Kamala D. Harris,385
+Riverside,24056,U.S. Senate,,DEM,Loretta L. Sanchez,396
+Riverside,24057,U.S. Senate,,DEM,Kamala D. Harris,347
+Riverside,24057,U.S. Senate,,DEM,Loretta L. Sanchez,287
+Riverside,24060,U.S. Senate,,DEM,Kamala D. Harris,436
+Riverside,24060,U.S. Senate,,DEM,Loretta L. Sanchez,382
+Riverside,24063,U.S. Senate,,DEM,Kamala D. Harris,401
+Riverside,24063,U.S. Senate,,DEM,Loretta L. Sanchez,342
+Riverside,24066,U.S. Senate,,DEM,Kamala D. Harris,492
+Riverside,24066,U.S. Senate,,DEM,Loretta L. Sanchez,346
+Riverside,24069,U.S. Senate,,DEM,Kamala D. Harris,785
+Riverside,24069,U.S. Senate,,DEM,Loretta L. Sanchez,576
+Riverside,24071,U.S. Senate,,DEM,Kamala D. Harris,695
+Riverside,24071,U.S. Senate,,DEM,Loretta L. Sanchez,412
+Riverside,24072,U.S. Senate,,DEM,Kamala D. Harris,992
+Riverside,24072,U.S. Senate,,DEM,Loretta L. Sanchez,672
+Riverside,24075,U.S. Senate,,DEM,Kamala D. Harris,848
+Riverside,24075,U.S. Senate,,DEM,Loretta L. Sanchez,544
+Riverside,24077,U.S. Senate,,DEM,Kamala D. Harris,520
+Riverside,24077,U.S. Senate,,DEM,Loretta L. Sanchez,361
+Riverside,24078,U.S. Senate,,DEM,Kamala D. Harris,651
+Riverside,24078,U.S. Senate,,DEM,Loretta L. Sanchez,469
+Riverside,24079,U.S. Senate,,DEM,Kamala D. Harris,856
+Riverside,24079,U.S. Senate,,DEM,Loretta L. Sanchez,611
+Riverside,24082,U.S. Senate,,DEM,Kamala D. Harris,630
+Riverside,24082,U.S. Senate,,DEM,Loretta L. Sanchez,442
+Riverside,24083,U.S. Senate,,DEM,Kamala D. Harris,393
+Riverside,24083,U.S. Senate,,DEM,Loretta L. Sanchez,317
+Riverside,24085,U.S. Senate,,DEM,Kamala D. Harris,570
+Riverside,24085,U.S. Senate,,DEM,Loretta L. Sanchez,478
+Riverside,24086,U.S. Senate,,DEM,Kamala D. Harris,486
+Riverside,24086,U.S. Senate,,DEM,Loretta L. Sanchez,343
+Riverside,24090,U.S. Senate,,DEM,Kamala D. Harris,761
+Riverside,24090,U.S. Senate,,DEM,Loretta L. Sanchez,545
+Riverside,24092,U.S. Senate,,DEM,Kamala D. Harris,641
+Riverside,24092,U.S. Senate,,DEM,Loretta L. Sanchez,466
+Riverside,24093,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,24093,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,24108,U.S. Senate,,DEM,Kamala D. Harris,69
+Riverside,24108,U.S. Senate,,DEM,Loretta L. Sanchez,80
+Riverside,24804,U.S. Senate,,DEM,Kamala D. Harris,2
+Riverside,24804,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,24805,U.S. Senate,,DEM,Kamala D. Harris,12
+Riverside,24805,U.S. Senate,,DEM,Loretta L. Sanchez,13
+Riverside,24806,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,24806,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,24820,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,24820,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,24825,U.S. Senate,,DEM,Kamala D. Harris,320
+Riverside,24825,U.S. Senate,,DEM,Loretta L. Sanchez,269
+Riverside,24826,U.S. Senate,,DEM,Kamala D. Harris,93
+Riverside,24826,U.S. Senate,,DEM,Loretta L. Sanchez,93
+Riverside,24829,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,24829,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,24830,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,24830,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Riverside,24831,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,24831,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,24832,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,24832,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,24833,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,24833,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,24834,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,24834,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,24835,U.S. Senate,,DEM,Kamala D. Harris,3
+Riverside,24835,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Riverside,24836,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,24836,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,30000,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,30000,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,30002,U.S. Senate,,DEM,Kamala D. Harris,476
+Riverside,30002,U.S. Senate,,DEM,Loretta L. Sanchez,446
+Riverside,30004,U.S. Senate,,DEM,Kamala D. Harris,440
+Riverside,30004,U.S. Senate,,DEM,Loretta L. Sanchez,311
+Riverside,30008,U.S. Senate,,DEM,Kamala D. Harris,398
+Riverside,30008,U.S. Senate,,DEM,Loretta L. Sanchez,435
+Riverside,30009,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,30009,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,30020,U.S. Senate,,DEM,Kamala D. Harris,544
+Riverside,30020,U.S. Senate,,DEM,Loretta L. Sanchez,519
+Riverside,30023,U.S. Senate,,DEM,Kamala D. Harris,355
+Riverside,30023,U.S. Senate,,DEM,Loretta L. Sanchez,322
+Riverside,30025,U.S. Senate,,DEM,Kamala D. Harris,250
+Riverside,30025,U.S. Senate,,DEM,Loretta L. Sanchez,225
+Riverside,30030,U.S. Senate,,DEM,Kamala D. Harris,469
+Riverside,30030,U.S. Senate,,DEM,Loretta L. Sanchez,495
+Riverside,30034,U.S. Senate,,DEM,Kamala D. Harris,438
+Riverside,30034,U.S. Senate,,DEM,Loretta L. Sanchez,518
+Riverside,30036,U.S. Senate,,DEM,Kamala D. Harris,676
+Riverside,30036,U.S. Senate,,DEM,Loretta L. Sanchez,531
+Riverside,30042,U.S. Senate,,DEM,Kamala D. Harris,608
+Riverside,30042,U.S. Senate,,DEM,Loretta L. Sanchez,569
+Riverside,30045,U.S. Senate,,DEM,Kamala D. Harris,80
+Riverside,30045,U.S. Senate,,DEM,Loretta L. Sanchez,53
+Riverside,30048,U.S. Senate,,DEM,Kamala D. Harris,70
+Riverside,30048,U.S. Senate,,DEM,Loretta L. Sanchez,49
+Riverside,30051,U.S. Senate,,DEM,Kamala D. Harris,128
+Riverside,30051,U.S. Senate,,DEM,Loretta L. Sanchez,47
+Riverside,30057,U.S. Senate,,DEM,Kamala D. Harris,145
+Riverside,30057,U.S. Senate,,DEM,Loretta L. Sanchez,109
+Riverside,30060,U.S. Senate,,DEM,Kamala D. Harris,399
+Riverside,30060,U.S. Senate,,DEM,Loretta L. Sanchez,351
+Riverside,30062,U.S. Senate,,DEM,Kamala D. Harris,1
+Riverside,30062,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Riverside,30904,U.S. Senate,,DEM,Kamala D. Harris,172
+Riverside,30904,U.S. Senate,,DEM,Loretta L. Sanchez,141
+Riverside,30909,U.S. Senate,,DEM,Kamala D. Harris,5
+Riverside,30909,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Riverside,30910,U.S. Senate,,DEM,Kamala D. Harris,28
+Riverside,30910,U.S. Senate,,DEM,Loretta L. Sanchez,35
+Riverside,30913,U.S. Senate,,DEM,Kamala D. Harris,73
+Riverside,30913,U.S. Senate,,DEM,Loretta L. Sanchez,71
+Riverside,30920,U.S. Senate,,DEM,Kamala D. Harris,10
+Riverside,30920,U.S. Senate,,DEM,Loretta L. Sanchez,8
+Riverside,30922,U.S. Senate,,DEM,Kamala D. Harris,11
+Riverside,30922,U.S. Senate,,DEM,Loretta L. Sanchez,10
+Riverside,30924,U.S. Senate,,DEM,Kamala D. Harris,12
+Riverside,30924,U.S. Senate,,DEM,Loretta L. Sanchez,10
+Riverside,30925,U.S. Senate,,DEM,Kamala D. Harris,14
+Riverside,30925,U.S. Senate,,DEM,Loretta L. Sanchez,5
+Riverside,30927,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,30927,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,30928,U.S. Senate,,DEM,Kamala D. Harris,1
+Riverside,30928,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,30929,U.S. Senate,,DEM,Kamala D. Harris,1
+Riverside,30929,U.S. Senate,,DEM,Loretta L. Sanchez,6
+Riverside,30930,U.S. Senate,,DEM,Kamala D. Harris,5
+Riverside,30930,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Riverside,30931,U.S. Senate,,DEM,Kamala D. Harris,7
+Riverside,30931,U.S. Senate,,DEM,Loretta L. Sanchez,14
+Riverside,30935,U.S. Senate,,DEM,Kamala D. Harris,5
+Riverside,30935,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,30937,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,30937,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Riverside,30938,U.S. Senate,,DEM,Kamala D. Harris,4
+Riverside,30938,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,30940,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,30940,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,30941,U.S. Senate,,DEM,Kamala D. Harris,3
+Riverside,30941,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Riverside,30943,U.S. Senate,,DEM,Kamala D. Harris,148
+Riverside,30943,U.S. Senate,,DEM,Loretta L. Sanchez,96
+Riverside,30946,U.S. Senate,,DEM,Kamala D. Harris,2
+Riverside,30946,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Riverside,30947,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,30947,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Riverside,30948,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,30948,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,30949,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,30949,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Riverside,30951,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,30951,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,30952,U.S. Senate,,DEM,Kamala D. Harris,680
+Riverside,30952,U.S. Senate,,DEM,Loretta L. Sanchez,602
+Riverside,30955,U.S. Senate,,DEM,Kamala D. Harris,28
+Riverside,30955,U.S. Senate,,DEM,Loretta L. Sanchez,29
+Riverside,30956,U.S. Senate,,DEM,Kamala D. Harris,3
+Riverside,30956,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,30957,U.S. Senate,,DEM,Kamala D. Harris,191
+Riverside,30957,U.S. Senate,,DEM,Loretta L. Sanchez,186
+Riverside,30958,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,30958,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Riverside,30965,U.S. Senate,,DEM,Kamala D. Harris,9
+Riverside,30965,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Riverside,30968,U.S. Senate,,DEM,Kamala D. Harris,1
+Riverside,30968,U.S. Senate,,DEM,Loretta L. Sanchez,6
+Riverside,30972,U.S. Senate,,DEM,Kamala D. Harris,8
+Riverside,30972,U.S. Senate,,DEM,Loretta L. Sanchez,26
+Riverside,30977,U.S. Senate,,DEM,Kamala D. Harris,29
+Riverside,30977,U.S. Senate,,DEM,Loretta L. Sanchez,21
+Riverside,30979,U.S. Senate,,DEM,Kamala D. Harris,990
+Riverside,30979,U.S. Senate,,DEM,Loretta L. Sanchez,753
+Riverside,30984,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,30984,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,30985,U.S. Senate,,DEM,Kamala D. Harris,4
+Riverside,30985,U.S. Senate,,DEM,Loretta L. Sanchez,6
+Riverside,30986,U.S. Senate,,DEM,Kamala D. Harris,1
+Riverside,30986,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,30990,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,30990,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,30992,U.S. Senate,,DEM,Kamala D. Harris,283
+Riverside,30992,U.S. Senate,,DEM,Loretta L. Sanchez,221
+Riverside,30994,U.S. Senate,,DEM,Kamala D. Harris,332
+Riverside,30994,U.S. Senate,,DEM,Loretta L. Sanchez,270
+Riverside,30996,U.S. Senate,,DEM,Kamala D. Harris,733
+Riverside,30996,U.S. Senate,,DEM,Loretta L. Sanchez,510
+Riverside,31100,U.S. Senate,,DEM,Kamala D. Harris,829
+Riverside,31100,U.S. Senate,,DEM,Loretta L. Sanchez,559
+Riverside,31105,U.S. Senate,,DEM,Kamala D. Harris,51
+Riverside,31105,U.S. Senate,,DEM,Loretta L. Sanchez,36
+Riverside,31110,U.S. Senate,,DEM,Kamala D. Harris,441
+Riverside,31110,U.S. Senate,,DEM,Loretta L. Sanchez,421
+Riverside,31112,U.S. Senate,,DEM,Kamala D. Harris,39
+Riverside,31112,U.S. Senate,,DEM,Loretta L. Sanchez,24
+Riverside,31113,U.S. Senate,,DEM,Kamala D. Harris,796
+Riverside,31113,U.S. Senate,,DEM,Loretta L. Sanchez,612
+Riverside,31118,U.S. Senate,,DEM,Kamala D. Harris,8
+Riverside,31118,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Riverside,31200,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,31200,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,31201,U.S. Senate,,DEM,Kamala D. Harris,1190
+Riverside,31201,U.S. Senate,,DEM,Loretta L. Sanchez,741
+Riverside,31206,U.S. Senate,,DEM,Kamala D. Harris,262
+Riverside,31206,U.S. Senate,,DEM,Loretta L. Sanchez,275
+Riverside,31208,U.S. Senate,,DEM,Kamala D. Harris,1147
+Riverside,31208,U.S. Senate,,DEM,Loretta L. Sanchez,771
+Riverside,31212,U.S. Senate,,DEM,Kamala D. Harris,233
+Riverside,31212,U.S. Senate,,DEM,Loretta L. Sanchez,230
+Riverside,31300,U.S. Senate,,DEM,Kamala D. Harris,306
+Riverside,31300,U.S. Senate,,DEM,Loretta L. Sanchez,302
+Riverside,31302,U.S. Senate,,DEM,Kamala D. Harris,1003
+Riverside,31302,U.S. Senate,,DEM,Loretta L. Sanchez,545
+Riverside,31305,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,31305,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,31307,U.S. Senate,,DEM,Kamala D. Harris,682
+Riverside,31307,U.S. Senate,,DEM,Loretta L. Sanchez,480
+Riverside,31313,U.S. Senate,,DEM,Kamala D. Harris,935
+Riverside,31313,U.S. Senate,,DEM,Loretta L. Sanchez,580
+Riverside,31400,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,31400,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Riverside,31405,U.S. Senate,,DEM,Kamala D. Harris,813
+Riverside,31405,U.S. Senate,,DEM,Loretta L. Sanchez,587
+Riverside,31407,U.S. Senate,,DEM,Kamala D. Harris,586
+Riverside,31407,U.S. Senate,,DEM,Loretta L. Sanchez,463
+Riverside,31408,U.S. Senate,,DEM,Kamala D. Harris,197
+Riverside,31408,U.S. Senate,,DEM,Loretta L. Sanchez,115
+Riverside,31413,U.S. Senate,,DEM,Kamala D. Harris,1162
+Riverside,31413,U.S. Senate,,DEM,Loretta L. Sanchez,854
+Riverside,31500,U.S. Senate,,DEM,Kamala D. Harris,609
+Riverside,31500,U.S. Senate,,DEM,Loretta L. Sanchez,405
+Riverside,31505,U.S. Senate,,DEM,Kamala D. Harris,132
+Riverside,31505,U.S. Senate,,DEM,Loretta L. Sanchez,82
+Riverside,31506,U.S. Senate,,DEM,Kamala D. Harris,515
+Riverside,31506,U.S. Senate,,DEM,Loretta L. Sanchez,378
+Riverside,31511,U.S. Senate,,DEM,Kamala D. Harris,371
+Riverside,31511,U.S. Senate,,DEM,Loretta L. Sanchez,378
+Riverside,31520,U.S. Senate,,DEM,Kamala D. Harris,405
+Riverside,31520,U.S. Senate,,DEM,Loretta L. Sanchez,272
+Riverside,31846,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,31846,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,31847,U.S. Senate,,DEM,Kamala D. Harris,1
+Riverside,31847,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Riverside,31850,U.S. Senate,,DEM,Kamala D. Harris,20
+Riverside,31850,U.S. Senate,,DEM,Loretta L. Sanchez,10
+Riverside,31853,U.S. Senate,,DEM,Kamala D. Harris,26
+Riverside,31853,U.S. Senate,,DEM,Loretta L. Sanchez,6
+Riverside,32003,U.S. Senate,,DEM,Kamala D. Harris,693
+Riverside,32003,U.S. Senate,,DEM,Loretta L. Sanchez,586
+Riverside,32007,U.S. Senate,,DEM,Kamala D. Harris,675
+Riverside,32007,U.S. Senate,,DEM,Loretta L. Sanchez,578
+Riverside,32009,U.S. Senate,,DEM,Kamala D. Harris,599
+Riverside,32009,U.S. Senate,,DEM,Loretta L. Sanchez,500
+Riverside,32011,U.S. Senate,,DEM,Kamala D. Harris,559
+Riverside,32011,U.S. Senate,,DEM,Loretta L. Sanchez,441
+Riverside,32017,U.S. Senate,,DEM,Kamala D. Harris,727
+Riverside,32017,U.S. Senate,,DEM,Loretta L. Sanchez,566
+Riverside,32021,U.S. Senate,,DEM,Kamala D. Harris,403
+Riverside,32021,U.S. Senate,,DEM,Loretta L. Sanchez,382
+Riverside,32022,U.S. Senate,,DEM,Kamala D. Harris,147
+Riverside,32022,U.S. Senate,,DEM,Loretta L. Sanchez,127
+Riverside,32049,U.S. Senate,,DEM,Kamala D. Harris,5
+Riverside,32049,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Riverside,32052,U.S. Senate,,DEM,Kamala D. Harris,420
+Riverside,32052,U.S. Senate,,DEM,Loretta L. Sanchez,338
+Riverside,32061,U.S. Senate,,DEM,Kamala D. Harris,684
+Riverside,32061,U.S. Senate,,DEM,Loretta L. Sanchez,526
+Riverside,32062,U.S. Senate,,DEM,Kamala D. Harris,680
+Riverside,32062,U.S. Senate,,DEM,Loretta L. Sanchez,517
+Riverside,32068,U.S. Senate,,DEM,Kamala D. Harris,638
+Riverside,32068,U.S. Senate,,DEM,Loretta L. Sanchez,474
+Riverside,32072,U.S. Senate,,DEM,Kamala D. Harris,714
+Riverside,32072,U.S. Senate,,DEM,Loretta L. Sanchez,559
+Riverside,32073,U.S. Senate,,DEM,Kamala D. Harris,994
+Riverside,32073,U.S. Senate,,DEM,Loretta L. Sanchez,663
+Riverside,32076,U.S. Senate,,DEM,Kamala D. Harris,497
+Riverside,32076,U.S. Senate,,DEM,Loretta L. Sanchez,351
+Riverside,32078,U.S. Senate,,DEM,Kamala D. Harris,346
+Riverside,32078,U.S. Senate,,DEM,Loretta L. Sanchez,342
+Riverside,32079,U.S. Senate,,DEM,Kamala D. Harris,554
+Riverside,32079,U.S. Senate,,DEM,Loretta L. Sanchez,462
+Riverside,32083,U.S. Senate,,DEM,Kamala D. Harris,602
+Riverside,32083,U.S. Senate,,DEM,Loretta L. Sanchez,494
+Riverside,32087,U.S. Senate,,DEM,Kamala D. Harris,577
+Riverside,32087,U.S. Senate,,DEM,Loretta L. Sanchez,451
+Riverside,32090,U.S. Senate,,DEM,Kamala D. Harris,386
+Riverside,32090,U.S. Senate,,DEM,Loretta L. Sanchez,332
+Riverside,32099,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,32099,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,32102,U.S. Senate,,DEM,Kamala D. Harris,516
+Riverside,32102,U.S. Senate,,DEM,Loretta L. Sanchez,499
+Riverside,32105,U.S. Senate,,DEM,Kamala D. Harris,526
+Riverside,32105,U.S. Senate,,DEM,Loretta L. Sanchez,437
+Riverside,32107,U.S. Senate,,DEM,Kamala D. Harris,394
+Riverside,32107,U.S. Senate,,DEM,Loretta L. Sanchez,380
+Riverside,32111,U.S. Senate,,DEM,Kamala D. Harris,723
+Riverside,32111,U.S. Senate,,DEM,Loretta L. Sanchez,544
+Riverside,32114,U.S. Senate,,DEM,Kamala D. Harris,772
+Riverside,32114,U.S. Senate,,DEM,Loretta L. Sanchez,663
+Riverside,32118,U.S. Senate,,DEM,Kamala D. Harris,752
+Riverside,32118,U.S. Senate,,DEM,Loretta L. Sanchez,526
+Riverside,32121,U.S. Senate,,DEM,Kamala D. Harris,857
+Riverside,32121,U.S. Senate,,DEM,Loretta L. Sanchez,651
+Riverside,32123,U.S. Senate,,DEM,Kamala D. Harris,662
+Riverside,32123,U.S. Senate,,DEM,Loretta L. Sanchez,533
+Riverside,32126,U.S. Senate,,DEM,Kamala D. Harris,462
+Riverside,32126,U.S. Senate,,DEM,Loretta L. Sanchez,361
+Riverside,32127,U.S. Senate,,DEM,Kamala D. Harris,791
+Riverside,32127,U.S. Senate,,DEM,Loretta L. Sanchez,637
+Riverside,32900,U.S. Senate,,DEM,Kamala D. Harris,3
+Riverside,32900,U.S. Senate,,DEM,Loretta L. Sanchez,5
+Riverside,32904,U.S. Senate,,DEM,Kamala D. Harris,158
+Riverside,32904,U.S. Senate,,DEM,Loretta L. Sanchez,236
+Riverside,33001,U.S. Senate,,DEM,Kamala D. Harris,211
+Riverside,33001,U.S. Senate,,DEM,Loretta L. Sanchez,202
+Riverside,33012,U.S. Senate,,DEM,Kamala D. Harris,692
+Riverside,33012,U.S. Senate,,DEM,Loretta L. Sanchez,429
+Riverside,33013,U.S. Senate,,DEM,Kamala D. Harris,1010
+Riverside,33013,U.S. Senate,,DEM,Loretta L. Sanchez,719
+Riverside,33023,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,33023,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,33024,U.S. Senate,,DEM,Kamala D. Harris,720
+Riverside,33024,U.S. Senate,,DEM,Loretta L. Sanchez,596
+Riverside,33027,U.S. Senate,,DEM,Kamala D. Harris,905
+Riverside,33027,U.S. Senate,,DEM,Loretta L. Sanchez,672
+Riverside,33028,U.S. Senate,,DEM,Kamala D. Harris,327
+Riverside,33028,U.S. Senate,,DEM,Loretta L. Sanchez,276
+Riverside,33029,U.S. Senate,,DEM,Kamala D. Harris,139
+Riverside,33029,U.S. Senate,,DEM,Loretta L. Sanchez,79
+Riverside,33032,U.S. Senate,,DEM,Kamala D. Harris,417
+Riverside,33032,U.S. Senate,,DEM,Loretta L. Sanchez,342
+Riverside,33036,U.S. Senate,,DEM,Kamala D. Harris,535
+Riverside,33036,U.S. Senate,,DEM,Loretta L. Sanchez,446
+Riverside,33038,U.S. Senate,,DEM,Kamala D. Harris,923
+Riverside,33038,U.S. Senate,,DEM,Loretta L. Sanchez,601
+Riverside,33040,U.S. Senate,,DEM,Kamala D. Harris,494
+Riverside,33040,U.S. Senate,,DEM,Loretta L. Sanchez,407
+Riverside,33044,U.S. Senate,,DEM,Kamala D. Harris,869
+Riverside,33044,U.S. Senate,,DEM,Loretta L. Sanchez,747
+Riverside,33045,U.S. Senate,,DEM,Kamala D. Harris,541
+Riverside,33045,U.S. Senate,,DEM,Loretta L. Sanchez,436
+Riverside,33049,U.S. Senate,,DEM,Kamala D. Harris,604
+Riverside,33049,U.S. Senate,,DEM,Loretta L. Sanchez,458
+Riverside,33054,U.S. Senate,,DEM,Kamala D. Harris,531
+Riverside,33054,U.S. Senate,,DEM,Loretta L. Sanchez,363
+Riverside,33058,U.S. Senate,,DEM,Kamala D. Harris,682
+Riverside,33058,U.S. Senate,,DEM,Loretta L. Sanchez,552
+Riverside,33059,U.S. Senate,,DEM,Kamala D. Harris,962
+Riverside,33059,U.S. Senate,,DEM,Loretta L. Sanchez,656
+Riverside,33061,U.S. Senate,,DEM,Kamala D. Harris,433
+Riverside,33061,U.S. Senate,,DEM,Loretta L. Sanchez,303
+Riverside,33062,U.S. Senate,,DEM,Kamala D. Harris,682
+Riverside,33062,U.S. Senate,,DEM,Loretta L. Sanchez,471
+Riverside,33067,U.S. Senate,,DEM,Kamala D. Harris,810
+Riverside,33067,U.S. Senate,,DEM,Loretta L. Sanchez,664
+Riverside,33069,U.S. Senate,,DEM,Kamala D. Harris,729
+Riverside,33069,U.S. Senate,,DEM,Loretta L. Sanchez,664
+Riverside,33073,U.S. Senate,,DEM,Kamala D. Harris,457
+Riverside,33073,U.S. Senate,,DEM,Loretta L. Sanchez,287
+Riverside,33077,U.S. Senate,,DEM,Kamala D. Harris,622
+Riverside,33077,U.S. Senate,,DEM,Loretta L. Sanchez,438
+Riverside,33078,U.S. Senate,,DEM,Kamala D. Harris,723
+Riverside,33078,U.S. Senate,,DEM,Loretta L. Sanchez,483
+Riverside,33082,U.S. Senate,,DEM,Kamala D. Harris,415
+Riverside,33082,U.S. Senate,,DEM,Loretta L. Sanchez,370
+Riverside,33083,U.S. Senate,,DEM,Kamala D. Harris,433
+Riverside,33083,U.S. Senate,,DEM,Loretta L. Sanchez,296
+Riverside,33087,U.S. Senate,,DEM,Kamala D. Harris,384
+Riverside,33087,U.S. Senate,,DEM,Loretta L. Sanchez,313
+Riverside,33090,U.S. Senate,,DEM,Kamala D. Harris,592
+Riverside,33090,U.S. Senate,,DEM,Loretta L. Sanchez,522
+Riverside,33092,U.S. Senate,,DEM,Kamala D. Harris,1016
+Riverside,33092,U.S. Senate,,DEM,Loretta L. Sanchez,709
+Riverside,33097,U.S. Senate,,DEM,Kamala D. Harris,558
+Riverside,33097,U.S. Senate,,DEM,Loretta L. Sanchez,466
+Riverside,33099,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,33099,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,35600,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,35600,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,35605,U.S. Senate,,DEM,Kamala D. Harris,111
+Riverside,35605,U.S. Senate,,DEM,Loretta L. Sanchez,71
+Riverside,35607,U.S. Senate,,DEM,Kamala D. Harris,78
+Riverside,35607,U.S. Senate,,DEM,Loretta L. Sanchez,70
+Riverside,35609,U.S. Senate,,DEM,Kamala D. Harris,256
+Riverside,35609,U.S. Senate,,DEM,Loretta L. Sanchez,252
+Riverside,35612,U.S. Senate,,DEM,Kamala D. Harris,21
+Riverside,35612,U.S. Senate,,DEM,Loretta L. Sanchez,24
+Riverside,35616,U.S. Senate,,DEM,Kamala D. Harris,1
+Riverside,35616,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Riverside,35617,U.S. Senate,,DEM,Kamala D. Harris,12
+Riverside,35617,U.S. Senate,,DEM,Loretta L. Sanchez,7
+Riverside,35618,U.S. Senate,,DEM,Kamala D. Harris,11
+Riverside,35618,U.S. Senate,,DEM,Loretta L. Sanchez,12
+Riverside,35619,U.S. Senate,,DEM,Kamala D. Harris,472
+Riverside,35619,U.S. Senate,,DEM,Loretta L. Sanchez,328
+Riverside,35620,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,35620,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,35622,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,35622,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,35625,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,35625,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,35626,U.S. Senate,,DEM,Kamala D. Harris,8
+Riverside,35626,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Riverside,35632,U.S. Senate,,DEM,Kamala D. Harris,731
+Riverside,35632,U.S. Senate,,DEM,Loretta L. Sanchez,533
+Riverside,36802,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,36802,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,36803,U.S. Senate,,DEM,Kamala D. Harris,24
+Riverside,36803,U.S. Senate,,DEM,Loretta L. Sanchez,25
+Riverside,36807,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,36807,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,36808,U.S. Senate,,DEM,Kamala D. Harris,18
+Riverside,36808,U.S. Senate,,DEM,Loretta L. Sanchez,19
+Riverside,36850,U.S. Senate,,DEM,Kamala D. Harris,49
+Riverside,36850,U.S. Senate,,DEM,Loretta L. Sanchez,41
+Riverside,36851,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,36851,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,36852,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,36852,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,36931,U.S. Senate,,DEM,Kamala D. Harris,62
+Riverside,36931,U.S. Senate,,DEM,Loretta L. Sanchez,74
+Riverside,36932,U.S. Senate,,DEM,Kamala D. Harris,1
+Riverside,36932,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,36933,U.S. Senate,,DEM,Kamala D. Harris,1
+Riverside,36933,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,37609,U.S. Senate,,DEM,Kamala D. Harris,1
+Riverside,37609,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Riverside,37610,U.S. Senate,,DEM,Kamala D. Harris,44
+Riverside,37610,U.S. Senate,,DEM,Loretta L. Sanchez,47
+Riverside,37612,U.S. Senate,,DEM,Kamala D. Harris,112
+Riverside,37612,U.S. Senate,,DEM,Loretta L. Sanchez,136
+Riverside,37621,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,37621,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,37622,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,37622,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,37623,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,37623,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,37624,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,37624,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,37625,U.S. Senate,,DEM,Kamala D. Harris,244
+Riverside,37625,U.S. Senate,,DEM,Loretta L. Sanchez,269
+Riverside,37626,U.S. Senate,,DEM,Kamala D. Harris,3
+Riverside,37626,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,37627,U.S. Senate,,DEM,Kamala D. Harris,9
+Riverside,37627,U.S. Senate,,DEM,Loretta L. Sanchez,9
+Riverside,37630,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,37630,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,37631,U.S. Senate,,DEM,Kamala D. Harris,11
+Riverside,37631,U.S. Senate,,DEM,Loretta L. Sanchez,8
+Riverside,37632,U.S. Senate,,DEM,Kamala D. Harris,389
+Riverside,37632,U.S. Senate,,DEM,Loretta L. Sanchez,358
+Riverside,37634,U.S. Senate,,DEM,Kamala D. Harris,71
+Riverside,37634,U.S. Senate,,DEM,Loretta L. Sanchez,30
+Riverside,37638,U.S. Senate,,DEM,Kamala D. Harris,43
+Riverside,37638,U.S. Senate,,DEM,Loretta L. Sanchez,40
+Riverside,37640,U.S. Senate,,DEM,Kamala D. Harris,7
+Riverside,37640,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Riverside,37651,U.S. Senate,,DEM,Kamala D. Harris,212
+Riverside,37651,U.S. Senate,,DEM,Loretta L. Sanchez,267
+Riverside,37654,U.S. Senate,,DEM,Kamala D. Harris,713
+Riverside,37654,U.S. Senate,,DEM,Loretta L. Sanchez,626
+Riverside,37659,U.S. Senate,,DEM,Kamala D. Harris,3
+Riverside,37659,U.S. Senate,,DEM,Loretta L. Sanchez,5
+Riverside,37660,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,37660,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,37664,U.S. Senate,,DEM,Kamala D. Harris,291
+Riverside,37664,U.S. Senate,,DEM,Loretta L. Sanchez,202
+Riverside,37665,U.S. Senate,,DEM,Kamala D. Harris,43
+Riverside,37665,U.S. Senate,,DEM,Loretta L. Sanchez,17
+Riverside,37666,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,37666,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,37671,U.S. Senate,,DEM,Kamala D. Harris,671
+Riverside,37671,U.S. Senate,,DEM,Loretta L. Sanchez,569
+Riverside,37672,U.S. Senate,,DEM,Kamala D. Harris,631
+Riverside,37672,U.S. Senate,,DEM,Loretta L. Sanchez,518
+Riverside,37684,U.S. Senate,,DEM,Kamala D. Harris,17
+Riverside,37684,U.S. Senate,,DEM,Loretta L. Sanchez,12
+Riverside,37685,U.S. Senate,,DEM,Kamala D. Harris,677
+Riverside,37685,U.S. Senate,,DEM,Loretta L. Sanchez,563
+Riverside,37689,U.S. Senate,,DEM,Kamala D. Harris,931
+Riverside,37689,U.S. Senate,,DEM,Loretta L. Sanchez,817
+Riverside,37691,U.S. Senate,,DEM,Kamala D. Harris,18
+Riverside,37691,U.S. Senate,,DEM,Loretta L. Sanchez,24
+Riverside,37701,U.S. Senate,,DEM,Kamala D. Harris,564
+Riverside,37701,U.S. Senate,,DEM,Loretta L. Sanchez,507
+Riverside,37704,U.S. Senate,,DEM,Kamala D. Harris,374
+Riverside,37704,U.S. Senate,,DEM,Loretta L. Sanchez,350
+Riverside,37709,U.S. Senate,,DEM,Kamala D. Harris,806
+Riverside,37709,U.S. Senate,,DEM,Loretta L. Sanchez,736
+Riverside,37712,U.S. Senate,,DEM,Kamala D. Harris,552
+Riverside,37712,U.S. Senate,,DEM,Loretta L. Sanchez,548
+Riverside,37717,U.S. Senate,,DEM,Kamala D. Harris,120
+Riverside,37717,U.S. Senate,,DEM,Loretta L. Sanchez,94
+Riverside,37718,U.S. Senate,,DEM,Kamala D. Harris,6
+Riverside,37718,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Riverside,37720,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,37720,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,37722,U.S. Senate,,DEM,Kamala D. Harris,66
+Riverside,37722,U.S. Senate,,DEM,Loretta L. Sanchez,40
+Riverside,37723,U.S. Senate,,DEM,Kamala D. Harris,107
+Riverside,37723,U.S. Senate,,DEM,Loretta L. Sanchez,111
+Riverside,37724,U.S. Senate,,DEM,Kamala D. Harris,696
+Riverside,37724,U.S. Senate,,DEM,Loretta L. Sanchez,504
+Riverside,37725,U.S. Senate,,DEM,Kamala D. Harris,323
+Riverside,37725,U.S. Senate,,DEM,Loretta L. Sanchez,271
+Riverside,37726,U.S. Senate,,DEM,Kamala D. Harris,765
+Riverside,37726,U.S. Senate,,DEM,Loretta L. Sanchez,659
+Riverside,37733,U.S. Senate,,DEM,Kamala D. Harris,52
+Riverside,37733,U.S. Senate,,DEM,Loretta L. Sanchez,60
+Riverside,37735,U.S. Senate,,DEM,Kamala D. Harris,338
+Riverside,37735,U.S. Senate,,DEM,Loretta L. Sanchez,279
+Riverside,37745,U.S. Senate,,DEM,Kamala D. Harris,16
+Riverside,37745,U.S. Senate,,DEM,Loretta L. Sanchez,13
+Riverside,37748,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,37748,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,37749,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,37749,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,37750,U.S. Senate,,DEM,Kamala D. Harris,55
+Riverside,37750,U.S. Senate,,DEM,Loretta L. Sanchez,37
+Riverside,37753,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,37753,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Riverside,37755,U.S. Senate,,DEM,Kamala D. Harris,1
+Riverside,37755,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,37758,U.S. Senate,,DEM,Kamala D. Harris,33
+Riverside,37758,U.S. Senate,,DEM,Loretta L. Sanchez,31
+Riverside,37763,U.S. Senate,,DEM,Kamala D. Harris,3
+Riverside,37763,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Riverside,37767,U.S. Senate,,DEM,Kamala D. Harris,45
+Riverside,37767,U.S. Senate,,DEM,Loretta L. Sanchez,33
+Riverside,37768,U.S. Senate,,DEM,Kamala D. Harris,1
+Riverside,37768,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Riverside,37801,U.S. Senate,,DEM,Kamala D. Harris,10
+Riverside,37801,U.S. Senate,,DEM,Loretta L. Sanchez,11
+Riverside,37802,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,37802,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,37803,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,37803,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,37804,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,37804,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,37807,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,37807,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,37811,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,37811,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,37813,U.S. Senate,,DEM,Kamala D. Harris,17
+Riverside,37813,U.S. Senate,,DEM,Loretta L. Sanchez,5
+Riverside,37820,U.S. Senate,,DEM,Kamala D. Harris,3
+Riverside,37820,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,37825,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,37825,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,37831,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,37831,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,37833,U.S. Senate,,DEM,Kamala D. Harris,15
+Riverside,37833,U.S. Senate,,DEM,Loretta L. Sanchez,15
+Riverside,37850,U.S. Senate,,DEM,Kamala D. Harris,2
+Riverside,37850,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,37853,U.S. Senate,,DEM,Kamala D. Harris,33
+Riverside,37853,U.S. Senate,,DEM,Loretta L. Sanchez,17
+Riverside,37856,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,37856,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,37857,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,37857,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,37858,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,37858,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,37880,U.S. Senate,,DEM,Kamala D. Harris,240
+Riverside,37880,U.S. Senate,,DEM,Loretta L. Sanchez,155
+Riverside,37882,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,37882,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,37884,U.S. Senate,,DEM,Kamala D. Harris,8
+Riverside,37884,U.S. Senate,,DEM,Loretta L. Sanchez,5
+Riverside,37890,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,37890,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,37896,U.S. Senate,,DEM,Kamala D. Harris,819
+Riverside,37896,U.S. Senate,,DEM,Loretta L. Sanchez,413
+Riverside,37901,U.S. Senate,,DEM,Kamala D. Harris,34
+Riverside,37901,U.S. Senate,,DEM,Loretta L. Sanchez,24
+Riverside,37919,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,37919,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,37923,U.S. Senate,,DEM,Kamala D. Harris,51
+Riverside,37923,U.S. Senate,,DEM,Loretta L. Sanchez,59
+Riverside,37925,U.S. Senate,,DEM,Kamala D. Harris,7
+Riverside,37925,U.S. Senate,,DEM,Loretta L. Sanchez,9
+Riverside,37927,U.S. Senate,,DEM,Kamala D. Harris,294
+Riverside,37927,U.S. Senate,,DEM,Loretta L. Sanchez,227
+Riverside,37931,U.S. Senate,,DEM,Kamala D. Harris,8
+Riverside,37931,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Riverside,37937,U.S. Senate,,DEM,Kamala D. Harris,22
+Riverside,37937,U.S. Senate,,DEM,Loretta L. Sanchez,27
+Riverside,37939,U.S. Senate,,DEM,Kamala D. Harris,38
+Riverside,37939,U.S. Senate,,DEM,Loretta L. Sanchez,35
+Riverside,37942,U.S. Senate,,DEM,Kamala D. Harris,58
+Riverside,37942,U.S. Senate,,DEM,Loretta L. Sanchez,55
+Riverside,37944,U.S. Senate,,DEM,Kamala D. Harris,119
+Riverside,37944,U.S. Senate,,DEM,Loretta L. Sanchez,75
+Riverside,37948,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,37948,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Riverside,37953,U.S. Senate,,DEM,Kamala D. Harris,35
+Riverside,37953,U.S. Senate,,DEM,Loretta L. Sanchez,28
+Riverside,37955,U.S. Senate,,DEM,Kamala D. Harris,82
+Riverside,37955,U.S. Senate,,DEM,Loretta L. Sanchez,32
+Riverside,37956,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,37956,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Riverside,37957,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,37957,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,37960,U.S. Senate,,DEM,Kamala D. Harris,201
+Riverside,37960,U.S. Senate,,DEM,Loretta L. Sanchez,192
+Riverside,37971,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,37971,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,37973,U.S. Senate,,DEM,Kamala D. Harris,116
+Riverside,37973,U.S. Senate,,DEM,Loretta L. Sanchez,94
+Riverside,37974,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,37974,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,37981,U.S. Senate,,DEM,Kamala D. Harris,1
+Riverside,37981,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,37982,U.S. Senate,,DEM,Kamala D. Harris,711
+Riverside,37982,U.S. Senate,,DEM,Loretta L. Sanchez,586
+Riverside,37990,U.S. Senate,,DEM,Kamala D. Harris,11
+Riverside,37990,U.S. Senate,,DEM,Loretta L. Sanchez,5
+Riverside,37997,U.S. Senate,,DEM,Kamala D. Harris,124
+Riverside,37997,U.S. Senate,,DEM,Loretta L. Sanchez,66
+Riverside,38603,U.S. Senate,,DEM,Kamala D. Harris,5
+Riverside,38603,U.S. Senate,,DEM,Loretta L. Sanchez,8
+Riverside,38901,U.S. Senate,,DEM,Kamala D. Harris,24
+Riverside,38901,U.S. Senate,,DEM,Loretta L. Sanchez,21
+Riverside,38902,U.S. Senate,,DEM,Kamala D. Harris,86
+Riverside,38902,U.S. Senate,,DEM,Loretta L. Sanchez,86
+Riverside,38905,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,38905,U.S. Senate,,DEM,Loretta L. Sanchez,14
+Riverside,38915,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,38915,U.S. Senate,,DEM,Loretta L. Sanchez,6
+Riverside,39823,U.S. Senate,,DEM,Kamala D. Harris,51
+Riverside,39823,U.S. Senate,,DEM,Loretta L. Sanchez,26
+Riverside,39827,U.S. Senate,,DEM,Kamala D. Harris,129
+Riverside,39827,U.S. Senate,,DEM,Loretta L. Sanchez,58
+Riverside,39900,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,39900,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,40000,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,40000,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,40004,U.S. Senate,,DEM,Kamala D. Harris,781
+Riverside,40004,U.S. Senate,,DEM,Loretta L. Sanchez,655
+Riverside,40007,U.S. Senate,,DEM,Kamala D. Harris,698
+Riverside,40007,U.S. Senate,,DEM,Loretta L. Sanchez,668
+Riverside,40014,U.S. Senate,,DEM,Kamala D. Harris,599
+Riverside,40014,U.S. Senate,,DEM,Loretta L. Sanchez,557
+Riverside,40017,U.S. Senate,,DEM,Kamala D. Harris,702
+Riverside,40017,U.S. Senate,,DEM,Loretta L. Sanchez,1013
+Riverside,40022,U.S. Senate,,DEM,Kamala D. Harris,6
+Riverside,40022,U.S. Senate,,DEM,Loretta L. Sanchez,8
+Riverside,40023,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,40023,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,40831,U.S. Senate,,DEM,Kamala D. Harris,204
+Riverside,40831,U.S. Senate,,DEM,Loretta L. Sanchez,478
+Riverside,40836,U.S. Senate,,DEM,Kamala D. Harris,145
+Riverside,40836,U.S. Senate,,DEM,Loretta L. Sanchez,150
+Riverside,40842,U.S. Senate,,DEM,Kamala D. Harris,27
+Riverside,40842,U.S. Senate,,DEM,Loretta L. Sanchez,28
+Riverside,40843,U.S. Senate,,DEM,Kamala D. Harris,1
+Riverside,40843,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Riverside,40862,U.S. Senate,,DEM,Kamala D. Harris,99
+Riverside,40862,U.S. Senate,,DEM,Loretta L. Sanchez,150
+Riverside,40870,U.S. Senate,,DEM,Kamala D. Harris,3
+Riverside,40870,U.S. Senate,,DEM,Loretta L. Sanchez,5
+Riverside,40880,U.S. Senate,,DEM,Kamala D. Harris,16
+Riverside,40880,U.S. Senate,,DEM,Loretta L. Sanchez,10
+Riverside,41000,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,41000,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,41002,U.S. Senate,,DEM,Kamala D. Harris,1
+Riverside,41002,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Riverside,41005,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,41005,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,41008,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,41008,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,41011,U.S. Senate,,DEM,Kamala D. Harris,1036
+Riverside,41011,U.S. Senate,,DEM,Loretta L. Sanchez,546
+Riverside,41020,U.S. Senate,,DEM,Kamala D. Harris,994
+Riverside,41020,U.S. Senate,,DEM,Loretta L. Sanchez,369
+Riverside,41021,U.S. Senate,,DEM,Kamala D. Harris,867
+Riverside,41021,U.S. Senate,,DEM,Loretta L. Sanchez,308
+Riverside,41024,U.S. Senate,,DEM,Kamala D. Harris,1268
+Riverside,41024,U.S. Senate,,DEM,Loretta L. Sanchez,420
+Riverside,41027,U.S. Senate,,DEM,Kamala D. Harris,268
+Riverside,41027,U.S. Senate,,DEM,Loretta L. Sanchez,89
+Riverside,41031,U.S. Senate,,DEM,Kamala D. Harris,1455
+Riverside,41031,U.S. Senate,,DEM,Loretta L. Sanchez,552
+Riverside,41037,U.S. Senate,,DEM,Kamala D. Harris,1527
+Riverside,41037,U.S. Senate,,DEM,Loretta L. Sanchez,701
+Riverside,41038,U.S. Senate,,DEM,Kamala D. Harris,2000
+Riverside,41038,U.S. Senate,,DEM,Loretta L. Sanchez,650
+Riverside,41045,U.S. Senate,,DEM,Kamala D. Harris,1305
+Riverside,41045,U.S. Senate,,DEM,Loretta L. Sanchez,462
+Riverside,41047,U.S. Senate,,DEM,Kamala D. Harris,1438
+Riverside,41047,U.S. Senate,,DEM,Loretta L. Sanchez,407
+Riverside,41054,U.S. Senate,,DEM,Kamala D. Harris,2
+Riverside,41054,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,41061,U.S. Senate,,DEM,Kamala D. Harris,746
+Riverside,41061,U.S. Senate,,DEM,Loretta L. Sanchez,351
+Riverside,41063,U.S. Senate,,DEM,Kamala D. Harris,8
+Riverside,41063,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Riverside,42000,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,42000,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,42006,U.S. Senate,,DEM,Kamala D. Harris,725
+Riverside,42006,U.S. Senate,,DEM,Loretta L. Sanchez,536
+Riverside,42009,U.S. Senate,,DEM,Kamala D. Harris,642
+Riverside,42009,U.S. Senate,,DEM,Loretta L. Sanchez,667
+Riverside,42011,U.S. Senate,,DEM,Kamala D. Harris,499
+Riverside,42011,U.S. Senate,,DEM,Loretta L. Sanchez,490
+Riverside,42014,U.S. Senate,,DEM,Kamala D. Harris,560
+Riverside,42014,U.S. Senate,,DEM,Loretta L. Sanchez,732
+Riverside,42015,U.S. Senate,,DEM,Kamala D. Harris,492
+Riverside,42015,U.S. Senate,,DEM,Loretta L. Sanchez,622
+Riverside,42019,U.S. Senate,,DEM,Kamala D. Harris,372
+Riverside,42019,U.S. Senate,,DEM,Loretta L. Sanchez,412
+Riverside,42022,U.S. Senate,,DEM,Kamala D. Harris,405
+Riverside,42022,U.S. Senate,,DEM,Loretta L. Sanchez,936
+Riverside,42024,U.S. Senate,,DEM,Kamala D. Harris,692
+Riverside,42024,U.S. Senate,,DEM,Loretta L. Sanchez,559
+Riverside,42029,U.S. Senate,,DEM,Kamala D. Harris,597
+Riverside,42029,U.S. Senate,,DEM,Loretta L. Sanchez,210
+Riverside,42030,U.S. Senate,,DEM,Kamala D. Harris,868
+Riverside,42030,U.S. Senate,,DEM,Loretta L. Sanchez,411
+Riverside,42040,U.S. Senate,,DEM,Kamala D. Harris,762
+Riverside,42040,U.S. Senate,,DEM,Loretta L. Sanchez,377
+Riverside,42047,U.S. Senate,,DEM,Kamala D. Harris,73
+Riverside,42047,U.S. Senate,,DEM,Loretta L. Sanchez,46
+Riverside,42048,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,42048,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,42801,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,42801,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,42802,U.S. Senate,,DEM,Kamala D. Harris,296
+Riverside,42802,U.S. Senate,,DEM,Loretta L. Sanchez,540
+Riverside,42803,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,42803,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,42804,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,42804,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,42808,U.S. Senate,,DEM,Kamala D. Harris,554
+Riverside,42808,U.S. Senate,,DEM,Loretta L. Sanchez,438
+Riverside,42813,U.S. Senate,,DEM,Kamala D. Harris,1
+Riverside,42813,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,42821,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,42821,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,42851,U.S. Senate,,DEM,Kamala D. Harris,340
+Riverside,42851,U.S. Senate,,DEM,Loretta L. Sanchez,285
+Riverside,42861,U.S. Senate,,DEM,Kamala D. Harris,293
+Riverside,42861,U.S. Senate,,DEM,Loretta L. Sanchez,247
+Riverside,42863,U.S. Senate,,DEM,Kamala D. Harris,2
+Riverside,42863,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Riverside,42866,U.S. Senate,,DEM,Kamala D. Harris,86
+Riverside,42866,U.S. Senate,,DEM,Loretta L. Sanchez,68
+Riverside,42870,U.S. Senate,,DEM,Kamala D. Harris,562
+Riverside,42870,U.S. Senate,,DEM,Loretta L. Sanchez,356
+Riverside,42900,U.S. Senate,,DEM,Kamala D. Harris,1282
+Riverside,42900,U.S. Senate,,DEM,Loretta L. Sanchez,589
+Riverside,42904,U.S. Senate,,DEM,Kamala D. Harris,1183
+Riverside,42904,U.S. Senate,,DEM,Loretta L. Sanchez,575
+Riverside,42910,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,42910,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,42950,U.S. Senate,,DEM,Kamala D. Harris,51
+Riverside,42950,U.S. Senate,,DEM,Loretta L. Sanchez,16
+Riverside,42974,U.S. Senate,,DEM,Kamala D. Harris,1
+Riverside,42974,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,42976,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,42976,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,43001,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,43001,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,43003,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,43003,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,43006,U.S. Senate,,DEM,Kamala D. Harris,1144
+Riverside,43006,U.S. Senate,,DEM,Loretta L. Sanchez,527
+Riverside,43009,U.S. Senate,,DEM,Kamala D. Harris,218
+Riverside,43009,U.S. Senate,,DEM,Loretta L. Sanchez,105
+Riverside,43012,U.S. Senate,,DEM,Kamala D. Harris,1041
+Riverside,43012,U.S. Senate,,DEM,Loretta L. Sanchez,422
+Riverside,43018,U.S. Senate,,DEM,Kamala D. Harris,2
+Riverside,43018,U.S. Senate,,DEM,Loretta L. Sanchez,9
+Riverside,43026,U.S. Senate,,DEM,Kamala D. Harris,1431
+Riverside,43026,U.S. Senate,,DEM,Loretta L. Sanchez,645
+Riverside,43031,U.S. Senate,,DEM,Kamala D. Harris,716
+Riverside,43031,U.S. Senate,,DEM,Loretta L. Sanchez,353
+Riverside,43035,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,43035,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,44000,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,44000,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,44003,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,44003,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,44005,U.S. Senate,,DEM,Kamala D. Harris,644
+Riverside,44005,U.S. Senate,,DEM,Loretta L. Sanchez,413
+Riverside,44011,U.S. Senate,,DEM,Kamala D. Harris,938
+Riverside,44011,U.S. Senate,,DEM,Loretta L. Sanchez,438
+Riverside,44015,U.S. Senate,,DEM,Kamala D. Harris,963
+Riverside,44015,U.S. Senate,,DEM,Loretta L. Sanchez,615
+Riverside,44019,U.S. Senate,,DEM,Kamala D. Harris,747
+Riverside,44019,U.S. Senate,,DEM,Loretta L. Sanchez,397
+Riverside,44022,U.S. Senate,,DEM,Kamala D. Harris,1143
+Riverside,44022,U.S. Senate,,DEM,Loretta L. Sanchez,667
+Riverside,44024,U.S. Senate,,DEM,Kamala D. Harris,1129
+Riverside,44024,U.S. Senate,,DEM,Loretta L. Sanchez,725
+Riverside,44029,U.S. Senate,,DEM,Kamala D. Harris,521
+Riverside,44029,U.S. Senate,,DEM,Loretta L. Sanchez,448
+Riverside,44030,U.S. Senate,,DEM,Kamala D. Harris,678
+Riverside,44030,U.S. Senate,,DEM,Loretta L. Sanchez,499
+Riverside,44031,U.S. Senate,,DEM,Kamala D. Harris,887
+Riverside,44031,U.S. Senate,,DEM,Loretta L. Sanchez,436
+Riverside,44032,U.S. Senate,,DEM,Kamala D. Harris,162
+Riverside,44032,U.S. Senate,,DEM,Loretta L. Sanchez,106
+Riverside,44039,U.S. Senate,,DEM,Kamala D. Harris,967
+Riverside,44039,U.S. Senate,,DEM,Loretta L. Sanchez,534
+Riverside,44041,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,44041,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,44043,U.S. Senate,,DEM,Kamala D. Harris,756
+Riverside,44043,U.S. Senate,,DEM,Loretta L. Sanchez,364
+Riverside,44046,U.S. Senate,,DEM,Kamala D. Harris,670
+Riverside,44046,U.S. Senate,,DEM,Loretta L. Sanchez,361
+Riverside,44047,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,44047,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,44048,U.S. Senate,,DEM,Kamala D. Harris,11
+Riverside,44048,U.S. Senate,,DEM,Loretta L. Sanchez,17
+Riverside,44900,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,44900,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,45001,U.S. Senate,,DEM,Kamala D. Harris,152
+Riverside,45001,U.S. Senate,,DEM,Loretta L. Sanchez,87
+Riverside,45002,U.S. Senate,,DEM,Kamala D. Harris,25
+Riverside,45002,U.S. Senate,,DEM,Loretta L. Sanchez,15
+Riverside,45003,U.S. Senate,,DEM,Kamala D. Harris,16
+Riverside,45003,U.S. Senate,,DEM,Loretta L. Sanchez,6
+Riverside,45004,U.S. Senate,,DEM,Kamala D. Harris,859
+Riverside,45004,U.S. Senate,,DEM,Loretta L. Sanchez,504
+Riverside,45905,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,45905,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,45907,U.S. Senate,,DEM,Kamala D. Harris,85
+Riverside,45907,U.S. Senate,,DEM,Loretta L. Sanchez,145
+Riverside,45908,U.S. Senate,,DEM,Kamala D. Harris,1
+Riverside,45908,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Riverside,45910,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,45910,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,45922,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,45922,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,45925,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,45925,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,45990,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,45990,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,45991,U.S. Senate,,DEM,Kamala D. Harris,21
+Riverside,45991,U.S. Senate,,DEM,Loretta L. Sanchez,63
+Riverside,45992,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,45992,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,46002,U.S. Senate,,DEM,Kamala D. Harris,284
+Riverside,46002,U.S. Senate,,DEM,Loretta L. Sanchez,189
+Riverside,46005,U.S. Senate,,DEM,Kamala D. Harris,444
+Riverside,46005,U.S. Senate,,DEM,Loretta L. Sanchez,282
+Riverside,46007,U.S. Senate,,DEM,Kamala D. Harris,740
+Riverside,46007,U.S. Senate,,DEM,Loretta L. Sanchez,554
+Riverside,46009,U.S. Senate,,DEM,Kamala D. Harris,900
+Riverside,46009,U.S. Senate,,DEM,Loretta L. Sanchez,787
+Riverside,46016,U.S. Senate,,DEM,Kamala D. Harris,867
+Riverside,46016,U.S. Senate,,DEM,Loretta L. Sanchez,505
+Riverside,46018,U.S. Senate,,DEM,Kamala D. Harris,779
+Riverside,46018,U.S. Senate,,DEM,Loretta L. Sanchez,693
+Riverside,46019,U.S. Senate,,DEM,Kamala D. Harris,715
+Riverside,46019,U.S. Senate,,DEM,Loretta L. Sanchez,531
+Riverside,46026,U.S. Senate,,DEM,Kamala D. Harris,646
+Riverside,46026,U.S. Senate,,DEM,Loretta L. Sanchez,611
+Riverside,46028,U.S. Senate,,DEM,Kamala D. Harris,514
+Riverside,46028,U.S. Senate,,DEM,Loretta L. Sanchez,434
+Riverside,46039,U.S. Senate,,DEM,Kamala D. Harris,718
+Riverside,46039,U.S. Senate,,DEM,Loretta L. Sanchez,433
+Riverside,46044,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,46044,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,46047,U.S. Senate,,DEM,Kamala D. Harris,612
+Riverside,46047,U.S. Senate,,DEM,Loretta L. Sanchez,251
+Riverside,46600,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,46600,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,46610,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,46610,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,46612,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,46612,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,46653,U.S. Senate,,DEM,Kamala D. Harris,10
+Riverside,46653,U.S. Senate,,DEM,Loretta L. Sanchez,63
+Riverside,46661,U.S. Senate,,DEM,Kamala D. Harris,2
+Riverside,46661,U.S. Senate,,DEM,Loretta L. Sanchez,6
+Riverside,46688,U.S. Senate,,DEM,Kamala D. Harris,43
+Riverside,46688,U.S. Senate,,DEM,Loretta L. Sanchez,103
+Riverside,46693,U.S. Senate,,DEM,Kamala D. Harris,5
+Riverside,46693,U.S. Senate,,DEM,Loretta L. Sanchez,12
+Riverside,46704,U.S. Senate,,DEM,Kamala D. Harris,177
+Riverside,46704,U.S. Senate,,DEM,Loretta L. Sanchez,387
+Riverside,46710,U.S. Senate,,DEM,Kamala D. Harris,85
+Riverside,46710,U.S. Senate,,DEM,Loretta L. Sanchez,209
+Riverside,46712,U.S. Senate,,DEM,Kamala D. Harris,42
+Riverside,46712,U.S. Senate,,DEM,Loretta L. Sanchez,92
+Riverside,46715,U.S. Senate,,DEM,Kamala D. Harris,2
+Riverside,46715,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Riverside,46757,U.S. Senate,,DEM,Kamala D. Harris,226
+Riverside,46757,U.S. Senate,,DEM,Loretta L. Sanchez,768
+Riverside,46758,U.S. Senate,,DEM,Kamala D. Harris,2
+Riverside,46758,U.S. Senate,,DEM,Loretta L. Sanchez,6
+Riverside,46762,U.S. Senate,,DEM,Kamala D. Harris,15
+Riverside,46762,U.S. Senate,,DEM,Loretta L. Sanchez,15
+Riverside,46800,U.S. Senate,,DEM,Kamala D. Harris,9
+Riverside,46800,U.S. Senate,,DEM,Loretta L. Sanchez,10
+Riverside,46813,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,46813,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Riverside,46823,U.S. Senate,,DEM,Kamala D. Harris,107
+Riverside,46823,U.S. Senate,,DEM,Loretta L. Sanchez,280
+Riverside,46828,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,46828,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,46901,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,46901,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,46902,U.S. Senate,,DEM,Kamala D. Harris,9
+Riverside,46902,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Riverside,46903,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,46903,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,46911,U.S. Senate,,DEM,Kamala D. Harris,26
+Riverside,46911,U.S. Senate,,DEM,Loretta L. Sanchez,25
+Riverside,46920,U.S. Senate,,DEM,Kamala D. Harris,2
+Riverside,46920,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,46931,U.S. Senate,,DEM,Kamala D. Harris,1
+Riverside,46931,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,47003,U.S. Senate,,DEM,Kamala D. Harris,1774
+Riverside,47003,U.S. Senate,,DEM,Loretta L. Sanchez,900
+Riverside,47011,U.S. Senate,,DEM,Kamala D. Harris,350
+Riverside,47011,U.S. Senate,,DEM,Loretta L. Sanchez,438
+Riverside,47013,U.S. Senate,,DEM,Kamala D. Harris,759
+Riverside,47013,U.S. Senate,,DEM,Loretta L. Sanchez,742
+Riverside,47016,U.S. Senate,,DEM,Kamala D. Harris,856
+Riverside,47016,U.S. Senate,,DEM,Loretta L. Sanchez,612
+Riverside,47019,U.S. Senate,,DEM,Kamala D. Harris,346
+Riverside,47019,U.S. Senate,,DEM,Loretta L. Sanchez,915
+Riverside,47022,U.S. Senate,,DEM,Kamala D. Harris,551
+Riverside,47022,U.S. Senate,,DEM,Loretta L. Sanchez,1045
+Riverside,47036,U.S. Senate,,DEM,Kamala D. Harris,532
+Riverside,47036,U.S. Senate,,DEM,Loretta L. Sanchez,1197
+Riverside,47037,U.S. Senate,,DEM,Kamala D. Harris,532
+Riverside,47037,U.S. Senate,,DEM,Loretta L. Sanchez,741
+Riverside,47039,U.S. Senate,,DEM,Kamala D. Harris,289
+Riverside,47039,U.S. Senate,,DEM,Loretta L. Sanchez,689
+Riverside,47041,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,47041,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,47042,U.S. Senate,,DEM,Kamala D. Harris,283
+Riverside,47042,U.S. Senate,,DEM,Loretta L. Sanchez,436
+Riverside,47044,U.S. Senate,,DEM,Kamala D. Harris,499
+Riverside,47044,U.S. Senate,,DEM,Loretta L. Sanchez,951
+Riverside,47048,U.S. Senate,,DEM,Kamala D. Harris,6
+Riverside,47048,U.S. Senate,,DEM,Loretta L. Sanchez,6
+Riverside,47049,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,47049,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,47053,U.S. Senate,,DEM,Kamala D. Harris,821
+Riverside,47053,U.S. Senate,,DEM,Loretta L. Sanchez,760
+Riverside,47055,U.S. Senate,,DEM,Kamala D. Harris,577
+Riverside,47055,U.S. Senate,,DEM,Loretta L. Sanchez,360
+Riverside,47058,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,47058,U.S. Senate,,DEM,Loretta L. Sanchez,10
+Riverside,47061,U.S. Senate,,DEM,Kamala D. Harris,462
+Riverside,47061,U.S. Senate,,DEM,Loretta L. Sanchez,491
+Riverside,47064,U.S. Senate,,DEM,Kamala D. Harris,329
+Riverside,47064,U.S. Senate,,DEM,Loretta L. Sanchez,349
+Riverside,47065,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,47065,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,48000,U.S. Senate,,DEM,Kamala D. Harris,25
+Riverside,48000,U.S. Senate,,DEM,Loretta L. Sanchez,22
+Riverside,48005,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,48005,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,48010,U.S. Senate,,DEM,Kamala D. Harris,365
+Riverside,48010,U.S. Senate,,DEM,Loretta L. Sanchez,999
+Riverside,48011,U.S. Senate,,DEM,Kamala D. Harris,355
+Riverside,48011,U.S. Senate,,DEM,Loretta L. Sanchez,1132
+Riverside,48012,U.S. Senate,,DEM,Kamala D. Harris,338
+Riverside,48012,U.S. Senate,,DEM,Loretta L. Sanchez,1032
+Riverside,48025,U.S. Senate,,DEM,Kamala D. Harris,336
+Riverside,48025,U.S. Senate,,DEM,Loretta L. Sanchez,1253
+Riverside,48032,U.S. Senate,,DEM,Kamala D. Harris,299
+Riverside,48032,U.S. Senate,,DEM,Loretta L. Sanchez,894
+Riverside,48036,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,48036,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,48800,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,48800,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,48806,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,48806,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,48851,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,48851,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,48852,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,48852,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,48853,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,48853,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,48870,U.S. Senate,,DEM,Kamala D. Harris,473
+Riverside,48870,U.S. Senate,,DEM,Loretta L. Sanchez,310
+Riverside,48900,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,48900,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,48902,U.S. Senate,,DEM,Kamala D. Harris,312
+Riverside,48902,U.S. Senate,,DEM,Loretta L. Sanchez,273
+Riverside,49000,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,49000,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,49007,U.S. Senate,,DEM,Kamala D. Harris,380
+Riverside,49007,U.S. Senate,,DEM,Loretta L. Sanchez,334
+Riverside,49009,U.S. Senate,,DEM,Kamala D. Harris,421
+Riverside,49009,U.S. Senate,,DEM,Loretta L. Sanchez,409
+Riverside,49011,U.S. Senate,,DEM,Kamala D. Harris,564
+Riverside,49011,U.S. Senate,,DEM,Loretta L. Sanchez,439
+Riverside,49800,U.S. Senate,,DEM,Kamala D. Harris,51
+Riverside,49800,U.S. Senate,,DEM,Loretta L. Sanchez,29
+Riverside,49812,U.S. Senate,,DEM,Kamala D. Harris,88
+Riverside,49812,U.S. Senate,,DEM,Loretta L. Sanchez,29
+Riverside,49813,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,49813,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,49820,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,49820,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,49821,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,49821,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,49826,U.S. Senate,,DEM,Kamala D. Harris,97
+Riverside,49826,U.S. Senate,,DEM,Loretta L. Sanchez,49
+Riverside,49830,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,49830,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,49841,U.S. Senate,,DEM,Kamala D. Harris,24
+Riverside,49841,U.S. Senate,,DEM,Loretta L. Sanchez,16
+Riverside,49843,U.S. Senate,,DEM,Kamala D. Harris,23
+Riverside,49843,U.S. Senate,,DEM,Loretta L. Sanchez,17
+Riverside,49852,U.S. Senate,,DEM,Kamala D. Harris,49
+Riverside,49852,U.S. Senate,,DEM,Loretta L. Sanchez,73
+Riverside,49854,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,49854,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,49860,U.S. Senate,,DEM,Kamala D. Harris,1
+Riverside,49860,U.S. Senate,,DEM,Loretta L. Sanchez,5
+Riverside,49870,U.S. Senate,,DEM,Kamala D. Harris,28
+Riverside,49870,U.S. Senate,,DEM,Loretta L. Sanchez,19
+Riverside,49880,U.S. Senate,,DEM,Kamala D. Harris,26
+Riverside,49880,U.S. Senate,,DEM,Loretta L. Sanchez,58
+Riverside,49900,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,49900,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,49901,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,49901,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,49903,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,49903,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,49907,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,49907,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,49908,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,49908,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,50100,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,50100,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,50102,U.S. Senate,,DEM,Kamala D. Harris,680
+Riverside,50102,U.S. Senate,,DEM,Loretta L. Sanchez,536
+Riverside,50110,U.S. Senate,,DEM,Kamala D. Harris,431
+Riverside,50110,U.S. Senate,,DEM,Loretta L. Sanchez,323
+Riverside,50111,U.S. Senate,,DEM,Kamala D. Harris,583
+Riverside,50111,U.S. Senate,,DEM,Loretta L. Sanchez,635
+Riverside,50116,U.S. Senate,,DEM,Kamala D. Harris,391
+Riverside,50116,U.S. Senate,,DEM,Loretta L. Sanchez,200
+Riverside,50117,U.S. Senate,,DEM,Kamala D. Harris,488
+Riverside,50117,U.S. Senate,,DEM,Loretta L. Sanchez,429
+Riverside,50119,U.S. Senate,,DEM,Kamala D. Harris,822
+Riverside,50119,U.S. Senate,,DEM,Loretta L. Sanchez,722
+Riverside,50121,U.S. Senate,,DEM,Kamala D. Harris,340
+Riverside,50121,U.S. Senate,,DEM,Loretta L. Sanchez,404
+Riverside,50126,U.S. Senate,,DEM,Kamala D. Harris,103
+Riverside,50126,U.S. Senate,,DEM,Loretta L. Sanchez,112
+Riverside,50127,U.S. Senate,,DEM,Kamala D. Harris,381
+Riverside,50127,U.S. Senate,,DEM,Loretta L. Sanchez,439
+Riverside,50130,U.S. Senate,,DEM,Kamala D. Harris,591
+Riverside,50130,U.S. Senate,,DEM,Loretta L. Sanchez,588
+Riverside,50203,U.S. Senate,,DEM,Kamala D. Harris,859
+Riverside,50203,U.S. Senate,,DEM,Loretta L. Sanchez,551
+Riverside,50205,U.S. Senate,,DEM,Kamala D. Harris,744
+Riverside,50205,U.S. Senate,,DEM,Loretta L. Sanchez,453
+Riverside,50209,U.S. Senate,,DEM,Kamala D. Harris,726
+Riverside,50209,U.S. Senate,,DEM,Loretta L. Sanchez,464
+Riverside,50213,U.S. Senate,,DEM,Kamala D. Harris,778
+Riverside,50213,U.S. Senate,,DEM,Loretta L. Sanchez,540
+Riverside,50216,U.S. Senate,,DEM,Kamala D. Harris,714
+Riverside,50216,U.S. Senate,,DEM,Loretta L. Sanchez,492
+Riverside,50221,U.S. Senate,,DEM,Kamala D. Harris,646
+Riverside,50221,U.S. Senate,,DEM,Loretta L. Sanchez,471
+Riverside,50223,U.S. Senate,,DEM,Kamala D. Harris,767
+Riverside,50223,U.S. Senate,,DEM,Loretta L. Sanchez,660
+Riverside,50226,U.S. Senate,,DEM,Kamala D. Harris,428
+Riverside,50226,U.S. Senate,,DEM,Loretta L. Sanchez,419
+Riverside,50227,U.S. Senate,,DEM,Kamala D. Harris,370
+Riverside,50227,U.S. Senate,,DEM,Loretta L. Sanchez,289
+Riverside,50228,U.S. Senate,,DEM,Kamala D. Harris,441
+Riverside,50228,U.S. Senate,,DEM,Loretta L. Sanchez,439
+Riverside,50235,U.S. Senate,,DEM,Kamala D. Harris,911
+Riverside,50235,U.S. Senate,,DEM,Loretta L. Sanchez,708
+Riverside,50237,U.S. Senate,,DEM,Kamala D. Harris,646
+Riverside,50237,U.S. Senate,,DEM,Loretta L. Sanchez,497
+Riverside,50240,U.S. Senate,,DEM,Kamala D. Harris,518
+Riverside,50240,U.S. Senate,,DEM,Loretta L. Sanchez,391
+Riverside,50241,U.S. Senate,,DEM,Kamala D. Harris,347
+Riverside,50241,U.S. Senate,,DEM,Loretta L. Sanchez,259
+Riverside,50300,U.S. Senate,,DEM,Kamala D. Harris,589
+Riverside,50300,U.S. Senate,,DEM,Loretta L. Sanchez,766
+Riverside,50304,U.S. Senate,,DEM,Kamala D. Harris,498
+Riverside,50304,U.S. Senate,,DEM,Loretta L. Sanchez,478
+Riverside,50306,U.S. Senate,,DEM,Kamala D. Harris,803
+Riverside,50306,U.S. Senate,,DEM,Loretta L. Sanchez,670
+Riverside,50307,U.S. Senate,,DEM,Kamala D. Harris,378
+Riverside,50307,U.S. Senate,,DEM,Loretta L. Sanchez,337
+Riverside,50309,U.S. Senate,,DEM,Kamala D. Harris,572
+Riverside,50309,U.S. Senate,,DEM,Loretta L. Sanchez,329
+Riverside,50313,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,50313,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,50314,U.S. Senate,,DEM,Kamala D. Harris,389
+Riverside,50314,U.S. Senate,,DEM,Loretta L. Sanchez,554
+Riverside,50317,U.S. Senate,,DEM,Kamala D. Harris,822
+Riverside,50317,U.S. Senate,,DEM,Loretta L. Sanchez,606
+Riverside,50323,U.S. Senate,,DEM,Kamala D. Harris,613
+Riverside,50323,U.S. Senate,,DEM,Loretta L. Sanchez,493
+Riverside,50324,U.S. Senate,,DEM,Kamala D. Harris,363
+Riverside,50324,U.S. Senate,,DEM,Loretta L. Sanchez,299
+Riverside,50327,U.S. Senate,,DEM,Kamala D. Harris,370
+Riverside,50327,U.S. Senate,,DEM,Loretta L. Sanchez,353
+Riverside,50328,U.S. Senate,,DEM,Kamala D. Harris,568
+Riverside,50328,U.S. Senate,,DEM,Loretta L. Sanchez,576
+Riverside,50331,U.S. Senate,,DEM,Kamala D. Harris,538
+Riverside,50331,U.S. Senate,,DEM,Loretta L. Sanchez,468
+Riverside,50402,U.S. Senate,,DEM,Kamala D. Harris,516
+Riverside,50402,U.S. Senate,,DEM,Loretta L. Sanchez,556
+Riverside,50403,U.S. Senate,,DEM,Kamala D. Harris,464
+Riverside,50403,U.S. Senate,,DEM,Loretta L. Sanchez,443
+Riverside,50404,U.S. Senate,,DEM,Kamala D. Harris,586
+Riverside,50404,U.S. Senate,,DEM,Loretta L. Sanchez,516
+Riverside,50405,U.S. Senate,,DEM,Kamala D. Harris,251
+Riverside,50405,U.S. Senate,,DEM,Loretta L. Sanchez,348
+Riverside,50408,U.S. Senate,,DEM,Kamala D. Harris,478
+Riverside,50408,U.S. Senate,,DEM,Loretta L. Sanchez,461
+Riverside,50412,U.S. Senate,,DEM,Kamala D. Harris,352
+Riverside,50412,U.S. Senate,,DEM,Loretta L. Sanchez,298
+Riverside,50413,U.S. Senate,,DEM,Kamala D. Harris,803
+Riverside,50413,U.S. Senate,,DEM,Loretta L. Sanchez,514
+Riverside,50417,U.S. Senate,,DEM,Kamala D. Harris,1078
+Riverside,50417,U.S. Senate,,DEM,Loretta L. Sanchez,700
+Riverside,50419,U.S. Senate,,DEM,Kamala D. Harris,844
+Riverside,50419,U.S. Senate,,DEM,Loretta L. Sanchez,531
+Riverside,50424,U.S. Senate,,DEM,Kamala D. Harris,836
+Riverside,50424,U.S. Senate,,DEM,Loretta L. Sanchez,475
+Riverside,50427,U.S. Senate,,DEM,Kamala D. Harris,516
+Riverside,50427,U.S. Senate,,DEM,Loretta L. Sanchez,250
+Riverside,50433,U.S. Senate,,DEM,Kamala D. Harris,1136
+Riverside,50433,U.S. Senate,,DEM,Loretta L. Sanchez,633
+Riverside,50435,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,50435,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,50436,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,50436,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,50789,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,50789,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Riverside,50791,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,50791,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,50792,U.S. Senate,,DEM,Kamala D. Harris,2
+Riverside,50792,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Riverside,50793,U.S. Senate,,DEM,Kamala D. Harris,4
+Riverside,50793,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Riverside,50794,U.S. Senate,,DEM,Kamala D. Harris,3
+Riverside,50794,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Riverside,50801,U.S. Senate,,DEM,Kamala D. Harris,130
+Riverside,50801,U.S. Senate,,DEM,Loretta L. Sanchez,108
+Riverside,50802,U.S. Senate,,DEM,Kamala D. Harris,66
+Riverside,50802,U.S. Senate,,DEM,Loretta L. Sanchez,33
+Riverside,50803,U.S. Senate,,DEM,Kamala D. Harris,10
+Riverside,50803,U.S. Senate,,DEM,Loretta L. Sanchez,6
+Riverside,50804,U.S. Senate,,DEM,Kamala D. Harris,15
+Riverside,50804,U.S. Senate,,DEM,Loretta L. Sanchez,12
+Riverside,50805,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,50805,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,50806,U.S. Senate,,DEM,Kamala D. Harris,2
+Riverside,50806,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,50807,U.S. Senate,,DEM,Kamala D. Harris,2
+Riverside,50807,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Riverside,50808,U.S. Senate,,DEM,Kamala D. Harris,2
+Riverside,50808,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,50809,U.S. Senate,,DEM,Kamala D. Harris,116
+Riverside,50809,U.S. Senate,,DEM,Loretta L. Sanchez,80
+Riverside,50811,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,50811,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Riverside,50812,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,50812,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,50813,U.S. Senate,,DEM,Kamala D. Harris,5
+Riverside,50813,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Riverside,50814,U.S. Senate,,DEM,Kamala D. Harris,4
+Riverside,50814,U.S. Senate,,DEM,Loretta L. Sanchez,10
+Riverside,50815,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,50815,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,50816,U.S. Senate,,DEM,Kamala D. Harris,24
+Riverside,50816,U.S. Senate,,DEM,Loretta L. Sanchez,19
+Riverside,50817,U.S. Senate,,DEM,Kamala D. Harris,1
+Riverside,50817,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,50818,U.S. Senate,,DEM,Kamala D. Harris,854
+Riverside,50818,U.S. Senate,,DEM,Loretta L. Sanchez,731
+Riverside,50819,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,50819,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,50821,U.S. Senate,,DEM,Kamala D. Harris,6
+Riverside,50821,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Riverside,50822,U.S. Senate,,DEM,Kamala D. Harris,4
+Riverside,50822,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Riverside,50825,U.S. Senate,,DEM,Kamala D. Harris,236
+Riverside,50825,U.S. Senate,,DEM,Loretta L. Sanchez,134
+Riverside,50826,U.S. Senate,,DEM,Kamala D. Harris,4
+Riverside,50826,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,50827,U.S. Senate,,DEM,Kamala D. Harris,5
+Riverside,50827,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Riverside,50828,U.S. Senate,,DEM,Kamala D. Harris,4
+Riverside,50828,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,50830,U.S. Senate,,DEM,Kamala D. Harris,89
+Riverside,50830,U.S. Senate,,DEM,Loretta L. Sanchez,77
+Riverside,50833,U.S. Senate,,DEM,Kamala D. Harris,54
+Riverside,50833,U.S. Senate,,DEM,Loretta L. Sanchez,72
+Riverside,50900,U.S. Senate,,DEM,Kamala D. Harris,3
+Riverside,50900,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,50901,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,50901,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,50906,U.S. Senate,,DEM,Kamala D. Harris,21
+Riverside,50906,U.S. Senate,,DEM,Loretta L. Sanchez,10
+Riverside,50916,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,50916,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,51000,U.S. Senate,,DEM,Kamala D. Harris,43
+Riverside,51000,U.S. Senate,,DEM,Loretta L. Sanchez,62
+Riverside,51001,U.S. Senate,,DEM,Kamala D. Harris,502
+Riverside,51001,U.S. Senate,,DEM,Loretta L. Sanchez,689
+Riverside,51003,U.S. Senate,,DEM,Kamala D. Harris,793
+Riverside,51003,U.S. Senate,,DEM,Loretta L. Sanchez,839
+Riverside,51005,U.S. Senate,,DEM,Kamala D. Harris,491
+Riverside,51005,U.S. Senate,,DEM,Loretta L. Sanchez,507
+Riverside,51009,U.S. Senate,,DEM,Kamala D. Harris,452
+Riverside,51009,U.S. Senate,,DEM,Loretta L. Sanchez,725
+Riverside,51011,U.S. Senate,,DEM,Kamala D. Harris,476
+Riverside,51011,U.S. Senate,,DEM,Loretta L. Sanchez,616
+Riverside,51019,U.S. Senate,,DEM,Kamala D. Harris,411
+Riverside,51019,U.S. Senate,,DEM,Loretta L. Sanchez,588
+Riverside,51021,U.S. Senate,,DEM,Kamala D. Harris,349
+Riverside,51021,U.S. Senate,,DEM,Loretta L. Sanchez,506
+Riverside,51022,U.S. Senate,,DEM,Kamala D. Harris,737
+Riverside,51022,U.S. Senate,,DEM,Loretta L. Sanchez,944
+Riverside,51026,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,51026,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,51027,U.S. Senate,,DEM,Kamala D. Harris,480
+Riverside,51027,U.S. Senate,,DEM,Loretta L. Sanchez,586
+Riverside,51035,U.S. Senate,,DEM,Kamala D. Harris,5
+Riverside,51035,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Riverside,51041,U.S. Senate,,DEM,Kamala D. Harris,428
+Riverside,51041,U.S. Senate,,DEM,Loretta L. Sanchez,448
+Riverside,51044,U.S. Senate,,DEM,Kamala D. Harris,826
+Riverside,51044,U.S. Senate,,DEM,Loretta L. Sanchez,743
+Riverside,51047,U.S. Senate,,DEM,Kamala D. Harris,381
+Riverside,51047,U.S. Senate,,DEM,Loretta L. Sanchez,585
+Riverside,51052,U.S. Senate,,DEM,Kamala D. Harris,201
+Riverside,51052,U.S. Senate,,DEM,Loretta L. Sanchez,249
+Riverside,51056,U.S. Senate,,DEM,Kamala D. Harris,520
+Riverside,51056,U.S. Senate,,DEM,Loretta L. Sanchez,653
+Riverside,51700,U.S. Senate,,DEM,Kamala D. Harris,15
+Riverside,51700,U.S. Senate,,DEM,Loretta L. Sanchez,17
+Riverside,51701,U.S. Senate,,DEM,Kamala D. Harris,82
+Riverside,51701,U.S. Senate,,DEM,Loretta L. Sanchez,40
+Riverside,51817,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,51817,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,51819,U.S. Senate,,DEM,Kamala D. Harris,8
+Riverside,51819,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Riverside,51827,U.S. Senate,,DEM,Kamala D. Harris,135
+Riverside,51827,U.S. Senate,,DEM,Loretta L. Sanchez,143
+Riverside,51830,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,51830,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,51833,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,51833,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,51836,U.S. Senate,,DEM,Kamala D. Harris,45
+Riverside,51836,U.S. Senate,,DEM,Loretta L. Sanchez,26
+Riverside,51837,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,51837,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,51838,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,51838,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,51839,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,51839,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,51840,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,51840,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,51841,U.S. Senate,,DEM,Kamala D. Harris,4
+Riverside,51841,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,51842,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,51842,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,51845,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,51845,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,51846,U.S. Senate,,DEM,Kamala D. Harris,31
+Riverside,51846,U.S. Senate,,DEM,Loretta L. Sanchez,28
+Riverside,51849,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,51849,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,51859,U.S. Senate,,DEM,Kamala D. Harris,268
+Riverside,51859,U.S. Senate,,DEM,Loretta L. Sanchez,229
+Riverside,51861,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,51861,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,51870,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,51870,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,51871,U.S. Senate,,DEM,Kamala D. Harris,22
+Riverside,51871,U.S. Senate,,DEM,Loretta L. Sanchez,18
+Riverside,51873,U.S. Senate,,DEM,Kamala D. Harris,11
+Riverside,51873,U.S. Senate,,DEM,Loretta L. Sanchez,18
+Riverside,51874,U.S. Senate,,DEM,Kamala D. Harris,67
+Riverside,51874,U.S. Senate,,DEM,Loretta L. Sanchez,60
+Riverside,51877,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,51877,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,51970,U.S. Senate,,DEM,Kamala D. Harris,75
+Riverside,51970,U.S. Senate,,DEM,Loretta L. Sanchez,31
+Riverside,51971,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,51971,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,51980,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,51980,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,52103,U.S. Senate,,DEM,Kamala D. Harris,145
+Riverside,52103,U.S. Senate,,DEM,Loretta L. Sanchez,97
+Riverside,52106,U.S. Senate,,DEM,Kamala D. Harris,1519
+Riverside,52106,U.S. Senate,,DEM,Loretta L. Sanchez,1022
+Riverside,52110,U.S. Senate,,DEM,Kamala D. Harris,570
+Riverside,52110,U.S. Senate,,DEM,Loretta L. Sanchez,441
+Riverside,52115,U.S. Senate,,DEM,Kamala D. Harris,1113
+Riverside,52115,U.S. Senate,,DEM,Loretta L. Sanchez,710
+Riverside,52116,U.S. Senate,,DEM,Kamala D. Harris,496
+Riverside,52116,U.S. Senate,,DEM,Loretta L. Sanchez,444
+Riverside,52123,U.S. Senate,,DEM,Kamala D. Harris,734
+Riverside,52123,U.S. Senate,,DEM,Loretta L. Sanchez,566
+Riverside,52124,U.S. Senate,,DEM,Kamala D. Harris,24
+Riverside,52124,U.S. Senate,,DEM,Loretta L. Sanchez,40
+Riverside,52201,U.S. Senate,,DEM,Kamala D. Harris,588
+Riverside,52201,U.S. Senate,,DEM,Loretta L. Sanchez,657
+Riverside,52203,U.S. Senate,,DEM,Kamala D. Harris,658
+Riverside,52203,U.S. Senate,,DEM,Loretta L. Sanchez,615
+Riverside,52209,U.S. Senate,,DEM,Kamala D. Harris,286
+Riverside,52209,U.S. Senate,,DEM,Loretta L. Sanchez,354
+Riverside,52210,U.S. Senate,,DEM,Kamala D. Harris,737
+Riverside,52210,U.S. Senate,,DEM,Loretta L. Sanchez,521
+Riverside,52216,U.S. Senate,,DEM,Kamala D. Harris,832
+Riverside,52216,U.S. Senate,,DEM,Loretta L. Sanchez,739
+Riverside,52222,U.S. Senate,,DEM,Kamala D. Harris,1
+Riverside,52222,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Riverside,52301,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,52301,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,52302,U.S. Senate,,DEM,Kamala D. Harris,78
+Riverside,52302,U.S. Senate,,DEM,Loretta L. Sanchez,74
+Riverside,52303,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,52303,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,52305,U.S. Senate,,DEM,Kamala D. Harris,875
+Riverside,52305,U.S. Senate,,DEM,Loretta L. Sanchez,703
+Riverside,52312,U.S. Senate,,DEM,Kamala D. Harris,487
+Riverside,52312,U.S. Senate,,DEM,Loretta L. Sanchez,418
+Riverside,52313,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,52313,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,52315,U.S. Senate,,DEM,Kamala D. Harris,72
+Riverside,52315,U.S. Senate,,DEM,Loretta L. Sanchez,55
+Riverside,52317,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,52317,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,52318,U.S. Senate,,DEM,Kamala D. Harris,572
+Riverside,52318,U.S. Senate,,DEM,Loretta L. Sanchez,505
+Riverside,52319,U.S. Senate,,DEM,Kamala D. Harris,13
+Riverside,52319,U.S. Senate,,DEM,Loretta L. Sanchez,12
+Riverside,52322,U.S. Senate,,DEM,Kamala D. Harris,450
+Riverside,52322,U.S. Senate,,DEM,Loretta L. Sanchez,351
+Riverside,52323,U.S. Senate,,DEM,Kamala D. Harris,38
+Riverside,52323,U.S. Senate,,DEM,Loretta L. Sanchez,60
+Riverside,52326,U.S. Senate,,DEM,Kamala D. Harris,607
+Riverside,52326,U.S. Senate,,DEM,Loretta L. Sanchez,416
+Riverside,52332,U.S. Senate,,DEM,Kamala D. Harris,5
+Riverside,52332,U.S. Senate,,DEM,Loretta L. Sanchez,12
+Riverside,52333,U.S. Senate,,DEM,Kamala D. Harris,202
+Riverside,52333,U.S. Senate,,DEM,Loretta L. Sanchez,180
+Riverside,52336,U.S. Senate,,DEM,Kamala D. Harris,52
+Riverside,52336,U.S. Senate,,DEM,Loretta L. Sanchez,24
+Riverside,52337,U.S. Senate,,DEM,Kamala D. Harris,73
+Riverside,52337,U.S. Senate,,DEM,Loretta L. Sanchez,82
+Riverside,52339,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,52339,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,52404,U.S. Senate,,DEM,Kamala D. Harris,78
+Riverside,52404,U.S. Senate,,DEM,Loretta L. Sanchez,129
+Riverside,52405,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,52405,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,52407,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,52407,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,52410,U.S. Senate,,DEM,Kamala D. Harris,1
+Riverside,52410,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,52411,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,52411,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,52412,U.S. Senate,,DEM,Kamala D. Harris,49
+Riverside,52412,U.S. Senate,,DEM,Loretta L. Sanchez,39
+Riverside,52413,U.S. Senate,,DEM,Kamala D. Harris,39
+Riverside,52413,U.S. Senate,,DEM,Loretta L. Sanchez,26
+Riverside,52419,U.S. Senate,,DEM,Kamala D. Harris,675
+Riverside,52419,U.S. Senate,,DEM,Loretta L. Sanchez,522
+Riverside,52420,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,52420,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,52423,U.S. Senate,,DEM,Kamala D. Harris,9
+Riverside,52423,U.S. Senate,,DEM,Loretta L. Sanchez,14
+Riverside,52424,U.S. Senate,,DEM,Kamala D. Harris,74
+Riverside,52424,U.S. Senate,,DEM,Loretta L. Sanchez,53
+Riverside,52425,U.S. Senate,,DEM,Kamala D. Harris,609
+Riverside,52425,U.S. Senate,,DEM,Loretta L. Sanchez,464
+Riverside,52427,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,52427,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,52428,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,52428,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,52431,U.S. Senate,,DEM,Kamala D. Harris,1152
+Riverside,52431,U.S. Senate,,DEM,Loretta L. Sanchez,872
+Riverside,52432,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,52432,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,52434,U.S. Senate,,DEM,Kamala D. Harris,17
+Riverside,52434,U.S. Senate,,DEM,Loretta L. Sanchez,9
+Riverside,52435,U.S. Senate,,DEM,Kamala D. Harris,222
+Riverside,52435,U.S. Senate,,DEM,Loretta L. Sanchez,145
+Riverside,52436,U.S. Senate,,DEM,Kamala D. Harris,32
+Riverside,52436,U.S. Senate,,DEM,Loretta L. Sanchez,17
+Riverside,52437,U.S. Senate,,DEM,Kamala D. Harris,45
+Riverside,52437,U.S. Senate,,DEM,Loretta L. Sanchez,27
+Riverside,52438,U.S. Senate,,DEM,Kamala D. Harris,323
+Riverside,52438,U.S. Senate,,DEM,Loretta L. Sanchez,412
+Riverside,52439,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,52439,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,52440,U.S. Senate,,DEM,Kamala D. Harris,88
+Riverside,52440,U.S. Senate,,DEM,Loretta L. Sanchez,52
+Riverside,52441,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,52441,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,52442,U.S. Senate,,DEM,Kamala D. Harris,808
+Riverside,52442,U.S. Senate,,DEM,Loretta L. Sanchez,554
+Riverside,52839,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,52839,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,52840,U.S. Senate,,DEM,Kamala D. Harris,66
+Riverside,52840,U.S. Senate,,DEM,Loretta L. Sanchez,46
+Riverside,52841,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,52841,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,52845,U.S. Senate,,DEM,Kamala D. Harris,19
+Riverside,52845,U.S. Senate,,DEM,Loretta L. Sanchez,27
+Riverside,52847,U.S. Senate,,DEM,Kamala D. Harris,89
+Riverside,52847,U.S. Senate,,DEM,Loretta L. Sanchez,57
+Riverside,52849,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,52849,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,52858,U.S. Senate,,DEM,Kamala D. Harris,2
+Riverside,52858,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Riverside,52863,U.S. Senate,,DEM,Kamala D. Harris,11
+Riverside,52863,U.S. Senate,,DEM,Loretta L. Sanchez,10
+Riverside,52864,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,52864,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,52867,U.S. Senate,,DEM,Kamala D. Harris,9
+Riverside,52867,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Riverside,52870,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,52870,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,52872,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,52872,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,52873,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,52873,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,52876,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,52876,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,52877,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,52877,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Riverside,52881,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,52881,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,52883,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,52883,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,52884,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,52884,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,52885,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,52885,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,52886,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,52886,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,52887,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,52887,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,52890,U.S. Senate,,DEM,Kamala D. Harris,2
+Riverside,52890,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,52894,U.S. Senate,,DEM,Kamala D. Harris,67
+Riverside,52894,U.S. Senate,,DEM,Loretta L. Sanchez,37
+Riverside,52895,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,52895,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,52897,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,52897,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,52900,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,52900,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,52901,U.S. Senate,,DEM,Kamala D. Harris,3
+Riverside,52901,U.S. Senate,,DEM,Loretta L. Sanchez,7
+Riverside,52903,U.S. Senate,,DEM,Kamala D. Harris,2
+Riverside,52903,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Riverside,52904,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,52904,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,52905,U.S. Senate,,DEM,Kamala D. Harris,1
+Riverside,52905,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Riverside,52907,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,52907,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,52919,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,52919,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,52920,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,52920,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,52921,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,52921,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,53000,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,53000,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,53002,U.S. Senate,,DEM,Kamala D. Harris,25
+Riverside,53002,U.S. Senate,,DEM,Loretta L. Sanchez,16
+Riverside,53003,U.S. Senate,,DEM,Kamala D. Harris,720
+Riverside,53003,U.S. Senate,,DEM,Loretta L. Sanchez,549
+Riverside,53010,U.S. Senate,,DEM,Kamala D. Harris,55
+Riverside,53010,U.S. Senate,,DEM,Loretta L. Sanchez,37
+Riverside,53011,U.S. Senate,,DEM,Kamala D. Harris,267
+Riverside,53011,U.S. Senate,,DEM,Loretta L. Sanchez,157
+Riverside,53017,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,53017,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,53018,U.S. Senate,,DEM,Kamala D. Harris,291
+Riverside,53018,U.S. Senate,,DEM,Loretta L. Sanchez,153
+Riverside,53020,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,53020,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,53025,U.S. Senate,,DEM,Kamala D. Harris,339
+Riverside,53025,U.S. Senate,,DEM,Loretta L. Sanchez,268
+Riverside,53038,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,53038,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,53042,U.S. Senate,,DEM,Kamala D. Harris,2
+Riverside,53042,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,54000,U.S. Senate,,DEM,Kamala D. Harris,1174
+Riverside,54000,U.S. Senate,,DEM,Loretta L. Sanchez,751
+Riverside,54005,U.S. Senate,,DEM,Kamala D. Harris,245
+Riverside,54005,U.S. Senate,,DEM,Loretta L. Sanchez,156
+Riverside,54007,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,54007,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,54008,U.S. Senate,,DEM,Kamala D. Harris,10
+Riverside,54008,U.S. Senate,,DEM,Loretta L. Sanchez,5
+Riverside,54010,U.S. Senate,,DEM,Kamala D. Harris,374
+Riverside,54010,U.S. Senate,,DEM,Loretta L. Sanchez,219
+Riverside,54012,U.S. Senate,,DEM,Kamala D. Harris,793
+Riverside,54012,U.S. Senate,,DEM,Loretta L. Sanchez,384
+Riverside,54016,U.S. Senate,,DEM,Kamala D. Harris,579
+Riverside,54016,U.S. Senate,,DEM,Loretta L. Sanchez,495
+Riverside,54019,U.S. Senate,,DEM,Kamala D. Harris,186
+Riverside,54019,U.S. Senate,,DEM,Loretta L. Sanchez,90
+Riverside,54022,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,54022,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,54024,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,54024,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,54025,U.S. Senate,,DEM,Kamala D. Harris,4
+Riverside,54025,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,54026,U.S. Senate,,DEM,Kamala D. Harris,463
+Riverside,54026,U.S. Senate,,DEM,Loretta L. Sanchez,413
+Riverside,54029,U.S. Senate,,DEM,Kamala D. Harris,376
+Riverside,54029,U.S. Senate,,DEM,Loretta L. Sanchez,352
+Riverside,54032,U.S. Senate,,DEM,Kamala D. Harris,1165
+Riverside,54032,U.S. Senate,,DEM,Loretta L. Sanchez,770
+Riverside,54035,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,54035,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,54036,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,54036,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,54037,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,54037,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,54046,U.S. Senate,,DEM,Kamala D. Harris,9
+Riverside,54046,U.S. Senate,,DEM,Loretta L. Sanchez,17
+Riverside,54050,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,54050,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,54052,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,54052,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,54054,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,54054,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,54055,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,54055,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,54058,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,54058,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,54059,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,54059,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,54064,U.S. Senate,,DEM,Kamala D. Harris,305
+Riverside,54064,U.S. Senate,,DEM,Loretta L. Sanchez,293
+Riverside,54067,U.S. Senate,,DEM,Kamala D. Harris,420
+Riverside,54067,U.S. Senate,,DEM,Loretta L. Sanchez,349
+Riverside,54069,U.S. Senate,,DEM,Kamala D. Harris,1638
+Riverside,54069,U.S. Senate,,DEM,Loretta L. Sanchez,851
+Riverside,54072,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,54072,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,54075,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,54075,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,54079,U.S. Senate,,DEM,Kamala D. Harris,12
+Riverside,54079,U.S. Senate,,DEM,Loretta L. Sanchez,10
+Riverside,54080,U.S. Senate,,DEM,Kamala D. Harris,2
+Riverside,54080,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Riverside,54081,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,54081,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,55100,U.S. Senate,,DEM,Kamala D. Harris,566
+Riverside,55100,U.S. Senate,,DEM,Loretta L. Sanchez,432
+Riverside,55103,U.S. Senate,,DEM,Kamala D. Harris,22
+Riverside,55103,U.S. Senate,,DEM,Loretta L. Sanchez,15
+Riverside,55200,U.S. Senate,,DEM,Kamala D. Harris,479
+Riverside,55200,U.S. Senate,,DEM,Loretta L. Sanchez,383
+Riverside,55201,U.S. Senate,,DEM,Kamala D. Harris,130
+Riverside,55201,U.S. Senate,,DEM,Loretta L. Sanchez,96
+Riverside,55300,U.S. Senate,,DEM,Kamala D. Harris,171
+Riverside,55300,U.S. Senate,,DEM,Loretta L. Sanchez,93
+Riverside,55301,U.S. Senate,,DEM,Kamala D. Harris,867
+Riverside,55301,U.S. Senate,,DEM,Loretta L. Sanchez,444
+Riverside,55306,U.S. Senate,,DEM,Kamala D. Harris,1165
+Riverside,55306,U.S. Senate,,DEM,Loretta L. Sanchez,516
+Riverside,55308,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,55308,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,55400,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,55400,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,55401,U.S. Senate,,DEM,Kamala D. Harris,16
+Riverside,55401,U.S. Senate,,DEM,Loretta L. Sanchez,25
+Riverside,55406,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,55406,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,55407,U.S. Senate,,DEM,Kamala D. Harris,111
+Riverside,55407,U.S. Senate,,DEM,Loretta L. Sanchez,76
+Riverside,55408,U.S. Senate,,DEM,Kamala D. Harris,229
+Riverside,55408,U.S. Senate,,DEM,Loretta L. Sanchez,188
+Riverside,55410,U.S. Senate,,DEM,Kamala D. Harris,622
+Riverside,55410,U.S. Senate,,DEM,Loretta L. Sanchez,468
+Riverside,55504,U.S. Senate,,DEM,Kamala D. Harris,729
+Riverside,55504,U.S. Senate,,DEM,Loretta L. Sanchez,550
+Riverside,55751,U.S. Senate,,DEM,Kamala D. Harris,1
+Riverside,55751,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,55790,U.S. Senate,,DEM,Kamala D. Harris,58
+Riverside,55790,U.S. Senate,,DEM,Loretta L. Sanchez,54
+Riverside,56900,U.S. Senate,,DEM,Kamala D. Harris,3
+Riverside,56900,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Riverside,56910,U.S. Senate,,DEM,Kamala D. Harris,64
+Riverside,56910,U.S. Senate,,DEM,Loretta L. Sanchez,97
+Riverside,56912,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,56912,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,56913,U.S. Senate,,DEM,Kamala D. Harris,443
+Riverside,56913,U.S. Senate,,DEM,Loretta L. Sanchez,488
+Riverside,56915,U.S. Senate,,DEM,Kamala D. Harris,19
+Riverside,56915,U.S. Senate,,DEM,Loretta L. Sanchez,24
+Riverside,56919,U.S. Senate,,DEM,Kamala D. Harris,597
+Riverside,56919,U.S. Senate,,DEM,Loretta L. Sanchez,761
+Riverside,56920,U.S. Senate,,DEM,Kamala D. Harris,44
+Riverside,56920,U.S. Senate,,DEM,Loretta L. Sanchez,25
+Riverside,56926,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,56926,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Riverside,56930,U.S. Senate,,DEM,Kamala D. Harris,327
+Riverside,56930,U.S. Senate,,DEM,Loretta L. Sanchez,344
+Riverside,56935,U.S. Senate,,DEM,Kamala D. Harris,3
+Riverside,56935,U.S. Senate,,DEM,Loretta L. Sanchez,6
+Riverside,58825,U.S. Senate,,DEM,Kamala D. Harris,5
+Riverside,58825,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Riverside,58830,U.S. Senate,,DEM,Kamala D. Harris,336
+Riverside,58830,U.S. Senate,,DEM,Loretta L. Sanchez,225
+Riverside,59800,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,59800,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,59802,U.S. Senate,,DEM,Kamala D. Harris,0
+Riverside,59802,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Riverside,59803,U.S. Senate,,DEM,Kamala D. Harris,21
+Riverside,59803,U.S. Senate,,DEM,Loretta L. Sanchez,26
+Riverside,59804,U.S. Senate,,DEM,Kamala D. Harris,73
+Riverside,59804,U.S. Senate,,DEM,Loretta L. Sanchez,73

--- a/2016/20161108__ca__general__sacramento__precinct.csv
+++ b/2016/20161108__ca__general__sacramento__precinct.csv
@@ -50679,2537 +50679,2537 @@ Sacramento,97527,Proposition 67,,N/A,Yes,64
 Sacramento,97527,Proposition 67,,N/A,No,114
 Sacramento,97784,Proposition 67,,N/A,Yes,18
 Sacramento,97784,Proposition 67,,N/A,No,27
-Sacramento,11267,U.S. Senate,,DEM,Kamala Harris,84
-Sacramento,11267,U.S. Senate,,DEM,Loretta Sanchez,57
-Sacramento,11397,U.S. Senate,,DEM,Kamala Harris,0
-Sacramento,11397,U.S. Senate,,DEM,Loretta Sanchez,0
-Sacramento,11974,U.S. Senate,,DEM,Kamala Harris,131
-Sacramento,11974,U.S. Senate,,DEM,Loretta Sanchez,83
-Sacramento,12170,U.S. Senate,,DEM,Kamala Harris,8
-Sacramento,12170,U.S. Senate,,DEM,Loretta Sanchez,2
-Sacramento,12356,U.S. Senate,,DEM,Kamala Harris,0
-Sacramento,12356,U.S. Senate,,DEM,Loretta Sanchez,1
-Sacramento,12669,U.S. Senate,,DEM,Kamala Harris,169
-Sacramento,12669,U.S. Senate,,DEM,Loretta Sanchez,63
-Sacramento,12681,U.S. Senate,,DEM,Kamala Harris,148
-Sacramento,12681,U.S. Senate,,DEM,Loretta Sanchez,77
-Sacramento,12702,U.S. Senate,,DEM,Kamala Harris,223
-Sacramento,12702,U.S. Senate,,DEM,Loretta Sanchez,116
-Sacramento,12747,U.S. Senate,,DEM,Kamala Harris,231
-Sacramento,12747,U.S. Senate,,DEM,Loretta Sanchez,129
-Sacramento,12786,U.S. Senate,,DEM,Kamala Harris,246
-Sacramento,12786,U.S. Senate,,DEM,Loretta Sanchez,109
-Sacramento,12807,U.S. Senate,,DEM,Kamala Harris,134
-Sacramento,12807,U.S. Senate,,DEM,Loretta Sanchez,71
-Sacramento,12884,U.S. Senate,,DEM,Kamala Harris,223
-Sacramento,12884,U.S. Senate,,DEM,Loretta Sanchez,126
-Sacramento,12943,U.S. Senate,,DEM,Kamala Harris,0
-Sacramento,12943,U.S. Senate,,DEM,Loretta Sanchez,1
-Sacramento,12988,U.S. Senate,,DEM,Kamala Harris,104
-Sacramento,12988,U.S. Senate,,DEM,Loretta Sanchez,50
-Sacramento,13032,U.S. Senate,,DEM,Kamala Harris,185
-Sacramento,13032,U.S. Senate,,DEM,Loretta Sanchez,172
-Sacramento,13239,U.S. Senate,,DEM,Kamala Harris,0
-Sacramento,13239,U.S. Senate,,DEM,Loretta Sanchez,0
-Sacramento,13328,U.S. Senate,,DEM,Kamala Harris,207
-Sacramento,13328,U.S. Senate,,DEM,Loretta Sanchez,185
-Sacramento,13424,U.S. Senate,,DEM,Kamala Harris,141
-Sacramento,13424,U.S. Senate,,DEM,Loretta Sanchez,123
-Sacramento,13551,U.S. Senate,,DEM,Kamala Harris,114
-Sacramento,13551,U.S. Senate,,DEM,Loretta Sanchez,111
-Sacramento,13635,U.S. Senate,,DEM,Kamala Harris,202
-Sacramento,13635,U.S. Senate,,DEM,Loretta Sanchez,148
-Sacramento,13658,U.S. Senate,,DEM,Kamala Harris,156
-Sacramento,13658,U.S. Senate,,DEM,Loretta Sanchez,110
-Sacramento,13706,U.S. Senate,,DEM,Kamala Harris,125
-Sacramento,13706,U.S. Senate,,DEM,Loretta Sanchez,107
-Sacramento,13993,U.S. Senate,,DEM,Kamala Harris,96
-Sacramento,13993,U.S. Senate,,DEM,Loretta Sanchez,65
-Sacramento,14314,U.S. Senate,,DEM,Kamala Harris,265
-Sacramento,14314,U.S. Senate,,DEM,Loretta Sanchez,128
-Sacramento,14502,U.S. Senate,,DEM,Kamala Harris,117
-Sacramento,14502,U.S. Senate,,DEM,Loretta Sanchez,50
-Sacramento,14564,U.S. Senate,,DEM,Kamala Harris,166
-Sacramento,14564,U.S. Senate,,DEM,Loretta Sanchez,91
-Sacramento,14693,U.S. Senate,,DEM,Kamala Harris,257
-Sacramento,14693,U.S. Senate,,DEM,Loretta Sanchez,135
-Sacramento,14783,U.S. Senate,,DEM,Kamala Harris,82
-Sacramento,14783,U.S. Senate,,DEM,Loretta Sanchez,43
-Sacramento,14820,U.S. Senate,,DEM,Kamala Harris,236
-Sacramento,14820,U.S. Senate,,DEM,Loretta Sanchez,95
-Sacramento,14971,U.S. Senate,,DEM,Kamala Harris,235
-Sacramento,14971,U.S. Senate,,DEM,Loretta Sanchez,124
-Sacramento,15018,U.S. Senate,,DEM,Kamala Harris,270
-Sacramento,15018,U.S. Senate,,DEM,Loretta Sanchez,143
-Sacramento,15102,U.S. Senate,,DEM,Kamala Harris,339
-Sacramento,15102,U.S. Senate,,DEM,Loretta Sanchez,117
-Sacramento,15287,U.S. Senate,,DEM,Kamala Harris,282
-Sacramento,15287,U.S. Senate,,DEM,Loretta Sanchez,146
-Sacramento,15321,U.S. Senate,,DEM,Kamala Harris,300
-Sacramento,15321,U.S. Senate,,DEM,Loretta Sanchez,140
-Sacramento,15530,U.S. Senate,,DEM,Kamala Harris,171
-Sacramento,15530,U.S. Senate,,DEM,Loretta Sanchez,90
-Sacramento,15749,U.S. Senate,,DEM,Kamala Harris,266
-Sacramento,15749,U.S. Senate,,DEM,Loretta Sanchez,114
-Sacramento,15941,U.S. Senate,,DEM,Kamala Harris,0
-Sacramento,15941,U.S. Senate,,DEM,Loretta Sanchez,0
-Sacramento,16002,U.S. Senate,,DEM,Kamala Harris,252
-Sacramento,16002,U.S. Senate,,DEM,Loretta Sanchez,161
-Sacramento,16107,U.S. Senate,,DEM,Kamala Harris,160
-Sacramento,16107,U.S. Senate,,DEM,Loretta Sanchez,159
-Sacramento,16318,U.S. Senate,,DEM,Kamala Harris,105
-Sacramento,16318,U.S. Senate,,DEM,Loretta Sanchez,83
-Sacramento,16463,U.S. Senate,,DEM,Kamala Harris,175
-Sacramento,16463,U.S. Senate,,DEM,Loretta Sanchez,167
-Sacramento,16573,U.S. Senate,,DEM,Kamala Harris,202
-Sacramento,16573,U.S. Senate,,DEM,Loretta Sanchez,154
-Sacramento,16801,U.S. Senate,,DEM,Kamala Harris,200
-Sacramento,16801,U.S. Senate,,DEM,Loretta Sanchez,125
-Sacramento,16836,U.S. Senate,,DEM,Kamala Harris,187
-Sacramento,16836,U.S. Senate,,DEM,Loretta Sanchez,122
-Sacramento,16869,U.S. Senate,,DEM,Kamala Harris,145
-Sacramento,16869,U.S. Senate,,DEM,Loretta Sanchez,67
-Sacramento,16944,U.S. Senate,,DEM,Kamala Harris,120
-Sacramento,16944,U.S. Senate,,DEM,Loretta Sanchez,107
-Sacramento,17428,U.S. Senate,,DEM,Kamala Harris,249
-Sacramento,17428,U.S. Senate,,DEM,Loretta Sanchez,119
-Sacramento,17512,U.S. Senate,,DEM,Kamala Harris,147
-Sacramento,17512,U.S. Senate,,DEM,Loretta Sanchez,71
-Sacramento,17630,U.S. Senate,,DEM,Kamala Harris,291
-Sacramento,17630,U.S. Senate,,DEM,Loretta Sanchez,156
-Sacramento,18012,U.S. Senate,,DEM,Kamala Harris,155
-Sacramento,18012,U.S. Senate,,DEM,Loretta Sanchez,114
-Sacramento,18119,U.S. Senate,,DEM,Kamala Harris,206
-Sacramento,18119,U.S. Senate,,DEM,Loretta Sanchez,161
-Sacramento,18143,U.S. Senate,,DEM,Kamala Harris,249
-Sacramento,18143,U.S. Senate,,DEM,Loretta Sanchez,128
-Sacramento,18213,U.S. Senate,,DEM,Kamala Harris,231
-Sacramento,18213,U.S. Senate,,DEM,Loretta Sanchez,162
-Sacramento,18220,U.S. Senate,,DEM,Kamala Harris,284
-Sacramento,18220,U.S. Senate,,DEM,Loretta Sanchez,187
-Sacramento,18385,U.S. Senate,,DEM,Kamala Harris,243
-Sacramento,18385,U.S. Senate,,DEM,Loretta Sanchez,137
-Sacramento,18501,U.S. Senate,,DEM,Kamala Harris,195
-Sacramento,18501,U.S. Senate,,DEM,Loretta Sanchez,105
-Sacramento,18562,U.S. Senate,,DEM,Kamala Harris,150
-Sacramento,18562,U.S. Senate,,DEM,Loretta Sanchez,186
-Sacramento,18588,U.S. Senate,,DEM,Kamala Harris,259
-Sacramento,18588,U.S. Senate,,DEM,Loretta Sanchez,199
-Sacramento,18791,U.S. Senate,,DEM,Kamala Harris,143
-Sacramento,18791,U.S. Senate,,DEM,Loretta Sanchez,178
-Sacramento,18840,U.S. Senate,,DEM,Kamala Harris,231
-Sacramento,18840,U.S. Senate,,DEM,Loretta Sanchez,187
-Sacramento,19081,U.S. Senate,,DEM,Kamala Harris,79
-Sacramento,19081,U.S. Senate,,DEM,Loretta Sanchez,118
-Sacramento,19319,U.S. Senate,,DEM,Kamala Harris,151
-Sacramento,19319,U.S. Senate,,DEM,Loretta Sanchez,141
-Sacramento,19325,U.S. Senate,,DEM,Kamala Harris,174
-Sacramento,19325,U.S. Senate,,DEM,Loretta Sanchez,149
-Sacramento,19427,U.S. Senate,,DEM,Kamala Harris,123
-Sacramento,19427,U.S. Senate,,DEM,Loretta Sanchez,120
-Sacramento,19455,U.S. Senate,,DEM,Kamala Harris,202
-Sacramento,19455,U.S. Senate,,DEM,Loretta Sanchez,126
-Sacramento,19532,U.S. Senate,,DEM,Kamala Harris,158
-Sacramento,19532,U.S. Senate,,DEM,Loretta Sanchez,109
-Sacramento,19646,U.S. Senate,,DEM,Kamala Harris,191
-Sacramento,19646,U.S. Senate,,DEM,Loretta Sanchez,103
-Sacramento,19685,U.S. Senate,,DEM,Kamala Harris,61
-Sacramento,19685,U.S. Senate,,DEM,Loretta Sanchez,32
-Sacramento,19800,U.S. Senate,,DEM,Kamala Harris,141
-Sacramento,19800,U.S. Senate,,DEM,Loretta Sanchez,111
-Sacramento,19948,U.S. Senate,,DEM,Kamala Harris,86
-Sacramento,19948,U.S. Senate,,DEM,Loretta Sanchez,64
-Sacramento,21013,U.S. Senate,,DEM,Kamala Harris,235
-Sacramento,21013,U.S. Senate,,DEM,Loretta Sanchez,180
-Sacramento,21065,U.S. Senate,,DEM,Kamala Harris,175
-Sacramento,21065,U.S. Senate,,DEM,Loretta Sanchez,127
-Sacramento,21134,U.S. Senate,,DEM,Kamala Harris,203
-Sacramento,21134,U.S. Senate,,DEM,Loretta Sanchez,159
-Sacramento,21159,U.S. Senate,,DEM,Kamala Harris,216
-Sacramento,21159,U.S. Senate,,DEM,Loretta Sanchez,126
-Sacramento,21203,U.S. Senate,,DEM,Kamala Harris,102
-Sacramento,21203,U.S. Senate,,DEM,Loretta Sanchez,81
-Sacramento,21231,U.S. Senate,,DEM,Kamala Harris,122
-Sacramento,21231,U.S. Senate,,DEM,Loretta Sanchez,72
-Sacramento,21248,U.S. Senate,,DEM,Kamala Harris,0
-Sacramento,21248,U.S. Senate,,DEM,Loretta Sanchez,4
-Sacramento,21318,U.S. Senate,,DEM,Kamala Harris,93
-Sacramento,21318,U.S. Senate,,DEM,Loretta Sanchez,72
-Sacramento,21362,U.S. Senate,,DEM,Kamala Harris,148
-Sacramento,21362,U.S. Senate,,DEM,Loretta Sanchez,85
-Sacramento,21405,U.S. Senate,,DEM,Kamala Harris,0
-Sacramento,21405,U.S. Senate,,DEM,Loretta Sanchez,0
-Sacramento,21489,U.S. Senate,,DEM,Kamala Harris,190
-Sacramento,21489,U.S. Senate,,DEM,Loretta Sanchez,138
-Sacramento,21615,U.S. Senate,,DEM,Kamala Harris,173
-Sacramento,21615,U.S. Senate,,DEM,Loretta Sanchez,129
-Sacramento,21621,U.S. Senate,,DEM,Kamala Harris,224
-Sacramento,21621,U.S. Senate,,DEM,Loretta Sanchez,105
-Sacramento,21712,U.S. Senate,,DEM,Kamala Harris,20
-Sacramento,21712,U.S. Senate,,DEM,Loretta Sanchez,16
-Sacramento,21725,U.S. Senate,,DEM,Kamala Harris,52
-Sacramento,21725,U.S. Senate,,DEM,Loretta Sanchez,24
-Sacramento,21783,U.S. Senate,,DEM,Kamala Harris,35
-Sacramento,21783,U.S. Senate,,DEM,Loretta Sanchez,19
-Sacramento,21800,U.S. Senate,,DEM,Kamala Harris,185
-Sacramento,21800,U.S. Senate,,DEM,Loretta Sanchez,123
-Sacramento,21846,U.S. Senate,,DEM,Kamala Harris,175
-Sacramento,21846,U.S. Senate,,DEM,Loretta Sanchez,137
-Sacramento,21895,U.S. Senate,,DEM,Kamala Harris,208
-Sacramento,21895,U.S. Senate,,DEM,Loretta Sanchez,163
-Sacramento,21961,U.S. Senate,,DEM,Kamala Harris,170
-Sacramento,21961,U.S. Senate,,DEM,Loretta Sanchez,109
-Sacramento,22003,U.S. Senate,,DEM,Kamala Harris,190
-Sacramento,22003,U.S. Senate,,DEM,Loretta Sanchez,145
-Sacramento,22034,U.S. Senate,,DEM,Kamala Harris,118
-Sacramento,22034,U.S. Senate,,DEM,Loretta Sanchez,77
-Sacramento,22061,U.S. Senate,,DEM,Kamala Harris,227
-Sacramento,22061,U.S. Senate,,DEM,Loretta Sanchez,120
-Sacramento,22090,U.S. Senate,,DEM,Kamala Harris,154
-Sacramento,22090,U.S. Senate,,DEM,Loretta Sanchez,119
-Sacramento,22139,U.S. Senate,,DEM,Kamala Harris,145
-Sacramento,22139,U.S. Senate,,DEM,Loretta Sanchez,127
-Sacramento,22143,U.S. Senate,,DEM,Kamala Harris,215
-Sacramento,22143,U.S. Senate,,DEM,Loretta Sanchez,144
-Sacramento,22300,U.S. Senate,,DEM,Kamala Harris,0
-Sacramento,22300,U.S. Senate,,DEM,Loretta Sanchez,0
-Sacramento,22325,U.S. Senate,,DEM,Kamala Harris,126
-Sacramento,22325,U.S. Senate,,DEM,Loretta Sanchez,74
-Sacramento,22396,U.S. Senate,,DEM,Kamala Harris,82
-Sacramento,22396,U.S. Senate,,DEM,Loretta Sanchez,60
-Sacramento,22406,U.S. Senate,,DEM,Kamala Harris,0
-Sacramento,22406,U.S. Senate,,DEM,Loretta Sanchez,0
-Sacramento,22412,U.S. Senate,,DEM,Kamala Harris,0
-Sacramento,22412,U.S. Senate,,DEM,Loretta Sanchez,0
-Sacramento,22427,U.S. Senate,,DEM,Kamala Harris,0
-Sacramento,22427,U.S. Senate,,DEM,Loretta Sanchez,0
-Sacramento,22453,U.S. Senate,,DEM,Kamala Harris,232
-Sacramento,22453,U.S. Senate,,DEM,Loretta Sanchez,149
-Sacramento,22464,U.S. Senate,,DEM,Kamala Harris,227
-Sacramento,22464,U.S. Senate,,DEM,Loretta Sanchez,121
-Sacramento,22533,U.S. Senate,,DEM,Kamala Harris,138
-Sacramento,22533,U.S. Senate,,DEM,Loretta Sanchez,83
-Sacramento,22552,U.S. Senate,,DEM,Kamala Harris,134
-Sacramento,22552,U.S. Senate,,DEM,Loretta Sanchez,99
-Sacramento,22599,U.S. Senate,,DEM,Kamala Harris,172
-Sacramento,22599,U.S. Senate,,DEM,Loretta Sanchez,119
-Sacramento,22610,U.S. Senate,,DEM,Kamala Harris,107
-Sacramento,22610,U.S. Senate,,DEM,Loretta Sanchez,70
-Sacramento,22685,U.S. Senate,,DEM,Kamala Harris,53
-Sacramento,22685,U.S. Senate,,DEM,Loretta Sanchez,22
-Sacramento,22694,U.S. Senate,,DEM,Kamala Harris,130
-Sacramento,22694,U.S. Senate,,DEM,Loretta Sanchez,105
-Sacramento,22709,U.S. Senate,,DEM,Kamala Harris,175
-Sacramento,22709,U.S. Senate,,DEM,Loretta Sanchez,123
-Sacramento,22730,U.S. Senate,,DEM,Kamala Harris,194
-Sacramento,22730,U.S. Senate,,DEM,Loretta Sanchez,84
-Sacramento,22824,U.S. Senate,,DEM,Kamala Harris,135
-Sacramento,22824,U.S. Senate,,DEM,Loretta Sanchez,91
-Sacramento,22847,U.S. Senate,,DEM,Kamala Harris,167
-Sacramento,22847,U.S. Senate,,DEM,Loretta Sanchez,75
-Sacramento,22873,U.S. Senate,,DEM,Kamala Harris,200
-Sacramento,22873,U.S. Senate,,DEM,Loretta Sanchez,122
-Sacramento,22898,U.S. Senate,,DEM,Kamala Harris,10
-Sacramento,22898,U.S. Senate,,DEM,Loretta Sanchez,4
-Sacramento,22997,U.S. Senate,,DEM,Kamala Harris,30
-Sacramento,22997,U.S. Senate,,DEM,Loretta Sanchez,15
-Sacramento,23002,U.S. Senate,,DEM,Kamala Harris,199
-Sacramento,23002,U.S. Senate,,DEM,Loretta Sanchez,157
-Sacramento,23077,U.S. Senate,,DEM,Kamala Harris,181
-Sacramento,23077,U.S. Senate,,DEM,Loretta Sanchez,168
-Sacramento,23221,U.S. Senate,,DEM,Kamala Harris,73
-Sacramento,23221,U.S. Senate,,DEM,Loretta Sanchez,37
-Sacramento,23240,U.S. Senate,,DEM,Kamala Harris,190
-Sacramento,23240,U.S. Senate,,DEM,Loretta Sanchez,153
-Sacramento,23264,U.S. Senate,,DEM,Kamala Harris,114
-Sacramento,23264,U.S. Senate,,DEM,Loretta Sanchez,89
-Sacramento,23313,U.S. Senate,,DEM,Kamala Harris,220
-Sacramento,23313,U.S. Senate,,DEM,Loretta Sanchez,157
-Sacramento,23423,U.S. Senate,,DEM,Kamala Harris,193
-Sacramento,23423,U.S. Senate,,DEM,Loretta Sanchez,135
-Sacramento,23519,U.S. Senate,,DEM,Kamala Harris,166
-Sacramento,23519,U.S. Senate,,DEM,Loretta Sanchez,139
-Sacramento,23542,U.S. Senate,,DEM,Kamala Harris,154
-Sacramento,23542,U.S. Senate,,DEM,Loretta Sanchez,124
-Sacramento,23637,U.S. Senate,,DEM,Kamala Harris,213
-Sacramento,23637,U.S. Senate,,DEM,Loretta Sanchez,163
-Sacramento,23733,U.S. Senate,,DEM,Kamala Harris,195
-Sacramento,23733,U.S. Senate,,DEM,Loretta Sanchez,126
-Sacramento,23769,U.S. Senate,,DEM,Kamala Harris,190
-Sacramento,23769,U.S. Senate,,DEM,Loretta Sanchez,107
-Sacramento,23879,U.S. Senate,,DEM,Kamala Harris,209
-Sacramento,23879,U.S. Senate,,DEM,Loretta Sanchez,162
-Sacramento,23905,U.S. Senate,,DEM,Kamala Harris,119
-Sacramento,23905,U.S. Senate,,DEM,Loretta Sanchez,106
-Sacramento,23970,U.S. Senate,,DEM,Kamala Harris,106
-Sacramento,23970,U.S. Senate,,DEM,Loretta Sanchez,85
-Sacramento,24005,U.S. Senate,,DEM,Kamala Harris,0
-Sacramento,24005,U.S. Senate,,DEM,Loretta Sanchez,0
-Sacramento,24033,U.S. Senate,,DEM,Kamala Harris,52
-Sacramento,24033,U.S. Senate,,DEM,Loretta Sanchez,26
-Sacramento,24067,U.S. Senate,,DEM,Kamala Harris,0
-Sacramento,24067,U.S. Senate,,DEM,Loretta Sanchez,0
-Sacramento,24148,U.S. Senate,,DEM,Kamala Harris,201
-Sacramento,24148,U.S. Senate,,DEM,Loretta Sanchez,119
-Sacramento,24182,U.S. Senate,,DEM,Kamala Harris,129
-Sacramento,24182,U.S. Senate,,DEM,Loretta Sanchez,81
-Sacramento,24263,U.S. Senate,,DEM,Kamala Harris,0
-Sacramento,24263,U.S. Senate,,DEM,Loretta Sanchez,1
-Sacramento,24352,U.S. Senate,,DEM,Kamala Harris,166
-Sacramento,24352,U.S. Senate,,DEM,Loretta Sanchez,106
-Sacramento,24360,U.S. Senate,,DEM,Kamala Harris,21
-Sacramento,24360,U.S. Senate,,DEM,Loretta Sanchez,17
-Sacramento,24385,U.S. Senate,,DEM,Kamala Harris,107
-Sacramento,24385,U.S. Senate,,DEM,Loretta Sanchez,53
-Sacramento,24438,U.S. Senate,,DEM,Kamala Harris,0
-Sacramento,24438,U.S. Senate,,DEM,Loretta Sanchez,0
-Sacramento,24500,U.S. Senate,,DEM,Kamala Harris,119
-Sacramento,24500,U.S. Senate,,DEM,Loretta Sanchez,71
-Sacramento,24557,U.S. Senate,,DEM,Kamala Harris,171
-Sacramento,24557,U.S. Senate,,DEM,Loretta Sanchez,109
-Sacramento,24651,U.S. Senate,,DEM,Kamala Harris,120
-Sacramento,24651,U.S. Senate,,DEM,Loretta Sanchez,90
-Sacramento,24669,U.S. Senate,,DEM,Kamala Harris,150
-Sacramento,24669,U.S. Senate,,DEM,Loretta Sanchez,110
-Sacramento,24684,U.S. Senate,,DEM,Kamala Harris,128
-Sacramento,24684,U.S. Senate,,DEM,Loretta Sanchez,66
-Sacramento,24739,U.S. Senate,,DEM,Kamala Harris,223
-Sacramento,24739,U.S. Senate,,DEM,Loretta Sanchez,112
-Sacramento,24801,U.S. Senate,,DEM,Kamala Harris,196
-Sacramento,24801,U.S. Senate,,DEM,Loretta Sanchez,119
-Sacramento,24874,U.S. Senate,,DEM,Kamala Harris,187
-Sacramento,24874,U.S. Senate,,DEM,Loretta Sanchez,92
-Sacramento,24908,U.S. Senate,,DEM,Kamala Harris,224
-Sacramento,24908,U.S. Senate,,DEM,Loretta Sanchez,128
-Sacramento,24927,U.S. Senate,,DEM,Kamala Harris,137
-Sacramento,24927,U.S. Senate,,DEM,Loretta Sanchez,92
-Sacramento,25011,U.S. Senate,,DEM,Kamala Harris,105
-Sacramento,25011,U.S. Senate,,DEM,Loretta Sanchez,69
-Sacramento,25076,U.S. Senate,,DEM,Kamala Harris,139
-Sacramento,25076,U.S. Senate,,DEM,Loretta Sanchez,66
-Sacramento,25155,U.S. Senate,,DEM,Kamala Harris,163
-Sacramento,25155,U.S. Senate,,DEM,Loretta Sanchez,121
-Sacramento,25234,U.S. Senate,,DEM,Kamala Harris,169
-Sacramento,25234,U.S. Senate,,DEM,Loretta Sanchez,81
-Sacramento,25404,U.S. Senate,,DEM,Kamala Harris,37
-Sacramento,25404,U.S. Senate,,DEM,Loretta Sanchez,12
-Sacramento,25432,U.S. Senate,,DEM,Kamala Harris,216
-Sacramento,25432,U.S. Senate,,DEM,Loretta Sanchez,126
-Sacramento,25493,U.S. Senate,,DEM,Kamala Harris,0
-Sacramento,25493,U.S. Senate,,DEM,Loretta Sanchez,0
-Sacramento,25501,U.S. Senate,,DEM,Kamala Harris,160
-Sacramento,25501,U.S. Senate,,DEM,Loretta Sanchez,83
-Sacramento,25536,U.S. Senate,,DEM,Kamala Harris,138
-Sacramento,25536,U.S. Senate,,DEM,Loretta Sanchez,68
-Sacramento,25588,U.S. Senate,,DEM,Kamala Harris,202
-Sacramento,25588,U.S. Senate,,DEM,Loretta Sanchez,131
-Sacramento,25696,U.S. Senate,,DEM,Kamala Harris,154
-Sacramento,25696,U.S. Senate,,DEM,Loretta Sanchez,114
-Sacramento,25703,U.S. Senate,,DEM,Kamala Harris,94
-Sacramento,25703,U.S. Senate,,DEM,Loretta Sanchez,46
-Sacramento,25741,U.S. Senate,,DEM,Kamala Harris,155
-Sacramento,25741,U.S. Senate,,DEM,Loretta Sanchez,91
-Sacramento,25812,U.S. Senate,,DEM,Kamala Harris,148
-Sacramento,25812,U.S. Senate,,DEM,Loretta Sanchez,73
-Sacramento,25845,U.S. Senate,,DEM,Kamala Harris,138
-Sacramento,25845,U.S. Senate,,DEM,Loretta Sanchez,114
-Sacramento,25919,U.S. Senate,,DEM,Kamala Harris,153
-Sacramento,25919,U.S. Senate,,DEM,Loretta Sanchez,99
-Sacramento,25935,U.S. Senate,,DEM,Kamala Harris,241
-Sacramento,25935,U.S. Senate,,DEM,Loretta Sanchez,163
-Sacramento,25990,U.S. Senate,,DEM,Kamala Harris,130
-Sacramento,25990,U.S. Senate,,DEM,Loretta Sanchez,70
-Sacramento,26069,U.S. Senate,,DEM,Kamala Harris,235
-Sacramento,26069,U.S. Senate,,DEM,Loretta Sanchez,131
-Sacramento,26086,U.S. Senate,,DEM,Kamala Harris,126
-Sacramento,26086,U.S. Senate,,DEM,Loretta Sanchez,71
-Sacramento,26171,U.S. Senate,,DEM,Kamala Harris,139
-Sacramento,26171,U.S. Senate,,DEM,Loretta Sanchez,125
-Sacramento,26275,U.S. Senate,,DEM,Kamala Harris,29
-Sacramento,26275,U.S. Senate,,DEM,Loretta Sanchez,15
-Sacramento,26370,U.S. Senate,,DEM,Kamala Harris,15
-Sacramento,26370,U.S. Senate,,DEM,Loretta Sanchez,9
-Sacramento,26413,U.S. Senate,,DEM,Kamala Harris,125
-Sacramento,26413,U.S. Senate,,DEM,Loretta Sanchez,80
-Sacramento,26442,U.S. Senate,,DEM,Kamala Harris,133
-Sacramento,26442,U.S. Senate,,DEM,Loretta Sanchez,100
-Sacramento,26512,U.S. Senate,,DEM,Kamala Harris,184
-Sacramento,26512,U.S. Senate,,DEM,Loretta Sanchez,119
-Sacramento,26597,U.S. Senate,,DEM,Kamala Harris,111
-Sacramento,26597,U.S. Senate,,DEM,Loretta Sanchez,66
-Sacramento,26625,U.S. Senate,,DEM,Kamala Harris,222
-Sacramento,26625,U.S. Senate,,DEM,Loretta Sanchez,133
-Sacramento,26683,U.S. Senate,,DEM,Kamala Harris,0
-Sacramento,26683,U.S. Senate,,DEM,Loretta Sanchez,0
-Sacramento,26715,U.S. Senate,,DEM,Kamala Harris,199
-Sacramento,26715,U.S. Senate,,DEM,Loretta Sanchez,94
-Sacramento,26747,U.S. Senate,,DEM,Kamala Harris,172
-Sacramento,26747,U.S. Senate,,DEM,Loretta Sanchez,104
-Sacramento,26808,U.S. Senate,,DEM,Kamala Harris,172
-Sacramento,26808,U.S. Senate,,DEM,Loretta Sanchez,84
-Sacramento,26830,U.S. Senate,,DEM,Kamala Harris,129
-Sacramento,26830,U.S. Senate,,DEM,Loretta Sanchez,109
-Sacramento,26861,U.S. Senate,,DEM,Kamala Harris,114
-Sacramento,26861,U.S. Senate,,DEM,Loretta Sanchez,73
-Sacramento,26893,U.S. Senate,,DEM,Kamala Harris,1
-Sacramento,26893,U.S. Senate,,DEM,Loretta Sanchez,0
-Sacramento,26916,U.S. Senate,,DEM,Kamala Harris,201
-Sacramento,26916,U.S. Senate,,DEM,Loretta Sanchez,116
-Sacramento,26978,U.S. Senate,,DEM,Kamala Harris,168
-Sacramento,26978,U.S. Senate,,DEM,Loretta Sanchez,89
-Sacramento,27031,U.S. Senate,,DEM,Kamala Harris,0
-Sacramento,27031,U.S. Senate,,DEM,Loretta Sanchez,0
-Sacramento,27046,U.S. Senate,,DEM,Kamala Harris,166
-Sacramento,27046,U.S. Senate,,DEM,Loretta Sanchez,86
-Sacramento,27098,U.S. Senate,,DEM,Kamala Harris,147
-Sacramento,27098,U.S. Senate,,DEM,Loretta Sanchez,72
-Sacramento,27100,U.S. Senate,,DEM,Kamala Harris,162
-Sacramento,27100,U.S. Senate,,DEM,Loretta Sanchez,97
-Sacramento,27212,U.S. Senate,,DEM,Kamala Harris,133
-Sacramento,27212,U.S. Senate,,DEM,Loretta Sanchez,76
-Sacramento,27223,U.S. Senate,,DEM,Kamala Harris,158
-Sacramento,27223,U.S. Senate,,DEM,Loretta Sanchez,74
-Sacramento,27320,U.S. Senate,,DEM,Kamala Harris,203
-Sacramento,27320,U.S. Senate,,DEM,Loretta Sanchez,105
-Sacramento,27506,U.S. Senate,,DEM,Kamala Harris,215
-Sacramento,27506,U.S. Senate,,DEM,Loretta Sanchez,112
-Sacramento,27595,U.S. Senate,,DEM,Kamala Harris,1
-Sacramento,27595,U.S. Senate,,DEM,Loretta Sanchez,2
-Sacramento,27602,U.S. Senate,,DEM,Kamala Harris,212
-Sacramento,27602,U.S. Senate,,DEM,Loretta Sanchez,104
-Sacramento,27648,U.S. Senate,,DEM,Kamala Harris,252
-Sacramento,27648,U.S. Senate,,DEM,Loretta Sanchez,158
-Sacramento,27719,U.S. Senate,,DEM,Kamala Harris,266
-Sacramento,27719,U.S. Senate,,DEM,Loretta Sanchez,98
-Sacramento,27721,U.S. Senate,,DEM,Kamala Harris,163
-Sacramento,27721,U.S. Senate,,DEM,Loretta Sanchez,79
-Sacramento,27872,U.S. Senate,,DEM,Kamala Harris,38
-Sacramento,27872,U.S. Senate,,DEM,Loretta Sanchez,18
-Sacramento,27915,U.S. Senate,,DEM,Kamala Harris,53
-Sacramento,27915,U.S. Senate,,DEM,Loretta Sanchez,30
-Sacramento,27971,U.S. Senate,,DEM,Kamala Harris,165
-Sacramento,27971,U.S. Senate,,DEM,Loretta Sanchez,64
-Sacramento,28014,U.S. Senate,,DEM,Kamala Harris,226
-Sacramento,28014,U.S. Senate,,DEM,Loretta Sanchez,128
-Sacramento,28200,U.S. Senate,,DEM,Kamala Harris,222
-Sacramento,28200,U.S. Senate,,DEM,Loretta Sanchez,128
-Sacramento,28299,U.S. Senate,,DEM,Kamala Harris,87
-Sacramento,28299,U.S. Senate,,DEM,Loretta Sanchez,50
-Sacramento,28368,U.S. Senate,,DEM,Kamala Harris,184
-Sacramento,28368,U.S. Senate,,DEM,Loretta Sanchez,80
-Sacramento,28392,U.S. Senate,,DEM,Kamala Harris,217
-Sacramento,28392,U.S. Senate,,DEM,Loretta Sanchez,112
-Sacramento,28417,U.S. Senate,,DEM,Kamala Harris,136
-Sacramento,28417,U.S. Senate,,DEM,Loretta Sanchez,65
-Sacramento,28522,U.S. Senate,,DEM,Kamala Harris,125
-Sacramento,28522,U.S. Senate,,DEM,Loretta Sanchez,58
-Sacramento,28530,U.S. Senate,,DEM,Kamala Harris,245
-Sacramento,28530,U.S. Senate,,DEM,Loretta Sanchez,97
-Sacramento,28656,U.S. Senate,,DEM,Kamala Harris,328
-Sacramento,28656,U.S. Senate,,DEM,Loretta Sanchez,121
-Sacramento,28773,U.S. Senate,,DEM,Kamala Harris,185
-Sacramento,28773,U.S. Senate,,DEM,Loretta Sanchez,102
-Sacramento,28809,U.S. Senate,,DEM,Kamala Harris,131
-Sacramento,28809,U.S. Senate,,DEM,Loretta Sanchez,61
-Sacramento,28939,U.S. Senate,,DEM,Kamala Harris,150
-Sacramento,28939,U.S. Senate,,DEM,Loretta Sanchez,83
-Sacramento,29043,U.S. Senate,,DEM,Kamala Harris,150
-Sacramento,29043,U.S. Senate,,DEM,Loretta Sanchez,70
-Sacramento,29128,U.S. Senate,,DEM,Kamala Harris,190
-Sacramento,29128,U.S. Senate,,DEM,Loretta Sanchez,92
-Sacramento,29205,U.S. Senate,,DEM,Kamala Harris,201
-Sacramento,29205,U.S. Senate,,DEM,Loretta Sanchez,109
-Sacramento,29298,U.S. Senate,,DEM,Kamala Harris,236
-Sacramento,29298,U.S. Senate,,DEM,Loretta Sanchez,129
-Sacramento,29434,U.S. Senate,,DEM,Kamala Harris,261
-Sacramento,29434,U.S. Senate,,DEM,Loretta Sanchez,133
-Sacramento,29661,U.S. Senate,,DEM,Kamala Harris,190
-Sacramento,29661,U.S. Senate,,DEM,Loretta Sanchez,83
-Sacramento,29825,U.S. Senate,,DEM,Kamala Harris,111
-Sacramento,29825,U.S. Senate,,DEM,Loretta Sanchez,48
-Sacramento,29848,U.S. Senate,,DEM,Kamala Harris,172
-Sacramento,29848,U.S. Senate,,DEM,Loretta Sanchez,86
-Sacramento,31066,U.S. Senate,,DEM,Kamala Harris,175
-Sacramento,31066,U.S. Senate,,DEM,Loretta Sanchez,156
-Sacramento,31082,U.S. Senate,,DEM,Kamala Harris,127
-Sacramento,31082,U.S. Senate,,DEM,Loretta Sanchez,102
-Sacramento,31193,U.S. Senate,,DEM,Kamala Harris,242
-Sacramento,31193,U.S. Senate,,DEM,Loretta Sanchez,164
-Sacramento,31271,U.S. Senate,,DEM,Kamala Harris,239
-Sacramento,31271,U.S. Senate,,DEM,Loretta Sanchez,167
-Sacramento,31348,U.S. Senate,,DEM,Kamala Harris,208
-Sacramento,31348,U.S. Senate,,DEM,Loretta Sanchez,151
-Sacramento,31432,U.S. Senate,,DEM,Kamala Harris,103
-Sacramento,31432,U.S. Senate,,DEM,Loretta Sanchez,89
-Sacramento,31461,U.S. Senate,,DEM,Kamala Harris,197
-Sacramento,31461,U.S. Senate,,DEM,Loretta Sanchez,155
-Sacramento,31538,U.S. Senate,,DEM,Kamala Harris,126
-Sacramento,31538,U.S. Senate,,DEM,Loretta Sanchez,84
-Sacramento,31574,U.S. Senate,,DEM,Kamala Harris,185
-Sacramento,31574,U.S. Senate,,DEM,Loretta Sanchez,131
-Sacramento,31631,U.S. Senate,,DEM,Kamala Harris,164
-Sacramento,31631,U.S. Senate,,DEM,Loretta Sanchez,101
-Sacramento,31662,U.S. Senate,,DEM,Kamala Harris,177
-Sacramento,31662,U.S. Senate,,DEM,Loretta Sanchez,110
-Sacramento,31765,U.S. Senate,,DEM,Kamala Harris,123
-Sacramento,31765,U.S. Senate,,DEM,Loretta Sanchez,82
-Sacramento,31808,U.S. Senate,,DEM,Kamala Harris,1
-Sacramento,31808,U.S. Senate,,DEM,Loretta Sanchez,2
-Sacramento,31839,U.S. Senate,,DEM,Kamala Harris,186
-Sacramento,31839,U.S. Senate,,DEM,Loretta Sanchez,126
-Sacramento,31900,U.S. Senate,,DEM,Kamala Harris,195
-Sacramento,31900,U.S. Senate,,DEM,Loretta Sanchez,109
-Sacramento,31981,U.S. Senate,,DEM,Kamala Harris,104
-Sacramento,31981,U.S. Senate,,DEM,Loretta Sanchez,54
-Sacramento,31994,U.S. Senate,,DEM,Kamala Harris,146
-Sacramento,31994,U.S. Senate,,DEM,Loretta Sanchez,101
-Sacramento,32101,U.S. Senate,,DEM,Kamala Harris,151
-Sacramento,32101,U.S. Senate,,DEM,Loretta Sanchez,125
-Sacramento,32206,U.S. Senate,,DEM,Kamala Harris,165
-Sacramento,32206,U.S. Senate,,DEM,Loretta Sanchez,124
-Sacramento,32435,U.S. Senate,,DEM,Kamala Harris,169
-Sacramento,32435,U.S. Senate,,DEM,Loretta Sanchez,130
-Sacramento,32554,U.S. Senate,,DEM,Kamala Harris,147
-Sacramento,32554,U.S. Senate,,DEM,Loretta Sanchez,106
-Sacramento,32773,U.S. Senate,,DEM,Kamala Harris,167
-Sacramento,32773,U.S. Senate,,DEM,Loretta Sanchez,121
-Sacramento,32872,U.S. Senate,,DEM,Kamala Harris,140
-Sacramento,32872,U.S. Senate,,DEM,Loretta Sanchez,109
-Sacramento,33017,U.S. Senate,,DEM,Kamala Harris,0
-Sacramento,33017,U.S. Senate,,DEM,Loretta Sanchez,0
-Sacramento,33108,U.S. Senate,,DEM,Kamala Harris,122
-Sacramento,33108,U.S. Senate,,DEM,Loretta Sanchez,90
-Sacramento,33126,U.S. Senate,,DEM,Kamala Harris,179
-Sacramento,33126,U.S. Senate,,DEM,Loretta Sanchez,110
-Sacramento,33227,U.S. Senate,,DEM,Kamala Harris,168
-Sacramento,33227,U.S. Senate,,DEM,Loretta Sanchez,83
-Sacramento,33431,U.S. Senate,,DEM,Kamala Harris,89
-Sacramento,33431,U.S. Senate,,DEM,Loretta Sanchez,61
-Sacramento,33529,U.S. Senate,,DEM,Kamala Harris,159
-Sacramento,33529,U.S. Senate,,DEM,Loretta Sanchez,94
-Sacramento,33622,U.S. Senate,,DEM,Kamala Harris,0
-Sacramento,33622,U.S. Senate,,DEM,Loretta Sanchez,0
-Sacramento,33713,U.S. Senate,,DEM,Kamala Harris,169
-Sacramento,33713,U.S. Senate,,DEM,Loretta Sanchez,100
-Sacramento,33774,U.S. Senate,,DEM,Kamala Harris,158
-Sacramento,33774,U.S. Senate,,DEM,Loretta Sanchez,101
-Sacramento,33818,U.S. Senate,,DEM,Kamala Harris,224
-Sacramento,33818,U.S. Senate,,DEM,Loretta Sanchez,133
-Sacramento,33997,U.S. Senate,,DEM,Kamala Harris,286
-Sacramento,33997,U.S. Senate,,DEM,Loretta Sanchez,108
-Sacramento,34064,U.S. Senate,,DEM,Kamala Harris,162
-Sacramento,34064,U.S. Senate,,DEM,Loretta Sanchez,94
-Sacramento,34180,U.S. Senate,,DEM,Kamala Harris,228
-Sacramento,34180,U.S. Senate,,DEM,Loretta Sanchez,152
-Sacramento,34322,U.S. Senate,,DEM,Kamala Harris,176
-Sacramento,34322,U.S. Senate,,DEM,Loretta Sanchez,149
-Sacramento,34410,U.S. Senate,,DEM,Kamala Harris,4
-Sacramento,34410,U.S. Senate,,DEM,Loretta Sanchez,3
-Sacramento,34452,U.S. Senate,,DEM,Kamala Harris,113
-Sacramento,34452,U.S. Senate,,DEM,Loretta Sanchez,79
-Sacramento,34600,U.S. Senate,,DEM,Kamala Harris,238
-Sacramento,34600,U.S. Senate,,DEM,Loretta Sanchez,155
-Sacramento,34726,U.S. Senate,,DEM,Kamala Harris,190
-Sacramento,34726,U.S. Senate,,DEM,Loretta Sanchez,114
-Sacramento,34824,U.S. Senate,,DEM,Kamala Harris,204
-Sacramento,34824,U.S. Senate,,DEM,Loretta Sanchez,129
-Sacramento,35026,U.S. Senate,,DEM,Kamala Harris,95
-Sacramento,35026,U.S. Senate,,DEM,Loretta Sanchez,38
-Sacramento,35088,U.S. Senate,,DEM,Kamala Harris,31
-Sacramento,35088,U.S. Senate,,DEM,Loretta Sanchez,8
-Sacramento,35127,U.S. Senate,,DEM,Kamala Harris,210
-Sacramento,35127,U.S. Senate,,DEM,Loretta Sanchez,144
-Sacramento,35215,U.S. Senate,,DEM,Kamala Harris,212
-Sacramento,35215,U.S. Senate,,DEM,Loretta Sanchez,143
-Sacramento,35260,U.S. Senate,,DEM,Kamala Harris,162
-Sacramento,35260,U.S. Senate,,DEM,Loretta Sanchez,109
-Sacramento,35383,U.S. Senate,,DEM,Kamala Harris,0
-Sacramento,35383,U.S. Senate,,DEM,Loretta Sanchez,0
-Sacramento,35402,U.S. Senate,,DEM,Kamala Harris,197
-Sacramento,35402,U.S. Senate,,DEM,Loretta Sanchez,127
-Sacramento,35500,U.S. Senate,,DEM,Kamala Harris,236
-Sacramento,35500,U.S. Senate,,DEM,Loretta Sanchez,144
-Sacramento,35636,U.S. Senate,,DEM,Kamala Harris,221
-Sacramento,35636,U.S. Senate,,DEM,Loretta Sanchez,123
-Sacramento,35678,U.S. Senate,,DEM,Kamala Harris,16
-Sacramento,35678,U.S. Senate,,DEM,Loretta Sanchez,12
-Sacramento,35797,U.S. Senate,,DEM,Kamala Harris,171
-Sacramento,35797,U.S. Senate,,DEM,Loretta Sanchez,124
-Sacramento,35852,U.S. Senate,,DEM,Kamala Harris,90
-Sacramento,35852,U.S. Senate,,DEM,Loretta Sanchez,70
-Sacramento,35886,U.S. Senate,,DEM,Kamala Harris,165
-Sacramento,35886,U.S. Senate,,DEM,Loretta Sanchez,94
-Sacramento,35961,U.S. Senate,,DEM,Kamala Harris,1
-Sacramento,35961,U.S. Senate,,DEM,Loretta Sanchez,0
-Sacramento,35989,U.S. Senate,,DEM,Kamala Harris,0
-Sacramento,35989,U.S. Senate,,DEM,Loretta Sanchez,0
-Sacramento,36005,U.S. Senate,,DEM,Kamala Harris,179
-Sacramento,36005,U.S. Senate,,DEM,Loretta Sanchez,110
-Sacramento,36104,U.S. Senate,,DEM,Kamala Harris,232
-Sacramento,36104,U.S. Senate,,DEM,Loretta Sanchez,115
-Sacramento,36274,U.S. Senate,,DEM,Kamala Harris,166
-Sacramento,36274,U.S. Senate,,DEM,Loretta Sanchez,123
-Sacramento,36389,U.S. Senate,,DEM,Kamala Harris,200
-Sacramento,36389,U.S. Senate,,DEM,Loretta Sanchez,165
-Sacramento,36407,U.S. Senate,,DEM,Kamala Harris,203
-Sacramento,36407,U.S. Senate,,DEM,Loretta Sanchez,137
-Sacramento,36433,U.S. Senate,,DEM,Kamala Harris,184
-Sacramento,36433,U.S. Senate,,DEM,Loretta Sanchez,96
-Sacramento,36556,U.S. Senate,,DEM,Kamala Harris,214
-Sacramento,36556,U.S. Senate,,DEM,Loretta Sanchez,101
-Sacramento,36602,U.S. Senate,,DEM,Kamala Harris,196
-Sacramento,36602,U.S. Senate,,DEM,Loretta Sanchez,111
-Sacramento,36645,U.S. Senate,,DEM,Kamala Harris,248
-Sacramento,36645,U.S. Senate,,DEM,Loretta Sanchez,145
-Sacramento,36781,U.S. Senate,,DEM,Kamala Harris,156
-Sacramento,36781,U.S. Senate,,DEM,Loretta Sanchez,80
-Sacramento,36844,U.S. Senate,,DEM,Kamala Harris,155
-Sacramento,36844,U.S. Senate,,DEM,Loretta Sanchez,89
-Sacramento,36973,U.S. Senate,,DEM,Kamala Harris,219
-Sacramento,36973,U.S. Senate,,DEM,Loretta Sanchez,97
-Sacramento,37109,U.S. Senate,,DEM,Kamala Harris,229
-Sacramento,37109,U.S. Senate,,DEM,Loretta Sanchez,123
-Sacramento,37138,U.S. Senate,,DEM,Kamala Harris,241
-Sacramento,37138,U.S. Senate,,DEM,Loretta Sanchez,151
-Sacramento,37258,U.S. Senate,,DEM,Kamala Harris,171
-Sacramento,37258,U.S. Senate,,DEM,Loretta Sanchez,118
-Sacramento,37296,U.S. Senate,,DEM,Kamala Harris,208
-Sacramento,37296,U.S. Senate,,DEM,Loretta Sanchez,103
-Sacramento,37830,U.S. Senate,,DEM,Kamala Harris,7
-Sacramento,37830,U.S. Senate,,DEM,Loretta Sanchez,4
-Sacramento,38113,U.S. Senate,,DEM,Kamala Harris,178
-Sacramento,38113,U.S. Senate,,DEM,Loretta Sanchez,105
-Sacramento,38570,U.S. Senate,,DEM,Kamala Harris,189
-Sacramento,38570,U.S. Senate,,DEM,Loretta Sanchez,107
-Sacramento,39027,U.S. Senate,,DEM,Kamala Harris,143
-Sacramento,39027,U.S. Senate,,DEM,Loretta Sanchez,65
-Sacramento,39226,U.S. Senate,,DEM,Kamala Harris,206
-Sacramento,39226,U.S. Senate,,DEM,Loretta Sanchez,131
-Sacramento,39423,U.S. Senate,,DEM,Kamala Harris,192
-Sacramento,39423,U.S. Senate,,DEM,Loretta Sanchez,95
-Sacramento,39471,U.S. Senate,,DEM,Kamala Harris,222
-Sacramento,39471,U.S. Senate,,DEM,Loretta Sanchez,105
-Sacramento,39508,U.S. Senate,,DEM,Kamala Harris,171
-Sacramento,39508,U.S. Senate,,DEM,Loretta Sanchez,95
-Sacramento,39704,U.S. Senate,,DEM,Kamala Harris,181
-Sacramento,39704,U.S. Senate,,DEM,Loretta Sanchez,116
-Sacramento,41017,U.S. Senate,,DEM,Kamala Harris,61
-Sacramento,41017,U.S. Senate,,DEM,Loretta Sanchez,28
-Sacramento,41109,U.S. Senate,,DEM,Kamala Harris,20
-Sacramento,41109,U.S. Senate,,DEM,Loretta Sanchez,13
-Sacramento,41165,U.S. Senate,,DEM,Kamala Harris,134
-Sacramento,41165,U.S. Senate,,DEM,Loretta Sanchez,66
-Sacramento,41216,U.S. Senate,,DEM,Kamala Harris,242
-Sacramento,41216,U.S. Senate,,DEM,Loretta Sanchez,142
-Sacramento,41262,U.S. Senate,,DEM,Kamala Harris,297
-Sacramento,41262,U.S. Senate,,DEM,Loretta Sanchez,105
-Sacramento,41321,U.S. Senate,,DEM,Kamala Harris,168
-Sacramento,41321,U.S. Senate,,DEM,Loretta Sanchez,77
-Sacramento,41378,U.S. Senate,,DEM,Kamala Harris,262
-Sacramento,41378,U.S. Senate,,DEM,Loretta Sanchez,90
-Sacramento,41464,U.S. Senate,,DEM,Kamala Harris,243
-Sacramento,41464,U.S. Senate,,DEM,Loretta Sanchez,92
-Sacramento,41560,U.S. Senate,,DEM,Kamala Harris,275
-Sacramento,41560,U.S. Senate,,DEM,Loretta Sanchez,96
-Sacramento,41572,U.S. Senate,,DEM,Kamala Harris,165
-Sacramento,41572,U.S. Senate,,DEM,Loretta Sanchez,81
-Sacramento,41673,U.S. Senate,,DEM,Kamala Harris,271
-Sacramento,41673,U.S. Senate,,DEM,Loretta Sanchez,124
-Sacramento,41686,U.S. Senate,,DEM,Kamala Harris,304
-Sacramento,41686,U.S. Senate,,DEM,Loretta Sanchez,137
-Sacramento,41722,U.S. Senate,,DEM,Kamala Harris,158
-Sacramento,41722,U.S. Senate,,DEM,Loretta Sanchez,74
-Sacramento,41769,U.S. Senate,,DEM,Kamala Harris,285
-Sacramento,41769,U.S. Senate,,DEM,Loretta Sanchez,128
-Sacramento,41818,U.S. Senate,,DEM,Kamala Harris,208
-Sacramento,41818,U.S. Senate,,DEM,Loretta Sanchez,96
-Sacramento,41899,U.S. Senate,,DEM,Kamala Harris,263
-Sacramento,41899,U.S. Senate,,DEM,Loretta Sanchez,105
-Sacramento,41976,U.S. Senate,,DEM,Kamala Harris,346
-Sacramento,41976,U.S. Senate,,DEM,Loretta Sanchez,128
-Sacramento,42016,U.S. Senate,,DEM,Kamala Harris,329
-Sacramento,42016,U.S. Senate,,DEM,Loretta Sanchez,99
-Sacramento,42258,U.S. Senate,,DEM,Kamala Harris,312
-Sacramento,42258,U.S. Senate,,DEM,Loretta Sanchez,73
-Sacramento,42312,U.S. Senate,,DEM,Kamala Harris,319
-Sacramento,42312,U.S. Senate,,DEM,Loretta Sanchez,112
-Sacramento,42351,U.S. Senate,,DEM,Kamala Harris,200
-Sacramento,42351,U.S. Senate,,DEM,Loretta Sanchez,75
-Sacramento,42363,U.S. Senate,,DEM,Kamala Harris,269
-Sacramento,42363,U.S. Senate,,DEM,Loretta Sanchez,94
-Sacramento,42434,U.S. Senate,,DEM,Kamala Harris,141
-Sacramento,42434,U.S. Senate,,DEM,Loretta Sanchez,57
-Sacramento,42459,U.S. Senate,,DEM,Kamala Harris,327
-Sacramento,42459,U.S. Senate,,DEM,Loretta Sanchez,106
-Sacramento,42509,U.S. Senate,,DEM,Kamala Harris,246
-Sacramento,42509,U.S. Senate,,DEM,Loretta Sanchez,102
-Sacramento,42605,U.S. Senate,,DEM,Kamala Harris,264
-Sacramento,42605,U.S. Senate,,DEM,Loretta Sanchez,88
-Sacramento,42707,U.S. Senate,,DEM,Kamala Harris,329
-Sacramento,42707,U.S. Senate,,DEM,Loretta Sanchez,129
-Sacramento,42821,U.S. Senate,,DEM,Kamala Harris,324
-Sacramento,42821,U.S. Senate,,DEM,Loretta Sanchez,121
-Sacramento,42854,U.S. Senate,,DEM,Kamala Harris,203
-Sacramento,42854,U.S. Senate,,DEM,Loretta Sanchez,97
-Sacramento,42946,U.S. Senate,,DEM,Kamala Harris,258
-Sacramento,42946,U.S. Senate,,DEM,Loretta Sanchez,103
-Sacramento,43033,U.S. Senate,,DEM,Kamala Harris,0
-Sacramento,43033,U.S. Senate,,DEM,Loretta Sanchez,0
-Sacramento,43148,U.S. Senate,,DEM,Kamala Harris,299
-Sacramento,43148,U.S. Senate,,DEM,Loretta Sanchez,124
-Sacramento,43242,U.S. Senate,,DEM,Kamala Harris,278
-Sacramento,43242,U.S. Senate,,DEM,Loretta Sanchez,92
-Sacramento,43329,U.S. Senate,,DEM,Kamala Harris,199
-Sacramento,43329,U.S. Senate,,DEM,Loretta Sanchez,211
-Sacramento,43400,U.S. Senate,,DEM,Kamala Harris,225
-Sacramento,43400,U.S. Senate,,DEM,Loretta Sanchez,109
-Sacramento,43439,U.S. Senate,,DEM,Kamala Harris,264
-Sacramento,43439,U.S. Senate,,DEM,Loretta Sanchez,115
-Sacramento,43691,U.S. Senate,,DEM,Kamala Harris,232
-Sacramento,43691,U.S. Senate,,DEM,Loretta Sanchez,114
-Sacramento,43738,U.S. Senate,,DEM,Kamala Harris,177
-Sacramento,43738,U.S. Senate,,DEM,Loretta Sanchez,102
-Sacramento,43845,U.S. Senate,,DEM,Kamala Harris,117
-Sacramento,43845,U.S. Senate,,DEM,Loretta Sanchez,54
-Sacramento,43915,U.S. Senate,,DEM,Kamala Harris,2
-Sacramento,43915,U.S. Senate,,DEM,Loretta Sanchez,3
-Sacramento,44013,U.S. Senate,,DEM,Kamala Harris,157
-Sacramento,44013,U.S. Senate,,DEM,Loretta Sanchez,55
-Sacramento,44059,U.S. Senate,,DEM,Kamala Harris,168
-Sacramento,44059,U.S. Senate,,DEM,Loretta Sanchez,94
-Sacramento,44158,U.S. Senate,,DEM,Kamala Harris,282
-Sacramento,44158,U.S. Senate,,DEM,Loretta Sanchez,69
-Sacramento,44191,U.S. Senate,,DEM,Kamala Harris,116
-Sacramento,44191,U.S. Senate,,DEM,Loretta Sanchez,45
-Sacramento,44209,U.S. Senate,,DEM,Kamala Harris,238
-Sacramento,44209,U.S. Senate,,DEM,Loretta Sanchez,109
-Sacramento,44274,U.S. Senate,,DEM,Kamala Harris,403
-Sacramento,44274,U.S. Senate,,DEM,Loretta Sanchez,88
-Sacramento,44346,U.S. Senate,,DEM,Kamala Harris,341
-Sacramento,44346,U.S. Senate,,DEM,Loretta Sanchez,104
-Sacramento,44507,U.S. Senate,,DEM,Kamala Harris,216
-Sacramento,44507,U.S. Senate,,DEM,Loretta Sanchez,64
-Sacramento,44520,U.S. Senate,,DEM,Kamala Harris,243
-Sacramento,44520,U.S. Senate,,DEM,Loretta Sanchez,63
-Sacramento,44549,U.S. Senate,,DEM,Kamala Harris,343
-Sacramento,44549,U.S. Senate,,DEM,Loretta Sanchez,108
-Sacramento,44601,U.S. Senate,,DEM,Kamala Harris,215
-Sacramento,44601,U.S. Senate,,DEM,Loretta Sanchez,140
-Sacramento,44625,U.S. Senate,,DEM,Kamala Harris,250
-Sacramento,44625,U.S. Senate,,DEM,Loretta Sanchez,91
-Sacramento,44663,U.S. Senate,,DEM,Kamala Harris,228
-Sacramento,44663,U.S. Senate,,DEM,Loretta Sanchez,67
-Sacramento,44706,U.S. Senate,,DEM,Kamala Harris,342
-Sacramento,44706,U.S. Senate,,DEM,Loretta Sanchez,136
-Sacramento,44757,U.S. Senate,,DEM,Kamala Harris,124
-Sacramento,44757,U.S. Senate,,DEM,Loretta Sanchez,49
-Sacramento,44804,U.S. Senate,,DEM,Kamala Harris,285
-Sacramento,44804,U.S. Senate,,DEM,Loretta Sanchez,148
-Sacramento,44903,U.S. Senate,,DEM,Kamala Harris,238
-Sacramento,44903,U.S. Senate,,DEM,Loretta Sanchez,139
-Sacramento,44992,U.S. Senate,,DEM,Kamala Harris,151
-Sacramento,44992,U.S. Senate,,DEM,Loretta Sanchez,114
-Sacramento,45015,U.S. Senate,,DEM,Kamala Harris,190
-Sacramento,45015,U.S. Senate,,DEM,Loretta Sanchez,113
-Sacramento,45058,U.S. Senate,,DEM,Kamala Harris,258
-Sacramento,45058,U.S. Senate,,DEM,Loretta Sanchez,111
-Sacramento,45107,U.S. Senate,,DEM,Kamala Harris,168
-Sacramento,45107,U.S. Senate,,DEM,Loretta Sanchez,114
-Sacramento,45164,U.S. Senate,,DEM,Kamala Harris,141
-Sacramento,45164,U.S. Senate,,DEM,Loretta Sanchez,102
-Sacramento,45241,U.S. Senate,,DEM,Kamala Harris,156
-Sacramento,45241,U.S. Senate,,DEM,Loretta Sanchez,130
-Sacramento,45314,U.S. Senate,,DEM,Kamala Harris,147
-Sacramento,45314,U.S. Senate,,DEM,Loretta Sanchez,152
-Sacramento,45418,U.S. Senate,,DEM,Kamala Harris,142
-Sacramento,45418,U.S. Senate,,DEM,Loretta Sanchez,149
-Sacramento,45453,U.S. Senate,,DEM,Kamala Harris,66
-Sacramento,45453,U.S. Senate,,DEM,Loretta Sanchez,67
-Sacramento,45482,U.S. Senate,,DEM,Kamala Harris,73
-Sacramento,45482,U.S. Senate,,DEM,Loretta Sanchez,59
-Sacramento,45511,U.S. Senate,,DEM,Kamala Harris,64
-Sacramento,45511,U.S. Senate,,DEM,Loretta Sanchez,70
-Sacramento,45548,U.S. Senate,,DEM,Kamala Harris,107
-Sacramento,45548,U.S. Senate,,DEM,Loretta Sanchez,115
-Sacramento,45624,U.S. Senate,,DEM,Kamala Harris,111
-Sacramento,45624,U.S. Senate,,DEM,Loretta Sanchez,143
-Sacramento,45670,U.S. Senate,,DEM,Kamala Harris,144
-Sacramento,45670,U.S. Senate,,DEM,Loretta Sanchez,167
-Sacramento,45701,U.S. Senate,,DEM,Kamala Harris,155
-Sacramento,45701,U.S. Senate,,DEM,Loretta Sanchez,152
-Sacramento,45736,U.S. Senate,,DEM,Kamala Harris,67
-Sacramento,45736,U.S. Senate,,DEM,Loretta Sanchez,59
-Sacramento,45774,U.S. Senate,,DEM,Kamala Harris,0
-Sacramento,45774,U.S. Senate,,DEM,Loretta Sanchez,2
-Sacramento,45847,U.S. Senate,,DEM,Kamala Harris,104
-Sacramento,45847,U.S. Senate,,DEM,Loretta Sanchez,132
-Sacramento,45908,U.S. Senate,,DEM,Kamala Harris,119
-Sacramento,45908,U.S. Senate,,DEM,Loretta Sanchez,102
-Sacramento,45956,U.S. Senate,,DEM,Kamala Harris,139
-Sacramento,45956,U.S. Senate,,DEM,Loretta Sanchez,139
-Sacramento,45997,U.S. Senate,,DEM,Kamala Harris,113
-Sacramento,45997,U.S. Senate,,DEM,Loretta Sanchez,67
-Sacramento,46014,U.S. Senate,,DEM,Kamala Harris,294
-Sacramento,46014,U.S. Senate,,DEM,Loretta Sanchez,117
-Sacramento,46098,U.S. Senate,,DEM,Kamala Harris,201
-Sacramento,46098,U.S. Senate,,DEM,Loretta Sanchez,104
-Sacramento,46153,U.S. Senate,,DEM,Kamala Harris,192
-Sacramento,46153,U.S. Senate,,DEM,Loretta Sanchez,137
-Sacramento,46220,U.S. Senate,,DEM,Kamala Harris,197
-Sacramento,46220,U.S. Senate,,DEM,Loretta Sanchez,106
-Sacramento,46307,U.S. Senate,,DEM,Kamala Harris,223
-Sacramento,46307,U.S. Senate,,DEM,Loretta Sanchez,126
-Sacramento,46344,U.S. Senate,,DEM,Kamala Harris,201
-Sacramento,46344,U.S. Senate,,DEM,Loretta Sanchez,171
-Sacramento,46422,U.S. Senate,,DEM,Kamala Harris,75
-Sacramento,46422,U.S. Senate,,DEM,Loretta Sanchez,73
-Sacramento,46477,U.S. Senate,,DEM,Kamala Harris,213
-Sacramento,46477,U.S. Senate,,DEM,Loretta Sanchez,172
-Sacramento,46618,U.S. Senate,,DEM,Kamala Harris,126
-Sacramento,46618,U.S. Senate,,DEM,Loretta Sanchez,133
-Sacramento,46690,U.S. Senate,,DEM,Kamala Harris,140
-Sacramento,46690,U.S. Senate,,DEM,Loretta Sanchez,114
-Sacramento,46739,U.S. Senate,,DEM,Kamala Harris,120
-Sacramento,46739,U.S. Senate,,DEM,Loretta Sanchez,84
-Sacramento,46828,U.S. Senate,,DEM,Kamala Harris,3
-Sacramento,46828,U.S. Senate,,DEM,Loretta Sanchez,1
-Sacramento,46867,U.S. Senate,,DEM,Kamala Harris,65
-Sacramento,46867,U.S. Senate,,DEM,Loretta Sanchez,56
-Sacramento,46872,U.S. Senate,,DEM,Kamala Harris,151
-Sacramento,46872,U.S. Senate,,DEM,Loretta Sanchez,119
-Sacramento,46971,U.S. Senate,,DEM,Kamala Harris,113
-Sacramento,46971,U.S. Senate,,DEM,Loretta Sanchez,58
-Sacramento,47018,U.S. Senate,,DEM,Kamala Harris,122
-Sacramento,47018,U.S. Senate,,DEM,Loretta Sanchez,40
-Sacramento,47051,U.S. Senate,,DEM,Kamala Harris,296
-Sacramento,47051,U.S. Senate,,DEM,Loretta Sanchez,118
-Sacramento,47116,U.S. Senate,,DEM,Kamala Harris,254
-Sacramento,47116,U.S. Senate,,DEM,Loretta Sanchez,146
-Sacramento,47154,U.S. Senate,,DEM,Kamala Harris,259
-Sacramento,47154,U.S. Senate,,DEM,Loretta Sanchez,99
-Sacramento,47199,U.S. Senate,,DEM,Kamala Harris,202
-Sacramento,47199,U.S. Senate,,DEM,Loretta Sanchez,79
-Sacramento,47226,U.S. Senate,,DEM,Kamala Harris,271
-Sacramento,47226,U.S. Senate,,DEM,Loretta Sanchez,132
-Sacramento,47249,U.S. Senate,,DEM,Kamala Harris,220
-Sacramento,47249,U.S. Senate,,DEM,Loretta Sanchez,96
-Sacramento,47302,U.S. Senate,,DEM,Kamala Harris,286
-Sacramento,47302,U.S. Senate,,DEM,Loretta Sanchez,92
-Sacramento,47348,U.S. Senate,,DEM,Kamala Harris,240
-Sacramento,47348,U.S. Senate,,DEM,Loretta Sanchez,128
-Sacramento,47436,U.S. Senate,,DEM,Kamala Harris,299
-Sacramento,47436,U.S. Senate,,DEM,Loretta Sanchez,136
-Sacramento,47530,U.S. Senate,,DEM,Kamala Harris,227
-Sacramento,47530,U.S. Senate,,DEM,Loretta Sanchez,106
-Sacramento,47541,U.S. Senate,,DEM,Kamala Harris,258
-Sacramento,47541,U.S. Senate,,DEM,Loretta Sanchez,125
-Sacramento,47563,U.S. Senate,,DEM,Kamala Harris,276
-Sacramento,47563,U.S. Senate,,DEM,Loretta Sanchez,120
-Sacramento,47619,U.S. Senate,,DEM,Kamala Harris,228
-Sacramento,47619,U.S. Senate,,DEM,Loretta Sanchez,97
-Sacramento,47712,U.S. Senate,,DEM,Kamala Harris,206
-Sacramento,47712,U.S. Senate,,DEM,Loretta Sanchez,93
-Sacramento,47724,U.S. Senate,,DEM,Kamala Harris,141
-Sacramento,47724,U.S. Senate,,DEM,Loretta Sanchez,55
-Sacramento,47814,U.S. Senate,,DEM,Kamala Harris,174
-Sacramento,47814,U.S. Senate,,DEM,Loretta Sanchez,94
-Sacramento,47833,U.S. Senate,,DEM,Kamala Harris,220
-Sacramento,47833,U.S. Senate,,DEM,Loretta Sanchez,81
-Sacramento,47879,U.S. Senate,,DEM,Kamala Harris,261
-Sacramento,47879,U.S. Senate,,DEM,Loretta Sanchez,110
-Sacramento,47943,U.S. Senate,,DEM,Kamala Harris,134
-Sacramento,47943,U.S. Senate,,DEM,Loretta Sanchez,72
-Sacramento,48122,U.S. Senate,,DEM,Kamala Harris,244
-Sacramento,48122,U.S. Senate,,DEM,Loretta Sanchez,117
-Sacramento,48150,U.S. Senate,,DEM,Kamala Harris,154
-Sacramento,48150,U.S. Senate,,DEM,Loretta Sanchez,119
-Sacramento,48252,U.S. Senate,,DEM,Kamala Harris,128
-Sacramento,48252,U.S. Senate,,DEM,Loretta Sanchez,81
-Sacramento,48305,U.S. Senate,,DEM,Kamala Harris,237
-Sacramento,48305,U.S. Senate,,DEM,Loretta Sanchez,130
-Sacramento,48320,U.S. Senate,,DEM,Kamala Harris,128
-Sacramento,48320,U.S. Senate,,DEM,Loretta Sanchez,87
-Sacramento,48396,U.S. Senate,,DEM,Kamala Harris,193
-Sacramento,48396,U.S. Senate,,DEM,Loretta Sanchez,118
-Sacramento,48447,U.S. Senate,,DEM,Kamala Harris,196
-Sacramento,48447,U.S. Senate,,DEM,Loretta Sanchez,146
-Sacramento,48475,U.S. Senate,,DEM,Kamala Harris,159
-Sacramento,48475,U.S. Senate,,DEM,Loretta Sanchez,114
-Sacramento,48524,U.S. Senate,,DEM,Kamala Harris,103
-Sacramento,48524,U.S. Senate,,DEM,Loretta Sanchez,106
-Sacramento,48579,U.S. Senate,,DEM,Kamala Harris,156
-Sacramento,48579,U.S. Senate,,DEM,Loretta Sanchez,107
-Sacramento,48613,U.S. Senate,,DEM,Kamala Harris,189
-Sacramento,48613,U.S. Senate,,DEM,Loretta Sanchez,105
-Sacramento,48637,U.S. Senate,,DEM,Kamala Harris,163
-Sacramento,48637,U.S. Senate,,DEM,Loretta Sanchez,83
-Sacramento,48689,U.S. Senate,,DEM,Kamala Harris,0
-Sacramento,48689,U.S. Senate,,DEM,Loretta Sanchez,0
-Sacramento,48703,U.S. Senate,,DEM,Kamala Harris,143
-Sacramento,48703,U.S. Senate,,DEM,Loretta Sanchez,88
-Sacramento,48728,U.S. Senate,,DEM,Kamala Harris,156
-Sacramento,48728,U.S. Senate,,DEM,Loretta Sanchez,91
-Sacramento,48810,U.S. Senate,,DEM,Kamala Harris,0
-Sacramento,48810,U.S. Senate,,DEM,Loretta Sanchez,0
-Sacramento,48864,U.S. Senate,,DEM,Kamala Harris,0
-Sacramento,48864,U.S. Senate,,DEM,Loretta Sanchez,0
-Sacramento,48892,U.S. Senate,,DEM,Kamala Harris,0
-Sacramento,48892,U.S. Senate,,DEM,Loretta Sanchez,0
-Sacramento,48906,U.S. Senate,,DEM,Kamala Harris,8
-Sacramento,48906,U.S. Senate,,DEM,Loretta Sanchez,8
-Sacramento,48917,U.S. Senate,,DEM,Kamala Harris,214
-Sacramento,48917,U.S. Senate,,DEM,Loretta Sanchez,122
-Sacramento,48949,U.S. Senate,,DEM,Kamala Harris,144
-Sacramento,48949,U.S. Senate,,DEM,Loretta Sanchez,73
-Sacramento,48995,U.S. Senate,,DEM,Kamala Harris,157
-Sacramento,48995,U.S. Senate,,DEM,Loretta Sanchez,126
-Sacramento,49006,U.S. Senate,,DEM,Kamala Harris,286
-Sacramento,49006,U.S. Senate,,DEM,Loretta Sanchez,175
-Sacramento,49061,U.S. Senate,,DEM,Kamala Harris,0
-Sacramento,49061,U.S. Senate,,DEM,Loretta Sanchez,0
-Sacramento,49085,U.S. Senate,,DEM,Kamala Harris,74
-Sacramento,49085,U.S. Senate,,DEM,Loretta Sanchez,43
-Sacramento,49100,U.S. Senate,,DEM,Kamala Harris,115
-Sacramento,49100,U.S. Senate,,DEM,Loretta Sanchez,85
-Sacramento,49156,U.S. Senate,,DEM,Kamala Harris,0
-Sacramento,49156,U.S. Senate,,DEM,Loretta Sanchez,0
-Sacramento,49162,U.S. Senate,,DEM,Kamala Harris,141
-Sacramento,49162,U.S. Senate,,DEM,Loretta Sanchez,111
-Sacramento,49208,U.S. Senate,,DEM,Kamala Harris,232
-Sacramento,49208,U.S. Senate,,DEM,Loretta Sanchez,169
-Sacramento,49263,U.S. Senate,,DEM,Kamala Harris,225
-Sacramento,49263,U.S. Senate,,DEM,Loretta Sanchez,148
-Sacramento,49316,U.S. Senate,,DEM,Kamala Harris,171
-Sacramento,49316,U.S. Senate,,DEM,Loretta Sanchez,108
-Sacramento,49373,U.S. Senate,,DEM,Kamala Harris,105
-Sacramento,49373,U.S. Senate,,DEM,Loretta Sanchez,45
-Sacramento,49401,U.S. Senate,,DEM,Kamala Harris,218
-Sacramento,49401,U.S. Senate,,DEM,Loretta Sanchez,150
-Sacramento,49457,U.S. Senate,,DEM,Kamala Harris,140
-Sacramento,49457,U.S. Senate,,DEM,Loretta Sanchez,106
-Sacramento,49472,U.S. Senate,,DEM,Kamala Harris,156
-Sacramento,49472,U.S. Senate,,DEM,Loretta Sanchez,95
-Sacramento,49503,U.S. Senate,,DEM,Kamala Harris,52
-Sacramento,49503,U.S. Senate,,DEM,Loretta Sanchez,42
-Sacramento,49542,U.S. Senate,,DEM,Kamala Harris,144
-Sacramento,49542,U.S. Senate,,DEM,Loretta Sanchez,90
-Sacramento,49596,U.S. Senate,,DEM,Kamala Harris,79
-Sacramento,49596,U.S. Senate,,DEM,Loretta Sanchez,49
-Sacramento,49629,U.S. Senate,,DEM,Kamala Harris,156
-Sacramento,49629,U.S. Senate,,DEM,Loretta Sanchez,119
-Sacramento,49705,U.S. Senate,,DEM,Kamala Harris,78
-Sacramento,49705,U.S. Senate,,DEM,Loretta Sanchez,39
-Sacramento,49732,U.S. Senate,,DEM,Kamala Harris,235
-Sacramento,49732,U.S. Senate,,DEM,Loretta Sanchez,161
-Sacramento,49766,U.S. Senate,,DEM,Kamala Harris,252
-Sacramento,49766,U.S. Senate,,DEM,Loretta Sanchez,110
-Sacramento,49791,U.S. Senate,,DEM,Kamala Harris,145
-Sacramento,49791,U.S. Senate,,DEM,Loretta Sanchez,66
-Sacramento,49802,U.S. Senate,,DEM,Kamala Harris,124
-Sacramento,49802,U.S. Senate,,DEM,Loretta Sanchez,64
-Sacramento,49923,U.S. Senate,,DEM,Kamala Harris,153
-Sacramento,49923,U.S. Senate,,DEM,Loretta Sanchez,96
-Sacramento,49981,U.S. Senate,,DEM,Kamala Harris,0
-Sacramento,49981,U.S. Senate,,DEM,Loretta Sanchez,0
-Sacramento,51127,U.S. Senate,,DEM,Kamala Harris,189
-Sacramento,51127,U.S. Senate,,DEM,Loretta Sanchez,100
-Sacramento,51180,U.S. Senate,,DEM,Kamala Harris,214
-Sacramento,51180,U.S. Senate,,DEM,Loretta Sanchez,138
-Sacramento,51317,U.S. Senate,,DEM,Kamala Harris,180
-Sacramento,51317,U.S. Senate,,DEM,Loretta Sanchez,88
-Sacramento,51415,U.S. Senate,,DEM,Kamala Harris,293
-Sacramento,51415,U.S. Senate,,DEM,Loretta Sanchez,211
-Sacramento,51565,U.S. Senate,,DEM,Kamala Harris,104
-Sacramento,51565,U.S. Senate,,DEM,Loretta Sanchez,50
-Sacramento,51582,U.S. Senate,,DEM,Kamala Harris,141
-Sacramento,51582,U.S. Senate,,DEM,Loretta Sanchez,78
-Sacramento,51646,U.S. Senate,,DEM,Kamala Harris,144
-Sacramento,51646,U.S. Senate,,DEM,Loretta Sanchez,81
-Sacramento,51729,U.S. Senate,,DEM,Kamala Harris,292
-Sacramento,51729,U.S. Senate,,DEM,Loretta Sanchez,158
-Sacramento,51844,U.S. Senate,,DEM,Kamala Harris,199
-Sacramento,51844,U.S. Senate,,DEM,Loretta Sanchez,120
-Sacramento,51922,U.S. Senate,,DEM,Kamala Harris,207
-Sacramento,51922,U.S. Senate,,DEM,Loretta Sanchez,129
-Sacramento,52129,U.S. Senate,,DEM,Kamala Harris,190
-Sacramento,52129,U.S. Senate,,DEM,Loretta Sanchez,114
-Sacramento,52218,U.S. Senate,,DEM,Kamala Harris,146
-Sacramento,52218,U.S. Senate,,DEM,Loretta Sanchez,86
-Sacramento,52260,U.S. Senate,,DEM,Kamala Harris,180
-Sacramento,52260,U.S. Senate,,DEM,Loretta Sanchez,93
-Sacramento,52405,U.S. Senate,,DEM,Kamala Harris,143
-Sacramento,52405,U.S. Senate,,DEM,Loretta Sanchez,68
-Sacramento,52516,U.S. Senate,,DEM,Kamala Harris,100
-Sacramento,52516,U.S. Senate,,DEM,Loretta Sanchez,57
-Sacramento,52627,U.S. Senate,,DEM,Kamala Harris,214
-Sacramento,52627,U.S. Senate,,DEM,Loretta Sanchez,133
-Sacramento,52723,U.S. Senate,,DEM,Kamala Harris,145
-Sacramento,52723,U.S. Senate,,DEM,Loretta Sanchez,81
-Sacramento,52750,U.S. Senate,,DEM,Kamala Harris,229
-Sacramento,52750,U.S. Senate,,DEM,Loretta Sanchez,145
-Sacramento,52868,U.S. Senate,,DEM,Kamala Harris,178
-Sacramento,52868,U.S. Senate,,DEM,Loretta Sanchez,94
-Sacramento,52957,U.S. Senate,,DEM,Kamala Harris,85
-Sacramento,52957,U.S. Senate,,DEM,Loretta Sanchez,41
-Sacramento,53014,U.S. Senate,,DEM,Kamala Harris,174
-Sacramento,53014,U.S. Senate,,DEM,Loretta Sanchez,88
-Sacramento,53067,U.S. Senate,,DEM,Kamala Harris,208
-Sacramento,53067,U.S. Senate,,DEM,Loretta Sanchez,151
-Sacramento,53137,U.S. Senate,,DEM,Kamala Harris,254
-Sacramento,53137,U.S. Senate,,DEM,Loretta Sanchez,124
-Sacramento,53205,U.S. Senate,,DEM,Kamala Harris,167
-Sacramento,53205,U.S. Senate,,DEM,Loretta Sanchez,92
-Sacramento,53261,U.S. Senate,,DEM,Kamala Harris,227
-Sacramento,53261,U.S. Senate,,DEM,Loretta Sanchez,161
-Sacramento,53318,U.S. Senate,,DEM,Kamala Harris,125
-Sacramento,53318,U.S. Senate,,DEM,Loretta Sanchez,71
-Sacramento,53363,U.S. Senate,,DEM,Kamala Harris,175
-Sacramento,53363,U.S. Senate,,DEM,Loretta Sanchez,127
-Sacramento,53435,U.S. Senate,,DEM,Kamala Harris,157
-Sacramento,53435,U.S. Senate,,DEM,Loretta Sanchez,92
-Sacramento,53512,U.S. Senate,,DEM,Kamala Harris,169
-Sacramento,53512,U.S. Senate,,DEM,Loretta Sanchez,109
-Sacramento,53594,U.S. Senate,,DEM,Kamala Harris,0
-Sacramento,53594,U.S. Senate,,DEM,Loretta Sanchez,0
-Sacramento,53610,U.S. Senate,,DEM,Kamala Harris,118
-Sacramento,53610,U.S. Senate,,DEM,Loretta Sanchez,63
-Sacramento,53657,U.S. Senate,,DEM,Kamala Harris,190
-Sacramento,53657,U.S. Senate,,DEM,Loretta Sanchez,103
-Sacramento,53707,U.S. Senate,,DEM,Kamala Harris,1
-Sacramento,53707,U.S. Senate,,DEM,Loretta Sanchez,4
-Sacramento,53764,U.S. Senate,,DEM,Kamala Harris,66
-Sacramento,53764,U.S. Senate,,DEM,Loretta Sanchez,29
-Sacramento,53773,U.S. Senate,,DEM,Kamala Harris,0
-Sacramento,53773,U.S. Senate,,DEM,Loretta Sanchez,1
-Sacramento,53821,U.S. Senate,,DEM,Kamala Harris,38
-Sacramento,53821,U.S. Senate,,DEM,Loretta Sanchez,15
-Sacramento,53855,U.S. Senate,,DEM,Kamala Harris,36
-Sacramento,53855,U.S. Senate,,DEM,Loretta Sanchez,13
-Sacramento,53903,U.S. Senate,,DEM,Kamala Harris,114
-Sacramento,53903,U.S. Senate,,DEM,Loretta Sanchez,84
-Sacramento,53932,U.S. Senate,,DEM,Kamala Harris,180
-Sacramento,53932,U.S. Senate,,DEM,Loretta Sanchez,93
-Sacramento,54279,U.S. Senate,,DEM,Kamala Harris,1
-Sacramento,54279,U.S. Senate,,DEM,Loretta Sanchez,2
-Sacramento,54353,U.S. Senate,,DEM,Kamala Harris,3
-Sacramento,54353,U.S. Senate,,DEM,Loretta Sanchez,8
-Sacramento,54416,U.S. Senate,,DEM,Kamala Harris,2
-Sacramento,54416,U.S. Senate,,DEM,Loretta Sanchez,0
-Sacramento,54713,U.S. Senate,,DEM,Kamala Harris,19
-Sacramento,54713,U.S. Senate,,DEM,Loretta Sanchez,5
-Sacramento,54835,U.S. Senate,,DEM,Kamala Harris,0
-Sacramento,54835,U.S. Senate,,DEM,Loretta Sanchez,0
-Sacramento,54899,U.S. Senate,,DEM,Kamala Harris,108
-Sacramento,54899,U.S. Senate,,DEM,Loretta Sanchez,57
-Sacramento,54924,U.S. Senate,,DEM,Kamala Harris,6
-Sacramento,54924,U.S. Senate,,DEM,Loretta Sanchez,2
-Sacramento,55016,U.S. Senate,,DEM,Kamala Harris,0
-Sacramento,55016,U.S. Senate,,DEM,Loretta Sanchez,0
-Sacramento,55160,U.S. Senate,,DEM,Kamala Harris,202
-Sacramento,55160,U.S. Senate,,DEM,Loretta Sanchez,141
-Sacramento,55203,U.S. Senate,,DEM,Kamala Harris,172
-Sacramento,55203,U.S. Senate,,DEM,Loretta Sanchez,98
-Sacramento,55281,U.S. Senate,,DEM,Kamala Harris,187
-Sacramento,55281,U.S. Senate,,DEM,Loretta Sanchez,132
-Sacramento,55410,U.S. Senate,,DEM,Kamala Harris,14
-Sacramento,55410,U.S. Senate,,DEM,Loretta Sanchez,12
-Sacramento,55700,U.S. Senate,,DEM,Kamala Harris,30
-Sacramento,55700,U.S. Senate,,DEM,Loretta Sanchez,32
-Sacramento,55936,U.S. Senate,,DEM,Kamala Harris,157
-Sacramento,55936,U.S. Senate,,DEM,Loretta Sanchez,91
-Sacramento,56122,U.S. Senate,,DEM,Kamala Harris,0
-Sacramento,56122,U.S. Senate,,DEM,Loretta Sanchez,0
-Sacramento,56165,U.S. Senate,,DEM,Kamala Harris,148
-Sacramento,56165,U.S. Senate,,DEM,Loretta Sanchez,91
-Sacramento,56250,U.S. Senate,,DEM,Kamala Harris,138
-Sacramento,56250,U.S. Senate,,DEM,Loretta Sanchez,101
-Sacramento,56399,U.S. Senate,,DEM,Kamala Harris,0
-Sacramento,56399,U.S. Senate,,DEM,Loretta Sanchez,0
-Sacramento,56412,U.S. Senate,,DEM,Kamala Harris,25
-Sacramento,56412,U.S. Senate,,DEM,Loretta Sanchez,19
-Sacramento,56701,U.S. Senate,,DEM,Kamala Harris,0
-Sacramento,56701,U.S. Senate,,DEM,Loretta Sanchez,0
-Sacramento,56798,U.S. Senate,,DEM,Kamala Harris,51
-Sacramento,56798,U.S. Senate,,DEM,Loretta Sanchez,42
-Sacramento,57019,U.S. Senate,,DEM,Kamala Harris,206
-Sacramento,57019,U.S. Senate,,DEM,Loretta Sanchez,126
-Sacramento,57101,U.S. Senate,,DEM,Kamala Harris,126
-Sacramento,57101,U.S. Senate,,DEM,Loretta Sanchez,103
-Sacramento,57157,U.S. Senate,,DEM,Kamala Harris,76
-Sacramento,57157,U.S. Senate,,DEM,Loretta Sanchez,58
-Sacramento,57315,U.S. Senate,,DEM,Kamala Harris,77
-Sacramento,57315,U.S. Senate,,DEM,Loretta Sanchez,69
-Sacramento,57430,U.S. Senate,,DEM,Kamala Harris,195
-Sacramento,57430,U.S. Senate,,DEM,Loretta Sanchez,148
-Sacramento,57509,U.S. Senate,,DEM,Kamala Harris,136
-Sacramento,57509,U.S. Senate,,DEM,Loretta Sanchez,85
-Sacramento,57566,U.S. Senate,,DEM,Kamala Harris,100
-Sacramento,57566,U.S. Senate,,DEM,Loretta Sanchez,64
-Sacramento,57639,U.S. Senate,,DEM,Kamala Harris,234
-Sacramento,57639,U.S. Senate,,DEM,Loretta Sanchez,133
-Sacramento,57688,U.S. Senate,,DEM,Kamala Harris,220
-Sacramento,57688,U.S. Senate,,DEM,Loretta Sanchez,113
-Sacramento,57703,U.S. Senate,,DEM,Kamala Harris,187
-Sacramento,57703,U.S. Senate,,DEM,Loretta Sanchez,116
-Sacramento,57735,U.S. Senate,,DEM,Kamala Harris,155
-Sacramento,57735,U.S. Senate,,DEM,Loretta Sanchez,112
-Sacramento,57862,U.S. Senate,,DEM,Kamala Harris,175
-Sacramento,57862,U.S. Senate,,DEM,Loretta Sanchez,99
-Sacramento,58346,U.S. Senate,,DEM,Kamala Harris,164
-Sacramento,58346,U.S. Senate,,DEM,Loretta Sanchez,99
-Sacramento,58437,U.S. Senate,,DEM,Kamala Harris,186
-Sacramento,58437,U.S. Senate,,DEM,Loretta Sanchez,110
-Sacramento,58460,U.S. Senate,,DEM,Kamala Harris,162
-Sacramento,58460,U.S. Senate,,DEM,Loretta Sanchez,80
-Sacramento,58782,U.S. Senate,,DEM,Kamala Harris,207
-Sacramento,58782,U.S. Senate,,DEM,Loretta Sanchez,106
-Sacramento,58828,U.S. Senate,,DEM,Kamala Harris,240
-Sacramento,58828,U.S. Senate,,DEM,Loretta Sanchez,119
-Sacramento,59352,U.S. Senate,,DEM,Kamala Harris,167
-Sacramento,59352,U.S. Senate,,DEM,Loretta Sanchez,106
-Sacramento,59406,U.S. Senate,,DEM,Kamala Harris,227
-Sacramento,59406,U.S. Senate,,DEM,Loretta Sanchez,129
-Sacramento,59562,U.S. Senate,,DEM,Kamala Harris,173
-Sacramento,59562,U.S. Senate,,DEM,Loretta Sanchez,68
-Sacramento,61020,U.S. Senate,,DEM,Kamala Harris,45
-Sacramento,61020,U.S. Senate,,DEM,Loretta Sanchez,15
-Sacramento,61124,U.S. Senate,,DEM,Kamala Harris,168
-Sacramento,61124,U.S. Senate,,DEM,Loretta Sanchez,69
-Sacramento,61169,U.S. Senate,,DEM,Kamala Harris,157
-Sacramento,61169,U.S. Senate,,DEM,Loretta Sanchez,97
-Sacramento,61207,U.S. Senate,,DEM,Kamala Harris,104
-Sacramento,61207,U.S. Senate,,DEM,Loretta Sanchez,48
-Sacramento,61263,U.S. Senate,,DEM,Kamala Harris,224
-Sacramento,61263,U.S. Senate,,DEM,Loretta Sanchez,95
-Sacramento,61312,U.S. Senate,,DEM,Kamala Harris,3
-Sacramento,61312,U.S. Senate,,DEM,Loretta Sanchez,0
-Sacramento,61373,U.S. Senate,,DEM,Kamala Harris,0
-Sacramento,61373,U.S. Senate,,DEM,Loretta Sanchez,0
-Sacramento,61411,U.S. Senate,,DEM,Kamala Harris,2
-Sacramento,61411,U.S. Senate,,DEM,Loretta Sanchez,6
-Sacramento,61462,U.S. Senate,,DEM,Kamala Harris,82
-Sacramento,61462,U.S. Senate,,DEM,Loretta Sanchez,37
-Sacramento,61549,U.S. Senate,,DEM,Kamala Harris,0
-Sacramento,61549,U.S. Senate,,DEM,Loretta Sanchez,0
-Sacramento,61709,U.S. Senate,,DEM,Kamala Harris,0
-Sacramento,61709,U.S. Senate,,DEM,Loretta Sanchez,0
-Sacramento,61983,U.S. Senate,,DEM,Kamala Harris,0
-Sacramento,61983,U.S. Senate,,DEM,Loretta Sanchez,0
-Sacramento,62136,U.S. Senate,,DEM,Kamala Harris,1
-Sacramento,62136,U.S. Senate,,DEM,Loretta Sanchez,1
-Sacramento,62192,U.S. Senate,,DEM,Kamala Harris,77
-Sacramento,62192,U.S. Senate,,DEM,Loretta Sanchez,34
-Sacramento,62479,U.S. Senate,,DEM,Kamala Harris,0
-Sacramento,62479,U.S. Senate,,DEM,Loretta Sanchez,0
-Sacramento,62755,U.S. Senate,,DEM,Kamala Harris,1
-Sacramento,62755,U.S. Senate,,DEM,Loretta Sanchez,1
-Sacramento,63106,U.S. Senate,,DEM,Kamala Harris,0
-Sacramento,63106,U.S. Senate,,DEM,Loretta Sanchez,0
-Sacramento,63814,U.S. Senate,,DEM,Kamala Harris,1
-Sacramento,63814,U.S. Senate,,DEM,Loretta Sanchez,0
-Sacramento,64012,U.S. Senate,,DEM,Kamala Harris,0
-Sacramento,64012,U.S. Senate,,DEM,Loretta Sanchez,0
-Sacramento,64204,U.S. Senate,,DEM,Kamala Harris,203
-Sacramento,64204,U.S. Senate,,DEM,Loretta Sanchez,99
-Sacramento,64251,U.S. Senate,,DEM,Kamala Harris,170
-Sacramento,64251,U.S. Senate,,DEM,Loretta Sanchez,103
-Sacramento,64427,U.S. Senate,,DEM,Kamala Harris,271
-Sacramento,64427,U.S. Senate,,DEM,Loretta Sanchez,115
-Sacramento,64541,U.S. Senate,,DEM,Kamala Harris,102
-Sacramento,64541,U.S. Senate,,DEM,Loretta Sanchez,85
-Sacramento,64746,U.S. Senate,,DEM,Kamala Harris,0
-Sacramento,64746,U.S. Senate,,DEM,Loretta Sanchez,0
-Sacramento,64833,U.S. Senate,,DEM,Kamala Harris,0
-Sacramento,64833,U.S. Senate,,DEM,Loretta Sanchez,0
-Sacramento,65601,U.S. Senate,,DEM,Kamala Harris,77
-Sacramento,65601,U.S. Senate,,DEM,Loretta Sanchez,50
-Sacramento,66358,U.S. Senate,,DEM,Kamala Harris,0
-Sacramento,66358,U.S. Senate,,DEM,Loretta Sanchez,0
-Sacramento,66401,U.S. Senate,,DEM,Kamala Harris,4
-Sacramento,66401,U.S. Senate,,DEM,Loretta Sanchez,3
-Sacramento,66532,U.S. Senate,,DEM,Kamala Harris,175
-Sacramento,66532,U.S. Senate,,DEM,Loretta Sanchez,115
-Sacramento,66741,U.S. Senate,,DEM,Kamala Harris,151
-Sacramento,66741,U.S. Senate,,DEM,Loretta Sanchez,97
-Sacramento,66879,U.S. Senate,,DEM,Kamala Harris,167
-Sacramento,66879,U.S. Senate,,DEM,Loretta Sanchez,105
-Sacramento,67160,U.S. Senate,,DEM,Kamala Harris,4
-Sacramento,67160,U.S. Senate,,DEM,Loretta Sanchez,0
-Sacramento,69300,U.S. Senate,,DEM,Kamala Harris,8
-Sacramento,69300,U.S. Senate,,DEM,Loretta Sanchez,4
-Sacramento,69964,U.S. Senate,,DEM,Kamala Harris,0
-Sacramento,69964,U.S. Senate,,DEM,Loretta Sanchez,0
-Sacramento,71126,U.S. Senate,,DEM,Kamala Harris,0
-Sacramento,71126,U.S. Senate,,DEM,Loretta Sanchez,0
-Sacramento,71158,U.S. Senate,,DEM,Kamala Harris,12
-Sacramento,71158,U.S. Senate,,DEM,Loretta Sanchez,5
-Sacramento,71205,U.S. Senate,,DEM,Kamala Harris,22
-Sacramento,71205,U.S. Senate,,DEM,Loretta Sanchez,25
-Sacramento,71383,U.S. Senate,,DEM,Kamala Harris,0
-Sacramento,71383,U.S. Senate,,DEM,Loretta Sanchez,0
-Sacramento,71429,U.S. Senate,,DEM,Kamala Harris,0
-Sacramento,71429,U.S. Senate,,DEM,Loretta Sanchez,0
-Sacramento,71620,U.S. Senate,,DEM,Kamala Harris,8
-Sacramento,71620,U.S. Senate,,DEM,Loretta Sanchez,17
-Sacramento,71655,U.S. Senate,,DEM,Kamala Harris,0
-Sacramento,71655,U.S. Senate,,DEM,Loretta Sanchez,2
-Sacramento,71731,U.S. Senate,,DEM,Kamala Harris,0
-Sacramento,71731,U.S. Senate,,DEM,Loretta Sanchez,1
-Sacramento,71866,U.S. Senate,,DEM,Kamala Harris,6
-Sacramento,71866,U.S. Senate,,DEM,Loretta Sanchez,13
-Sacramento,72015,U.S. Senate,,DEM,Kamala Harris,0
-Sacramento,72015,U.S. Senate,,DEM,Loretta Sanchez,0
-Sacramento,72023,U.S. Senate,,DEM,Kamala Harris,0
-Sacramento,72023,U.S. Senate,,DEM,Loretta Sanchez,0
-Sacramento,72052,U.S. Senate,,DEM,Kamala Harris,0
-Sacramento,72052,U.S. Senate,,DEM,Loretta Sanchez,0
-Sacramento,72060,U.S. Senate,,DEM,Kamala Harris,0
-Sacramento,72060,U.S. Senate,,DEM,Loretta Sanchez,0
-Sacramento,72122,U.S. Senate,,DEM,Kamala Harris,0
-Sacramento,72122,U.S. Senate,,DEM,Loretta Sanchez,0
-Sacramento,72234,U.S. Senate,,DEM,Kamala Harris,0
-Sacramento,72234,U.S. Senate,,DEM,Loretta Sanchez,0
-Sacramento,72268,U.S. Senate,,DEM,Kamala Harris,4
-Sacramento,72268,U.S. Senate,,DEM,Loretta Sanchez,1
-Sacramento,72293,U.S. Senate,,DEM,Kamala Harris,217
-Sacramento,72293,U.S. Senate,,DEM,Loretta Sanchez,109
-Sacramento,72329,U.S. Senate,,DEM,Kamala Harris,216
-Sacramento,72329,U.S. Senate,,DEM,Loretta Sanchez,128
-Sacramento,72436,U.S. Senate,,DEM,Kamala Harris,160
-Sacramento,72436,U.S. Senate,,DEM,Loretta Sanchez,74
-Sacramento,72495,U.S. Senate,,DEM,Kamala Harris,196
-Sacramento,72495,U.S. Senate,,DEM,Loretta Sanchez,103
-Sacramento,72564,U.S. Senate,,DEM,Kamala Harris,173
-Sacramento,72564,U.S. Senate,,DEM,Loretta Sanchez,70
-Sacramento,72606,U.S. Senate,,DEM,Kamala Harris,205
-Sacramento,72606,U.S. Senate,,DEM,Loretta Sanchez,82
-Sacramento,72631,U.S. Senate,,DEM,Kamala Harris,204
-Sacramento,72631,U.S. Senate,,DEM,Loretta Sanchez,76
-Sacramento,72713,U.S. Senate,,DEM,Kamala Harris,240
-Sacramento,72713,U.S. Senate,,DEM,Loretta Sanchez,104
-Sacramento,72762,U.S. Senate,,DEM,Kamala Harris,161
-Sacramento,72762,U.S. Senate,,DEM,Loretta Sanchez,103
-Sacramento,72796,U.S. Senate,,DEM,Kamala Harris,151
-Sacramento,72796,U.S. Senate,,DEM,Loretta Sanchez,88
-Sacramento,72804,U.S. Senate,,DEM,Kamala Harris,242
-Sacramento,72804,U.S. Senate,,DEM,Loretta Sanchez,106
-Sacramento,72828,U.S. Senate,,DEM,Kamala Harris,222
-Sacramento,72828,U.S. Senate,,DEM,Loretta Sanchez,92
-Sacramento,72966,U.S. Senate,,DEM,Kamala Harris,79
-Sacramento,72966,U.S. Senate,,DEM,Loretta Sanchez,59
-Sacramento,73018,U.S. Senate,,DEM,Kamala Harris,236
-Sacramento,73018,U.S. Senate,,DEM,Loretta Sanchez,108
-Sacramento,73096,U.S. Senate,,DEM,Kamala Harris,153
-Sacramento,73096,U.S. Senate,,DEM,Loretta Sanchez,91
-Sacramento,73114,U.S. Senate,,DEM,Kamala Harris,171
-Sacramento,73114,U.S. Senate,,DEM,Loretta Sanchez,79
-Sacramento,73129,U.S. Senate,,DEM,Kamala Harris,247
-Sacramento,73129,U.S. Senate,,DEM,Loretta Sanchez,173
-Sacramento,73171,U.S. Senate,,DEM,Kamala Harris,132
-Sacramento,73171,U.S. Senate,,DEM,Loretta Sanchez,78
-Sacramento,73180,U.S. Senate,,DEM,Kamala Harris,253
-Sacramento,73180,U.S. Senate,,DEM,Loretta Sanchez,147
-Sacramento,73345,U.S. Senate,,DEM,Kamala Harris,189
-Sacramento,73345,U.S. Senate,,DEM,Loretta Sanchez,107
-Sacramento,73350,U.S. Senate,,DEM,Kamala Harris,207
-Sacramento,73350,U.S. Senate,,DEM,Loretta Sanchez,129
-Sacramento,73430,U.S. Senate,,DEM,Kamala Harris,222
-Sacramento,73430,U.S. Senate,,DEM,Loretta Sanchez,133
-Sacramento,73469,U.S. Senate,,DEM,Kamala Harris,173
-Sacramento,73469,U.S. Senate,,DEM,Loretta Sanchez,107
-Sacramento,73558,U.S. Senate,,DEM,Kamala Harris,165
-Sacramento,73558,U.S. Senate,,DEM,Loretta Sanchez,93
-Sacramento,73599,U.S. Senate,,DEM,Kamala Harris,221
-Sacramento,73599,U.S. Senate,,DEM,Loretta Sanchez,109
-Sacramento,73611,U.S. Senate,,DEM,Kamala Harris,159
-Sacramento,73611,U.S. Senate,,DEM,Loretta Sanchez,91
-Sacramento,73662,U.S. Senate,,DEM,Kamala Harris,227
-Sacramento,73662,U.S. Senate,,DEM,Loretta Sanchez,125
-Sacramento,73700,U.S. Senate,,DEM,Kamala Harris,263
-Sacramento,73700,U.S. Senate,,DEM,Loretta Sanchez,133
-Sacramento,73723,U.S. Senate,,DEM,Kamala Harris,151
-Sacramento,73723,U.S. Senate,,DEM,Loretta Sanchez,100
-Sacramento,73817,U.S. Senate,,DEM,Kamala Harris,232
-Sacramento,73817,U.S. Senate,,DEM,Loretta Sanchez,129
-Sacramento,73849,U.S. Senate,,DEM,Kamala Harris,187
-Sacramento,73849,U.S. Senate,,DEM,Loretta Sanchez,103
-Sacramento,73972,U.S. Senate,,DEM,Kamala Harris,209
-Sacramento,73972,U.S. Senate,,DEM,Loretta Sanchez,97
-Sacramento,74135,U.S. Senate,,DEM,Kamala Harris,34
-Sacramento,74135,U.S. Senate,,DEM,Loretta Sanchez,31
-Sacramento,74266,U.S. Senate,,DEM,Kamala Harris,107
-Sacramento,74266,U.S. Senate,,DEM,Loretta Sanchez,82
-Sacramento,74561,U.S. Senate,,DEM,Kamala Harris,19
-Sacramento,74561,U.S. Senate,,DEM,Loretta Sanchez,27
-Sacramento,74802,U.S. Senate,,DEM,Kamala Harris,0
-Sacramento,74802,U.S. Senate,,DEM,Loretta Sanchez,0
-Sacramento,75490,U.S. Senate,,DEM,Kamala Harris,0
-Sacramento,75490,U.S. Senate,,DEM,Loretta Sanchez,0
-Sacramento,75621,U.S. Senate,,DEM,Kamala Harris,49
-Sacramento,75621,U.S. Senate,,DEM,Loretta Sanchez,62
-Sacramento,76733,U.S. Senate,,DEM,Kamala Harris,20
-Sacramento,76733,U.S. Senate,,DEM,Loretta Sanchez,23
-Sacramento,77164,U.S. Senate,,DEM,Kamala Harris,90
-Sacramento,77164,U.S. Senate,,DEM,Loretta Sanchez,55
-Sacramento,77380,U.S. Senate,,DEM,Kamala Harris,48
-Sacramento,77380,U.S. Senate,,DEM,Loretta Sanchez,44
-Sacramento,78116,U.S. Senate,,DEM,Kamala Harris,29
-Sacramento,78116,U.S. Senate,,DEM,Loretta Sanchez,26
-Sacramento,78342,U.S. Senate,,DEM,Kamala Harris,78
-Sacramento,78342,U.S. Senate,,DEM,Loretta Sanchez,71
-Sacramento,78428,U.S. Senate,,DEM,Kamala Harris,23
-Sacramento,78428,U.S. Senate,,DEM,Loretta Sanchez,22
-Sacramento,8011974,U.S. Senate,,DEM,Kamala Harris,354
-Sacramento,8011974,U.S. Senate,,DEM,Loretta Sanchez,140
-Sacramento,8012669,U.S. Senate,,DEM,Kamala Harris,665
-Sacramento,8012669,U.S. Senate,,DEM,Loretta Sanchez,228
-Sacramento,8012681,U.S. Senate,,DEM,Kamala Harris,364
-Sacramento,8012681,U.S. Senate,,DEM,Loretta Sanchez,163
-Sacramento,8012702,U.S. Senate,,DEM,Kamala Harris,508
-Sacramento,8012702,U.S. Senate,,DEM,Loretta Sanchez,183
-Sacramento,8012747,U.S. Senate,,DEM,Kamala Harris,487
-Sacramento,8012747,U.S. Senate,,DEM,Loretta Sanchez,175
-Sacramento,8012786,U.S. Senate,,DEM,Kamala Harris,541
-Sacramento,8012786,U.S. Senate,,DEM,Loretta Sanchez,153
-Sacramento,8012807,U.S. Senate,,DEM,Kamala Harris,346
-Sacramento,8012807,U.S. Senate,,DEM,Loretta Sanchez,140
-Sacramento,8012884,U.S. Senate,,DEM,Kamala Harris,400
-Sacramento,8012884,U.S. Senate,,DEM,Loretta Sanchez,161
-Sacramento,8013032,U.S. Senate,,DEM,Kamala Harris,344
-Sacramento,8013032,U.S. Senate,,DEM,Loretta Sanchez,207
-Sacramento,8013328,U.S. Senate,,DEM,Kamala Harris,377
-Sacramento,8013328,U.S. Senate,,DEM,Loretta Sanchez,274
-Sacramento,8013424,U.S. Senate,,DEM,Kamala Harris,301
-Sacramento,8013424,U.S. Senate,,DEM,Loretta Sanchez,196
-Sacramento,8013551,U.S. Senate,,DEM,Kamala Harris,259
-Sacramento,8013551,U.S. Senate,,DEM,Loretta Sanchez,168
-Sacramento,8013635,U.S. Senate,,DEM,Kamala Harris,333
-Sacramento,8013635,U.S. Senate,,DEM,Loretta Sanchez,257
-Sacramento,8013658,U.S. Senate,,DEM,Kamala Harris,333
-Sacramento,8013658,U.S. Senate,,DEM,Loretta Sanchez,178
-Sacramento,8013706,U.S. Senate,,DEM,Kamala Harris,197
-Sacramento,8013706,U.S. Senate,,DEM,Loretta Sanchez,160
-Sacramento,8013993,U.S. Senate,,DEM,Kamala Harris,150
-Sacramento,8013993,U.S. Senate,,DEM,Loretta Sanchez,113
-Sacramento,8014314,U.S. Senate,,DEM,Kamala Harris,696
-Sacramento,8014314,U.S. Senate,,DEM,Loretta Sanchez,251
-Sacramento,8014502,U.S. Senate,,DEM,Kamala Harris,380
-Sacramento,8014502,U.S. Senate,,DEM,Loretta Sanchez,130
-Sacramento,8014564,U.S. Senate,,DEM,Kamala Harris,278
-Sacramento,8014564,U.S. Senate,,DEM,Loretta Sanchez,129
-Sacramento,8014693,U.S. Senate,,DEM,Kamala Harris,518
-Sacramento,8014693,U.S. Senate,,DEM,Loretta Sanchez,214
-Sacramento,8014820,U.S. Senate,,DEM,Kamala Harris,493
-Sacramento,8014820,U.S. Senate,,DEM,Loretta Sanchez,214
-Sacramento,8014971,U.S. Senate,,DEM,Kamala Harris,460
-Sacramento,8014971,U.S. Senate,,DEM,Loretta Sanchez,183
-Sacramento,8015018,U.S. Senate,,DEM,Kamala Harris,518
-Sacramento,8015018,U.S. Senate,,DEM,Loretta Sanchez,207
-Sacramento,8015102,U.S. Senate,,DEM,Kamala Harris,642
-Sacramento,8015102,U.S. Senate,,DEM,Loretta Sanchez,228
-Sacramento,8015287,U.S. Senate,,DEM,Kamala Harris,493
-Sacramento,8015287,U.S. Senate,,DEM,Loretta Sanchez,230
-Sacramento,8015321,U.S. Senate,,DEM,Kamala Harris,502
-Sacramento,8015321,U.S. Senate,,DEM,Loretta Sanchez,208
-Sacramento,8015530,U.S. Senate,,DEM,Kamala Harris,239
-Sacramento,8015530,U.S. Senate,,DEM,Loretta Sanchez,126
-Sacramento,8015749,U.S. Senate,,DEM,Kamala Harris,534
-Sacramento,8015749,U.S. Senate,,DEM,Loretta Sanchez,214
-Sacramento,8016002,U.S. Senate,,DEM,Kamala Harris,438
-Sacramento,8016002,U.S. Senate,,DEM,Loretta Sanchez,262
-Sacramento,8016107,U.S. Senate,,DEM,Kamala Harris,329
-Sacramento,8016107,U.S. Senate,,DEM,Loretta Sanchez,197
-Sacramento,8016318,U.S. Senate,,DEM,Kamala Harris,187
-Sacramento,8016318,U.S. Senate,,DEM,Loretta Sanchez,143
-Sacramento,8016463,U.S. Senate,,DEM,Kamala Harris,246
-Sacramento,8016463,U.S. Senate,,DEM,Loretta Sanchez,201
-Sacramento,8016573,U.S. Senate,,DEM,Kamala Harris,333
-Sacramento,8016573,U.S. Senate,,DEM,Loretta Sanchez,198
-Sacramento,8016801,U.S. Senate,,DEM,Kamala Harris,329
-Sacramento,8016801,U.S. Senate,,DEM,Loretta Sanchez,188
-Sacramento,8016836,U.S. Senate,,DEM,Kamala Harris,282
-Sacramento,8016836,U.S. Senate,,DEM,Loretta Sanchez,154
-Sacramento,8016869,U.S. Senate,,DEM,Kamala Harris,219
-Sacramento,8016869,U.S. Senate,,DEM,Loretta Sanchez,106
-Sacramento,8016944,U.S. Senate,,DEM,Kamala Harris,228
-Sacramento,8016944,U.S. Senate,,DEM,Loretta Sanchez,143
-Sacramento,8017428,U.S. Senate,,DEM,Kamala Harris,444
-Sacramento,8017428,U.S. Senate,,DEM,Loretta Sanchez,167
-Sacramento,8017512,U.S. Senate,,DEM,Kamala Harris,353
-Sacramento,8017512,U.S. Senate,,DEM,Loretta Sanchez,152
-Sacramento,8017630,U.S. Senate,,DEM,Kamala Harris,637
-Sacramento,8017630,U.S. Senate,,DEM,Loretta Sanchez,199
-Sacramento,8018012,U.S. Senate,,DEM,Kamala Harris,254
-Sacramento,8018012,U.S. Senate,,DEM,Loretta Sanchez,118
-Sacramento,8018119,U.S. Senate,,DEM,Kamala Harris,335
-Sacramento,8018119,U.S. Senate,,DEM,Loretta Sanchez,205
-Sacramento,8018143,U.S. Senate,,DEM,Kamala Harris,383
-Sacramento,8018143,U.S. Senate,,DEM,Loretta Sanchez,173
-Sacramento,8018213,U.S. Senate,,DEM,Kamala Harris,462
-Sacramento,8018213,U.S. Senate,,DEM,Loretta Sanchez,194
-Sacramento,8018220,U.S. Senate,,DEM,Kamala Harris,475
-Sacramento,8018220,U.S. Senate,,DEM,Loretta Sanchez,251
-Sacramento,8018385,U.S. Senate,,DEM,Kamala Harris,395
-Sacramento,8018385,U.S. Senate,,DEM,Loretta Sanchez,169
-Sacramento,8018501,U.S. Senate,,DEM,Kamala Harris,286
-Sacramento,8018501,U.S. Senate,,DEM,Loretta Sanchez,170
-Sacramento,8018562,U.S. Senate,,DEM,Kamala Harris,305
-Sacramento,8018562,U.S. Senate,,DEM,Loretta Sanchez,200
-Sacramento,8018588,U.S. Senate,,DEM,Kamala Harris,402
-Sacramento,8018588,U.S. Senate,,DEM,Loretta Sanchez,263
-Sacramento,8018791,U.S. Senate,,DEM,Kamala Harris,273
-Sacramento,8018791,U.S. Senate,,DEM,Loretta Sanchez,199
-Sacramento,8018840,U.S. Senate,,DEM,Kamala Harris,445
-Sacramento,8018840,U.S. Senate,,DEM,Loretta Sanchez,239
-Sacramento,8019081,U.S. Senate,,DEM,Kamala Harris,159
-Sacramento,8019081,U.S. Senate,,DEM,Loretta Sanchez,125
-Sacramento,8019319,U.S. Senate,,DEM,Kamala Harris,238
-Sacramento,8019319,U.S. Senate,,DEM,Loretta Sanchez,188
-Sacramento,8019325,U.S. Senate,,DEM,Kamala Harris,288
-Sacramento,8019325,U.S. Senate,,DEM,Loretta Sanchez,183
-Sacramento,8019427,U.S. Senate,,DEM,Kamala Harris,227
-Sacramento,8019427,U.S. Senate,,DEM,Loretta Sanchez,152
-Sacramento,8019455,U.S. Senate,,DEM,Kamala Harris,286
-Sacramento,8019455,U.S. Senate,,DEM,Loretta Sanchez,185
-Sacramento,8019532,U.S. Senate,,DEM,Kamala Harris,261
-Sacramento,8019532,U.S. Senate,,DEM,Loretta Sanchez,157
-Sacramento,8019646,U.S. Senate,,DEM,Kamala Harris,369
-Sacramento,8019646,U.S. Senate,,DEM,Loretta Sanchez,130
-Sacramento,8019685,U.S. Senate,,DEM,Kamala Harris,96
-Sacramento,8019685,U.S. Senate,,DEM,Loretta Sanchez,70
-Sacramento,8019800,U.S. Senate,,DEM,Kamala Harris,246
-Sacramento,8019800,U.S. Senate,,DEM,Loretta Sanchez,169
-Sacramento,8019948,U.S. Senate,,DEM,Kamala Harris,149
-Sacramento,8019948,U.S. Senate,,DEM,Loretta Sanchez,75
-Sacramento,8021013,U.S. Senate,,DEM,Kamala Harris,445
-Sacramento,8021013,U.S. Senate,,DEM,Loretta Sanchez,280
-Sacramento,8021065,U.S. Senate,,DEM,Kamala Harris,364
-Sacramento,8021065,U.S. Senate,,DEM,Loretta Sanchez,214
-Sacramento,8021134,U.S. Senate,,DEM,Kamala Harris,351
-Sacramento,8021134,U.S. Senate,,DEM,Loretta Sanchez,196
-Sacramento,8021159,U.S. Senate,,DEM,Kamala Harris,478
-Sacramento,8021159,U.S. Senate,,DEM,Loretta Sanchez,265
-Sacramento,8021203,U.S. Senate,,DEM,Kamala Harris,154
-Sacramento,8021203,U.S. Senate,,DEM,Loretta Sanchez,100
-Sacramento,8021231,U.S. Senate,,DEM,Kamala Harris,243
-Sacramento,8021231,U.S. Senate,,DEM,Loretta Sanchez,102
-Sacramento,8021318,U.S. Senate,,DEM,Kamala Harris,204
-Sacramento,8021318,U.S. Senate,,DEM,Loretta Sanchez,117
-Sacramento,8021362,U.S. Senate,,DEM,Kamala Harris,281
-Sacramento,8021362,U.S. Senate,,DEM,Loretta Sanchez,165
-Sacramento,8021489,U.S. Senate,,DEM,Kamala Harris,414
-Sacramento,8021489,U.S. Senate,,DEM,Loretta Sanchez,244
-Sacramento,8021615,U.S. Senate,,DEM,Kamala Harris,242
-Sacramento,8021615,U.S. Senate,,DEM,Loretta Sanchez,168
-Sacramento,8021621,U.S. Senate,,DEM,Kamala Harris,347
-Sacramento,8021621,U.S. Senate,,DEM,Loretta Sanchez,218
-Sacramento,8021800,U.S. Senate,,DEM,Kamala Harris,290
-Sacramento,8021800,U.S. Senate,,DEM,Loretta Sanchez,204
-Sacramento,8021846,U.S. Senate,,DEM,Kamala Harris,245
-Sacramento,8021846,U.S. Senate,,DEM,Loretta Sanchez,157
-Sacramento,8021895,U.S. Senate,,DEM,Kamala Harris,405
-Sacramento,8021895,U.S. Senate,,DEM,Loretta Sanchez,208
-Sacramento,8021961,U.S. Senate,,DEM,Kamala Harris,244
-Sacramento,8021961,U.S. Senate,,DEM,Loretta Sanchez,186
-Sacramento,8022003,U.S. Senate,,DEM,Kamala Harris,237
-Sacramento,8022003,U.S. Senate,,DEM,Loretta Sanchez,156
-Sacramento,8022034,U.S. Senate,,DEM,Kamala Harris,252
-Sacramento,8022034,U.S. Senate,,DEM,Loretta Sanchez,181
-Sacramento,8022061,U.S. Senate,,DEM,Kamala Harris,406
-Sacramento,8022061,U.S. Senate,,DEM,Loretta Sanchez,227
-Sacramento,8022090,U.S. Senate,,DEM,Kamala Harris,287
-Sacramento,8022090,U.S. Senate,,DEM,Loretta Sanchez,169
-Sacramento,8022139,U.S. Senate,,DEM,Kamala Harris,332
-Sacramento,8022139,U.S. Senate,,DEM,Loretta Sanchez,220
-Sacramento,8022143,U.S. Senate,,DEM,Kamala Harris,368
-Sacramento,8022143,U.S. Senate,,DEM,Loretta Sanchez,165
-Sacramento,8022396,U.S. Senate,,DEM,Kamala Harris,147
-Sacramento,8022396,U.S. Senate,,DEM,Loretta Sanchez,83
-Sacramento,8022453,U.S. Senate,,DEM,Kamala Harris,423
-Sacramento,8022453,U.S. Senate,,DEM,Loretta Sanchez,231
-Sacramento,8022464,U.S. Senate,,DEM,Kamala Harris,413
-Sacramento,8022464,U.S. Senate,,DEM,Loretta Sanchez,193
-Sacramento,8022533,U.S. Senate,,DEM,Kamala Harris,234
-Sacramento,8022533,U.S. Senate,,DEM,Loretta Sanchez,120
-Sacramento,8022552,U.S. Senate,,DEM,Kamala Harris,266
-Sacramento,8022552,U.S. Senate,,DEM,Loretta Sanchez,189
-Sacramento,8022599,U.S. Senate,,DEM,Kamala Harris,328
-Sacramento,8022599,U.S. Senate,,DEM,Loretta Sanchez,164
-Sacramento,8022610,U.S. Senate,,DEM,Kamala Harris,251
-Sacramento,8022610,U.S. Senate,,DEM,Loretta Sanchez,111
-Sacramento,8022694,U.S. Senate,,DEM,Kamala Harris,284
-Sacramento,8022694,U.S. Senate,,DEM,Loretta Sanchez,141
-Sacramento,8022709,U.S. Senate,,DEM,Kamala Harris,397
-Sacramento,8022709,U.S. Senate,,DEM,Loretta Sanchez,191
-Sacramento,8022730,U.S. Senate,,DEM,Kamala Harris,410
-Sacramento,8022730,U.S. Senate,,DEM,Loretta Sanchez,216
-Sacramento,8022824,U.S. Senate,,DEM,Kamala Harris,271
-Sacramento,8022824,U.S. Senate,,DEM,Loretta Sanchez,117
-Sacramento,8022847,U.S. Senate,,DEM,Kamala Harris,258
-Sacramento,8022847,U.S. Senate,,DEM,Loretta Sanchez,129
-Sacramento,8022873,U.S. Senate,,DEM,Kamala Harris,325
-Sacramento,8022873,U.S. Senate,,DEM,Loretta Sanchez,196
-Sacramento,8023002,U.S. Senate,,DEM,Kamala Harris,424
-Sacramento,8023002,U.S. Senate,,DEM,Loretta Sanchez,246
-Sacramento,8023077,U.S. Senate,,DEM,Kamala Harris,399
-Sacramento,8023077,U.S. Senate,,DEM,Loretta Sanchez,244
-Sacramento,8023240,U.S. Senate,,DEM,Kamala Harris,399
-Sacramento,8023240,U.S. Senate,,DEM,Loretta Sanchez,253
-Sacramento,8023264,U.S. Senate,,DEM,Kamala Harris,185
-Sacramento,8023264,U.S. Senate,,DEM,Loretta Sanchez,147
-Sacramento,8023313,U.S. Senate,,DEM,Kamala Harris,488
-Sacramento,8023313,U.S. Senate,,DEM,Loretta Sanchez,273
-Sacramento,8023423,U.S. Senate,,DEM,Kamala Harris,327
-Sacramento,8023423,U.S. Senate,,DEM,Loretta Sanchez,209
-Sacramento,8023519,U.S. Senate,,DEM,Kamala Harris,350
-Sacramento,8023519,U.S. Senate,,DEM,Loretta Sanchez,216
-Sacramento,8023542,U.S. Senate,,DEM,Kamala Harris,482
-Sacramento,8023542,U.S. Senate,,DEM,Loretta Sanchez,238
-Sacramento,8023637,U.S. Senate,,DEM,Kamala Harris,495
-Sacramento,8023637,U.S. Senate,,DEM,Loretta Sanchez,261
-Sacramento,8023733,U.S. Senate,,DEM,Kamala Harris,538
-Sacramento,8023733,U.S. Senate,,DEM,Loretta Sanchez,307
-Sacramento,8023769,U.S. Senate,,DEM,Kamala Harris,443
-Sacramento,8023769,U.S. Senate,,DEM,Loretta Sanchez,257
-Sacramento,8023879,U.S. Senate,,DEM,Kamala Harris,428
-Sacramento,8023879,U.S. Senate,,DEM,Loretta Sanchez,215
-Sacramento,8023905,U.S. Senate,,DEM,Kamala Harris,306
-Sacramento,8023905,U.S. Senate,,DEM,Loretta Sanchez,172
-Sacramento,8023970,U.S. Senate,,DEM,Kamala Harris,347
-Sacramento,8023970,U.S. Senate,,DEM,Loretta Sanchez,144
-Sacramento,8024148,U.S. Senate,,DEM,Kamala Harris,417
-Sacramento,8024148,U.S. Senate,,DEM,Loretta Sanchez,215
-Sacramento,8024182,U.S. Senate,,DEM,Kamala Harris,252
-Sacramento,8024182,U.S. Senate,,DEM,Loretta Sanchez,144
-Sacramento,8024352,U.S. Senate,,DEM,Kamala Harris,430
-Sacramento,8024352,U.S. Senate,,DEM,Loretta Sanchez,237
-Sacramento,8024500,U.S. Senate,,DEM,Kamala Harris,303
-Sacramento,8024500,U.S. Senate,,DEM,Loretta Sanchez,163
-Sacramento,8024557,U.S. Senate,,DEM,Kamala Harris,385
-Sacramento,8024557,U.S. Senate,,DEM,Loretta Sanchez,203
-Sacramento,8024651,U.S. Senate,,DEM,Kamala Harris,252
-Sacramento,8024651,U.S. Senate,,DEM,Loretta Sanchez,172
-Sacramento,8024669,U.S. Senate,,DEM,Kamala Harris,342
-Sacramento,8024669,U.S. Senate,,DEM,Loretta Sanchez,180
-Sacramento,8024684,U.S. Senate,,DEM,Kamala Harris,286
-Sacramento,8024684,U.S. Senate,,DEM,Loretta Sanchez,128
-Sacramento,8024739,U.S. Senate,,DEM,Kamala Harris,417
-Sacramento,8024739,U.S. Senate,,DEM,Loretta Sanchez,211
-Sacramento,8024801,U.S. Senate,,DEM,Kamala Harris,486
-Sacramento,8024801,U.S. Senate,,DEM,Loretta Sanchez,235
-Sacramento,8024874,U.S. Senate,,DEM,Kamala Harris,440
-Sacramento,8024874,U.S. Senate,,DEM,Loretta Sanchez,175
-Sacramento,8024908,U.S. Senate,,DEM,Kamala Harris,443
-Sacramento,8024908,U.S. Senate,,DEM,Loretta Sanchez,169
-Sacramento,8024927,U.S. Senate,,DEM,Kamala Harris,336
-Sacramento,8024927,U.S. Senate,,DEM,Loretta Sanchez,162
-Sacramento,8025011,U.S. Senate,,DEM,Kamala Harris,163
-Sacramento,8025011,U.S. Senate,,DEM,Loretta Sanchez,93
-Sacramento,8025076,U.S. Senate,,DEM,Kamala Harris,350
-Sacramento,8025076,U.S. Senate,,DEM,Loretta Sanchez,195
-Sacramento,8025155,U.S. Senate,,DEM,Kamala Harris,457
-Sacramento,8025155,U.S. Senate,,DEM,Loretta Sanchez,211
-Sacramento,8025234,U.S. Senate,,DEM,Kamala Harris,304
-Sacramento,8025234,U.S. Senate,,DEM,Loretta Sanchez,170
-Sacramento,8025432,U.S. Senate,,DEM,Kamala Harris,474
-Sacramento,8025432,U.S. Senate,,DEM,Loretta Sanchez,210
-Sacramento,8025501,U.S. Senate,,DEM,Kamala Harris,331
-Sacramento,8025501,U.S. Senate,,DEM,Loretta Sanchez,147
-Sacramento,8025536,U.S. Senate,,DEM,Kamala Harris,369
-Sacramento,8025536,U.S. Senate,,DEM,Loretta Sanchez,162
-Sacramento,8025588,U.S. Senate,,DEM,Kamala Harris,525
-Sacramento,8025588,U.S. Senate,,DEM,Loretta Sanchez,241
-Sacramento,8025696,U.S. Senate,,DEM,Kamala Harris,442
-Sacramento,8025696,U.S. Senate,,DEM,Loretta Sanchez,205
-Sacramento,8025703,U.S. Senate,,DEM,Kamala Harris,275
-Sacramento,8025703,U.S. Senate,,DEM,Loretta Sanchez,129
-Sacramento,8025741,U.S. Senate,,DEM,Kamala Harris,316
-Sacramento,8025741,U.S. Senate,,DEM,Loretta Sanchez,139
-Sacramento,8025812,U.S. Senate,,DEM,Kamala Harris,281
-Sacramento,8025812,U.S. Senate,,DEM,Loretta Sanchez,138
-Sacramento,8025845,U.S. Senate,,DEM,Kamala Harris,336
-Sacramento,8025845,U.S. Senate,,DEM,Loretta Sanchez,184
-Sacramento,8025919,U.S. Senate,,DEM,Kamala Harris,432
-Sacramento,8025919,U.S. Senate,,DEM,Loretta Sanchez,204
-Sacramento,8025935,U.S. Senate,,DEM,Kamala Harris,525
-Sacramento,8025935,U.S. Senate,,DEM,Loretta Sanchez,276
-Sacramento,8025990,U.S. Senate,,DEM,Kamala Harris,282
-Sacramento,8025990,U.S. Senate,,DEM,Loretta Sanchez,127
-Sacramento,8026069,U.S. Senate,,DEM,Kamala Harris,474
-Sacramento,8026069,U.S. Senate,,DEM,Loretta Sanchez,273
-Sacramento,8026086,U.S. Senate,,DEM,Kamala Harris,203
-Sacramento,8026086,U.S. Senate,,DEM,Loretta Sanchez,91
-Sacramento,8026171,U.S. Senate,,DEM,Kamala Harris,319
-Sacramento,8026171,U.S. Senate,,DEM,Loretta Sanchez,220
-Sacramento,8026413,U.S. Senate,,DEM,Kamala Harris,325
-Sacramento,8026413,U.S. Senate,,DEM,Loretta Sanchez,129
-Sacramento,8026442,U.S. Senate,,DEM,Kamala Harris,319
-Sacramento,8026442,U.S. Senate,,DEM,Loretta Sanchez,160
-Sacramento,8026512,U.S. Senate,,DEM,Kamala Harris,378
-Sacramento,8026512,U.S. Senate,,DEM,Loretta Sanchez,194
-Sacramento,8026597,U.S. Senate,,DEM,Kamala Harris,233
-Sacramento,8026597,U.S. Senate,,DEM,Loretta Sanchez,106
-Sacramento,8026625,U.S. Senate,,DEM,Kamala Harris,509
-Sacramento,8026625,U.S. Senate,,DEM,Loretta Sanchez,224
-Sacramento,8026715,U.S. Senate,,DEM,Kamala Harris,466
-Sacramento,8026715,U.S. Senate,,DEM,Loretta Sanchez,202
-Sacramento,8026747,U.S. Senate,,DEM,Kamala Harris,338
-Sacramento,8026747,U.S. Senate,,DEM,Loretta Sanchez,191
-Sacramento,8026808,U.S. Senate,,DEM,Kamala Harris,449
-Sacramento,8026808,U.S. Senate,,DEM,Loretta Sanchez,219
-Sacramento,8026830,U.S. Senate,,DEM,Kamala Harris,389
-Sacramento,8026830,U.S. Senate,,DEM,Loretta Sanchez,198
-Sacramento,8026916,U.S. Senate,,DEM,Kamala Harris,471
-Sacramento,8026916,U.S. Senate,,DEM,Loretta Sanchez,230
-Sacramento,8026978,U.S. Senate,,DEM,Kamala Harris,322
-Sacramento,8026978,U.S. Senate,,DEM,Loretta Sanchez,156
-Sacramento,8027046,U.S. Senate,,DEM,Kamala Harris,332
-Sacramento,8027046,U.S. Senate,,DEM,Loretta Sanchez,155
-Sacramento,8027098,U.S. Senate,,DEM,Kamala Harris,270
-Sacramento,8027098,U.S. Senate,,DEM,Loretta Sanchez,118
-Sacramento,8027100,U.S. Senate,,DEM,Kamala Harris,318
-Sacramento,8027100,U.S. Senate,,DEM,Loretta Sanchez,156
-Sacramento,8027212,U.S. Senate,,DEM,Kamala Harris,298
-Sacramento,8027212,U.S. Senate,,DEM,Loretta Sanchez,137
-Sacramento,8027223,U.S. Senate,,DEM,Kamala Harris,417
-Sacramento,8027223,U.S. Senate,,DEM,Loretta Sanchez,178
-Sacramento,8027320,U.S. Senate,,DEM,Kamala Harris,290
-Sacramento,8027320,U.S. Senate,,DEM,Loretta Sanchez,167
-Sacramento,8027506,U.S. Senate,,DEM,Kamala Harris,424
-Sacramento,8027506,U.S. Senate,,DEM,Loretta Sanchez,153
-Sacramento,8027602,U.S. Senate,,DEM,Kamala Harris,487
-Sacramento,8027602,U.S. Senate,,DEM,Loretta Sanchez,207
-Sacramento,8027648,U.S. Senate,,DEM,Kamala Harris,476
-Sacramento,8027648,U.S. Senate,,DEM,Loretta Sanchez,239
-Sacramento,8027719,U.S. Senate,,DEM,Kamala Harris,549
-Sacramento,8027719,U.S. Senate,,DEM,Loretta Sanchez,182
-Sacramento,8027721,U.S. Senate,,DEM,Kamala Harris,317
-Sacramento,8027721,U.S. Senate,,DEM,Loretta Sanchez,126
-Sacramento,8027915,U.S. Senate,,DEM,Kamala Harris,218
-Sacramento,8027915,U.S. Senate,,DEM,Loretta Sanchez,96
-Sacramento,8027971,U.S. Senate,,DEM,Kamala Harris,399
-Sacramento,8027971,U.S. Senate,,DEM,Loretta Sanchez,179
-Sacramento,8028014,U.S. Senate,,DEM,Kamala Harris,517
-Sacramento,8028014,U.S. Senate,,DEM,Loretta Sanchez,211
-Sacramento,8028200,U.S. Senate,,DEM,Kamala Harris,417
-Sacramento,8028200,U.S. Senate,,DEM,Loretta Sanchez,164
-Sacramento,8028299,U.S. Senate,,DEM,Kamala Harris,267
-Sacramento,8028299,U.S. Senate,,DEM,Loretta Sanchez,142
-Sacramento,8028368,U.S. Senate,,DEM,Kamala Harris,373
-Sacramento,8028368,U.S. Senate,,DEM,Loretta Sanchez,169
-Sacramento,8028392,U.S. Senate,,DEM,Kamala Harris,488
-Sacramento,8028392,U.S. Senate,,DEM,Loretta Sanchez,225
-Sacramento,8028417,U.S. Senate,,DEM,Kamala Harris,277
-Sacramento,8028417,U.S. Senate,,DEM,Loretta Sanchez,124
-Sacramento,8028522,U.S. Senate,,DEM,Kamala Harris,251
-Sacramento,8028522,U.S. Senate,,DEM,Loretta Sanchez,88
-Sacramento,8028530,U.S. Senate,,DEM,Kamala Harris,530
-Sacramento,8028530,U.S. Senate,,DEM,Loretta Sanchez,205
-Sacramento,8028656,U.S. Senate,,DEM,Kamala Harris,547
-Sacramento,8028656,U.S. Senate,,DEM,Loretta Sanchez,226
-Sacramento,8028773,U.S. Senate,,DEM,Kamala Harris,430
-Sacramento,8028773,U.S. Senate,,DEM,Loretta Sanchez,231
-Sacramento,8028809,U.S. Senate,,DEM,Kamala Harris,390
-Sacramento,8028809,U.S. Senate,,DEM,Loretta Sanchez,151
-Sacramento,8028939,U.S. Senate,,DEM,Kamala Harris,450
-Sacramento,8028939,U.S. Senate,,DEM,Loretta Sanchez,199
-Sacramento,8029043,U.S. Senate,,DEM,Kamala Harris,268
-Sacramento,8029043,U.S. Senate,,DEM,Loretta Sanchez,120
-Sacramento,8029128,U.S. Senate,,DEM,Kamala Harris,391
-Sacramento,8029128,U.S. Senate,,DEM,Loretta Sanchez,168
-Sacramento,8029205,U.S. Senate,,DEM,Kamala Harris,534
-Sacramento,8029205,U.S. Senate,,DEM,Loretta Sanchez,256
-Sacramento,8029298,U.S. Senate,,DEM,Kamala Harris,543
-Sacramento,8029298,U.S. Senate,,DEM,Loretta Sanchez,217
-Sacramento,8029434,U.S. Senate,,DEM,Kamala Harris,526
-Sacramento,8029434,U.S. Senate,,DEM,Loretta Sanchez,206
-Sacramento,8029661,U.S. Senate,,DEM,Kamala Harris,417
-Sacramento,8029661,U.S. Senate,,DEM,Loretta Sanchez,212
-Sacramento,8029825,U.S. Senate,,DEM,Kamala Harris,259
-Sacramento,8029825,U.S. Senate,,DEM,Loretta Sanchez,121
-Sacramento,8029848,U.S. Senate,,DEM,Kamala Harris,483
-Sacramento,8029848,U.S. Senate,,DEM,Loretta Sanchez,186
-Sacramento,8031066,U.S. Senate,,DEM,Kamala Harris,415
-Sacramento,8031066,U.S. Senate,,DEM,Loretta Sanchez,239
-Sacramento,8031082,U.S. Senate,,DEM,Kamala Harris,208
-Sacramento,8031082,U.S. Senate,,DEM,Loretta Sanchez,125
-Sacramento,8031193,U.S. Senate,,DEM,Kamala Harris,452
-Sacramento,8031193,U.S. Senate,,DEM,Loretta Sanchez,253
-Sacramento,8031271,U.S. Senate,,DEM,Kamala Harris,469
-Sacramento,8031271,U.S. Senate,,DEM,Loretta Sanchez,293
-Sacramento,8031348,U.S. Senate,,DEM,Kamala Harris,486
-Sacramento,8031348,U.S. Senate,,DEM,Loretta Sanchez,242
-Sacramento,8031432,U.S. Senate,,DEM,Kamala Harris,251
-Sacramento,8031432,U.S. Senate,,DEM,Loretta Sanchez,172
-Sacramento,8031461,U.S. Senate,,DEM,Kamala Harris,410
-Sacramento,8031461,U.S. Senate,,DEM,Loretta Sanchez,250
-Sacramento,8031538,U.S. Senate,,DEM,Kamala Harris,283
-Sacramento,8031538,U.S. Senate,,DEM,Loretta Sanchez,182
-Sacramento,8031574,U.S. Senate,,DEM,Kamala Harris,385
-Sacramento,8031574,U.S. Senate,,DEM,Loretta Sanchez,244
-Sacramento,8031631,U.S. Senate,,DEM,Kamala Harris,297
-Sacramento,8031631,U.S. Senate,,DEM,Loretta Sanchez,188
-Sacramento,8031662,U.S. Senate,,DEM,Kamala Harris,354
-Sacramento,8031662,U.S. Senate,,DEM,Loretta Sanchez,205
-Sacramento,8031765,U.S. Senate,,DEM,Kamala Harris,265
-Sacramento,8031765,U.S. Senate,,DEM,Loretta Sanchez,129
-Sacramento,8031839,U.S. Senate,,DEM,Kamala Harris,362
-Sacramento,8031839,U.S. Senate,,DEM,Loretta Sanchez,216
-Sacramento,8031900,U.S. Senate,,DEM,Kamala Harris,343
-Sacramento,8031900,U.S. Senate,,DEM,Loretta Sanchez,193
-Sacramento,8031994,U.S. Senate,,DEM,Kamala Harris,252
-Sacramento,8031994,U.S. Senate,,DEM,Loretta Sanchez,201
-Sacramento,8032101,U.S. Senate,,DEM,Kamala Harris,298
-Sacramento,8032101,U.S. Senate,,DEM,Loretta Sanchez,164
-Sacramento,8032206,U.S. Senate,,DEM,Kamala Harris,348
-Sacramento,8032206,U.S. Senate,,DEM,Loretta Sanchez,239
-Sacramento,8032435,U.S. Senate,,DEM,Kamala Harris,366
-Sacramento,8032435,U.S. Senate,,DEM,Loretta Sanchez,200
-Sacramento,8032554,U.S. Senate,,DEM,Kamala Harris,321
-Sacramento,8032554,U.S. Senate,,DEM,Loretta Sanchez,179
-Sacramento,8032773,U.S. Senate,,DEM,Kamala Harris,338
-Sacramento,8032773,U.S. Senate,,DEM,Loretta Sanchez,192
-Sacramento,8032872,U.S. Senate,,DEM,Kamala Harris,305
-Sacramento,8032872,U.S. Senate,,DEM,Loretta Sanchez,156
-Sacramento,8033108,U.S. Senate,,DEM,Kamala Harris,385
-Sacramento,8033108,U.S. Senate,,DEM,Loretta Sanchez,232
-Sacramento,8033126,U.S. Senate,,DEM,Kamala Harris,510
-Sacramento,8033126,U.S. Senate,,DEM,Loretta Sanchez,247
-Sacramento,8033227,U.S. Senate,,DEM,Kamala Harris,604
-Sacramento,8033227,U.S. Senate,,DEM,Loretta Sanchez,304
-Sacramento,8033431,U.S. Senate,,DEM,Kamala Harris,247
-Sacramento,8033431,U.S. Senate,,DEM,Loretta Sanchez,166
-Sacramento,8033529,U.S. Senate,,DEM,Kamala Harris,306
-Sacramento,8033529,U.S. Senate,,DEM,Loretta Sanchez,203
-Sacramento,8033713,U.S. Senate,,DEM,Kamala Harris,329
-Sacramento,8033713,U.S. Senate,,DEM,Loretta Sanchez,157
-Sacramento,8033774,U.S. Senate,,DEM,Kamala Harris,472
-Sacramento,8033774,U.S. Senate,,DEM,Loretta Sanchez,216
-Sacramento,8033818,U.S. Senate,,DEM,Kamala Harris,531
-Sacramento,8033818,U.S. Senate,,DEM,Loretta Sanchez,264
-Sacramento,8033997,U.S. Senate,,DEM,Kamala Harris,628
-Sacramento,8033997,U.S. Senate,,DEM,Loretta Sanchez,268
-Sacramento,8034064,U.S. Senate,,DEM,Kamala Harris,352
-Sacramento,8034064,U.S. Senate,,DEM,Loretta Sanchez,185
-Sacramento,8034180,U.S. Senate,,DEM,Kamala Harris,538
-Sacramento,8034180,U.S. Senate,,DEM,Loretta Sanchez,242
-Sacramento,8034322,U.S. Senate,,DEM,Kamala Harris,444
-Sacramento,8034322,U.S. Senate,,DEM,Loretta Sanchez,257
-Sacramento,8034452,U.S. Senate,,DEM,Kamala Harris,254
-Sacramento,8034452,U.S. Senate,,DEM,Loretta Sanchez,137
-Sacramento,8034600,U.S. Senate,,DEM,Kamala Harris,528
-Sacramento,8034600,U.S. Senate,,DEM,Loretta Sanchez,311
-Sacramento,8034726,U.S. Senate,,DEM,Kamala Harris,436
-Sacramento,8034726,U.S. Senate,,DEM,Loretta Sanchez,217
-Sacramento,8034824,U.S. Senate,,DEM,Kamala Harris,531
-Sacramento,8034824,U.S. Senate,,DEM,Loretta Sanchez,267
-Sacramento,8035127,U.S. Senate,,DEM,Kamala Harris,491
-Sacramento,8035127,U.S. Senate,,DEM,Loretta Sanchez,270
-Sacramento,8035215,U.S. Senate,,DEM,Kamala Harris,309
-Sacramento,8035215,U.S. Senate,,DEM,Loretta Sanchez,162
-Sacramento,8035260,U.S. Senate,,DEM,Kamala Harris,261
-Sacramento,8035260,U.S. Senate,,DEM,Loretta Sanchez,176
-Sacramento,8035402,U.S. Senate,,DEM,Kamala Harris,342
-Sacramento,8035402,U.S. Senate,,DEM,Loretta Sanchez,206
-Sacramento,8035500,U.S. Senate,,DEM,Kamala Harris,486
-Sacramento,8035500,U.S. Senate,,DEM,Loretta Sanchez,249
-Sacramento,8035636,U.S. Senate,,DEM,Kamala Harris,531
-Sacramento,8035636,U.S. Senate,,DEM,Loretta Sanchez,244
-Sacramento,8035797,U.S. Senate,,DEM,Kamala Harris,414
-Sacramento,8035797,U.S. Senate,,DEM,Loretta Sanchez,184
-Sacramento,8035852,U.S. Senate,,DEM,Kamala Harris,337
-Sacramento,8035852,U.S. Senate,,DEM,Loretta Sanchez,149
-Sacramento,8035886,U.S. Senate,,DEM,Kamala Harris,358
-Sacramento,8035886,U.S. Senate,,DEM,Loretta Sanchez,172
-Sacramento,8036005,U.S. Senate,,DEM,Kamala Harris,487
-Sacramento,8036005,U.S. Senate,,DEM,Loretta Sanchez,207
-Sacramento,8036104,U.S. Senate,,DEM,Kamala Harris,502
-Sacramento,8036104,U.S. Senate,,DEM,Loretta Sanchez,219
-Sacramento,8036274,U.S. Senate,,DEM,Kamala Harris,364
-Sacramento,8036274,U.S. Senate,,DEM,Loretta Sanchez,183
-Sacramento,8036389,U.S. Senate,,DEM,Kamala Harris,490
-Sacramento,8036389,U.S. Senate,,DEM,Loretta Sanchez,233
-Sacramento,8036407,U.S. Senate,,DEM,Kamala Harris,471
-Sacramento,8036407,U.S. Senate,,DEM,Loretta Sanchez,252
-Sacramento,8036433,U.S. Senate,,DEM,Kamala Harris,518
-Sacramento,8036433,U.S. Senate,,DEM,Loretta Sanchez,206
-Sacramento,8036556,U.S. Senate,,DEM,Kamala Harris,474
-Sacramento,8036556,U.S. Senate,,DEM,Loretta Sanchez,203
-Sacramento,8036602,U.S. Senate,,DEM,Kamala Harris,289
-Sacramento,8036602,U.S. Senate,,DEM,Loretta Sanchez,162
-Sacramento,8036645,U.S. Senate,,DEM,Kamala Harris,439
-Sacramento,8036645,U.S. Senate,,DEM,Loretta Sanchez,236
-Sacramento,8036781,U.S. Senate,,DEM,Kamala Harris,447
-Sacramento,8036781,U.S. Senate,,DEM,Loretta Sanchez,246
-Sacramento,8036844,U.S. Senate,,DEM,Kamala Harris,333
-Sacramento,8036844,U.S. Senate,,DEM,Loretta Sanchez,158
-Sacramento,8036973,U.S. Senate,,DEM,Kamala Harris,603
-Sacramento,8036973,U.S. Senate,,DEM,Loretta Sanchez,257
-Sacramento,8037109,U.S. Senate,,DEM,Kamala Harris,394
-Sacramento,8037109,U.S. Senate,,DEM,Loretta Sanchez,253
-Sacramento,8037138,U.S. Senate,,DEM,Kamala Harris,492
-Sacramento,8037138,U.S. Senate,,DEM,Loretta Sanchez,218
-Sacramento,8037258,U.S. Senate,,DEM,Kamala Harris,453
-Sacramento,8037258,U.S. Senate,,DEM,Loretta Sanchez,189
-Sacramento,8037296,U.S. Senate,,DEM,Kamala Harris,445
-Sacramento,8037296,U.S. Senate,,DEM,Loretta Sanchez,198
-Sacramento,8038113,U.S. Senate,,DEM,Kamala Harris,346
-Sacramento,8038113,U.S. Senate,,DEM,Loretta Sanchez,247
-Sacramento,8038570,U.S. Senate,,DEM,Kamala Harris,465
-Sacramento,8038570,U.S. Senate,,DEM,Loretta Sanchez,207
-Sacramento,8039027,U.S. Senate,,DEM,Kamala Harris,333
-Sacramento,8039027,U.S. Senate,,DEM,Loretta Sanchez,132
-Sacramento,8039226,U.S. Senate,,DEM,Kamala Harris,440
-Sacramento,8039226,U.S. Senate,,DEM,Loretta Sanchez,227
-Sacramento,8039423,U.S. Senate,,DEM,Kamala Harris,475
-Sacramento,8039423,U.S. Senate,,DEM,Loretta Sanchez,223
-Sacramento,8039471,U.S. Senate,,DEM,Kamala Harris,441
-Sacramento,8039471,U.S. Senate,,DEM,Loretta Sanchez,205
-Sacramento,8039508,U.S. Senate,,DEM,Kamala Harris,459
-Sacramento,8039508,U.S. Senate,,DEM,Loretta Sanchez,243
-Sacramento,8039704,U.S. Senate,,DEM,Kamala Harris,393
-Sacramento,8039704,U.S. Senate,,DEM,Loretta Sanchez,172
-Sacramento,8041017,U.S. Senate,,DEM,Kamala Harris,117
-Sacramento,8041017,U.S. Senate,,DEM,Loretta Sanchez,51
-Sacramento,8041165,U.S. Senate,,DEM,Kamala Harris,325
-Sacramento,8041165,U.S. Senate,,DEM,Loretta Sanchez,125
-Sacramento,8041216,U.S. Senate,,DEM,Kamala Harris,470
-Sacramento,8041216,U.S. Senate,,DEM,Loretta Sanchez,183
-Sacramento,8041262,U.S. Senate,,DEM,Kamala Harris,472
-Sacramento,8041262,U.S. Senate,,DEM,Loretta Sanchez,147
-Sacramento,8041321,U.S. Senate,,DEM,Kamala Harris,353
-Sacramento,8041321,U.S. Senate,,DEM,Loretta Sanchez,133
-Sacramento,8041378,U.S. Senate,,DEM,Kamala Harris,460
-Sacramento,8041378,U.S. Senate,,DEM,Loretta Sanchez,154
-Sacramento,8041464,U.S. Senate,,DEM,Kamala Harris,450
-Sacramento,8041464,U.S. Senate,,DEM,Loretta Sanchez,152
-Sacramento,8041560,U.S. Senate,,DEM,Kamala Harris,453
-Sacramento,8041560,U.S. Senate,,DEM,Loretta Sanchez,152
-Sacramento,8041572,U.S. Senate,,DEM,Kamala Harris,300
-Sacramento,8041572,U.S. Senate,,DEM,Loretta Sanchez,74
-Sacramento,8041673,U.S. Senate,,DEM,Kamala Harris,433
-Sacramento,8041673,U.S. Senate,,DEM,Loretta Sanchez,116
-Sacramento,8041686,U.S. Senate,,DEM,Kamala Harris,500
-Sacramento,8041686,U.S. Senate,,DEM,Loretta Sanchez,143
-Sacramento,8041722,U.S. Senate,,DEM,Kamala Harris,392
-Sacramento,8041722,U.S. Senate,,DEM,Loretta Sanchez,133
-Sacramento,8041769,U.S. Senate,,DEM,Kamala Harris,401
-Sacramento,8041769,U.S. Senate,,DEM,Loretta Sanchez,132
-Sacramento,8041818,U.S. Senate,,DEM,Kamala Harris,313
-Sacramento,8041818,U.S. Senate,,DEM,Loretta Sanchez,97
-Sacramento,8041899,U.S. Senate,,DEM,Kamala Harris,389
-Sacramento,8041899,U.S. Senate,,DEM,Loretta Sanchez,139
-Sacramento,8041976,U.S. Senate,,DEM,Kamala Harris,552
-Sacramento,8041976,U.S. Senate,,DEM,Loretta Sanchez,178
-Sacramento,8042016,U.S. Senate,,DEM,Kamala Harris,541
-Sacramento,8042016,U.S. Senate,,DEM,Loretta Sanchez,155
-Sacramento,8042258,U.S. Senate,,DEM,Kamala Harris,400
-Sacramento,8042258,U.S. Senate,,DEM,Loretta Sanchez,103
-Sacramento,8042312,U.S. Senate,,DEM,Kamala Harris,489
-Sacramento,8042312,U.S. Senate,,DEM,Loretta Sanchez,134
-Sacramento,8042351,U.S. Senate,,DEM,Kamala Harris,423
-Sacramento,8042351,U.S. Senate,,DEM,Loretta Sanchez,105
-Sacramento,8042363,U.S. Senate,,DEM,Kamala Harris,480
-Sacramento,8042363,U.S. Senate,,DEM,Loretta Sanchez,127
-Sacramento,8042434,U.S. Senate,,DEM,Kamala Harris,271
-Sacramento,8042434,U.S. Senate,,DEM,Loretta Sanchez,65
-Sacramento,8042459,U.S. Senate,,DEM,Kamala Harris,510
-Sacramento,8042459,U.S. Senate,,DEM,Loretta Sanchez,131
-Sacramento,8042509,U.S. Senate,,DEM,Kamala Harris,492
-Sacramento,8042509,U.S. Senate,,DEM,Loretta Sanchez,131
-Sacramento,8042605,U.S. Senate,,DEM,Kamala Harris,512
-Sacramento,8042605,U.S. Senate,,DEM,Loretta Sanchez,220
-Sacramento,8042707,U.S. Senate,,DEM,Kamala Harris,544
-Sacramento,8042707,U.S. Senate,,DEM,Loretta Sanchez,180
-Sacramento,8042821,U.S. Senate,,DEM,Kamala Harris,571
-Sacramento,8042821,U.S. Senate,,DEM,Loretta Sanchez,152
-Sacramento,8042854,U.S. Senate,,DEM,Kamala Harris,337
-Sacramento,8042854,U.S. Senate,,DEM,Loretta Sanchez,128
-Sacramento,8042946,U.S. Senate,,DEM,Kamala Harris,483
-Sacramento,8042946,U.S. Senate,,DEM,Loretta Sanchez,171
-Sacramento,8043148,U.S. Senate,,DEM,Kamala Harris,510
-Sacramento,8043148,U.S. Senate,,DEM,Loretta Sanchez,183
-Sacramento,8043242,U.S. Senate,,DEM,Kamala Harris,478
-Sacramento,8043242,U.S. Senate,,DEM,Loretta Sanchez,133
-Sacramento,8043329,U.S. Senate,,DEM,Kamala Harris,296
-Sacramento,8043329,U.S. Senate,,DEM,Loretta Sanchez,226
-Sacramento,8043400,U.S. Senate,,DEM,Kamala Harris,612
-Sacramento,8043400,U.S. Senate,,DEM,Loretta Sanchez,227
-Sacramento,8043439,U.S. Senate,,DEM,Kamala Harris,677
-Sacramento,8043439,U.S. Senate,,DEM,Loretta Sanchez,228
-Sacramento,8043691,U.S. Senate,,DEM,Kamala Harris,531
-Sacramento,8043691,U.S. Senate,,DEM,Loretta Sanchez,229
-Sacramento,8043738,U.S. Senate,,DEM,Kamala Harris,347
-Sacramento,8043738,U.S. Senate,,DEM,Loretta Sanchez,127
-Sacramento,8043845,U.S. Senate,,DEM,Kamala Harris,311
-Sacramento,8043845,U.S. Senate,,DEM,Loretta Sanchez,168
-Sacramento,8044013,U.S. Senate,,DEM,Kamala Harris,377
-Sacramento,8044013,U.S. Senate,,DEM,Loretta Sanchez,108
-Sacramento,8044059,U.S. Senate,,DEM,Kamala Harris,262
-Sacramento,8044059,U.S. Senate,,DEM,Loretta Sanchez,103
-Sacramento,8044158,U.S. Senate,,DEM,Kamala Harris,632
-Sacramento,8044158,U.S. Senate,,DEM,Loretta Sanchez,131
-Sacramento,8044191,U.S. Senate,,DEM,Kamala Harris,206
-Sacramento,8044191,U.S. Senate,,DEM,Loretta Sanchez,62
-Sacramento,8044209,U.S. Senate,,DEM,Kamala Harris,376
-Sacramento,8044209,U.S. Senate,,DEM,Loretta Sanchez,133
-Sacramento,8044274,U.S. Senate,,DEM,Kamala Harris,605
-Sacramento,8044274,U.S. Senate,,DEM,Loretta Sanchez,112
-Sacramento,8044346,U.S. Senate,,DEM,Kamala Harris,594
-Sacramento,8044346,U.S. Senate,,DEM,Loretta Sanchez,126
-Sacramento,8044507,U.S. Senate,,DEM,Kamala Harris,478
-Sacramento,8044507,U.S. Senate,,DEM,Loretta Sanchez,132
-Sacramento,8044520,U.S. Senate,,DEM,Kamala Harris,511
-Sacramento,8044520,U.S. Senate,,DEM,Loretta Sanchez,143
-Sacramento,8044549,U.S. Senate,,DEM,Kamala Harris,720
-Sacramento,8044549,U.S. Senate,,DEM,Loretta Sanchez,206
-Sacramento,8044601,U.S. Senate,,DEM,Kamala Harris,434
-Sacramento,8044601,U.S. Senate,,DEM,Loretta Sanchez,173
-Sacramento,8044625,U.S. Senate,,DEM,Kamala Harris,429
-Sacramento,8044625,U.S. Senate,,DEM,Loretta Sanchez,132
-Sacramento,8044663,U.S. Senate,,DEM,Kamala Harris,431
-Sacramento,8044663,U.S. Senate,,DEM,Loretta Sanchez,141
-Sacramento,8044706,U.S. Senate,,DEM,Kamala Harris,577
-Sacramento,8044706,U.S. Senate,,DEM,Loretta Sanchez,158
-Sacramento,8044757,U.S. Senate,,DEM,Kamala Harris,229
-Sacramento,8044757,U.S. Senate,,DEM,Loretta Sanchez,90
-Sacramento,8044804,U.S. Senate,,DEM,Kamala Harris,520
-Sacramento,8044804,U.S. Senate,,DEM,Loretta Sanchez,181
-Sacramento,8044903,U.S. Senate,,DEM,Kamala Harris,435
-Sacramento,8044903,U.S. Senate,,DEM,Loretta Sanchez,157
-Sacramento,8044992,U.S. Senate,,DEM,Kamala Harris,376
-Sacramento,8044992,U.S. Senate,,DEM,Loretta Sanchez,172
-Sacramento,8045015,U.S. Senate,,DEM,Kamala Harris,370
-Sacramento,8045015,U.S. Senate,,DEM,Loretta Sanchez,148
-Sacramento,8045058,U.S. Senate,,DEM,Kamala Harris,491
-Sacramento,8045058,U.S. Senate,,DEM,Loretta Sanchez,159
-Sacramento,8045107,U.S. Senate,,DEM,Kamala Harris,252
-Sacramento,8045107,U.S. Senate,,DEM,Loretta Sanchez,110
-Sacramento,8045164,U.S. Senate,,DEM,Kamala Harris,228
-Sacramento,8045164,U.S. Senate,,DEM,Loretta Sanchez,106
-Sacramento,8045241,U.S. Senate,,DEM,Kamala Harris,314
-Sacramento,8045241,U.S. Senate,,DEM,Loretta Sanchez,184
-Sacramento,8045314,U.S. Senate,,DEM,Kamala Harris,269
-Sacramento,8045314,U.S. Senate,,DEM,Loretta Sanchez,212
-Sacramento,8045418,U.S. Senate,,DEM,Kamala Harris,269
-Sacramento,8045418,U.S. Senate,,DEM,Loretta Sanchez,148
-Sacramento,8045453,U.S. Senate,,DEM,Kamala Harris,153
-Sacramento,8045453,U.S. Senate,,DEM,Loretta Sanchez,123
-Sacramento,8045482,U.S. Senate,,DEM,Kamala Harris,179
-Sacramento,8045482,U.S. Senate,,DEM,Loretta Sanchez,108
-Sacramento,8045511,U.S. Senate,,DEM,Kamala Harris,72
-Sacramento,8045511,U.S. Senate,,DEM,Loretta Sanchez,84
-Sacramento,8045548,U.S. Senate,,DEM,Kamala Harris,254
-Sacramento,8045548,U.S. Senate,,DEM,Loretta Sanchez,204
-Sacramento,8045624,U.S. Senate,,DEM,Kamala Harris,231
-Sacramento,8045624,U.S. Senate,,DEM,Loretta Sanchez,178
-Sacramento,8045670,U.S. Senate,,DEM,Kamala Harris,331
-Sacramento,8045670,U.S. Senate,,DEM,Loretta Sanchez,245
-Sacramento,8045701,U.S. Senate,,DEM,Kamala Harris,323
-Sacramento,8045701,U.S. Senate,,DEM,Loretta Sanchez,221
-Sacramento,8045736,U.S. Senate,,DEM,Kamala Harris,263
-Sacramento,8045736,U.S. Senate,,DEM,Loretta Sanchez,178
-Sacramento,8045847,U.S. Senate,,DEM,Kamala Harris,194
-Sacramento,8045847,U.S. Senate,,DEM,Loretta Sanchez,129
-Sacramento,8045908,U.S. Senate,,DEM,Kamala Harris,221
-Sacramento,8045908,U.S. Senate,,DEM,Loretta Sanchez,106
-Sacramento,8045956,U.S. Senate,,DEM,Kamala Harris,248
-Sacramento,8045956,U.S. Senate,,DEM,Loretta Sanchez,215
-Sacramento,8046014,U.S. Senate,,DEM,Kamala Harris,636
-Sacramento,8046014,U.S. Senate,,DEM,Loretta Sanchez,201
-Sacramento,8046098,U.S. Senate,,DEM,Kamala Harris,382
-Sacramento,8046098,U.S. Senate,,DEM,Loretta Sanchez,121
-Sacramento,8046153,U.S. Senate,,DEM,Kamala Harris,345
-Sacramento,8046153,U.S. Senate,,DEM,Loretta Sanchez,193
-Sacramento,8046220,U.S. Senate,,DEM,Kamala Harris,326
-Sacramento,8046220,U.S. Senate,,DEM,Loretta Sanchez,113
-Sacramento,8046307,U.S. Senate,,DEM,Kamala Harris,450
-Sacramento,8046307,U.S. Senate,,DEM,Loretta Sanchez,166
-Sacramento,8046344,U.S. Senate,,DEM,Kamala Harris,299
-Sacramento,8046344,U.S. Senate,,DEM,Loretta Sanchez,187
-Sacramento,8046422,U.S. Senate,,DEM,Kamala Harris,149
-Sacramento,8046422,U.S. Senate,,DEM,Loretta Sanchez,118
-Sacramento,8046477,U.S. Senate,,DEM,Kamala Harris,399
-Sacramento,8046477,U.S. Senate,,DEM,Loretta Sanchez,232
-Sacramento,8046618,U.S. Senate,,DEM,Kamala Harris,276
-Sacramento,8046618,U.S. Senate,,DEM,Loretta Sanchez,254
-Sacramento,8046690,U.S. Senate,,DEM,Kamala Harris,341
-Sacramento,8046690,U.S. Senate,,DEM,Loretta Sanchez,178
-Sacramento,8046739,U.S. Senate,,DEM,Kamala Harris,201
-Sacramento,8046739,U.S. Senate,,DEM,Loretta Sanchez,107
-Sacramento,8046872,U.S. Senate,,DEM,Kamala Harris,280
-Sacramento,8046872,U.S. Senate,,DEM,Loretta Sanchez,178
-Sacramento,8047018,U.S. Senate,,DEM,Kamala Harris,256
-Sacramento,8047018,U.S. Senate,,DEM,Loretta Sanchez,102
-Sacramento,8047051,U.S. Senate,,DEM,Kamala Harris,528
-Sacramento,8047051,U.S. Senate,,DEM,Loretta Sanchez,196
-Sacramento,8047116,U.S. Senate,,DEM,Kamala Harris,541
-Sacramento,8047116,U.S. Senate,,DEM,Loretta Sanchez,220
-Sacramento,8047154,U.S. Senate,,DEM,Kamala Harris,533
-Sacramento,8047154,U.S. Senate,,DEM,Loretta Sanchez,205
-Sacramento,8047199,U.S. Senate,,DEM,Kamala Harris,494
-Sacramento,8047199,U.S. Senate,,DEM,Loretta Sanchez,152
-Sacramento,8047226,U.S. Senate,,DEM,Kamala Harris,613
-Sacramento,8047226,U.S. Senate,,DEM,Loretta Sanchez,180
-Sacramento,8047249,U.S. Senate,,DEM,Kamala Harris,486
-Sacramento,8047249,U.S. Senate,,DEM,Loretta Sanchez,187
-Sacramento,8047302,U.S. Senate,,DEM,Kamala Harris,628
-Sacramento,8047302,U.S. Senate,,DEM,Loretta Sanchez,211
-Sacramento,8047348,U.S. Senate,,DEM,Kamala Harris,632
-Sacramento,8047348,U.S. Senate,,DEM,Loretta Sanchez,181
-Sacramento,8047436,U.S. Senate,,DEM,Kamala Harris,681
-Sacramento,8047436,U.S. Senate,,DEM,Loretta Sanchez,228
-Sacramento,8047530,U.S. Senate,,DEM,Kamala Harris,551
-Sacramento,8047530,U.S. Senate,,DEM,Loretta Sanchez,159
-Sacramento,8047541,U.S. Senate,,DEM,Kamala Harris,564
-Sacramento,8047541,U.S. Senate,,DEM,Loretta Sanchez,171
-Sacramento,8047563,U.S. Senate,,DEM,Kamala Harris,586
-Sacramento,8047563,U.S. Senate,,DEM,Loretta Sanchez,204
-Sacramento,8047619,U.S. Senate,,DEM,Kamala Harris,577
-Sacramento,8047619,U.S. Senate,,DEM,Loretta Sanchez,199
-Sacramento,8047712,U.S. Senate,,DEM,Kamala Harris,639
-Sacramento,8047712,U.S. Senate,,DEM,Loretta Sanchez,226
-Sacramento,8047724,U.S. Senate,,DEM,Kamala Harris,431
-Sacramento,8047724,U.S. Senate,,DEM,Loretta Sanchez,148
-Sacramento,8047814,U.S. Senate,,DEM,Kamala Harris,333
-Sacramento,8047814,U.S. Senate,,DEM,Loretta Sanchez,139
-Sacramento,8047833,U.S. Senate,,DEM,Kamala Harris,468
-Sacramento,8047833,U.S. Senate,,DEM,Loretta Sanchez,148
-Sacramento,8047879,U.S. Senate,,DEM,Kamala Harris,588
-Sacramento,8047879,U.S. Senate,,DEM,Loretta Sanchez,204
-Sacramento,8047943,U.S. Senate,,DEM,Kamala Harris,379
-Sacramento,8047943,U.S. Senate,,DEM,Loretta Sanchez,147
-Sacramento,8048122,U.S. Senate,,DEM,Kamala Harris,519
-Sacramento,8048122,U.S. Senate,,DEM,Loretta Sanchez,202
-Sacramento,8048150,U.S. Senate,,DEM,Kamala Harris,245
-Sacramento,8048150,U.S. Senate,,DEM,Loretta Sanchez,119
-Sacramento,8048252,U.S. Senate,,DEM,Kamala Harris,265
-Sacramento,8048252,U.S. Senate,,DEM,Loretta Sanchez,173
-Sacramento,8048305,U.S. Senate,,DEM,Kamala Harris,334
-Sacramento,8048305,U.S. Senate,,DEM,Loretta Sanchez,148
-Sacramento,8048320,U.S. Senate,,DEM,Kamala Harris,289
-Sacramento,8048320,U.S. Senate,,DEM,Loretta Sanchez,133
-Sacramento,8048396,U.S. Senate,,DEM,Kamala Harris,422
-Sacramento,8048396,U.S. Senate,,DEM,Loretta Sanchez,208
-Sacramento,8048447,U.S. Senate,,DEM,Kamala Harris,286
-Sacramento,8048447,U.S. Senate,,DEM,Loretta Sanchez,181
-Sacramento,8048475,U.S. Senate,,DEM,Kamala Harris,295
-Sacramento,8048475,U.S. Senate,,DEM,Loretta Sanchez,164
-Sacramento,8048524,U.S. Senate,,DEM,Kamala Harris,234
-Sacramento,8048524,U.S. Senate,,DEM,Loretta Sanchez,151
-Sacramento,8048579,U.S. Senate,,DEM,Kamala Harris,369
-Sacramento,8048579,U.S. Senate,,DEM,Loretta Sanchez,164
-Sacramento,8048613,U.S. Senate,,DEM,Kamala Harris,329
-Sacramento,8048613,U.S. Senate,,DEM,Loretta Sanchez,166
-Sacramento,8048637,U.S. Senate,,DEM,Kamala Harris,261
-Sacramento,8048637,U.S. Senate,,DEM,Loretta Sanchez,135
-Sacramento,8048703,U.S. Senate,,DEM,Kamala Harris,230
-Sacramento,8048703,U.S. Senate,,DEM,Loretta Sanchez,166
-Sacramento,8048728,U.S. Senate,,DEM,Kamala Harris,340
-Sacramento,8048728,U.S. Senate,,DEM,Loretta Sanchez,150
-Sacramento,8048917,U.S. Senate,,DEM,Kamala Harris,387
-Sacramento,8048917,U.S. Senate,,DEM,Loretta Sanchez,148
-Sacramento,8048949,U.S. Senate,,DEM,Kamala Harris,209
-Sacramento,8048949,U.S. Senate,,DEM,Loretta Sanchez,100
-Sacramento,8048995,U.S. Senate,,DEM,Kamala Harris,295
-Sacramento,8048995,U.S. Senate,,DEM,Loretta Sanchez,228
-Sacramento,8049006,U.S. Senate,,DEM,Kamala Harris,418
-Sacramento,8049006,U.S. Senate,,DEM,Loretta Sanchez,234
-Sacramento,8049085,U.S. Senate,,DEM,Kamala Harris,126
-Sacramento,8049085,U.S. Senate,,DEM,Loretta Sanchez,52
-Sacramento,8049100,U.S. Senate,,DEM,Kamala Harris,304
-Sacramento,8049100,U.S. Senate,,DEM,Loretta Sanchez,200
-Sacramento,8049162,U.S. Senate,,DEM,Kamala Harris,294
-Sacramento,8049162,U.S. Senate,,DEM,Loretta Sanchez,186
-Sacramento,8049208,U.S. Senate,,DEM,Kamala Harris,384
-Sacramento,8049208,U.S. Senate,,DEM,Loretta Sanchez,292
-Sacramento,8049263,U.S. Senate,,DEM,Kamala Harris,412
-Sacramento,8049263,U.S. Senate,,DEM,Loretta Sanchez,215
-Sacramento,8049316,U.S. Senate,,DEM,Kamala Harris,325
-Sacramento,8049316,U.S. Senate,,DEM,Loretta Sanchez,189
-Sacramento,8049373,U.S. Senate,,DEM,Kamala Harris,347
-Sacramento,8049373,U.S. Senate,,DEM,Loretta Sanchez,153
-Sacramento,8049401,U.S. Senate,,DEM,Kamala Harris,348
-Sacramento,8049401,U.S. Senate,,DEM,Loretta Sanchez,217
-Sacramento,8049457,U.S. Senate,,DEM,Kamala Harris,289
-Sacramento,8049457,U.S. Senate,,DEM,Loretta Sanchez,171
-Sacramento,8049472,U.S. Senate,,DEM,Kamala Harris,302
-Sacramento,8049472,U.S. Senate,,DEM,Loretta Sanchez,162
-Sacramento,8049503,U.S. Senate,,DEM,Kamala Harris,84
-Sacramento,8049503,U.S. Senate,,DEM,Loretta Sanchez,33
-Sacramento,8049542,U.S. Senate,,DEM,Kamala Harris,350
-Sacramento,8049542,U.S. Senate,,DEM,Loretta Sanchez,149
-Sacramento,8049596,U.S. Senate,,DEM,Kamala Harris,240
-Sacramento,8049596,U.S. Senate,,DEM,Loretta Sanchez,170
-Sacramento,8049629,U.S. Senate,,DEM,Kamala Harris,242
-Sacramento,8049629,U.S. Senate,,DEM,Loretta Sanchez,143
-Sacramento,8049732,U.S. Senate,,DEM,Kamala Harris,479
-Sacramento,8049732,U.S. Senate,,DEM,Loretta Sanchez,211
-Sacramento,8049766,U.S. Senate,,DEM,Kamala Harris,412
-Sacramento,8049766,U.S. Senate,,DEM,Loretta Sanchez,174
-Sacramento,8049802,U.S. Senate,,DEM,Kamala Harris,189
-Sacramento,8049802,U.S. Senate,,DEM,Loretta Sanchez,88
-Sacramento,8049923,U.S. Senate,,DEM,Kamala Harris,347
-Sacramento,8049923,U.S. Senate,,DEM,Loretta Sanchez,194
-Sacramento,8051127,U.S. Senate,,DEM,Kamala Harris,393
-Sacramento,8051127,U.S. Senate,,DEM,Loretta Sanchez,166
-Sacramento,8051180,U.S. Senate,,DEM,Kamala Harris,431
-Sacramento,8051180,U.S. Senate,,DEM,Loretta Sanchez,193
-Sacramento,8051317,U.S. Senate,,DEM,Kamala Harris,391
-Sacramento,8051317,U.S. Senate,,DEM,Loretta Sanchez,149
-Sacramento,8051415,U.S. Senate,,DEM,Kamala Harris,517
-Sacramento,8051415,U.S. Senate,,DEM,Loretta Sanchez,198
-Sacramento,8051565,U.S. Senate,,DEM,Kamala Harris,171
-Sacramento,8051565,U.S. Senate,,DEM,Loretta Sanchez,73
-Sacramento,8051582,U.S. Senate,,DEM,Kamala Harris,312
-Sacramento,8051582,U.S. Senate,,DEM,Loretta Sanchez,110
-Sacramento,8051646,U.S. Senate,,DEM,Kamala Harris,298
-Sacramento,8051646,U.S. Senate,,DEM,Loretta Sanchez,153
-Sacramento,8051729,U.S. Senate,,DEM,Kamala Harris,552
-Sacramento,8051729,U.S. Senate,,DEM,Loretta Sanchez,239
-Sacramento,8051844,U.S. Senate,,DEM,Kamala Harris,404
-Sacramento,8051844,U.S. Senate,,DEM,Loretta Sanchez,169
-Sacramento,8051922,U.S. Senate,,DEM,Kamala Harris,455
-Sacramento,8051922,U.S. Senate,,DEM,Loretta Sanchez,205
-Sacramento,8052129,U.S. Senate,,DEM,Kamala Harris,434
-Sacramento,8052129,U.S. Senate,,DEM,Loretta Sanchez,194
-Sacramento,8052218,U.S. Senate,,DEM,Kamala Harris,344
-Sacramento,8052218,U.S. Senate,,DEM,Loretta Sanchez,146
-Sacramento,8052260,U.S. Senate,,DEM,Kamala Harris,385
-Sacramento,8052260,U.S. Senate,,DEM,Loretta Sanchez,180
-Sacramento,8052405,U.S. Senate,,DEM,Kamala Harris,264
-Sacramento,8052405,U.S. Senate,,DEM,Loretta Sanchez,129
-Sacramento,8052516,U.S. Senate,,DEM,Kamala Harris,276
-Sacramento,8052516,U.S. Senate,,DEM,Loretta Sanchez,121
-Sacramento,8052627,U.S. Senate,,DEM,Kamala Harris,466
-Sacramento,8052627,U.S. Senate,,DEM,Loretta Sanchez,231
-Sacramento,8052723,U.S. Senate,,DEM,Kamala Harris,327
-Sacramento,8052723,U.S. Senate,,DEM,Loretta Sanchez,185
-Sacramento,8052750,U.S. Senate,,DEM,Kamala Harris,466
-Sacramento,8052750,U.S. Senate,,DEM,Loretta Sanchez,236
-Sacramento,8052868,U.S. Senate,,DEM,Kamala Harris,355
-Sacramento,8052868,U.S. Senate,,DEM,Loretta Sanchez,180
-Sacramento,8053014,U.S. Senate,,DEM,Kamala Harris,362
-Sacramento,8053014,U.S. Senate,,DEM,Loretta Sanchez,172
-Sacramento,8053067,U.S. Senate,,DEM,Kamala Harris,415
-Sacramento,8053067,U.S. Senate,,DEM,Loretta Sanchez,214
-Sacramento,8053137,U.S. Senate,,DEM,Kamala Harris,439
-Sacramento,8053137,U.S. Senate,,DEM,Loretta Sanchez,185
-Sacramento,8053205,U.S. Senate,,DEM,Kamala Harris,385
-Sacramento,8053205,U.S. Senate,,DEM,Loretta Sanchez,199
-Sacramento,8053261,U.S. Senate,,DEM,Kamala Harris,402
-Sacramento,8053261,U.S. Senate,,DEM,Loretta Sanchez,212
-Sacramento,8053318,U.S. Senate,,DEM,Kamala Harris,281
-Sacramento,8053318,U.S. Senate,,DEM,Loretta Sanchez,135
-Sacramento,8053363,U.S. Senate,,DEM,Kamala Harris,393
-Sacramento,8053363,U.S. Senate,,DEM,Loretta Sanchez,228
-Sacramento,8053435,U.S. Senate,,DEM,Kamala Harris,367
-Sacramento,8053435,U.S. Senate,,DEM,Loretta Sanchez,159
-Sacramento,8053512,U.S. Senate,,DEM,Kamala Harris,288
-Sacramento,8053512,U.S. Senate,,DEM,Loretta Sanchez,157
-Sacramento,8053610,U.S. Senate,,DEM,Kamala Harris,237
-Sacramento,8053610,U.S. Senate,,DEM,Loretta Sanchez,109
-Sacramento,8053657,U.S. Senate,,DEM,Kamala Harris,444
-Sacramento,8053657,U.S. Senate,,DEM,Loretta Sanchez,196
-Sacramento,8053764,U.S. Senate,,DEM,Kamala Harris,179
-Sacramento,8053764,U.S. Senate,,DEM,Loretta Sanchez,69
-Sacramento,8053903,U.S. Senate,,DEM,Kamala Harris,296
-Sacramento,8053903,U.S. Senate,,DEM,Loretta Sanchez,156
-Sacramento,8053932,U.S. Senate,,DEM,Kamala Harris,372
-Sacramento,8053932,U.S. Senate,,DEM,Loretta Sanchez,183
-Sacramento,8055160,U.S. Senate,,DEM,Kamala Harris,392
-Sacramento,8055160,U.S. Senate,,DEM,Loretta Sanchez,201
-Sacramento,8055203,U.S. Senate,,DEM,Kamala Harris,357
-Sacramento,8055203,U.S. Senate,,DEM,Loretta Sanchez,160
-Sacramento,8055281,U.S. Senate,,DEM,Kamala Harris,329
-Sacramento,8055281,U.S. Senate,,DEM,Loretta Sanchez,187
-Sacramento,8055936,U.S. Senate,,DEM,Kamala Harris,496
-Sacramento,8055936,U.S. Senate,,DEM,Loretta Sanchez,252
-Sacramento,8056165,U.S. Senate,,DEM,Kamala Harris,266
-Sacramento,8056165,U.S. Senate,,DEM,Loretta Sanchez,154
-Sacramento,8056250,U.S. Senate,,DEM,Kamala Harris,306
-Sacramento,8056250,U.S. Senate,,DEM,Loretta Sanchez,149
-Sacramento,8056798,U.S. Senate,,DEM,Kamala Harris,158
-Sacramento,8056798,U.S. Senate,,DEM,Loretta Sanchez,99
-Sacramento,8057019,U.S. Senate,,DEM,Kamala Harris,407
-Sacramento,8057019,U.S. Senate,,DEM,Loretta Sanchez,234
-Sacramento,8057101,U.S. Senate,,DEM,Kamala Harris,257
-Sacramento,8057101,U.S. Senate,,DEM,Loretta Sanchez,157
-Sacramento,8057157,U.S. Senate,,DEM,Kamala Harris,294
-Sacramento,8057157,U.S. Senate,,DEM,Loretta Sanchez,181
-Sacramento,8057315,U.S. Senate,,DEM,Kamala Harris,229
-Sacramento,8057315,U.S. Senate,,DEM,Loretta Sanchez,138
-Sacramento,8057430,U.S. Senate,,DEM,Kamala Harris,408
-Sacramento,8057430,U.S. Senate,,DEM,Loretta Sanchez,208
-Sacramento,8057509,U.S. Senate,,DEM,Kamala Harris,275
-Sacramento,8057509,U.S. Senate,,DEM,Loretta Sanchez,155
-Sacramento,8057566,U.S. Senate,,DEM,Kamala Harris,208
-Sacramento,8057566,U.S. Senate,,DEM,Loretta Sanchez,106
-Sacramento,8057639,U.S. Senate,,DEM,Kamala Harris,409
-Sacramento,8057639,U.S. Senate,,DEM,Loretta Sanchez,211
-Sacramento,8057688,U.S. Senate,,DEM,Kamala Harris,403
-Sacramento,8057688,U.S. Senate,,DEM,Loretta Sanchez,199
-Sacramento,8057703,U.S. Senate,,DEM,Kamala Harris,347
-Sacramento,8057703,U.S. Senate,,DEM,Loretta Sanchez,210
-Sacramento,8057735,U.S. Senate,,DEM,Kamala Harris,416
-Sacramento,8057735,U.S. Senate,,DEM,Loretta Sanchez,201
-Sacramento,8057862,U.S. Senate,,DEM,Kamala Harris,374
-Sacramento,8057862,U.S. Senate,,DEM,Loretta Sanchez,186
-Sacramento,8058346,U.S. Senate,,DEM,Kamala Harris,408
-Sacramento,8058346,U.S. Senate,,DEM,Loretta Sanchez,198
-Sacramento,8058437,U.S. Senate,,DEM,Kamala Harris,399
-Sacramento,8058437,U.S. Senate,,DEM,Loretta Sanchez,213
-Sacramento,8058460,U.S. Senate,,DEM,Kamala Harris,395
-Sacramento,8058460,U.S. Senate,,DEM,Loretta Sanchez,188
-Sacramento,8058782,U.S. Senate,,DEM,Kamala Harris,450
-Sacramento,8058782,U.S. Senate,,DEM,Loretta Sanchez,237
-Sacramento,8058828,U.S. Senate,,DEM,Kamala Harris,592
-Sacramento,8058828,U.S. Senate,,DEM,Loretta Sanchez,259
-Sacramento,8059352,U.S. Senate,,DEM,Kamala Harris,475
-Sacramento,8059352,U.S. Senate,,DEM,Loretta Sanchez,189
-Sacramento,8059406,U.S. Senate,,DEM,Kamala Harris,437
-Sacramento,8059406,U.S. Senate,,DEM,Loretta Sanchez,229
-Sacramento,8059562,U.S. Senate,,DEM,Kamala Harris,507
-Sacramento,8059562,U.S. Senate,,DEM,Loretta Sanchez,249
-Sacramento,8061020,U.S. Senate,,DEM,Kamala Harris,178
-Sacramento,8061020,U.S. Senate,,DEM,Loretta Sanchez,83
-Sacramento,8061124,U.S. Senate,,DEM,Kamala Harris,576
-Sacramento,8061124,U.S. Senate,,DEM,Loretta Sanchez,229
-Sacramento,8061169,U.S. Senate,,DEM,Kamala Harris,596
-Sacramento,8061169,U.S. Senate,,DEM,Loretta Sanchez,263
-Sacramento,8061207,U.S. Senate,,DEM,Kamala Harris,459
-Sacramento,8061207,U.S. Senate,,DEM,Loretta Sanchez,213
-Sacramento,8061263,U.S. Senate,,DEM,Kamala Harris,457
-Sacramento,8061263,U.S. Senate,,DEM,Loretta Sanchez,194
-Sacramento,8064204,U.S. Senate,,DEM,Kamala Harris,399
-Sacramento,8064204,U.S. Senate,,DEM,Loretta Sanchez,230
-Sacramento,8064251,U.S. Senate,,DEM,Kamala Harris,431
-Sacramento,8064251,U.S. Senate,,DEM,Loretta Sanchez,189
-Sacramento,8064427,U.S. Senate,,DEM,Kamala Harris,477
-Sacramento,8064427,U.S. Senate,,DEM,Loretta Sanchez,210
-Sacramento,8064541,U.S. Senate,,DEM,Kamala Harris,415
-Sacramento,8064541,U.S. Senate,,DEM,Loretta Sanchez,171
-Sacramento,8065601,U.S. Senate,,DEM,Kamala Harris,173
-Sacramento,8065601,U.S. Senate,,DEM,Loretta Sanchez,97
-Sacramento,8066532,U.S. Senate,,DEM,Kamala Harris,491
-Sacramento,8066532,U.S. Senate,,DEM,Loretta Sanchez,266
-Sacramento,8066741,U.S. Senate,,DEM,Kamala Harris,405
-Sacramento,8066741,U.S. Senate,,DEM,Loretta Sanchez,175
-Sacramento,8066879,U.S. Senate,,DEM,Kamala Harris,341
-Sacramento,8066879,U.S. Senate,,DEM,Loretta Sanchez,183
-Sacramento,8072293,U.S. Senate,,DEM,Kamala Harris,519
-Sacramento,8072293,U.S. Senate,,DEM,Loretta Sanchez,210
-Sacramento,8072329,U.S. Senate,,DEM,Kamala Harris,459
-Sacramento,8072329,U.S. Senate,,DEM,Loretta Sanchez,206
-Sacramento,8072436,U.S. Senate,,DEM,Kamala Harris,479
-Sacramento,8072436,U.S. Senate,,DEM,Loretta Sanchez,158
-Sacramento,8072495,U.S. Senate,,DEM,Kamala Harris,502
-Sacramento,8072495,U.S. Senate,,DEM,Loretta Sanchez,205
-Sacramento,8072564,U.S. Senate,,DEM,Kamala Harris,348
-Sacramento,8072564,U.S. Senate,,DEM,Loretta Sanchez,154
-Sacramento,8072606,U.S. Senate,,DEM,Kamala Harris,470
-Sacramento,8072606,U.S. Senate,,DEM,Loretta Sanchez,167
-Sacramento,8072631,U.S. Senate,,DEM,Kamala Harris,362
-Sacramento,8072631,U.S. Senate,,DEM,Loretta Sanchez,143
-Sacramento,8072713,U.S. Senate,,DEM,Kamala Harris,480
-Sacramento,8072713,U.S. Senate,,DEM,Loretta Sanchez,212
-Sacramento,8072762,U.S. Senate,,DEM,Kamala Harris,414
-Sacramento,8072762,U.S. Senate,,DEM,Loretta Sanchez,217
-Sacramento,8072796,U.S. Senate,,DEM,Kamala Harris,386
-Sacramento,8072796,U.S. Senate,,DEM,Loretta Sanchez,191
-Sacramento,8072804,U.S. Senate,,DEM,Kamala Harris,440
-Sacramento,8072804,U.S. Senate,,DEM,Loretta Sanchez,233
-Sacramento,8072828,U.S. Senate,,DEM,Kamala Harris,435
-Sacramento,8072828,U.S. Senate,,DEM,Loretta Sanchez,183
-Sacramento,8073018,U.S. Senate,,DEM,Kamala Harris,482
-Sacramento,8073018,U.S. Senate,,DEM,Loretta Sanchez,236
-Sacramento,8073096,U.S. Senate,,DEM,Kamala Harris,383
-Sacramento,8073096,U.S. Senate,,DEM,Loretta Sanchez,180
-Sacramento,8073114,U.S. Senate,,DEM,Kamala Harris,491
-Sacramento,8073114,U.S. Senate,,DEM,Loretta Sanchez,185
-Sacramento,8073129,U.S. Senate,,DEM,Kamala Harris,626
-Sacramento,8073129,U.S. Senate,,DEM,Loretta Sanchez,270
-Sacramento,8073171,U.S. Senate,,DEM,Kamala Harris,320
-Sacramento,8073171,U.S. Senate,,DEM,Loretta Sanchez,152
-Sacramento,8073180,U.S. Senate,,DEM,Kamala Harris,533
-Sacramento,8073180,U.S. Senate,,DEM,Loretta Sanchez,204
-Sacramento,8073345,U.S. Senate,,DEM,Kamala Harris,499
-Sacramento,8073345,U.S. Senate,,DEM,Loretta Sanchez,210
-Sacramento,8073350,U.S. Senate,,DEM,Kamala Harris,398
-Sacramento,8073350,U.S. Senate,,DEM,Loretta Sanchez,189
-Sacramento,8073430,U.S. Senate,,DEM,Kamala Harris,456
-Sacramento,8073430,U.S. Senate,,DEM,Loretta Sanchez,255
-Sacramento,8073469,U.S. Senate,,DEM,Kamala Harris,366
-Sacramento,8073469,U.S. Senate,,DEM,Loretta Sanchez,165
-Sacramento,8073558,U.S. Senate,,DEM,Kamala Harris,435
-Sacramento,8073558,U.S. Senate,,DEM,Loretta Sanchez,177
-Sacramento,8073599,U.S. Senate,,DEM,Kamala Harris,543
-Sacramento,8073599,U.S. Senate,,DEM,Loretta Sanchez,222
-Sacramento,8073611,U.S. Senate,,DEM,Kamala Harris,376
-Sacramento,8073611,U.S. Senate,,DEM,Loretta Sanchez,191
-Sacramento,8073662,U.S. Senate,,DEM,Kamala Harris,553
-Sacramento,8073662,U.S. Senate,,DEM,Loretta Sanchez,269
-Sacramento,8073700,U.S. Senate,,DEM,Kamala Harris,583
-Sacramento,8073700,U.S. Senate,,DEM,Loretta Sanchez,254
-Sacramento,8073723,U.S. Senate,,DEM,Kamala Harris,509
-Sacramento,8073723,U.S. Senate,,DEM,Loretta Sanchez,206
-Sacramento,8073817,U.S. Senate,,DEM,Kamala Harris,503
-Sacramento,8073817,U.S. Senate,,DEM,Loretta Sanchez,230
-Sacramento,8073849,U.S. Senate,,DEM,Kamala Harris,438
-Sacramento,8073849,U.S. Senate,,DEM,Loretta Sanchez,237
-Sacramento,8073972,U.S. Senate,,DEM,Kamala Harris,572
-Sacramento,8073972,U.S. Senate,,DEM,Loretta Sanchez,220
-Sacramento,8077164,U.S. Senate,,DEM,Kamala Harris,252
-Sacramento,8077164,U.S. Senate,,DEM,Loretta Sanchez,126
-Sacramento,8077380,U.S. Senate,,DEM,Kamala Harris,72
-Sacramento,8077380,U.S. Senate,,DEM,Loretta Sanchez,59
-Sacramento,8078342,U.S. Senate,,DEM,Kamala Harris,152
-Sacramento,8078342,U.S. Senate,,DEM,Loretta Sanchez,153
-Sacramento,8081268,U.S. Senate,,DEM,Kamala Harris,452
-Sacramento,8081268,U.S. Senate,,DEM,Loretta Sanchez,194
-Sacramento,8081309,U.S. Senate,,DEM,Kamala Harris,503
-Sacramento,8081309,U.S. Senate,,DEM,Loretta Sanchez,220
-Sacramento,8081364,U.S. Senate,,DEM,Kamala Harris,582
-Sacramento,8081364,U.S. Senate,,DEM,Loretta Sanchez,251
-Sacramento,8081550,U.S. Senate,,DEM,Kamala Harris,676
-Sacramento,8081550,U.S. Senate,,DEM,Loretta Sanchez,309
-Sacramento,8081652,U.S. Senate,,DEM,Kamala Harris,353
-Sacramento,8081652,U.S. Senate,,DEM,Loretta Sanchez,167
-Sacramento,8082009,U.S. Senate,,DEM,Kamala Harris,578
-Sacramento,8082009,U.S. Senate,,DEM,Loretta Sanchez,239
-Sacramento,8082021,U.S. Senate,,DEM,Kamala Harris,271
-Sacramento,8082021,U.S. Senate,,DEM,Loretta Sanchez,132
-Sacramento,8082077,U.S. Senate,,DEM,Kamala Harris,555
-Sacramento,8082077,U.S. Senate,,DEM,Loretta Sanchez,261
-Sacramento,8082185,U.S. Senate,,DEM,Kamala Harris,510
-Sacramento,8082185,U.S. Senate,,DEM,Loretta Sanchez,269
-Sacramento,8082276,U.S. Senate,,DEM,Kamala Harris,425
-Sacramento,8082276,U.S. Senate,,DEM,Loretta Sanchez,264
-Sacramento,8082291,U.S. Senate,,DEM,Kamala Harris,265
-Sacramento,8082291,U.S. Senate,,DEM,Loretta Sanchez,152
-Sacramento,8082314,U.S. Senate,,DEM,Kamala Harris,461
-Sacramento,8082314,U.S. Senate,,DEM,Loretta Sanchez,164
-Sacramento,8082343,U.S. Senate,,DEM,Kamala Harris,571
-Sacramento,8082343,U.S. Senate,,DEM,Loretta Sanchez,300
-Sacramento,8082504,U.S. Senate,,DEM,Kamala Harris,457
-Sacramento,8082504,U.S. Senate,,DEM,Loretta Sanchez,253
-Sacramento,8082510,U.S. Senate,,DEM,Kamala Harris,283
-Sacramento,8082510,U.S. Senate,,DEM,Loretta Sanchez,192
-Sacramento,8082597,U.S. Senate,,DEM,Kamala Harris,424
-Sacramento,8082597,U.S. Senate,,DEM,Loretta Sanchez,242
-Sacramento,8082645,U.S. Senate,,DEM,Kamala Harris,375
-Sacramento,8082645,U.S. Senate,,DEM,Loretta Sanchez,195
-Sacramento,8082696,U.S. Senate,,DEM,Kamala Harris,382
-Sacramento,8082696,U.S. Senate,,DEM,Loretta Sanchez,226
-Sacramento,8082706,U.S. Senate,,DEM,Kamala Harris,419
-Sacramento,8082706,U.S. Senate,,DEM,Loretta Sanchez,278
-Sacramento,8082812,U.S. Senate,,DEM,Kamala Harris,282
-Sacramento,8082812,U.S. Senate,,DEM,Loretta Sanchez,164
-Sacramento,8082844,U.S. Senate,,DEM,Kamala Harris,372
-Sacramento,8082844,U.S. Senate,,DEM,Loretta Sanchez,218
-Sacramento,8082880,U.S. Senate,,DEM,Kamala Harris,222
-Sacramento,8082880,U.S. Senate,,DEM,Loretta Sanchez,145
-Sacramento,8083003,U.S. Senate,,DEM,Kamala Harris,377
-Sacramento,8083003,U.S. Senate,,DEM,Loretta Sanchez,266
-Sacramento,8083213,U.S. Senate,,DEM,Kamala Harris,347
-Sacramento,8083213,U.S. Senate,,DEM,Loretta Sanchez,241
-Sacramento,8083305,U.S. Senate,,DEM,Kamala Harris,353
-Sacramento,8083305,U.S. Senate,,DEM,Loretta Sanchez,157
-Sacramento,8083398,U.S. Senate,,DEM,Kamala Harris,428
-Sacramento,8083398,U.S. Senate,,DEM,Loretta Sanchez,172
-Sacramento,8083408,U.S. Senate,,DEM,Kamala Harris,418
-Sacramento,8083408,U.S. Senate,,DEM,Loretta Sanchez,205
-Sacramento,8083511,U.S. Senate,,DEM,Kamala Harris,418
-Sacramento,8083511,U.S. Senate,,DEM,Loretta Sanchez,199
-Sacramento,8083562,U.S. Senate,,DEM,Kamala Harris,392
-Sacramento,8083562,U.S. Senate,,DEM,Loretta Sanchez,212
-Sacramento,8083714,U.S. Senate,,DEM,Kamala Harris,131
-Sacramento,8083714,U.S. Senate,,DEM,Loretta Sanchez,89
-Sacramento,8088242,U.S. Senate,,DEM,Kamala Harris,340
-Sacramento,8088242,U.S. Senate,,DEM,Loretta Sanchez,237
-Sacramento,8088515,U.S. Senate,,DEM,Kamala Harris,347
-Sacramento,8088515,U.S. Senate,,DEM,Loretta Sanchez,293
-Sacramento,8088616,U.S. Senate,,DEM,Kamala Harris,287
-Sacramento,8088616,U.S. Senate,,DEM,Loretta Sanchez,276
-Sacramento,8088707,U.S. Senate,,DEM,Kamala Harris,269
-Sacramento,8088707,U.S. Senate,,DEM,Loretta Sanchez,224
-Sacramento,8088780,U.S. Senate,,DEM,Kamala Harris,260
-Sacramento,8088780,U.S. Senate,,DEM,Loretta Sanchez,299
-Sacramento,8089113,U.S. Senate,,DEM,Kamala Harris,365
-Sacramento,8089113,U.S. Senate,,DEM,Loretta Sanchez,287
-Sacramento,8089238,U.S. Senate,,DEM,Kamala Harris,388
-Sacramento,8089238,U.S. Senate,,DEM,Loretta Sanchez,332
-Sacramento,8089324,U.S. Senate,,DEM,Kamala Harris,289
-Sacramento,8089324,U.S. Senate,,DEM,Loretta Sanchez,251
-Sacramento,8089436,U.S. Senate,,DEM,Kamala Harris,246
-Sacramento,8089436,U.S. Senate,,DEM,Loretta Sanchez,170
-Sacramento,8091059,U.S. Senate,,DEM,Kamala Harris,315
-Sacramento,8091059,U.S. Senate,,DEM,Loretta Sanchez,227
-Sacramento,8091382,U.S. Senate,,DEM,Kamala Harris,390
-Sacramento,8091382,U.S. Senate,,DEM,Loretta Sanchez,261
-Sacramento,8091771,U.S. Senate,,DEM,Kamala Harris,200
-Sacramento,8091771,U.S. Senate,,DEM,Loretta Sanchez,117
-Sacramento,8091968,U.S. Senate,,DEM,Kamala Harris,208
-Sacramento,8091968,U.S. Senate,,DEM,Loretta Sanchez,134
-Sacramento,8094803,U.S. Senate,,DEM,Kamala Harris,153
-Sacramento,8094803,U.S. Senate,,DEM,Loretta Sanchez,142
-Sacramento,8096439,U.S. Senate,,DEM,Kamala Harris,186
-Sacramento,8096439,U.S. Senate,,DEM,Loretta Sanchez,124
-Sacramento,81268,U.S. Senate,,DEM,Kamala Harris,216
-Sacramento,81268,U.S. Senate,,DEM,Loretta Sanchez,140
-Sacramento,81309,U.S. Senate,,DEM,Kamala Harris,217
-Sacramento,81309,U.S. Senate,,DEM,Loretta Sanchez,137
-Sacramento,81364,U.S. Senate,,DEM,Kamala Harris,290
-Sacramento,81364,U.S. Senate,,DEM,Loretta Sanchez,115
-Sacramento,81550,U.S. Senate,,DEM,Kamala Harris,116
-Sacramento,81550,U.S. Senate,,DEM,Loretta Sanchez,94
-Sacramento,81652,U.S. Senate,,DEM,Kamala Harris,123
-Sacramento,81652,U.S. Senate,,DEM,Loretta Sanchez,61
-Sacramento,82009,U.S. Senate,,DEM,Kamala Harris,207
-Sacramento,82009,U.S. Senate,,DEM,Loretta Sanchez,133
-Sacramento,82021,U.S. Senate,,DEM,Kamala Harris,129
-Sacramento,82021,U.S. Senate,,DEM,Loretta Sanchez,87
-Sacramento,82077,U.S. Senate,,DEM,Kamala Harris,235
-Sacramento,82077,U.S. Senate,,DEM,Loretta Sanchez,133
-Sacramento,82185,U.S. Senate,,DEM,Kamala Harris,167
-Sacramento,82185,U.S. Senate,,DEM,Loretta Sanchez,89
-Sacramento,82276,U.S. Senate,,DEM,Kamala Harris,194
-Sacramento,82276,U.S. Senate,,DEM,Loretta Sanchez,108
-Sacramento,82291,U.S. Senate,,DEM,Kamala Harris,84
-Sacramento,82291,U.S. Senate,,DEM,Loretta Sanchez,60
-Sacramento,82314,U.S. Senate,,DEM,Kamala Harris,176
-Sacramento,82314,U.S. Senate,,DEM,Loretta Sanchez,106
-Sacramento,82343,U.S. Senate,,DEM,Kamala Harris,216
-Sacramento,82343,U.S. Senate,,DEM,Loretta Sanchez,128
-Sacramento,82504,U.S. Senate,,DEM,Kamala Harris,178
-Sacramento,82504,U.S. Senate,,DEM,Loretta Sanchez,129
-Sacramento,82510,U.S. Senate,,DEM,Kamala Harris,170
-Sacramento,82510,U.S. Senate,,DEM,Loretta Sanchez,121
-Sacramento,82597,U.S. Senate,,DEM,Kamala Harris,191
-Sacramento,82597,U.S. Senate,,DEM,Loretta Sanchez,133
-Sacramento,82645,U.S. Senate,,DEM,Kamala Harris,177
-Sacramento,82645,U.S. Senate,,DEM,Loretta Sanchez,93
-Sacramento,82696,U.S. Senate,,DEM,Kamala Harris,189
-Sacramento,82696,U.S. Senate,,DEM,Loretta Sanchez,141
-Sacramento,82706,U.S. Senate,,DEM,Kamala Harris,177
-Sacramento,82706,U.S. Senate,,DEM,Loretta Sanchez,124
-Sacramento,82812,U.S. Senate,,DEM,Kamala Harris,138
-Sacramento,82812,U.S. Senate,,DEM,Loretta Sanchez,90
-Sacramento,82844,U.S. Senate,,DEM,Kamala Harris,182
-Sacramento,82844,U.S. Senate,,DEM,Loretta Sanchez,153
-Sacramento,82880,U.S. Senate,,DEM,Kamala Harris,120
-Sacramento,82880,U.S. Senate,,DEM,Loretta Sanchez,67
-Sacramento,82967,U.S. Senate,,DEM,Kamala Harris,0
-Sacramento,82967,U.S. Senate,,DEM,Loretta Sanchez,0
-Sacramento,83003,U.S. Senate,,DEM,Kamala Harris,123
-Sacramento,83003,U.S. Senate,,DEM,Loretta Sanchez,106
-Sacramento,83213,U.S. Senate,,DEM,Kamala Harris,142
-Sacramento,83213,U.S. Senate,,DEM,Loretta Sanchez,101
-Sacramento,83305,U.S. Senate,,DEM,Kamala Harris,152
-Sacramento,83305,U.S. Senate,,DEM,Loretta Sanchez,118
-Sacramento,83398,U.S. Senate,,DEM,Kamala Harris,162
-Sacramento,83398,U.S. Senate,,DEM,Loretta Sanchez,90
-Sacramento,83408,U.S. Senate,,DEM,Kamala Harris,185
-Sacramento,83408,U.S. Senate,,DEM,Loretta Sanchez,105
-Sacramento,83511,U.S. Senate,,DEM,Kamala Harris,154
-Sacramento,83511,U.S. Senate,,DEM,Loretta Sanchez,102
-Sacramento,83562,U.S. Senate,,DEM,Kamala Harris,165
-Sacramento,83562,U.S. Senate,,DEM,Loretta Sanchez,88
-Sacramento,83714,U.S. Senate,,DEM,Kamala Harris,36
-Sacramento,83714,U.S. Senate,,DEM,Loretta Sanchez,41
-Sacramento,83856,U.S. Senate,,DEM,Kamala Harris,14
-Sacramento,83856,U.S. Senate,,DEM,Loretta Sanchez,8
-Sacramento,83900,U.S. Senate,,DEM,Kamala Harris,22
-Sacramento,83900,U.S. Senate,,DEM,Loretta Sanchez,18
-Sacramento,84391,U.S. Senate,,DEM,Kamala Harris,0
-Sacramento,84391,U.S. Senate,,DEM,Loretta Sanchez,0
-Sacramento,84610,U.S. Senate,,DEM,Kamala Harris,0
-Sacramento,84610,U.S. Senate,,DEM,Loretta Sanchez,0
-Sacramento,84815,U.S. Senate,,DEM,Kamala Harris,0
-Sacramento,84815,U.S. Senate,,DEM,Loretta Sanchez,0
-Sacramento,84996,U.S. Senate,,DEM,Kamala Harris,0
-Sacramento,84996,U.S. Senate,,DEM,Loretta Sanchez,0
-Sacramento,85145,U.S. Senate,,DEM,Kamala Harris,0
-Sacramento,85145,U.S. Senate,,DEM,Loretta Sanchez,0
-Sacramento,85261,U.S. Senate,,DEM,Kamala Harris,0
-Sacramento,85261,U.S. Senate,,DEM,Loretta Sanchez,0
-Sacramento,85426,U.S. Senate,,DEM,Kamala Harris,0
-Sacramento,85426,U.S. Senate,,DEM,Loretta Sanchez,0
-Sacramento,85680,U.S. Senate,,DEM,Kamala Harris,0
-Sacramento,85680,U.S. Senate,,DEM,Loretta Sanchez,0
-Sacramento,85859,U.S. Senate,,DEM,Kamala Harris,2
-Sacramento,85859,U.S. Senate,,DEM,Loretta Sanchez,0
-Sacramento,85914,U.S. Senate,,DEM,Kamala Harris,0
-Sacramento,85914,U.S. Senate,,DEM,Loretta Sanchez,0
-Sacramento,85988,U.S. Senate,,DEM,Kamala Harris,4
-Sacramento,85988,U.S. Senate,,DEM,Loretta Sanchez,3
-Sacramento,86271,U.S. Senate,,DEM,Kamala Harris,2
-Sacramento,86271,U.S. Senate,,DEM,Loretta Sanchez,3
-Sacramento,86376,U.S. Senate,,DEM,Kamala Harris,1
-Sacramento,86376,U.S. Senate,,DEM,Loretta Sanchez,3
-Sacramento,86648,U.S. Senate,,DEM,Kamala Harris,19
-Sacramento,86648,U.S. Senate,,DEM,Loretta Sanchez,22
-Sacramento,86807,U.S. Senate,,DEM,Kamala Harris,44
-Sacramento,86807,U.S. Senate,,DEM,Loretta Sanchez,47
-Sacramento,86921,U.S. Senate,,DEM,Kamala Harris,49
-Sacramento,86921,U.S. Senate,,DEM,Loretta Sanchez,46
-Sacramento,87126,U.S. Senate,,DEM,Kamala Harris,0
-Sacramento,87126,U.S. Senate,,DEM,Loretta Sanchez,0
-Sacramento,87338,U.S. Senate,,DEM,Kamala Harris,1
-Sacramento,87338,U.S. Senate,,DEM,Loretta Sanchez,1
-Sacramento,87549,U.S. Senate,,DEM,Kamala Harris,2
-Sacramento,87549,U.S. Senate,,DEM,Loretta Sanchez,6
-Sacramento,87704,U.S. Senate,,DEM,Kamala Harris,0
-Sacramento,87704,U.S. Senate,,DEM,Loretta Sanchez,0
-Sacramento,87819,U.S. Senate,,DEM,Kamala Harris,0
-Sacramento,87819,U.S. Senate,,DEM,Loretta Sanchez,0
-Sacramento,87972,U.S. Senate,,DEM,Kamala Harris,0
-Sacramento,87972,U.S. Senate,,DEM,Loretta Sanchez,0
-Sacramento,88006,U.S. Senate,,DEM,Kamala Harris,0
-Sacramento,88006,U.S. Senate,,DEM,Loretta Sanchez,0
-Sacramento,88117,U.S. Senate,,DEM,Kamala Harris,20
-Sacramento,88117,U.S. Senate,,DEM,Loretta Sanchez,25
-Sacramento,88242,U.S. Senate,,DEM,Kamala Harris,104
-Sacramento,88242,U.S. Senate,,DEM,Loretta Sanchez,95
-Sacramento,88515,U.S. Senate,,DEM,Kamala Harris,178
-Sacramento,88515,U.S. Senate,,DEM,Loretta Sanchez,217
-Sacramento,88616,U.S. Senate,,DEM,Kamala Harris,154
-Sacramento,88616,U.S. Senate,,DEM,Loretta Sanchez,160
-Sacramento,88707,U.S. Senate,,DEM,Kamala Harris,110
-Sacramento,88707,U.S. Senate,,DEM,Loretta Sanchez,149
-Sacramento,88780,U.S. Senate,,DEM,Kamala Harris,129
-Sacramento,88780,U.S. Senate,,DEM,Loretta Sanchez,144
-Sacramento,88941,U.S. Senate,,DEM,Kamala Harris,14
-Sacramento,88941,U.S. Senate,,DEM,Loretta Sanchez,12
-Sacramento,89113,U.S. Senate,,DEM,Kamala Harris,119
-Sacramento,89113,U.S. Senate,,DEM,Loretta Sanchez,153
-Sacramento,89238,U.S. Senate,,DEM,Kamala Harris,169
-Sacramento,89238,U.S. Senate,,DEM,Loretta Sanchez,185
-Sacramento,89324,U.S. Senate,,DEM,Kamala Harris,153
-Sacramento,89324,U.S. Senate,,DEM,Loretta Sanchez,157
-Sacramento,89436,U.S. Senate,,DEM,Kamala Harris,101
-Sacramento,89436,U.S. Senate,,DEM,Loretta Sanchez,99
-Sacramento,89600,U.S. Senate,,DEM,Kamala Harris,17
-Sacramento,89600,U.S. Senate,,DEM,Loretta Sanchez,36
-Sacramento,89867,U.S. Senate,,DEM,Kamala Harris,0
-Sacramento,89867,U.S. Senate,,DEM,Loretta Sanchez,0
-Sacramento,91059,U.S. Senate,,DEM,Kamala Harris,142
-Sacramento,91059,U.S. Senate,,DEM,Loretta Sanchez,127
-Sacramento,91382,U.S. Senate,,DEM,Kamala Harris,138
-Sacramento,91382,U.S. Senate,,DEM,Loretta Sanchez,118
-Sacramento,91771,U.S. Senate,,DEM,Kamala Harris,98
-Sacramento,91771,U.S. Senate,,DEM,Loretta Sanchez,70
-Sacramento,91968,U.S. Senate,,DEM,Kamala Harris,123
-Sacramento,91968,U.S. Senate,,DEM,Loretta Sanchez,111
-Sacramento,94349,U.S. Senate,,DEM,Kamala Harris,0
-Sacramento,94349,U.S. Senate,,DEM,Loretta Sanchez,1
-Sacramento,94686,U.S. Senate,,DEM,Kamala Harris,10
-Sacramento,94686,U.S. Senate,,DEM,Loretta Sanchez,5
-Sacramento,94803,U.S. Senate,,DEM,Kamala Harris,86
-Sacramento,94803,U.S. Senate,,DEM,Loretta Sanchez,87
-Sacramento,96439,U.S. Senate,,DEM,Kamala Harris,107
-Sacramento,96439,U.S. Senate,,DEM,Loretta Sanchez,91
-Sacramento,97527,U.S. Senate,,DEM,Kamala Harris,96
-Sacramento,97527,U.S. Senate,,DEM,Loretta Sanchez,55
-Sacramento,97784,U.S. Senate,,DEM,Kamala Harris,24
-Sacramento,97784,U.S. Senate,,DEM,Loretta Sanchez,10
+Sacramento,11267,U.S. Senate,,DEM,Kamala D. Harris,84
+Sacramento,11267,U.S. Senate,,DEM,Loretta L. Sanchez,57
+Sacramento,11397,U.S. Senate,,DEM,Kamala D. Harris,0
+Sacramento,11397,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sacramento,11974,U.S. Senate,,DEM,Kamala D. Harris,131
+Sacramento,11974,U.S. Senate,,DEM,Loretta L. Sanchez,83
+Sacramento,12170,U.S. Senate,,DEM,Kamala D. Harris,8
+Sacramento,12170,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Sacramento,12356,U.S. Senate,,DEM,Kamala D. Harris,0
+Sacramento,12356,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Sacramento,12669,U.S. Senate,,DEM,Kamala D. Harris,169
+Sacramento,12669,U.S. Senate,,DEM,Loretta L. Sanchez,63
+Sacramento,12681,U.S. Senate,,DEM,Kamala D. Harris,148
+Sacramento,12681,U.S. Senate,,DEM,Loretta L. Sanchez,77
+Sacramento,12702,U.S. Senate,,DEM,Kamala D. Harris,223
+Sacramento,12702,U.S. Senate,,DEM,Loretta L. Sanchez,116
+Sacramento,12747,U.S. Senate,,DEM,Kamala D. Harris,231
+Sacramento,12747,U.S. Senate,,DEM,Loretta L. Sanchez,129
+Sacramento,12786,U.S. Senate,,DEM,Kamala D. Harris,246
+Sacramento,12786,U.S. Senate,,DEM,Loretta L. Sanchez,109
+Sacramento,12807,U.S. Senate,,DEM,Kamala D. Harris,134
+Sacramento,12807,U.S. Senate,,DEM,Loretta L. Sanchez,71
+Sacramento,12884,U.S. Senate,,DEM,Kamala D. Harris,223
+Sacramento,12884,U.S. Senate,,DEM,Loretta L. Sanchez,126
+Sacramento,12943,U.S. Senate,,DEM,Kamala D. Harris,0
+Sacramento,12943,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Sacramento,12988,U.S. Senate,,DEM,Kamala D. Harris,104
+Sacramento,12988,U.S. Senate,,DEM,Loretta L. Sanchez,50
+Sacramento,13032,U.S. Senate,,DEM,Kamala D. Harris,185
+Sacramento,13032,U.S. Senate,,DEM,Loretta L. Sanchez,172
+Sacramento,13239,U.S. Senate,,DEM,Kamala D. Harris,0
+Sacramento,13239,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sacramento,13328,U.S. Senate,,DEM,Kamala D. Harris,207
+Sacramento,13328,U.S. Senate,,DEM,Loretta L. Sanchez,185
+Sacramento,13424,U.S. Senate,,DEM,Kamala D. Harris,141
+Sacramento,13424,U.S. Senate,,DEM,Loretta L. Sanchez,123
+Sacramento,13551,U.S. Senate,,DEM,Kamala D. Harris,114
+Sacramento,13551,U.S. Senate,,DEM,Loretta L. Sanchez,111
+Sacramento,13635,U.S. Senate,,DEM,Kamala D. Harris,202
+Sacramento,13635,U.S. Senate,,DEM,Loretta L. Sanchez,148
+Sacramento,13658,U.S. Senate,,DEM,Kamala D. Harris,156
+Sacramento,13658,U.S. Senate,,DEM,Loretta L. Sanchez,110
+Sacramento,13706,U.S. Senate,,DEM,Kamala D. Harris,125
+Sacramento,13706,U.S. Senate,,DEM,Loretta L. Sanchez,107
+Sacramento,13993,U.S. Senate,,DEM,Kamala D. Harris,96
+Sacramento,13993,U.S. Senate,,DEM,Loretta L. Sanchez,65
+Sacramento,14314,U.S. Senate,,DEM,Kamala D. Harris,265
+Sacramento,14314,U.S. Senate,,DEM,Loretta L. Sanchez,128
+Sacramento,14502,U.S. Senate,,DEM,Kamala D. Harris,117
+Sacramento,14502,U.S. Senate,,DEM,Loretta L. Sanchez,50
+Sacramento,14564,U.S. Senate,,DEM,Kamala D. Harris,166
+Sacramento,14564,U.S. Senate,,DEM,Loretta L. Sanchez,91
+Sacramento,14693,U.S. Senate,,DEM,Kamala D. Harris,257
+Sacramento,14693,U.S. Senate,,DEM,Loretta L. Sanchez,135
+Sacramento,14783,U.S. Senate,,DEM,Kamala D. Harris,82
+Sacramento,14783,U.S. Senate,,DEM,Loretta L. Sanchez,43
+Sacramento,14820,U.S. Senate,,DEM,Kamala D. Harris,236
+Sacramento,14820,U.S. Senate,,DEM,Loretta L. Sanchez,95
+Sacramento,14971,U.S. Senate,,DEM,Kamala D. Harris,235
+Sacramento,14971,U.S. Senate,,DEM,Loretta L. Sanchez,124
+Sacramento,15018,U.S. Senate,,DEM,Kamala D. Harris,270
+Sacramento,15018,U.S. Senate,,DEM,Loretta L. Sanchez,143
+Sacramento,15102,U.S. Senate,,DEM,Kamala D. Harris,339
+Sacramento,15102,U.S. Senate,,DEM,Loretta L. Sanchez,117
+Sacramento,15287,U.S. Senate,,DEM,Kamala D. Harris,282
+Sacramento,15287,U.S. Senate,,DEM,Loretta L. Sanchez,146
+Sacramento,15321,U.S. Senate,,DEM,Kamala D. Harris,300
+Sacramento,15321,U.S. Senate,,DEM,Loretta L. Sanchez,140
+Sacramento,15530,U.S. Senate,,DEM,Kamala D. Harris,171
+Sacramento,15530,U.S. Senate,,DEM,Loretta L. Sanchez,90
+Sacramento,15749,U.S. Senate,,DEM,Kamala D. Harris,266
+Sacramento,15749,U.S. Senate,,DEM,Loretta L. Sanchez,114
+Sacramento,15941,U.S. Senate,,DEM,Kamala D. Harris,0
+Sacramento,15941,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sacramento,16002,U.S. Senate,,DEM,Kamala D. Harris,252
+Sacramento,16002,U.S. Senate,,DEM,Loretta L. Sanchez,161
+Sacramento,16107,U.S. Senate,,DEM,Kamala D. Harris,160
+Sacramento,16107,U.S. Senate,,DEM,Loretta L. Sanchez,159
+Sacramento,16318,U.S. Senate,,DEM,Kamala D. Harris,105
+Sacramento,16318,U.S. Senate,,DEM,Loretta L. Sanchez,83
+Sacramento,16463,U.S. Senate,,DEM,Kamala D. Harris,175
+Sacramento,16463,U.S. Senate,,DEM,Loretta L. Sanchez,167
+Sacramento,16573,U.S. Senate,,DEM,Kamala D. Harris,202
+Sacramento,16573,U.S. Senate,,DEM,Loretta L. Sanchez,154
+Sacramento,16801,U.S. Senate,,DEM,Kamala D. Harris,200
+Sacramento,16801,U.S. Senate,,DEM,Loretta L. Sanchez,125
+Sacramento,16836,U.S. Senate,,DEM,Kamala D. Harris,187
+Sacramento,16836,U.S. Senate,,DEM,Loretta L. Sanchez,122
+Sacramento,16869,U.S. Senate,,DEM,Kamala D. Harris,145
+Sacramento,16869,U.S. Senate,,DEM,Loretta L. Sanchez,67
+Sacramento,16944,U.S. Senate,,DEM,Kamala D. Harris,120
+Sacramento,16944,U.S. Senate,,DEM,Loretta L. Sanchez,107
+Sacramento,17428,U.S. Senate,,DEM,Kamala D. Harris,249
+Sacramento,17428,U.S. Senate,,DEM,Loretta L. Sanchez,119
+Sacramento,17512,U.S. Senate,,DEM,Kamala D. Harris,147
+Sacramento,17512,U.S. Senate,,DEM,Loretta L. Sanchez,71
+Sacramento,17630,U.S. Senate,,DEM,Kamala D. Harris,291
+Sacramento,17630,U.S. Senate,,DEM,Loretta L. Sanchez,156
+Sacramento,18012,U.S. Senate,,DEM,Kamala D. Harris,155
+Sacramento,18012,U.S. Senate,,DEM,Loretta L. Sanchez,114
+Sacramento,18119,U.S. Senate,,DEM,Kamala D. Harris,206
+Sacramento,18119,U.S. Senate,,DEM,Loretta L. Sanchez,161
+Sacramento,18143,U.S. Senate,,DEM,Kamala D. Harris,249
+Sacramento,18143,U.S. Senate,,DEM,Loretta L. Sanchez,128
+Sacramento,18213,U.S. Senate,,DEM,Kamala D. Harris,231
+Sacramento,18213,U.S. Senate,,DEM,Loretta L. Sanchez,162
+Sacramento,18220,U.S. Senate,,DEM,Kamala D. Harris,284
+Sacramento,18220,U.S. Senate,,DEM,Loretta L. Sanchez,187
+Sacramento,18385,U.S. Senate,,DEM,Kamala D. Harris,243
+Sacramento,18385,U.S. Senate,,DEM,Loretta L. Sanchez,137
+Sacramento,18501,U.S. Senate,,DEM,Kamala D. Harris,195
+Sacramento,18501,U.S. Senate,,DEM,Loretta L. Sanchez,105
+Sacramento,18562,U.S. Senate,,DEM,Kamala D. Harris,150
+Sacramento,18562,U.S. Senate,,DEM,Loretta L. Sanchez,186
+Sacramento,18588,U.S. Senate,,DEM,Kamala D. Harris,259
+Sacramento,18588,U.S. Senate,,DEM,Loretta L. Sanchez,199
+Sacramento,18791,U.S. Senate,,DEM,Kamala D. Harris,143
+Sacramento,18791,U.S. Senate,,DEM,Loretta L. Sanchez,178
+Sacramento,18840,U.S. Senate,,DEM,Kamala D. Harris,231
+Sacramento,18840,U.S. Senate,,DEM,Loretta L. Sanchez,187
+Sacramento,19081,U.S. Senate,,DEM,Kamala D. Harris,79
+Sacramento,19081,U.S. Senate,,DEM,Loretta L. Sanchez,118
+Sacramento,19319,U.S. Senate,,DEM,Kamala D. Harris,151
+Sacramento,19319,U.S. Senate,,DEM,Loretta L. Sanchez,141
+Sacramento,19325,U.S. Senate,,DEM,Kamala D. Harris,174
+Sacramento,19325,U.S. Senate,,DEM,Loretta L. Sanchez,149
+Sacramento,19427,U.S. Senate,,DEM,Kamala D. Harris,123
+Sacramento,19427,U.S. Senate,,DEM,Loretta L. Sanchez,120
+Sacramento,19455,U.S. Senate,,DEM,Kamala D. Harris,202
+Sacramento,19455,U.S. Senate,,DEM,Loretta L. Sanchez,126
+Sacramento,19532,U.S. Senate,,DEM,Kamala D. Harris,158
+Sacramento,19532,U.S. Senate,,DEM,Loretta L. Sanchez,109
+Sacramento,19646,U.S. Senate,,DEM,Kamala D. Harris,191
+Sacramento,19646,U.S. Senate,,DEM,Loretta L. Sanchez,103
+Sacramento,19685,U.S. Senate,,DEM,Kamala D. Harris,61
+Sacramento,19685,U.S. Senate,,DEM,Loretta L. Sanchez,32
+Sacramento,19800,U.S. Senate,,DEM,Kamala D. Harris,141
+Sacramento,19800,U.S. Senate,,DEM,Loretta L. Sanchez,111
+Sacramento,19948,U.S. Senate,,DEM,Kamala D. Harris,86
+Sacramento,19948,U.S. Senate,,DEM,Loretta L. Sanchez,64
+Sacramento,21013,U.S. Senate,,DEM,Kamala D. Harris,235
+Sacramento,21013,U.S. Senate,,DEM,Loretta L. Sanchez,180
+Sacramento,21065,U.S. Senate,,DEM,Kamala D. Harris,175
+Sacramento,21065,U.S. Senate,,DEM,Loretta L. Sanchez,127
+Sacramento,21134,U.S. Senate,,DEM,Kamala D. Harris,203
+Sacramento,21134,U.S. Senate,,DEM,Loretta L. Sanchez,159
+Sacramento,21159,U.S. Senate,,DEM,Kamala D. Harris,216
+Sacramento,21159,U.S. Senate,,DEM,Loretta L. Sanchez,126
+Sacramento,21203,U.S. Senate,,DEM,Kamala D. Harris,102
+Sacramento,21203,U.S. Senate,,DEM,Loretta L. Sanchez,81
+Sacramento,21231,U.S. Senate,,DEM,Kamala D. Harris,122
+Sacramento,21231,U.S. Senate,,DEM,Loretta L. Sanchez,72
+Sacramento,21248,U.S. Senate,,DEM,Kamala D. Harris,0
+Sacramento,21248,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Sacramento,21318,U.S. Senate,,DEM,Kamala D. Harris,93
+Sacramento,21318,U.S. Senate,,DEM,Loretta L. Sanchez,72
+Sacramento,21362,U.S. Senate,,DEM,Kamala D. Harris,148
+Sacramento,21362,U.S. Senate,,DEM,Loretta L. Sanchez,85
+Sacramento,21405,U.S. Senate,,DEM,Kamala D. Harris,0
+Sacramento,21405,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sacramento,21489,U.S. Senate,,DEM,Kamala D. Harris,190
+Sacramento,21489,U.S. Senate,,DEM,Loretta L. Sanchez,138
+Sacramento,21615,U.S. Senate,,DEM,Kamala D. Harris,173
+Sacramento,21615,U.S. Senate,,DEM,Loretta L. Sanchez,129
+Sacramento,21621,U.S. Senate,,DEM,Kamala D. Harris,224
+Sacramento,21621,U.S. Senate,,DEM,Loretta L. Sanchez,105
+Sacramento,21712,U.S. Senate,,DEM,Kamala D. Harris,20
+Sacramento,21712,U.S. Senate,,DEM,Loretta L. Sanchez,16
+Sacramento,21725,U.S. Senate,,DEM,Kamala D. Harris,52
+Sacramento,21725,U.S. Senate,,DEM,Loretta L. Sanchez,24
+Sacramento,21783,U.S. Senate,,DEM,Kamala D. Harris,35
+Sacramento,21783,U.S. Senate,,DEM,Loretta L. Sanchez,19
+Sacramento,21800,U.S. Senate,,DEM,Kamala D. Harris,185
+Sacramento,21800,U.S. Senate,,DEM,Loretta L. Sanchez,123
+Sacramento,21846,U.S. Senate,,DEM,Kamala D. Harris,175
+Sacramento,21846,U.S. Senate,,DEM,Loretta L. Sanchez,137
+Sacramento,21895,U.S. Senate,,DEM,Kamala D. Harris,208
+Sacramento,21895,U.S. Senate,,DEM,Loretta L. Sanchez,163
+Sacramento,21961,U.S. Senate,,DEM,Kamala D. Harris,170
+Sacramento,21961,U.S. Senate,,DEM,Loretta L. Sanchez,109
+Sacramento,22003,U.S. Senate,,DEM,Kamala D. Harris,190
+Sacramento,22003,U.S. Senate,,DEM,Loretta L. Sanchez,145
+Sacramento,22034,U.S. Senate,,DEM,Kamala D. Harris,118
+Sacramento,22034,U.S. Senate,,DEM,Loretta L. Sanchez,77
+Sacramento,22061,U.S. Senate,,DEM,Kamala D. Harris,227
+Sacramento,22061,U.S. Senate,,DEM,Loretta L. Sanchez,120
+Sacramento,22090,U.S. Senate,,DEM,Kamala D. Harris,154
+Sacramento,22090,U.S. Senate,,DEM,Loretta L. Sanchez,119
+Sacramento,22139,U.S. Senate,,DEM,Kamala D. Harris,145
+Sacramento,22139,U.S. Senate,,DEM,Loretta L. Sanchez,127
+Sacramento,22143,U.S. Senate,,DEM,Kamala D. Harris,215
+Sacramento,22143,U.S. Senate,,DEM,Loretta L. Sanchez,144
+Sacramento,22300,U.S. Senate,,DEM,Kamala D. Harris,0
+Sacramento,22300,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sacramento,22325,U.S. Senate,,DEM,Kamala D. Harris,126
+Sacramento,22325,U.S. Senate,,DEM,Loretta L. Sanchez,74
+Sacramento,22396,U.S. Senate,,DEM,Kamala D. Harris,82
+Sacramento,22396,U.S. Senate,,DEM,Loretta L. Sanchez,60
+Sacramento,22406,U.S. Senate,,DEM,Kamala D. Harris,0
+Sacramento,22406,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sacramento,22412,U.S. Senate,,DEM,Kamala D. Harris,0
+Sacramento,22412,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sacramento,22427,U.S. Senate,,DEM,Kamala D. Harris,0
+Sacramento,22427,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sacramento,22453,U.S. Senate,,DEM,Kamala D. Harris,232
+Sacramento,22453,U.S. Senate,,DEM,Loretta L. Sanchez,149
+Sacramento,22464,U.S. Senate,,DEM,Kamala D. Harris,227
+Sacramento,22464,U.S. Senate,,DEM,Loretta L. Sanchez,121
+Sacramento,22533,U.S. Senate,,DEM,Kamala D. Harris,138
+Sacramento,22533,U.S. Senate,,DEM,Loretta L. Sanchez,83
+Sacramento,22552,U.S. Senate,,DEM,Kamala D. Harris,134
+Sacramento,22552,U.S. Senate,,DEM,Loretta L. Sanchez,99
+Sacramento,22599,U.S. Senate,,DEM,Kamala D. Harris,172
+Sacramento,22599,U.S. Senate,,DEM,Loretta L. Sanchez,119
+Sacramento,22610,U.S. Senate,,DEM,Kamala D. Harris,107
+Sacramento,22610,U.S. Senate,,DEM,Loretta L. Sanchez,70
+Sacramento,22685,U.S. Senate,,DEM,Kamala D. Harris,53
+Sacramento,22685,U.S. Senate,,DEM,Loretta L. Sanchez,22
+Sacramento,22694,U.S. Senate,,DEM,Kamala D. Harris,130
+Sacramento,22694,U.S. Senate,,DEM,Loretta L. Sanchez,105
+Sacramento,22709,U.S. Senate,,DEM,Kamala D. Harris,175
+Sacramento,22709,U.S. Senate,,DEM,Loretta L. Sanchez,123
+Sacramento,22730,U.S. Senate,,DEM,Kamala D. Harris,194
+Sacramento,22730,U.S. Senate,,DEM,Loretta L. Sanchez,84
+Sacramento,22824,U.S. Senate,,DEM,Kamala D. Harris,135
+Sacramento,22824,U.S. Senate,,DEM,Loretta L. Sanchez,91
+Sacramento,22847,U.S. Senate,,DEM,Kamala D. Harris,167
+Sacramento,22847,U.S. Senate,,DEM,Loretta L. Sanchez,75
+Sacramento,22873,U.S. Senate,,DEM,Kamala D. Harris,200
+Sacramento,22873,U.S. Senate,,DEM,Loretta L. Sanchez,122
+Sacramento,22898,U.S. Senate,,DEM,Kamala D. Harris,10
+Sacramento,22898,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Sacramento,22997,U.S. Senate,,DEM,Kamala D. Harris,30
+Sacramento,22997,U.S. Senate,,DEM,Loretta L. Sanchez,15
+Sacramento,23002,U.S. Senate,,DEM,Kamala D. Harris,199
+Sacramento,23002,U.S. Senate,,DEM,Loretta L. Sanchez,157
+Sacramento,23077,U.S. Senate,,DEM,Kamala D. Harris,181
+Sacramento,23077,U.S. Senate,,DEM,Loretta L. Sanchez,168
+Sacramento,23221,U.S. Senate,,DEM,Kamala D. Harris,73
+Sacramento,23221,U.S. Senate,,DEM,Loretta L. Sanchez,37
+Sacramento,23240,U.S. Senate,,DEM,Kamala D. Harris,190
+Sacramento,23240,U.S. Senate,,DEM,Loretta L. Sanchez,153
+Sacramento,23264,U.S. Senate,,DEM,Kamala D. Harris,114
+Sacramento,23264,U.S. Senate,,DEM,Loretta L. Sanchez,89
+Sacramento,23313,U.S. Senate,,DEM,Kamala D. Harris,220
+Sacramento,23313,U.S. Senate,,DEM,Loretta L. Sanchez,157
+Sacramento,23423,U.S. Senate,,DEM,Kamala D. Harris,193
+Sacramento,23423,U.S. Senate,,DEM,Loretta L. Sanchez,135
+Sacramento,23519,U.S. Senate,,DEM,Kamala D. Harris,166
+Sacramento,23519,U.S. Senate,,DEM,Loretta L. Sanchez,139
+Sacramento,23542,U.S. Senate,,DEM,Kamala D. Harris,154
+Sacramento,23542,U.S. Senate,,DEM,Loretta L. Sanchez,124
+Sacramento,23637,U.S. Senate,,DEM,Kamala D. Harris,213
+Sacramento,23637,U.S. Senate,,DEM,Loretta L. Sanchez,163
+Sacramento,23733,U.S. Senate,,DEM,Kamala D. Harris,195
+Sacramento,23733,U.S. Senate,,DEM,Loretta L. Sanchez,126
+Sacramento,23769,U.S. Senate,,DEM,Kamala D. Harris,190
+Sacramento,23769,U.S. Senate,,DEM,Loretta L. Sanchez,107
+Sacramento,23879,U.S. Senate,,DEM,Kamala D. Harris,209
+Sacramento,23879,U.S. Senate,,DEM,Loretta L. Sanchez,162
+Sacramento,23905,U.S. Senate,,DEM,Kamala D. Harris,119
+Sacramento,23905,U.S. Senate,,DEM,Loretta L. Sanchez,106
+Sacramento,23970,U.S. Senate,,DEM,Kamala D. Harris,106
+Sacramento,23970,U.S. Senate,,DEM,Loretta L. Sanchez,85
+Sacramento,24005,U.S. Senate,,DEM,Kamala D. Harris,0
+Sacramento,24005,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sacramento,24033,U.S. Senate,,DEM,Kamala D. Harris,52
+Sacramento,24033,U.S. Senate,,DEM,Loretta L. Sanchez,26
+Sacramento,24067,U.S. Senate,,DEM,Kamala D. Harris,0
+Sacramento,24067,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sacramento,24148,U.S. Senate,,DEM,Kamala D. Harris,201
+Sacramento,24148,U.S. Senate,,DEM,Loretta L. Sanchez,119
+Sacramento,24182,U.S. Senate,,DEM,Kamala D. Harris,129
+Sacramento,24182,U.S. Senate,,DEM,Loretta L. Sanchez,81
+Sacramento,24263,U.S. Senate,,DEM,Kamala D. Harris,0
+Sacramento,24263,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Sacramento,24352,U.S. Senate,,DEM,Kamala D. Harris,166
+Sacramento,24352,U.S. Senate,,DEM,Loretta L. Sanchez,106
+Sacramento,24360,U.S. Senate,,DEM,Kamala D. Harris,21
+Sacramento,24360,U.S. Senate,,DEM,Loretta L. Sanchez,17
+Sacramento,24385,U.S. Senate,,DEM,Kamala D. Harris,107
+Sacramento,24385,U.S. Senate,,DEM,Loretta L. Sanchez,53
+Sacramento,24438,U.S. Senate,,DEM,Kamala D. Harris,0
+Sacramento,24438,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sacramento,24500,U.S. Senate,,DEM,Kamala D. Harris,119
+Sacramento,24500,U.S. Senate,,DEM,Loretta L. Sanchez,71
+Sacramento,24557,U.S. Senate,,DEM,Kamala D. Harris,171
+Sacramento,24557,U.S. Senate,,DEM,Loretta L. Sanchez,109
+Sacramento,24651,U.S. Senate,,DEM,Kamala D. Harris,120
+Sacramento,24651,U.S. Senate,,DEM,Loretta L. Sanchez,90
+Sacramento,24669,U.S. Senate,,DEM,Kamala D. Harris,150
+Sacramento,24669,U.S. Senate,,DEM,Loretta L. Sanchez,110
+Sacramento,24684,U.S. Senate,,DEM,Kamala D. Harris,128
+Sacramento,24684,U.S. Senate,,DEM,Loretta L. Sanchez,66
+Sacramento,24739,U.S. Senate,,DEM,Kamala D. Harris,223
+Sacramento,24739,U.S. Senate,,DEM,Loretta L. Sanchez,112
+Sacramento,24801,U.S. Senate,,DEM,Kamala D. Harris,196
+Sacramento,24801,U.S. Senate,,DEM,Loretta L. Sanchez,119
+Sacramento,24874,U.S. Senate,,DEM,Kamala D. Harris,187
+Sacramento,24874,U.S. Senate,,DEM,Loretta L. Sanchez,92
+Sacramento,24908,U.S. Senate,,DEM,Kamala D. Harris,224
+Sacramento,24908,U.S. Senate,,DEM,Loretta L. Sanchez,128
+Sacramento,24927,U.S. Senate,,DEM,Kamala D. Harris,137
+Sacramento,24927,U.S. Senate,,DEM,Loretta L. Sanchez,92
+Sacramento,25011,U.S. Senate,,DEM,Kamala D. Harris,105
+Sacramento,25011,U.S. Senate,,DEM,Loretta L. Sanchez,69
+Sacramento,25076,U.S. Senate,,DEM,Kamala D. Harris,139
+Sacramento,25076,U.S. Senate,,DEM,Loretta L. Sanchez,66
+Sacramento,25155,U.S. Senate,,DEM,Kamala D. Harris,163
+Sacramento,25155,U.S. Senate,,DEM,Loretta L. Sanchez,121
+Sacramento,25234,U.S. Senate,,DEM,Kamala D. Harris,169
+Sacramento,25234,U.S. Senate,,DEM,Loretta L. Sanchez,81
+Sacramento,25404,U.S. Senate,,DEM,Kamala D. Harris,37
+Sacramento,25404,U.S. Senate,,DEM,Loretta L. Sanchez,12
+Sacramento,25432,U.S. Senate,,DEM,Kamala D. Harris,216
+Sacramento,25432,U.S. Senate,,DEM,Loretta L. Sanchez,126
+Sacramento,25493,U.S. Senate,,DEM,Kamala D. Harris,0
+Sacramento,25493,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sacramento,25501,U.S. Senate,,DEM,Kamala D. Harris,160
+Sacramento,25501,U.S. Senate,,DEM,Loretta L. Sanchez,83
+Sacramento,25536,U.S. Senate,,DEM,Kamala D. Harris,138
+Sacramento,25536,U.S. Senate,,DEM,Loretta L. Sanchez,68
+Sacramento,25588,U.S. Senate,,DEM,Kamala D. Harris,202
+Sacramento,25588,U.S. Senate,,DEM,Loretta L. Sanchez,131
+Sacramento,25696,U.S. Senate,,DEM,Kamala D. Harris,154
+Sacramento,25696,U.S. Senate,,DEM,Loretta L. Sanchez,114
+Sacramento,25703,U.S. Senate,,DEM,Kamala D. Harris,94
+Sacramento,25703,U.S. Senate,,DEM,Loretta L. Sanchez,46
+Sacramento,25741,U.S. Senate,,DEM,Kamala D. Harris,155
+Sacramento,25741,U.S. Senate,,DEM,Loretta L. Sanchez,91
+Sacramento,25812,U.S. Senate,,DEM,Kamala D. Harris,148
+Sacramento,25812,U.S. Senate,,DEM,Loretta L. Sanchez,73
+Sacramento,25845,U.S. Senate,,DEM,Kamala D. Harris,138
+Sacramento,25845,U.S. Senate,,DEM,Loretta L. Sanchez,114
+Sacramento,25919,U.S. Senate,,DEM,Kamala D. Harris,153
+Sacramento,25919,U.S. Senate,,DEM,Loretta L. Sanchez,99
+Sacramento,25935,U.S. Senate,,DEM,Kamala D. Harris,241
+Sacramento,25935,U.S. Senate,,DEM,Loretta L. Sanchez,163
+Sacramento,25990,U.S. Senate,,DEM,Kamala D. Harris,130
+Sacramento,25990,U.S. Senate,,DEM,Loretta L. Sanchez,70
+Sacramento,26069,U.S. Senate,,DEM,Kamala D. Harris,235
+Sacramento,26069,U.S. Senate,,DEM,Loretta L. Sanchez,131
+Sacramento,26086,U.S. Senate,,DEM,Kamala D. Harris,126
+Sacramento,26086,U.S. Senate,,DEM,Loretta L. Sanchez,71
+Sacramento,26171,U.S. Senate,,DEM,Kamala D. Harris,139
+Sacramento,26171,U.S. Senate,,DEM,Loretta L. Sanchez,125
+Sacramento,26275,U.S. Senate,,DEM,Kamala D. Harris,29
+Sacramento,26275,U.S. Senate,,DEM,Loretta L. Sanchez,15
+Sacramento,26370,U.S. Senate,,DEM,Kamala D. Harris,15
+Sacramento,26370,U.S. Senate,,DEM,Loretta L. Sanchez,9
+Sacramento,26413,U.S. Senate,,DEM,Kamala D. Harris,125
+Sacramento,26413,U.S. Senate,,DEM,Loretta L. Sanchez,80
+Sacramento,26442,U.S. Senate,,DEM,Kamala D. Harris,133
+Sacramento,26442,U.S. Senate,,DEM,Loretta L. Sanchez,100
+Sacramento,26512,U.S. Senate,,DEM,Kamala D. Harris,184
+Sacramento,26512,U.S. Senate,,DEM,Loretta L. Sanchez,119
+Sacramento,26597,U.S. Senate,,DEM,Kamala D. Harris,111
+Sacramento,26597,U.S. Senate,,DEM,Loretta L. Sanchez,66
+Sacramento,26625,U.S. Senate,,DEM,Kamala D. Harris,222
+Sacramento,26625,U.S. Senate,,DEM,Loretta L. Sanchez,133
+Sacramento,26683,U.S. Senate,,DEM,Kamala D. Harris,0
+Sacramento,26683,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sacramento,26715,U.S. Senate,,DEM,Kamala D. Harris,199
+Sacramento,26715,U.S. Senate,,DEM,Loretta L. Sanchez,94
+Sacramento,26747,U.S. Senate,,DEM,Kamala D. Harris,172
+Sacramento,26747,U.S. Senate,,DEM,Loretta L. Sanchez,104
+Sacramento,26808,U.S. Senate,,DEM,Kamala D. Harris,172
+Sacramento,26808,U.S. Senate,,DEM,Loretta L. Sanchez,84
+Sacramento,26830,U.S. Senate,,DEM,Kamala D. Harris,129
+Sacramento,26830,U.S. Senate,,DEM,Loretta L. Sanchez,109
+Sacramento,26861,U.S. Senate,,DEM,Kamala D. Harris,114
+Sacramento,26861,U.S. Senate,,DEM,Loretta L. Sanchez,73
+Sacramento,26893,U.S. Senate,,DEM,Kamala D. Harris,1
+Sacramento,26893,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sacramento,26916,U.S. Senate,,DEM,Kamala D. Harris,201
+Sacramento,26916,U.S. Senate,,DEM,Loretta L. Sanchez,116
+Sacramento,26978,U.S. Senate,,DEM,Kamala D. Harris,168
+Sacramento,26978,U.S. Senate,,DEM,Loretta L. Sanchez,89
+Sacramento,27031,U.S. Senate,,DEM,Kamala D. Harris,0
+Sacramento,27031,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sacramento,27046,U.S. Senate,,DEM,Kamala D. Harris,166
+Sacramento,27046,U.S. Senate,,DEM,Loretta L. Sanchez,86
+Sacramento,27098,U.S. Senate,,DEM,Kamala D. Harris,147
+Sacramento,27098,U.S. Senate,,DEM,Loretta L. Sanchez,72
+Sacramento,27100,U.S. Senate,,DEM,Kamala D. Harris,162
+Sacramento,27100,U.S. Senate,,DEM,Loretta L. Sanchez,97
+Sacramento,27212,U.S. Senate,,DEM,Kamala D. Harris,133
+Sacramento,27212,U.S. Senate,,DEM,Loretta L. Sanchez,76
+Sacramento,27223,U.S. Senate,,DEM,Kamala D. Harris,158
+Sacramento,27223,U.S. Senate,,DEM,Loretta L. Sanchez,74
+Sacramento,27320,U.S. Senate,,DEM,Kamala D. Harris,203
+Sacramento,27320,U.S. Senate,,DEM,Loretta L. Sanchez,105
+Sacramento,27506,U.S. Senate,,DEM,Kamala D. Harris,215
+Sacramento,27506,U.S. Senate,,DEM,Loretta L. Sanchez,112
+Sacramento,27595,U.S. Senate,,DEM,Kamala D. Harris,1
+Sacramento,27595,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Sacramento,27602,U.S. Senate,,DEM,Kamala D. Harris,212
+Sacramento,27602,U.S. Senate,,DEM,Loretta L. Sanchez,104
+Sacramento,27648,U.S. Senate,,DEM,Kamala D. Harris,252
+Sacramento,27648,U.S. Senate,,DEM,Loretta L. Sanchez,158
+Sacramento,27719,U.S. Senate,,DEM,Kamala D. Harris,266
+Sacramento,27719,U.S. Senate,,DEM,Loretta L. Sanchez,98
+Sacramento,27721,U.S. Senate,,DEM,Kamala D. Harris,163
+Sacramento,27721,U.S. Senate,,DEM,Loretta L. Sanchez,79
+Sacramento,27872,U.S. Senate,,DEM,Kamala D. Harris,38
+Sacramento,27872,U.S. Senate,,DEM,Loretta L. Sanchez,18
+Sacramento,27915,U.S. Senate,,DEM,Kamala D. Harris,53
+Sacramento,27915,U.S. Senate,,DEM,Loretta L. Sanchez,30
+Sacramento,27971,U.S. Senate,,DEM,Kamala D. Harris,165
+Sacramento,27971,U.S. Senate,,DEM,Loretta L. Sanchez,64
+Sacramento,28014,U.S. Senate,,DEM,Kamala D. Harris,226
+Sacramento,28014,U.S. Senate,,DEM,Loretta L. Sanchez,128
+Sacramento,28200,U.S. Senate,,DEM,Kamala D. Harris,222
+Sacramento,28200,U.S. Senate,,DEM,Loretta L. Sanchez,128
+Sacramento,28299,U.S. Senate,,DEM,Kamala D. Harris,87
+Sacramento,28299,U.S. Senate,,DEM,Loretta L. Sanchez,50
+Sacramento,28368,U.S. Senate,,DEM,Kamala D. Harris,184
+Sacramento,28368,U.S. Senate,,DEM,Loretta L. Sanchez,80
+Sacramento,28392,U.S. Senate,,DEM,Kamala D. Harris,217
+Sacramento,28392,U.S. Senate,,DEM,Loretta L. Sanchez,112
+Sacramento,28417,U.S. Senate,,DEM,Kamala D. Harris,136
+Sacramento,28417,U.S. Senate,,DEM,Loretta L. Sanchez,65
+Sacramento,28522,U.S. Senate,,DEM,Kamala D. Harris,125
+Sacramento,28522,U.S. Senate,,DEM,Loretta L. Sanchez,58
+Sacramento,28530,U.S. Senate,,DEM,Kamala D. Harris,245
+Sacramento,28530,U.S. Senate,,DEM,Loretta L. Sanchez,97
+Sacramento,28656,U.S. Senate,,DEM,Kamala D. Harris,328
+Sacramento,28656,U.S. Senate,,DEM,Loretta L. Sanchez,121
+Sacramento,28773,U.S. Senate,,DEM,Kamala D. Harris,185
+Sacramento,28773,U.S. Senate,,DEM,Loretta L. Sanchez,102
+Sacramento,28809,U.S. Senate,,DEM,Kamala D. Harris,131
+Sacramento,28809,U.S. Senate,,DEM,Loretta L. Sanchez,61
+Sacramento,28939,U.S. Senate,,DEM,Kamala D. Harris,150
+Sacramento,28939,U.S. Senate,,DEM,Loretta L. Sanchez,83
+Sacramento,29043,U.S. Senate,,DEM,Kamala D. Harris,150
+Sacramento,29043,U.S. Senate,,DEM,Loretta L. Sanchez,70
+Sacramento,29128,U.S. Senate,,DEM,Kamala D. Harris,190
+Sacramento,29128,U.S. Senate,,DEM,Loretta L. Sanchez,92
+Sacramento,29205,U.S. Senate,,DEM,Kamala D. Harris,201
+Sacramento,29205,U.S. Senate,,DEM,Loretta L. Sanchez,109
+Sacramento,29298,U.S. Senate,,DEM,Kamala D. Harris,236
+Sacramento,29298,U.S. Senate,,DEM,Loretta L. Sanchez,129
+Sacramento,29434,U.S. Senate,,DEM,Kamala D. Harris,261
+Sacramento,29434,U.S. Senate,,DEM,Loretta L. Sanchez,133
+Sacramento,29661,U.S. Senate,,DEM,Kamala D. Harris,190
+Sacramento,29661,U.S. Senate,,DEM,Loretta L. Sanchez,83
+Sacramento,29825,U.S. Senate,,DEM,Kamala D. Harris,111
+Sacramento,29825,U.S. Senate,,DEM,Loretta L. Sanchez,48
+Sacramento,29848,U.S. Senate,,DEM,Kamala D. Harris,172
+Sacramento,29848,U.S. Senate,,DEM,Loretta L. Sanchez,86
+Sacramento,31066,U.S. Senate,,DEM,Kamala D. Harris,175
+Sacramento,31066,U.S. Senate,,DEM,Loretta L. Sanchez,156
+Sacramento,31082,U.S. Senate,,DEM,Kamala D. Harris,127
+Sacramento,31082,U.S. Senate,,DEM,Loretta L. Sanchez,102
+Sacramento,31193,U.S. Senate,,DEM,Kamala D. Harris,242
+Sacramento,31193,U.S. Senate,,DEM,Loretta L. Sanchez,164
+Sacramento,31271,U.S. Senate,,DEM,Kamala D. Harris,239
+Sacramento,31271,U.S. Senate,,DEM,Loretta L. Sanchez,167
+Sacramento,31348,U.S. Senate,,DEM,Kamala D. Harris,208
+Sacramento,31348,U.S. Senate,,DEM,Loretta L. Sanchez,151
+Sacramento,31432,U.S. Senate,,DEM,Kamala D. Harris,103
+Sacramento,31432,U.S. Senate,,DEM,Loretta L. Sanchez,89
+Sacramento,31461,U.S. Senate,,DEM,Kamala D. Harris,197
+Sacramento,31461,U.S. Senate,,DEM,Loretta L. Sanchez,155
+Sacramento,31538,U.S. Senate,,DEM,Kamala D. Harris,126
+Sacramento,31538,U.S. Senate,,DEM,Loretta L. Sanchez,84
+Sacramento,31574,U.S. Senate,,DEM,Kamala D. Harris,185
+Sacramento,31574,U.S. Senate,,DEM,Loretta L. Sanchez,131
+Sacramento,31631,U.S. Senate,,DEM,Kamala D. Harris,164
+Sacramento,31631,U.S. Senate,,DEM,Loretta L. Sanchez,101
+Sacramento,31662,U.S. Senate,,DEM,Kamala D. Harris,177
+Sacramento,31662,U.S. Senate,,DEM,Loretta L. Sanchez,110
+Sacramento,31765,U.S. Senate,,DEM,Kamala D. Harris,123
+Sacramento,31765,U.S. Senate,,DEM,Loretta L. Sanchez,82
+Sacramento,31808,U.S. Senate,,DEM,Kamala D. Harris,1
+Sacramento,31808,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Sacramento,31839,U.S. Senate,,DEM,Kamala D. Harris,186
+Sacramento,31839,U.S. Senate,,DEM,Loretta L. Sanchez,126
+Sacramento,31900,U.S. Senate,,DEM,Kamala D. Harris,195
+Sacramento,31900,U.S. Senate,,DEM,Loretta L. Sanchez,109
+Sacramento,31981,U.S. Senate,,DEM,Kamala D. Harris,104
+Sacramento,31981,U.S. Senate,,DEM,Loretta L. Sanchez,54
+Sacramento,31994,U.S. Senate,,DEM,Kamala D. Harris,146
+Sacramento,31994,U.S. Senate,,DEM,Loretta L. Sanchez,101
+Sacramento,32101,U.S. Senate,,DEM,Kamala D. Harris,151
+Sacramento,32101,U.S. Senate,,DEM,Loretta L. Sanchez,125
+Sacramento,32206,U.S. Senate,,DEM,Kamala D. Harris,165
+Sacramento,32206,U.S. Senate,,DEM,Loretta L. Sanchez,124
+Sacramento,32435,U.S. Senate,,DEM,Kamala D. Harris,169
+Sacramento,32435,U.S. Senate,,DEM,Loretta L. Sanchez,130
+Sacramento,32554,U.S. Senate,,DEM,Kamala D. Harris,147
+Sacramento,32554,U.S. Senate,,DEM,Loretta L. Sanchez,106
+Sacramento,32773,U.S. Senate,,DEM,Kamala D. Harris,167
+Sacramento,32773,U.S. Senate,,DEM,Loretta L. Sanchez,121
+Sacramento,32872,U.S. Senate,,DEM,Kamala D. Harris,140
+Sacramento,32872,U.S. Senate,,DEM,Loretta L. Sanchez,109
+Sacramento,33017,U.S. Senate,,DEM,Kamala D. Harris,0
+Sacramento,33017,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sacramento,33108,U.S. Senate,,DEM,Kamala D. Harris,122
+Sacramento,33108,U.S. Senate,,DEM,Loretta L. Sanchez,90
+Sacramento,33126,U.S. Senate,,DEM,Kamala D. Harris,179
+Sacramento,33126,U.S. Senate,,DEM,Loretta L. Sanchez,110
+Sacramento,33227,U.S. Senate,,DEM,Kamala D. Harris,168
+Sacramento,33227,U.S. Senate,,DEM,Loretta L. Sanchez,83
+Sacramento,33431,U.S. Senate,,DEM,Kamala D. Harris,89
+Sacramento,33431,U.S. Senate,,DEM,Loretta L. Sanchez,61
+Sacramento,33529,U.S. Senate,,DEM,Kamala D. Harris,159
+Sacramento,33529,U.S. Senate,,DEM,Loretta L. Sanchez,94
+Sacramento,33622,U.S. Senate,,DEM,Kamala D. Harris,0
+Sacramento,33622,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sacramento,33713,U.S. Senate,,DEM,Kamala D. Harris,169
+Sacramento,33713,U.S. Senate,,DEM,Loretta L. Sanchez,100
+Sacramento,33774,U.S. Senate,,DEM,Kamala D. Harris,158
+Sacramento,33774,U.S. Senate,,DEM,Loretta L. Sanchez,101
+Sacramento,33818,U.S. Senate,,DEM,Kamala D. Harris,224
+Sacramento,33818,U.S. Senate,,DEM,Loretta L. Sanchez,133
+Sacramento,33997,U.S. Senate,,DEM,Kamala D. Harris,286
+Sacramento,33997,U.S. Senate,,DEM,Loretta L. Sanchez,108
+Sacramento,34064,U.S. Senate,,DEM,Kamala D. Harris,162
+Sacramento,34064,U.S. Senate,,DEM,Loretta L. Sanchez,94
+Sacramento,34180,U.S. Senate,,DEM,Kamala D. Harris,228
+Sacramento,34180,U.S. Senate,,DEM,Loretta L. Sanchez,152
+Sacramento,34322,U.S. Senate,,DEM,Kamala D. Harris,176
+Sacramento,34322,U.S. Senate,,DEM,Loretta L. Sanchez,149
+Sacramento,34410,U.S. Senate,,DEM,Kamala D. Harris,4
+Sacramento,34410,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Sacramento,34452,U.S. Senate,,DEM,Kamala D. Harris,113
+Sacramento,34452,U.S. Senate,,DEM,Loretta L. Sanchez,79
+Sacramento,34600,U.S. Senate,,DEM,Kamala D. Harris,238
+Sacramento,34600,U.S. Senate,,DEM,Loretta L. Sanchez,155
+Sacramento,34726,U.S. Senate,,DEM,Kamala D. Harris,190
+Sacramento,34726,U.S. Senate,,DEM,Loretta L. Sanchez,114
+Sacramento,34824,U.S. Senate,,DEM,Kamala D. Harris,204
+Sacramento,34824,U.S. Senate,,DEM,Loretta L. Sanchez,129
+Sacramento,35026,U.S. Senate,,DEM,Kamala D. Harris,95
+Sacramento,35026,U.S. Senate,,DEM,Loretta L. Sanchez,38
+Sacramento,35088,U.S. Senate,,DEM,Kamala D. Harris,31
+Sacramento,35088,U.S. Senate,,DEM,Loretta L. Sanchez,8
+Sacramento,35127,U.S. Senate,,DEM,Kamala D. Harris,210
+Sacramento,35127,U.S. Senate,,DEM,Loretta L. Sanchez,144
+Sacramento,35215,U.S. Senate,,DEM,Kamala D. Harris,212
+Sacramento,35215,U.S. Senate,,DEM,Loretta L. Sanchez,143
+Sacramento,35260,U.S. Senate,,DEM,Kamala D. Harris,162
+Sacramento,35260,U.S. Senate,,DEM,Loretta L. Sanchez,109
+Sacramento,35383,U.S. Senate,,DEM,Kamala D. Harris,0
+Sacramento,35383,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sacramento,35402,U.S. Senate,,DEM,Kamala D. Harris,197
+Sacramento,35402,U.S. Senate,,DEM,Loretta L. Sanchez,127
+Sacramento,35500,U.S. Senate,,DEM,Kamala D. Harris,236
+Sacramento,35500,U.S. Senate,,DEM,Loretta L. Sanchez,144
+Sacramento,35636,U.S. Senate,,DEM,Kamala D. Harris,221
+Sacramento,35636,U.S. Senate,,DEM,Loretta L. Sanchez,123
+Sacramento,35678,U.S. Senate,,DEM,Kamala D. Harris,16
+Sacramento,35678,U.S. Senate,,DEM,Loretta L. Sanchez,12
+Sacramento,35797,U.S. Senate,,DEM,Kamala D. Harris,171
+Sacramento,35797,U.S. Senate,,DEM,Loretta L. Sanchez,124
+Sacramento,35852,U.S. Senate,,DEM,Kamala D. Harris,90
+Sacramento,35852,U.S. Senate,,DEM,Loretta L. Sanchez,70
+Sacramento,35886,U.S. Senate,,DEM,Kamala D. Harris,165
+Sacramento,35886,U.S. Senate,,DEM,Loretta L. Sanchez,94
+Sacramento,35961,U.S. Senate,,DEM,Kamala D. Harris,1
+Sacramento,35961,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sacramento,35989,U.S. Senate,,DEM,Kamala D. Harris,0
+Sacramento,35989,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sacramento,36005,U.S. Senate,,DEM,Kamala D. Harris,179
+Sacramento,36005,U.S. Senate,,DEM,Loretta L. Sanchez,110
+Sacramento,36104,U.S. Senate,,DEM,Kamala D. Harris,232
+Sacramento,36104,U.S. Senate,,DEM,Loretta L. Sanchez,115
+Sacramento,36274,U.S. Senate,,DEM,Kamala D. Harris,166
+Sacramento,36274,U.S. Senate,,DEM,Loretta L. Sanchez,123
+Sacramento,36389,U.S. Senate,,DEM,Kamala D. Harris,200
+Sacramento,36389,U.S. Senate,,DEM,Loretta L. Sanchez,165
+Sacramento,36407,U.S. Senate,,DEM,Kamala D. Harris,203
+Sacramento,36407,U.S. Senate,,DEM,Loretta L. Sanchez,137
+Sacramento,36433,U.S. Senate,,DEM,Kamala D. Harris,184
+Sacramento,36433,U.S. Senate,,DEM,Loretta L. Sanchez,96
+Sacramento,36556,U.S. Senate,,DEM,Kamala D. Harris,214
+Sacramento,36556,U.S. Senate,,DEM,Loretta L. Sanchez,101
+Sacramento,36602,U.S. Senate,,DEM,Kamala D. Harris,196
+Sacramento,36602,U.S. Senate,,DEM,Loretta L. Sanchez,111
+Sacramento,36645,U.S. Senate,,DEM,Kamala D. Harris,248
+Sacramento,36645,U.S. Senate,,DEM,Loretta L. Sanchez,145
+Sacramento,36781,U.S. Senate,,DEM,Kamala D. Harris,156
+Sacramento,36781,U.S. Senate,,DEM,Loretta L. Sanchez,80
+Sacramento,36844,U.S. Senate,,DEM,Kamala D. Harris,155
+Sacramento,36844,U.S. Senate,,DEM,Loretta L. Sanchez,89
+Sacramento,36973,U.S. Senate,,DEM,Kamala D. Harris,219
+Sacramento,36973,U.S. Senate,,DEM,Loretta L. Sanchez,97
+Sacramento,37109,U.S. Senate,,DEM,Kamala D. Harris,229
+Sacramento,37109,U.S. Senate,,DEM,Loretta L. Sanchez,123
+Sacramento,37138,U.S. Senate,,DEM,Kamala D. Harris,241
+Sacramento,37138,U.S. Senate,,DEM,Loretta L. Sanchez,151
+Sacramento,37258,U.S. Senate,,DEM,Kamala D. Harris,171
+Sacramento,37258,U.S. Senate,,DEM,Loretta L. Sanchez,118
+Sacramento,37296,U.S. Senate,,DEM,Kamala D. Harris,208
+Sacramento,37296,U.S. Senate,,DEM,Loretta L. Sanchez,103
+Sacramento,37830,U.S. Senate,,DEM,Kamala D. Harris,7
+Sacramento,37830,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Sacramento,38113,U.S. Senate,,DEM,Kamala D. Harris,178
+Sacramento,38113,U.S. Senate,,DEM,Loretta L. Sanchez,105
+Sacramento,38570,U.S. Senate,,DEM,Kamala D. Harris,189
+Sacramento,38570,U.S. Senate,,DEM,Loretta L. Sanchez,107
+Sacramento,39027,U.S. Senate,,DEM,Kamala D. Harris,143
+Sacramento,39027,U.S. Senate,,DEM,Loretta L. Sanchez,65
+Sacramento,39226,U.S. Senate,,DEM,Kamala D. Harris,206
+Sacramento,39226,U.S. Senate,,DEM,Loretta L. Sanchez,131
+Sacramento,39423,U.S. Senate,,DEM,Kamala D. Harris,192
+Sacramento,39423,U.S. Senate,,DEM,Loretta L. Sanchez,95
+Sacramento,39471,U.S. Senate,,DEM,Kamala D. Harris,222
+Sacramento,39471,U.S. Senate,,DEM,Loretta L. Sanchez,105
+Sacramento,39508,U.S. Senate,,DEM,Kamala D. Harris,171
+Sacramento,39508,U.S. Senate,,DEM,Loretta L. Sanchez,95
+Sacramento,39704,U.S. Senate,,DEM,Kamala D. Harris,181
+Sacramento,39704,U.S. Senate,,DEM,Loretta L. Sanchez,116
+Sacramento,41017,U.S. Senate,,DEM,Kamala D. Harris,61
+Sacramento,41017,U.S. Senate,,DEM,Loretta L. Sanchez,28
+Sacramento,41109,U.S. Senate,,DEM,Kamala D. Harris,20
+Sacramento,41109,U.S. Senate,,DEM,Loretta L. Sanchez,13
+Sacramento,41165,U.S. Senate,,DEM,Kamala D. Harris,134
+Sacramento,41165,U.S. Senate,,DEM,Loretta L. Sanchez,66
+Sacramento,41216,U.S. Senate,,DEM,Kamala D. Harris,242
+Sacramento,41216,U.S. Senate,,DEM,Loretta L. Sanchez,142
+Sacramento,41262,U.S. Senate,,DEM,Kamala D. Harris,297
+Sacramento,41262,U.S. Senate,,DEM,Loretta L. Sanchez,105
+Sacramento,41321,U.S. Senate,,DEM,Kamala D. Harris,168
+Sacramento,41321,U.S. Senate,,DEM,Loretta L. Sanchez,77
+Sacramento,41378,U.S. Senate,,DEM,Kamala D. Harris,262
+Sacramento,41378,U.S. Senate,,DEM,Loretta L. Sanchez,90
+Sacramento,41464,U.S. Senate,,DEM,Kamala D. Harris,243
+Sacramento,41464,U.S. Senate,,DEM,Loretta L. Sanchez,92
+Sacramento,41560,U.S. Senate,,DEM,Kamala D. Harris,275
+Sacramento,41560,U.S. Senate,,DEM,Loretta L. Sanchez,96
+Sacramento,41572,U.S. Senate,,DEM,Kamala D. Harris,165
+Sacramento,41572,U.S. Senate,,DEM,Loretta L. Sanchez,81
+Sacramento,41673,U.S. Senate,,DEM,Kamala D. Harris,271
+Sacramento,41673,U.S. Senate,,DEM,Loretta L. Sanchez,124
+Sacramento,41686,U.S. Senate,,DEM,Kamala D. Harris,304
+Sacramento,41686,U.S. Senate,,DEM,Loretta L. Sanchez,137
+Sacramento,41722,U.S. Senate,,DEM,Kamala D. Harris,158
+Sacramento,41722,U.S. Senate,,DEM,Loretta L. Sanchez,74
+Sacramento,41769,U.S. Senate,,DEM,Kamala D. Harris,285
+Sacramento,41769,U.S. Senate,,DEM,Loretta L. Sanchez,128
+Sacramento,41818,U.S. Senate,,DEM,Kamala D. Harris,208
+Sacramento,41818,U.S. Senate,,DEM,Loretta L. Sanchez,96
+Sacramento,41899,U.S. Senate,,DEM,Kamala D. Harris,263
+Sacramento,41899,U.S. Senate,,DEM,Loretta L. Sanchez,105
+Sacramento,41976,U.S. Senate,,DEM,Kamala D. Harris,346
+Sacramento,41976,U.S. Senate,,DEM,Loretta L. Sanchez,128
+Sacramento,42016,U.S. Senate,,DEM,Kamala D. Harris,329
+Sacramento,42016,U.S. Senate,,DEM,Loretta L. Sanchez,99
+Sacramento,42258,U.S. Senate,,DEM,Kamala D. Harris,312
+Sacramento,42258,U.S. Senate,,DEM,Loretta L. Sanchez,73
+Sacramento,42312,U.S. Senate,,DEM,Kamala D. Harris,319
+Sacramento,42312,U.S. Senate,,DEM,Loretta L. Sanchez,112
+Sacramento,42351,U.S. Senate,,DEM,Kamala D. Harris,200
+Sacramento,42351,U.S. Senate,,DEM,Loretta L. Sanchez,75
+Sacramento,42363,U.S. Senate,,DEM,Kamala D. Harris,269
+Sacramento,42363,U.S. Senate,,DEM,Loretta L. Sanchez,94
+Sacramento,42434,U.S. Senate,,DEM,Kamala D. Harris,141
+Sacramento,42434,U.S. Senate,,DEM,Loretta L. Sanchez,57
+Sacramento,42459,U.S. Senate,,DEM,Kamala D. Harris,327
+Sacramento,42459,U.S. Senate,,DEM,Loretta L. Sanchez,106
+Sacramento,42509,U.S. Senate,,DEM,Kamala D. Harris,246
+Sacramento,42509,U.S. Senate,,DEM,Loretta L. Sanchez,102
+Sacramento,42605,U.S. Senate,,DEM,Kamala D. Harris,264
+Sacramento,42605,U.S. Senate,,DEM,Loretta L. Sanchez,88
+Sacramento,42707,U.S. Senate,,DEM,Kamala D. Harris,329
+Sacramento,42707,U.S. Senate,,DEM,Loretta L. Sanchez,129
+Sacramento,42821,U.S. Senate,,DEM,Kamala D. Harris,324
+Sacramento,42821,U.S. Senate,,DEM,Loretta L. Sanchez,121
+Sacramento,42854,U.S. Senate,,DEM,Kamala D. Harris,203
+Sacramento,42854,U.S. Senate,,DEM,Loretta L. Sanchez,97
+Sacramento,42946,U.S. Senate,,DEM,Kamala D. Harris,258
+Sacramento,42946,U.S. Senate,,DEM,Loretta L. Sanchez,103
+Sacramento,43033,U.S. Senate,,DEM,Kamala D. Harris,0
+Sacramento,43033,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sacramento,43148,U.S. Senate,,DEM,Kamala D. Harris,299
+Sacramento,43148,U.S. Senate,,DEM,Loretta L. Sanchez,124
+Sacramento,43242,U.S. Senate,,DEM,Kamala D. Harris,278
+Sacramento,43242,U.S. Senate,,DEM,Loretta L. Sanchez,92
+Sacramento,43329,U.S. Senate,,DEM,Kamala D. Harris,199
+Sacramento,43329,U.S. Senate,,DEM,Loretta L. Sanchez,211
+Sacramento,43400,U.S. Senate,,DEM,Kamala D. Harris,225
+Sacramento,43400,U.S. Senate,,DEM,Loretta L. Sanchez,109
+Sacramento,43439,U.S. Senate,,DEM,Kamala D. Harris,264
+Sacramento,43439,U.S. Senate,,DEM,Loretta L. Sanchez,115
+Sacramento,43691,U.S. Senate,,DEM,Kamala D. Harris,232
+Sacramento,43691,U.S. Senate,,DEM,Loretta L. Sanchez,114
+Sacramento,43738,U.S. Senate,,DEM,Kamala D. Harris,177
+Sacramento,43738,U.S. Senate,,DEM,Loretta L. Sanchez,102
+Sacramento,43845,U.S. Senate,,DEM,Kamala D. Harris,117
+Sacramento,43845,U.S. Senate,,DEM,Loretta L. Sanchez,54
+Sacramento,43915,U.S. Senate,,DEM,Kamala D. Harris,2
+Sacramento,43915,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Sacramento,44013,U.S. Senate,,DEM,Kamala D. Harris,157
+Sacramento,44013,U.S. Senate,,DEM,Loretta L. Sanchez,55
+Sacramento,44059,U.S. Senate,,DEM,Kamala D. Harris,168
+Sacramento,44059,U.S. Senate,,DEM,Loretta L. Sanchez,94
+Sacramento,44158,U.S. Senate,,DEM,Kamala D. Harris,282
+Sacramento,44158,U.S. Senate,,DEM,Loretta L. Sanchez,69
+Sacramento,44191,U.S. Senate,,DEM,Kamala D. Harris,116
+Sacramento,44191,U.S. Senate,,DEM,Loretta L. Sanchez,45
+Sacramento,44209,U.S. Senate,,DEM,Kamala D. Harris,238
+Sacramento,44209,U.S. Senate,,DEM,Loretta L. Sanchez,109
+Sacramento,44274,U.S. Senate,,DEM,Kamala D. Harris,403
+Sacramento,44274,U.S. Senate,,DEM,Loretta L. Sanchez,88
+Sacramento,44346,U.S. Senate,,DEM,Kamala D. Harris,341
+Sacramento,44346,U.S. Senate,,DEM,Loretta L. Sanchez,104
+Sacramento,44507,U.S. Senate,,DEM,Kamala D. Harris,216
+Sacramento,44507,U.S. Senate,,DEM,Loretta L. Sanchez,64
+Sacramento,44520,U.S. Senate,,DEM,Kamala D. Harris,243
+Sacramento,44520,U.S. Senate,,DEM,Loretta L. Sanchez,63
+Sacramento,44549,U.S. Senate,,DEM,Kamala D. Harris,343
+Sacramento,44549,U.S. Senate,,DEM,Loretta L. Sanchez,108
+Sacramento,44601,U.S. Senate,,DEM,Kamala D. Harris,215
+Sacramento,44601,U.S. Senate,,DEM,Loretta L. Sanchez,140
+Sacramento,44625,U.S. Senate,,DEM,Kamala D. Harris,250
+Sacramento,44625,U.S. Senate,,DEM,Loretta L. Sanchez,91
+Sacramento,44663,U.S. Senate,,DEM,Kamala D. Harris,228
+Sacramento,44663,U.S. Senate,,DEM,Loretta L. Sanchez,67
+Sacramento,44706,U.S. Senate,,DEM,Kamala D. Harris,342
+Sacramento,44706,U.S. Senate,,DEM,Loretta L. Sanchez,136
+Sacramento,44757,U.S. Senate,,DEM,Kamala D. Harris,124
+Sacramento,44757,U.S. Senate,,DEM,Loretta L. Sanchez,49
+Sacramento,44804,U.S. Senate,,DEM,Kamala D. Harris,285
+Sacramento,44804,U.S. Senate,,DEM,Loretta L. Sanchez,148
+Sacramento,44903,U.S. Senate,,DEM,Kamala D. Harris,238
+Sacramento,44903,U.S. Senate,,DEM,Loretta L. Sanchez,139
+Sacramento,44992,U.S. Senate,,DEM,Kamala D. Harris,151
+Sacramento,44992,U.S. Senate,,DEM,Loretta L. Sanchez,114
+Sacramento,45015,U.S. Senate,,DEM,Kamala D. Harris,190
+Sacramento,45015,U.S. Senate,,DEM,Loretta L. Sanchez,113
+Sacramento,45058,U.S. Senate,,DEM,Kamala D. Harris,258
+Sacramento,45058,U.S. Senate,,DEM,Loretta L. Sanchez,111
+Sacramento,45107,U.S. Senate,,DEM,Kamala D. Harris,168
+Sacramento,45107,U.S. Senate,,DEM,Loretta L. Sanchez,114
+Sacramento,45164,U.S. Senate,,DEM,Kamala D. Harris,141
+Sacramento,45164,U.S. Senate,,DEM,Loretta L. Sanchez,102
+Sacramento,45241,U.S. Senate,,DEM,Kamala D. Harris,156
+Sacramento,45241,U.S. Senate,,DEM,Loretta L. Sanchez,130
+Sacramento,45314,U.S. Senate,,DEM,Kamala D. Harris,147
+Sacramento,45314,U.S. Senate,,DEM,Loretta L. Sanchez,152
+Sacramento,45418,U.S. Senate,,DEM,Kamala D. Harris,142
+Sacramento,45418,U.S. Senate,,DEM,Loretta L. Sanchez,149
+Sacramento,45453,U.S. Senate,,DEM,Kamala D. Harris,66
+Sacramento,45453,U.S. Senate,,DEM,Loretta L. Sanchez,67
+Sacramento,45482,U.S. Senate,,DEM,Kamala D. Harris,73
+Sacramento,45482,U.S. Senate,,DEM,Loretta L. Sanchez,59
+Sacramento,45511,U.S. Senate,,DEM,Kamala D. Harris,64
+Sacramento,45511,U.S. Senate,,DEM,Loretta L. Sanchez,70
+Sacramento,45548,U.S. Senate,,DEM,Kamala D. Harris,107
+Sacramento,45548,U.S. Senate,,DEM,Loretta L. Sanchez,115
+Sacramento,45624,U.S. Senate,,DEM,Kamala D. Harris,111
+Sacramento,45624,U.S. Senate,,DEM,Loretta L. Sanchez,143
+Sacramento,45670,U.S. Senate,,DEM,Kamala D. Harris,144
+Sacramento,45670,U.S. Senate,,DEM,Loretta L. Sanchez,167
+Sacramento,45701,U.S. Senate,,DEM,Kamala D. Harris,155
+Sacramento,45701,U.S. Senate,,DEM,Loretta L. Sanchez,152
+Sacramento,45736,U.S. Senate,,DEM,Kamala D. Harris,67
+Sacramento,45736,U.S. Senate,,DEM,Loretta L. Sanchez,59
+Sacramento,45774,U.S. Senate,,DEM,Kamala D. Harris,0
+Sacramento,45774,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Sacramento,45847,U.S. Senate,,DEM,Kamala D. Harris,104
+Sacramento,45847,U.S. Senate,,DEM,Loretta L. Sanchez,132
+Sacramento,45908,U.S. Senate,,DEM,Kamala D. Harris,119
+Sacramento,45908,U.S. Senate,,DEM,Loretta L. Sanchez,102
+Sacramento,45956,U.S. Senate,,DEM,Kamala D. Harris,139
+Sacramento,45956,U.S. Senate,,DEM,Loretta L. Sanchez,139
+Sacramento,45997,U.S. Senate,,DEM,Kamala D. Harris,113
+Sacramento,45997,U.S. Senate,,DEM,Loretta L. Sanchez,67
+Sacramento,46014,U.S. Senate,,DEM,Kamala D. Harris,294
+Sacramento,46014,U.S. Senate,,DEM,Loretta L. Sanchez,117
+Sacramento,46098,U.S. Senate,,DEM,Kamala D. Harris,201
+Sacramento,46098,U.S. Senate,,DEM,Loretta L. Sanchez,104
+Sacramento,46153,U.S. Senate,,DEM,Kamala D. Harris,192
+Sacramento,46153,U.S. Senate,,DEM,Loretta L. Sanchez,137
+Sacramento,46220,U.S. Senate,,DEM,Kamala D. Harris,197
+Sacramento,46220,U.S. Senate,,DEM,Loretta L. Sanchez,106
+Sacramento,46307,U.S. Senate,,DEM,Kamala D. Harris,223
+Sacramento,46307,U.S. Senate,,DEM,Loretta L. Sanchez,126
+Sacramento,46344,U.S. Senate,,DEM,Kamala D. Harris,201
+Sacramento,46344,U.S. Senate,,DEM,Loretta L. Sanchez,171
+Sacramento,46422,U.S. Senate,,DEM,Kamala D. Harris,75
+Sacramento,46422,U.S. Senate,,DEM,Loretta L. Sanchez,73
+Sacramento,46477,U.S. Senate,,DEM,Kamala D. Harris,213
+Sacramento,46477,U.S. Senate,,DEM,Loretta L. Sanchez,172
+Sacramento,46618,U.S. Senate,,DEM,Kamala D. Harris,126
+Sacramento,46618,U.S. Senate,,DEM,Loretta L. Sanchez,133
+Sacramento,46690,U.S. Senate,,DEM,Kamala D. Harris,140
+Sacramento,46690,U.S. Senate,,DEM,Loretta L. Sanchez,114
+Sacramento,46739,U.S. Senate,,DEM,Kamala D. Harris,120
+Sacramento,46739,U.S. Senate,,DEM,Loretta L. Sanchez,84
+Sacramento,46828,U.S. Senate,,DEM,Kamala D. Harris,3
+Sacramento,46828,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Sacramento,46867,U.S. Senate,,DEM,Kamala D. Harris,65
+Sacramento,46867,U.S. Senate,,DEM,Loretta L. Sanchez,56
+Sacramento,46872,U.S. Senate,,DEM,Kamala D. Harris,151
+Sacramento,46872,U.S. Senate,,DEM,Loretta L. Sanchez,119
+Sacramento,46971,U.S. Senate,,DEM,Kamala D. Harris,113
+Sacramento,46971,U.S. Senate,,DEM,Loretta L. Sanchez,58
+Sacramento,47018,U.S. Senate,,DEM,Kamala D. Harris,122
+Sacramento,47018,U.S. Senate,,DEM,Loretta L. Sanchez,40
+Sacramento,47051,U.S. Senate,,DEM,Kamala D. Harris,296
+Sacramento,47051,U.S. Senate,,DEM,Loretta L. Sanchez,118
+Sacramento,47116,U.S. Senate,,DEM,Kamala D. Harris,254
+Sacramento,47116,U.S. Senate,,DEM,Loretta L. Sanchez,146
+Sacramento,47154,U.S. Senate,,DEM,Kamala D. Harris,259
+Sacramento,47154,U.S. Senate,,DEM,Loretta L. Sanchez,99
+Sacramento,47199,U.S. Senate,,DEM,Kamala D. Harris,202
+Sacramento,47199,U.S. Senate,,DEM,Loretta L. Sanchez,79
+Sacramento,47226,U.S. Senate,,DEM,Kamala D. Harris,271
+Sacramento,47226,U.S. Senate,,DEM,Loretta L. Sanchez,132
+Sacramento,47249,U.S. Senate,,DEM,Kamala D. Harris,220
+Sacramento,47249,U.S. Senate,,DEM,Loretta L. Sanchez,96
+Sacramento,47302,U.S. Senate,,DEM,Kamala D. Harris,286
+Sacramento,47302,U.S. Senate,,DEM,Loretta L. Sanchez,92
+Sacramento,47348,U.S. Senate,,DEM,Kamala D. Harris,240
+Sacramento,47348,U.S. Senate,,DEM,Loretta L. Sanchez,128
+Sacramento,47436,U.S. Senate,,DEM,Kamala D. Harris,299
+Sacramento,47436,U.S. Senate,,DEM,Loretta L. Sanchez,136
+Sacramento,47530,U.S. Senate,,DEM,Kamala D. Harris,227
+Sacramento,47530,U.S. Senate,,DEM,Loretta L. Sanchez,106
+Sacramento,47541,U.S. Senate,,DEM,Kamala D. Harris,258
+Sacramento,47541,U.S. Senate,,DEM,Loretta L. Sanchez,125
+Sacramento,47563,U.S. Senate,,DEM,Kamala D. Harris,276
+Sacramento,47563,U.S. Senate,,DEM,Loretta L. Sanchez,120
+Sacramento,47619,U.S. Senate,,DEM,Kamala D. Harris,228
+Sacramento,47619,U.S. Senate,,DEM,Loretta L. Sanchez,97
+Sacramento,47712,U.S. Senate,,DEM,Kamala D. Harris,206
+Sacramento,47712,U.S. Senate,,DEM,Loretta L. Sanchez,93
+Sacramento,47724,U.S. Senate,,DEM,Kamala D. Harris,141
+Sacramento,47724,U.S. Senate,,DEM,Loretta L. Sanchez,55
+Sacramento,47814,U.S. Senate,,DEM,Kamala D. Harris,174
+Sacramento,47814,U.S. Senate,,DEM,Loretta L. Sanchez,94
+Sacramento,47833,U.S. Senate,,DEM,Kamala D. Harris,220
+Sacramento,47833,U.S. Senate,,DEM,Loretta L. Sanchez,81
+Sacramento,47879,U.S. Senate,,DEM,Kamala D. Harris,261
+Sacramento,47879,U.S. Senate,,DEM,Loretta L. Sanchez,110
+Sacramento,47943,U.S. Senate,,DEM,Kamala D. Harris,134
+Sacramento,47943,U.S. Senate,,DEM,Loretta L. Sanchez,72
+Sacramento,48122,U.S. Senate,,DEM,Kamala D. Harris,244
+Sacramento,48122,U.S. Senate,,DEM,Loretta L. Sanchez,117
+Sacramento,48150,U.S. Senate,,DEM,Kamala D. Harris,154
+Sacramento,48150,U.S. Senate,,DEM,Loretta L. Sanchez,119
+Sacramento,48252,U.S. Senate,,DEM,Kamala D. Harris,128
+Sacramento,48252,U.S. Senate,,DEM,Loretta L. Sanchez,81
+Sacramento,48305,U.S. Senate,,DEM,Kamala D. Harris,237
+Sacramento,48305,U.S. Senate,,DEM,Loretta L. Sanchez,130
+Sacramento,48320,U.S. Senate,,DEM,Kamala D. Harris,128
+Sacramento,48320,U.S. Senate,,DEM,Loretta L. Sanchez,87
+Sacramento,48396,U.S. Senate,,DEM,Kamala D. Harris,193
+Sacramento,48396,U.S. Senate,,DEM,Loretta L. Sanchez,118
+Sacramento,48447,U.S. Senate,,DEM,Kamala D. Harris,196
+Sacramento,48447,U.S. Senate,,DEM,Loretta L. Sanchez,146
+Sacramento,48475,U.S. Senate,,DEM,Kamala D. Harris,159
+Sacramento,48475,U.S. Senate,,DEM,Loretta L. Sanchez,114
+Sacramento,48524,U.S. Senate,,DEM,Kamala D. Harris,103
+Sacramento,48524,U.S. Senate,,DEM,Loretta L. Sanchez,106
+Sacramento,48579,U.S. Senate,,DEM,Kamala D. Harris,156
+Sacramento,48579,U.S. Senate,,DEM,Loretta L. Sanchez,107
+Sacramento,48613,U.S. Senate,,DEM,Kamala D. Harris,189
+Sacramento,48613,U.S. Senate,,DEM,Loretta L. Sanchez,105
+Sacramento,48637,U.S. Senate,,DEM,Kamala D. Harris,163
+Sacramento,48637,U.S. Senate,,DEM,Loretta L. Sanchez,83
+Sacramento,48689,U.S. Senate,,DEM,Kamala D. Harris,0
+Sacramento,48689,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sacramento,48703,U.S. Senate,,DEM,Kamala D. Harris,143
+Sacramento,48703,U.S. Senate,,DEM,Loretta L. Sanchez,88
+Sacramento,48728,U.S. Senate,,DEM,Kamala D. Harris,156
+Sacramento,48728,U.S. Senate,,DEM,Loretta L. Sanchez,91
+Sacramento,48810,U.S. Senate,,DEM,Kamala D. Harris,0
+Sacramento,48810,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sacramento,48864,U.S. Senate,,DEM,Kamala D. Harris,0
+Sacramento,48864,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sacramento,48892,U.S. Senate,,DEM,Kamala D. Harris,0
+Sacramento,48892,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sacramento,48906,U.S. Senate,,DEM,Kamala D. Harris,8
+Sacramento,48906,U.S. Senate,,DEM,Loretta L. Sanchez,8
+Sacramento,48917,U.S. Senate,,DEM,Kamala D. Harris,214
+Sacramento,48917,U.S. Senate,,DEM,Loretta L. Sanchez,122
+Sacramento,48949,U.S. Senate,,DEM,Kamala D. Harris,144
+Sacramento,48949,U.S. Senate,,DEM,Loretta L. Sanchez,73
+Sacramento,48995,U.S. Senate,,DEM,Kamala D. Harris,157
+Sacramento,48995,U.S. Senate,,DEM,Loretta L. Sanchez,126
+Sacramento,49006,U.S. Senate,,DEM,Kamala D. Harris,286
+Sacramento,49006,U.S. Senate,,DEM,Loretta L. Sanchez,175
+Sacramento,49061,U.S. Senate,,DEM,Kamala D. Harris,0
+Sacramento,49061,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sacramento,49085,U.S. Senate,,DEM,Kamala D. Harris,74
+Sacramento,49085,U.S. Senate,,DEM,Loretta L. Sanchez,43
+Sacramento,49100,U.S. Senate,,DEM,Kamala D. Harris,115
+Sacramento,49100,U.S. Senate,,DEM,Loretta L. Sanchez,85
+Sacramento,49156,U.S. Senate,,DEM,Kamala D. Harris,0
+Sacramento,49156,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sacramento,49162,U.S. Senate,,DEM,Kamala D. Harris,141
+Sacramento,49162,U.S. Senate,,DEM,Loretta L. Sanchez,111
+Sacramento,49208,U.S. Senate,,DEM,Kamala D. Harris,232
+Sacramento,49208,U.S. Senate,,DEM,Loretta L. Sanchez,169
+Sacramento,49263,U.S. Senate,,DEM,Kamala D. Harris,225
+Sacramento,49263,U.S. Senate,,DEM,Loretta L. Sanchez,148
+Sacramento,49316,U.S. Senate,,DEM,Kamala D. Harris,171
+Sacramento,49316,U.S. Senate,,DEM,Loretta L. Sanchez,108
+Sacramento,49373,U.S. Senate,,DEM,Kamala D. Harris,105
+Sacramento,49373,U.S. Senate,,DEM,Loretta L. Sanchez,45
+Sacramento,49401,U.S. Senate,,DEM,Kamala D. Harris,218
+Sacramento,49401,U.S. Senate,,DEM,Loretta L. Sanchez,150
+Sacramento,49457,U.S. Senate,,DEM,Kamala D. Harris,140
+Sacramento,49457,U.S. Senate,,DEM,Loretta L. Sanchez,106
+Sacramento,49472,U.S. Senate,,DEM,Kamala D. Harris,156
+Sacramento,49472,U.S. Senate,,DEM,Loretta L. Sanchez,95
+Sacramento,49503,U.S. Senate,,DEM,Kamala D. Harris,52
+Sacramento,49503,U.S. Senate,,DEM,Loretta L. Sanchez,42
+Sacramento,49542,U.S. Senate,,DEM,Kamala D. Harris,144
+Sacramento,49542,U.S. Senate,,DEM,Loretta L. Sanchez,90
+Sacramento,49596,U.S. Senate,,DEM,Kamala D. Harris,79
+Sacramento,49596,U.S. Senate,,DEM,Loretta L. Sanchez,49
+Sacramento,49629,U.S. Senate,,DEM,Kamala D. Harris,156
+Sacramento,49629,U.S. Senate,,DEM,Loretta L. Sanchez,119
+Sacramento,49705,U.S. Senate,,DEM,Kamala D. Harris,78
+Sacramento,49705,U.S. Senate,,DEM,Loretta L. Sanchez,39
+Sacramento,49732,U.S. Senate,,DEM,Kamala D. Harris,235
+Sacramento,49732,U.S. Senate,,DEM,Loretta L. Sanchez,161
+Sacramento,49766,U.S. Senate,,DEM,Kamala D. Harris,252
+Sacramento,49766,U.S. Senate,,DEM,Loretta L. Sanchez,110
+Sacramento,49791,U.S. Senate,,DEM,Kamala D. Harris,145
+Sacramento,49791,U.S. Senate,,DEM,Loretta L. Sanchez,66
+Sacramento,49802,U.S. Senate,,DEM,Kamala D. Harris,124
+Sacramento,49802,U.S. Senate,,DEM,Loretta L. Sanchez,64
+Sacramento,49923,U.S. Senate,,DEM,Kamala D. Harris,153
+Sacramento,49923,U.S. Senate,,DEM,Loretta L. Sanchez,96
+Sacramento,49981,U.S. Senate,,DEM,Kamala D. Harris,0
+Sacramento,49981,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sacramento,51127,U.S. Senate,,DEM,Kamala D. Harris,189
+Sacramento,51127,U.S. Senate,,DEM,Loretta L. Sanchez,100
+Sacramento,51180,U.S. Senate,,DEM,Kamala D. Harris,214
+Sacramento,51180,U.S. Senate,,DEM,Loretta L. Sanchez,138
+Sacramento,51317,U.S. Senate,,DEM,Kamala D. Harris,180
+Sacramento,51317,U.S. Senate,,DEM,Loretta L. Sanchez,88
+Sacramento,51415,U.S. Senate,,DEM,Kamala D. Harris,293
+Sacramento,51415,U.S. Senate,,DEM,Loretta L. Sanchez,211
+Sacramento,51565,U.S. Senate,,DEM,Kamala D. Harris,104
+Sacramento,51565,U.S. Senate,,DEM,Loretta L. Sanchez,50
+Sacramento,51582,U.S. Senate,,DEM,Kamala D. Harris,141
+Sacramento,51582,U.S. Senate,,DEM,Loretta L. Sanchez,78
+Sacramento,51646,U.S. Senate,,DEM,Kamala D. Harris,144
+Sacramento,51646,U.S. Senate,,DEM,Loretta L. Sanchez,81
+Sacramento,51729,U.S. Senate,,DEM,Kamala D. Harris,292
+Sacramento,51729,U.S. Senate,,DEM,Loretta L. Sanchez,158
+Sacramento,51844,U.S. Senate,,DEM,Kamala D. Harris,199
+Sacramento,51844,U.S. Senate,,DEM,Loretta L. Sanchez,120
+Sacramento,51922,U.S. Senate,,DEM,Kamala D. Harris,207
+Sacramento,51922,U.S. Senate,,DEM,Loretta L. Sanchez,129
+Sacramento,52129,U.S. Senate,,DEM,Kamala D. Harris,190
+Sacramento,52129,U.S. Senate,,DEM,Loretta L. Sanchez,114
+Sacramento,52218,U.S. Senate,,DEM,Kamala D. Harris,146
+Sacramento,52218,U.S. Senate,,DEM,Loretta L. Sanchez,86
+Sacramento,52260,U.S. Senate,,DEM,Kamala D. Harris,180
+Sacramento,52260,U.S. Senate,,DEM,Loretta L. Sanchez,93
+Sacramento,52405,U.S. Senate,,DEM,Kamala D. Harris,143
+Sacramento,52405,U.S. Senate,,DEM,Loretta L. Sanchez,68
+Sacramento,52516,U.S. Senate,,DEM,Kamala D. Harris,100
+Sacramento,52516,U.S. Senate,,DEM,Loretta L. Sanchez,57
+Sacramento,52627,U.S. Senate,,DEM,Kamala D. Harris,214
+Sacramento,52627,U.S. Senate,,DEM,Loretta L. Sanchez,133
+Sacramento,52723,U.S. Senate,,DEM,Kamala D. Harris,145
+Sacramento,52723,U.S. Senate,,DEM,Loretta L. Sanchez,81
+Sacramento,52750,U.S. Senate,,DEM,Kamala D. Harris,229
+Sacramento,52750,U.S. Senate,,DEM,Loretta L. Sanchez,145
+Sacramento,52868,U.S. Senate,,DEM,Kamala D. Harris,178
+Sacramento,52868,U.S. Senate,,DEM,Loretta L. Sanchez,94
+Sacramento,52957,U.S. Senate,,DEM,Kamala D. Harris,85
+Sacramento,52957,U.S. Senate,,DEM,Loretta L. Sanchez,41
+Sacramento,53014,U.S. Senate,,DEM,Kamala D. Harris,174
+Sacramento,53014,U.S. Senate,,DEM,Loretta L. Sanchez,88
+Sacramento,53067,U.S. Senate,,DEM,Kamala D. Harris,208
+Sacramento,53067,U.S. Senate,,DEM,Loretta L. Sanchez,151
+Sacramento,53137,U.S. Senate,,DEM,Kamala D. Harris,254
+Sacramento,53137,U.S. Senate,,DEM,Loretta L. Sanchez,124
+Sacramento,53205,U.S. Senate,,DEM,Kamala D. Harris,167
+Sacramento,53205,U.S. Senate,,DEM,Loretta L. Sanchez,92
+Sacramento,53261,U.S. Senate,,DEM,Kamala D. Harris,227
+Sacramento,53261,U.S. Senate,,DEM,Loretta L. Sanchez,161
+Sacramento,53318,U.S. Senate,,DEM,Kamala D. Harris,125
+Sacramento,53318,U.S. Senate,,DEM,Loretta L. Sanchez,71
+Sacramento,53363,U.S. Senate,,DEM,Kamala D. Harris,175
+Sacramento,53363,U.S. Senate,,DEM,Loretta L. Sanchez,127
+Sacramento,53435,U.S. Senate,,DEM,Kamala D. Harris,157
+Sacramento,53435,U.S. Senate,,DEM,Loretta L. Sanchez,92
+Sacramento,53512,U.S. Senate,,DEM,Kamala D. Harris,169
+Sacramento,53512,U.S. Senate,,DEM,Loretta L. Sanchez,109
+Sacramento,53594,U.S. Senate,,DEM,Kamala D. Harris,0
+Sacramento,53594,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sacramento,53610,U.S. Senate,,DEM,Kamala D. Harris,118
+Sacramento,53610,U.S. Senate,,DEM,Loretta L. Sanchez,63
+Sacramento,53657,U.S. Senate,,DEM,Kamala D. Harris,190
+Sacramento,53657,U.S. Senate,,DEM,Loretta L. Sanchez,103
+Sacramento,53707,U.S. Senate,,DEM,Kamala D. Harris,1
+Sacramento,53707,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Sacramento,53764,U.S. Senate,,DEM,Kamala D. Harris,66
+Sacramento,53764,U.S. Senate,,DEM,Loretta L. Sanchez,29
+Sacramento,53773,U.S. Senate,,DEM,Kamala D. Harris,0
+Sacramento,53773,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Sacramento,53821,U.S. Senate,,DEM,Kamala D. Harris,38
+Sacramento,53821,U.S. Senate,,DEM,Loretta L. Sanchez,15
+Sacramento,53855,U.S. Senate,,DEM,Kamala D. Harris,36
+Sacramento,53855,U.S. Senate,,DEM,Loretta L. Sanchez,13
+Sacramento,53903,U.S. Senate,,DEM,Kamala D. Harris,114
+Sacramento,53903,U.S. Senate,,DEM,Loretta L. Sanchez,84
+Sacramento,53932,U.S. Senate,,DEM,Kamala D. Harris,180
+Sacramento,53932,U.S. Senate,,DEM,Loretta L. Sanchez,93
+Sacramento,54279,U.S. Senate,,DEM,Kamala D. Harris,1
+Sacramento,54279,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Sacramento,54353,U.S. Senate,,DEM,Kamala D. Harris,3
+Sacramento,54353,U.S. Senate,,DEM,Loretta L. Sanchez,8
+Sacramento,54416,U.S. Senate,,DEM,Kamala D. Harris,2
+Sacramento,54416,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sacramento,54713,U.S. Senate,,DEM,Kamala D. Harris,19
+Sacramento,54713,U.S. Senate,,DEM,Loretta L. Sanchez,5
+Sacramento,54835,U.S. Senate,,DEM,Kamala D. Harris,0
+Sacramento,54835,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sacramento,54899,U.S. Senate,,DEM,Kamala D. Harris,108
+Sacramento,54899,U.S. Senate,,DEM,Loretta L. Sanchez,57
+Sacramento,54924,U.S. Senate,,DEM,Kamala D. Harris,6
+Sacramento,54924,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Sacramento,55016,U.S. Senate,,DEM,Kamala D. Harris,0
+Sacramento,55016,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sacramento,55160,U.S. Senate,,DEM,Kamala D. Harris,202
+Sacramento,55160,U.S. Senate,,DEM,Loretta L. Sanchez,141
+Sacramento,55203,U.S. Senate,,DEM,Kamala D. Harris,172
+Sacramento,55203,U.S. Senate,,DEM,Loretta L. Sanchez,98
+Sacramento,55281,U.S. Senate,,DEM,Kamala D. Harris,187
+Sacramento,55281,U.S. Senate,,DEM,Loretta L. Sanchez,132
+Sacramento,55410,U.S. Senate,,DEM,Kamala D. Harris,14
+Sacramento,55410,U.S. Senate,,DEM,Loretta L. Sanchez,12
+Sacramento,55700,U.S. Senate,,DEM,Kamala D. Harris,30
+Sacramento,55700,U.S. Senate,,DEM,Loretta L. Sanchez,32
+Sacramento,55936,U.S. Senate,,DEM,Kamala D. Harris,157
+Sacramento,55936,U.S. Senate,,DEM,Loretta L. Sanchez,91
+Sacramento,56122,U.S. Senate,,DEM,Kamala D. Harris,0
+Sacramento,56122,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sacramento,56165,U.S. Senate,,DEM,Kamala D. Harris,148
+Sacramento,56165,U.S. Senate,,DEM,Loretta L. Sanchez,91
+Sacramento,56250,U.S. Senate,,DEM,Kamala D. Harris,138
+Sacramento,56250,U.S. Senate,,DEM,Loretta L. Sanchez,101
+Sacramento,56399,U.S. Senate,,DEM,Kamala D. Harris,0
+Sacramento,56399,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sacramento,56412,U.S. Senate,,DEM,Kamala D. Harris,25
+Sacramento,56412,U.S. Senate,,DEM,Loretta L. Sanchez,19
+Sacramento,56701,U.S. Senate,,DEM,Kamala D. Harris,0
+Sacramento,56701,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sacramento,56798,U.S. Senate,,DEM,Kamala D. Harris,51
+Sacramento,56798,U.S. Senate,,DEM,Loretta L. Sanchez,42
+Sacramento,57019,U.S. Senate,,DEM,Kamala D. Harris,206
+Sacramento,57019,U.S. Senate,,DEM,Loretta L. Sanchez,126
+Sacramento,57101,U.S. Senate,,DEM,Kamala D. Harris,126
+Sacramento,57101,U.S. Senate,,DEM,Loretta L. Sanchez,103
+Sacramento,57157,U.S. Senate,,DEM,Kamala D. Harris,76
+Sacramento,57157,U.S. Senate,,DEM,Loretta L. Sanchez,58
+Sacramento,57315,U.S. Senate,,DEM,Kamala D. Harris,77
+Sacramento,57315,U.S. Senate,,DEM,Loretta L. Sanchez,69
+Sacramento,57430,U.S. Senate,,DEM,Kamala D. Harris,195
+Sacramento,57430,U.S. Senate,,DEM,Loretta L. Sanchez,148
+Sacramento,57509,U.S. Senate,,DEM,Kamala D. Harris,136
+Sacramento,57509,U.S. Senate,,DEM,Loretta L. Sanchez,85
+Sacramento,57566,U.S. Senate,,DEM,Kamala D. Harris,100
+Sacramento,57566,U.S. Senate,,DEM,Loretta L. Sanchez,64
+Sacramento,57639,U.S. Senate,,DEM,Kamala D. Harris,234
+Sacramento,57639,U.S. Senate,,DEM,Loretta L. Sanchez,133
+Sacramento,57688,U.S. Senate,,DEM,Kamala D. Harris,220
+Sacramento,57688,U.S. Senate,,DEM,Loretta L. Sanchez,113
+Sacramento,57703,U.S. Senate,,DEM,Kamala D. Harris,187
+Sacramento,57703,U.S. Senate,,DEM,Loretta L. Sanchez,116
+Sacramento,57735,U.S. Senate,,DEM,Kamala D. Harris,155
+Sacramento,57735,U.S. Senate,,DEM,Loretta L. Sanchez,112
+Sacramento,57862,U.S. Senate,,DEM,Kamala D. Harris,175
+Sacramento,57862,U.S. Senate,,DEM,Loretta L. Sanchez,99
+Sacramento,58346,U.S. Senate,,DEM,Kamala D. Harris,164
+Sacramento,58346,U.S. Senate,,DEM,Loretta L. Sanchez,99
+Sacramento,58437,U.S. Senate,,DEM,Kamala D. Harris,186
+Sacramento,58437,U.S. Senate,,DEM,Loretta L. Sanchez,110
+Sacramento,58460,U.S. Senate,,DEM,Kamala D. Harris,162
+Sacramento,58460,U.S. Senate,,DEM,Loretta L. Sanchez,80
+Sacramento,58782,U.S. Senate,,DEM,Kamala D. Harris,207
+Sacramento,58782,U.S. Senate,,DEM,Loretta L. Sanchez,106
+Sacramento,58828,U.S. Senate,,DEM,Kamala D. Harris,240
+Sacramento,58828,U.S. Senate,,DEM,Loretta L. Sanchez,119
+Sacramento,59352,U.S. Senate,,DEM,Kamala D. Harris,167
+Sacramento,59352,U.S. Senate,,DEM,Loretta L. Sanchez,106
+Sacramento,59406,U.S. Senate,,DEM,Kamala D. Harris,227
+Sacramento,59406,U.S. Senate,,DEM,Loretta L. Sanchez,129
+Sacramento,59562,U.S. Senate,,DEM,Kamala D. Harris,173
+Sacramento,59562,U.S. Senate,,DEM,Loretta L. Sanchez,68
+Sacramento,61020,U.S. Senate,,DEM,Kamala D. Harris,45
+Sacramento,61020,U.S. Senate,,DEM,Loretta L. Sanchez,15
+Sacramento,61124,U.S. Senate,,DEM,Kamala D. Harris,168
+Sacramento,61124,U.S. Senate,,DEM,Loretta L. Sanchez,69
+Sacramento,61169,U.S. Senate,,DEM,Kamala D. Harris,157
+Sacramento,61169,U.S. Senate,,DEM,Loretta L. Sanchez,97
+Sacramento,61207,U.S. Senate,,DEM,Kamala D. Harris,104
+Sacramento,61207,U.S. Senate,,DEM,Loretta L. Sanchez,48
+Sacramento,61263,U.S. Senate,,DEM,Kamala D. Harris,224
+Sacramento,61263,U.S. Senate,,DEM,Loretta L. Sanchez,95
+Sacramento,61312,U.S. Senate,,DEM,Kamala D. Harris,3
+Sacramento,61312,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sacramento,61373,U.S. Senate,,DEM,Kamala D. Harris,0
+Sacramento,61373,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sacramento,61411,U.S. Senate,,DEM,Kamala D. Harris,2
+Sacramento,61411,U.S. Senate,,DEM,Loretta L. Sanchez,6
+Sacramento,61462,U.S. Senate,,DEM,Kamala D. Harris,82
+Sacramento,61462,U.S. Senate,,DEM,Loretta L. Sanchez,37
+Sacramento,61549,U.S. Senate,,DEM,Kamala D. Harris,0
+Sacramento,61549,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sacramento,61709,U.S. Senate,,DEM,Kamala D. Harris,0
+Sacramento,61709,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sacramento,61983,U.S. Senate,,DEM,Kamala D. Harris,0
+Sacramento,61983,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sacramento,62136,U.S. Senate,,DEM,Kamala D. Harris,1
+Sacramento,62136,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Sacramento,62192,U.S. Senate,,DEM,Kamala D. Harris,77
+Sacramento,62192,U.S. Senate,,DEM,Loretta L. Sanchez,34
+Sacramento,62479,U.S. Senate,,DEM,Kamala D. Harris,0
+Sacramento,62479,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sacramento,62755,U.S. Senate,,DEM,Kamala D. Harris,1
+Sacramento,62755,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Sacramento,63106,U.S. Senate,,DEM,Kamala D. Harris,0
+Sacramento,63106,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sacramento,63814,U.S. Senate,,DEM,Kamala D. Harris,1
+Sacramento,63814,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sacramento,64012,U.S. Senate,,DEM,Kamala D. Harris,0
+Sacramento,64012,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sacramento,64204,U.S. Senate,,DEM,Kamala D. Harris,203
+Sacramento,64204,U.S. Senate,,DEM,Loretta L. Sanchez,99
+Sacramento,64251,U.S. Senate,,DEM,Kamala D. Harris,170
+Sacramento,64251,U.S. Senate,,DEM,Loretta L. Sanchez,103
+Sacramento,64427,U.S. Senate,,DEM,Kamala D. Harris,271
+Sacramento,64427,U.S. Senate,,DEM,Loretta L. Sanchez,115
+Sacramento,64541,U.S. Senate,,DEM,Kamala D. Harris,102
+Sacramento,64541,U.S. Senate,,DEM,Loretta L. Sanchez,85
+Sacramento,64746,U.S. Senate,,DEM,Kamala D. Harris,0
+Sacramento,64746,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sacramento,64833,U.S. Senate,,DEM,Kamala D. Harris,0
+Sacramento,64833,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sacramento,65601,U.S. Senate,,DEM,Kamala D. Harris,77
+Sacramento,65601,U.S. Senate,,DEM,Loretta L. Sanchez,50
+Sacramento,66358,U.S. Senate,,DEM,Kamala D. Harris,0
+Sacramento,66358,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sacramento,66401,U.S. Senate,,DEM,Kamala D. Harris,4
+Sacramento,66401,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Sacramento,66532,U.S. Senate,,DEM,Kamala D. Harris,175
+Sacramento,66532,U.S. Senate,,DEM,Loretta L. Sanchez,115
+Sacramento,66741,U.S. Senate,,DEM,Kamala D. Harris,151
+Sacramento,66741,U.S. Senate,,DEM,Loretta L. Sanchez,97
+Sacramento,66879,U.S. Senate,,DEM,Kamala D. Harris,167
+Sacramento,66879,U.S. Senate,,DEM,Loretta L. Sanchez,105
+Sacramento,67160,U.S. Senate,,DEM,Kamala D. Harris,4
+Sacramento,67160,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sacramento,69300,U.S. Senate,,DEM,Kamala D. Harris,8
+Sacramento,69300,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Sacramento,69964,U.S. Senate,,DEM,Kamala D. Harris,0
+Sacramento,69964,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sacramento,71126,U.S. Senate,,DEM,Kamala D. Harris,0
+Sacramento,71126,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sacramento,71158,U.S. Senate,,DEM,Kamala D. Harris,12
+Sacramento,71158,U.S. Senate,,DEM,Loretta L. Sanchez,5
+Sacramento,71205,U.S. Senate,,DEM,Kamala D. Harris,22
+Sacramento,71205,U.S. Senate,,DEM,Loretta L. Sanchez,25
+Sacramento,71383,U.S. Senate,,DEM,Kamala D. Harris,0
+Sacramento,71383,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sacramento,71429,U.S. Senate,,DEM,Kamala D. Harris,0
+Sacramento,71429,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sacramento,71620,U.S. Senate,,DEM,Kamala D. Harris,8
+Sacramento,71620,U.S. Senate,,DEM,Loretta L. Sanchez,17
+Sacramento,71655,U.S. Senate,,DEM,Kamala D. Harris,0
+Sacramento,71655,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Sacramento,71731,U.S. Senate,,DEM,Kamala D. Harris,0
+Sacramento,71731,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Sacramento,71866,U.S. Senate,,DEM,Kamala D. Harris,6
+Sacramento,71866,U.S. Senate,,DEM,Loretta L. Sanchez,13
+Sacramento,72015,U.S. Senate,,DEM,Kamala D. Harris,0
+Sacramento,72015,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sacramento,72023,U.S. Senate,,DEM,Kamala D. Harris,0
+Sacramento,72023,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sacramento,72052,U.S. Senate,,DEM,Kamala D. Harris,0
+Sacramento,72052,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sacramento,72060,U.S. Senate,,DEM,Kamala D. Harris,0
+Sacramento,72060,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sacramento,72122,U.S. Senate,,DEM,Kamala D. Harris,0
+Sacramento,72122,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sacramento,72234,U.S. Senate,,DEM,Kamala D. Harris,0
+Sacramento,72234,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sacramento,72268,U.S. Senate,,DEM,Kamala D. Harris,4
+Sacramento,72268,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Sacramento,72293,U.S. Senate,,DEM,Kamala D. Harris,217
+Sacramento,72293,U.S. Senate,,DEM,Loretta L. Sanchez,109
+Sacramento,72329,U.S. Senate,,DEM,Kamala D. Harris,216
+Sacramento,72329,U.S. Senate,,DEM,Loretta L. Sanchez,128
+Sacramento,72436,U.S. Senate,,DEM,Kamala D. Harris,160
+Sacramento,72436,U.S. Senate,,DEM,Loretta L. Sanchez,74
+Sacramento,72495,U.S. Senate,,DEM,Kamala D. Harris,196
+Sacramento,72495,U.S. Senate,,DEM,Loretta L. Sanchez,103
+Sacramento,72564,U.S. Senate,,DEM,Kamala D. Harris,173
+Sacramento,72564,U.S. Senate,,DEM,Loretta L. Sanchez,70
+Sacramento,72606,U.S. Senate,,DEM,Kamala D. Harris,205
+Sacramento,72606,U.S. Senate,,DEM,Loretta L. Sanchez,82
+Sacramento,72631,U.S. Senate,,DEM,Kamala D. Harris,204
+Sacramento,72631,U.S. Senate,,DEM,Loretta L. Sanchez,76
+Sacramento,72713,U.S. Senate,,DEM,Kamala D. Harris,240
+Sacramento,72713,U.S. Senate,,DEM,Loretta L. Sanchez,104
+Sacramento,72762,U.S. Senate,,DEM,Kamala D. Harris,161
+Sacramento,72762,U.S. Senate,,DEM,Loretta L. Sanchez,103
+Sacramento,72796,U.S. Senate,,DEM,Kamala D. Harris,151
+Sacramento,72796,U.S. Senate,,DEM,Loretta L. Sanchez,88
+Sacramento,72804,U.S. Senate,,DEM,Kamala D. Harris,242
+Sacramento,72804,U.S. Senate,,DEM,Loretta L. Sanchez,106
+Sacramento,72828,U.S. Senate,,DEM,Kamala D. Harris,222
+Sacramento,72828,U.S. Senate,,DEM,Loretta L. Sanchez,92
+Sacramento,72966,U.S. Senate,,DEM,Kamala D. Harris,79
+Sacramento,72966,U.S. Senate,,DEM,Loretta L. Sanchez,59
+Sacramento,73018,U.S. Senate,,DEM,Kamala D. Harris,236
+Sacramento,73018,U.S. Senate,,DEM,Loretta L. Sanchez,108
+Sacramento,73096,U.S. Senate,,DEM,Kamala D. Harris,153
+Sacramento,73096,U.S. Senate,,DEM,Loretta L. Sanchez,91
+Sacramento,73114,U.S. Senate,,DEM,Kamala D. Harris,171
+Sacramento,73114,U.S. Senate,,DEM,Loretta L. Sanchez,79
+Sacramento,73129,U.S. Senate,,DEM,Kamala D. Harris,247
+Sacramento,73129,U.S. Senate,,DEM,Loretta L. Sanchez,173
+Sacramento,73171,U.S. Senate,,DEM,Kamala D. Harris,132
+Sacramento,73171,U.S. Senate,,DEM,Loretta L. Sanchez,78
+Sacramento,73180,U.S. Senate,,DEM,Kamala D. Harris,253
+Sacramento,73180,U.S. Senate,,DEM,Loretta L. Sanchez,147
+Sacramento,73345,U.S. Senate,,DEM,Kamala D. Harris,189
+Sacramento,73345,U.S. Senate,,DEM,Loretta L. Sanchez,107
+Sacramento,73350,U.S. Senate,,DEM,Kamala D. Harris,207
+Sacramento,73350,U.S. Senate,,DEM,Loretta L. Sanchez,129
+Sacramento,73430,U.S. Senate,,DEM,Kamala D. Harris,222
+Sacramento,73430,U.S. Senate,,DEM,Loretta L. Sanchez,133
+Sacramento,73469,U.S. Senate,,DEM,Kamala D. Harris,173
+Sacramento,73469,U.S. Senate,,DEM,Loretta L. Sanchez,107
+Sacramento,73558,U.S. Senate,,DEM,Kamala D. Harris,165
+Sacramento,73558,U.S. Senate,,DEM,Loretta L. Sanchez,93
+Sacramento,73599,U.S. Senate,,DEM,Kamala D. Harris,221
+Sacramento,73599,U.S. Senate,,DEM,Loretta L. Sanchez,109
+Sacramento,73611,U.S. Senate,,DEM,Kamala D. Harris,159
+Sacramento,73611,U.S. Senate,,DEM,Loretta L. Sanchez,91
+Sacramento,73662,U.S. Senate,,DEM,Kamala D. Harris,227
+Sacramento,73662,U.S. Senate,,DEM,Loretta L. Sanchez,125
+Sacramento,73700,U.S. Senate,,DEM,Kamala D. Harris,263
+Sacramento,73700,U.S. Senate,,DEM,Loretta L. Sanchez,133
+Sacramento,73723,U.S. Senate,,DEM,Kamala D. Harris,151
+Sacramento,73723,U.S. Senate,,DEM,Loretta L. Sanchez,100
+Sacramento,73817,U.S. Senate,,DEM,Kamala D. Harris,232
+Sacramento,73817,U.S. Senate,,DEM,Loretta L. Sanchez,129
+Sacramento,73849,U.S. Senate,,DEM,Kamala D. Harris,187
+Sacramento,73849,U.S. Senate,,DEM,Loretta L. Sanchez,103
+Sacramento,73972,U.S. Senate,,DEM,Kamala D. Harris,209
+Sacramento,73972,U.S. Senate,,DEM,Loretta L. Sanchez,97
+Sacramento,74135,U.S. Senate,,DEM,Kamala D. Harris,34
+Sacramento,74135,U.S. Senate,,DEM,Loretta L. Sanchez,31
+Sacramento,74266,U.S. Senate,,DEM,Kamala D. Harris,107
+Sacramento,74266,U.S. Senate,,DEM,Loretta L. Sanchez,82
+Sacramento,74561,U.S. Senate,,DEM,Kamala D. Harris,19
+Sacramento,74561,U.S. Senate,,DEM,Loretta L. Sanchez,27
+Sacramento,74802,U.S. Senate,,DEM,Kamala D. Harris,0
+Sacramento,74802,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sacramento,75490,U.S. Senate,,DEM,Kamala D. Harris,0
+Sacramento,75490,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sacramento,75621,U.S. Senate,,DEM,Kamala D. Harris,49
+Sacramento,75621,U.S. Senate,,DEM,Loretta L. Sanchez,62
+Sacramento,76733,U.S. Senate,,DEM,Kamala D. Harris,20
+Sacramento,76733,U.S. Senate,,DEM,Loretta L. Sanchez,23
+Sacramento,77164,U.S. Senate,,DEM,Kamala D. Harris,90
+Sacramento,77164,U.S. Senate,,DEM,Loretta L. Sanchez,55
+Sacramento,77380,U.S. Senate,,DEM,Kamala D. Harris,48
+Sacramento,77380,U.S. Senate,,DEM,Loretta L. Sanchez,44
+Sacramento,78116,U.S. Senate,,DEM,Kamala D. Harris,29
+Sacramento,78116,U.S. Senate,,DEM,Loretta L. Sanchez,26
+Sacramento,78342,U.S. Senate,,DEM,Kamala D. Harris,78
+Sacramento,78342,U.S. Senate,,DEM,Loretta L. Sanchez,71
+Sacramento,78428,U.S. Senate,,DEM,Kamala D. Harris,23
+Sacramento,78428,U.S. Senate,,DEM,Loretta L. Sanchez,22
+Sacramento,8011974,U.S. Senate,,DEM,Kamala D. Harris,354
+Sacramento,8011974,U.S. Senate,,DEM,Loretta L. Sanchez,140
+Sacramento,8012669,U.S. Senate,,DEM,Kamala D. Harris,665
+Sacramento,8012669,U.S. Senate,,DEM,Loretta L. Sanchez,228
+Sacramento,8012681,U.S. Senate,,DEM,Kamala D. Harris,364
+Sacramento,8012681,U.S. Senate,,DEM,Loretta L. Sanchez,163
+Sacramento,8012702,U.S. Senate,,DEM,Kamala D. Harris,508
+Sacramento,8012702,U.S. Senate,,DEM,Loretta L. Sanchez,183
+Sacramento,8012747,U.S. Senate,,DEM,Kamala D. Harris,487
+Sacramento,8012747,U.S. Senate,,DEM,Loretta L. Sanchez,175
+Sacramento,8012786,U.S. Senate,,DEM,Kamala D. Harris,541
+Sacramento,8012786,U.S. Senate,,DEM,Loretta L. Sanchez,153
+Sacramento,8012807,U.S. Senate,,DEM,Kamala D. Harris,346
+Sacramento,8012807,U.S. Senate,,DEM,Loretta L. Sanchez,140
+Sacramento,8012884,U.S. Senate,,DEM,Kamala D. Harris,400
+Sacramento,8012884,U.S. Senate,,DEM,Loretta L. Sanchez,161
+Sacramento,8013032,U.S. Senate,,DEM,Kamala D. Harris,344
+Sacramento,8013032,U.S. Senate,,DEM,Loretta L. Sanchez,207
+Sacramento,8013328,U.S. Senate,,DEM,Kamala D. Harris,377
+Sacramento,8013328,U.S. Senate,,DEM,Loretta L. Sanchez,274
+Sacramento,8013424,U.S. Senate,,DEM,Kamala D. Harris,301
+Sacramento,8013424,U.S. Senate,,DEM,Loretta L. Sanchez,196
+Sacramento,8013551,U.S. Senate,,DEM,Kamala D. Harris,259
+Sacramento,8013551,U.S. Senate,,DEM,Loretta L. Sanchez,168
+Sacramento,8013635,U.S. Senate,,DEM,Kamala D. Harris,333
+Sacramento,8013635,U.S. Senate,,DEM,Loretta L. Sanchez,257
+Sacramento,8013658,U.S. Senate,,DEM,Kamala D. Harris,333
+Sacramento,8013658,U.S. Senate,,DEM,Loretta L. Sanchez,178
+Sacramento,8013706,U.S. Senate,,DEM,Kamala D. Harris,197
+Sacramento,8013706,U.S. Senate,,DEM,Loretta L. Sanchez,160
+Sacramento,8013993,U.S. Senate,,DEM,Kamala D. Harris,150
+Sacramento,8013993,U.S. Senate,,DEM,Loretta L. Sanchez,113
+Sacramento,8014314,U.S. Senate,,DEM,Kamala D. Harris,696
+Sacramento,8014314,U.S. Senate,,DEM,Loretta L. Sanchez,251
+Sacramento,8014502,U.S. Senate,,DEM,Kamala D. Harris,380
+Sacramento,8014502,U.S. Senate,,DEM,Loretta L. Sanchez,130
+Sacramento,8014564,U.S. Senate,,DEM,Kamala D. Harris,278
+Sacramento,8014564,U.S. Senate,,DEM,Loretta L. Sanchez,129
+Sacramento,8014693,U.S. Senate,,DEM,Kamala D. Harris,518
+Sacramento,8014693,U.S. Senate,,DEM,Loretta L. Sanchez,214
+Sacramento,8014820,U.S. Senate,,DEM,Kamala D. Harris,493
+Sacramento,8014820,U.S. Senate,,DEM,Loretta L. Sanchez,214
+Sacramento,8014971,U.S. Senate,,DEM,Kamala D. Harris,460
+Sacramento,8014971,U.S. Senate,,DEM,Loretta L. Sanchez,183
+Sacramento,8015018,U.S. Senate,,DEM,Kamala D. Harris,518
+Sacramento,8015018,U.S. Senate,,DEM,Loretta L. Sanchez,207
+Sacramento,8015102,U.S. Senate,,DEM,Kamala D. Harris,642
+Sacramento,8015102,U.S. Senate,,DEM,Loretta L. Sanchez,228
+Sacramento,8015287,U.S. Senate,,DEM,Kamala D. Harris,493
+Sacramento,8015287,U.S. Senate,,DEM,Loretta L. Sanchez,230
+Sacramento,8015321,U.S. Senate,,DEM,Kamala D. Harris,502
+Sacramento,8015321,U.S. Senate,,DEM,Loretta L. Sanchez,208
+Sacramento,8015530,U.S. Senate,,DEM,Kamala D. Harris,239
+Sacramento,8015530,U.S. Senate,,DEM,Loretta L. Sanchez,126
+Sacramento,8015749,U.S. Senate,,DEM,Kamala D. Harris,534
+Sacramento,8015749,U.S. Senate,,DEM,Loretta L. Sanchez,214
+Sacramento,8016002,U.S. Senate,,DEM,Kamala D. Harris,438
+Sacramento,8016002,U.S. Senate,,DEM,Loretta L. Sanchez,262
+Sacramento,8016107,U.S. Senate,,DEM,Kamala D. Harris,329
+Sacramento,8016107,U.S. Senate,,DEM,Loretta L. Sanchez,197
+Sacramento,8016318,U.S. Senate,,DEM,Kamala D. Harris,187
+Sacramento,8016318,U.S. Senate,,DEM,Loretta L. Sanchez,143
+Sacramento,8016463,U.S. Senate,,DEM,Kamala D. Harris,246
+Sacramento,8016463,U.S. Senate,,DEM,Loretta L. Sanchez,201
+Sacramento,8016573,U.S. Senate,,DEM,Kamala D. Harris,333
+Sacramento,8016573,U.S. Senate,,DEM,Loretta L. Sanchez,198
+Sacramento,8016801,U.S. Senate,,DEM,Kamala D. Harris,329
+Sacramento,8016801,U.S. Senate,,DEM,Loretta L. Sanchez,188
+Sacramento,8016836,U.S. Senate,,DEM,Kamala D. Harris,282
+Sacramento,8016836,U.S. Senate,,DEM,Loretta L. Sanchez,154
+Sacramento,8016869,U.S. Senate,,DEM,Kamala D. Harris,219
+Sacramento,8016869,U.S. Senate,,DEM,Loretta L. Sanchez,106
+Sacramento,8016944,U.S. Senate,,DEM,Kamala D. Harris,228
+Sacramento,8016944,U.S. Senate,,DEM,Loretta L. Sanchez,143
+Sacramento,8017428,U.S. Senate,,DEM,Kamala D. Harris,444
+Sacramento,8017428,U.S. Senate,,DEM,Loretta L. Sanchez,167
+Sacramento,8017512,U.S. Senate,,DEM,Kamala D. Harris,353
+Sacramento,8017512,U.S. Senate,,DEM,Loretta L. Sanchez,152
+Sacramento,8017630,U.S. Senate,,DEM,Kamala D. Harris,637
+Sacramento,8017630,U.S. Senate,,DEM,Loretta L. Sanchez,199
+Sacramento,8018012,U.S. Senate,,DEM,Kamala D. Harris,254
+Sacramento,8018012,U.S. Senate,,DEM,Loretta L. Sanchez,118
+Sacramento,8018119,U.S. Senate,,DEM,Kamala D. Harris,335
+Sacramento,8018119,U.S. Senate,,DEM,Loretta L. Sanchez,205
+Sacramento,8018143,U.S. Senate,,DEM,Kamala D. Harris,383
+Sacramento,8018143,U.S. Senate,,DEM,Loretta L. Sanchez,173
+Sacramento,8018213,U.S. Senate,,DEM,Kamala D. Harris,462
+Sacramento,8018213,U.S. Senate,,DEM,Loretta L. Sanchez,194
+Sacramento,8018220,U.S. Senate,,DEM,Kamala D. Harris,475
+Sacramento,8018220,U.S. Senate,,DEM,Loretta L. Sanchez,251
+Sacramento,8018385,U.S. Senate,,DEM,Kamala D. Harris,395
+Sacramento,8018385,U.S. Senate,,DEM,Loretta L. Sanchez,169
+Sacramento,8018501,U.S. Senate,,DEM,Kamala D. Harris,286
+Sacramento,8018501,U.S. Senate,,DEM,Loretta L. Sanchez,170
+Sacramento,8018562,U.S. Senate,,DEM,Kamala D. Harris,305
+Sacramento,8018562,U.S. Senate,,DEM,Loretta L. Sanchez,200
+Sacramento,8018588,U.S. Senate,,DEM,Kamala D. Harris,402
+Sacramento,8018588,U.S. Senate,,DEM,Loretta L. Sanchez,263
+Sacramento,8018791,U.S. Senate,,DEM,Kamala D. Harris,273
+Sacramento,8018791,U.S. Senate,,DEM,Loretta L. Sanchez,199
+Sacramento,8018840,U.S. Senate,,DEM,Kamala D. Harris,445
+Sacramento,8018840,U.S. Senate,,DEM,Loretta L. Sanchez,239
+Sacramento,8019081,U.S. Senate,,DEM,Kamala D. Harris,159
+Sacramento,8019081,U.S. Senate,,DEM,Loretta L. Sanchez,125
+Sacramento,8019319,U.S. Senate,,DEM,Kamala D. Harris,238
+Sacramento,8019319,U.S. Senate,,DEM,Loretta L. Sanchez,188
+Sacramento,8019325,U.S. Senate,,DEM,Kamala D. Harris,288
+Sacramento,8019325,U.S. Senate,,DEM,Loretta L. Sanchez,183
+Sacramento,8019427,U.S. Senate,,DEM,Kamala D. Harris,227
+Sacramento,8019427,U.S. Senate,,DEM,Loretta L. Sanchez,152
+Sacramento,8019455,U.S. Senate,,DEM,Kamala D. Harris,286
+Sacramento,8019455,U.S. Senate,,DEM,Loretta L. Sanchez,185
+Sacramento,8019532,U.S. Senate,,DEM,Kamala D. Harris,261
+Sacramento,8019532,U.S. Senate,,DEM,Loretta L. Sanchez,157
+Sacramento,8019646,U.S. Senate,,DEM,Kamala D. Harris,369
+Sacramento,8019646,U.S. Senate,,DEM,Loretta L. Sanchez,130
+Sacramento,8019685,U.S. Senate,,DEM,Kamala D. Harris,96
+Sacramento,8019685,U.S. Senate,,DEM,Loretta L. Sanchez,70
+Sacramento,8019800,U.S. Senate,,DEM,Kamala D. Harris,246
+Sacramento,8019800,U.S. Senate,,DEM,Loretta L. Sanchez,169
+Sacramento,8019948,U.S. Senate,,DEM,Kamala D. Harris,149
+Sacramento,8019948,U.S. Senate,,DEM,Loretta L. Sanchez,75
+Sacramento,8021013,U.S. Senate,,DEM,Kamala D. Harris,445
+Sacramento,8021013,U.S. Senate,,DEM,Loretta L. Sanchez,280
+Sacramento,8021065,U.S. Senate,,DEM,Kamala D. Harris,364
+Sacramento,8021065,U.S. Senate,,DEM,Loretta L. Sanchez,214
+Sacramento,8021134,U.S. Senate,,DEM,Kamala D. Harris,351
+Sacramento,8021134,U.S. Senate,,DEM,Loretta L. Sanchez,196
+Sacramento,8021159,U.S. Senate,,DEM,Kamala D. Harris,478
+Sacramento,8021159,U.S. Senate,,DEM,Loretta L. Sanchez,265
+Sacramento,8021203,U.S. Senate,,DEM,Kamala D. Harris,154
+Sacramento,8021203,U.S. Senate,,DEM,Loretta L. Sanchez,100
+Sacramento,8021231,U.S. Senate,,DEM,Kamala D. Harris,243
+Sacramento,8021231,U.S. Senate,,DEM,Loretta L. Sanchez,102
+Sacramento,8021318,U.S. Senate,,DEM,Kamala D. Harris,204
+Sacramento,8021318,U.S. Senate,,DEM,Loretta L. Sanchez,117
+Sacramento,8021362,U.S. Senate,,DEM,Kamala D. Harris,281
+Sacramento,8021362,U.S. Senate,,DEM,Loretta L. Sanchez,165
+Sacramento,8021489,U.S. Senate,,DEM,Kamala D. Harris,414
+Sacramento,8021489,U.S. Senate,,DEM,Loretta L. Sanchez,244
+Sacramento,8021615,U.S. Senate,,DEM,Kamala D. Harris,242
+Sacramento,8021615,U.S. Senate,,DEM,Loretta L. Sanchez,168
+Sacramento,8021621,U.S. Senate,,DEM,Kamala D. Harris,347
+Sacramento,8021621,U.S. Senate,,DEM,Loretta L. Sanchez,218
+Sacramento,8021800,U.S. Senate,,DEM,Kamala D. Harris,290
+Sacramento,8021800,U.S. Senate,,DEM,Loretta L. Sanchez,204
+Sacramento,8021846,U.S. Senate,,DEM,Kamala D. Harris,245
+Sacramento,8021846,U.S. Senate,,DEM,Loretta L. Sanchez,157
+Sacramento,8021895,U.S. Senate,,DEM,Kamala D. Harris,405
+Sacramento,8021895,U.S. Senate,,DEM,Loretta L. Sanchez,208
+Sacramento,8021961,U.S. Senate,,DEM,Kamala D. Harris,244
+Sacramento,8021961,U.S. Senate,,DEM,Loretta L. Sanchez,186
+Sacramento,8022003,U.S. Senate,,DEM,Kamala D. Harris,237
+Sacramento,8022003,U.S. Senate,,DEM,Loretta L. Sanchez,156
+Sacramento,8022034,U.S. Senate,,DEM,Kamala D. Harris,252
+Sacramento,8022034,U.S. Senate,,DEM,Loretta L. Sanchez,181
+Sacramento,8022061,U.S. Senate,,DEM,Kamala D. Harris,406
+Sacramento,8022061,U.S. Senate,,DEM,Loretta L. Sanchez,227
+Sacramento,8022090,U.S. Senate,,DEM,Kamala D. Harris,287
+Sacramento,8022090,U.S. Senate,,DEM,Loretta L. Sanchez,169
+Sacramento,8022139,U.S. Senate,,DEM,Kamala D. Harris,332
+Sacramento,8022139,U.S. Senate,,DEM,Loretta L. Sanchez,220
+Sacramento,8022143,U.S. Senate,,DEM,Kamala D. Harris,368
+Sacramento,8022143,U.S. Senate,,DEM,Loretta L. Sanchez,165
+Sacramento,8022396,U.S. Senate,,DEM,Kamala D. Harris,147
+Sacramento,8022396,U.S. Senate,,DEM,Loretta L. Sanchez,83
+Sacramento,8022453,U.S. Senate,,DEM,Kamala D. Harris,423
+Sacramento,8022453,U.S. Senate,,DEM,Loretta L. Sanchez,231
+Sacramento,8022464,U.S. Senate,,DEM,Kamala D. Harris,413
+Sacramento,8022464,U.S. Senate,,DEM,Loretta L. Sanchez,193
+Sacramento,8022533,U.S. Senate,,DEM,Kamala D. Harris,234
+Sacramento,8022533,U.S. Senate,,DEM,Loretta L. Sanchez,120
+Sacramento,8022552,U.S. Senate,,DEM,Kamala D. Harris,266
+Sacramento,8022552,U.S. Senate,,DEM,Loretta L. Sanchez,189
+Sacramento,8022599,U.S. Senate,,DEM,Kamala D. Harris,328
+Sacramento,8022599,U.S. Senate,,DEM,Loretta L. Sanchez,164
+Sacramento,8022610,U.S. Senate,,DEM,Kamala D. Harris,251
+Sacramento,8022610,U.S. Senate,,DEM,Loretta L. Sanchez,111
+Sacramento,8022694,U.S. Senate,,DEM,Kamala D. Harris,284
+Sacramento,8022694,U.S. Senate,,DEM,Loretta L. Sanchez,141
+Sacramento,8022709,U.S. Senate,,DEM,Kamala D. Harris,397
+Sacramento,8022709,U.S. Senate,,DEM,Loretta L. Sanchez,191
+Sacramento,8022730,U.S. Senate,,DEM,Kamala D. Harris,410
+Sacramento,8022730,U.S. Senate,,DEM,Loretta L. Sanchez,216
+Sacramento,8022824,U.S. Senate,,DEM,Kamala D. Harris,271
+Sacramento,8022824,U.S. Senate,,DEM,Loretta L. Sanchez,117
+Sacramento,8022847,U.S. Senate,,DEM,Kamala D. Harris,258
+Sacramento,8022847,U.S. Senate,,DEM,Loretta L. Sanchez,129
+Sacramento,8022873,U.S. Senate,,DEM,Kamala D. Harris,325
+Sacramento,8022873,U.S. Senate,,DEM,Loretta L. Sanchez,196
+Sacramento,8023002,U.S. Senate,,DEM,Kamala D. Harris,424
+Sacramento,8023002,U.S. Senate,,DEM,Loretta L. Sanchez,246
+Sacramento,8023077,U.S. Senate,,DEM,Kamala D. Harris,399
+Sacramento,8023077,U.S. Senate,,DEM,Loretta L. Sanchez,244
+Sacramento,8023240,U.S. Senate,,DEM,Kamala D. Harris,399
+Sacramento,8023240,U.S. Senate,,DEM,Loretta L. Sanchez,253
+Sacramento,8023264,U.S. Senate,,DEM,Kamala D. Harris,185
+Sacramento,8023264,U.S. Senate,,DEM,Loretta L. Sanchez,147
+Sacramento,8023313,U.S. Senate,,DEM,Kamala D. Harris,488
+Sacramento,8023313,U.S. Senate,,DEM,Loretta L. Sanchez,273
+Sacramento,8023423,U.S. Senate,,DEM,Kamala D. Harris,327
+Sacramento,8023423,U.S. Senate,,DEM,Loretta L. Sanchez,209
+Sacramento,8023519,U.S. Senate,,DEM,Kamala D. Harris,350
+Sacramento,8023519,U.S. Senate,,DEM,Loretta L. Sanchez,216
+Sacramento,8023542,U.S. Senate,,DEM,Kamala D. Harris,482
+Sacramento,8023542,U.S. Senate,,DEM,Loretta L. Sanchez,238
+Sacramento,8023637,U.S. Senate,,DEM,Kamala D. Harris,495
+Sacramento,8023637,U.S. Senate,,DEM,Loretta L. Sanchez,261
+Sacramento,8023733,U.S. Senate,,DEM,Kamala D. Harris,538
+Sacramento,8023733,U.S. Senate,,DEM,Loretta L. Sanchez,307
+Sacramento,8023769,U.S. Senate,,DEM,Kamala D. Harris,443
+Sacramento,8023769,U.S. Senate,,DEM,Loretta L. Sanchez,257
+Sacramento,8023879,U.S. Senate,,DEM,Kamala D. Harris,428
+Sacramento,8023879,U.S. Senate,,DEM,Loretta L. Sanchez,215
+Sacramento,8023905,U.S. Senate,,DEM,Kamala D. Harris,306
+Sacramento,8023905,U.S. Senate,,DEM,Loretta L. Sanchez,172
+Sacramento,8023970,U.S. Senate,,DEM,Kamala D. Harris,347
+Sacramento,8023970,U.S. Senate,,DEM,Loretta L. Sanchez,144
+Sacramento,8024148,U.S. Senate,,DEM,Kamala D. Harris,417
+Sacramento,8024148,U.S. Senate,,DEM,Loretta L. Sanchez,215
+Sacramento,8024182,U.S. Senate,,DEM,Kamala D. Harris,252
+Sacramento,8024182,U.S. Senate,,DEM,Loretta L. Sanchez,144
+Sacramento,8024352,U.S. Senate,,DEM,Kamala D. Harris,430
+Sacramento,8024352,U.S. Senate,,DEM,Loretta L. Sanchez,237
+Sacramento,8024500,U.S. Senate,,DEM,Kamala D. Harris,303
+Sacramento,8024500,U.S. Senate,,DEM,Loretta L. Sanchez,163
+Sacramento,8024557,U.S. Senate,,DEM,Kamala D. Harris,385
+Sacramento,8024557,U.S. Senate,,DEM,Loretta L. Sanchez,203
+Sacramento,8024651,U.S. Senate,,DEM,Kamala D. Harris,252
+Sacramento,8024651,U.S. Senate,,DEM,Loretta L. Sanchez,172
+Sacramento,8024669,U.S. Senate,,DEM,Kamala D. Harris,342
+Sacramento,8024669,U.S. Senate,,DEM,Loretta L. Sanchez,180
+Sacramento,8024684,U.S. Senate,,DEM,Kamala D. Harris,286
+Sacramento,8024684,U.S. Senate,,DEM,Loretta L. Sanchez,128
+Sacramento,8024739,U.S. Senate,,DEM,Kamala D. Harris,417
+Sacramento,8024739,U.S. Senate,,DEM,Loretta L. Sanchez,211
+Sacramento,8024801,U.S. Senate,,DEM,Kamala D. Harris,486
+Sacramento,8024801,U.S. Senate,,DEM,Loretta L. Sanchez,235
+Sacramento,8024874,U.S. Senate,,DEM,Kamala D. Harris,440
+Sacramento,8024874,U.S. Senate,,DEM,Loretta L. Sanchez,175
+Sacramento,8024908,U.S. Senate,,DEM,Kamala D. Harris,443
+Sacramento,8024908,U.S. Senate,,DEM,Loretta L. Sanchez,169
+Sacramento,8024927,U.S. Senate,,DEM,Kamala D. Harris,336
+Sacramento,8024927,U.S. Senate,,DEM,Loretta L. Sanchez,162
+Sacramento,8025011,U.S. Senate,,DEM,Kamala D. Harris,163
+Sacramento,8025011,U.S. Senate,,DEM,Loretta L. Sanchez,93
+Sacramento,8025076,U.S. Senate,,DEM,Kamala D. Harris,350
+Sacramento,8025076,U.S. Senate,,DEM,Loretta L. Sanchez,195
+Sacramento,8025155,U.S. Senate,,DEM,Kamala D. Harris,457
+Sacramento,8025155,U.S. Senate,,DEM,Loretta L. Sanchez,211
+Sacramento,8025234,U.S. Senate,,DEM,Kamala D. Harris,304
+Sacramento,8025234,U.S. Senate,,DEM,Loretta L. Sanchez,170
+Sacramento,8025432,U.S. Senate,,DEM,Kamala D. Harris,474
+Sacramento,8025432,U.S. Senate,,DEM,Loretta L. Sanchez,210
+Sacramento,8025501,U.S. Senate,,DEM,Kamala D. Harris,331
+Sacramento,8025501,U.S. Senate,,DEM,Loretta L. Sanchez,147
+Sacramento,8025536,U.S. Senate,,DEM,Kamala D. Harris,369
+Sacramento,8025536,U.S. Senate,,DEM,Loretta L. Sanchez,162
+Sacramento,8025588,U.S. Senate,,DEM,Kamala D. Harris,525
+Sacramento,8025588,U.S. Senate,,DEM,Loretta L. Sanchez,241
+Sacramento,8025696,U.S. Senate,,DEM,Kamala D. Harris,442
+Sacramento,8025696,U.S. Senate,,DEM,Loretta L. Sanchez,205
+Sacramento,8025703,U.S. Senate,,DEM,Kamala D. Harris,275
+Sacramento,8025703,U.S. Senate,,DEM,Loretta L. Sanchez,129
+Sacramento,8025741,U.S. Senate,,DEM,Kamala D. Harris,316
+Sacramento,8025741,U.S. Senate,,DEM,Loretta L. Sanchez,139
+Sacramento,8025812,U.S. Senate,,DEM,Kamala D. Harris,281
+Sacramento,8025812,U.S. Senate,,DEM,Loretta L. Sanchez,138
+Sacramento,8025845,U.S. Senate,,DEM,Kamala D. Harris,336
+Sacramento,8025845,U.S. Senate,,DEM,Loretta L. Sanchez,184
+Sacramento,8025919,U.S. Senate,,DEM,Kamala D. Harris,432
+Sacramento,8025919,U.S. Senate,,DEM,Loretta L. Sanchez,204
+Sacramento,8025935,U.S. Senate,,DEM,Kamala D. Harris,525
+Sacramento,8025935,U.S. Senate,,DEM,Loretta L. Sanchez,276
+Sacramento,8025990,U.S. Senate,,DEM,Kamala D. Harris,282
+Sacramento,8025990,U.S. Senate,,DEM,Loretta L. Sanchez,127
+Sacramento,8026069,U.S. Senate,,DEM,Kamala D. Harris,474
+Sacramento,8026069,U.S. Senate,,DEM,Loretta L. Sanchez,273
+Sacramento,8026086,U.S. Senate,,DEM,Kamala D. Harris,203
+Sacramento,8026086,U.S. Senate,,DEM,Loretta L. Sanchez,91
+Sacramento,8026171,U.S. Senate,,DEM,Kamala D. Harris,319
+Sacramento,8026171,U.S. Senate,,DEM,Loretta L. Sanchez,220
+Sacramento,8026413,U.S. Senate,,DEM,Kamala D. Harris,325
+Sacramento,8026413,U.S. Senate,,DEM,Loretta L. Sanchez,129
+Sacramento,8026442,U.S. Senate,,DEM,Kamala D. Harris,319
+Sacramento,8026442,U.S. Senate,,DEM,Loretta L. Sanchez,160
+Sacramento,8026512,U.S. Senate,,DEM,Kamala D. Harris,378
+Sacramento,8026512,U.S. Senate,,DEM,Loretta L. Sanchez,194
+Sacramento,8026597,U.S. Senate,,DEM,Kamala D. Harris,233
+Sacramento,8026597,U.S. Senate,,DEM,Loretta L. Sanchez,106
+Sacramento,8026625,U.S. Senate,,DEM,Kamala D. Harris,509
+Sacramento,8026625,U.S. Senate,,DEM,Loretta L. Sanchez,224
+Sacramento,8026715,U.S. Senate,,DEM,Kamala D. Harris,466
+Sacramento,8026715,U.S. Senate,,DEM,Loretta L. Sanchez,202
+Sacramento,8026747,U.S. Senate,,DEM,Kamala D. Harris,338
+Sacramento,8026747,U.S. Senate,,DEM,Loretta L. Sanchez,191
+Sacramento,8026808,U.S. Senate,,DEM,Kamala D. Harris,449
+Sacramento,8026808,U.S. Senate,,DEM,Loretta L. Sanchez,219
+Sacramento,8026830,U.S. Senate,,DEM,Kamala D. Harris,389
+Sacramento,8026830,U.S. Senate,,DEM,Loretta L. Sanchez,198
+Sacramento,8026916,U.S. Senate,,DEM,Kamala D. Harris,471
+Sacramento,8026916,U.S. Senate,,DEM,Loretta L. Sanchez,230
+Sacramento,8026978,U.S. Senate,,DEM,Kamala D. Harris,322
+Sacramento,8026978,U.S. Senate,,DEM,Loretta L. Sanchez,156
+Sacramento,8027046,U.S. Senate,,DEM,Kamala D. Harris,332
+Sacramento,8027046,U.S. Senate,,DEM,Loretta L. Sanchez,155
+Sacramento,8027098,U.S. Senate,,DEM,Kamala D. Harris,270
+Sacramento,8027098,U.S. Senate,,DEM,Loretta L. Sanchez,118
+Sacramento,8027100,U.S. Senate,,DEM,Kamala D. Harris,318
+Sacramento,8027100,U.S. Senate,,DEM,Loretta L. Sanchez,156
+Sacramento,8027212,U.S. Senate,,DEM,Kamala D. Harris,298
+Sacramento,8027212,U.S. Senate,,DEM,Loretta L. Sanchez,137
+Sacramento,8027223,U.S. Senate,,DEM,Kamala D. Harris,417
+Sacramento,8027223,U.S. Senate,,DEM,Loretta L. Sanchez,178
+Sacramento,8027320,U.S. Senate,,DEM,Kamala D. Harris,290
+Sacramento,8027320,U.S. Senate,,DEM,Loretta L. Sanchez,167
+Sacramento,8027506,U.S. Senate,,DEM,Kamala D. Harris,424
+Sacramento,8027506,U.S. Senate,,DEM,Loretta L. Sanchez,153
+Sacramento,8027602,U.S. Senate,,DEM,Kamala D. Harris,487
+Sacramento,8027602,U.S. Senate,,DEM,Loretta L. Sanchez,207
+Sacramento,8027648,U.S. Senate,,DEM,Kamala D. Harris,476
+Sacramento,8027648,U.S. Senate,,DEM,Loretta L. Sanchez,239
+Sacramento,8027719,U.S. Senate,,DEM,Kamala D. Harris,549
+Sacramento,8027719,U.S. Senate,,DEM,Loretta L. Sanchez,182
+Sacramento,8027721,U.S. Senate,,DEM,Kamala D. Harris,317
+Sacramento,8027721,U.S. Senate,,DEM,Loretta L. Sanchez,126
+Sacramento,8027915,U.S. Senate,,DEM,Kamala D. Harris,218
+Sacramento,8027915,U.S. Senate,,DEM,Loretta L. Sanchez,96
+Sacramento,8027971,U.S. Senate,,DEM,Kamala D. Harris,399
+Sacramento,8027971,U.S. Senate,,DEM,Loretta L. Sanchez,179
+Sacramento,8028014,U.S. Senate,,DEM,Kamala D. Harris,517
+Sacramento,8028014,U.S. Senate,,DEM,Loretta L. Sanchez,211
+Sacramento,8028200,U.S. Senate,,DEM,Kamala D. Harris,417
+Sacramento,8028200,U.S. Senate,,DEM,Loretta L. Sanchez,164
+Sacramento,8028299,U.S. Senate,,DEM,Kamala D. Harris,267
+Sacramento,8028299,U.S. Senate,,DEM,Loretta L. Sanchez,142
+Sacramento,8028368,U.S. Senate,,DEM,Kamala D. Harris,373
+Sacramento,8028368,U.S. Senate,,DEM,Loretta L. Sanchez,169
+Sacramento,8028392,U.S. Senate,,DEM,Kamala D. Harris,488
+Sacramento,8028392,U.S. Senate,,DEM,Loretta L. Sanchez,225
+Sacramento,8028417,U.S. Senate,,DEM,Kamala D. Harris,277
+Sacramento,8028417,U.S. Senate,,DEM,Loretta L. Sanchez,124
+Sacramento,8028522,U.S. Senate,,DEM,Kamala D. Harris,251
+Sacramento,8028522,U.S. Senate,,DEM,Loretta L. Sanchez,88
+Sacramento,8028530,U.S. Senate,,DEM,Kamala D. Harris,530
+Sacramento,8028530,U.S. Senate,,DEM,Loretta L. Sanchez,205
+Sacramento,8028656,U.S. Senate,,DEM,Kamala D. Harris,547
+Sacramento,8028656,U.S. Senate,,DEM,Loretta L. Sanchez,226
+Sacramento,8028773,U.S. Senate,,DEM,Kamala D. Harris,430
+Sacramento,8028773,U.S. Senate,,DEM,Loretta L. Sanchez,231
+Sacramento,8028809,U.S. Senate,,DEM,Kamala D. Harris,390
+Sacramento,8028809,U.S. Senate,,DEM,Loretta L. Sanchez,151
+Sacramento,8028939,U.S. Senate,,DEM,Kamala D. Harris,450
+Sacramento,8028939,U.S. Senate,,DEM,Loretta L. Sanchez,199
+Sacramento,8029043,U.S. Senate,,DEM,Kamala D. Harris,268
+Sacramento,8029043,U.S. Senate,,DEM,Loretta L. Sanchez,120
+Sacramento,8029128,U.S. Senate,,DEM,Kamala D. Harris,391
+Sacramento,8029128,U.S. Senate,,DEM,Loretta L. Sanchez,168
+Sacramento,8029205,U.S. Senate,,DEM,Kamala D. Harris,534
+Sacramento,8029205,U.S. Senate,,DEM,Loretta L. Sanchez,256
+Sacramento,8029298,U.S. Senate,,DEM,Kamala D. Harris,543
+Sacramento,8029298,U.S. Senate,,DEM,Loretta L. Sanchez,217
+Sacramento,8029434,U.S. Senate,,DEM,Kamala D. Harris,526
+Sacramento,8029434,U.S. Senate,,DEM,Loretta L. Sanchez,206
+Sacramento,8029661,U.S. Senate,,DEM,Kamala D. Harris,417
+Sacramento,8029661,U.S. Senate,,DEM,Loretta L. Sanchez,212
+Sacramento,8029825,U.S. Senate,,DEM,Kamala D. Harris,259
+Sacramento,8029825,U.S. Senate,,DEM,Loretta L. Sanchez,121
+Sacramento,8029848,U.S. Senate,,DEM,Kamala D. Harris,483
+Sacramento,8029848,U.S. Senate,,DEM,Loretta L. Sanchez,186
+Sacramento,8031066,U.S. Senate,,DEM,Kamala D. Harris,415
+Sacramento,8031066,U.S. Senate,,DEM,Loretta L. Sanchez,239
+Sacramento,8031082,U.S. Senate,,DEM,Kamala D. Harris,208
+Sacramento,8031082,U.S. Senate,,DEM,Loretta L. Sanchez,125
+Sacramento,8031193,U.S. Senate,,DEM,Kamala D. Harris,452
+Sacramento,8031193,U.S. Senate,,DEM,Loretta L. Sanchez,253
+Sacramento,8031271,U.S. Senate,,DEM,Kamala D. Harris,469
+Sacramento,8031271,U.S. Senate,,DEM,Loretta L. Sanchez,293
+Sacramento,8031348,U.S. Senate,,DEM,Kamala D. Harris,486
+Sacramento,8031348,U.S. Senate,,DEM,Loretta L. Sanchez,242
+Sacramento,8031432,U.S. Senate,,DEM,Kamala D. Harris,251
+Sacramento,8031432,U.S. Senate,,DEM,Loretta L. Sanchez,172
+Sacramento,8031461,U.S. Senate,,DEM,Kamala D. Harris,410
+Sacramento,8031461,U.S. Senate,,DEM,Loretta L. Sanchez,250
+Sacramento,8031538,U.S. Senate,,DEM,Kamala D. Harris,283
+Sacramento,8031538,U.S. Senate,,DEM,Loretta L. Sanchez,182
+Sacramento,8031574,U.S. Senate,,DEM,Kamala D. Harris,385
+Sacramento,8031574,U.S. Senate,,DEM,Loretta L. Sanchez,244
+Sacramento,8031631,U.S. Senate,,DEM,Kamala D. Harris,297
+Sacramento,8031631,U.S. Senate,,DEM,Loretta L. Sanchez,188
+Sacramento,8031662,U.S. Senate,,DEM,Kamala D. Harris,354
+Sacramento,8031662,U.S. Senate,,DEM,Loretta L. Sanchez,205
+Sacramento,8031765,U.S. Senate,,DEM,Kamala D. Harris,265
+Sacramento,8031765,U.S. Senate,,DEM,Loretta L. Sanchez,129
+Sacramento,8031839,U.S. Senate,,DEM,Kamala D. Harris,362
+Sacramento,8031839,U.S. Senate,,DEM,Loretta L. Sanchez,216
+Sacramento,8031900,U.S. Senate,,DEM,Kamala D. Harris,343
+Sacramento,8031900,U.S. Senate,,DEM,Loretta L. Sanchez,193
+Sacramento,8031994,U.S. Senate,,DEM,Kamala D. Harris,252
+Sacramento,8031994,U.S. Senate,,DEM,Loretta L. Sanchez,201
+Sacramento,8032101,U.S. Senate,,DEM,Kamala D. Harris,298
+Sacramento,8032101,U.S. Senate,,DEM,Loretta L. Sanchez,164
+Sacramento,8032206,U.S. Senate,,DEM,Kamala D. Harris,348
+Sacramento,8032206,U.S. Senate,,DEM,Loretta L. Sanchez,239
+Sacramento,8032435,U.S. Senate,,DEM,Kamala D. Harris,366
+Sacramento,8032435,U.S. Senate,,DEM,Loretta L. Sanchez,200
+Sacramento,8032554,U.S. Senate,,DEM,Kamala D. Harris,321
+Sacramento,8032554,U.S. Senate,,DEM,Loretta L. Sanchez,179
+Sacramento,8032773,U.S. Senate,,DEM,Kamala D. Harris,338
+Sacramento,8032773,U.S. Senate,,DEM,Loretta L. Sanchez,192
+Sacramento,8032872,U.S. Senate,,DEM,Kamala D. Harris,305
+Sacramento,8032872,U.S. Senate,,DEM,Loretta L. Sanchez,156
+Sacramento,8033108,U.S. Senate,,DEM,Kamala D. Harris,385
+Sacramento,8033108,U.S. Senate,,DEM,Loretta L. Sanchez,232
+Sacramento,8033126,U.S. Senate,,DEM,Kamala D. Harris,510
+Sacramento,8033126,U.S. Senate,,DEM,Loretta L. Sanchez,247
+Sacramento,8033227,U.S. Senate,,DEM,Kamala D. Harris,604
+Sacramento,8033227,U.S. Senate,,DEM,Loretta L. Sanchez,304
+Sacramento,8033431,U.S. Senate,,DEM,Kamala D. Harris,247
+Sacramento,8033431,U.S. Senate,,DEM,Loretta L. Sanchez,166
+Sacramento,8033529,U.S. Senate,,DEM,Kamala D. Harris,306
+Sacramento,8033529,U.S. Senate,,DEM,Loretta L. Sanchez,203
+Sacramento,8033713,U.S. Senate,,DEM,Kamala D. Harris,329
+Sacramento,8033713,U.S. Senate,,DEM,Loretta L. Sanchez,157
+Sacramento,8033774,U.S. Senate,,DEM,Kamala D. Harris,472
+Sacramento,8033774,U.S. Senate,,DEM,Loretta L. Sanchez,216
+Sacramento,8033818,U.S. Senate,,DEM,Kamala D. Harris,531
+Sacramento,8033818,U.S. Senate,,DEM,Loretta L. Sanchez,264
+Sacramento,8033997,U.S. Senate,,DEM,Kamala D. Harris,628
+Sacramento,8033997,U.S. Senate,,DEM,Loretta L. Sanchez,268
+Sacramento,8034064,U.S. Senate,,DEM,Kamala D. Harris,352
+Sacramento,8034064,U.S. Senate,,DEM,Loretta L. Sanchez,185
+Sacramento,8034180,U.S. Senate,,DEM,Kamala D. Harris,538
+Sacramento,8034180,U.S. Senate,,DEM,Loretta L. Sanchez,242
+Sacramento,8034322,U.S. Senate,,DEM,Kamala D. Harris,444
+Sacramento,8034322,U.S. Senate,,DEM,Loretta L. Sanchez,257
+Sacramento,8034452,U.S. Senate,,DEM,Kamala D. Harris,254
+Sacramento,8034452,U.S. Senate,,DEM,Loretta L. Sanchez,137
+Sacramento,8034600,U.S. Senate,,DEM,Kamala D. Harris,528
+Sacramento,8034600,U.S. Senate,,DEM,Loretta L. Sanchez,311
+Sacramento,8034726,U.S. Senate,,DEM,Kamala D. Harris,436
+Sacramento,8034726,U.S. Senate,,DEM,Loretta L. Sanchez,217
+Sacramento,8034824,U.S. Senate,,DEM,Kamala D. Harris,531
+Sacramento,8034824,U.S. Senate,,DEM,Loretta L. Sanchez,267
+Sacramento,8035127,U.S. Senate,,DEM,Kamala D. Harris,491
+Sacramento,8035127,U.S. Senate,,DEM,Loretta L. Sanchez,270
+Sacramento,8035215,U.S. Senate,,DEM,Kamala D. Harris,309
+Sacramento,8035215,U.S. Senate,,DEM,Loretta L. Sanchez,162
+Sacramento,8035260,U.S. Senate,,DEM,Kamala D. Harris,261
+Sacramento,8035260,U.S. Senate,,DEM,Loretta L. Sanchez,176
+Sacramento,8035402,U.S. Senate,,DEM,Kamala D. Harris,342
+Sacramento,8035402,U.S. Senate,,DEM,Loretta L. Sanchez,206
+Sacramento,8035500,U.S. Senate,,DEM,Kamala D. Harris,486
+Sacramento,8035500,U.S. Senate,,DEM,Loretta L. Sanchez,249
+Sacramento,8035636,U.S. Senate,,DEM,Kamala D. Harris,531
+Sacramento,8035636,U.S. Senate,,DEM,Loretta L. Sanchez,244
+Sacramento,8035797,U.S. Senate,,DEM,Kamala D. Harris,414
+Sacramento,8035797,U.S. Senate,,DEM,Loretta L. Sanchez,184
+Sacramento,8035852,U.S. Senate,,DEM,Kamala D. Harris,337
+Sacramento,8035852,U.S. Senate,,DEM,Loretta L. Sanchez,149
+Sacramento,8035886,U.S. Senate,,DEM,Kamala D. Harris,358
+Sacramento,8035886,U.S. Senate,,DEM,Loretta L. Sanchez,172
+Sacramento,8036005,U.S. Senate,,DEM,Kamala D. Harris,487
+Sacramento,8036005,U.S. Senate,,DEM,Loretta L. Sanchez,207
+Sacramento,8036104,U.S. Senate,,DEM,Kamala D. Harris,502
+Sacramento,8036104,U.S. Senate,,DEM,Loretta L. Sanchez,219
+Sacramento,8036274,U.S. Senate,,DEM,Kamala D. Harris,364
+Sacramento,8036274,U.S. Senate,,DEM,Loretta L. Sanchez,183
+Sacramento,8036389,U.S. Senate,,DEM,Kamala D. Harris,490
+Sacramento,8036389,U.S. Senate,,DEM,Loretta L. Sanchez,233
+Sacramento,8036407,U.S. Senate,,DEM,Kamala D. Harris,471
+Sacramento,8036407,U.S. Senate,,DEM,Loretta L. Sanchez,252
+Sacramento,8036433,U.S. Senate,,DEM,Kamala D. Harris,518
+Sacramento,8036433,U.S. Senate,,DEM,Loretta L. Sanchez,206
+Sacramento,8036556,U.S. Senate,,DEM,Kamala D. Harris,474
+Sacramento,8036556,U.S. Senate,,DEM,Loretta L. Sanchez,203
+Sacramento,8036602,U.S. Senate,,DEM,Kamala D. Harris,289
+Sacramento,8036602,U.S. Senate,,DEM,Loretta L. Sanchez,162
+Sacramento,8036645,U.S. Senate,,DEM,Kamala D. Harris,439
+Sacramento,8036645,U.S. Senate,,DEM,Loretta L. Sanchez,236
+Sacramento,8036781,U.S. Senate,,DEM,Kamala D. Harris,447
+Sacramento,8036781,U.S. Senate,,DEM,Loretta L. Sanchez,246
+Sacramento,8036844,U.S. Senate,,DEM,Kamala D. Harris,333
+Sacramento,8036844,U.S. Senate,,DEM,Loretta L. Sanchez,158
+Sacramento,8036973,U.S. Senate,,DEM,Kamala D. Harris,603
+Sacramento,8036973,U.S. Senate,,DEM,Loretta L. Sanchez,257
+Sacramento,8037109,U.S. Senate,,DEM,Kamala D. Harris,394
+Sacramento,8037109,U.S. Senate,,DEM,Loretta L. Sanchez,253
+Sacramento,8037138,U.S. Senate,,DEM,Kamala D. Harris,492
+Sacramento,8037138,U.S. Senate,,DEM,Loretta L. Sanchez,218
+Sacramento,8037258,U.S. Senate,,DEM,Kamala D. Harris,453
+Sacramento,8037258,U.S. Senate,,DEM,Loretta L. Sanchez,189
+Sacramento,8037296,U.S. Senate,,DEM,Kamala D. Harris,445
+Sacramento,8037296,U.S. Senate,,DEM,Loretta L. Sanchez,198
+Sacramento,8038113,U.S. Senate,,DEM,Kamala D. Harris,346
+Sacramento,8038113,U.S. Senate,,DEM,Loretta L. Sanchez,247
+Sacramento,8038570,U.S. Senate,,DEM,Kamala D. Harris,465
+Sacramento,8038570,U.S. Senate,,DEM,Loretta L. Sanchez,207
+Sacramento,8039027,U.S. Senate,,DEM,Kamala D. Harris,333
+Sacramento,8039027,U.S. Senate,,DEM,Loretta L. Sanchez,132
+Sacramento,8039226,U.S. Senate,,DEM,Kamala D. Harris,440
+Sacramento,8039226,U.S. Senate,,DEM,Loretta L. Sanchez,227
+Sacramento,8039423,U.S. Senate,,DEM,Kamala D. Harris,475
+Sacramento,8039423,U.S. Senate,,DEM,Loretta L. Sanchez,223
+Sacramento,8039471,U.S. Senate,,DEM,Kamala D. Harris,441
+Sacramento,8039471,U.S. Senate,,DEM,Loretta L. Sanchez,205
+Sacramento,8039508,U.S. Senate,,DEM,Kamala D. Harris,459
+Sacramento,8039508,U.S. Senate,,DEM,Loretta L. Sanchez,243
+Sacramento,8039704,U.S. Senate,,DEM,Kamala D. Harris,393
+Sacramento,8039704,U.S. Senate,,DEM,Loretta L. Sanchez,172
+Sacramento,8041017,U.S. Senate,,DEM,Kamala D. Harris,117
+Sacramento,8041017,U.S. Senate,,DEM,Loretta L. Sanchez,51
+Sacramento,8041165,U.S. Senate,,DEM,Kamala D. Harris,325
+Sacramento,8041165,U.S. Senate,,DEM,Loretta L. Sanchez,125
+Sacramento,8041216,U.S. Senate,,DEM,Kamala D. Harris,470
+Sacramento,8041216,U.S. Senate,,DEM,Loretta L. Sanchez,183
+Sacramento,8041262,U.S. Senate,,DEM,Kamala D. Harris,472
+Sacramento,8041262,U.S. Senate,,DEM,Loretta L. Sanchez,147
+Sacramento,8041321,U.S. Senate,,DEM,Kamala D. Harris,353
+Sacramento,8041321,U.S. Senate,,DEM,Loretta L. Sanchez,133
+Sacramento,8041378,U.S. Senate,,DEM,Kamala D. Harris,460
+Sacramento,8041378,U.S. Senate,,DEM,Loretta L. Sanchez,154
+Sacramento,8041464,U.S. Senate,,DEM,Kamala D. Harris,450
+Sacramento,8041464,U.S. Senate,,DEM,Loretta L. Sanchez,152
+Sacramento,8041560,U.S. Senate,,DEM,Kamala D. Harris,453
+Sacramento,8041560,U.S. Senate,,DEM,Loretta L. Sanchez,152
+Sacramento,8041572,U.S. Senate,,DEM,Kamala D. Harris,300
+Sacramento,8041572,U.S. Senate,,DEM,Loretta L. Sanchez,74
+Sacramento,8041673,U.S. Senate,,DEM,Kamala D. Harris,433
+Sacramento,8041673,U.S. Senate,,DEM,Loretta L. Sanchez,116
+Sacramento,8041686,U.S. Senate,,DEM,Kamala D. Harris,500
+Sacramento,8041686,U.S. Senate,,DEM,Loretta L. Sanchez,143
+Sacramento,8041722,U.S. Senate,,DEM,Kamala D. Harris,392
+Sacramento,8041722,U.S. Senate,,DEM,Loretta L. Sanchez,133
+Sacramento,8041769,U.S. Senate,,DEM,Kamala D. Harris,401
+Sacramento,8041769,U.S. Senate,,DEM,Loretta L. Sanchez,132
+Sacramento,8041818,U.S. Senate,,DEM,Kamala D. Harris,313
+Sacramento,8041818,U.S. Senate,,DEM,Loretta L. Sanchez,97
+Sacramento,8041899,U.S. Senate,,DEM,Kamala D. Harris,389
+Sacramento,8041899,U.S. Senate,,DEM,Loretta L. Sanchez,139
+Sacramento,8041976,U.S. Senate,,DEM,Kamala D. Harris,552
+Sacramento,8041976,U.S. Senate,,DEM,Loretta L. Sanchez,178
+Sacramento,8042016,U.S. Senate,,DEM,Kamala D. Harris,541
+Sacramento,8042016,U.S. Senate,,DEM,Loretta L. Sanchez,155
+Sacramento,8042258,U.S. Senate,,DEM,Kamala D. Harris,400
+Sacramento,8042258,U.S. Senate,,DEM,Loretta L. Sanchez,103
+Sacramento,8042312,U.S. Senate,,DEM,Kamala D. Harris,489
+Sacramento,8042312,U.S. Senate,,DEM,Loretta L. Sanchez,134
+Sacramento,8042351,U.S. Senate,,DEM,Kamala D. Harris,423
+Sacramento,8042351,U.S. Senate,,DEM,Loretta L. Sanchez,105
+Sacramento,8042363,U.S. Senate,,DEM,Kamala D. Harris,480
+Sacramento,8042363,U.S. Senate,,DEM,Loretta L. Sanchez,127
+Sacramento,8042434,U.S. Senate,,DEM,Kamala D. Harris,271
+Sacramento,8042434,U.S. Senate,,DEM,Loretta L. Sanchez,65
+Sacramento,8042459,U.S. Senate,,DEM,Kamala D. Harris,510
+Sacramento,8042459,U.S. Senate,,DEM,Loretta L. Sanchez,131
+Sacramento,8042509,U.S. Senate,,DEM,Kamala D. Harris,492
+Sacramento,8042509,U.S. Senate,,DEM,Loretta L. Sanchez,131
+Sacramento,8042605,U.S. Senate,,DEM,Kamala D. Harris,512
+Sacramento,8042605,U.S. Senate,,DEM,Loretta L. Sanchez,220
+Sacramento,8042707,U.S. Senate,,DEM,Kamala D. Harris,544
+Sacramento,8042707,U.S. Senate,,DEM,Loretta L. Sanchez,180
+Sacramento,8042821,U.S. Senate,,DEM,Kamala D. Harris,571
+Sacramento,8042821,U.S. Senate,,DEM,Loretta L. Sanchez,152
+Sacramento,8042854,U.S. Senate,,DEM,Kamala D. Harris,337
+Sacramento,8042854,U.S. Senate,,DEM,Loretta L. Sanchez,128
+Sacramento,8042946,U.S. Senate,,DEM,Kamala D. Harris,483
+Sacramento,8042946,U.S. Senate,,DEM,Loretta L. Sanchez,171
+Sacramento,8043148,U.S. Senate,,DEM,Kamala D. Harris,510
+Sacramento,8043148,U.S. Senate,,DEM,Loretta L. Sanchez,183
+Sacramento,8043242,U.S. Senate,,DEM,Kamala D. Harris,478
+Sacramento,8043242,U.S. Senate,,DEM,Loretta L. Sanchez,133
+Sacramento,8043329,U.S. Senate,,DEM,Kamala D. Harris,296
+Sacramento,8043329,U.S. Senate,,DEM,Loretta L. Sanchez,226
+Sacramento,8043400,U.S. Senate,,DEM,Kamala D. Harris,612
+Sacramento,8043400,U.S. Senate,,DEM,Loretta L. Sanchez,227
+Sacramento,8043439,U.S. Senate,,DEM,Kamala D. Harris,677
+Sacramento,8043439,U.S. Senate,,DEM,Loretta L. Sanchez,228
+Sacramento,8043691,U.S. Senate,,DEM,Kamala D. Harris,531
+Sacramento,8043691,U.S. Senate,,DEM,Loretta L. Sanchez,229
+Sacramento,8043738,U.S. Senate,,DEM,Kamala D. Harris,347
+Sacramento,8043738,U.S. Senate,,DEM,Loretta L. Sanchez,127
+Sacramento,8043845,U.S. Senate,,DEM,Kamala D. Harris,311
+Sacramento,8043845,U.S. Senate,,DEM,Loretta L. Sanchez,168
+Sacramento,8044013,U.S. Senate,,DEM,Kamala D. Harris,377
+Sacramento,8044013,U.S. Senate,,DEM,Loretta L. Sanchez,108
+Sacramento,8044059,U.S. Senate,,DEM,Kamala D. Harris,262
+Sacramento,8044059,U.S. Senate,,DEM,Loretta L. Sanchez,103
+Sacramento,8044158,U.S. Senate,,DEM,Kamala D. Harris,632
+Sacramento,8044158,U.S. Senate,,DEM,Loretta L. Sanchez,131
+Sacramento,8044191,U.S. Senate,,DEM,Kamala D. Harris,206
+Sacramento,8044191,U.S. Senate,,DEM,Loretta L. Sanchez,62
+Sacramento,8044209,U.S. Senate,,DEM,Kamala D. Harris,376
+Sacramento,8044209,U.S. Senate,,DEM,Loretta L. Sanchez,133
+Sacramento,8044274,U.S. Senate,,DEM,Kamala D. Harris,605
+Sacramento,8044274,U.S. Senate,,DEM,Loretta L. Sanchez,112
+Sacramento,8044346,U.S. Senate,,DEM,Kamala D. Harris,594
+Sacramento,8044346,U.S. Senate,,DEM,Loretta L. Sanchez,126
+Sacramento,8044507,U.S. Senate,,DEM,Kamala D. Harris,478
+Sacramento,8044507,U.S. Senate,,DEM,Loretta L. Sanchez,132
+Sacramento,8044520,U.S. Senate,,DEM,Kamala D. Harris,511
+Sacramento,8044520,U.S. Senate,,DEM,Loretta L. Sanchez,143
+Sacramento,8044549,U.S. Senate,,DEM,Kamala D. Harris,720
+Sacramento,8044549,U.S. Senate,,DEM,Loretta L. Sanchez,206
+Sacramento,8044601,U.S. Senate,,DEM,Kamala D. Harris,434
+Sacramento,8044601,U.S. Senate,,DEM,Loretta L. Sanchez,173
+Sacramento,8044625,U.S. Senate,,DEM,Kamala D. Harris,429
+Sacramento,8044625,U.S. Senate,,DEM,Loretta L. Sanchez,132
+Sacramento,8044663,U.S. Senate,,DEM,Kamala D. Harris,431
+Sacramento,8044663,U.S. Senate,,DEM,Loretta L. Sanchez,141
+Sacramento,8044706,U.S. Senate,,DEM,Kamala D. Harris,577
+Sacramento,8044706,U.S. Senate,,DEM,Loretta L. Sanchez,158
+Sacramento,8044757,U.S. Senate,,DEM,Kamala D. Harris,229
+Sacramento,8044757,U.S. Senate,,DEM,Loretta L. Sanchez,90
+Sacramento,8044804,U.S. Senate,,DEM,Kamala D. Harris,520
+Sacramento,8044804,U.S. Senate,,DEM,Loretta L. Sanchez,181
+Sacramento,8044903,U.S. Senate,,DEM,Kamala D. Harris,435
+Sacramento,8044903,U.S. Senate,,DEM,Loretta L. Sanchez,157
+Sacramento,8044992,U.S. Senate,,DEM,Kamala D. Harris,376
+Sacramento,8044992,U.S. Senate,,DEM,Loretta L. Sanchez,172
+Sacramento,8045015,U.S. Senate,,DEM,Kamala D. Harris,370
+Sacramento,8045015,U.S. Senate,,DEM,Loretta L. Sanchez,148
+Sacramento,8045058,U.S. Senate,,DEM,Kamala D. Harris,491
+Sacramento,8045058,U.S. Senate,,DEM,Loretta L. Sanchez,159
+Sacramento,8045107,U.S. Senate,,DEM,Kamala D. Harris,252
+Sacramento,8045107,U.S. Senate,,DEM,Loretta L. Sanchez,110
+Sacramento,8045164,U.S. Senate,,DEM,Kamala D. Harris,228
+Sacramento,8045164,U.S. Senate,,DEM,Loretta L. Sanchez,106
+Sacramento,8045241,U.S. Senate,,DEM,Kamala D. Harris,314
+Sacramento,8045241,U.S. Senate,,DEM,Loretta L. Sanchez,184
+Sacramento,8045314,U.S. Senate,,DEM,Kamala D. Harris,269
+Sacramento,8045314,U.S. Senate,,DEM,Loretta L. Sanchez,212
+Sacramento,8045418,U.S. Senate,,DEM,Kamala D. Harris,269
+Sacramento,8045418,U.S. Senate,,DEM,Loretta L. Sanchez,148
+Sacramento,8045453,U.S. Senate,,DEM,Kamala D. Harris,153
+Sacramento,8045453,U.S. Senate,,DEM,Loretta L. Sanchez,123
+Sacramento,8045482,U.S. Senate,,DEM,Kamala D. Harris,179
+Sacramento,8045482,U.S. Senate,,DEM,Loretta L. Sanchez,108
+Sacramento,8045511,U.S. Senate,,DEM,Kamala D. Harris,72
+Sacramento,8045511,U.S. Senate,,DEM,Loretta L. Sanchez,84
+Sacramento,8045548,U.S. Senate,,DEM,Kamala D. Harris,254
+Sacramento,8045548,U.S. Senate,,DEM,Loretta L. Sanchez,204
+Sacramento,8045624,U.S. Senate,,DEM,Kamala D. Harris,231
+Sacramento,8045624,U.S. Senate,,DEM,Loretta L. Sanchez,178
+Sacramento,8045670,U.S. Senate,,DEM,Kamala D. Harris,331
+Sacramento,8045670,U.S. Senate,,DEM,Loretta L. Sanchez,245
+Sacramento,8045701,U.S. Senate,,DEM,Kamala D. Harris,323
+Sacramento,8045701,U.S. Senate,,DEM,Loretta L. Sanchez,221
+Sacramento,8045736,U.S. Senate,,DEM,Kamala D. Harris,263
+Sacramento,8045736,U.S. Senate,,DEM,Loretta L. Sanchez,178
+Sacramento,8045847,U.S. Senate,,DEM,Kamala D. Harris,194
+Sacramento,8045847,U.S. Senate,,DEM,Loretta L. Sanchez,129
+Sacramento,8045908,U.S. Senate,,DEM,Kamala D. Harris,221
+Sacramento,8045908,U.S. Senate,,DEM,Loretta L. Sanchez,106
+Sacramento,8045956,U.S. Senate,,DEM,Kamala D. Harris,248
+Sacramento,8045956,U.S. Senate,,DEM,Loretta L. Sanchez,215
+Sacramento,8046014,U.S. Senate,,DEM,Kamala D. Harris,636
+Sacramento,8046014,U.S. Senate,,DEM,Loretta L. Sanchez,201
+Sacramento,8046098,U.S. Senate,,DEM,Kamala D. Harris,382
+Sacramento,8046098,U.S. Senate,,DEM,Loretta L. Sanchez,121
+Sacramento,8046153,U.S. Senate,,DEM,Kamala D. Harris,345
+Sacramento,8046153,U.S. Senate,,DEM,Loretta L. Sanchez,193
+Sacramento,8046220,U.S. Senate,,DEM,Kamala D. Harris,326
+Sacramento,8046220,U.S. Senate,,DEM,Loretta L. Sanchez,113
+Sacramento,8046307,U.S. Senate,,DEM,Kamala D. Harris,450
+Sacramento,8046307,U.S. Senate,,DEM,Loretta L. Sanchez,166
+Sacramento,8046344,U.S. Senate,,DEM,Kamala D. Harris,299
+Sacramento,8046344,U.S. Senate,,DEM,Loretta L. Sanchez,187
+Sacramento,8046422,U.S. Senate,,DEM,Kamala D. Harris,149
+Sacramento,8046422,U.S. Senate,,DEM,Loretta L. Sanchez,118
+Sacramento,8046477,U.S. Senate,,DEM,Kamala D. Harris,399
+Sacramento,8046477,U.S. Senate,,DEM,Loretta L. Sanchez,232
+Sacramento,8046618,U.S. Senate,,DEM,Kamala D. Harris,276
+Sacramento,8046618,U.S. Senate,,DEM,Loretta L. Sanchez,254
+Sacramento,8046690,U.S. Senate,,DEM,Kamala D. Harris,341
+Sacramento,8046690,U.S. Senate,,DEM,Loretta L. Sanchez,178
+Sacramento,8046739,U.S. Senate,,DEM,Kamala D. Harris,201
+Sacramento,8046739,U.S. Senate,,DEM,Loretta L. Sanchez,107
+Sacramento,8046872,U.S. Senate,,DEM,Kamala D. Harris,280
+Sacramento,8046872,U.S. Senate,,DEM,Loretta L. Sanchez,178
+Sacramento,8047018,U.S. Senate,,DEM,Kamala D. Harris,256
+Sacramento,8047018,U.S. Senate,,DEM,Loretta L. Sanchez,102
+Sacramento,8047051,U.S. Senate,,DEM,Kamala D. Harris,528
+Sacramento,8047051,U.S. Senate,,DEM,Loretta L. Sanchez,196
+Sacramento,8047116,U.S. Senate,,DEM,Kamala D. Harris,541
+Sacramento,8047116,U.S. Senate,,DEM,Loretta L. Sanchez,220
+Sacramento,8047154,U.S. Senate,,DEM,Kamala D. Harris,533
+Sacramento,8047154,U.S. Senate,,DEM,Loretta L. Sanchez,205
+Sacramento,8047199,U.S. Senate,,DEM,Kamala D. Harris,494
+Sacramento,8047199,U.S. Senate,,DEM,Loretta L. Sanchez,152
+Sacramento,8047226,U.S. Senate,,DEM,Kamala D. Harris,613
+Sacramento,8047226,U.S. Senate,,DEM,Loretta L. Sanchez,180
+Sacramento,8047249,U.S. Senate,,DEM,Kamala D. Harris,486
+Sacramento,8047249,U.S. Senate,,DEM,Loretta L. Sanchez,187
+Sacramento,8047302,U.S. Senate,,DEM,Kamala D. Harris,628
+Sacramento,8047302,U.S. Senate,,DEM,Loretta L. Sanchez,211
+Sacramento,8047348,U.S. Senate,,DEM,Kamala D. Harris,632
+Sacramento,8047348,U.S. Senate,,DEM,Loretta L. Sanchez,181
+Sacramento,8047436,U.S. Senate,,DEM,Kamala D. Harris,681
+Sacramento,8047436,U.S. Senate,,DEM,Loretta L. Sanchez,228
+Sacramento,8047530,U.S. Senate,,DEM,Kamala D. Harris,551
+Sacramento,8047530,U.S. Senate,,DEM,Loretta L. Sanchez,159
+Sacramento,8047541,U.S. Senate,,DEM,Kamala D. Harris,564
+Sacramento,8047541,U.S. Senate,,DEM,Loretta L. Sanchez,171
+Sacramento,8047563,U.S. Senate,,DEM,Kamala D. Harris,586
+Sacramento,8047563,U.S. Senate,,DEM,Loretta L. Sanchez,204
+Sacramento,8047619,U.S. Senate,,DEM,Kamala D. Harris,577
+Sacramento,8047619,U.S. Senate,,DEM,Loretta L. Sanchez,199
+Sacramento,8047712,U.S. Senate,,DEM,Kamala D. Harris,639
+Sacramento,8047712,U.S. Senate,,DEM,Loretta L. Sanchez,226
+Sacramento,8047724,U.S. Senate,,DEM,Kamala D. Harris,431
+Sacramento,8047724,U.S. Senate,,DEM,Loretta L. Sanchez,148
+Sacramento,8047814,U.S. Senate,,DEM,Kamala D. Harris,333
+Sacramento,8047814,U.S. Senate,,DEM,Loretta L. Sanchez,139
+Sacramento,8047833,U.S. Senate,,DEM,Kamala D. Harris,468
+Sacramento,8047833,U.S. Senate,,DEM,Loretta L. Sanchez,148
+Sacramento,8047879,U.S. Senate,,DEM,Kamala D. Harris,588
+Sacramento,8047879,U.S. Senate,,DEM,Loretta L. Sanchez,204
+Sacramento,8047943,U.S. Senate,,DEM,Kamala D. Harris,379
+Sacramento,8047943,U.S. Senate,,DEM,Loretta L. Sanchez,147
+Sacramento,8048122,U.S. Senate,,DEM,Kamala D. Harris,519
+Sacramento,8048122,U.S. Senate,,DEM,Loretta L. Sanchez,202
+Sacramento,8048150,U.S. Senate,,DEM,Kamala D. Harris,245
+Sacramento,8048150,U.S. Senate,,DEM,Loretta L. Sanchez,119
+Sacramento,8048252,U.S. Senate,,DEM,Kamala D. Harris,265
+Sacramento,8048252,U.S. Senate,,DEM,Loretta L. Sanchez,173
+Sacramento,8048305,U.S. Senate,,DEM,Kamala D. Harris,334
+Sacramento,8048305,U.S. Senate,,DEM,Loretta L. Sanchez,148
+Sacramento,8048320,U.S. Senate,,DEM,Kamala D. Harris,289
+Sacramento,8048320,U.S. Senate,,DEM,Loretta L. Sanchez,133
+Sacramento,8048396,U.S. Senate,,DEM,Kamala D. Harris,422
+Sacramento,8048396,U.S. Senate,,DEM,Loretta L. Sanchez,208
+Sacramento,8048447,U.S. Senate,,DEM,Kamala D. Harris,286
+Sacramento,8048447,U.S. Senate,,DEM,Loretta L. Sanchez,181
+Sacramento,8048475,U.S. Senate,,DEM,Kamala D. Harris,295
+Sacramento,8048475,U.S. Senate,,DEM,Loretta L. Sanchez,164
+Sacramento,8048524,U.S. Senate,,DEM,Kamala D. Harris,234
+Sacramento,8048524,U.S. Senate,,DEM,Loretta L. Sanchez,151
+Sacramento,8048579,U.S. Senate,,DEM,Kamala D. Harris,369
+Sacramento,8048579,U.S. Senate,,DEM,Loretta L. Sanchez,164
+Sacramento,8048613,U.S. Senate,,DEM,Kamala D. Harris,329
+Sacramento,8048613,U.S. Senate,,DEM,Loretta L. Sanchez,166
+Sacramento,8048637,U.S. Senate,,DEM,Kamala D. Harris,261
+Sacramento,8048637,U.S. Senate,,DEM,Loretta L. Sanchez,135
+Sacramento,8048703,U.S. Senate,,DEM,Kamala D. Harris,230
+Sacramento,8048703,U.S. Senate,,DEM,Loretta L. Sanchez,166
+Sacramento,8048728,U.S. Senate,,DEM,Kamala D. Harris,340
+Sacramento,8048728,U.S. Senate,,DEM,Loretta L. Sanchez,150
+Sacramento,8048917,U.S. Senate,,DEM,Kamala D. Harris,387
+Sacramento,8048917,U.S. Senate,,DEM,Loretta L. Sanchez,148
+Sacramento,8048949,U.S. Senate,,DEM,Kamala D. Harris,209
+Sacramento,8048949,U.S. Senate,,DEM,Loretta L. Sanchez,100
+Sacramento,8048995,U.S. Senate,,DEM,Kamala D. Harris,295
+Sacramento,8048995,U.S. Senate,,DEM,Loretta L. Sanchez,228
+Sacramento,8049006,U.S. Senate,,DEM,Kamala D. Harris,418
+Sacramento,8049006,U.S. Senate,,DEM,Loretta L. Sanchez,234
+Sacramento,8049085,U.S. Senate,,DEM,Kamala D. Harris,126
+Sacramento,8049085,U.S. Senate,,DEM,Loretta L. Sanchez,52
+Sacramento,8049100,U.S. Senate,,DEM,Kamala D. Harris,304
+Sacramento,8049100,U.S. Senate,,DEM,Loretta L. Sanchez,200
+Sacramento,8049162,U.S. Senate,,DEM,Kamala D. Harris,294
+Sacramento,8049162,U.S. Senate,,DEM,Loretta L. Sanchez,186
+Sacramento,8049208,U.S. Senate,,DEM,Kamala D. Harris,384
+Sacramento,8049208,U.S. Senate,,DEM,Loretta L. Sanchez,292
+Sacramento,8049263,U.S. Senate,,DEM,Kamala D. Harris,412
+Sacramento,8049263,U.S. Senate,,DEM,Loretta L. Sanchez,215
+Sacramento,8049316,U.S. Senate,,DEM,Kamala D. Harris,325
+Sacramento,8049316,U.S. Senate,,DEM,Loretta L. Sanchez,189
+Sacramento,8049373,U.S. Senate,,DEM,Kamala D. Harris,347
+Sacramento,8049373,U.S. Senate,,DEM,Loretta L. Sanchez,153
+Sacramento,8049401,U.S. Senate,,DEM,Kamala D. Harris,348
+Sacramento,8049401,U.S. Senate,,DEM,Loretta L. Sanchez,217
+Sacramento,8049457,U.S. Senate,,DEM,Kamala D. Harris,289
+Sacramento,8049457,U.S. Senate,,DEM,Loretta L. Sanchez,171
+Sacramento,8049472,U.S. Senate,,DEM,Kamala D. Harris,302
+Sacramento,8049472,U.S. Senate,,DEM,Loretta L. Sanchez,162
+Sacramento,8049503,U.S. Senate,,DEM,Kamala D. Harris,84
+Sacramento,8049503,U.S. Senate,,DEM,Loretta L. Sanchez,33
+Sacramento,8049542,U.S. Senate,,DEM,Kamala D. Harris,350
+Sacramento,8049542,U.S. Senate,,DEM,Loretta L. Sanchez,149
+Sacramento,8049596,U.S. Senate,,DEM,Kamala D. Harris,240
+Sacramento,8049596,U.S. Senate,,DEM,Loretta L. Sanchez,170
+Sacramento,8049629,U.S. Senate,,DEM,Kamala D. Harris,242
+Sacramento,8049629,U.S. Senate,,DEM,Loretta L. Sanchez,143
+Sacramento,8049732,U.S. Senate,,DEM,Kamala D. Harris,479
+Sacramento,8049732,U.S. Senate,,DEM,Loretta L. Sanchez,211
+Sacramento,8049766,U.S. Senate,,DEM,Kamala D. Harris,412
+Sacramento,8049766,U.S. Senate,,DEM,Loretta L. Sanchez,174
+Sacramento,8049802,U.S. Senate,,DEM,Kamala D. Harris,189
+Sacramento,8049802,U.S. Senate,,DEM,Loretta L. Sanchez,88
+Sacramento,8049923,U.S. Senate,,DEM,Kamala D. Harris,347
+Sacramento,8049923,U.S. Senate,,DEM,Loretta L. Sanchez,194
+Sacramento,8051127,U.S. Senate,,DEM,Kamala D. Harris,393
+Sacramento,8051127,U.S. Senate,,DEM,Loretta L. Sanchez,166
+Sacramento,8051180,U.S. Senate,,DEM,Kamala D. Harris,431
+Sacramento,8051180,U.S. Senate,,DEM,Loretta L. Sanchez,193
+Sacramento,8051317,U.S. Senate,,DEM,Kamala D. Harris,391
+Sacramento,8051317,U.S. Senate,,DEM,Loretta L. Sanchez,149
+Sacramento,8051415,U.S. Senate,,DEM,Kamala D. Harris,517
+Sacramento,8051415,U.S. Senate,,DEM,Loretta L. Sanchez,198
+Sacramento,8051565,U.S. Senate,,DEM,Kamala D. Harris,171
+Sacramento,8051565,U.S. Senate,,DEM,Loretta L. Sanchez,73
+Sacramento,8051582,U.S. Senate,,DEM,Kamala D. Harris,312
+Sacramento,8051582,U.S. Senate,,DEM,Loretta L. Sanchez,110
+Sacramento,8051646,U.S. Senate,,DEM,Kamala D. Harris,298
+Sacramento,8051646,U.S. Senate,,DEM,Loretta L. Sanchez,153
+Sacramento,8051729,U.S. Senate,,DEM,Kamala D. Harris,552
+Sacramento,8051729,U.S. Senate,,DEM,Loretta L. Sanchez,239
+Sacramento,8051844,U.S. Senate,,DEM,Kamala D. Harris,404
+Sacramento,8051844,U.S. Senate,,DEM,Loretta L. Sanchez,169
+Sacramento,8051922,U.S. Senate,,DEM,Kamala D. Harris,455
+Sacramento,8051922,U.S. Senate,,DEM,Loretta L. Sanchez,205
+Sacramento,8052129,U.S. Senate,,DEM,Kamala D. Harris,434
+Sacramento,8052129,U.S. Senate,,DEM,Loretta L. Sanchez,194
+Sacramento,8052218,U.S. Senate,,DEM,Kamala D. Harris,344
+Sacramento,8052218,U.S. Senate,,DEM,Loretta L. Sanchez,146
+Sacramento,8052260,U.S. Senate,,DEM,Kamala D. Harris,385
+Sacramento,8052260,U.S. Senate,,DEM,Loretta L. Sanchez,180
+Sacramento,8052405,U.S. Senate,,DEM,Kamala D. Harris,264
+Sacramento,8052405,U.S. Senate,,DEM,Loretta L. Sanchez,129
+Sacramento,8052516,U.S. Senate,,DEM,Kamala D. Harris,276
+Sacramento,8052516,U.S. Senate,,DEM,Loretta L. Sanchez,121
+Sacramento,8052627,U.S. Senate,,DEM,Kamala D. Harris,466
+Sacramento,8052627,U.S. Senate,,DEM,Loretta L. Sanchez,231
+Sacramento,8052723,U.S. Senate,,DEM,Kamala D. Harris,327
+Sacramento,8052723,U.S. Senate,,DEM,Loretta L. Sanchez,185
+Sacramento,8052750,U.S. Senate,,DEM,Kamala D. Harris,466
+Sacramento,8052750,U.S. Senate,,DEM,Loretta L. Sanchez,236
+Sacramento,8052868,U.S. Senate,,DEM,Kamala D. Harris,355
+Sacramento,8052868,U.S. Senate,,DEM,Loretta L. Sanchez,180
+Sacramento,8053014,U.S. Senate,,DEM,Kamala D. Harris,362
+Sacramento,8053014,U.S. Senate,,DEM,Loretta L. Sanchez,172
+Sacramento,8053067,U.S. Senate,,DEM,Kamala D. Harris,415
+Sacramento,8053067,U.S. Senate,,DEM,Loretta L. Sanchez,214
+Sacramento,8053137,U.S. Senate,,DEM,Kamala D. Harris,439
+Sacramento,8053137,U.S. Senate,,DEM,Loretta L. Sanchez,185
+Sacramento,8053205,U.S. Senate,,DEM,Kamala D. Harris,385
+Sacramento,8053205,U.S. Senate,,DEM,Loretta L. Sanchez,199
+Sacramento,8053261,U.S. Senate,,DEM,Kamala D. Harris,402
+Sacramento,8053261,U.S. Senate,,DEM,Loretta L. Sanchez,212
+Sacramento,8053318,U.S. Senate,,DEM,Kamala D. Harris,281
+Sacramento,8053318,U.S. Senate,,DEM,Loretta L. Sanchez,135
+Sacramento,8053363,U.S. Senate,,DEM,Kamala D. Harris,393
+Sacramento,8053363,U.S. Senate,,DEM,Loretta L. Sanchez,228
+Sacramento,8053435,U.S. Senate,,DEM,Kamala D. Harris,367
+Sacramento,8053435,U.S. Senate,,DEM,Loretta L. Sanchez,159
+Sacramento,8053512,U.S. Senate,,DEM,Kamala D. Harris,288
+Sacramento,8053512,U.S. Senate,,DEM,Loretta L. Sanchez,157
+Sacramento,8053610,U.S. Senate,,DEM,Kamala D. Harris,237
+Sacramento,8053610,U.S. Senate,,DEM,Loretta L. Sanchez,109
+Sacramento,8053657,U.S. Senate,,DEM,Kamala D. Harris,444
+Sacramento,8053657,U.S. Senate,,DEM,Loretta L. Sanchez,196
+Sacramento,8053764,U.S. Senate,,DEM,Kamala D. Harris,179
+Sacramento,8053764,U.S. Senate,,DEM,Loretta L. Sanchez,69
+Sacramento,8053903,U.S. Senate,,DEM,Kamala D. Harris,296
+Sacramento,8053903,U.S. Senate,,DEM,Loretta L. Sanchez,156
+Sacramento,8053932,U.S. Senate,,DEM,Kamala D. Harris,372
+Sacramento,8053932,U.S. Senate,,DEM,Loretta L. Sanchez,183
+Sacramento,8055160,U.S. Senate,,DEM,Kamala D. Harris,392
+Sacramento,8055160,U.S. Senate,,DEM,Loretta L. Sanchez,201
+Sacramento,8055203,U.S. Senate,,DEM,Kamala D. Harris,357
+Sacramento,8055203,U.S. Senate,,DEM,Loretta L. Sanchez,160
+Sacramento,8055281,U.S. Senate,,DEM,Kamala D. Harris,329
+Sacramento,8055281,U.S. Senate,,DEM,Loretta L. Sanchez,187
+Sacramento,8055936,U.S. Senate,,DEM,Kamala D. Harris,496
+Sacramento,8055936,U.S. Senate,,DEM,Loretta L. Sanchez,252
+Sacramento,8056165,U.S. Senate,,DEM,Kamala D. Harris,266
+Sacramento,8056165,U.S. Senate,,DEM,Loretta L. Sanchez,154
+Sacramento,8056250,U.S. Senate,,DEM,Kamala D. Harris,306
+Sacramento,8056250,U.S. Senate,,DEM,Loretta L. Sanchez,149
+Sacramento,8056798,U.S. Senate,,DEM,Kamala D. Harris,158
+Sacramento,8056798,U.S. Senate,,DEM,Loretta L. Sanchez,99
+Sacramento,8057019,U.S. Senate,,DEM,Kamala D. Harris,407
+Sacramento,8057019,U.S. Senate,,DEM,Loretta L. Sanchez,234
+Sacramento,8057101,U.S. Senate,,DEM,Kamala D. Harris,257
+Sacramento,8057101,U.S. Senate,,DEM,Loretta L. Sanchez,157
+Sacramento,8057157,U.S. Senate,,DEM,Kamala D. Harris,294
+Sacramento,8057157,U.S. Senate,,DEM,Loretta L. Sanchez,181
+Sacramento,8057315,U.S. Senate,,DEM,Kamala D. Harris,229
+Sacramento,8057315,U.S. Senate,,DEM,Loretta L. Sanchez,138
+Sacramento,8057430,U.S. Senate,,DEM,Kamala D. Harris,408
+Sacramento,8057430,U.S. Senate,,DEM,Loretta L. Sanchez,208
+Sacramento,8057509,U.S. Senate,,DEM,Kamala D. Harris,275
+Sacramento,8057509,U.S. Senate,,DEM,Loretta L. Sanchez,155
+Sacramento,8057566,U.S. Senate,,DEM,Kamala D. Harris,208
+Sacramento,8057566,U.S. Senate,,DEM,Loretta L. Sanchez,106
+Sacramento,8057639,U.S. Senate,,DEM,Kamala D. Harris,409
+Sacramento,8057639,U.S. Senate,,DEM,Loretta L. Sanchez,211
+Sacramento,8057688,U.S. Senate,,DEM,Kamala D. Harris,403
+Sacramento,8057688,U.S. Senate,,DEM,Loretta L. Sanchez,199
+Sacramento,8057703,U.S. Senate,,DEM,Kamala D. Harris,347
+Sacramento,8057703,U.S. Senate,,DEM,Loretta L. Sanchez,210
+Sacramento,8057735,U.S. Senate,,DEM,Kamala D. Harris,416
+Sacramento,8057735,U.S. Senate,,DEM,Loretta L. Sanchez,201
+Sacramento,8057862,U.S. Senate,,DEM,Kamala D. Harris,374
+Sacramento,8057862,U.S. Senate,,DEM,Loretta L. Sanchez,186
+Sacramento,8058346,U.S. Senate,,DEM,Kamala D. Harris,408
+Sacramento,8058346,U.S. Senate,,DEM,Loretta L. Sanchez,198
+Sacramento,8058437,U.S. Senate,,DEM,Kamala D. Harris,399
+Sacramento,8058437,U.S. Senate,,DEM,Loretta L. Sanchez,213
+Sacramento,8058460,U.S. Senate,,DEM,Kamala D. Harris,395
+Sacramento,8058460,U.S. Senate,,DEM,Loretta L. Sanchez,188
+Sacramento,8058782,U.S. Senate,,DEM,Kamala D. Harris,450
+Sacramento,8058782,U.S. Senate,,DEM,Loretta L. Sanchez,237
+Sacramento,8058828,U.S. Senate,,DEM,Kamala D. Harris,592
+Sacramento,8058828,U.S. Senate,,DEM,Loretta L. Sanchez,259
+Sacramento,8059352,U.S. Senate,,DEM,Kamala D. Harris,475
+Sacramento,8059352,U.S. Senate,,DEM,Loretta L. Sanchez,189
+Sacramento,8059406,U.S. Senate,,DEM,Kamala D. Harris,437
+Sacramento,8059406,U.S. Senate,,DEM,Loretta L. Sanchez,229
+Sacramento,8059562,U.S. Senate,,DEM,Kamala D. Harris,507
+Sacramento,8059562,U.S. Senate,,DEM,Loretta L. Sanchez,249
+Sacramento,8061020,U.S. Senate,,DEM,Kamala D. Harris,178
+Sacramento,8061020,U.S. Senate,,DEM,Loretta L. Sanchez,83
+Sacramento,8061124,U.S. Senate,,DEM,Kamala D. Harris,576
+Sacramento,8061124,U.S. Senate,,DEM,Loretta L. Sanchez,229
+Sacramento,8061169,U.S. Senate,,DEM,Kamala D. Harris,596
+Sacramento,8061169,U.S. Senate,,DEM,Loretta L. Sanchez,263
+Sacramento,8061207,U.S. Senate,,DEM,Kamala D. Harris,459
+Sacramento,8061207,U.S. Senate,,DEM,Loretta L. Sanchez,213
+Sacramento,8061263,U.S. Senate,,DEM,Kamala D. Harris,457
+Sacramento,8061263,U.S. Senate,,DEM,Loretta L. Sanchez,194
+Sacramento,8064204,U.S. Senate,,DEM,Kamala D. Harris,399
+Sacramento,8064204,U.S. Senate,,DEM,Loretta L. Sanchez,230
+Sacramento,8064251,U.S. Senate,,DEM,Kamala D. Harris,431
+Sacramento,8064251,U.S. Senate,,DEM,Loretta L. Sanchez,189
+Sacramento,8064427,U.S. Senate,,DEM,Kamala D. Harris,477
+Sacramento,8064427,U.S. Senate,,DEM,Loretta L. Sanchez,210
+Sacramento,8064541,U.S. Senate,,DEM,Kamala D. Harris,415
+Sacramento,8064541,U.S. Senate,,DEM,Loretta L. Sanchez,171
+Sacramento,8065601,U.S. Senate,,DEM,Kamala D. Harris,173
+Sacramento,8065601,U.S. Senate,,DEM,Loretta L. Sanchez,97
+Sacramento,8066532,U.S. Senate,,DEM,Kamala D. Harris,491
+Sacramento,8066532,U.S. Senate,,DEM,Loretta L. Sanchez,266
+Sacramento,8066741,U.S. Senate,,DEM,Kamala D. Harris,405
+Sacramento,8066741,U.S. Senate,,DEM,Loretta L. Sanchez,175
+Sacramento,8066879,U.S. Senate,,DEM,Kamala D. Harris,341
+Sacramento,8066879,U.S. Senate,,DEM,Loretta L. Sanchez,183
+Sacramento,8072293,U.S. Senate,,DEM,Kamala D. Harris,519
+Sacramento,8072293,U.S. Senate,,DEM,Loretta L. Sanchez,210
+Sacramento,8072329,U.S. Senate,,DEM,Kamala D. Harris,459
+Sacramento,8072329,U.S. Senate,,DEM,Loretta L. Sanchez,206
+Sacramento,8072436,U.S. Senate,,DEM,Kamala D. Harris,479
+Sacramento,8072436,U.S. Senate,,DEM,Loretta L. Sanchez,158
+Sacramento,8072495,U.S. Senate,,DEM,Kamala D. Harris,502
+Sacramento,8072495,U.S. Senate,,DEM,Loretta L. Sanchez,205
+Sacramento,8072564,U.S. Senate,,DEM,Kamala D. Harris,348
+Sacramento,8072564,U.S. Senate,,DEM,Loretta L. Sanchez,154
+Sacramento,8072606,U.S. Senate,,DEM,Kamala D. Harris,470
+Sacramento,8072606,U.S. Senate,,DEM,Loretta L. Sanchez,167
+Sacramento,8072631,U.S. Senate,,DEM,Kamala D. Harris,362
+Sacramento,8072631,U.S. Senate,,DEM,Loretta L. Sanchez,143
+Sacramento,8072713,U.S. Senate,,DEM,Kamala D. Harris,480
+Sacramento,8072713,U.S. Senate,,DEM,Loretta L. Sanchez,212
+Sacramento,8072762,U.S. Senate,,DEM,Kamala D. Harris,414
+Sacramento,8072762,U.S. Senate,,DEM,Loretta L. Sanchez,217
+Sacramento,8072796,U.S. Senate,,DEM,Kamala D. Harris,386
+Sacramento,8072796,U.S. Senate,,DEM,Loretta L. Sanchez,191
+Sacramento,8072804,U.S. Senate,,DEM,Kamala D. Harris,440
+Sacramento,8072804,U.S. Senate,,DEM,Loretta L. Sanchez,233
+Sacramento,8072828,U.S. Senate,,DEM,Kamala D. Harris,435
+Sacramento,8072828,U.S. Senate,,DEM,Loretta L. Sanchez,183
+Sacramento,8073018,U.S. Senate,,DEM,Kamala D. Harris,482
+Sacramento,8073018,U.S. Senate,,DEM,Loretta L. Sanchez,236
+Sacramento,8073096,U.S. Senate,,DEM,Kamala D. Harris,383
+Sacramento,8073096,U.S. Senate,,DEM,Loretta L. Sanchez,180
+Sacramento,8073114,U.S. Senate,,DEM,Kamala D. Harris,491
+Sacramento,8073114,U.S. Senate,,DEM,Loretta L. Sanchez,185
+Sacramento,8073129,U.S. Senate,,DEM,Kamala D. Harris,626
+Sacramento,8073129,U.S. Senate,,DEM,Loretta L. Sanchez,270
+Sacramento,8073171,U.S. Senate,,DEM,Kamala D. Harris,320
+Sacramento,8073171,U.S. Senate,,DEM,Loretta L. Sanchez,152
+Sacramento,8073180,U.S. Senate,,DEM,Kamala D. Harris,533
+Sacramento,8073180,U.S. Senate,,DEM,Loretta L. Sanchez,204
+Sacramento,8073345,U.S. Senate,,DEM,Kamala D. Harris,499
+Sacramento,8073345,U.S. Senate,,DEM,Loretta L. Sanchez,210
+Sacramento,8073350,U.S. Senate,,DEM,Kamala D. Harris,398
+Sacramento,8073350,U.S. Senate,,DEM,Loretta L. Sanchez,189
+Sacramento,8073430,U.S. Senate,,DEM,Kamala D. Harris,456
+Sacramento,8073430,U.S. Senate,,DEM,Loretta L. Sanchez,255
+Sacramento,8073469,U.S. Senate,,DEM,Kamala D. Harris,366
+Sacramento,8073469,U.S. Senate,,DEM,Loretta L. Sanchez,165
+Sacramento,8073558,U.S. Senate,,DEM,Kamala D. Harris,435
+Sacramento,8073558,U.S. Senate,,DEM,Loretta L. Sanchez,177
+Sacramento,8073599,U.S. Senate,,DEM,Kamala D. Harris,543
+Sacramento,8073599,U.S. Senate,,DEM,Loretta L. Sanchez,222
+Sacramento,8073611,U.S. Senate,,DEM,Kamala D. Harris,376
+Sacramento,8073611,U.S. Senate,,DEM,Loretta L. Sanchez,191
+Sacramento,8073662,U.S. Senate,,DEM,Kamala D. Harris,553
+Sacramento,8073662,U.S. Senate,,DEM,Loretta L. Sanchez,269
+Sacramento,8073700,U.S. Senate,,DEM,Kamala D. Harris,583
+Sacramento,8073700,U.S. Senate,,DEM,Loretta L. Sanchez,254
+Sacramento,8073723,U.S. Senate,,DEM,Kamala D. Harris,509
+Sacramento,8073723,U.S. Senate,,DEM,Loretta L. Sanchez,206
+Sacramento,8073817,U.S. Senate,,DEM,Kamala D. Harris,503
+Sacramento,8073817,U.S. Senate,,DEM,Loretta L. Sanchez,230
+Sacramento,8073849,U.S. Senate,,DEM,Kamala D. Harris,438
+Sacramento,8073849,U.S. Senate,,DEM,Loretta L. Sanchez,237
+Sacramento,8073972,U.S. Senate,,DEM,Kamala D. Harris,572
+Sacramento,8073972,U.S. Senate,,DEM,Loretta L. Sanchez,220
+Sacramento,8077164,U.S. Senate,,DEM,Kamala D. Harris,252
+Sacramento,8077164,U.S. Senate,,DEM,Loretta L. Sanchez,126
+Sacramento,8077380,U.S. Senate,,DEM,Kamala D. Harris,72
+Sacramento,8077380,U.S. Senate,,DEM,Loretta L. Sanchez,59
+Sacramento,8078342,U.S. Senate,,DEM,Kamala D. Harris,152
+Sacramento,8078342,U.S. Senate,,DEM,Loretta L. Sanchez,153
+Sacramento,8081268,U.S. Senate,,DEM,Kamala D. Harris,452
+Sacramento,8081268,U.S. Senate,,DEM,Loretta L. Sanchez,194
+Sacramento,8081309,U.S. Senate,,DEM,Kamala D. Harris,503
+Sacramento,8081309,U.S. Senate,,DEM,Loretta L. Sanchez,220
+Sacramento,8081364,U.S. Senate,,DEM,Kamala D. Harris,582
+Sacramento,8081364,U.S. Senate,,DEM,Loretta L. Sanchez,251
+Sacramento,8081550,U.S. Senate,,DEM,Kamala D. Harris,676
+Sacramento,8081550,U.S. Senate,,DEM,Loretta L. Sanchez,309
+Sacramento,8081652,U.S. Senate,,DEM,Kamala D. Harris,353
+Sacramento,8081652,U.S. Senate,,DEM,Loretta L. Sanchez,167
+Sacramento,8082009,U.S. Senate,,DEM,Kamala D. Harris,578
+Sacramento,8082009,U.S. Senate,,DEM,Loretta L. Sanchez,239
+Sacramento,8082021,U.S. Senate,,DEM,Kamala D. Harris,271
+Sacramento,8082021,U.S. Senate,,DEM,Loretta L. Sanchez,132
+Sacramento,8082077,U.S. Senate,,DEM,Kamala D. Harris,555
+Sacramento,8082077,U.S. Senate,,DEM,Loretta L. Sanchez,261
+Sacramento,8082185,U.S. Senate,,DEM,Kamala D. Harris,510
+Sacramento,8082185,U.S. Senate,,DEM,Loretta L. Sanchez,269
+Sacramento,8082276,U.S. Senate,,DEM,Kamala D. Harris,425
+Sacramento,8082276,U.S. Senate,,DEM,Loretta L. Sanchez,264
+Sacramento,8082291,U.S. Senate,,DEM,Kamala D. Harris,265
+Sacramento,8082291,U.S. Senate,,DEM,Loretta L. Sanchez,152
+Sacramento,8082314,U.S. Senate,,DEM,Kamala D. Harris,461
+Sacramento,8082314,U.S. Senate,,DEM,Loretta L. Sanchez,164
+Sacramento,8082343,U.S. Senate,,DEM,Kamala D. Harris,571
+Sacramento,8082343,U.S. Senate,,DEM,Loretta L. Sanchez,300
+Sacramento,8082504,U.S. Senate,,DEM,Kamala D. Harris,457
+Sacramento,8082504,U.S. Senate,,DEM,Loretta L. Sanchez,253
+Sacramento,8082510,U.S. Senate,,DEM,Kamala D. Harris,283
+Sacramento,8082510,U.S. Senate,,DEM,Loretta L. Sanchez,192
+Sacramento,8082597,U.S. Senate,,DEM,Kamala D. Harris,424
+Sacramento,8082597,U.S. Senate,,DEM,Loretta L. Sanchez,242
+Sacramento,8082645,U.S. Senate,,DEM,Kamala D. Harris,375
+Sacramento,8082645,U.S. Senate,,DEM,Loretta L. Sanchez,195
+Sacramento,8082696,U.S. Senate,,DEM,Kamala D. Harris,382
+Sacramento,8082696,U.S. Senate,,DEM,Loretta L. Sanchez,226
+Sacramento,8082706,U.S. Senate,,DEM,Kamala D. Harris,419
+Sacramento,8082706,U.S. Senate,,DEM,Loretta L. Sanchez,278
+Sacramento,8082812,U.S. Senate,,DEM,Kamala D. Harris,282
+Sacramento,8082812,U.S. Senate,,DEM,Loretta L. Sanchez,164
+Sacramento,8082844,U.S. Senate,,DEM,Kamala D. Harris,372
+Sacramento,8082844,U.S. Senate,,DEM,Loretta L. Sanchez,218
+Sacramento,8082880,U.S. Senate,,DEM,Kamala D. Harris,222
+Sacramento,8082880,U.S. Senate,,DEM,Loretta L. Sanchez,145
+Sacramento,8083003,U.S. Senate,,DEM,Kamala D. Harris,377
+Sacramento,8083003,U.S. Senate,,DEM,Loretta L. Sanchez,266
+Sacramento,8083213,U.S. Senate,,DEM,Kamala D. Harris,347
+Sacramento,8083213,U.S. Senate,,DEM,Loretta L. Sanchez,241
+Sacramento,8083305,U.S. Senate,,DEM,Kamala D. Harris,353
+Sacramento,8083305,U.S. Senate,,DEM,Loretta L. Sanchez,157
+Sacramento,8083398,U.S. Senate,,DEM,Kamala D. Harris,428
+Sacramento,8083398,U.S. Senate,,DEM,Loretta L. Sanchez,172
+Sacramento,8083408,U.S. Senate,,DEM,Kamala D. Harris,418
+Sacramento,8083408,U.S. Senate,,DEM,Loretta L. Sanchez,205
+Sacramento,8083511,U.S. Senate,,DEM,Kamala D. Harris,418
+Sacramento,8083511,U.S. Senate,,DEM,Loretta L. Sanchez,199
+Sacramento,8083562,U.S. Senate,,DEM,Kamala D. Harris,392
+Sacramento,8083562,U.S. Senate,,DEM,Loretta L. Sanchez,212
+Sacramento,8083714,U.S. Senate,,DEM,Kamala D. Harris,131
+Sacramento,8083714,U.S. Senate,,DEM,Loretta L. Sanchez,89
+Sacramento,8088242,U.S. Senate,,DEM,Kamala D. Harris,340
+Sacramento,8088242,U.S. Senate,,DEM,Loretta L. Sanchez,237
+Sacramento,8088515,U.S. Senate,,DEM,Kamala D. Harris,347
+Sacramento,8088515,U.S. Senate,,DEM,Loretta L. Sanchez,293
+Sacramento,8088616,U.S. Senate,,DEM,Kamala D. Harris,287
+Sacramento,8088616,U.S. Senate,,DEM,Loretta L. Sanchez,276
+Sacramento,8088707,U.S. Senate,,DEM,Kamala D. Harris,269
+Sacramento,8088707,U.S. Senate,,DEM,Loretta L. Sanchez,224
+Sacramento,8088780,U.S. Senate,,DEM,Kamala D. Harris,260
+Sacramento,8088780,U.S. Senate,,DEM,Loretta L. Sanchez,299
+Sacramento,8089113,U.S. Senate,,DEM,Kamala D. Harris,365
+Sacramento,8089113,U.S. Senate,,DEM,Loretta L. Sanchez,287
+Sacramento,8089238,U.S. Senate,,DEM,Kamala D. Harris,388
+Sacramento,8089238,U.S. Senate,,DEM,Loretta L. Sanchez,332
+Sacramento,8089324,U.S. Senate,,DEM,Kamala D. Harris,289
+Sacramento,8089324,U.S. Senate,,DEM,Loretta L. Sanchez,251
+Sacramento,8089436,U.S. Senate,,DEM,Kamala D. Harris,246
+Sacramento,8089436,U.S. Senate,,DEM,Loretta L. Sanchez,170
+Sacramento,8091059,U.S. Senate,,DEM,Kamala D. Harris,315
+Sacramento,8091059,U.S. Senate,,DEM,Loretta L. Sanchez,227
+Sacramento,8091382,U.S. Senate,,DEM,Kamala D. Harris,390
+Sacramento,8091382,U.S. Senate,,DEM,Loretta L. Sanchez,261
+Sacramento,8091771,U.S. Senate,,DEM,Kamala D. Harris,200
+Sacramento,8091771,U.S. Senate,,DEM,Loretta L. Sanchez,117
+Sacramento,8091968,U.S. Senate,,DEM,Kamala D. Harris,208
+Sacramento,8091968,U.S. Senate,,DEM,Loretta L. Sanchez,134
+Sacramento,8094803,U.S. Senate,,DEM,Kamala D. Harris,153
+Sacramento,8094803,U.S. Senate,,DEM,Loretta L. Sanchez,142
+Sacramento,8096439,U.S. Senate,,DEM,Kamala D. Harris,186
+Sacramento,8096439,U.S. Senate,,DEM,Loretta L. Sanchez,124
+Sacramento,81268,U.S. Senate,,DEM,Kamala D. Harris,216
+Sacramento,81268,U.S. Senate,,DEM,Loretta L. Sanchez,140
+Sacramento,81309,U.S. Senate,,DEM,Kamala D. Harris,217
+Sacramento,81309,U.S. Senate,,DEM,Loretta L. Sanchez,137
+Sacramento,81364,U.S. Senate,,DEM,Kamala D. Harris,290
+Sacramento,81364,U.S. Senate,,DEM,Loretta L. Sanchez,115
+Sacramento,81550,U.S. Senate,,DEM,Kamala D. Harris,116
+Sacramento,81550,U.S. Senate,,DEM,Loretta L. Sanchez,94
+Sacramento,81652,U.S. Senate,,DEM,Kamala D. Harris,123
+Sacramento,81652,U.S. Senate,,DEM,Loretta L. Sanchez,61
+Sacramento,82009,U.S. Senate,,DEM,Kamala D. Harris,207
+Sacramento,82009,U.S. Senate,,DEM,Loretta L. Sanchez,133
+Sacramento,82021,U.S. Senate,,DEM,Kamala D. Harris,129
+Sacramento,82021,U.S. Senate,,DEM,Loretta L. Sanchez,87
+Sacramento,82077,U.S. Senate,,DEM,Kamala D. Harris,235
+Sacramento,82077,U.S. Senate,,DEM,Loretta L. Sanchez,133
+Sacramento,82185,U.S. Senate,,DEM,Kamala D. Harris,167
+Sacramento,82185,U.S. Senate,,DEM,Loretta L. Sanchez,89
+Sacramento,82276,U.S. Senate,,DEM,Kamala D. Harris,194
+Sacramento,82276,U.S. Senate,,DEM,Loretta L. Sanchez,108
+Sacramento,82291,U.S. Senate,,DEM,Kamala D. Harris,84
+Sacramento,82291,U.S. Senate,,DEM,Loretta L. Sanchez,60
+Sacramento,82314,U.S. Senate,,DEM,Kamala D. Harris,176
+Sacramento,82314,U.S. Senate,,DEM,Loretta L. Sanchez,106
+Sacramento,82343,U.S. Senate,,DEM,Kamala D. Harris,216
+Sacramento,82343,U.S. Senate,,DEM,Loretta L. Sanchez,128
+Sacramento,82504,U.S. Senate,,DEM,Kamala D. Harris,178
+Sacramento,82504,U.S. Senate,,DEM,Loretta L. Sanchez,129
+Sacramento,82510,U.S. Senate,,DEM,Kamala D. Harris,170
+Sacramento,82510,U.S. Senate,,DEM,Loretta L. Sanchez,121
+Sacramento,82597,U.S. Senate,,DEM,Kamala D. Harris,191
+Sacramento,82597,U.S. Senate,,DEM,Loretta L. Sanchez,133
+Sacramento,82645,U.S. Senate,,DEM,Kamala D. Harris,177
+Sacramento,82645,U.S. Senate,,DEM,Loretta L. Sanchez,93
+Sacramento,82696,U.S. Senate,,DEM,Kamala D. Harris,189
+Sacramento,82696,U.S. Senate,,DEM,Loretta L. Sanchez,141
+Sacramento,82706,U.S. Senate,,DEM,Kamala D. Harris,177
+Sacramento,82706,U.S. Senate,,DEM,Loretta L. Sanchez,124
+Sacramento,82812,U.S. Senate,,DEM,Kamala D. Harris,138
+Sacramento,82812,U.S. Senate,,DEM,Loretta L. Sanchez,90
+Sacramento,82844,U.S. Senate,,DEM,Kamala D. Harris,182
+Sacramento,82844,U.S. Senate,,DEM,Loretta L. Sanchez,153
+Sacramento,82880,U.S. Senate,,DEM,Kamala D. Harris,120
+Sacramento,82880,U.S. Senate,,DEM,Loretta L. Sanchez,67
+Sacramento,82967,U.S. Senate,,DEM,Kamala D. Harris,0
+Sacramento,82967,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sacramento,83003,U.S. Senate,,DEM,Kamala D. Harris,123
+Sacramento,83003,U.S. Senate,,DEM,Loretta L. Sanchez,106
+Sacramento,83213,U.S. Senate,,DEM,Kamala D. Harris,142
+Sacramento,83213,U.S. Senate,,DEM,Loretta L. Sanchez,101
+Sacramento,83305,U.S. Senate,,DEM,Kamala D. Harris,152
+Sacramento,83305,U.S. Senate,,DEM,Loretta L. Sanchez,118
+Sacramento,83398,U.S. Senate,,DEM,Kamala D. Harris,162
+Sacramento,83398,U.S. Senate,,DEM,Loretta L. Sanchez,90
+Sacramento,83408,U.S. Senate,,DEM,Kamala D. Harris,185
+Sacramento,83408,U.S. Senate,,DEM,Loretta L. Sanchez,105
+Sacramento,83511,U.S. Senate,,DEM,Kamala D. Harris,154
+Sacramento,83511,U.S. Senate,,DEM,Loretta L. Sanchez,102
+Sacramento,83562,U.S. Senate,,DEM,Kamala D. Harris,165
+Sacramento,83562,U.S. Senate,,DEM,Loretta L. Sanchez,88
+Sacramento,83714,U.S. Senate,,DEM,Kamala D. Harris,36
+Sacramento,83714,U.S. Senate,,DEM,Loretta L. Sanchez,41
+Sacramento,83856,U.S. Senate,,DEM,Kamala D. Harris,14
+Sacramento,83856,U.S. Senate,,DEM,Loretta L. Sanchez,8
+Sacramento,83900,U.S. Senate,,DEM,Kamala D. Harris,22
+Sacramento,83900,U.S. Senate,,DEM,Loretta L. Sanchez,18
+Sacramento,84391,U.S. Senate,,DEM,Kamala D. Harris,0
+Sacramento,84391,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sacramento,84610,U.S. Senate,,DEM,Kamala D. Harris,0
+Sacramento,84610,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sacramento,84815,U.S. Senate,,DEM,Kamala D. Harris,0
+Sacramento,84815,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sacramento,84996,U.S. Senate,,DEM,Kamala D. Harris,0
+Sacramento,84996,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sacramento,85145,U.S. Senate,,DEM,Kamala D. Harris,0
+Sacramento,85145,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sacramento,85261,U.S. Senate,,DEM,Kamala D. Harris,0
+Sacramento,85261,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sacramento,85426,U.S. Senate,,DEM,Kamala D. Harris,0
+Sacramento,85426,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sacramento,85680,U.S. Senate,,DEM,Kamala D. Harris,0
+Sacramento,85680,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sacramento,85859,U.S. Senate,,DEM,Kamala D. Harris,2
+Sacramento,85859,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sacramento,85914,U.S. Senate,,DEM,Kamala D. Harris,0
+Sacramento,85914,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sacramento,85988,U.S. Senate,,DEM,Kamala D. Harris,4
+Sacramento,85988,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Sacramento,86271,U.S. Senate,,DEM,Kamala D. Harris,2
+Sacramento,86271,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Sacramento,86376,U.S. Senate,,DEM,Kamala D. Harris,1
+Sacramento,86376,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Sacramento,86648,U.S. Senate,,DEM,Kamala D. Harris,19
+Sacramento,86648,U.S. Senate,,DEM,Loretta L. Sanchez,22
+Sacramento,86807,U.S. Senate,,DEM,Kamala D. Harris,44
+Sacramento,86807,U.S. Senate,,DEM,Loretta L. Sanchez,47
+Sacramento,86921,U.S. Senate,,DEM,Kamala D. Harris,49
+Sacramento,86921,U.S. Senate,,DEM,Loretta L. Sanchez,46
+Sacramento,87126,U.S. Senate,,DEM,Kamala D. Harris,0
+Sacramento,87126,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sacramento,87338,U.S. Senate,,DEM,Kamala D. Harris,1
+Sacramento,87338,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Sacramento,87549,U.S. Senate,,DEM,Kamala D. Harris,2
+Sacramento,87549,U.S. Senate,,DEM,Loretta L. Sanchez,6
+Sacramento,87704,U.S. Senate,,DEM,Kamala D. Harris,0
+Sacramento,87704,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sacramento,87819,U.S. Senate,,DEM,Kamala D. Harris,0
+Sacramento,87819,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sacramento,87972,U.S. Senate,,DEM,Kamala D. Harris,0
+Sacramento,87972,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sacramento,88006,U.S. Senate,,DEM,Kamala D. Harris,0
+Sacramento,88006,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sacramento,88117,U.S. Senate,,DEM,Kamala D. Harris,20
+Sacramento,88117,U.S. Senate,,DEM,Loretta L. Sanchez,25
+Sacramento,88242,U.S. Senate,,DEM,Kamala D. Harris,104
+Sacramento,88242,U.S. Senate,,DEM,Loretta L. Sanchez,95
+Sacramento,88515,U.S. Senate,,DEM,Kamala D. Harris,178
+Sacramento,88515,U.S. Senate,,DEM,Loretta L. Sanchez,217
+Sacramento,88616,U.S. Senate,,DEM,Kamala D. Harris,154
+Sacramento,88616,U.S. Senate,,DEM,Loretta L. Sanchez,160
+Sacramento,88707,U.S. Senate,,DEM,Kamala D. Harris,110
+Sacramento,88707,U.S. Senate,,DEM,Loretta L. Sanchez,149
+Sacramento,88780,U.S. Senate,,DEM,Kamala D. Harris,129
+Sacramento,88780,U.S. Senate,,DEM,Loretta L. Sanchez,144
+Sacramento,88941,U.S. Senate,,DEM,Kamala D. Harris,14
+Sacramento,88941,U.S. Senate,,DEM,Loretta L. Sanchez,12
+Sacramento,89113,U.S. Senate,,DEM,Kamala D. Harris,119
+Sacramento,89113,U.S. Senate,,DEM,Loretta L. Sanchez,153
+Sacramento,89238,U.S. Senate,,DEM,Kamala D. Harris,169
+Sacramento,89238,U.S. Senate,,DEM,Loretta L. Sanchez,185
+Sacramento,89324,U.S. Senate,,DEM,Kamala D. Harris,153
+Sacramento,89324,U.S. Senate,,DEM,Loretta L. Sanchez,157
+Sacramento,89436,U.S. Senate,,DEM,Kamala D. Harris,101
+Sacramento,89436,U.S. Senate,,DEM,Loretta L. Sanchez,99
+Sacramento,89600,U.S. Senate,,DEM,Kamala D. Harris,17
+Sacramento,89600,U.S. Senate,,DEM,Loretta L. Sanchez,36
+Sacramento,89867,U.S. Senate,,DEM,Kamala D. Harris,0
+Sacramento,89867,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sacramento,91059,U.S. Senate,,DEM,Kamala D. Harris,142
+Sacramento,91059,U.S. Senate,,DEM,Loretta L. Sanchez,127
+Sacramento,91382,U.S. Senate,,DEM,Kamala D. Harris,138
+Sacramento,91382,U.S. Senate,,DEM,Loretta L. Sanchez,118
+Sacramento,91771,U.S. Senate,,DEM,Kamala D. Harris,98
+Sacramento,91771,U.S. Senate,,DEM,Loretta L. Sanchez,70
+Sacramento,91968,U.S. Senate,,DEM,Kamala D. Harris,123
+Sacramento,91968,U.S. Senate,,DEM,Loretta L. Sanchez,111
+Sacramento,94349,U.S. Senate,,DEM,Kamala D. Harris,0
+Sacramento,94349,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Sacramento,94686,U.S. Senate,,DEM,Kamala D. Harris,10
+Sacramento,94686,U.S. Senate,,DEM,Loretta L. Sanchez,5
+Sacramento,94803,U.S. Senate,,DEM,Kamala D. Harris,86
+Sacramento,94803,U.S. Senate,,DEM,Loretta L. Sanchez,87
+Sacramento,96439,U.S. Senate,,DEM,Kamala D. Harris,107
+Sacramento,96439,U.S. Senate,,DEM,Loretta L. Sanchez,91
+Sacramento,97527,U.S. Senate,,DEM,Kamala D. Harris,96
+Sacramento,97527,U.S. Senate,,DEM,Loretta L. Sanchez,55
+Sacramento,97784,U.S. Senate,,DEM,Kamala D. Harris,24
+Sacramento,97784,U.S. Senate,,DEM,Loretta L. Sanchez,10

--- a/2016/20161108__ca__general__san_benito__precinct.csv
+++ b/2016/20161108__ca__general__san_benito__precinct.csv
@@ -2159,111 +2159,111 @@ San Benito,9585002,Proposition 67,,N/A,Yes,7
 San Benito,9585002,Proposition 67,,N/A,No,3
 San Benito,9585006,Proposition 67,,N/A,Yes,15
 San Benito,9585006,Proposition 67,,N/A,No,16
-San Benito,130001,U.S. Senate,,DEM,Kamala Harris,266
-San Benito,130001,U.S. Senate,,DEM,Loretta Sanchez,405
-San Benito,130002,U.S. Senate,,DEM,Kamala Harris,329
-San Benito,130002,U.S. Senate,,DEM,Loretta Sanchez,601
-San Benito,135109,U.S. Senate,,DEM,Kamala Harris,321
-San Benito,135109,U.S. Senate,,DEM,Loretta Sanchez,368
-San Benito,135423,U.S. Senate,,DEM,Kamala Harris,161
-San Benito,135423,U.S. Senate,,DEM,Loretta Sanchez,261
-San Benito,135425,U.S. Senate,,DEM,Kamala Harris,245
-San Benito,135425,U.S. Senate,,DEM,Loretta Sanchez,336
-San Benito,201001,U.S. Senate,,DEM,Kamala Harris,108
-San Benito,201001,U.S. Senate,,DEM,Loretta Sanchez,215
-San Benito,205001,U.S. Senate,,DEM,Kamala Harris,150
-San Benito,205001,U.S. Senate,,DEM,Loretta Sanchez,401
-San Benito,235320,U.S. Senate,,DEM,Kamala Harris,96
-San Benito,235320,U.S. Senate,,DEM,Loretta Sanchez,141
-San Benito,235321,U.S. Senate,,DEM,Kamala Harris,154
-San Benito,235321,U.S. Senate,,DEM,Loretta Sanchez,226
-San Benito,235426,U.S. Senate,,DEM,Kamala Harris,284
-San Benito,235426,U.S. Senate,,DEM,Loretta Sanchez,483
-San Benito,240001,U.S. Senate,,DEM,Kamala Harris,210
-San Benito,240001,U.S. Senate,,DEM,Loretta Sanchez,404
-San Benito,265000,U.S. Senate,,DEM,Kamala Harris,243
-San Benito,265000,U.S. Senate,,DEM,Loretta Sanchez,455
-San Benito,335111,U.S. Senate,,DEM,Kamala Harris,120
-San Benito,335111,U.S. Senate,,DEM,Loretta Sanchez,154
-San Benito,335213,U.S. Senate,,DEM,Kamala Harris,486
-San Benito,335213,U.S. Senate,,DEM,Loretta Sanchez,568
-San Benito,335315,U.S. Senate,,DEM,Kamala Harris,361
-San Benito,335315,U.S. Senate,,DEM,Loretta Sanchez,380
-San Benito,335316,U.S. Senate,,DEM,Kamala Harris,557
-San Benito,335316,U.S. Senate,,DEM,Loretta Sanchez,837
-San Benito,420002,U.S. Senate,,DEM,Kamala Harris,185
-San Benito,420002,U.S. Senate,,DEM,Loretta Sanchez,384
-San Benito,435427,U.S. Senate,,DEM,Kamala Harris,223
-San Benito,435427,U.S. Senate,,DEM,Loretta Sanchez,327
-San Benito,435438,U.S. Senate,,DEM,Kamala Harris,351
-San Benito,435438,U.S. Senate,,DEM,Loretta Sanchez,498
-San Benito,458001,U.S. Senate,,DEM,Kamala Harris,128
-San Benito,458001,U.S. Senate,,DEM,Loretta Sanchez,380
-San Benito,458002,U.S. Senate,,DEM,Kamala Harris,196
-San Benito,458002,U.S. Senate,,DEM,Loretta Sanchez,432
-San Benito,470000,U.S. Senate,,DEM,Kamala Harris,161
-San Benito,470000,U.S. Senate,,DEM,Loretta Sanchez,229
-San Benito,475000,U.S. Senate,,DEM,Kamala Harris,33
-San Benito,475000,U.S. Senate,,DEM,Loretta Sanchez,68
-San Benito,480003,U.S. Senate,,DEM,Kamala Harris,117
-San Benito,480003,U.S. Senate,,DEM,Loretta Sanchez,210
-San Benito,535105,U.S. Senate,,DEM,Kamala Harris,150
-San Benito,535105,U.S. Senate,,DEM,Loretta Sanchez,148
-San Benito,535135,U.S. Senate,,DEM,Kamala Harris,183
-San Benito,535135,U.S. Senate,,DEM,Loretta Sanchez,131
-San Benito,535136,U.S. Senate,,DEM,Kamala Harris,450
-San Benito,535136,U.S. Senate,,DEM,Loretta Sanchez,527
-San Benito,535212,U.S. Senate,,DEM,Kamala Harris,462
-San Benito,535212,U.S. Senate,,DEM,Loretta Sanchez,406
-San Benito,535228,U.S. Senate,,DEM,Kamala Harris,185
-San Benito,535228,U.S. Senate,,DEM,Loretta Sanchez,203
-San Benito,9130003,U.S. Senate,,DEM,Kamala Harris,7
-San Benito,9130003,U.S. Senate,,DEM,Loretta Sanchez,24
-San Benito,9130004,U.S. Senate,,DEM,Kamala Harris,63
-San Benito,9130004,U.S. Senate,,DEM,Loretta Sanchez,76
-San Benito,9130005,U.S. Senate,,DEM,Kamala Harris,54
-San Benito,9130005,U.S. Senate,,DEM,Loretta Sanchez,66
-San Benito,9135101,U.S. Senate,,DEM,Kamala Harris,1
-San Benito,9135101,U.S. Senate,,DEM,Loretta Sanchez,3
-San Benito,9135102,U.S. Senate,,DEM,Kamala Harris,3
-San Benito,9135102,U.S. Senate,,DEM,Loretta Sanchez,8
-San Benito,9135318,U.S. Senate,,DEM,Kamala Harris,50
-San Benito,9135318,U.S. Senate,,DEM,Loretta Sanchez,116
-San Benito,9145001,U.S. Senate,,DEM,Kamala Harris,64
-San Benito,9145001,U.S. Senate,,DEM,Loretta Sanchez,109
-San Benito,9185003,U.S. Senate,,DEM,Kamala Harris,3
-San Benito,9185003,U.S. Senate,,DEM,Loretta Sanchez,6
-San Benito,9235214,U.S. Senate,,DEM,Kamala Harris,45
-San Benito,9235214,U.S. Senate,,DEM,Loretta Sanchez,40
-San Benito,9240004,U.S. Senate,,DEM,Kamala Harris,8
-San Benito,9240004,U.S. Senate,,DEM,Loretta Sanchez,3
-San Benito,9280001,U.S. Senate,,DEM,Kamala Harris,51
-San Benito,9280001,U.S. Senate,,DEM,Loretta Sanchez,56
-San Benito,9280002,U.S. Senate,,DEM,Kamala Harris,41
-San Benito,9280002,U.S. Senate,,DEM,Loretta Sanchez,74
-San Benito,9335319,U.S. Senate,,DEM,Kamala Harris,15
-San Benito,9335319,U.S. Senate,,DEM,Loretta Sanchez,20
-San Benito,9395003,U.S. Senate,,DEM,Kamala Harris,3
-San Benito,9395003,U.S. Senate,,DEM,Loretta Sanchez,8
-San Benito,9410000,U.S. Senate,,DEM,Kamala Harris,18
-San Benito,9410000,U.S. Senate,,DEM,Loretta Sanchez,25
-San Benito,9412000,U.S. Senate,,DEM,Kamala Harris,0
-San Benito,9412000,U.S. Senate,,DEM,Loretta Sanchez,1
-San Benito,9415000,U.S. Senate,,DEM,Kamala Harris,36
-San Benito,9415000,U.S. Senate,,DEM,Loretta Sanchez,49
-San Benito,9420001,U.S. Senate,,DEM,Kamala Harris,36
-San Benito,9420001,U.S. Senate,,DEM,Loretta Sanchez,53
-San Benito,9450000,U.S. Senate,,DEM,Kamala Harris,71
-San Benito,9450000,U.S. Senate,,DEM,Loretta Sanchez,99
-San Benito,9460000,U.S. Senate,,DEM,Kamala Harris,18
-San Benito,9460000,U.S. Senate,,DEM,Loretta Sanchez,35
-San Benito,9480005,U.S. Senate,,DEM,Kamala Harris,10
-San Benito,9480005,U.S. Senate,,DEM,Loretta Sanchez,19
-San Benito,9545003,U.S. Senate,,DEM,Kamala Harris,2
-San Benito,9545003,U.S. Senate,,DEM,Loretta Sanchez,5
-San Benito,9585001,U.S. Senate,,DEM,Kamala Harris,34
-San Benito,9585001,U.S. Senate,,DEM,Loretta Sanchez,59
-San Benito,9585002,U.S. Senate,,DEM,Kamala Harris,5
-San Benito,9585002,U.S. Senate,,DEM,Loretta Sanchez,6
-San Benito,9585006,U.S. Senate,,DEM,Kamala Harris,15
-San Benito,9585006,U.S. Senate,,DEM,Loretta Sanchez,13
+San Benito,130001,U.S. Senate,,DEM,Kamala D. Harris,266
+San Benito,130001,U.S. Senate,,DEM,Loretta L. Sanchez,405
+San Benito,130002,U.S. Senate,,DEM,Kamala D. Harris,329
+San Benito,130002,U.S. Senate,,DEM,Loretta L. Sanchez,601
+San Benito,135109,U.S. Senate,,DEM,Kamala D. Harris,321
+San Benito,135109,U.S. Senate,,DEM,Loretta L. Sanchez,368
+San Benito,135423,U.S. Senate,,DEM,Kamala D. Harris,161
+San Benito,135423,U.S. Senate,,DEM,Loretta L. Sanchez,261
+San Benito,135425,U.S. Senate,,DEM,Kamala D. Harris,245
+San Benito,135425,U.S. Senate,,DEM,Loretta L. Sanchez,336
+San Benito,201001,U.S. Senate,,DEM,Kamala D. Harris,108
+San Benito,201001,U.S. Senate,,DEM,Loretta L. Sanchez,215
+San Benito,205001,U.S. Senate,,DEM,Kamala D. Harris,150
+San Benito,205001,U.S. Senate,,DEM,Loretta L. Sanchez,401
+San Benito,235320,U.S. Senate,,DEM,Kamala D. Harris,96
+San Benito,235320,U.S. Senate,,DEM,Loretta L. Sanchez,141
+San Benito,235321,U.S. Senate,,DEM,Kamala D. Harris,154
+San Benito,235321,U.S. Senate,,DEM,Loretta L. Sanchez,226
+San Benito,235426,U.S. Senate,,DEM,Kamala D. Harris,284
+San Benito,235426,U.S. Senate,,DEM,Loretta L. Sanchez,483
+San Benito,240001,U.S. Senate,,DEM,Kamala D. Harris,210
+San Benito,240001,U.S. Senate,,DEM,Loretta L. Sanchez,404
+San Benito,265000,U.S. Senate,,DEM,Kamala D. Harris,243
+San Benito,265000,U.S. Senate,,DEM,Loretta L. Sanchez,455
+San Benito,335111,U.S. Senate,,DEM,Kamala D. Harris,120
+San Benito,335111,U.S. Senate,,DEM,Loretta L. Sanchez,154
+San Benito,335213,U.S. Senate,,DEM,Kamala D. Harris,486
+San Benito,335213,U.S. Senate,,DEM,Loretta L. Sanchez,568
+San Benito,335315,U.S. Senate,,DEM,Kamala D. Harris,361
+San Benito,335315,U.S. Senate,,DEM,Loretta L. Sanchez,380
+San Benito,335316,U.S. Senate,,DEM,Kamala D. Harris,557
+San Benito,335316,U.S. Senate,,DEM,Loretta L. Sanchez,837
+San Benito,420002,U.S. Senate,,DEM,Kamala D. Harris,185
+San Benito,420002,U.S. Senate,,DEM,Loretta L. Sanchez,384
+San Benito,435427,U.S. Senate,,DEM,Kamala D. Harris,223
+San Benito,435427,U.S. Senate,,DEM,Loretta L. Sanchez,327
+San Benito,435438,U.S. Senate,,DEM,Kamala D. Harris,351
+San Benito,435438,U.S. Senate,,DEM,Loretta L. Sanchez,498
+San Benito,458001,U.S. Senate,,DEM,Kamala D. Harris,128
+San Benito,458001,U.S. Senate,,DEM,Loretta L. Sanchez,380
+San Benito,458002,U.S. Senate,,DEM,Kamala D. Harris,196
+San Benito,458002,U.S. Senate,,DEM,Loretta L. Sanchez,432
+San Benito,470000,U.S. Senate,,DEM,Kamala D. Harris,161
+San Benito,470000,U.S. Senate,,DEM,Loretta L. Sanchez,229
+San Benito,475000,U.S. Senate,,DEM,Kamala D. Harris,33
+San Benito,475000,U.S. Senate,,DEM,Loretta L. Sanchez,68
+San Benito,480003,U.S. Senate,,DEM,Kamala D. Harris,117
+San Benito,480003,U.S. Senate,,DEM,Loretta L. Sanchez,210
+San Benito,535105,U.S. Senate,,DEM,Kamala D. Harris,150
+San Benito,535105,U.S. Senate,,DEM,Loretta L. Sanchez,148
+San Benito,535135,U.S. Senate,,DEM,Kamala D. Harris,183
+San Benito,535135,U.S. Senate,,DEM,Loretta L. Sanchez,131
+San Benito,535136,U.S. Senate,,DEM,Kamala D. Harris,450
+San Benito,535136,U.S. Senate,,DEM,Loretta L. Sanchez,527
+San Benito,535212,U.S. Senate,,DEM,Kamala D. Harris,462
+San Benito,535212,U.S. Senate,,DEM,Loretta L. Sanchez,406
+San Benito,535228,U.S. Senate,,DEM,Kamala D. Harris,185
+San Benito,535228,U.S. Senate,,DEM,Loretta L. Sanchez,203
+San Benito,9130003,U.S. Senate,,DEM,Kamala D. Harris,7
+San Benito,9130003,U.S. Senate,,DEM,Loretta L. Sanchez,24
+San Benito,9130004,U.S. Senate,,DEM,Kamala D. Harris,63
+San Benito,9130004,U.S. Senate,,DEM,Loretta L. Sanchez,76
+San Benito,9130005,U.S. Senate,,DEM,Kamala D. Harris,54
+San Benito,9130005,U.S. Senate,,DEM,Loretta L. Sanchez,66
+San Benito,9135101,U.S. Senate,,DEM,Kamala D. Harris,1
+San Benito,9135101,U.S. Senate,,DEM,Loretta L. Sanchez,3
+San Benito,9135102,U.S. Senate,,DEM,Kamala D. Harris,3
+San Benito,9135102,U.S. Senate,,DEM,Loretta L. Sanchez,8
+San Benito,9135318,U.S. Senate,,DEM,Kamala D. Harris,50
+San Benito,9135318,U.S. Senate,,DEM,Loretta L. Sanchez,116
+San Benito,9145001,U.S. Senate,,DEM,Kamala D. Harris,64
+San Benito,9145001,U.S. Senate,,DEM,Loretta L. Sanchez,109
+San Benito,9185003,U.S. Senate,,DEM,Kamala D. Harris,3
+San Benito,9185003,U.S. Senate,,DEM,Loretta L. Sanchez,6
+San Benito,9235214,U.S. Senate,,DEM,Kamala D. Harris,45
+San Benito,9235214,U.S. Senate,,DEM,Loretta L. Sanchez,40
+San Benito,9240004,U.S. Senate,,DEM,Kamala D. Harris,8
+San Benito,9240004,U.S. Senate,,DEM,Loretta L. Sanchez,3
+San Benito,9280001,U.S. Senate,,DEM,Kamala D. Harris,51
+San Benito,9280001,U.S. Senate,,DEM,Loretta L. Sanchez,56
+San Benito,9280002,U.S. Senate,,DEM,Kamala D. Harris,41
+San Benito,9280002,U.S. Senate,,DEM,Loretta L. Sanchez,74
+San Benito,9335319,U.S. Senate,,DEM,Kamala D. Harris,15
+San Benito,9335319,U.S. Senate,,DEM,Loretta L. Sanchez,20
+San Benito,9395003,U.S. Senate,,DEM,Kamala D. Harris,3
+San Benito,9395003,U.S. Senate,,DEM,Loretta L. Sanchez,8
+San Benito,9410000,U.S. Senate,,DEM,Kamala D. Harris,18
+San Benito,9410000,U.S. Senate,,DEM,Loretta L. Sanchez,25
+San Benito,9412000,U.S. Senate,,DEM,Kamala D. Harris,0
+San Benito,9412000,U.S. Senate,,DEM,Loretta L. Sanchez,1
+San Benito,9415000,U.S. Senate,,DEM,Kamala D. Harris,36
+San Benito,9415000,U.S. Senate,,DEM,Loretta L. Sanchez,49
+San Benito,9420001,U.S. Senate,,DEM,Kamala D. Harris,36
+San Benito,9420001,U.S. Senate,,DEM,Loretta L. Sanchez,53
+San Benito,9450000,U.S. Senate,,DEM,Kamala D. Harris,71
+San Benito,9450000,U.S. Senate,,DEM,Loretta L. Sanchez,99
+San Benito,9460000,U.S. Senate,,DEM,Kamala D. Harris,18
+San Benito,9460000,U.S. Senate,,DEM,Loretta L. Sanchez,35
+San Benito,9480005,U.S. Senate,,DEM,Kamala D. Harris,10
+San Benito,9480005,U.S. Senate,,DEM,Loretta L. Sanchez,19
+San Benito,9545003,U.S. Senate,,DEM,Kamala D. Harris,2
+San Benito,9545003,U.S. Senate,,DEM,Loretta L. Sanchez,5
+San Benito,9585001,U.S. Senate,,DEM,Kamala D. Harris,34
+San Benito,9585001,U.S. Senate,,DEM,Loretta L. Sanchez,59
+San Benito,9585002,U.S. Senate,,DEM,Kamala D. Harris,5
+San Benito,9585002,U.S. Senate,,DEM,Loretta L. Sanchez,6
+San Benito,9585006,U.S. Senate,,DEM,Kamala D. Harris,15
+San Benito,9585006,U.S. Senate,,DEM,Loretta L. Sanchez,13

--- a/2016/20161108__ca__general__san_bernardino__precinct.csv
+++ b/2016/20161108__ca__general__san_bernardino__precinct.csv
@@ -71559,3581 +71559,3581 @@ San Bernardino,YUV0274,Proposition 67,,N/A,Yes,599
 San Bernardino,YUV0274,Proposition 67,,N/A,No,981
 San Bernardino,YUV0275,Proposition 67,,N/A,Yes,511
 San Bernardino,YUV0275,Proposition 67,,N/A,No,889
-San Bernardino,ADE0110,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,ADE0110,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,ADE0111,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,ADE0111,U.S. Senate,,DEM,Loretta Sanchez,1
-San Bernardino,ADE0380,U.S. Senate,,DEM,Kamala Harris,307
-San Bernardino,ADE0380,U.S. Senate,,DEM,Loretta Sanchez,346
-San Bernardino,ADE0381,U.S. Senate,,DEM,Kamala Harris,394
-San Bernardino,ADE0381,U.S. Senate,,DEM,Loretta Sanchez,331
-San Bernardino,ADE0382,U.S. Senate,,DEM,Kamala Harris,480
-San Bernardino,ADE0382,U.S. Senate,,DEM,Loretta Sanchez,426
-San Bernardino,ADE0383,U.S. Senate,,DEM,Kamala Harris,600
-San Bernardino,ADE0383,U.S. Senate,,DEM,Loretta Sanchez,552
-San Bernardino,ADE0384,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,ADE0384,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,ADE0385,U.S. Senate,,DEM,Kamala Harris,1
-San Bernardino,ADE0385,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,ADE0386,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,ADE0386,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,ADE0387,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,ADE0387,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,ADE0388,U.S. Senate,,DEM,Kamala Harris,9
-San Bernardino,ADE0388,U.S. Senate,,DEM,Loretta Sanchez,2
-San Bernardino,ADE0389,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,ADE0389,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,ADE0390,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,ADE0390,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,ADE0391,U.S. Senate,,DEM,Kamala Harris,72
-San Bernardino,ADE0391,U.S. Senate,,DEM,Loretta Sanchez,86
-San Bernardino,ADE0392,U.S. Senate,,DEM,Kamala Harris,612
-San Bernardino,ADE0392,U.S. Senate,,DEM,Loretta Sanchez,623
-San Bernardino,ADE0393,U.S. Senate,,DEM,Kamala Harris,421
-San Bernardino,ADE0393,U.S. Senate,,DEM,Loretta Sanchez,424
-San Bernardino,ADE0394,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,ADE0394,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,ADE0395,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,ADE0395,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,ADE0396,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,ADE0396,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,ADE0397,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,ADE0397,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,APP0001,U.S. Senate,,DEM,Kamala Harris,5
-San Bernardino,APP0001,U.S. Senate,,DEM,Loretta Sanchez,3
-San Bernardino,APP0296,U.S. Senate,,DEM,Kamala Harris,12
-San Bernardino,APP0296,U.S. Senate,,DEM,Loretta Sanchez,3
-San Bernardino,APP0297,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,APP0297,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,APP0298,U.S. Senate,,DEM,Kamala Harris,132
-San Bernardino,APP0298,U.S. Senate,,DEM,Loretta Sanchez,163
-San Bernardino,APP0299,U.S. Senate,,DEM,Kamala Harris,203
-San Bernardino,APP0299,U.S. Senate,,DEM,Loretta Sanchez,161
-San Bernardino,APP0300,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,APP0300,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,APP0301,U.S. Senate,,DEM,Kamala Harris,550
-San Bernardino,APP0301,U.S. Senate,,DEM,Loretta Sanchez,446
-San Bernardino,APP0302,U.S. Senate,,DEM,Kamala Harris,442
-San Bernardino,APP0302,U.S. Senate,,DEM,Loretta Sanchez,419
-San Bernardino,APP0303,U.S. Senate,,DEM,Kamala Harris,526
-San Bernardino,APP0303,U.S. Senate,,DEM,Loretta Sanchez,429
-San Bernardino,APP0304,U.S. Senate,,DEM,Kamala Harris,518
-San Bernardino,APP0304,U.S. Senate,,DEM,Loretta Sanchez,476
-San Bernardino,APP0305,U.S. Senate,,DEM,Kamala Harris,473
-San Bernardino,APP0305,U.S. Senate,,DEM,Loretta Sanchez,425
-San Bernardino,APP0306,U.S. Senate,,DEM,Kamala Harris,489
-San Bernardino,APP0306,U.S. Senate,,DEM,Loretta Sanchez,449
-San Bernardino,APP0307,U.S. Senate,,DEM,Kamala Harris,343
-San Bernardino,APP0307,U.S. Senate,,DEM,Loretta Sanchez,362
-San Bernardino,APP0308,U.S. Senate,,DEM,Kamala Harris,444
-San Bernardino,APP0308,U.S. Senate,,DEM,Loretta Sanchez,315
-San Bernardino,APP0309,U.S. Senate,,DEM,Kamala Harris,510
-San Bernardino,APP0309,U.S. Senate,,DEM,Loretta Sanchez,506
-San Bernardino,APP0310,U.S. Senate,,DEM,Kamala Harris,402
-San Bernardino,APP0310,U.S. Senate,,DEM,Loretta Sanchez,348
-San Bernardino,APP0311,U.S. Senate,,DEM,Kamala Harris,573
-San Bernardino,APP0311,U.S. Senate,,DEM,Loretta Sanchez,577
-San Bernardino,APP0312,U.S. Senate,,DEM,Kamala Harris,530
-San Bernardino,APP0312,U.S. Senate,,DEM,Loretta Sanchez,403
-San Bernardino,APP0313,U.S. Senate,,DEM,Kamala Harris,566
-San Bernardino,APP0313,U.S. Senate,,DEM,Loretta Sanchez,450
-San Bernardino,APP0314,U.S. Senate,,DEM,Kamala Harris,453
-San Bernardino,APP0314,U.S. Senate,,DEM,Loretta Sanchez,324
-San Bernardino,APP0315,U.S. Senate,,DEM,Kamala Harris,398
-San Bernardino,APP0315,U.S. Senate,,DEM,Loretta Sanchez,295
-San Bernardino,APP0316,U.S. Senate,,DEM,Kamala Harris,424
-San Bernardino,APP0316,U.S. Senate,,DEM,Loretta Sanchez,376
-San Bernardino,APP0317,U.S. Senate,,DEM,Kamala Harris,380
-San Bernardino,APP0317,U.S. Senate,,DEM,Loretta Sanchez,366
-San Bernardino,APP0318,U.S. Senate,,DEM,Kamala Harris,384
-San Bernardino,APP0318,U.S. Senate,,DEM,Loretta Sanchez,317
-San Bernardino,APP0319,U.S. Senate,,DEM,Kamala Harris,344
-San Bernardino,APP0319,U.S. Senate,,DEM,Loretta Sanchez,315
-San Bernardino,APP0320,U.S. Senate,,DEM,Kamala Harris,1275
-San Bernardino,APP0320,U.S. Senate,,DEM,Loretta Sanchez,835
-San Bernardino,APP0321,U.S. Senate,,DEM,Kamala Harris,144
-San Bernardino,APP0321,U.S. Senate,,DEM,Loretta Sanchez,124
-San Bernardino,APP0322,U.S. Senate,,DEM,Kamala Harris,450
-San Bernardino,APP0322,U.S. Senate,,DEM,Loretta Sanchez,438
-San Bernardino,APP0323,U.S. Senate,,DEM,Kamala Harris,294
-San Bernardino,APP0323,U.S. Senate,,DEM,Loretta Sanchez,264
-San Bernardino,APP0324,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,APP0324,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,APP0326,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,APP0326,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,APP0327,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,APP0327,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,APP0328,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,APP0328,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,APP0398,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,APP0398,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,APP1609,U.S. Senate,,DEM,Kamala Harris,337
-San Bernardino,APP1609,U.S. Senate,,DEM,Loretta Sanchez,305
-San Bernardino,BAR0132,U.S. Senate,,DEM,Kamala Harris,138
-San Bernardino,BAR0132,U.S. Senate,,DEM,Loretta Sanchez,141
-San Bernardino,BAR0133,U.S. Senate,,DEM,Kamala Harris,1
-San Bernardino,BAR0133,U.S. Senate,,DEM,Loretta Sanchez,4
-San Bernardino,BAR0134,U.S. Senate,,DEM,Kamala Harris,10
-San Bernardino,BAR0134,U.S. Senate,,DEM,Loretta Sanchez,10
-San Bernardino,BAR0135,U.S. Senate,,DEM,Kamala Harris,251
-San Bernardino,BAR0135,U.S. Senate,,DEM,Loretta Sanchez,297
-San Bernardino,BAR0136,U.S. Senate,,DEM,Kamala Harris,272
-San Bernardino,BAR0136,U.S. Senate,,DEM,Loretta Sanchez,287
-San Bernardino,BAR0137,U.S. Senate,,DEM,Kamala Harris,444
-San Bernardino,BAR0137,U.S. Senate,,DEM,Loretta Sanchez,444
-San Bernardino,BAR0138,U.S. Senate,,DEM,Kamala Harris,409
-San Bernardino,BAR0138,U.S. Senate,,DEM,Loretta Sanchez,349
-San Bernardino,BAR0139,U.S. Senate,,DEM,Kamala Harris,530
-San Bernardino,BAR0139,U.S. Senate,,DEM,Loretta Sanchez,471
-San Bernardino,BAR0140,U.S. Senate,,DEM,Kamala Harris,424
-San Bernardino,BAR0140,U.S. Senate,,DEM,Loretta Sanchez,402
-San Bernardino,BAR0141,U.S. Senate,,DEM,Kamala Harris,8
-San Bernardino,BAR0141,U.S. Senate,,DEM,Loretta Sanchez,8
-San Bernardino,BAR0142,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,BAR0142,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,BAR0143,U.S. Senate,,DEM,Kamala Harris,6
-San Bernardino,BAR0143,U.S. Senate,,DEM,Loretta Sanchez,5
-San Bernardino,BAR0144,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,BAR0144,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,BAR0179,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,BAR0179,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,BIG0572,U.S. Senate,,DEM,Kamala Harris,233
-San Bernardino,BIG0572,U.S. Senate,,DEM,Loretta Sanchez,125
-San Bernardino,BIG0573,U.S. Senate,,DEM,Kamala Harris,251
-San Bernardino,BIG0573,U.S. Senate,,DEM,Loretta Sanchez,172
-San Bernardino,BIG0574,U.S. Senate,,DEM,Kamala Harris,377
-San Bernardino,BIG0574,U.S. Senate,,DEM,Loretta Sanchez,253
-San Bernardino,BIG0575,U.S. Senate,,DEM,Kamala Harris,160
-San Bernardino,BIG0575,U.S. Senate,,DEM,Loretta Sanchez,97
-San Bernardino,BIG0576,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,BIG0576,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,BIG1744,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,BIG1744,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,BIG1745,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,BIG1745,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,BIG1746,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,BIG1746,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,BIG1747,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,BIG1747,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,BIG1748,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,BIG1748,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,BIG1749,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,BIG1749,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,BIG1750,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,BIG1750,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,BIG1751,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,BIG1751,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,BIG1752,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,BIG1752,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,BIG1753,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,BIG1753,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,BIG1754,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,BIG1754,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,BIG1755,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,BIG1755,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,BIG1756,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,BIG1756,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,BIG1757,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,BIG1757,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,BIG1758,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,BIG1758,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,BIG1759,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,BIG1759,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,BIG1760,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,BIG1760,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,BIG1761,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,BIG1761,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,BIG1762,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,BIG1762,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,BIG1763,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,BIG1763,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,CHH1461,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,CHH1461,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,CHH1462,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,CHH1462,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,CHH1463,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,CHH1463,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,CHH1464,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,CHH1464,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,CHH1535,U.S. Senate,,DEM,Kamala Harris,566
-San Bernardino,CHH1535,U.S. Senate,,DEM,Loretta Sanchez,399
-San Bernardino,CHH1536,U.S. Senate,,DEM,Kamala Harris,588
-San Bernardino,CHH1536,U.S. Senate,,DEM,Loretta Sanchez,473
-San Bernardino,CHH1537,U.S. Senate,,DEM,Kamala Harris,658
-San Bernardino,CHH1537,U.S. Senate,,DEM,Loretta Sanchez,448
-San Bernardino,CHH1538,U.S. Senate,,DEM,Kamala Harris,667
-San Bernardino,CHH1538,U.S. Senate,,DEM,Loretta Sanchez,391
-San Bernardino,CHH1539,U.S. Senate,,DEM,Kamala Harris,494
-San Bernardino,CHH1539,U.S. Senate,,DEM,Loretta Sanchez,385
-San Bernardino,CHH1540,U.S. Senate,,DEM,Kamala Harris,504
-San Bernardino,CHH1540,U.S. Senate,,DEM,Loretta Sanchez,496
-San Bernardino,CHH1541,U.S. Senate,,DEM,Kamala Harris,476
-San Bernardino,CHH1541,U.S. Senate,,DEM,Loretta Sanchez,529
-San Bernardino,CHH1542,U.S. Senate,,DEM,Kamala Harris,626
-San Bernardino,CHH1542,U.S. Senate,,DEM,Loretta Sanchez,612
-San Bernardino,CHH1543,U.S. Senate,,DEM,Kamala Harris,711
-San Bernardino,CHH1543,U.S. Senate,,DEM,Loretta Sanchez,616
-San Bernardino,CHH1544,U.S. Senate,,DEM,Kamala Harris,603
-San Bernardino,CHH1544,U.S. Senate,,DEM,Loretta Sanchez,491
-San Bernardino,CHH1545,U.S. Senate,,DEM,Kamala Harris,512
-San Bernardino,CHH1545,U.S. Senate,,DEM,Loretta Sanchez,420
-San Bernardino,CHH1546,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,CHH1546,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,CHH1547,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,CHH1547,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,CHH1548,U.S. Senate,,DEM,Kamala Harris,619
-San Bernardino,CHH1548,U.S. Senate,,DEM,Loretta Sanchez,462
-San Bernardino,CHH1549,U.S. Senate,,DEM,Kamala Harris,642
-San Bernardino,CHH1549,U.S. Senate,,DEM,Loretta Sanchez,426
-San Bernardino,CHH1550,U.S. Senate,,DEM,Kamala Harris,500
-San Bernardino,CHH1550,U.S. Senate,,DEM,Loretta Sanchez,314
-San Bernardino,CHH1551,U.S. Senate,,DEM,Kamala Harris,681
-San Bernardino,CHH1551,U.S. Senate,,DEM,Loretta Sanchez,480
-San Bernardino,CHH1552,U.S. Senate,,DEM,Kamala Harris,719
-San Bernardino,CHH1552,U.S. Senate,,DEM,Loretta Sanchez,555
-San Bernardino,CHH1553,U.S. Senate,,DEM,Kamala Harris,610
-San Bernardino,CHH1553,U.S. Senate,,DEM,Loretta Sanchez,455
-San Bernardino,CHH1554,U.S. Senate,,DEM,Kamala Harris,599
-San Bernardino,CHH1554,U.S. Senate,,DEM,Loretta Sanchez,445
-San Bernardino,CHH1555,U.S. Senate,,DEM,Kamala Harris,647
-San Bernardino,CHH1555,U.S. Senate,,DEM,Loretta Sanchez,405
-San Bernardino,CHH1556,U.S. Senate,,DEM,Kamala Harris,636
-San Bernardino,CHH1556,U.S. Senate,,DEM,Loretta Sanchez,407
-San Bernardino,CHH1557,U.S. Senate,,DEM,Kamala Harris,573
-San Bernardino,CHH1557,U.S. Senate,,DEM,Loretta Sanchez,372
-San Bernardino,CHH1558,U.S. Senate,,DEM,Kamala Harris,663
-San Bernardino,CHH1558,U.S. Senate,,DEM,Loretta Sanchez,426
-San Bernardino,CHH1559,U.S. Senate,,DEM,Kamala Harris,685
-San Bernardino,CHH1559,U.S. Senate,,DEM,Loretta Sanchez,434
-San Bernardino,CHH1560,U.S. Senate,,DEM,Kamala Harris,412
-San Bernardino,CHH1560,U.S. Senate,,DEM,Loretta Sanchez,327
-San Bernardino,CN11465,U.S. Senate,,DEM,Kamala Harris,21
-San Bernardino,CN11465,U.S. Senate,,DEM,Loretta Sanchez,18
-San Bernardino,CN11466,U.S. Senate,,DEM,Kamala Harris,109
-San Bernardino,CN11466,U.S. Senate,,DEM,Loretta Sanchez,119
-San Bernardino,CN11467,U.S. Senate,,DEM,Kamala Harris,117
-San Bernardino,CN11467,U.S. Senate,,DEM,Loretta Sanchez,81
-San Bernardino,CN11468,U.S. Senate,,DEM,Kamala Harris,172
-San Bernardino,CN11468,U.S. Senate,,DEM,Loretta Sanchez,140
-San Bernardino,CN11469,U.S. Senate,,DEM,Kamala Harris,85
-San Bernardino,CN11469,U.S. Senate,,DEM,Loretta Sanchez,64
-San Bernardino,CN11470,U.S. Senate,,DEM,Kamala Harris,96
-San Bernardino,CN11470,U.S. Senate,,DEM,Loretta Sanchez,90
-San Bernardino,CN11471,U.S. Senate,,DEM,Kamala Harris,396
-San Bernardino,CN11471,U.S. Senate,,DEM,Loretta Sanchez,426
-San Bernardino,CN11484,U.S. Senate,,DEM,Kamala Harris,4
-San Bernardino,CN11484,U.S. Senate,,DEM,Loretta Sanchez,18
-San Bernardino,CN11485,U.S. Senate,,DEM,Kamala Harris,196
-San Bernardino,CN11485,U.S. Senate,,DEM,Loretta Sanchez,200
-San Bernardino,CN11486,U.S. Senate,,DEM,Kamala Harris,7
-San Bernardino,CN11486,U.S. Senate,,DEM,Loretta Sanchez,1
-San Bernardino,CN11487,U.S. Senate,,DEM,Kamala Harris,701
-San Bernardino,CN11487,U.S. Senate,,DEM,Loretta Sanchez,633
-San Bernardino,CN11490,U.S. Senate,,DEM,Kamala Harris,446
-San Bernardino,CN11490,U.S. Senate,,DEM,Loretta Sanchez,468
-San Bernardino,CN11774,U.S. Senate,,DEM,Kamala Harris,173
-San Bernardino,CN11774,U.S. Senate,,DEM,Loretta Sanchez,262
-San Bernardino,CN11789,U.S. Senate,,DEM,Kamala Harris,47
-San Bernardino,CN11789,U.S. Senate,,DEM,Loretta Sanchez,76
-San Bernardino,CN21488,U.S. Senate,,DEM,Kamala Harris,209
-San Bernardino,CN21488,U.S. Senate,,DEM,Loretta Sanchez,200
-San Bernardino,CN21489,U.S. Senate,,DEM,Kamala Harris,229
-San Bernardino,CN21489,U.S. Senate,,DEM,Loretta Sanchez,117
-San Bernardino,CN21492,U.S. Senate,,DEM,Kamala Harris,453
-San Bernardino,CN21492,U.S. Senate,,DEM,Loretta Sanchez,406
-San Bernardino,CN21495,U.S. Senate,,DEM,Kamala Harris,52
-San Bernardino,CN21495,U.S. Senate,,DEM,Loretta Sanchez,61
-San Bernardino,CN21496,U.S. Senate,,DEM,Kamala Harris,560
-San Bernardino,CN21496,U.S. Senate,,DEM,Loretta Sanchez,435
-San Bernardino,CN21497,U.S. Senate,,DEM,Kamala Harris,526
-San Bernardino,CN21497,U.S. Senate,,DEM,Loretta Sanchez,419
-San Bernardino,CN21498,U.S. Senate,,DEM,Kamala Harris,579
-San Bernardino,CN21498,U.S. Senate,,DEM,Loretta Sanchez,435
-San Bernardino,CN21499,U.S. Senate,,DEM,Kamala Harris,508
-San Bernardino,CN21499,U.S. Senate,,DEM,Loretta Sanchez,435
-San Bernardino,CN21500,U.S. Senate,,DEM,Kamala Harris,504
-San Bernardino,CN21500,U.S. Senate,,DEM,Loretta Sanchez,455
-San Bernardino,CN31388,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,CN31388,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,CN31478,U.S. Senate,,DEM,Kamala Harris,350
-San Bernardino,CN31478,U.S. Senate,,DEM,Loretta Sanchez,335
-San Bernardino,CN31479,U.S. Senate,,DEM,Kamala Harris,1029
-San Bernardino,CN31479,U.S. Senate,,DEM,Loretta Sanchez,658
-San Bernardino,CN31491,U.S. Senate,,DEM,Kamala Harris,438
-San Bernardino,CN31491,U.S. Senate,,DEM,Loretta Sanchez,381
-San Bernardino,CN31493,U.S. Senate,,DEM,Kamala Harris,230
-San Bernardino,CN31493,U.S. Senate,,DEM,Loretta Sanchez,389
-San Bernardino,CN31494,U.S. Senate,,DEM,Kamala Harris,503
-San Bernardino,CN31494,U.S. Senate,,DEM,Loretta Sanchez,528
-San Bernardino,CN31501,U.S. Senate,,DEM,Kamala Harris,526
-San Bernardino,CN31501,U.S. Senate,,DEM,Loretta Sanchez,419
-San Bernardino,CN41472,U.S. Senate,,DEM,Kamala Harris,489
-San Bernardino,CN41472,U.S. Senate,,DEM,Loretta Sanchez,405
-San Bernardino,CN41473,U.S. Senate,,DEM,Kamala Harris,556
-San Bernardino,CN41473,U.S. Senate,,DEM,Loretta Sanchez,501
-San Bernardino,CN41474,U.S. Senate,,DEM,Kamala Harris,482
-San Bernardino,CN41474,U.S. Senate,,DEM,Loretta Sanchez,418
-San Bernardino,CN41475,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,CN41475,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,CN41476,U.S. Senate,,DEM,Kamala Harris,423
-San Bernardino,CN41476,U.S. Senate,,DEM,Loretta Sanchez,373
-San Bernardino,CN41477,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,CN41477,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,CN41480,U.S. Senate,,DEM,Kamala Harris,1212
-San Bernardino,CN41480,U.S. Senate,,DEM,Loretta Sanchez,808
-San Bernardino,CN41481,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,CN41481,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,CN41482,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,CN41482,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,CN41483,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,CN41483,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,CN41534,U.S. Senate,,DEM,Kamala Harris,104
-San Bernardino,CN41534,U.S. Senate,,DEM,Loretta Sanchez,78
-San Bernardino,CN41561,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,CN41561,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,CN41562,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,CN41562,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,CN41563,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,CN41563,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,CN41564,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,CN41564,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,CN41565,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,CN41565,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,CN41773,U.S. Senate,,DEM,Kamala Harris,45
-San Bernardino,CN41773,U.S. Senate,,DEM,Loretta Sanchez,56
-San Bernardino,CO10920,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,CO10920,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,CO10921,U.S. Senate,,DEM,Kamala Harris,2
-San Bernardino,CO10921,U.S. Senate,,DEM,Loretta Sanchez,1
-San Bernardino,CO10922,U.S. Senate,,DEM,Kamala Harris,182
-San Bernardino,CO10922,U.S. Senate,,DEM,Loretta Sanchez,200
-San Bernardino,CO10923,U.S. Senate,,DEM,Kamala Harris,3
-San Bernardino,CO10923,U.S. Senate,,DEM,Loretta Sanchez,1
-San Bernardino,CO10924,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,CO10924,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,CO10925,U.S. Senate,,DEM,Kamala Harris,2
-San Bernardino,CO10925,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,CO10926,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,CO10926,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,CO10955,U.S. Senate,,DEM,Kamala Harris,193
-San Bernardino,CO10955,U.S. Senate,,DEM,Loretta Sanchez,227
-San Bernardino,CO10956,U.S. Senate,,DEM,Kamala Harris,381
-San Bernardino,CO10956,U.S. Senate,,DEM,Loretta Sanchez,489
-San Bernardino,CO10957,U.S. Senate,,DEM,Kamala Harris,264
-San Bernardino,CO10957,U.S. Senate,,DEM,Loretta Sanchez,255
-San Bernardino,CO10958,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,CO10958,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,CO20927,U.S. Senate,,DEM,Kamala Harris,407
-San Bernardino,CO20927,U.S. Senate,,DEM,Loretta Sanchez,475
-San Bernardino,CO20928,U.S. Senate,,DEM,Kamala Harris,297
-San Bernardino,CO20928,U.S. Senate,,DEM,Loretta Sanchez,406
-San Bernardino,CO20929,U.S. Senate,,DEM,Kamala Harris,224
-San Bernardino,CO20929,U.S. Senate,,DEM,Loretta Sanchez,290
-San Bernardino,CO20959,U.S. Senate,,DEM,Kamala Harris,17
-San Bernardino,CO20959,U.S. Senate,,DEM,Loretta Sanchez,12
-San Bernardino,CO20998,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,CO20998,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,CO30930,U.S. Senate,,DEM,Kamala Harris,372
-San Bernardino,CO30930,U.S. Senate,,DEM,Loretta Sanchez,596
-San Bernardino,CO30931,U.S. Senate,,DEM,Kamala Harris,372
-San Bernardino,CO30931,U.S. Senate,,DEM,Loretta Sanchez,492
-San Bernardino,CO30999,U.S. Senate,,DEM,Kamala Harris,2
-San Bernardino,CO30999,U.S. Senate,,DEM,Loretta Sanchez,7
-San Bernardino,CO31000,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,CO31000,U.S. Senate,,DEM,Loretta Sanchez,1
-San Bernardino,CO40932,U.S. Senate,,DEM,Kamala Harris,271
-San Bernardino,CO40932,U.S. Senate,,DEM,Loretta Sanchez,370
-San Bernardino,CO40933,U.S. Senate,,DEM,Kamala Harris,292
-San Bernardino,CO40933,U.S. Senate,,DEM,Loretta Sanchez,374
-San Bernardino,CO40934,U.S. Senate,,DEM,Kamala Harris,250
-San Bernardino,CO40934,U.S. Senate,,DEM,Loretta Sanchez,373
-San Bernardino,CO50893,U.S. Senate,,DEM,Kamala Harris,541
-San Bernardino,CO50893,U.S. Senate,,DEM,Loretta Sanchez,469
-San Bernardino,CO50894,U.S. Senate,,DEM,Kamala Harris,367
-San Bernardino,CO50894,U.S. Senate,,DEM,Loretta Sanchez,281
-San Bernardino,CO50895,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,CO50895,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,CO50896,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,CO50896,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,CO50897,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,CO50897,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,CO50898,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,CO50898,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,CO50899,U.S. Senate,,DEM,Kamala Harris,8
-San Bernardino,CO50899,U.S. Senate,,DEM,Loretta Sanchez,1
-San Bernardino,CO50900,U.S. Senate,,DEM,Kamala Harris,303
-San Bernardino,CO50900,U.S. Senate,,DEM,Loretta Sanchez,216
-San Bernardino,CO50901,U.S. Senate,,DEM,Kamala Harris,257
-San Bernardino,CO50901,U.S. Senate,,DEM,Loretta Sanchez,182
-San Bernardino,CO50902,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,CO50902,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,CO50935,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,CO50935,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,CO60903,U.S. Senate,,DEM,Kamala Harris,1
-San Bernardino,CO60903,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,CO60904,U.S. Senate,,DEM,Kamala Harris,2
-San Bernardino,CO60904,U.S. Senate,,DEM,Loretta Sanchez,5
-San Bernardino,CO60905,U.S. Senate,,DEM,Kamala Harris,194
-San Bernardino,CO60905,U.S. Senate,,DEM,Loretta Sanchez,110
-San Bernardino,CO60936,U.S. Senate,,DEM,Kamala Harris,314
-San Bernardino,CO60936,U.S. Senate,,DEM,Loretta Sanchez,354
-San Bernardino,CO60937,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,CO60937,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,CO60938,U.S. Senate,,DEM,Kamala Harris,484
-San Bernardino,CO60938,U.S. Senate,,DEM,Loretta Sanchez,340
-San Bernardino,CO60939,U.S. Senate,,DEM,Kamala Harris,12
-San Bernardino,CO60939,U.S. Senate,,DEM,Loretta Sanchez,39
-San Bernardino,CO61001,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,CO61001,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,CO61644,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,CO61644,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,FON0881,U.S. Senate,,DEM,Kamala Harris,6
-San Bernardino,FON0881,U.S. Senate,,DEM,Loretta Sanchez,14
-San Bernardino,FON0882,U.S. Senate,,DEM,Kamala Harris,524
-San Bernardino,FON0882,U.S. Senate,,DEM,Loretta Sanchez,407
-San Bernardino,FON0883,U.S. Senate,,DEM,Kamala Harris,678
-San Bernardino,FON0883,U.S. Senate,,DEM,Loretta Sanchez,486
-San Bernardino,FON0884,U.S. Senate,,DEM,Kamala Harris,464
-San Bernardino,FON0884,U.S. Senate,,DEM,Loretta Sanchez,368
-San Bernardino,FON0885,U.S. Senate,,DEM,Kamala Harris,398
-San Bernardino,FON0885,U.S. Senate,,DEM,Loretta Sanchez,275
-San Bernardino,FON0886,U.S. Senate,,DEM,Kamala Harris,414
-San Bernardino,FON0886,U.S. Senate,,DEM,Loretta Sanchez,217
-San Bernardino,FON0887,U.S. Senate,,DEM,Kamala Harris,40
-San Bernardino,FON0887,U.S. Senate,,DEM,Loretta Sanchez,39
-San Bernardino,FON0888,U.S. Senate,,DEM,Kamala Harris,176
-San Bernardino,FON0888,U.S. Senate,,DEM,Loretta Sanchez,97
-San Bernardino,FON0889,U.S. Senate,,DEM,Kamala Harris,92
-San Bernardino,FON0889,U.S. Senate,,DEM,Loretta Sanchez,98
-San Bernardino,FON0890,U.S. Senate,,DEM,Kamala Harris,581
-San Bernardino,FON0890,U.S. Senate,,DEM,Loretta Sanchez,451
-San Bernardino,FON0891,U.S. Senate,,DEM,Kamala Harris,517
-San Bernardino,FON0891,U.S. Senate,,DEM,Loretta Sanchez,360
-San Bernardino,FON0892,U.S. Senate,,DEM,Kamala Harris,622
-San Bernardino,FON0892,U.S. Senate,,DEM,Loretta Sanchez,431
-San Bernardino,FON0952,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,FON0952,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,FON0960,U.S. Senate,,DEM,Kamala Harris,69
-San Bernardino,FON0960,U.S. Senate,,DEM,Loretta Sanchez,32
-San Bernardino,FON1295,U.S. Senate,,DEM,Kamala Harris,1
-San Bernardino,FON1295,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,FON1296,U.S. Senate,,DEM,Kamala Harris,570
-San Bernardino,FON1296,U.S. Senate,,DEM,Loretta Sanchez,506
-San Bernardino,FON1297,U.S. Senate,,DEM,Kamala Harris,571
-San Bernardino,FON1297,U.S. Senate,,DEM,Loretta Sanchez,463
-San Bernardino,FON1298,U.S. Senate,,DEM,Kamala Harris,522
-San Bernardino,FON1298,U.S. Senate,,DEM,Loretta Sanchez,481
-San Bernardino,FON1299,U.S. Senate,,DEM,Kamala Harris,261
-San Bernardino,FON1299,U.S. Senate,,DEM,Loretta Sanchez,234
-San Bernardino,FON1300,U.S. Senate,,DEM,Kamala Harris,649
-San Bernardino,FON1300,U.S. Senate,,DEM,Loretta Sanchez,434
-San Bernardino,FON1301,U.S. Senate,,DEM,Kamala Harris,599
-San Bernardino,FON1301,U.S. Senate,,DEM,Loretta Sanchez,506
-San Bernardino,FON1302,U.S. Senate,,DEM,Kamala Harris,575
-San Bernardino,FON1302,U.S. Senate,,DEM,Loretta Sanchez,397
-San Bernardino,FON1303,U.S. Senate,,DEM,Kamala Harris,630
-San Bernardino,FON1303,U.S. Senate,,DEM,Loretta Sanchez,380
-San Bernardino,FON1304,U.S. Senate,,DEM,Kamala Harris,557
-San Bernardino,FON1304,U.S. Senate,,DEM,Loretta Sanchez,401
-San Bernardino,FON1305,U.S. Senate,,DEM,Kamala Harris,631
-San Bernardino,FON1305,U.S. Senate,,DEM,Loretta Sanchez,430
-San Bernardino,FON1306,U.S. Senate,,DEM,Kamala Harris,679
-San Bernardino,FON1306,U.S. Senate,,DEM,Loretta Sanchez,491
-San Bernardino,FON1307,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,FON1307,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,FON1308,U.S. Senate,,DEM,Kamala Harris,772
-San Bernardino,FON1308,U.S. Senate,,DEM,Loretta Sanchez,677
-San Bernardino,FON1309,U.S. Senate,,DEM,Kamala Harris,804
-San Bernardino,FON1309,U.S. Senate,,DEM,Loretta Sanchez,658
-San Bernardino,FON1310,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,FON1310,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,FON1311,U.S. Senate,,DEM,Kamala Harris,337
-San Bernardino,FON1311,U.S. Senate,,DEM,Loretta Sanchez,441
-San Bernardino,FON1312,U.S. Senate,,DEM,Kamala Harris,255
-San Bernardino,FON1312,U.S. Senate,,DEM,Loretta Sanchez,391
-San Bernardino,FON1313,U.S. Senate,,DEM,Kamala Harris,404
-San Bernardino,FON1313,U.S. Senate,,DEM,Loretta Sanchez,611
-San Bernardino,FON1314,U.S. Senate,,DEM,Kamala Harris,454
-San Bernardino,FON1314,U.S. Senate,,DEM,Loretta Sanchez,584
-San Bernardino,FON1315,U.S. Senate,,DEM,Kamala Harris,629
-San Bernardino,FON1315,U.S. Senate,,DEM,Loretta Sanchez,597
-San Bernardino,FON1316,U.S. Senate,,DEM,Kamala Harris,634
-San Bernardino,FON1316,U.S. Senate,,DEM,Loretta Sanchez,560
-San Bernardino,FON1317,U.S. Senate,,DEM,Kamala Harris,50
-San Bernardino,FON1317,U.S. Senate,,DEM,Loretta Sanchez,70
-San Bernardino,FON1318,U.S. Senate,,DEM,Kamala Harris,429
-San Bernardino,FON1318,U.S. Senate,,DEM,Loretta Sanchez,595
-San Bernardino,FON1319,U.S. Senate,,DEM,Kamala Harris,354
-San Bernardino,FON1319,U.S. Senate,,DEM,Loretta Sanchez,635
-San Bernardino,FON1320,U.S. Senate,,DEM,Kamala Harris,171
-San Bernardino,FON1320,U.S. Senate,,DEM,Loretta Sanchez,210
-San Bernardino,FON1321,U.S. Senate,,DEM,Kamala Harris,254
-San Bernardino,FON1321,U.S. Senate,,DEM,Loretta Sanchez,357
-San Bernardino,FON1322,U.S. Senate,,DEM,Kamala Harris,320
-San Bernardino,FON1322,U.S. Senate,,DEM,Loretta Sanchez,523
-San Bernardino,FON1323,U.S. Senate,,DEM,Kamala Harris,449
-San Bernardino,FON1323,U.S. Senate,,DEM,Loretta Sanchez,623
-San Bernardino,FON1324,U.S. Senate,,DEM,Kamala Harris,246
-San Bernardino,FON1324,U.S. Senate,,DEM,Loretta Sanchez,343
-San Bernardino,FON1325,U.S. Senate,,DEM,Kamala Harris,465
-San Bernardino,FON1325,U.S. Senate,,DEM,Loretta Sanchez,571
-San Bernardino,FON1326,U.S. Senate,,DEM,Kamala Harris,473
-San Bernardino,FON1326,U.S. Senate,,DEM,Loretta Sanchez,672
-San Bernardino,FON1327,U.S. Senate,,DEM,Kamala Harris,524
-San Bernardino,FON1327,U.S. Senate,,DEM,Loretta Sanchez,604
-San Bernardino,FON1328,U.S. Senate,,DEM,Kamala Harris,484
-San Bernardino,FON1328,U.S. Senate,,DEM,Loretta Sanchez,583
-San Bernardino,FON1329,U.S. Senate,,DEM,Kamala Harris,2
-San Bernardino,FON1329,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,FON1330,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,FON1330,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,FON1331,U.S. Senate,,DEM,Kamala Harris,122
-San Bernardino,FON1331,U.S. Senate,,DEM,Loretta Sanchez,164
-San Bernardino,FON1332,U.S. Senate,,DEM,Kamala Harris,37
-San Bernardino,FON1332,U.S. Senate,,DEM,Loretta Sanchez,75
-San Bernardino,FON1333,U.S. Senate,,DEM,Kamala Harris,85
-San Bernardino,FON1333,U.S. Senate,,DEM,Loretta Sanchez,157
-San Bernardino,FON1334,U.S. Senate,,DEM,Kamala Harris,3
-San Bernardino,FON1334,U.S. Senate,,DEM,Loretta Sanchez,5
-San Bernardino,FON1335,U.S. Senate,,DEM,Kamala Harris,456
-San Bernardino,FON1335,U.S. Senate,,DEM,Loretta Sanchez,448
-San Bernardino,FON1336,U.S. Senate,,DEM,Kamala Harris,8
-San Bernardino,FON1336,U.S. Senate,,DEM,Loretta Sanchez,9
-San Bernardino,FON1337,U.S. Senate,,DEM,Kamala Harris,272
-San Bernardino,FON1337,U.S. Senate,,DEM,Loretta Sanchez,189
-San Bernardino,FON1360,U.S. Senate,,DEM,Kamala Harris,407
-San Bernardino,FON1360,U.S. Senate,,DEM,Loretta Sanchez,506
-San Bernardino,FON1361,U.S. Senate,,DEM,Kamala Harris,370
-San Bernardino,FON1361,U.S. Senate,,DEM,Loretta Sanchez,530
-San Bernardino,FON1362,U.S. Senate,,DEM,Kamala Harris,422
-San Bernardino,FON1362,U.S. Senate,,DEM,Loretta Sanchez,565
-San Bernardino,FON1363,U.S. Senate,,DEM,Kamala Harris,474
-San Bernardino,FON1363,U.S. Senate,,DEM,Loretta Sanchez,622
-San Bernardino,FON1364,U.S. Senate,,DEM,Kamala Harris,528
-San Bernardino,FON1364,U.S. Senate,,DEM,Loretta Sanchez,644
-San Bernardino,FON1365,U.S. Senate,,DEM,Kamala Harris,389
-San Bernardino,FON1365,U.S. Senate,,DEM,Loretta Sanchez,532
-San Bernardino,FON1366,U.S. Senate,,DEM,Kamala Harris,264
-San Bernardino,FON1366,U.S. Senate,,DEM,Loretta Sanchez,374
-San Bernardino,FON1367,U.S. Senate,,DEM,Kamala Harris,350
-San Bernardino,FON1367,U.S. Senate,,DEM,Loretta Sanchez,427
-San Bernardino,FON1368,U.S. Senate,,DEM,Kamala Harris,458
-San Bernardino,FON1368,U.S. Senate,,DEM,Loretta Sanchez,666
-San Bernardino,FON1369,U.S. Senate,,DEM,Kamala Harris,444
-San Bernardino,FON1369,U.S. Senate,,DEM,Loretta Sanchez,563
-San Bernardino,FON1370,U.S. Senate,,DEM,Kamala Harris,126
-San Bernardino,FON1370,U.S. Senate,,DEM,Loretta Sanchez,126
-San Bernardino,FON1371,U.S. Senate,,DEM,Kamala Harris,99
-San Bernardino,FON1371,U.S. Senate,,DEM,Loretta Sanchez,146
-San Bernardino,FON1375,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,FON1375,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,FON1376,U.S. Senate,,DEM,Kamala Harris,377
-San Bernardino,FON1376,U.S. Senate,,DEM,Loretta Sanchez,368
-San Bernardino,FON1533,U.S. Senate,,DEM,Kamala Harris,53
-San Bernardino,FON1533,U.S. Senate,,DEM,Loretta Sanchez,65
-San Bernardino,FON1575,U.S. Senate,,DEM,Kamala Harris,104
-San Bernardino,FON1575,U.S. Senate,,DEM,Loretta Sanchez,145
-San Bernardino,GRA0906,U.S. Senate,,DEM,Kamala Harris,106
-San Bernardino,GRA0906,U.S. Senate,,DEM,Loretta Sanchez,109
-San Bernardino,GRA0907,U.S. Senate,,DEM,Kamala Harris,637
-San Bernardino,GRA0907,U.S. Senate,,DEM,Loretta Sanchez,462
-San Bernardino,GRA0908,U.S. Senate,,DEM,Kamala Harris,631
-San Bernardino,GRA0908,U.S. Senate,,DEM,Loretta Sanchez,448
-San Bernardino,GRA0909,U.S. Senate,,DEM,Kamala Harris,547
-San Bernardino,GRA0909,U.S. Senate,,DEM,Loretta Sanchez,417
-San Bernardino,GRA0910,U.S. Senate,,DEM,Kamala Harris,522
-San Bernardino,GRA0910,U.S. Senate,,DEM,Loretta Sanchez,385
-San Bernardino,GRA0911,U.S. Senate,,DEM,Kamala Harris,16
-San Bernardino,GRA0911,U.S. Senate,,DEM,Loretta Sanchez,15
-San Bernardino,GRA0912,U.S. Senate,,DEM,Kamala Harris,5
-San Bernardino,GRA0912,U.S. Senate,,DEM,Loretta Sanchez,5
-San Bernardino,GRA0913,U.S. Senate,,DEM,Kamala Harris,7
-San Bernardino,GRA0913,U.S. Senate,,DEM,Loretta Sanchez,17
-San Bernardino,HES0325,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,HES0325,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,HES0329,U.S. Senate,,DEM,Kamala Harris,459
-San Bernardino,HES0329,U.S. Senate,,DEM,Loretta Sanchez,525
-San Bernardino,HES0330,U.S. Senate,,DEM,Kamala Harris,462
-San Bernardino,HES0330,U.S. Senate,,DEM,Loretta Sanchez,512
-San Bernardino,HES0331,U.S. Senate,,DEM,Kamala Harris,380
-San Bernardino,HES0331,U.S. Senate,,DEM,Loretta Sanchez,489
-San Bernardino,HES0332,U.S. Senate,,DEM,Kamala Harris,382
-San Bernardino,HES0332,U.S. Senate,,DEM,Loretta Sanchez,394
-San Bernardino,HES0333,U.S. Senate,,DEM,Kamala Harris,353
-San Bernardino,HES0333,U.S. Senate,,DEM,Loretta Sanchez,491
-San Bernardino,HES0334,U.S. Senate,,DEM,Kamala Harris,44
-San Bernardino,HES0334,U.S. Senate,,DEM,Loretta Sanchez,46
-San Bernardino,HES0335,U.S. Senate,,DEM,Kamala Harris,255
-San Bernardino,HES0335,U.S. Senate,,DEM,Loretta Sanchez,347
-San Bernardino,HES0336,U.S. Senate,,DEM,Kamala Harris,385
-San Bernardino,HES0336,U.S. Senate,,DEM,Loretta Sanchez,421
-San Bernardino,HES0337,U.S. Senate,,DEM,Kamala Harris,473
-San Bernardino,HES0337,U.S. Senate,,DEM,Loretta Sanchez,591
-San Bernardino,HES0338,U.S. Senate,,DEM,Kamala Harris,401
-San Bernardino,HES0338,U.S. Senate,,DEM,Loretta Sanchez,495
-San Bernardino,HES0339,U.S. Senate,,DEM,Kamala Harris,406
-San Bernardino,HES0339,U.S. Senate,,DEM,Loretta Sanchez,456
-San Bernardino,HES0340,U.S. Senate,,DEM,Kamala Harris,32
-San Bernardino,HES0340,U.S. Senate,,DEM,Loretta Sanchez,24
-San Bernardino,HES0341,U.S. Senate,,DEM,Kamala Harris,565
-San Bernardino,HES0341,U.S. Senate,,DEM,Loretta Sanchez,558
-San Bernardino,HES0342,U.S. Senate,,DEM,Kamala Harris,513
-San Bernardino,HES0342,U.S. Senate,,DEM,Loretta Sanchez,614
-San Bernardino,HES0343,U.S. Senate,,DEM,Kamala Harris,296
-San Bernardino,HES0343,U.S. Senate,,DEM,Loretta Sanchez,354
-San Bernardino,HES0344,U.S. Senate,,DEM,Kamala Harris,81
-San Bernardino,HES0344,U.S. Senate,,DEM,Loretta Sanchez,73
-San Bernardino,HES0345,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,HES0345,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,HES0346,U.S. Senate,,DEM,Kamala Harris,377
-San Bernardino,HES0346,U.S. Senate,,DEM,Loretta Sanchez,438
-San Bernardino,HES0347,U.S. Senate,,DEM,Kamala Harris,375
-San Bernardino,HES0347,U.S. Senate,,DEM,Loretta Sanchez,329
-San Bernardino,HES0348,U.S. Senate,,DEM,Kamala Harris,328
-San Bernardino,HES0348,U.S. Senate,,DEM,Loretta Sanchez,353
-San Bernardino,HES0349,U.S. Senate,,DEM,Kamala Harris,485
-San Bernardino,HES0349,U.S. Senate,,DEM,Loretta Sanchez,486
-San Bernardino,HES0350,U.S. Senate,,DEM,Kamala Harris,584
-San Bernardino,HES0350,U.S. Senate,,DEM,Loretta Sanchez,572
-San Bernardino,HES0351,U.S. Senate,,DEM,Kamala Harris,352
-San Bernardino,HES0351,U.S. Senate,,DEM,Loretta Sanchez,403
-San Bernardino,HES0352,U.S. Senate,,DEM,Kamala Harris,195
-San Bernardino,HES0352,U.S. Senate,,DEM,Loretta Sanchez,208
-San Bernardino,HES0353,U.S. Senate,,DEM,Kamala Harris,459
-San Bernardino,HES0353,U.S. Senate,,DEM,Loretta Sanchez,445
-San Bernardino,HES0354,U.S. Senate,,DEM,Kamala Harris,381
-San Bernardino,HES0354,U.S. Senate,,DEM,Loretta Sanchez,452
-San Bernardino,HES0355,U.S. Senate,,DEM,Kamala Harris,487
-San Bernardino,HES0355,U.S. Senate,,DEM,Loretta Sanchez,528
-San Bernardino,HES0356,U.S. Senate,,DEM,Kamala Harris,474
-San Bernardino,HES0356,U.S. Senate,,DEM,Loretta Sanchez,513
-San Bernardino,HES0357,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,HES0357,U.S. Senate,,DEM,Loretta Sanchez,1
-San Bernardino,HES0358,U.S. Senate,,DEM,Kamala Harris,1
-San Bernardino,HES0358,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,HES0370,U.S. Senate,,DEM,Kamala Harris,3
-San Bernardino,HES0370,U.S. Senate,,DEM,Loretta Sanchez,5
-San Bernardino,HES0371,U.S. Senate,,DEM,Kamala Harris,8
-San Bernardino,HES0371,U.S. Senate,,DEM,Loretta Sanchez,4
-San Bernardino,HES1606,U.S. Senate,,DEM,Kamala Harris,197
-San Bernardino,HES1606,U.S. Senate,,DEM,Loretta Sanchez,191
-San Bernardino,HES1607,U.S. Senate,,DEM,Kamala Harris,141
-San Bernardino,HES1607,U.S. Senate,,DEM,Loretta Sanchez,212
-San Bernardino,HI10750,U.S. Senate,,DEM,Kamala Harris,288
-San Bernardino,HI10750,U.S. Senate,,DEM,Loretta Sanchez,292
-San Bernardino,HI10751,U.S. Senate,,DEM,Kamala Harris,310
-San Bernardino,HI10751,U.S. Senate,,DEM,Loretta Sanchez,277
-San Bernardino,HI10752,U.S. Senate,,DEM,Kamala Harris,107
-San Bernardino,HI10752,U.S. Senate,,DEM,Loretta Sanchez,115
-San Bernardino,HI10753,U.S. Senate,,DEM,Kamala Harris,168
-San Bernardino,HI10753,U.S. Senate,,DEM,Loretta Sanchez,153
-San Bernardino,HI11156,U.S. Senate,,DEM,Kamala Harris,1
-San Bernardino,HI11156,U.S. Senate,,DEM,Loretta Sanchez,3
-San Bernardino,HI20746,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,HI20746,U.S. Senate,,DEM,Loretta Sanchez,6
-San Bernardino,HI20747,U.S. Senate,,DEM,Kamala Harris,200
-San Bernardino,HI20747,U.S. Senate,,DEM,Loretta Sanchez,135
-San Bernardino,HI21154,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,HI21154,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,HI21155,U.S. Senate,,DEM,Kamala Harris,5
-San Bernardino,HI21155,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,HI21639,U.S. Senate,,DEM,Kamala Harris,85
-San Bernardino,HI21639,U.S. Senate,,DEM,Loretta Sanchez,73
-San Bernardino,HI21770,U.S. Senate,,DEM,Kamala Harris,607
-San Bernardino,HI21770,U.S. Senate,,DEM,Loretta Sanchez,542
-San Bernardino,HI30748,U.S. Senate,,DEM,Kamala Harris,477
-San Bernardino,HI30748,U.S. Senate,,DEM,Loretta Sanchez,376
-San Bernardino,HI30754,U.S. Senate,,DEM,Kamala Harris,489
-San Bernardino,HI30754,U.S. Senate,,DEM,Loretta Sanchez,446
-San Bernardino,HI30755,U.S. Senate,,DEM,Kamala Harris,174
-San Bernardino,HI30755,U.S. Senate,,DEM,Loretta Sanchez,168
-San Bernardino,HI30757,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,HI30757,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,HI30758,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,HI30758,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,HI31765,U.S. Senate,,DEM,Kamala Harris,376
-San Bernardino,HI31765,U.S. Senate,,DEM,Loretta Sanchez,300
-San Bernardino,HI31766,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,HI31766,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,HI31767,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,HI31767,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,HI31768,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,HI31768,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,HI31769,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,HI31769,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,HI40719,U.S. Senate,,DEM,Kamala Harris,476
-San Bernardino,HI40719,U.S. Senate,,DEM,Loretta Sanchez,299
-San Bernardino,HI40721,U.S. Senate,,DEM,Kamala Harris,430
-San Bernardino,HI40721,U.S. Senate,,DEM,Loretta Sanchez,277
-San Bernardino,HI40722,U.S. Senate,,DEM,Kamala Harris,538
-San Bernardino,HI40722,U.S. Senate,,DEM,Loretta Sanchez,307
-San Bernardino,HI40727,U.S. Senate,,DEM,Kamala Harris,29
-San Bernardino,HI40727,U.S. Senate,,DEM,Loretta Sanchez,36
-San Bernardino,HI40728,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,HI40728,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,HI40729,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,HI40729,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,HI40749,U.S. Senate,,DEM,Kamala Harris,511
-San Bernardino,HI40749,U.S. Senate,,DEM,Loretta Sanchez,393
-San Bernardino,HI40756,U.S. Senate,,DEM,Kamala Harris,138
-San Bernardino,HI40756,U.S. Senate,,DEM,Loretta Sanchez,93
-San Bernardino,HI41622,U.S. Senate,,DEM,Kamala Harris,365
-San Bernardino,HI41622,U.S. Senate,,DEM,Loretta Sanchez,226
-San Bernardino,HI41764,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,HI41764,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,HI50604,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,HI50604,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,HI50720,U.S. Senate,,DEM,Kamala Harris,750
-San Bernardino,HI50720,U.S. Senate,,DEM,Loretta Sanchez,433
-San Bernardino,HI50723,U.S. Senate,,DEM,Kamala Harris,997
-San Bernardino,HI50723,U.S. Senate,,DEM,Loretta Sanchez,549
-San Bernardino,HI50724,U.S. Senate,,DEM,Kamala Harris,51
-San Bernardino,HI50724,U.S. Senate,,DEM,Loretta Sanchez,45
-San Bernardino,HI50725,U.S. Senate,,DEM,Kamala Harris,782
-San Bernardino,HI50725,U.S. Senate,,DEM,Loretta Sanchez,502
-San Bernardino,HI50726,U.S. Senate,,DEM,Kamala Harris,56
-San Bernardino,HI50726,U.S. Senate,,DEM,Loretta Sanchez,29
-San Bernardino,HI50730,U.S. Senate,,DEM,Kamala Harris,35
-San Bernardino,HI50730,U.S. Senate,,DEM,Loretta Sanchez,27
-San Bernardino,HI50731,U.S. Senate,,DEM,Kamala Harris,16
-San Bernardino,HI50731,U.S. Senate,,DEM,Loretta Sanchez,21
-San Bernardino,HI50732,U.S. Senate,,DEM,Kamala Harris,1
-San Bernardino,HI50732,U.S. Senate,,DEM,Loretta Sanchez,1
-San Bernardino,HI50733,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,HI50733,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,HI50734,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,HI50734,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,HI50735,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,HI50735,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,HI51695,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,HI51695,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,HI51696,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,HI51696,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,HI51771,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,HI51771,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,LOM1091,U.S. Senate,,DEM,Kamala Harris,325
-San Bernardino,LOM1091,U.S. Senate,,DEM,Loretta Sanchez,168
-San Bernardino,LOM1092,U.S. Senate,,DEM,Kamala Harris,6
-San Bernardino,LOM1092,U.S. Senate,,DEM,Loretta Sanchez,1
-San Bernardino,LOM1093,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,LOM1093,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,LOM1095,U.S. Senate,,DEM,Kamala Harris,669
-San Bernardino,LOM1095,U.S. Senate,,DEM,Loretta Sanchez,386
-San Bernardino,LOM1096,U.S. Senate,,DEM,Kamala Harris,599
-San Bernardino,LOM1096,U.S. Senate,,DEM,Loretta Sanchez,393
-San Bernardino,LOM1097,U.S. Senate,,DEM,Kamala Harris,193
-San Bernardino,LOM1097,U.S. Senate,,DEM,Loretta Sanchez,102
-San Bernardino,LOM1098,U.S. Senate,,DEM,Kamala Harris,876
-San Bernardino,LOM1098,U.S. Senate,,DEM,Loretta Sanchez,442
-San Bernardino,LOM1099,U.S. Senate,,DEM,Kamala Harris,67
-San Bernardino,LOM1099,U.S. Senate,,DEM,Loretta Sanchez,34
-San Bernardino,LOM1100,U.S. Senate,,DEM,Kamala Harris,650
-San Bernardino,LOM1100,U.S. Senate,,DEM,Loretta Sanchez,365
-San Bernardino,LOM1101,U.S. Senate,,DEM,Kamala Harris,658
-San Bernardino,LOM1101,U.S. Senate,,DEM,Loretta Sanchez,339
-San Bernardino,LOM1102,U.S. Senate,,DEM,Kamala Harris,73
-San Bernardino,LOM1102,U.S. Senate,,DEM,Loretta Sanchez,46
-San Bernardino,LOM1209,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,LOM1209,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,LOM1210,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,LOM1210,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,LOM1211,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,LOM1211,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,LOM1631,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,LOM1631,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,MON1389,U.S. Senate,,DEM,Kamala Harris,586
-San Bernardino,MON1389,U.S. Senate,,DEM,Loretta Sanchez,494
-San Bernardino,MON1390,U.S. Senate,,DEM,Kamala Harris,456
-San Bernardino,MON1390,U.S. Senate,,DEM,Loretta Sanchez,491
-San Bernardino,MON1391,U.S. Senate,,DEM,Kamala Harris,462
-San Bernardino,MON1391,U.S. Senate,,DEM,Loretta Sanchez,415
-San Bernardino,MON1392,U.S. Senate,,DEM,Kamala Harris,521
-San Bernardino,MON1392,U.S. Senate,,DEM,Loretta Sanchez,449
-San Bernardino,MON1393,U.S. Senate,,DEM,Kamala Harris,591
-San Bernardino,MON1393,U.S. Senate,,DEM,Loretta Sanchez,577
-San Bernardino,MON1394,U.S. Senate,,DEM,Kamala Harris,536
-San Bernardino,MON1394,U.S. Senate,,DEM,Loretta Sanchez,547
-San Bernardino,MON1395,U.S. Senate,,DEM,Kamala Harris,412
-San Bernardino,MON1395,U.S. Senate,,DEM,Loretta Sanchez,434
-San Bernardino,MON1396,U.S. Senate,,DEM,Kamala Harris,429
-San Bernardino,MON1396,U.S. Senate,,DEM,Loretta Sanchez,485
-San Bernardino,MON1397,U.S. Senate,,DEM,Kamala Harris,620
-San Bernardino,MON1397,U.S. Senate,,DEM,Loretta Sanchez,498
-San Bernardino,MON1521,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,MON1521,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,NEE0060,U.S. Senate,,DEM,Kamala Harris,134
-San Bernardino,NEE0060,U.S. Senate,,DEM,Loretta Sanchez,86
-San Bernardino,NEE0061,U.S. Senate,,DEM,Kamala Harris,450
-San Bernardino,NEE0061,U.S. Senate,,DEM,Loretta Sanchez,339
-San Bernardino,ONT1027,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,ONT1027,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,ONT1398,U.S. Senate,,DEM,Kamala Harris,429
-San Bernardino,ONT1398,U.S. Senate,,DEM,Loretta Sanchez,418
-San Bernardino,ONT1399,U.S. Senate,,DEM,Kamala Harris,320
-San Bernardino,ONT1399,U.S. Senate,,DEM,Loretta Sanchez,267
-San Bernardino,ONT1400,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,ONT1400,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,ONT1401,U.S. Senate,,DEM,Kamala Harris,392
-San Bernardino,ONT1401,U.S. Senate,,DEM,Loretta Sanchez,370
-San Bernardino,ONT1402,U.S. Senate,,DEM,Kamala Harris,583
-San Bernardino,ONT1402,U.S. Senate,,DEM,Loretta Sanchez,574
-San Bernardino,ONT1403,U.S. Senate,,DEM,Kamala Harris,633
-San Bernardino,ONT1403,U.S. Senate,,DEM,Loretta Sanchez,583
-San Bernardino,ONT1404,U.S. Senate,,DEM,Kamala Harris,341
-San Bernardino,ONT1404,U.S. Senate,,DEM,Loretta Sanchez,280
-San Bernardino,ONT1405,U.S. Senate,,DEM,Kamala Harris,669
-San Bernardino,ONT1405,U.S. Senate,,DEM,Loretta Sanchez,528
-San Bernardino,ONT1406,U.S. Senate,,DEM,Kamala Harris,527
-San Bernardino,ONT1406,U.S. Senate,,DEM,Loretta Sanchez,485
-San Bernardino,ONT1407,U.S. Senate,,DEM,Kamala Harris,236
-San Bernardino,ONT1407,U.S. Senate,,DEM,Loretta Sanchez,259
-San Bernardino,ONT1408,U.S. Senate,,DEM,Kamala Harris,49
-San Bernardino,ONT1408,U.S. Senate,,DEM,Loretta Sanchez,54
-San Bernardino,ONT1409,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,ONT1409,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,ONT1410,U.S. Senate,,DEM,Kamala Harris,421
-San Bernardino,ONT1410,U.S. Senate,,DEM,Loretta Sanchez,529
-San Bernardino,ONT1411,U.S. Senate,,DEM,Kamala Harris,341
-San Bernardino,ONT1411,U.S. Senate,,DEM,Loretta Sanchez,252
-San Bernardino,ONT1412,U.S. Senate,,DEM,Kamala Harris,400
-San Bernardino,ONT1412,U.S. Senate,,DEM,Loretta Sanchez,580
-San Bernardino,ONT1413,U.S. Senate,,DEM,Kamala Harris,162
-San Bernardino,ONT1413,U.S. Senate,,DEM,Loretta Sanchez,174
-San Bernardino,ONT1414,U.S. Senate,,DEM,Kamala Harris,469
-San Bernardino,ONT1414,U.S. Senate,,DEM,Loretta Sanchez,498
-San Bernardino,ONT1415,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,ONT1415,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,ONT1416,U.S. Senate,,DEM,Kamala Harris,311
-San Bernardino,ONT1416,U.S. Senate,,DEM,Loretta Sanchez,391
-San Bernardino,ONT1417,U.S. Senate,,DEM,Kamala Harris,4
-San Bernardino,ONT1417,U.S. Senate,,DEM,Loretta Sanchez,2
-San Bernardino,ONT1418,U.S. Senate,,DEM,Kamala Harris,389
-San Bernardino,ONT1418,U.S. Senate,,DEM,Loretta Sanchez,451
-San Bernardino,ONT1419,U.S. Senate,,DEM,Kamala Harris,239
-San Bernardino,ONT1419,U.S. Senate,,DEM,Loretta Sanchez,217
-San Bernardino,ONT1420,U.S. Senate,,DEM,Kamala Harris,420
-San Bernardino,ONT1420,U.S. Senate,,DEM,Loretta Sanchez,329
-San Bernardino,ONT1421,U.S. Senate,,DEM,Kamala Harris,385
-San Bernardino,ONT1421,U.S. Senate,,DEM,Loretta Sanchez,472
-San Bernardino,ONT1422,U.S. Senate,,DEM,Kamala Harris,541
-San Bernardino,ONT1422,U.S. Senate,,DEM,Loretta Sanchez,459
-San Bernardino,ONT1423,U.S. Senate,,DEM,Kamala Harris,5
-San Bernardino,ONT1423,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,ONT1424,U.S. Senate,,DEM,Kamala Harris,280
-San Bernardino,ONT1424,U.S. Senate,,DEM,Loretta Sanchez,252
-San Bernardino,ONT1425,U.S. Senate,,DEM,Kamala Harris,85
-San Bernardino,ONT1425,U.S. Senate,,DEM,Loretta Sanchez,25
-San Bernardino,ONT1426,U.S. Senate,,DEM,Kamala Harris,324
-San Bernardino,ONT1426,U.S. Senate,,DEM,Loretta Sanchez,301
-San Bernardino,ONT1427,U.S. Senate,,DEM,Kamala Harris,172
-San Bernardino,ONT1427,U.S. Senate,,DEM,Loretta Sanchez,216
-San Bernardino,ONT1428,U.S. Senate,,DEM,Kamala Harris,385
-San Bernardino,ONT1428,U.S. Senate,,DEM,Loretta Sanchez,587
-San Bernardino,ONT1429,U.S. Senate,,DEM,Kamala Harris,500
-San Bernardino,ONT1429,U.S. Senate,,DEM,Loretta Sanchez,428
-San Bernardino,ONT1430,U.S. Senate,,DEM,Kamala Harris,473
-San Bernardino,ONT1430,U.S. Senate,,DEM,Loretta Sanchez,457
-San Bernardino,ONT1431,U.S. Senate,,DEM,Kamala Harris,387
-San Bernardino,ONT1431,U.S. Senate,,DEM,Loretta Sanchez,497
-San Bernardino,ONT1432,U.S. Senate,,DEM,Kamala Harris,378
-San Bernardino,ONT1432,U.S. Senate,,DEM,Loretta Sanchez,555
-San Bernardino,ONT1433,U.S. Senate,,DEM,Kamala Harris,466
-San Bernardino,ONT1433,U.S. Senate,,DEM,Loretta Sanchez,530
-San Bernardino,ONT1434,U.S. Senate,,DEM,Kamala Harris,648
-San Bernardino,ONT1434,U.S. Senate,,DEM,Loretta Sanchez,554
-San Bernardino,ONT1435,U.S. Senate,,DEM,Kamala Harris,422
-San Bernardino,ONT1435,U.S. Senate,,DEM,Loretta Sanchez,391
-San Bernardino,ONT1436,U.S. Senate,,DEM,Kamala Harris,303
-San Bernardino,ONT1436,U.S. Senate,,DEM,Loretta Sanchez,328
-San Bernardino,ONT1437,U.S. Senate,,DEM,Kamala Harris,32
-San Bernardino,ONT1437,U.S. Senate,,DEM,Loretta Sanchez,25
-San Bernardino,ONT1438,U.S. Senate,,DEM,Kamala Harris,94
-San Bernardino,ONT1438,U.S. Senate,,DEM,Loretta Sanchez,40
-San Bernardino,ONT1439,U.S. Senate,,DEM,Kamala Harris,63
-San Bernardino,ONT1439,U.S. Senate,,DEM,Loretta Sanchez,50
-San Bernardino,ONT1440,U.S. Senate,,DEM,Kamala Harris,400
-San Bernardino,ONT1440,U.S. Senate,,DEM,Loretta Sanchez,284
-San Bernardino,ONT1441,U.S. Senate,,DEM,Kamala Harris,596
-San Bernardino,ONT1441,U.S. Senate,,DEM,Loretta Sanchez,365
-San Bernardino,ONT1442,U.S. Senate,,DEM,Kamala Harris,475
-San Bernardino,ONT1442,U.S. Senate,,DEM,Loretta Sanchez,524
-San Bernardino,ONT1443,U.S. Senate,,DEM,Kamala Harris,659
-San Bernardino,ONT1443,U.S. Senate,,DEM,Loretta Sanchez,517
-San Bernardino,ONT1444,U.S. Senate,,DEM,Kamala Harris,585
-San Bernardino,ONT1444,U.S. Senate,,DEM,Loretta Sanchez,476
-San Bernardino,ONT1445,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,ONT1445,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,ONT1446,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,ONT1446,U.S. Senate,,DEM,Loretta Sanchez,1
-San Bernardino,ONT1447,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,ONT1447,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,ONT1448,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,ONT1448,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,ONT1449,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,ONT1449,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,ONT1450,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,ONT1450,U.S. Senate,,DEM,Loretta Sanchez,1
-San Bernardino,ONT1451,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,ONT1451,U.S. Senate,,DEM,Loretta Sanchez,1
-San Bernardino,ONT1452,U.S. Senate,,DEM,Kamala Harris,810
-San Bernardino,ONT1452,U.S. Senate,,DEM,Loretta Sanchez,388
-San Bernardino,ONT1453,U.S. Senate,,DEM,Kamala Harris,56
-San Bernardino,ONT1453,U.S. Senate,,DEM,Loretta Sanchez,30
-San Bernardino,ONT1502,U.S. Senate,,DEM,Kamala Harris,2
-San Bernardino,ONT1502,U.S. Senate,,DEM,Loretta Sanchez,2
-San Bernardino,ONT1503,U.S. Senate,,DEM,Kamala Harris,34
-San Bernardino,ONT1503,U.S. Senate,,DEM,Loretta Sanchez,42
-San Bernardino,ONT1504,U.S. Senate,,DEM,Kamala Harris,107
-San Bernardino,ONT1504,U.S. Senate,,DEM,Loretta Sanchez,63
-San Bernardino,ONT1505,U.S. Senate,,DEM,Kamala Harris,555
-San Bernardino,ONT1505,U.S. Senate,,DEM,Loretta Sanchez,568
-San Bernardino,ONT1506,U.S. Senate,,DEM,Kamala Harris,538
-San Bernardino,ONT1506,U.S. Senate,,DEM,Loretta Sanchez,464
-San Bernardino,ONT1507,U.S. Senate,,DEM,Kamala Harris,507
-San Bernardino,ONT1507,U.S. Senate,,DEM,Loretta Sanchez,483
-San Bernardino,ONT1508,U.S. Senate,,DEM,Kamala Harris,400
-San Bernardino,ONT1508,U.S. Senate,,DEM,Loretta Sanchez,457
-San Bernardino,ONT1509,U.S. Senate,,DEM,Kamala Harris,14
-San Bernardino,ONT1509,U.S. Senate,,DEM,Loretta Sanchez,40
-San Bernardino,ONT1570,U.S. Senate,,DEM,Kamala Harris,216
-San Bernardino,ONT1570,U.S. Senate,,DEM,Loretta Sanchez,217
-San Bernardino,ONT1571,U.S. Senate,,DEM,Kamala Harris,447
-San Bernardino,ONT1571,U.S. Senate,,DEM,Loretta Sanchez,341
-San Bernardino,ONT1572,U.S. Senate,,DEM,Kamala Harris,183
-San Bernardino,ONT1572,U.S. Senate,,DEM,Loretta Sanchez,231
-San Bernardino,ONT1576,U.S. Senate,,DEM,Kamala Harris,71
-San Bernardino,ONT1576,U.S. Senate,,DEM,Loretta Sanchez,58
-San Bernardino,ONT1577,U.S. Senate,,DEM,Kamala Harris,71
-San Bernardino,ONT1577,U.S. Senate,,DEM,Loretta Sanchez,92
-San Bernardino,ONT1730,U.S. Senate,,DEM,Kamala Harris,166
-San Bernardino,ONT1730,U.S. Senate,,DEM,Loretta Sanchez,144
-San Bernardino,ONT1731,U.S. Senate,,DEM,Kamala Harris,473
-San Bernardino,ONT1731,U.S. Senate,,DEM,Loretta Sanchez,384
-San Bernardino,ONT1732,U.S. Senate,,DEM,Kamala Harris,226
-San Bernardino,ONT1732,U.S. Senate,,DEM,Loretta Sanchez,127
-San Bernardino,RAN0835,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,RAN0835,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,RAN1028,U.S. Senate,,DEM,Kamala Harris,538
-San Bernardino,RAN1028,U.S. Senate,,DEM,Loretta Sanchez,347
-San Bernardino,RAN1029,U.S. Senate,,DEM,Kamala Harris,563
-San Bernardino,RAN1029,U.S. Senate,,DEM,Loretta Sanchez,454
-San Bernardino,RAN1030,U.S. Senate,,DEM,Kamala Harris,603
-San Bernardino,RAN1030,U.S. Senate,,DEM,Loretta Sanchez,399
-San Bernardino,RAN1031,U.S. Senate,,DEM,Kamala Harris,764
-San Bernardino,RAN1031,U.S. Senate,,DEM,Loretta Sanchez,494
-San Bernardino,RAN1032,U.S. Senate,,DEM,Kamala Harris,666
-San Bernardino,RAN1032,U.S. Senate,,DEM,Loretta Sanchez,442
-San Bernardino,RAN1033,U.S. Senate,,DEM,Kamala Harris,609
-San Bernardino,RAN1033,U.S. Senate,,DEM,Loretta Sanchez,368
-San Bernardino,RAN1034,U.S. Senate,,DEM,Kamala Harris,617
-San Bernardino,RAN1034,U.S. Senate,,DEM,Loretta Sanchez,345
-San Bernardino,RAN1035,U.S. Senate,,DEM,Kamala Harris,198
-San Bernardino,RAN1035,U.S. Senate,,DEM,Loretta Sanchez,95
-San Bernardino,RAN1036,U.S. Senate,,DEM,Kamala Harris,475
-San Bernardino,RAN1036,U.S. Senate,,DEM,Loretta Sanchez,330
-San Bernardino,RAN1037,U.S. Senate,,DEM,Kamala Harris,381
-San Bernardino,RAN1037,U.S. Senate,,DEM,Loretta Sanchez,256
-San Bernardino,RAN1038,U.S. Senate,,DEM,Kamala Harris,522
-San Bernardino,RAN1038,U.S. Senate,,DEM,Loretta Sanchez,364
-San Bernardino,RAN1039,U.S. Senate,,DEM,Kamala Harris,310
-San Bernardino,RAN1039,U.S. Senate,,DEM,Loretta Sanchez,177
-San Bernardino,RAN1040,U.S. Senate,,DEM,Kamala Harris,465
-San Bernardino,RAN1040,U.S. Senate,,DEM,Loretta Sanchez,299
-San Bernardino,RAN1041,U.S. Senate,,DEM,Kamala Harris,846
-San Bernardino,RAN1041,U.S. Senate,,DEM,Loretta Sanchez,408
-San Bernardino,RAN1042,U.S. Senate,,DEM,Kamala Harris,711
-San Bernardino,RAN1042,U.S. Senate,,DEM,Loretta Sanchez,321
-San Bernardino,RAN1043,U.S. Senate,,DEM,Kamala Harris,632
-San Bernardino,RAN1043,U.S. Senate,,DEM,Loretta Sanchez,318
-San Bernardino,RAN1044,U.S. Senate,,DEM,Kamala Harris,741
-San Bernardino,RAN1044,U.S. Senate,,DEM,Loretta Sanchez,380
-San Bernardino,RAN1045,U.S. Senate,,DEM,Kamala Harris,747
-San Bernardino,RAN1045,U.S. Senate,,DEM,Loretta Sanchez,465
-San Bernardino,RAN1046,U.S. Senate,,DEM,Kamala Harris,591
-San Bernardino,RAN1046,U.S. Senate,,DEM,Loretta Sanchez,415
-San Bernardino,RAN1047,U.S. Senate,,DEM,Kamala Harris,704
-San Bernardino,RAN1047,U.S. Senate,,DEM,Loretta Sanchez,437
-San Bernardino,RAN1048,U.S. Senate,,DEM,Kamala Harris,551
-San Bernardino,RAN1048,U.S. Senate,,DEM,Loretta Sanchez,315
-San Bernardino,RAN1049,U.S. Senate,,DEM,Kamala Harris,517
-San Bernardino,RAN1049,U.S. Senate,,DEM,Loretta Sanchez,327
-San Bernardino,RAN1050,U.S. Senate,,DEM,Kamala Harris,355
-San Bernardino,RAN1050,U.S. Senate,,DEM,Loretta Sanchez,217
-San Bernardino,RAN1051,U.S. Senate,,DEM,Kamala Harris,685
-San Bernardino,RAN1051,U.S. Senate,,DEM,Loretta Sanchez,370
-San Bernardino,RAN1052,U.S. Senate,,DEM,Kamala Harris,321
-San Bernardino,RAN1052,U.S. Senate,,DEM,Loretta Sanchez,201
-San Bernardino,RAN1053,U.S. Senate,,DEM,Kamala Harris,365
-San Bernardino,RAN1053,U.S. Senate,,DEM,Loretta Sanchez,226
-San Bernardino,RAN1054,U.S. Senate,,DEM,Kamala Harris,356
-San Bernardino,RAN1054,U.S. Senate,,DEM,Loretta Sanchez,212
-San Bernardino,RAN1055,U.S. Senate,,DEM,Kamala Harris,747
-San Bernardino,RAN1055,U.S. Senate,,DEM,Loretta Sanchez,378
-San Bernardino,RAN1056,U.S. Senate,,DEM,Kamala Harris,924
-San Bernardino,RAN1056,U.S. Senate,,DEM,Loretta Sanchez,524
-San Bernardino,RAN1057,U.S. Senate,,DEM,Kamala Harris,626
-San Bernardino,RAN1057,U.S. Senate,,DEM,Loretta Sanchez,359
-San Bernardino,RAN1058,U.S. Senate,,DEM,Kamala Harris,665
-San Bernardino,RAN1058,U.S. Senate,,DEM,Loretta Sanchez,385
-San Bernardino,RAN1059,U.S. Senate,,DEM,Kamala Harris,464
-San Bernardino,RAN1059,U.S. Senate,,DEM,Loretta Sanchez,321
-San Bernardino,RAN1060,U.S. Senate,,DEM,Kamala Harris,584
-San Bernardino,RAN1060,U.S. Senate,,DEM,Loretta Sanchez,405
-San Bernardino,RAN1061,U.S. Senate,,DEM,Kamala Harris,579
-San Bernardino,RAN1061,U.S. Senate,,DEM,Loretta Sanchez,454
-San Bernardino,RAN1062,U.S. Senate,,DEM,Kamala Harris,627
-San Bernardino,RAN1062,U.S. Senate,,DEM,Loretta Sanchez,411
-San Bernardino,RAN1063,U.S. Senate,,DEM,Kamala Harris,300
-San Bernardino,RAN1063,U.S. Senate,,DEM,Loretta Sanchez,205
-San Bernardino,RAN1064,U.S. Senate,,DEM,Kamala Harris,569
-San Bernardino,RAN1064,U.S. Senate,,DEM,Loretta Sanchez,470
-San Bernardino,RAN1065,U.S. Senate,,DEM,Kamala Harris,612
-San Bernardino,RAN1065,U.S. Senate,,DEM,Loretta Sanchez,432
-San Bernardino,RAN1066,U.S. Senate,,DEM,Kamala Harris,704
-San Bernardino,RAN1066,U.S. Senate,,DEM,Loretta Sanchez,514
-San Bernardino,RAN1067,U.S. Senate,,DEM,Kamala Harris,474
-San Bernardino,RAN1067,U.S. Senate,,DEM,Loretta Sanchez,346
-San Bernardino,RAN1068,U.S. Senate,,DEM,Kamala Harris,764
-San Bernardino,RAN1068,U.S. Senate,,DEM,Loretta Sanchez,363
-San Bernardino,RAN1069,U.S. Senate,,DEM,Kamala Harris,720
-San Bernardino,RAN1069,U.S. Senate,,DEM,Loretta Sanchez,362
-San Bernardino,RAN1070,U.S. Senate,,DEM,Kamala Harris,583
-San Bernardino,RAN1070,U.S. Senate,,DEM,Loretta Sanchez,355
-San Bernardino,RAN1071,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,RAN1071,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,RAN1072,U.S. Senate,,DEM,Kamala Harris,461
-San Bernardino,RAN1072,U.S. Senate,,DEM,Loretta Sanchez,399
-San Bernardino,RAN1073,U.S. Senate,,DEM,Kamala Harris,148
-San Bernardino,RAN1073,U.S. Senate,,DEM,Loretta Sanchez,123
-San Bernardino,RAN1074,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,RAN1074,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,RAN1075,U.S. Senate,,DEM,Kamala Harris,613
-San Bernardino,RAN1075,U.S. Senate,,DEM,Loretta Sanchez,244
-San Bernardino,RAN1076,U.S. Senate,,DEM,Kamala Harris,603
-San Bernardino,RAN1076,U.S. Senate,,DEM,Loretta Sanchez,499
-San Bernardino,RAN1077,U.S. Senate,,DEM,Kamala Harris,745
-San Bernardino,RAN1077,U.S. Senate,,DEM,Loretta Sanchez,463
-San Bernardino,RAN1078,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,RAN1078,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,RAN1079,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,RAN1079,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,RAN1080,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,RAN1080,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,RAN1081,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,RAN1081,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,RAN1082,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,RAN1082,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,RAN1083,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,RAN1083,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,RAN1084,U.S. Senate,,DEM,Kamala Harris,12
-San Bernardino,RAN1084,U.S. Senate,,DEM,Loretta Sanchez,19
-San Bernardino,RAN1086,U.S. Senate,,DEM,Kamala Harris,11
-San Bernardino,RAN1086,U.S. Senate,,DEM,Loretta Sanchez,11
-San Bernardino,RAN1260,U.S. Senate,,DEM,Kamala Harris,599
-San Bernardino,RAN1260,U.S. Senate,,DEM,Loretta Sanchez,461
-San Bernardino,RAN1261,U.S. Senate,,DEM,Kamala Harris,665
-San Bernardino,RAN1261,U.S. Senate,,DEM,Loretta Sanchez,481
-San Bernardino,RAN1262,U.S. Senate,,DEM,Kamala Harris,603
-San Bernardino,RAN1262,U.S. Senate,,DEM,Loretta Sanchez,458
-San Bernardino,RAN1263,U.S. Senate,,DEM,Kamala Harris,637
-San Bernardino,RAN1263,U.S. Senate,,DEM,Loretta Sanchez,479
-San Bernardino,RAN1264,U.S. Senate,,DEM,Kamala Harris,626
-San Bernardino,RAN1264,U.S. Senate,,DEM,Loretta Sanchez,480
-San Bernardino,RAN1265,U.S. Senate,,DEM,Kamala Harris,635
-San Bernardino,RAN1265,U.S. Senate,,DEM,Loretta Sanchez,499
-San Bernardino,RAN1266,U.S. Senate,,DEM,Kamala Harris,582
-San Bernardino,RAN1266,U.S. Senate,,DEM,Loretta Sanchez,416
-San Bernardino,RAN1267,U.S. Senate,,DEM,Kamala Harris,545
-San Bernardino,RAN1267,U.S. Senate,,DEM,Loretta Sanchez,427
-San Bernardino,RAN1272,U.S. Senate,,DEM,Kamala Harris,17
-San Bernardino,RAN1272,U.S. Senate,,DEM,Loretta Sanchez,7
-San Bernardino,RAN1454,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,RAN1454,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,RAN1455,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,RAN1455,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,RAN1456,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,RAN1456,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,RAN1568,U.S. Senate,,DEM,Kamala Harris,346
-San Bernardino,RAN1568,U.S. Senate,,DEM,Loretta Sanchez,174
-San Bernardino,RAN1569,U.S. Senate,,DEM,Kamala Harris,159
-San Bernardino,RAN1569,U.S. Senate,,DEM,Loretta Sanchez,83
-San Bernardino,RAN1573,U.S. Senate,,DEM,Kamala Harris,449
-San Bernardino,RAN1573,U.S. Senate,,DEM,Loretta Sanchez,256
-San Bernardino,RAN1574,U.S. Senate,,DEM,Kamala Harris,3
-San Bernardino,RAN1574,U.S. Senate,,DEM,Loretta Sanchez,5
-San Bernardino,RAN1735,U.S. Senate,,DEM,Kamala Harris,182
-San Bernardino,RAN1735,U.S. Senate,,DEM,Loretta Sanchez,107
-San Bernardino,RAN1736,U.S. Senate,,DEM,Kamala Harris,206
-San Bernardino,RAN1736,U.S. Senate,,DEM,Loretta Sanchez,137
-San Bernardino,RAN1737,U.S. Senate,,DEM,Kamala Harris,164
-San Bernardino,RAN1737,U.S. Senate,,DEM,Loretta Sanchez,125
-San Bernardino,RAN1738,U.S. Senate,,DEM,Kamala Harris,123
-San Bernardino,RAN1738,U.S. Senate,,DEM,Loretta Sanchez,65
-San Bernardino,RAN1739,U.S. Senate,,DEM,Kamala Harris,157
-San Bernardino,RAN1739,U.S. Senate,,DEM,Loretta Sanchez,149
-San Bernardino,RAN1740,U.S. Senate,,DEM,Kamala Harris,66
-San Bernardino,RAN1740,U.S. Senate,,DEM,Loretta Sanchez,60
-San Bernardino,RAN1741,U.S. Senate,,DEM,Kamala Harris,10
-San Bernardino,RAN1741,U.S. Senate,,DEM,Loretta Sanchez,12
-San Bernardino,RAN1742,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,RAN1742,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,RED0768,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,RED0768,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,RED0782,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,RED0782,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,RED1103,U.S. Senate,,DEM,Kamala Harris,674
-San Bernardino,RED1103,U.S. Senate,,DEM,Loretta Sanchez,362
-San Bernardino,RED1104,U.S. Senate,,DEM,Kamala Harris,360
-San Bernardino,RED1104,U.S. Senate,,DEM,Loretta Sanchez,219
-San Bernardino,RED1105,U.S. Senate,,DEM,Kamala Harris,501
-San Bernardino,RED1105,U.S. Senate,,DEM,Loretta Sanchez,399
-San Bernardino,RED1106,U.S. Senate,,DEM,Kamala Harris,525
-San Bernardino,RED1106,U.S. Senate,,DEM,Loretta Sanchez,474
-San Bernardino,RED1107,U.S. Senate,,DEM,Kamala Harris,719
-San Bernardino,RED1107,U.S. Senate,,DEM,Loretta Sanchez,402
-San Bernardino,RED1108,U.S. Senate,,DEM,Kamala Harris,492
-San Bernardino,RED1108,U.S. Senate,,DEM,Loretta Sanchez,377
-San Bernardino,RED1109,U.S. Senate,,DEM,Kamala Harris,554
-San Bernardino,RED1109,U.S. Senate,,DEM,Loretta Sanchez,389
-San Bernardino,RED1110,U.S. Senate,,DEM,Kamala Harris,220
-San Bernardino,RED1110,U.S. Senate,,DEM,Loretta Sanchez,275
-San Bernardino,RED1111,U.S. Senate,,DEM,Kamala Harris,463
-San Bernardino,RED1111,U.S. Senate,,DEM,Loretta Sanchez,283
-San Bernardino,RED1112,U.S. Senate,,DEM,Kamala Harris,659
-San Bernardino,RED1112,U.S. Senate,,DEM,Loretta Sanchez,395
-San Bernardino,RED1113,U.S. Senate,,DEM,Kamala Harris,567
-San Bernardino,RED1113,U.S. Senate,,DEM,Loretta Sanchez,347
-San Bernardino,RED1114,U.S. Senate,,DEM,Kamala Harris,23
-San Bernardino,RED1114,U.S. Senate,,DEM,Loretta Sanchez,17
-San Bernardino,RED1115,U.S. Senate,,DEM,Kamala Harris,603
-San Bernardino,RED1115,U.S. Senate,,DEM,Loretta Sanchez,359
-San Bernardino,RED1116,U.S. Senate,,DEM,Kamala Harris,404
-San Bernardino,RED1116,U.S. Senate,,DEM,Loretta Sanchez,229
-San Bernardino,RED1117,U.S. Senate,,DEM,Kamala Harris,393
-San Bernardino,RED1117,U.S. Senate,,DEM,Loretta Sanchez,213
-San Bernardino,RED1118,U.S. Senate,,DEM,Kamala Harris,758
-San Bernardino,RED1118,U.S. Senate,,DEM,Loretta Sanchez,443
-San Bernardino,RED1119,U.S. Senate,,DEM,Kamala Harris,776
-San Bernardino,RED1119,U.S. Senate,,DEM,Loretta Sanchez,402
-San Bernardino,RED1120,U.S. Senate,,DEM,Kamala Harris,672
-San Bernardino,RED1120,U.S. Senate,,DEM,Loretta Sanchez,348
-San Bernardino,RED1121,U.S. Senate,,DEM,Kamala Harris,785
-San Bernardino,RED1121,U.S. Senate,,DEM,Loretta Sanchez,402
-San Bernardino,RED1122,U.S. Senate,,DEM,Kamala Harris,628
-San Bernardino,RED1122,U.S. Senate,,DEM,Loretta Sanchez,310
-San Bernardino,RED1123,U.S. Senate,,DEM,Kamala Harris,555
-San Bernardino,RED1123,U.S. Senate,,DEM,Loretta Sanchez,277
-San Bernardino,RED1124,U.S. Senate,,DEM,Kamala Harris,642
-San Bernardino,RED1124,U.S. Senate,,DEM,Loretta Sanchez,390
-San Bernardino,RED1125,U.S. Senate,,DEM,Kamala Harris,642
-San Bernardino,RED1125,U.S. Senate,,DEM,Loretta Sanchez,408
-San Bernardino,RED1126,U.S. Senate,,DEM,Kamala Harris,438
-San Bernardino,RED1126,U.S. Senate,,DEM,Loretta Sanchez,310
-San Bernardino,RED1127,U.S. Senate,,DEM,Kamala Harris,625
-San Bernardino,RED1127,U.S. Senate,,DEM,Loretta Sanchez,410
-San Bernardino,RED1128,U.S. Senate,,DEM,Kamala Harris,241
-San Bernardino,RED1128,U.S. Senate,,DEM,Loretta Sanchez,133
-San Bernardino,RED1129,U.S. Senate,,DEM,Kamala Harris,511
-San Bernardino,RED1129,U.S. Senate,,DEM,Loretta Sanchez,304
-San Bernardino,RED1130,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,RED1130,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,RED1131,U.S. Senate,,DEM,Kamala Harris,22
-San Bernardino,RED1131,U.S. Senate,,DEM,Loretta Sanchez,20
-San Bernardino,RED1132,U.S. Senate,,DEM,Kamala Harris,1
-San Bernardino,RED1132,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,RED1133,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,RED1133,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,RED1134,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,RED1134,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,RED1135,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,RED1135,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,RED1136,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,RED1136,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,RED1137,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,RED1137,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,RED1138,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,RED1138,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,RED1139,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,RED1139,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,RED1140,U.S. Senate,,DEM,Kamala Harris,7
-San Bernardino,RED1140,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,RED1157,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,RED1157,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,RED1158,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,RED1158,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,RED1159,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,RED1159,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,RED1205,U.S. Senate,,DEM,Kamala Harris,68
-San Bernardino,RED1205,U.S. Senate,,DEM,Loretta Sanchez,52
-San Bernardino,RED1206,U.S. Senate,,DEM,Kamala Harris,18
-San Bernardino,RED1206,U.S. Senate,,DEM,Loretta Sanchez,14
-San Bernardino,RED1212,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,RED1212,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,RED1273,U.S. Senate,,DEM,Kamala Harris,2
-San Bernardino,RED1273,U.S. Senate,,DEM,Loretta Sanchez,2
-San Bernardino,RED1620,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,RED1620,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,RED1621,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,RED1621,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,RED1625,U.S. Senate,,DEM,Kamala Harris,349
-San Bernardino,RED1625,U.S. Senate,,DEM,Loretta Sanchez,251
-San Bernardino,RED1626,U.S. Senate,,DEM,Kamala Harris,371
-San Bernardino,RED1626,U.S. Senate,,DEM,Loretta Sanchez,265
-San Bernardino,RED1629,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,RED1629,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,RED1664,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,RED1664,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,RED1665,U.S. Senate,,DEM,Kamala Harris,2
-San Bernardino,RED1665,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,RED1667,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,RED1667,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,RED1668,U.S. Senate,,DEM,Kamala Harris,2
-San Bernardino,RED1668,U.S. Senate,,DEM,Loretta Sanchez,1
-San Bernardino,RED1707,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,RED1707,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,RIA0866,U.S. Senate,,DEM,Kamala Harris,6
-San Bernardino,RIA0866,U.S. Senate,,DEM,Loretta Sanchez,3
-San Bernardino,RIA0872,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,RIA0872,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,RIA0953,U.S. Senate,,DEM,Kamala Harris,348
-San Bernardino,RIA0953,U.S. Senate,,DEM,Loretta Sanchez,376
-San Bernardino,RIA0954,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,RIA0954,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,RIA0961,U.S. Senate,,DEM,Kamala Harris,699
-San Bernardino,RIA0961,U.S. Senate,,DEM,Loretta Sanchez,549
-San Bernardino,RIA0962,U.S. Senate,,DEM,Kamala Harris,551
-San Bernardino,RIA0962,U.S. Senate,,DEM,Loretta Sanchez,453
-San Bernardino,RIA0963,U.S. Senate,,DEM,Kamala Harris,590
-San Bernardino,RIA0963,U.S. Senate,,DEM,Loretta Sanchez,468
-San Bernardino,RIA0964,U.S. Senate,,DEM,Kamala Harris,592
-San Bernardino,RIA0964,U.S. Senate,,DEM,Loretta Sanchez,470
-San Bernardino,RIA0965,U.S. Senate,,DEM,Kamala Harris,611
-San Bernardino,RIA0965,U.S. Senate,,DEM,Loretta Sanchez,412
-San Bernardino,RIA0966,U.S. Senate,,DEM,Kamala Harris,294
-San Bernardino,RIA0966,U.S. Senate,,DEM,Loretta Sanchez,162
-San Bernardino,RIA0967,U.S. Senate,,DEM,Kamala Harris,673
-San Bernardino,RIA0967,U.S. Senate,,DEM,Loretta Sanchez,499
-San Bernardino,RIA0968,U.S. Senate,,DEM,Kamala Harris,533
-San Bernardino,RIA0968,U.S. Senate,,DEM,Loretta Sanchez,479
-San Bernardino,RIA0969,U.S. Senate,,DEM,Kamala Harris,501
-San Bernardino,RIA0969,U.S. Senate,,DEM,Loretta Sanchez,472
-San Bernardino,RIA0970,U.S. Senate,,DEM,Kamala Harris,598
-San Bernardino,RIA0970,U.S. Senate,,DEM,Loretta Sanchez,389
-San Bernardino,RIA0971,U.S. Senate,,DEM,Kamala Harris,373
-San Bernardino,RIA0971,U.S. Senate,,DEM,Loretta Sanchez,523
-San Bernardino,RIA0972,U.S. Senate,,DEM,Kamala Harris,464
-San Bernardino,RIA0972,U.S. Senate,,DEM,Loretta Sanchez,441
-San Bernardino,RIA0973,U.S. Senate,,DEM,Kamala Harris,378
-San Bernardino,RIA0973,U.S. Senate,,DEM,Loretta Sanchez,573
-San Bernardino,RIA0974,U.S. Senate,,DEM,Kamala Harris,495
-San Bernardino,RIA0974,U.S. Senate,,DEM,Loretta Sanchez,465
-San Bernardino,RIA0975,U.S. Senate,,DEM,Kamala Harris,487
-San Bernardino,RIA0975,U.S. Senate,,DEM,Loretta Sanchez,401
-San Bernardino,RIA0976,U.S. Senate,,DEM,Kamala Harris,491
-San Bernardino,RIA0976,U.S. Senate,,DEM,Loretta Sanchez,546
-San Bernardino,RIA0977,U.S. Senate,,DEM,Kamala Harris,59
-San Bernardino,RIA0977,U.S. Senate,,DEM,Loretta Sanchez,68
-San Bernardino,RIA0978,U.S. Senate,,DEM,Kamala Harris,1
-San Bernardino,RIA0978,U.S. Senate,,DEM,Loretta Sanchez,1
-San Bernardino,RIA0979,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,RIA0979,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,RIA0980,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,RIA0980,U.S. Senate,,DEM,Loretta Sanchez,1
-San Bernardino,RIA1338,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,RIA1338,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,RIA1339,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,RIA1339,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,RIA1340,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,RIA1340,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,RIA1341,U.S. Senate,,DEM,Kamala Harris,10
-San Bernardino,RIA1341,U.S. Senate,,DEM,Loretta Sanchez,10
-San Bernardino,RIA1342,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,RIA1342,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,RIA1343,U.S. Senate,,DEM,Kamala Harris,2
-San Bernardino,RIA1343,U.S. Senate,,DEM,Loretta Sanchez,2
-San Bernardino,RIA1344,U.S. Senate,,DEM,Kamala Harris,169
-San Bernardino,RIA1344,U.S. Senate,,DEM,Loretta Sanchez,260
-San Bernardino,RIA1345,U.S. Senate,,DEM,Kamala Harris,8
-San Bernardino,RIA1345,U.S. Senate,,DEM,Loretta Sanchez,11
-San Bernardino,RIA1346,U.S. Senate,,DEM,Kamala Harris,55
-San Bernardino,RIA1346,U.S. Senate,,DEM,Loretta Sanchez,41
-San Bernardino,RIA1347,U.S. Senate,,DEM,Kamala Harris,152
-San Bernardino,RIA1347,U.S. Senate,,DEM,Loretta Sanchez,191
-San Bernardino,RIA1372,U.S. Senate,,DEM,Kamala Harris,283
-San Bernardino,RIA1372,U.S. Senate,,DEM,Loretta Sanchez,296
-San Bernardino,RIA1373,U.S. Senate,,DEM,Kamala Harris,170
-San Bernardino,RIA1373,U.S. Senate,,DEM,Loretta Sanchez,188
-San Bernardino,RIA1374,U.S. Senate,,DEM,Kamala Harris,97
-San Bernardino,RIA1374,U.S. Senate,,DEM,Loretta Sanchez,82
-San Bernardino,RIA1377,U.S. Senate,,DEM,Kamala Harris,296
-San Bernardino,RIA1377,U.S. Senate,,DEM,Loretta Sanchez,436
-San Bernardino,RIA1378,U.S. Senate,,DEM,Kamala Harris,362
-San Bernardino,RIA1378,U.S. Senate,,DEM,Loretta Sanchez,415
-San Bernardino,RIA1379,U.S. Senate,,DEM,Kamala Harris,375
-San Bernardino,RIA1379,U.S. Senate,,DEM,Loretta Sanchez,434
-San Bernardino,RIA1380,U.S. Senate,,DEM,Kamala Harris,534
-San Bernardino,RIA1380,U.S. Senate,,DEM,Loretta Sanchez,563
-San Bernardino,RIA1381,U.S. Senate,,DEM,Kamala Harris,469
-San Bernardino,RIA1381,U.S. Senate,,DEM,Loretta Sanchez,610
-San Bernardino,RIA1382,U.S. Senate,,DEM,Kamala Harris,500
-San Bernardino,RIA1382,U.S. Senate,,DEM,Loretta Sanchez,604
-San Bernardino,RIA1383,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,RIA1383,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,RIA1384,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,RIA1384,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,RIA1385,U.S. Senate,,DEM,Kamala Harris,321
-San Bernardino,RIA1385,U.S. Senate,,DEM,Loretta Sanchez,328
-San Bernardino,RIA1640,U.S. Senate,,DEM,Kamala Harris,92
-San Bernardino,RIA1640,U.S. Senate,,DEM,Loretta Sanchez,153
-San Bernardino,RIA1641,U.S. Senate,,DEM,Kamala Harris,1
-San Bernardino,RIA1641,U.S. Senate,,DEM,Loretta Sanchez,1
-San Bernardino,RIA1642,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,RIA1642,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,RIA1643,U.S. Senate,,DEM,Kamala Harris,2
-San Bernardino,RIA1643,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,RIA1772,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,RIA1772,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,RIA1784,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,RIA1784,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,RIA1785,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,RIA1785,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,RIA1786,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,RIA1786,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,RIA1787,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,RIA1787,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,RIA1788,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,RIA1788,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,SB00696,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,SB00696,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,SB00697,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,SB00697,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,SB00863,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,SB00863,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,SB11002,U.S. Senate,,DEM,Kamala Harris,303
-San Bernardino,SB11002,U.S. Senate,,DEM,Loretta Sanchez,332
-San Bernardino,SB11003,U.S. Senate,,DEM,Kamala Harris,273
-San Bernardino,SB11003,U.S. Senate,,DEM,Loretta Sanchez,387
-San Bernardino,SB11004,U.S. Senate,,DEM,Kamala Harris,284
-San Bernardino,SB11004,U.S. Senate,,DEM,Loretta Sanchez,360
-San Bernardino,SB11005,U.S. Senate,,DEM,Kamala Harris,310
-San Bernardino,SB11005,U.S. Senate,,DEM,Loretta Sanchez,342
-San Bernardino,SB11006,U.S. Senate,,DEM,Kamala Harris,300
-San Bernardino,SB11006,U.S. Senate,,DEM,Loretta Sanchez,288
-San Bernardino,SB11160,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,SB11160,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,SB11161,U.S. Senate,,DEM,Kamala Harris,77
-San Bernardino,SB11161,U.S. Senate,,DEM,Loretta Sanchez,52
-San Bernardino,SB11162,U.S. Senate,,DEM,Kamala Harris,1
-San Bernardino,SB11162,U.S. Senate,,DEM,Loretta Sanchez,1
-San Bernardino,SB11163,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,SB11163,U.S. Senate,,DEM,Loretta Sanchez,2
-San Bernardino,SB11215,U.S. Senate,,DEM,Kamala Harris,5
-San Bernardino,SB11215,U.S. Senate,,DEM,Loretta Sanchez,16
-San Bernardino,SB11216,U.S. Senate,,DEM,Kamala Harris,47
-San Bernardino,SB11216,U.S. Senate,,DEM,Loretta Sanchez,48
-San Bernardino,SB11217,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,SB11217,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,SB11218,U.S. Senate,,DEM,Kamala Harris,50
-San Bernardino,SB11218,U.S. Senate,,DEM,Loretta Sanchez,76
-San Bernardino,SB11219,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,SB11219,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,SB11220,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,SB11220,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,SB11221,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,SB11221,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,SB11222,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,SB11222,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,SB11223,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,SB11223,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,SB11224,U.S. Senate,,DEM,Kamala Harris,94
-San Bernardino,SB11224,U.S. Senate,,DEM,Loretta Sanchez,78
-San Bernardino,SB11225,U.S. Senate,,DEM,Kamala Harris,131
-San Bernardino,SB11225,U.S. Senate,,DEM,Loretta Sanchez,94
-San Bernardino,SB11226,U.S. Senate,,DEM,Kamala Harris,3
-San Bernardino,SB11226,U.S. Senate,,DEM,Loretta Sanchez,1
-San Bernardino,SB11227,U.S. Senate,,DEM,Kamala Harris,1
-San Bernardino,SB11227,U.S. Senate,,DEM,Loretta Sanchez,1
-San Bernardino,SB11228,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,SB11228,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,SB11229,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,SB11229,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,SB11230,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,SB11230,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,SB11231,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,SB11231,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,SB11232,U.S. Senate,,DEM,Kamala Harris,21
-San Bernardino,SB11232,U.S. Senate,,DEM,Loretta Sanchez,12
-San Bernardino,SB11233,U.S. Senate,,DEM,Kamala Harris,144
-San Bernardino,SB11233,U.S. Senate,,DEM,Loretta Sanchez,164
-San Bernardino,SB11632,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,SB11632,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,SB11633,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,SB11633,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,SB11634,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,SB11634,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,SB11635,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,SB11635,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,SB11636,U.S. Senate,,DEM,Kamala Harris,1
-San Bernardino,SB11636,U.S. Senate,,DEM,Loretta Sanchez,1
-San Bernardino,SB11669,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,SB11669,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,SB11715,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,SB11715,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,SB11720,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,SB11720,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,SB11722,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,SB11722,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,SB21007,U.S. Senate,,DEM,Kamala Harris,69
-San Bernardino,SB21007,U.S. Senate,,DEM,Loretta Sanchez,94
-San Bernardino,SB21164,U.S. Senate,,DEM,Kamala Harris,124
-San Bernardino,SB21164,U.S. Senate,,DEM,Loretta Sanchez,86
-San Bernardino,SB21165,U.S. Senate,,DEM,Kamala Harris,169
-San Bernardino,SB21165,U.S. Senate,,DEM,Loretta Sanchez,181
-San Bernardino,SB21166,U.S. Senate,,DEM,Kamala Harris,259
-San Bernardino,SB21166,U.S. Senate,,DEM,Loretta Sanchez,202
-San Bernardino,SB21167,U.S. Senate,,DEM,Kamala Harris,21
-San Bernardino,SB21167,U.S. Senate,,DEM,Loretta Sanchez,36
-San Bernardino,SB21168,U.S. Senate,,DEM,Kamala Harris,23
-San Bernardino,SB21168,U.S. Senate,,DEM,Loretta Sanchez,21
-San Bernardino,SB21169,U.S. Senate,,DEM,Kamala Harris,41
-San Bernardino,SB21169,U.S. Senate,,DEM,Loretta Sanchez,17
-San Bernardino,SB21234,U.S. Senate,,DEM,Kamala Harris,504
-San Bernardino,SB21234,U.S. Senate,,DEM,Loretta Sanchez,452
-San Bernardino,SB21235,U.S. Senate,,DEM,Kamala Harris,300
-San Bernardino,SB21235,U.S. Senate,,DEM,Loretta Sanchez,271
-San Bernardino,SB21236,U.S. Senate,,DEM,Kamala Harris,369
-San Bernardino,SB21236,U.S. Senate,,DEM,Loretta Sanchez,298
-San Bernardino,SB21237,U.S. Senate,,DEM,Kamala Harris,389
-San Bernardino,SB21237,U.S. Senate,,DEM,Loretta Sanchez,358
-San Bernardino,SB21238,U.S. Senate,,DEM,Kamala Harris,379
-San Bernardino,SB21238,U.S. Senate,,DEM,Loretta Sanchez,398
-San Bernardino,SB21251,U.S. Senate,,DEM,Kamala Harris,3
-San Bernardino,SB21251,U.S. Senate,,DEM,Loretta Sanchez,4
-San Bernardino,SB21657,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,SB21657,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,SB21662,U.S. Senate,,DEM,Kamala Harris,144
-San Bernardino,SB21662,U.S. Senate,,DEM,Loretta Sanchez,95
-San Bernardino,SB30914,U.S. Senate,,DEM,Kamala Harris,307
-San Bernardino,SB30914,U.S. Senate,,DEM,Loretta Sanchez,229
-San Bernardino,SB30940,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,SB30940,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,SB30941,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,SB30941,U.S. Senate,,DEM,Loretta Sanchez,4
-San Bernardino,SB30942,U.S. Senate,,DEM,Kamala Harris,3
-San Bernardino,SB30942,U.S. Senate,,DEM,Loretta Sanchez,2
-San Bernardino,SB30943,U.S. Senate,,DEM,Kamala Harris,99
-San Bernardino,SB30943,U.S. Senate,,DEM,Loretta Sanchez,104
-San Bernardino,SB30944,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,SB30944,U.S. Senate,,DEM,Loretta Sanchez,2
-San Bernardino,SB30945,U.S. Senate,,DEM,Kamala Harris,5
-San Bernardino,SB30945,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,SB30946,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,SB30946,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,SB30947,U.S. Senate,,DEM,Kamala Harris,2
-San Bernardino,SB30947,U.S. Senate,,DEM,Loretta Sanchez,1
-San Bernardino,SB30981,U.S. Senate,,DEM,Kamala Harris,348
-San Bernardino,SB30981,U.S. Senate,,DEM,Loretta Sanchez,508
-San Bernardino,SB30982,U.S. Senate,,DEM,Kamala Harris,206
-San Bernardino,SB30982,U.S. Senate,,DEM,Loretta Sanchez,321
-San Bernardino,SB30983,U.S. Senate,,DEM,Kamala Harris,232
-San Bernardino,SB30983,U.S. Senate,,DEM,Loretta Sanchez,246
-San Bernardino,SB30984,U.S. Senate,,DEM,Kamala Harris,105
-San Bernardino,SB30984,U.S. Senate,,DEM,Loretta Sanchez,145
-San Bernardino,SB30985,U.S. Senate,,DEM,Kamala Harris,136
-San Bernardino,SB30985,U.S. Senate,,DEM,Loretta Sanchez,175
-San Bernardino,SB31008,U.S. Senate,,DEM,Kamala Harris,229
-San Bernardino,SB31008,U.S. Senate,,DEM,Loretta Sanchez,403
-San Bernardino,SB31009,U.S. Senate,,DEM,Kamala Harris,3
-San Bernardino,SB31009,U.S. Senate,,DEM,Loretta Sanchez,3
-San Bernardino,SB31010,U.S. Senate,,DEM,Kamala Harris,215
-San Bernardino,SB31010,U.S. Senate,,DEM,Loretta Sanchez,275
-San Bernardino,SB31011,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,SB31011,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,SB31012,U.S. Senate,,DEM,Kamala Harris,1
-San Bernardino,SB31012,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,SB31013,U.S. Senate,,DEM,Kamala Harris,33
-San Bernardino,SB31013,U.S. Senate,,DEM,Loretta Sanchez,29
-San Bernardino,SB31014,U.S. Senate,,DEM,Kamala Harris,33
-San Bernardino,SB31014,U.S. Senate,,DEM,Loretta Sanchez,44
-San Bernardino,SB31094,U.S. Senate,,DEM,Kamala Harris,188
-San Bernardino,SB31094,U.S. Senate,,DEM,Loretta Sanchez,130
-San Bernardino,SB31207,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,SB31207,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,SB31208,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,SB31208,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,SB31213,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,SB31213,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,SB31214,U.S. Senate,,DEM,Kamala Harris,556
-San Bernardino,SB31214,U.S. Senate,,DEM,Loretta Sanchez,442
-San Bernardino,SB31655,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,SB31655,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,SB31656,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,SB31656,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,SB31658,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,SB31658,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,SB31659,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,SB31659,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,SB31660,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,SB31660,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,SB31661,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,SB31661,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,SB31716,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,SB31716,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,SB31717,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,SB31717,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,SB31718,U.S. Senate,,DEM,Kamala Harris,34
-San Bernardino,SB31718,U.S. Senate,,DEM,Loretta Sanchez,38
-San Bernardino,SB31719,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,SB31719,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,SB31721,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,SB31721,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,SB40615,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,SB40615,U.S. Senate,,DEM,Loretta Sanchez,2
-San Bernardino,SB40616,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,SB40616,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,SB40617,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,SB40617,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,SB40618,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,SB40618,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,SB40637,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,SB40637,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,SB40638,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,SB40638,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,SB40710,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,SB40710,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,SB40712,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,SB40712,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,SB41141,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,SB41141,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,SB41142,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,SB41142,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,SB41170,U.S. Senate,,DEM,Kamala Harris,519
-San Bernardino,SB41170,U.S. Senate,,DEM,Loretta Sanchez,323
-San Bernardino,SB41171,U.S. Senate,,DEM,Kamala Harris,3
-San Bernardino,SB41171,U.S. Senate,,DEM,Loretta Sanchez,3
-San Bernardino,SB41172,U.S. Senate,,DEM,Kamala Harris,2
-San Bernardino,SB41172,U.S. Senate,,DEM,Loretta Sanchez,6
-San Bernardino,SB41173,U.S. Senate,,DEM,Kamala Harris,413
-San Bernardino,SB41173,U.S. Senate,,DEM,Loretta Sanchez,268
-San Bernardino,SB41174,U.S. Senate,,DEM,Kamala Harris,431
-San Bernardino,SB41174,U.S. Senate,,DEM,Loretta Sanchez,281
-San Bernardino,SB41175,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,SB41175,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,SB41176,U.S. Senate,,DEM,Kamala Harris,3
-San Bernardino,SB41176,U.S. Senate,,DEM,Loretta Sanchez,6
-San Bernardino,SB41177,U.S. Senate,,DEM,Kamala Harris,83
-San Bernardino,SB41177,U.S. Senate,,DEM,Loretta Sanchez,68
-San Bernardino,SB41178,U.S. Senate,,DEM,Kamala Harris,1
-San Bernardino,SB41178,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,SB41179,U.S. Senate,,DEM,Kamala Harris,160
-San Bernardino,SB41179,U.S. Senate,,DEM,Loretta Sanchez,111
-San Bernardino,SB41180,U.S. Senate,,DEM,Kamala Harris,442
-San Bernardino,SB41180,U.S. Senate,,DEM,Loretta Sanchez,247
-San Bernardino,SB41181,U.S. Senate,,DEM,Kamala Harris,33
-San Bernardino,SB41181,U.S. Senate,,DEM,Loretta Sanchez,8
-San Bernardino,SB41182,U.S. Senate,,DEM,Kamala Harris,100
-San Bernardino,SB41182,U.S. Senate,,DEM,Loretta Sanchez,54
-San Bernardino,SB41183,U.S. Senate,,DEM,Kamala Harris,284
-San Bernardino,SB41183,U.S. Senate,,DEM,Loretta Sanchez,160
-San Bernardino,SB41184,U.S. Senate,,DEM,Kamala Harris,30
-San Bernardino,SB41184,U.S. Senate,,DEM,Loretta Sanchez,25
-San Bernardino,SB41185,U.S. Senate,,DEM,Kamala Harris,84
-San Bernardino,SB41185,U.S. Senate,,DEM,Loretta Sanchez,47
-San Bernardino,SB41186,U.S. Senate,,DEM,Kamala Harris,459
-San Bernardino,SB41186,U.S. Senate,,DEM,Loretta Sanchez,327
-San Bernardino,SB41187,U.S. Senate,,DEM,Kamala Harris,53
-San Bernardino,SB41187,U.S. Senate,,DEM,Loretta Sanchez,32
-San Bernardino,SB41197,U.S. Senate,,DEM,Kamala Harris,75
-San Bernardino,SB41197,U.S. Senate,,DEM,Loretta Sanchez,36
-San Bernardino,SB41239,U.S. Senate,,DEM,Kamala Harris,618
-San Bernardino,SB41239,U.S. Senate,,DEM,Loretta Sanchez,461
-San Bernardino,SB41240,U.S. Senate,,DEM,Kamala Harris,522
-San Bernardino,SB41240,U.S. Senate,,DEM,Loretta Sanchez,398
-San Bernardino,SB41241,U.S. Senate,,DEM,Kamala Harris,602
-San Bernardino,SB41241,U.S. Senate,,DEM,Loretta Sanchez,438
-San Bernardino,SB41672,U.S. Senate,,DEM,Kamala Harris,48
-San Bernardino,SB41672,U.S. Senate,,DEM,Loretta Sanchez,31
-San Bernardino,SB41674,U.S. Senate,,DEM,Kamala Harris,1
-San Bernardino,SB41674,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,SB41675,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,SB41675,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,SB41723,U.S. Senate,,DEM,Kamala Harris,228
-San Bernardino,SB41723,U.S. Senate,,DEM,Loretta Sanchez,142
-San Bernardino,SB41724,U.S. Senate,,DEM,Kamala Harris,78
-San Bernardino,SB41724,U.S. Senate,,DEM,Loretta Sanchez,60
-San Bernardino,SB41743,U.S. Senate,,DEM,Kamala Harris,88
-San Bernardino,SB41743,U.S. Senate,,DEM,Loretta Sanchez,51
-San Bernardino,SB51085,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,SB51085,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,SB51087,U.S. Senate,,DEM,Kamala Harris,585
-San Bernardino,SB51087,U.S. Senate,,DEM,Loretta Sanchez,329
-San Bernardino,SB51088,U.S. Senate,,DEM,Kamala Harris,557
-San Bernardino,SB51088,U.S. Senate,,DEM,Loretta Sanchez,358
-San Bernardino,SB51089,U.S. Senate,,DEM,Kamala Harris,532
-San Bernardino,SB51089,U.S. Senate,,DEM,Loretta Sanchez,325
-San Bernardino,SB51090,U.S. Senate,,DEM,Kamala Harris,543
-San Bernardino,SB51090,U.S. Senate,,DEM,Loretta Sanchez,336
-San Bernardino,SB51242,U.S. Senate,,DEM,Kamala Harris,52
-San Bernardino,SB51242,U.S. Senate,,DEM,Loretta Sanchez,49
-San Bernardino,SB51243,U.S. Senate,,DEM,Kamala Harris,229
-San Bernardino,SB51243,U.S. Senate,,DEM,Loretta Sanchez,192
-San Bernardino,SB51244,U.S. Senate,,DEM,Kamala Harris,536
-San Bernardino,SB51244,U.S. Senate,,DEM,Loretta Sanchez,306
-San Bernardino,SB51245,U.S. Senate,,DEM,Kamala Harris,644
-San Bernardino,SB51245,U.S. Senate,,DEM,Loretta Sanchez,415
-San Bernardino,SB51246,U.S. Senate,,DEM,Kamala Harris,599
-San Bernardino,SB51246,U.S. Senate,,DEM,Loretta Sanchez,461
-San Bernardino,SB51247,U.S. Senate,,DEM,Kamala Harris,627
-San Bernardino,SB51247,U.S. Senate,,DEM,Loretta Sanchez,399
-San Bernardino,SB51248,U.S. Senate,,DEM,Kamala Harris,555
-San Bernardino,SB51248,U.S. Senate,,DEM,Loretta Sanchez,352
-San Bernardino,SB60873,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,SB60873,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,SB60986,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,SB60986,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,SB60987,U.S. Senate,,DEM,Kamala Harris,472
-San Bernardino,SB60987,U.S. Senate,,DEM,Loretta Sanchez,422
-San Bernardino,SB60988,U.S. Senate,,DEM,Kamala Harris,420
-San Bernardino,SB60988,U.S. Senate,,DEM,Loretta Sanchez,431
-San Bernardino,SB60989,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,SB60989,U.S. Senate,,DEM,Loretta Sanchez,1
-San Bernardino,SB61015,U.S. Senate,,DEM,Kamala Harris,383
-San Bernardino,SB61015,U.S. Senate,,DEM,Loretta Sanchez,295
-San Bernardino,SB61016,U.S. Senate,,DEM,Kamala Harris,498
-San Bernardino,SB61016,U.S. Senate,,DEM,Loretta Sanchez,381
-San Bernardino,SB61017,U.S. Senate,,DEM,Kamala Harris,376
-San Bernardino,SB61017,U.S. Senate,,DEM,Loretta Sanchez,408
-San Bernardino,SB61018,U.S. Senate,,DEM,Kamala Harris,1
-San Bernardino,SB61018,U.S. Senate,,DEM,Loretta Sanchez,3
-San Bernardino,SB61019,U.S. Senate,,DEM,Kamala Harris,208
-San Bernardino,SB61019,U.S. Senate,,DEM,Loretta Sanchez,193
-San Bernardino,SB61020,U.S. Senate,,DEM,Kamala Harris,107
-San Bernardino,SB61020,U.S. Senate,,DEM,Loretta Sanchez,112
-San Bernardino,SB61021,U.S. Senate,,DEM,Kamala Harris,40
-San Bernardino,SB61021,U.S. Senate,,DEM,Loretta Sanchez,14
-San Bernardino,SB61249,U.S. Senate,,DEM,Kamala Harris,218
-San Bernardino,SB61249,U.S. Senate,,DEM,Loretta Sanchez,266
-San Bernardino,SB61250,U.S. Senate,,DEM,Kamala Harris,325
-San Bernardino,SB61250,U.S. Senate,,DEM,Loretta Sanchez,293
-San Bernardino,SB61252,U.S. Senate,,DEM,Kamala Harris,13
-San Bernardino,SB61252,U.S. Senate,,DEM,Loretta Sanchez,6
-San Bernardino,SB61253,U.S. Senate,,DEM,Kamala Harris,9
-San Bernardino,SB61253,U.S. Senate,,DEM,Loretta Sanchez,15
-San Bernardino,SB61619,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,SB61619,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,SB61654,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,SB61654,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,SB61663,U.S. Senate,,DEM,Kamala Harris,28
-San Bernardino,SB61663,U.S. Senate,,DEM,Loretta Sanchez,38
-San Bernardino,SB71188,U.S. Senate,,DEM,Kamala Harris,526
-San Bernardino,SB71188,U.S. Senate,,DEM,Loretta Sanchez,361
-San Bernardino,SB71189,U.S. Senate,,DEM,Kamala Harris,168
-San Bernardino,SB71189,U.S. Senate,,DEM,Loretta Sanchez,164
-San Bernardino,SB71190,U.S. Senate,,DEM,Kamala Harris,499
-San Bernardino,SB71190,U.S. Senate,,DEM,Loretta Sanchez,408
-San Bernardino,SB71191,U.S. Senate,,DEM,Kamala Harris,61
-San Bernardino,SB71191,U.S. Senate,,DEM,Loretta Sanchez,62
-San Bernardino,SB71192,U.S. Senate,,DEM,Kamala Harris,185
-San Bernardino,SB71192,U.S. Senate,,DEM,Loretta Sanchez,129
-San Bernardino,SB71193,U.S. Senate,,DEM,Kamala Harris,139
-San Bernardino,SB71193,U.S. Senate,,DEM,Loretta Sanchez,107
-San Bernardino,SB71194,U.S. Senate,,DEM,Kamala Harris,2
-San Bernardino,SB71194,U.S. Senate,,DEM,Loretta Sanchez,2
-San Bernardino,SB71195,U.S. Senate,,DEM,Kamala Harris,207
-San Bernardino,SB71195,U.S. Senate,,DEM,Loretta Sanchez,158
-San Bernardino,SB71196,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,SB71196,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,SB71198,U.S. Senate,,DEM,Kamala Harris,192
-San Bernardino,SB71198,U.S. Senate,,DEM,Loretta Sanchez,139
-San Bernardino,SB71254,U.S. Senate,,DEM,Kamala Harris,558
-San Bernardino,SB71254,U.S. Senate,,DEM,Loretta Sanchez,406
-San Bernardino,SB71255,U.S. Senate,,DEM,Kamala Harris,565
-San Bernardino,SB71255,U.S. Senate,,DEM,Loretta Sanchez,387
-San Bernardino,SB71256,U.S. Senate,,DEM,Kamala Harris,389
-San Bernardino,SB71256,U.S. Senate,,DEM,Loretta Sanchez,381
-San Bernardino,SB71257,U.S. Senate,,DEM,Kamala Harris,346
-San Bernardino,SB71257,U.S. Senate,,DEM,Loretta Sanchez,233
-San Bernardino,SB71670,U.S. Senate,,DEM,Kamala Harris,98
-San Bernardino,SB71670,U.S. Senate,,DEM,Loretta Sanchez,48
-San Bernardino,SB71671,U.S. Senate,,DEM,Kamala Harris,8
-San Bernardino,SB71671,U.S. Senate,,DEM,Loretta Sanchez,4
-San Bernardino,TWE0210,U.S. Senate,,DEM,Kamala Harris,110
-San Bernardino,TWE0210,U.S. Senate,,DEM,Loretta Sanchez,94
-San Bernardino,TWE0211,U.S. Senate,,DEM,Kamala Harris,624
-San Bernardino,TWE0211,U.S. Senate,,DEM,Loretta Sanchez,399
-San Bernardino,TWE0212,U.S. Senate,,DEM,Kamala Harris,631
-San Bernardino,TWE0212,U.S. Senate,,DEM,Loretta Sanchez,379
-San Bernardino,TWE0213,U.S. Senate,,DEM,Kamala Harris,371
-San Bernardino,TWE0213,U.S. Senate,,DEM,Loretta Sanchez,224
-San Bernardino,TWE0214,U.S. Senate,,DEM,Kamala Harris,375
-San Bernardino,TWE0214,U.S. Senate,,DEM,Loretta Sanchez,237
-San Bernardino,TWE0215,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,TWE0215,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0002,U.S. Senate,,DEM,Kamala Harris,7
-San Bernardino,UNI0002,U.S. Senate,,DEM,Loretta Sanchez,4
-San Bernardino,UNI0003,U.S. Senate,,DEM,Kamala Harris,7
-San Bernardino,UNI0003,U.S. Senate,,DEM,Loretta Sanchez,7
-San Bernardino,UNI0004,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0004,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0005,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0005,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0006,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0006,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0007,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0007,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0008,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0008,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0009,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0009,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0010,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0010,U.S. Senate,,DEM,Loretta Sanchez,1
-San Bernardino,UNI0011,U.S. Senate,,DEM,Kamala Harris,332
-San Bernardino,UNI0011,U.S. Senate,,DEM,Loretta Sanchez,367
-San Bernardino,UNI0012,U.S. Senate,,DEM,Kamala Harris,113
-San Bernardino,UNI0012,U.S. Senate,,DEM,Loretta Sanchez,127
-San Bernardino,UNI0013,U.S. Senate,,DEM,Kamala Harris,92
-San Bernardino,UNI0013,U.S. Senate,,DEM,Loretta Sanchez,83
-San Bernardino,UNI0014,U.S. Senate,,DEM,Kamala Harris,216
-San Bernardino,UNI0014,U.S. Senate,,DEM,Loretta Sanchez,198
-San Bernardino,UNI0015,U.S. Senate,,DEM,Kamala Harris,91
-San Bernardino,UNI0015,U.S. Senate,,DEM,Loretta Sanchez,73
-San Bernardino,UNI0016,U.S. Senate,,DEM,Kamala Harris,44
-San Bernardino,UNI0016,U.S. Senate,,DEM,Loretta Sanchez,39
-San Bernardino,UNI0017,U.S. Senate,,DEM,Kamala Harris,112
-San Bernardino,UNI0017,U.S. Senate,,DEM,Loretta Sanchez,101
-San Bernardino,UNI0018,U.S. Senate,,DEM,Kamala Harris,80
-San Bernardino,UNI0018,U.S. Senate,,DEM,Loretta Sanchez,67
-San Bernardino,UNI0019,U.S. Senate,,DEM,Kamala Harris,32
-San Bernardino,UNI0019,U.S. Senate,,DEM,Loretta Sanchez,21
-San Bernardino,UNI0020,U.S. Senate,,DEM,Kamala Harris,38
-San Bernardino,UNI0020,U.S. Senate,,DEM,Loretta Sanchez,26
-San Bernardino,UNI0021,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0021,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0022,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0022,U.S. Senate,,DEM,Loretta Sanchez,2
-San Bernardino,UNI0023,U.S. Senate,,DEM,Kamala Harris,24
-San Bernardino,UNI0023,U.S. Senate,,DEM,Loretta Sanchez,32
-San Bernardino,UNI0024,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0024,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0025,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0025,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0026,U.S. Senate,,DEM,Kamala Harris,6
-San Bernardino,UNI0026,U.S. Senate,,DEM,Loretta Sanchez,3
-San Bernardino,UNI0027,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0027,U.S. Senate,,DEM,Loretta Sanchez,1
-San Bernardino,UNI0028,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0028,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0029,U.S. Senate,,DEM,Kamala Harris,6
-San Bernardino,UNI0029,U.S. Senate,,DEM,Loretta Sanchez,4
-San Bernardino,UNI0030,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0030,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0031,U.S. Senate,,DEM,Kamala Harris,104
-San Bernardino,UNI0031,U.S. Senate,,DEM,Loretta Sanchez,98
-San Bernardino,UNI0032,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0032,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0033,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0033,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0034,U.S. Senate,,DEM,Kamala Harris,11
-San Bernardino,UNI0034,U.S. Senate,,DEM,Loretta Sanchez,11
-San Bernardino,UNI0035,U.S. Senate,,DEM,Kamala Harris,18
-San Bernardino,UNI0035,U.S. Senate,,DEM,Loretta Sanchez,12
-San Bernardino,UNI0036,U.S. Senate,,DEM,Kamala Harris,9
-San Bernardino,UNI0036,U.S. Senate,,DEM,Loretta Sanchez,2
-San Bernardino,UNI0037,U.S. Senate,,DEM,Kamala Harris,5
-San Bernardino,UNI0037,U.S. Senate,,DEM,Loretta Sanchez,3
-San Bernardino,UNI0038,U.S. Senate,,DEM,Kamala Harris,2
-San Bernardino,UNI0038,U.S. Senate,,DEM,Loretta Sanchez,1
-San Bernardino,UNI0039,U.S. Senate,,DEM,Kamala Harris,315
-San Bernardino,UNI0039,U.S. Senate,,DEM,Loretta Sanchez,356
-San Bernardino,UNI0040,U.S. Senate,,DEM,Kamala Harris,10
-San Bernardino,UNI0040,U.S. Senate,,DEM,Loretta Sanchez,16
-San Bernardino,UNI0041,U.S. Senate,,DEM,Kamala Harris,24
-San Bernardino,UNI0041,U.S. Senate,,DEM,Loretta Sanchez,22
-San Bernardino,UNI0042,U.S. Senate,,DEM,Kamala Harris,216
-San Bernardino,UNI0042,U.S. Senate,,DEM,Loretta Sanchez,204
-San Bernardino,UNI0043,U.S. Senate,,DEM,Kamala Harris,52
-San Bernardino,UNI0043,U.S. Senate,,DEM,Loretta Sanchez,56
-San Bernardino,UNI0044,U.S. Senate,,DEM,Kamala Harris,71
-San Bernardino,UNI0044,U.S. Senate,,DEM,Loretta Sanchez,56
-San Bernardino,UNI0045,U.S. Senate,,DEM,Kamala Harris,13
-San Bernardino,UNI0045,U.S. Senate,,DEM,Loretta Sanchez,15
-San Bernardino,UNI0046,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0046,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0047,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0047,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0048,U.S. Senate,,DEM,Kamala Harris,1
-San Bernardino,UNI0048,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0049,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0049,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0050,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0050,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0051,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0051,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0052,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0052,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0053,U.S. Senate,,DEM,Kamala Harris,8
-San Bernardino,UNI0053,U.S. Senate,,DEM,Loretta Sanchez,8
-San Bernardino,UNI0054,U.S. Senate,,DEM,Kamala Harris,19
-San Bernardino,UNI0054,U.S. Senate,,DEM,Loretta Sanchez,27
-San Bernardino,UNI0055,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0055,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0056,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0056,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0057,U.S. Senate,,DEM,Kamala Harris,8
-San Bernardino,UNI0057,U.S. Senate,,DEM,Loretta Sanchez,1
-San Bernardino,UNI0058,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0058,U.S. Senate,,DEM,Loretta Sanchez,1
-San Bernardino,UNI0059,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0059,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0062,U.S. Senate,,DEM,Kamala Harris,15
-San Bernardino,UNI0062,U.S. Senate,,DEM,Loretta Sanchez,15
-San Bernardino,UNI0063,U.S. Senate,,DEM,Kamala Harris,105
-San Bernardino,UNI0063,U.S. Senate,,DEM,Loretta Sanchez,76
-San Bernardino,UNI0064,U.S. Senate,,DEM,Kamala Harris,1
-San Bernardino,UNI0064,U.S. Senate,,DEM,Loretta Sanchez,3
-San Bernardino,UNI0065,U.S. Senate,,DEM,Kamala Harris,7
-San Bernardino,UNI0065,U.S. Senate,,DEM,Loretta Sanchez,2
-San Bernardino,UNI0066,U.S. Senate,,DEM,Kamala Harris,58
-San Bernardino,UNI0066,U.S. Senate,,DEM,Loretta Sanchez,33
-San Bernardino,UNI0067,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0067,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0068,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0068,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0069,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0069,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0070,U.S. Senate,,DEM,Kamala Harris,8
-San Bernardino,UNI0070,U.S. Senate,,DEM,Loretta Sanchez,6
-San Bernardino,UNI0071,U.S. Senate,,DEM,Kamala Harris,4
-San Bernardino,UNI0071,U.S. Senate,,DEM,Loretta Sanchez,1
-San Bernardino,UNI0072,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0072,U.S. Senate,,DEM,Loretta Sanchez,1
-San Bernardino,UNI0073,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0073,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0074,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0074,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0075,U.S. Senate,,DEM,Kamala Harris,29
-San Bernardino,UNI0075,U.S. Senate,,DEM,Loretta Sanchez,30
-San Bernardino,UNI0076,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0076,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0077,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0077,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0078,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0078,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0079,U.S. Senate,,DEM,Kamala Harris,10
-San Bernardino,UNI0079,U.S. Senate,,DEM,Loretta Sanchez,12
-San Bernardino,UNI0080,U.S. Senate,,DEM,Kamala Harris,39
-San Bernardino,UNI0080,U.S. Senate,,DEM,Loretta Sanchez,35
-San Bernardino,UNI0081,U.S. Senate,,DEM,Kamala Harris,9
-San Bernardino,UNI0081,U.S. Senate,,DEM,Loretta Sanchez,5
-San Bernardino,UNI0082,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0082,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0083,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0083,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0084,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0084,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0085,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0085,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0086,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0086,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0087,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0087,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0088,U.S. Senate,,DEM,Kamala Harris,7
-San Bernardino,UNI0088,U.S. Senate,,DEM,Loretta Sanchez,3
-San Bernardino,UNI0089,U.S. Senate,,DEM,Kamala Harris,42
-San Bernardino,UNI0089,U.S. Senate,,DEM,Loretta Sanchez,57
-San Bernardino,UNI0090,U.S. Senate,,DEM,Kamala Harris,143
-San Bernardino,UNI0090,U.S. Senate,,DEM,Loretta Sanchez,140
-San Bernardino,UNI0091,U.S. Senate,,DEM,Kamala Harris,14
-San Bernardino,UNI0091,U.S. Senate,,DEM,Loretta Sanchez,9
-San Bernardino,UNI0092,U.S. Senate,,DEM,Kamala Harris,5
-San Bernardino,UNI0092,U.S. Senate,,DEM,Loretta Sanchez,1
-San Bernardino,UNI0093,U.S. Senate,,DEM,Kamala Harris,60
-San Bernardino,UNI0093,U.S. Senate,,DEM,Loretta Sanchez,58
-San Bernardino,UNI0094,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0094,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0095,U.S. Senate,,DEM,Kamala Harris,1
-San Bernardino,UNI0095,U.S. Senate,,DEM,Loretta Sanchez,1
-San Bernardino,UNI0096,U.S. Senate,,DEM,Kamala Harris,42
-San Bernardino,UNI0096,U.S. Senate,,DEM,Loretta Sanchez,23
-San Bernardino,UNI0097,U.S. Senate,,DEM,Kamala Harris,229
-San Bernardino,UNI0097,U.S. Senate,,DEM,Loretta Sanchez,179
-San Bernardino,UNI0098,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0098,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0099,U.S. Senate,,DEM,Kamala Harris,1
-San Bernardino,UNI0099,U.S. Senate,,DEM,Loretta Sanchez,2
-San Bernardino,UNI0100,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0100,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0101,U.S. Senate,,DEM,Kamala Harris,187
-San Bernardino,UNI0101,U.S. Senate,,DEM,Loretta Sanchez,128
-San Bernardino,UNI0102,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0102,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0103,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0103,U.S. Senate,,DEM,Loretta Sanchez,1
-San Bernardino,UNI0104,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0104,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0105,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0105,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0106,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0106,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0107,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0107,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0108,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0108,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0109,U.S. Senate,,DEM,Kamala Harris,198
-San Bernardino,UNI0109,U.S. Senate,,DEM,Loretta Sanchez,195
-San Bernardino,UNI0112,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0112,U.S. Senate,,DEM,Loretta Sanchez,6
-San Bernardino,UNI0113,U.S. Senate,,DEM,Kamala Harris,2
-San Bernardino,UNI0113,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0114,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0114,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0115,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0115,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0116,U.S. Senate,,DEM,Kamala Harris,1
-San Bernardino,UNI0116,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0117,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0117,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0118,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0118,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0119,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0119,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0120,U.S. Senate,,DEM,Kamala Harris,608
-San Bernardino,UNI0120,U.S. Senate,,DEM,Loretta Sanchez,504
-San Bernardino,UNI0121,U.S. Senate,,DEM,Kamala Harris,423
-San Bernardino,UNI0121,U.S. Senate,,DEM,Loretta Sanchez,401
-San Bernardino,UNI0122,U.S. Senate,,DEM,Kamala Harris,9
-San Bernardino,UNI0122,U.S. Senate,,DEM,Loretta Sanchez,8
-San Bernardino,UNI0123,U.S. Senate,,DEM,Kamala Harris,18
-San Bernardino,UNI0123,U.S. Senate,,DEM,Loretta Sanchez,24
-San Bernardino,UNI0124,U.S. Senate,,DEM,Kamala Harris,14
-San Bernardino,UNI0124,U.S. Senate,,DEM,Loretta Sanchez,19
-San Bernardino,UNI0125,U.S. Senate,,DEM,Kamala Harris,25
-San Bernardino,UNI0125,U.S. Senate,,DEM,Loretta Sanchez,25
-San Bernardino,UNI0126,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0126,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0127,U.S. Senate,,DEM,Kamala Harris,9
-San Bernardino,UNI0127,U.S. Senate,,DEM,Loretta Sanchez,11
-San Bernardino,UNI0128,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0128,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0129,U.S. Senate,,DEM,Kamala Harris,30
-San Bernardino,UNI0129,U.S. Senate,,DEM,Loretta Sanchez,27
-San Bernardino,UNI0130,U.S. Senate,,DEM,Kamala Harris,21
-San Bernardino,UNI0130,U.S. Senate,,DEM,Loretta Sanchez,23
-San Bernardino,UNI0131,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0131,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0145,U.S. Senate,,DEM,Kamala Harris,7
-San Bernardino,UNI0145,U.S. Senate,,DEM,Loretta Sanchez,3
-San Bernardino,UNI0146,U.S. Senate,,DEM,Kamala Harris,40
-San Bernardino,UNI0146,U.S. Senate,,DEM,Loretta Sanchez,26
-San Bernardino,UNI0147,U.S. Senate,,DEM,Kamala Harris,12
-San Bernardino,UNI0147,U.S. Senate,,DEM,Loretta Sanchez,12
-San Bernardino,UNI0148,U.S. Senate,,DEM,Kamala Harris,349
-San Bernardino,UNI0148,U.S. Senate,,DEM,Loretta Sanchez,329
-San Bernardino,UNI0149,U.S. Senate,,DEM,Kamala Harris,23
-San Bernardino,UNI0149,U.S. Senate,,DEM,Loretta Sanchez,22
-San Bernardino,UNI0150,U.S. Senate,,DEM,Kamala Harris,3
-San Bernardino,UNI0150,U.S. Senate,,DEM,Loretta Sanchez,2
-San Bernardino,UNI0151,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0151,U.S. Senate,,DEM,Loretta Sanchez,1
-San Bernardino,UNI0152,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0152,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0153,U.S. Senate,,DEM,Kamala Harris,130
-San Bernardino,UNI0153,U.S. Senate,,DEM,Loretta Sanchez,71
-San Bernardino,UNI0154,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0154,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0155,U.S. Senate,,DEM,Kamala Harris,222
-San Bernardino,UNI0155,U.S. Senate,,DEM,Loretta Sanchez,190
-San Bernardino,UNI0156,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0156,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0157,U.S. Senate,,DEM,Kamala Harris,529
-San Bernardino,UNI0157,U.S. Senate,,DEM,Loretta Sanchez,457
-San Bernardino,UNI0158,U.S. Senate,,DEM,Kamala Harris,72
-San Bernardino,UNI0158,U.S. Senate,,DEM,Loretta Sanchez,50
-San Bernardino,UNI0159,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0159,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0160,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0160,U.S. Senate,,DEM,Loretta Sanchez,1
-San Bernardino,UNI0161,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0161,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0162,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0162,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0163,U.S. Senate,,DEM,Kamala Harris,16
-San Bernardino,UNI0163,U.S. Senate,,DEM,Loretta Sanchez,3
-San Bernardino,UNI0164,U.S. Senate,,DEM,Kamala Harris,43
-San Bernardino,UNI0164,U.S. Senate,,DEM,Loretta Sanchez,50
-San Bernardino,UNI0165,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0165,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0166,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0166,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0167,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0167,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0168,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0168,U.S. Senate,,DEM,Loretta Sanchez,2
-San Bernardino,UNI0169,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0169,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0170,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0170,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0171,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0171,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0172,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0172,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0173,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0173,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0174,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0174,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0175,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0175,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0176,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0176,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0177,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0177,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0178,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0178,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0180,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0180,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0181,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0181,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0182,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0182,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0183,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0183,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0184,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0184,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0185,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0185,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0186,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0186,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0187,U.S. Senate,,DEM,Kamala Harris,6
-San Bernardino,UNI0187,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0188,U.S. Senate,,DEM,Kamala Harris,34
-San Bernardino,UNI0188,U.S. Senate,,DEM,Loretta Sanchez,16
-San Bernardino,UNI0189,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0189,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0190,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0190,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0191,U.S. Senate,,DEM,Kamala Harris,8
-San Bernardino,UNI0191,U.S. Senate,,DEM,Loretta Sanchez,3
-San Bernardino,UNI0192,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0192,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0193,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0193,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0194,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0194,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0195,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0195,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0196,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0196,U.S. Senate,,DEM,Loretta Sanchez,1
-San Bernardino,UNI0197,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0197,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0198,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0198,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0199,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0199,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0200,U.S. Senate,,DEM,Kamala Harris,9
-San Bernardino,UNI0200,U.S. Senate,,DEM,Loretta Sanchez,8
-San Bernardino,UNI0201,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0201,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0202,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0202,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0203,U.S. Senate,,DEM,Kamala Harris,170
-San Bernardino,UNI0203,U.S. Senate,,DEM,Loretta Sanchez,89
-San Bernardino,UNI0204,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0204,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0205,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0205,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0206,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0206,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0207,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0207,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0208,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0208,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0209,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0209,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0216,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0216,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0217,U.S. Senate,,DEM,Kamala Harris,22
-San Bernardino,UNI0217,U.S. Senate,,DEM,Loretta Sanchez,11
-San Bernardino,UNI0218,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0218,U.S. Senate,,DEM,Loretta Sanchez,1
-San Bernardino,UNI0219,U.S. Senate,,DEM,Kamala Harris,8
-San Bernardino,UNI0219,U.S. Senate,,DEM,Loretta Sanchez,2
-San Bernardino,UNI0220,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0220,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0221,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0221,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0222,U.S. Senate,,DEM,Kamala Harris,68
-San Bernardino,UNI0222,U.S. Senate,,DEM,Loretta Sanchez,34
-San Bernardino,UNI0223,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0223,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0224,U.S. Senate,,DEM,Kamala Harris,202
-San Bernardino,UNI0224,U.S. Senate,,DEM,Loretta Sanchez,135
-San Bernardino,UNI0225,U.S. Senate,,DEM,Kamala Harris,21
-San Bernardino,UNI0225,U.S. Senate,,DEM,Loretta Sanchez,10
-San Bernardino,UNI0226,U.S. Senate,,DEM,Kamala Harris,163
-San Bernardino,UNI0226,U.S. Senate,,DEM,Loretta Sanchez,88
-San Bernardino,UNI0227,U.S. Senate,,DEM,Kamala Harris,621
-San Bernardino,UNI0227,U.S. Senate,,DEM,Loretta Sanchez,301
-San Bernardino,UNI0228,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0228,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0229,U.S. Senate,,DEM,Kamala Harris,164
-San Bernardino,UNI0229,U.S. Senate,,DEM,Loretta Sanchez,109
-San Bernardino,UNI0230,U.S. Senate,,DEM,Kamala Harris,699
-San Bernardino,UNI0230,U.S. Senate,,DEM,Loretta Sanchez,322
-San Bernardino,UNI0231,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0231,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0232,U.S. Senate,,DEM,Kamala Harris,33
-San Bernardino,UNI0232,U.S. Senate,,DEM,Loretta Sanchez,16
-San Bernardino,UNI0233,U.S. Senate,,DEM,Kamala Harris,5
-San Bernardino,UNI0233,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0234,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0234,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0235,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0235,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0236,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0236,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0237,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0237,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0238,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0238,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0239,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0239,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0240,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0240,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0241,U.S. Senate,,DEM,Kamala Harris,4
-San Bernardino,UNI0241,U.S. Senate,,DEM,Loretta Sanchez,1
-San Bernardino,UNI0242,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0242,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0243,U.S. Senate,,DEM,Kamala Harris,1
-San Bernardino,UNI0243,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0244,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0244,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0245,U.S. Senate,,DEM,Kamala Harris,227
-San Bernardino,UNI0245,U.S. Senate,,DEM,Loretta Sanchez,118
-San Bernardino,UNI0246,U.S. Senate,,DEM,Kamala Harris,2
-San Bernardino,UNI0246,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0247,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0247,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0248,U.S. Senate,,DEM,Kamala Harris,167
-San Bernardino,UNI0248,U.S. Senate,,DEM,Loretta Sanchez,47
-San Bernardino,UNI0249,U.S. Senate,,DEM,Kamala Harris,224
-San Bernardino,UNI0249,U.S. Senate,,DEM,Loretta Sanchez,129
-San Bernardino,UNI0250,U.S. Senate,,DEM,Kamala Harris,3
-San Bernardino,UNI0250,U.S. Senate,,DEM,Loretta Sanchez,1
-San Bernardino,UNI0251,U.S. Senate,,DEM,Kamala Harris,124
-San Bernardino,UNI0251,U.S. Senate,,DEM,Loretta Sanchez,80
-San Bernardino,UNI0252,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0252,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0253,U.S. Senate,,DEM,Kamala Harris,6
-San Bernardino,UNI0253,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0254,U.S. Senate,,DEM,Kamala Harris,561
-San Bernardino,UNI0254,U.S. Senate,,DEM,Loretta Sanchez,357
-San Bernardino,UNI0255,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0255,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0256,U.S. Senate,,DEM,Kamala Harris,3
-San Bernardino,UNI0256,U.S. Senate,,DEM,Loretta Sanchez,3
-San Bernardino,UNI0257,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0257,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0258,U.S. Senate,,DEM,Kamala Harris,4
-San Bernardino,UNI0258,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0259,U.S. Senate,,DEM,Kamala Harris,637
-San Bernardino,UNI0259,U.S. Senate,,DEM,Loretta Sanchez,415
-San Bernardino,UNI0260,U.S. Senate,,DEM,Kamala Harris,54
-San Bernardino,UNI0260,U.S. Senate,,DEM,Loretta Sanchez,35
-San Bernardino,UNI0261,U.S. Senate,,DEM,Kamala Harris,5
-San Bernardino,UNI0261,U.S. Senate,,DEM,Loretta Sanchez,6
-San Bernardino,UNI0262,U.S. Senate,,DEM,Kamala Harris,2
-San Bernardino,UNI0262,U.S. Senate,,DEM,Loretta Sanchez,1
-San Bernardino,UNI0263,U.S. Senate,,DEM,Kamala Harris,3
-San Bernardino,UNI0263,U.S. Senate,,DEM,Loretta Sanchez,1
-San Bernardino,UNI0264,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0264,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0276,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0276,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0277,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0277,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0278,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0278,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0279,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0279,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0280,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0280,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0281,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0281,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0282,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0282,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0283,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0283,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0284,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0284,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0285,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0285,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0286,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0286,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0287,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0287,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0288,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0288,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0289,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0289,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0290,U.S. Senate,,DEM,Kamala Harris,8
-San Bernardino,UNI0290,U.S. Senate,,DEM,Loretta Sanchez,6
-San Bernardino,UNI0291,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0291,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0292,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0292,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0293,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0293,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0294,U.S. Senate,,DEM,Kamala Harris,1
-San Bernardino,UNI0294,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0295,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0295,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0359,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0359,U.S. Senate,,DEM,Loretta Sanchez,1
-San Bernardino,UNI0360,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0360,U.S. Senate,,DEM,Loretta Sanchez,2
-San Bernardino,UNI0361,U.S. Senate,,DEM,Kamala Harris,218
-San Bernardino,UNI0361,U.S. Senate,,DEM,Loretta Sanchez,200
-San Bernardino,UNI0362,U.S. Senate,,DEM,Kamala Harris,260
-San Bernardino,UNI0362,U.S. Senate,,DEM,Loretta Sanchez,258
-San Bernardino,UNI0363,U.S. Senate,,DEM,Kamala Harris,61
-San Bernardino,UNI0363,U.S. Senate,,DEM,Loretta Sanchez,80
-San Bernardino,UNI0364,U.S. Senate,,DEM,Kamala Harris,223
-San Bernardino,UNI0364,U.S. Senate,,DEM,Loretta Sanchez,192
-San Bernardino,UNI0365,U.S. Senate,,DEM,Kamala Harris,3
-San Bernardino,UNI0365,U.S. Senate,,DEM,Loretta Sanchez,5
-San Bernardino,UNI0366,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0366,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0367,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0367,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0372,U.S. Senate,,DEM,Kamala Harris,300
-San Bernardino,UNI0372,U.S. Senate,,DEM,Loretta Sanchez,260
-San Bernardino,UNI0373,U.S. Senate,,DEM,Kamala Harris,61
-San Bernardino,UNI0373,U.S. Senate,,DEM,Loretta Sanchez,61
-San Bernardino,UNI0374,U.S. Senate,,DEM,Kamala Harris,116
-San Bernardino,UNI0374,U.S. Senate,,DEM,Loretta Sanchez,120
-San Bernardino,UNI0375,U.S. Senate,,DEM,Kamala Harris,157
-San Bernardino,UNI0375,U.S. Senate,,DEM,Loretta Sanchez,164
-San Bernardino,UNI0376,U.S. Senate,,DEM,Kamala Harris,387
-San Bernardino,UNI0376,U.S. Senate,,DEM,Loretta Sanchez,324
-San Bernardino,UNI0399,U.S. Senate,,DEM,Kamala Harris,59
-San Bernardino,UNI0399,U.S. Senate,,DEM,Loretta Sanchez,79
-San Bernardino,UNI0400,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0400,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0401,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0401,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0402,U.S. Senate,,DEM,Kamala Harris,6
-San Bernardino,UNI0402,U.S. Senate,,DEM,Loretta Sanchez,7
-San Bernardino,UNI0403,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0403,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0404,U.S. Senate,,DEM,Kamala Harris,10
-San Bernardino,UNI0404,U.S. Senate,,DEM,Loretta Sanchez,6
-San Bernardino,UNI0405,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0405,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0406,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0406,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0407,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0407,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0408,U.S. Senate,,DEM,Kamala Harris,104
-San Bernardino,UNI0408,U.S. Senate,,DEM,Loretta Sanchez,94
-San Bernardino,UNI0409,U.S. Senate,,DEM,Kamala Harris,362
-San Bernardino,UNI0409,U.S. Senate,,DEM,Loretta Sanchez,402
-San Bernardino,UNI0410,U.S. Senate,,DEM,Kamala Harris,72
-San Bernardino,UNI0410,U.S. Senate,,DEM,Loretta Sanchez,64
-San Bernardino,UNI0411,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0411,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0412,U.S. Senate,,DEM,Kamala Harris,284
-San Bernardino,UNI0412,U.S. Senate,,DEM,Loretta Sanchez,224
-San Bernardino,UNI0413,U.S. Senate,,DEM,Kamala Harris,539
-San Bernardino,UNI0413,U.S. Senate,,DEM,Loretta Sanchez,416
-San Bernardino,UNI0414,U.S. Senate,,DEM,Kamala Harris,562
-San Bernardino,UNI0414,U.S. Senate,,DEM,Loretta Sanchez,476
-San Bernardino,UNI0415,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0415,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0416,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0416,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0417,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0417,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0461,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0461,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0462,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0462,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0463,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0463,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0464,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0464,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0465,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0465,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0466,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0466,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0467,U.S. Senate,,DEM,Kamala Harris,5
-San Bernardino,UNI0467,U.S. Senate,,DEM,Loretta Sanchez,5
-San Bernardino,UNI0468,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0468,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0469,U.S. Senate,,DEM,Kamala Harris,16
-San Bernardino,UNI0469,U.S. Senate,,DEM,Loretta Sanchez,27
-San Bernardino,UNI0470,U.S. Senate,,DEM,Kamala Harris,28
-San Bernardino,UNI0470,U.S. Senate,,DEM,Loretta Sanchez,15
-San Bernardino,UNI0471,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0471,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0472,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0472,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0473,U.S. Senate,,DEM,Kamala Harris,9
-San Bernardino,UNI0473,U.S. Senate,,DEM,Loretta Sanchez,10
-San Bernardino,UNI0474,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0474,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0475,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0475,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0476,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0476,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0477,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0477,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0478,U.S. Senate,,DEM,Kamala Harris,361
-San Bernardino,UNI0478,U.S. Senate,,DEM,Loretta Sanchez,361
-San Bernardino,UNI0479,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0479,U.S. Senate,,DEM,Loretta Sanchez,2
-San Bernardino,UNI0480,U.S. Senate,,DEM,Kamala Harris,540
-San Bernardino,UNI0480,U.S. Senate,,DEM,Loretta Sanchez,592
-San Bernardino,UNI0481,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0481,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0482,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0482,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0483,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0483,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0484,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0484,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0485,U.S. Senate,,DEM,Kamala Harris,95
-San Bernardino,UNI0485,U.S. Senate,,DEM,Loretta Sanchez,52
-San Bernardino,UNI0486,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0486,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0487,U.S. Senate,,DEM,Kamala Harris,215
-San Bernardino,UNI0487,U.S. Senate,,DEM,Loretta Sanchez,130
-San Bernardino,UNI0488,U.S. Senate,,DEM,Kamala Harris,132
-San Bernardino,UNI0488,U.S. Senate,,DEM,Loretta Sanchez,59
-San Bernardino,UNI0489,U.S. Senate,,DEM,Kamala Harris,402
-San Bernardino,UNI0489,U.S. Senate,,DEM,Loretta Sanchez,294
-San Bernardino,UNI0490,U.S. Senate,,DEM,Kamala Harris,185
-San Bernardino,UNI0490,U.S. Senate,,DEM,Loretta Sanchez,130
-San Bernardino,UNI0491,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0491,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0492,U.S. Senate,,DEM,Kamala Harris,1
-San Bernardino,UNI0492,U.S. Senate,,DEM,Loretta Sanchez,1
-San Bernardino,UNI0493,U.S. Senate,,DEM,Kamala Harris,1
-San Bernardino,UNI0493,U.S. Senate,,DEM,Loretta Sanchez,1
-San Bernardino,UNI0494,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0494,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0495,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0495,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0496,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0496,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0497,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0497,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0498,U.S. Senate,,DEM,Kamala Harris,2
-San Bernardino,UNI0498,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0499,U.S. Senate,,DEM,Kamala Harris,3
-San Bernardino,UNI0499,U.S. Senate,,DEM,Loretta Sanchez,5
-San Bernardino,UNI0500,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0500,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0501,U.S. Senate,,DEM,Kamala Harris,5
-San Bernardino,UNI0501,U.S. Senate,,DEM,Loretta Sanchez,2
-San Bernardino,UNI0502,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0502,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0503,U.S. Senate,,DEM,Kamala Harris,28
-San Bernardino,UNI0503,U.S. Senate,,DEM,Loretta Sanchez,24
-San Bernardino,UNI0504,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0504,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0505,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0505,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0506,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0506,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0507,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0507,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0508,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0508,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0509,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0509,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0510,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0510,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0511,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0511,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0512,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0512,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0513,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0513,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0514,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0514,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0515,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0515,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0516,U.S. Senate,,DEM,Kamala Harris,153
-San Bernardino,UNI0516,U.S. Senate,,DEM,Loretta Sanchez,104
-San Bernardino,UNI0517,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0517,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0518,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0518,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0519,U.S. Senate,,DEM,Kamala Harris,27
-San Bernardino,UNI0519,U.S. Senate,,DEM,Loretta Sanchez,6
-San Bernardino,UNI0520,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0520,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0521,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0521,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0522,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0522,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0523,U.S. Senate,,DEM,Kamala Harris,26
-San Bernardino,UNI0523,U.S. Senate,,DEM,Loretta Sanchez,10
-San Bernardino,UNI0524,U.S. Senate,,DEM,Kamala Harris,8
-San Bernardino,UNI0524,U.S. Senate,,DEM,Loretta Sanchez,5
-San Bernardino,UNI0525,U.S. Senate,,DEM,Kamala Harris,327
-San Bernardino,UNI0525,U.S. Senate,,DEM,Loretta Sanchez,254
-San Bernardino,UNI0526,U.S. Senate,,DEM,Kamala Harris,35
-San Bernardino,UNI0526,U.S. Senate,,DEM,Loretta Sanchez,32
-San Bernardino,UNI0527,U.S. Senate,,DEM,Kamala Harris,26
-San Bernardino,UNI0527,U.S. Senate,,DEM,Loretta Sanchez,28
-San Bernardino,UNI0528,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0528,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0529,U.S. Senate,,DEM,Kamala Harris,87
-San Bernardino,UNI0529,U.S. Senate,,DEM,Loretta Sanchez,57
-San Bernardino,UNI0530,U.S. Senate,,DEM,Kamala Harris,684
-San Bernardino,UNI0530,U.S. Senate,,DEM,Loretta Sanchez,506
-San Bernardino,UNI0531,U.S. Senate,,DEM,Kamala Harris,270
-San Bernardino,UNI0531,U.S. Senate,,DEM,Loretta Sanchez,174
-San Bernardino,UNI0532,U.S. Senate,,DEM,Kamala Harris,737
-San Bernardino,UNI0532,U.S. Senate,,DEM,Loretta Sanchez,479
-San Bernardino,UNI0533,U.S. Senate,,DEM,Kamala Harris,190
-San Bernardino,UNI0533,U.S. Senate,,DEM,Loretta Sanchez,92
-San Bernardino,UNI0534,U.S. Senate,,DEM,Kamala Harris,88
-San Bernardino,UNI0534,U.S. Senate,,DEM,Loretta Sanchez,68
-San Bernardino,UNI0535,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0535,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0536,U.S. Senate,,DEM,Kamala Harris,254
-San Bernardino,UNI0536,U.S. Senate,,DEM,Loretta Sanchez,136
-San Bernardino,UNI0537,U.S. Senate,,DEM,Kamala Harris,20
-San Bernardino,UNI0537,U.S. Senate,,DEM,Loretta Sanchez,18
-San Bernardino,UNI0538,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0538,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0539,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0539,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0540,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0540,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0541,U.S. Senate,,DEM,Kamala Harris,1
-San Bernardino,UNI0541,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0542,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0542,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0543,U.S. Senate,,DEM,Kamala Harris,226
-San Bernardino,UNI0543,U.S. Senate,,DEM,Loretta Sanchez,162
-San Bernardino,UNI0544,U.S. Senate,,DEM,Kamala Harris,76
-San Bernardino,UNI0544,U.S. Senate,,DEM,Loretta Sanchez,52
-San Bernardino,UNI0545,U.S. Senate,,DEM,Kamala Harris,11
-San Bernardino,UNI0545,U.S. Senate,,DEM,Loretta Sanchez,6
-San Bernardino,UNI0546,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0546,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0547,U.S. Senate,,DEM,Kamala Harris,1
-San Bernardino,UNI0547,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0548,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0548,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0549,U.S. Senate,,DEM,Kamala Harris,207
-San Bernardino,UNI0549,U.S. Senate,,DEM,Loretta Sanchez,162
-San Bernardino,UNI0550,U.S. Senate,,DEM,Kamala Harris,2
-San Bernardino,UNI0550,U.S. Senate,,DEM,Loretta Sanchez,1
-San Bernardino,UNI0551,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0551,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0552,U.S. Senate,,DEM,Kamala Harris,26
-San Bernardino,UNI0552,U.S. Senate,,DEM,Loretta Sanchez,18
-San Bernardino,UNI0553,U.S. Senate,,DEM,Kamala Harris,3
-San Bernardino,UNI0553,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0554,U.S. Senate,,DEM,Kamala Harris,21
-San Bernardino,UNI0554,U.S. Senate,,DEM,Loretta Sanchez,30
-San Bernardino,UNI0555,U.S. Senate,,DEM,Kamala Harris,1
-San Bernardino,UNI0555,U.S. Senate,,DEM,Loretta Sanchez,2
-San Bernardino,UNI0556,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0556,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0557,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0557,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0558,U.S. Senate,,DEM,Kamala Harris,351
-San Bernardino,UNI0558,U.S. Senate,,DEM,Loretta Sanchez,222
-San Bernardino,UNI0559,U.S. Senate,,DEM,Kamala Harris,388
-San Bernardino,UNI0559,U.S. Senate,,DEM,Loretta Sanchez,284
-San Bernardino,UNI0560,U.S. Senate,,DEM,Kamala Harris,429
-San Bernardino,UNI0560,U.S. Senate,,DEM,Loretta Sanchez,268
-San Bernardino,UNI0561,U.S. Senate,,DEM,Kamala Harris,2
-San Bernardino,UNI0561,U.S. Senate,,DEM,Loretta Sanchez,2
-San Bernardino,UNI0562,U.S. Senate,,DEM,Kamala Harris,20
-San Bernardino,UNI0562,U.S. Senate,,DEM,Loretta Sanchez,18
-San Bernardino,UNI0563,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0563,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0564,U.S. Senate,,DEM,Kamala Harris,9
-San Bernardino,UNI0564,U.S. Senate,,DEM,Loretta Sanchez,4
-San Bernardino,UNI0565,U.S. Senate,,DEM,Kamala Harris,53
-San Bernardino,UNI0565,U.S. Senate,,DEM,Loretta Sanchez,32
-San Bernardino,UNI0566,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0566,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0567,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0567,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0568,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0568,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0569,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0569,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0570,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0570,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0571,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0571,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0577,U.S. Senate,,DEM,Kamala Harris,148
-San Bernardino,UNI0577,U.S. Senate,,DEM,Loretta Sanchez,102
-San Bernardino,UNI0578,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0578,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0579,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0579,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0580,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0580,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0581,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0581,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0582,U.S. Senate,,DEM,Kamala Harris,23
-San Bernardino,UNI0582,U.S. Senate,,DEM,Loretta Sanchez,17
-San Bernardino,UNI0583,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0583,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0584,U.S. Senate,,DEM,Kamala Harris,1
-San Bernardino,UNI0584,U.S. Senate,,DEM,Loretta Sanchez,1
-San Bernardino,UNI0585,U.S. Senate,,DEM,Kamala Harris,294
-San Bernardino,UNI0585,U.S. Senate,,DEM,Loretta Sanchez,207
-San Bernardino,UNI0586,U.S. Senate,,DEM,Kamala Harris,42
-San Bernardino,UNI0586,U.S. Senate,,DEM,Loretta Sanchez,32
-San Bernardino,UNI0587,U.S. Senate,,DEM,Kamala Harris,565
-San Bernardino,UNI0587,U.S. Senate,,DEM,Loretta Sanchez,449
-San Bernardino,UNI0588,U.S. Senate,,DEM,Kamala Harris,272
-San Bernardino,UNI0588,U.S. Senate,,DEM,Loretta Sanchez,187
-San Bernardino,UNI0589,U.S. Senate,,DEM,Kamala Harris,425
-San Bernardino,UNI0589,U.S. Senate,,DEM,Loretta Sanchez,309
-San Bernardino,UNI0590,U.S. Senate,,DEM,Kamala Harris,172
-San Bernardino,UNI0590,U.S. Senate,,DEM,Loretta Sanchez,153
-San Bernardino,UNI0591,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0591,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0592,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0592,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0593,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0593,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0594,U.S. Senate,,DEM,Kamala Harris,94
-San Bernardino,UNI0594,U.S. Senate,,DEM,Loretta Sanchez,65
-San Bernardino,UNI0595,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0595,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0596,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0596,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0597,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0597,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0598,U.S. Senate,,DEM,Kamala Harris,2
-San Bernardino,UNI0598,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0599,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0599,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0600,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0600,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0601,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0601,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0602,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0602,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0603,U.S. Senate,,DEM,Kamala Harris,1
-San Bernardino,UNI0603,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0605,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0605,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0606,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0606,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0607,U.S. Senate,,DEM,Kamala Harris,244
-San Bernardino,UNI0607,U.S. Senate,,DEM,Loretta Sanchez,181
-San Bernardino,UNI0608,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0608,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0609,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0609,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0610,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0610,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0611,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0611,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0612,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0612,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0613,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0613,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0614,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0614,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0619,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0619,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0620,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0620,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0621,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0621,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0622,U.S. Senate,,DEM,Kamala Harris,4
-San Bernardino,UNI0622,U.S. Senate,,DEM,Loretta Sanchez,1
-San Bernardino,UNI0623,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0623,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0624,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0624,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0625,U.S. Senate,,DEM,Kamala Harris,7
-San Bernardino,UNI0625,U.S. Senate,,DEM,Loretta Sanchez,6
-San Bernardino,UNI0626,U.S. Senate,,DEM,Kamala Harris,3
-San Bernardino,UNI0626,U.S. Senate,,DEM,Loretta Sanchez,6
-San Bernardino,UNI0627,U.S. Senate,,DEM,Kamala Harris,4
-San Bernardino,UNI0627,U.S. Senate,,DEM,Loretta Sanchez,4
-San Bernardino,UNI0628,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0628,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0629,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0629,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0630,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0630,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0631,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0631,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0632,U.S. Senate,,DEM,Kamala Harris,52
-San Bernardino,UNI0632,U.S. Senate,,DEM,Loretta Sanchez,30
-San Bernardino,UNI0633,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0633,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0634,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0634,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0635,U.S. Senate,,DEM,Kamala Harris,1
-San Bernardino,UNI0635,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0636,U.S. Senate,,DEM,Kamala Harris,2
-San Bernardino,UNI0636,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0639,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0639,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0640,U.S. Senate,,DEM,Kamala Harris,16
-San Bernardino,UNI0640,U.S. Senate,,DEM,Loretta Sanchez,6
-San Bernardino,UNI0641,U.S. Senate,,DEM,Kamala Harris,2
-San Bernardino,UNI0641,U.S. Senate,,DEM,Loretta Sanchez,6
-San Bernardino,UNI0642,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0642,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0643,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0643,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0644,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0644,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0645,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0645,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0646,U.S. Senate,,DEM,Kamala Harris,6
-San Bernardino,UNI0646,U.S. Senate,,DEM,Loretta Sanchez,9
-San Bernardino,UNI0647,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0647,U.S. Senate,,DEM,Loretta Sanchez,2
-San Bernardino,UNI0648,U.S. Senate,,DEM,Kamala Harris,480
-San Bernardino,UNI0648,U.S. Senate,,DEM,Loretta Sanchez,449
-San Bernardino,UNI0649,U.S. Senate,,DEM,Kamala Harris,513
-San Bernardino,UNI0649,U.S. Senate,,DEM,Loretta Sanchez,469
-San Bernardino,UNI0650,U.S. Senate,,DEM,Kamala Harris,611
-San Bernardino,UNI0650,U.S. Senate,,DEM,Loretta Sanchez,491
-San Bernardino,UNI0651,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0651,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0652,U.S. Senate,,DEM,Kamala Harris,495
-San Bernardino,UNI0652,U.S. Senate,,DEM,Loretta Sanchez,429
-San Bernardino,UNI0653,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0653,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0654,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0654,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0655,U.S. Senate,,DEM,Kamala Harris,657
-San Bernardino,UNI0655,U.S. Senate,,DEM,Loretta Sanchez,445
-San Bernardino,UNI0656,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0656,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0657,U.S. Senate,,DEM,Kamala Harris,355
-San Bernardino,UNI0657,U.S. Senate,,DEM,Loretta Sanchez,200
-San Bernardino,UNI0658,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0658,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0659,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0659,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0660,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0660,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0661,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0661,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0662,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0662,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0663,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0663,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0664,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0664,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0665,U.S. Senate,,DEM,Kamala Harris,3
-San Bernardino,UNI0665,U.S. Senate,,DEM,Loretta Sanchez,1
-San Bernardino,UNI0666,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0666,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0667,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0667,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0668,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0668,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0669,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0669,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0670,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0670,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0671,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0671,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0672,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0672,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0673,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0673,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0674,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0674,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0675,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0675,U.S. Senate,,DEM,Loretta Sanchez,1
-San Bernardino,UNI0676,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0676,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0677,U.S. Senate,,DEM,Kamala Harris,74
-San Bernardino,UNI0677,U.S. Senate,,DEM,Loretta Sanchez,63
-San Bernardino,UNI0678,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0678,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0679,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0679,U.S. Senate,,DEM,Loretta Sanchez,2
-San Bernardino,UNI0680,U.S. Senate,,DEM,Kamala Harris,1
-San Bernardino,UNI0680,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0681,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0681,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0682,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0682,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0683,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0683,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0684,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0684,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0685,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0685,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0686,U.S. Senate,,DEM,Kamala Harris,18
-San Bernardino,UNI0686,U.S. Senate,,DEM,Loretta Sanchez,6
-San Bernardino,UNI0687,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0687,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0688,U.S. Senate,,DEM,Kamala Harris,76
-San Bernardino,UNI0688,U.S. Senate,,DEM,Loretta Sanchez,37
-San Bernardino,UNI0689,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0689,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0690,U.S. Senate,,DEM,Kamala Harris,1
-San Bernardino,UNI0690,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0691,U.S. Senate,,DEM,Kamala Harris,134
-San Bernardino,UNI0691,U.S. Senate,,DEM,Loretta Sanchez,116
-San Bernardino,UNI0692,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0692,U.S. Senate,,DEM,Loretta Sanchez,1
-San Bernardino,UNI0693,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0693,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0694,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0694,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0695,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0695,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0698,U.S. Senate,,DEM,Kamala Harris,10
-San Bernardino,UNI0698,U.S. Senate,,DEM,Loretta Sanchez,6
-San Bernardino,UNI0699,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0699,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0700,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0700,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0701,U.S. Senate,,DEM,Kamala Harris,280
-San Bernardino,UNI0701,U.S. Senate,,DEM,Loretta Sanchez,208
-San Bernardino,UNI0702,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0702,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0703,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0703,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0704,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0704,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0705,U.S. Senate,,DEM,Kamala Harris,3
-San Bernardino,UNI0705,U.S. Senate,,DEM,Loretta Sanchez,4
-San Bernardino,UNI0706,U.S. Senate,,DEM,Kamala Harris,7
-San Bernardino,UNI0706,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0707,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0707,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0708,U.S. Senate,,DEM,Kamala Harris,3
-San Bernardino,UNI0708,U.S. Senate,,DEM,Loretta Sanchez,1
-San Bernardino,UNI0709,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0709,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0711,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0711,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0713,U.S. Senate,,DEM,Kamala Harris,3
-San Bernardino,UNI0713,U.S. Senate,,DEM,Loretta Sanchez,4
-San Bernardino,UNI0714,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0714,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0715,U.S. Senate,,DEM,Kamala Harris,8
-San Bernardino,UNI0715,U.S. Senate,,DEM,Loretta Sanchez,7
-San Bernardino,UNI0716,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0716,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0717,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0717,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0718,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0718,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0736,U.S. Senate,,DEM,Kamala Harris,114
-San Bernardino,UNI0736,U.S. Senate,,DEM,Loretta Sanchez,83
-San Bernardino,UNI0737,U.S. Senate,,DEM,Kamala Harris,38
-San Bernardino,UNI0737,U.S. Senate,,DEM,Loretta Sanchez,22
-San Bernardino,UNI0738,U.S. Senate,,DEM,Kamala Harris,20
-San Bernardino,UNI0738,U.S. Senate,,DEM,Loretta Sanchez,15
-San Bernardino,UNI0739,U.S. Senate,,DEM,Kamala Harris,42
-San Bernardino,UNI0739,U.S. Senate,,DEM,Loretta Sanchez,38
-San Bernardino,UNI0740,U.S. Senate,,DEM,Kamala Harris,10
-San Bernardino,UNI0740,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0741,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0741,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0742,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0742,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0743,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0743,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0744,U.S. Senate,,DEM,Kamala Harris,1
-San Bernardino,UNI0744,U.S. Senate,,DEM,Loretta Sanchez,4
-San Bernardino,UNI0745,U.S. Senate,,DEM,Kamala Harris,3
-San Bernardino,UNI0745,U.S. Senate,,DEM,Loretta Sanchez,3
-San Bernardino,UNI0759,U.S. Senate,,DEM,Kamala Harris,21
-San Bernardino,UNI0759,U.S. Senate,,DEM,Loretta Sanchez,8
-San Bernardino,UNI0760,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0760,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0761,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0761,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0762,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0762,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0763,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0763,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0764,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0764,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0765,U.S. Senate,,DEM,Kamala Harris,1
-San Bernardino,UNI0765,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0766,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0766,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0767,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0767,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0769,U.S. Senate,,DEM,Kamala Harris,670
-San Bernardino,UNI0769,U.S. Senate,,DEM,Loretta Sanchez,425
-San Bernardino,UNI0770,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0770,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0771,U.S. Senate,,DEM,Kamala Harris,16
-San Bernardino,UNI0771,U.S. Senate,,DEM,Loretta Sanchez,23
-San Bernardino,UNI0772,U.S. Senate,,DEM,Kamala Harris,17
-San Bernardino,UNI0772,U.S. Senate,,DEM,Loretta Sanchez,10
-San Bernardino,UNI0773,U.S. Senate,,DEM,Kamala Harris,23
-San Bernardino,UNI0773,U.S. Senate,,DEM,Loretta Sanchez,14
-San Bernardino,UNI0774,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0774,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0775,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0775,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0776,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0776,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0777,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0777,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0778,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0778,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0779,U.S. Senate,,DEM,Kamala Harris,4
-San Bernardino,UNI0779,U.S. Senate,,DEM,Loretta Sanchez,2
-San Bernardino,UNI0780,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0780,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0783,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0783,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0784,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0784,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0785,U.S. Senate,,DEM,Kamala Harris,84
-San Bernardino,UNI0785,U.S. Senate,,DEM,Loretta Sanchez,55
-San Bernardino,UNI0786,U.S. Senate,,DEM,Kamala Harris,24
-San Bernardino,UNI0786,U.S. Senate,,DEM,Loretta Sanchez,21
-San Bernardino,UNI0787,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0787,U.S. Senate,,DEM,Loretta Sanchez,2
-San Bernardino,UNI0788,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0788,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0789,U.S. Senate,,DEM,Kamala Harris,2
-San Bernardino,UNI0789,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0790,U.S. Senate,,DEM,Kamala Harris,11
-San Bernardino,UNI0790,U.S. Senate,,DEM,Loretta Sanchez,9
-San Bernardino,UNI0791,U.S. Senate,,DEM,Kamala Harris,4
-San Bernardino,UNI0791,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0792,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0792,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0793,U.S. Senate,,DEM,Kamala Harris,5
-San Bernardino,UNI0793,U.S. Senate,,DEM,Loretta Sanchez,1
-San Bernardino,UNI0794,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0794,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0795,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0795,U.S. Senate,,DEM,Loretta Sanchez,4
-San Bernardino,UNI0796,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0796,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0797,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0797,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0798,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0798,U.S. Senate,,DEM,Loretta Sanchez,1
-San Bernardino,UNI0799,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0799,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0808,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0808,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0834,U.S. Senate,,DEM,Kamala Harris,61
-San Bernardino,UNI0834,U.S. Senate,,DEM,Loretta Sanchez,30
-San Bernardino,UNI0838,U.S. Senate,,DEM,Kamala Harris,4
-San Bernardino,UNI0838,U.S. Senate,,DEM,Loretta Sanchez,6
-San Bernardino,UNI0839,U.S. Senate,,DEM,Kamala Harris,429
-San Bernardino,UNI0839,U.S. Senate,,DEM,Loretta Sanchez,340
-San Bernardino,UNI0840,U.S. Senate,,DEM,Kamala Harris,383
-San Bernardino,UNI0840,U.S. Senate,,DEM,Loretta Sanchez,312
-San Bernardino,UNI0856,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0856,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0857,U.S. Senate,,DEM,Kamala Harris,12
-San Bernardino,UNI0857,U.S. Senate,,DEM,Loretta Sanchez,12
-San Bernardino,UNI0858,U.S. Senate,,DEM,Kamala Harris,2
-San Bernardino,UNI0858,U.S. Senate,,DEM,Loretta Sanchez,1
-San Bernardino,UNI0859,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0859,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0860,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0860,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0861,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0861,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0862,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0862,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0864,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0864,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0865,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0865,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0867,U.S. Senate,,DEM,Kamala Harris,499
-San Bernardino,UNI0867,U.S. Senate,,DEM,Loretta Sanchez,319
-San Bernardino,UNI0868,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0868,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0869,U.S. Senate,,DEM,Kamala Harris,163
-San Bernardino,UNI0869,U.S. Senate,,DEM,Loretta Sanchez,104
-San Bernardino,UNI0870,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0870,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0871,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0871,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0874,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0874,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0875,U.S. Senate,,DEM,Kamala Harris,15
-San Bernardino,UNI0875,U.S. Senate,,DEM,Loretta Sanchez,7
-San Bernardino,UNI0876,U.S. Senate,,DEM,Kamala Harris,22
-San Bernardino,UNI0876,U.S. Senate,,DEM,Loretta Sanchez,32
-San Bernardino,UNI0877,U.S. Senate,,DEM,Kamala Harris,660
-San Bernardino,UNI0877,U.S. Senate,,DEM,Loretta Sanchez,439
-San Bernardino,UNI0878,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0878,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0879,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0879,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0880,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0880,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0915,U.S. Senate,,DEM,Kamala Harris,34
-San Bernardino,UNI0915,U.S. Senate,,DEM,Loretta Sanchez,47
-San Bernardino,UNI0916,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0916,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0917,U.S. Senate,,DEM,Kamala Harris,7
-San Bernardino,UNI0917,U.S. Senate,,DEM,Loretta Sanchez,5
-San Bernardino,UNI0918,U.S. Senate,,DEM,Kamala Harris,3
-San Bernardino,UNI0918,U.S. Senate,,DEM,Loretta Sanchez,2
-San Bernardino,UNI0919,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0919,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0948,U.S. Senate,,DEM,Kamala Harris,227
-San Bernardino,UNI0948,U.S. Senate,,DEM,Loretta Sanchez,322
-San Bernardino,UNI0949,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0949,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0950,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0950,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0951,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0951,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0990,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0990,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0991,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0991,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI0992,U.S. Senate,,DEM,Kamala Harris,121
-San Bernardino,UNI0992,U.S. Senate,,DEM,Loretta Sanchez,136
-San Bernardino,UNI0993,U.S. Senate,,DEM,Kamala Harris,35
-San Bernardino,UNI0993,U.S. Senate,,DEM,Loretta Sanchez,51
-San Bernardino,UNI0994,U.S. Senate,,DEM,Kamala Harris,66
-San Bernardino,UNI0994,U.S. Senate,,DEM,Loretta Sanchez,47
-San Bernardino,UNI0995,U.S. Senate,,DEM,Kamala Harris,3
-San Bernardino,UNI0995,U.S. Senate,,DEM,Loretta Sanchez,1
-San Bernardino,UNI0996,U.S. Senate,,DEM,Kamala Harris,1
-San Bernardino,UNI0996,U.S. Senate,,DEM,Loretta Sanchez,3
-San Bernardino,UNI0997,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI0997,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI1022,U.S. Senate,,DEM,Kamala Harris,59
-San Bernardino,UNI1022,U.S. Senate,,DEM,Loretta Sanchez,82
-San Bernardino,UNI1023,U.S. Senate,,DEM,Kamala Harris,251
-San Bernardino,UNI1023,U.S. Senate,,DEM,Loretta Sanchez,379
-San Bernardino,UNI1024,U.S. Senate,,DEM,Kamala Harris,239
-San Bernardino,UNI1024,U.S. Senate,,DEM,Loretta Sanchez,345
-San Bernardino,UNI1025,U.S. Senate,,DEM,Kamala Harris,130
-San Bernardino,UNI1025,U.S. Senate,,DEM,Loretta Sanchez,188
-San Bernardino,UNI1026,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI1026,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI1143,U.S. Senate,,DEM,Kamala Harris,416
-San Bernardino,UNI1143,U.S. Senate,,DEM,Loretta Sanchez,260
-San Bernardino,UNI1144,U.S. Senate,,DEM,Kamala Harris,1
-San Bernardino,UNI1144,U.S. Senate,,DEM,Loretta Sanchez,1
-San Bernardino,UNI1145,U.S. Senate,,DEM,Kamala Harris,17
-San Bernardino,UNI1145,U.S. Senate,,DEM,Loretta Sanchez,11
-San Bernardino,UNI1146,U.S. Senate,,DEM,Kamala Harris,6
-San Bernardino,UNI1146,U.S. Senate,,DEM,Loretta Sanchez,5
-San Bernardino,UNI1147,U.S. Senate,,DEM,Kamala Harris,13
-San Bernardino,UNI1147,U.S. Senate,,DEM,Loretta Sanchez,3
-San Bernardino,UNI1148,U.S. Senate,,DEM,Kamala Harris,3
-San Bernardino,UNI1148,U.S. Senate,,DEM,Loretta Sanchez,3
-San Bernardino,UNI1149,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI1149,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI1150,U.S. Senate,,DEM,Kamala Harris,97
-San Bernardino,UNI1150,U.S. Senate,,DEM,Loretta Sanchez,17
-San Bernardino,UNI1151,U.S. Senate,,DEM,Kamala Harris,4
-San Bernardino,UNI1151,U.S. Senate,,DEM,Loretta Sanchez,3
-San Bernardino,UNI1152,U.S. Senate,,DEM,Kamala Harris,4
-San Bernardino,UNI1152,U.S. Senate,,DEM,Loretta Sanchez,5
-San Bernardino,UNI1153,U.S. Senate,,DEM,Kamala Harris,11
-San Bernardino,UNI1153,U.S. Senate,,DEM,Loretta Sanchez,8
-San Bernardino,UNI1199,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI1199,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI1200,U.S. Senate,,DEM,Kamala Harris,324
-San Bernardino,UNI1200,U.S. Senate,,DEM,Loretta Sanchez,252
-San Bernardino,UNI1201,U.S. Senate,,DEM,Kamala Harris,431
-San Bernardino,UNI1201,U.S. Senate,,DEM,Loretta Sanchez,326
-San Bernardino,UNI1202,U.S. Senate,,DEM,Kamala Harris,513
-San Bernardino,UNI1202,U.S. Senate,,DEM,Loretta Sanchez,420
-San Bernardino,UNI1203,U.S. Senate,,DEM,Kamala Harris,305
-San Bernardino,UNI1203,U.S. Senate,,DEM,Loretta Sanchez,278
-San Bernardino,UNI1204,U.S. Senate,,DEM,Kamala Harris,260
-San Bernardino,UNI1204,U.S. Senate,,DEM,Loretta Sanchez,233
-San Bernardino,UNI1258,U.S. Senate,,DEM,Kamala Harris,379
-San Bernardino,UNI1258,U.S. Senate,,DEM,Loretta Sanchez,341
-San Bernardino,UNI1259,U.S. Senate,,DEM,Kamala Harris,142
-San Bernardino,UNI1259,U.S. Senate,,DEM,Loretta Sanchez,146
-San Bernardino,UNI1268,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI1268,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI1269,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI1269,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI1270,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI1270,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI1271,U.S. Senate,,DEM,Kamala Harris,4
-San Bernardino,UNI1271,U.S. Senate,,DEM,Loretta Sanchez,3
-San Bernardino,UNI1274,U.S. Senate,,DEM,Kamala Harris,273
-San Bernardino,UNI1274,U.S. Senate,,DEM,Loretta Sanchez,204
-San Bernardino,UNI1348,U.S. Senate,,DEM,Kamala Harris,187
-San Bernardino,UNI1348,U.S. Senate,,DEM,Loretta Sanchez,206
-San Bernardino,UNI1349,U.S. Senate,,DEM,Kamala Harris,58
-San Bernardino,UNI1349,U.S. Senate,,DEM,Loretta Sanchez,76
-San Bernardino,UNI1350,U.S. Senate,,DEM,Kamala Harris,362
-San Bernardino,UNI1350,U.S. Senate,,DEM,Loretta Sanchez,554
-San Bernardino,UNI1351,U.S. Senate,,DEM,Kamala Harris,216
-San Bernardino,UNI1351,U.S. Senate,,DEM,Loretta Sanchez,359
-San Bernardino,UNI1352,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI1352,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI1353,U.S. Senate,,DEM,Kamala Harris,381
-San Bernardino,UNI1353,U.S. Senate,,DEM,Loretta Sanchez,544
-San Bernardino,UNI1354,U.S. Senate,,DEM,Kamala Harris,393
-San Bernardino,UNI1354,U.S. Senate,,DEM,Loretta Sanchez,580
-San Bernardino,UNI1355,U.S. Senate,,DEM,Kamala Harris,306
-San Bernardino,UNI1355,U.S. Senate,,DEM,Loretta Sanchez,594
-San Bernardino,UNI1356,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI1356,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI1357,U.S. Senate,,DEM,Kamala Harris,32
-San Bernardino,UNI1357,U.S. Senate,,DEM,Loretta Sanchez,63
-San Bernardino,UNI1358,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI1358,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI1359,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI1359,U.S. Senate,,DEM,Loretta Sanchez,2
-San Bernardino,UNI1386,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI1386,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI1387,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI1387,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI1457,U.S. Senate,,DEM,Kamala Harris,306
-San Bernardino,UNI1457,U.S. Senate,,DEM,Loretta Sanchez,444
-San Bernardino,UNI1458,U.S. Senate,,DEM,Kamala Harris,136
-San Bernardino,UNI1458,U.S. Senate,,DEM,Loretta Sanchez,148
-San Bernardino,UNI1459,U.S. Senate,,DEM,Kamala Harris,136
-San Bernardino,UNI1459,U.S. Senate,,DEM,Loretta Sanchez,182
-San Bernardino,UNI1510,U.S. Senate,,DEM,Kamala Harris,395
-San Bernardino,UNI1510,U.S. Senate,,DEM,Loretta Sanchez,469
-San Bernardino,UNI1511,U.S. Senate,,DEM,Kamala Harris,17
-San Bernardino,UNI1511,U.S. Senate,,DEM,Loretta Sanchez,14
-San Bernardino,UNI1512,U.S. Senate,,DEM,Kamala Harris,4
-San Bernardino,UNI1512,U.S. Senate,,DEM,Loretta Sanchez,4
-San Bernardino,UNI1513,U.S. Senate,,DEM,Kamala Harris,2
-San Bernardino,UNI1513,U.S. Senate,,DEM,Loretta Sanchez,2
-San Bernardino,UNI1514,U.S. Senate,,DEM,Kamala Harris,98
-San Bernardino,UNI1514,U.S. Senate,,DEM,Loretta Sanchez,68
-San Bernardino,UNI1515,U.S. Senate,,DEM,Kamala Harris,5
-San Bernardino,UNI1515,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI1516,U.S. Senate,,DEM,Kamala Harris,4
-San Bernardino,UNI1516,U.S. Senate,,DEM,Loretta Sanchez,6
-San Bernardino,UNI1517,U.S. Senate,,DEM,Kamala Harris,294
-San Bernardino,UNI1517,U.S. Senate,,DEM,Loretta Sanchez,290
-San Bernardino,UNI1518,U.S. Senate,,DEM,Kamala Harris,23
-San Bernardino,UNI1518,U.S. Senate,,DEM,Loretta Sanchez,12
-San Bernardino,UNI1519,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI1519,U.S. Senate,,DEM,Loretta Sanchez,1
-San Bernardino,UNI1520,U.S. Senate,,DEM,Kamala Harris,16
-San Bernardino,UNI1520,U.S. Senate,,DEM,Loretta Sanchez,26
-San Bernardino,UNI1525,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI1525,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI1526,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI1526,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI1527,U.S. Senate,,DEM,Kamala Harris,424
-San Bernardino,UNI1527,U.S. Senate,,DEM,Loretta Sanchez,530
-San Bernardino,UNI1528,U.S. Senate,,DEM,Kamala Harris,318
-San Bernardino,UNI1528,U.S. Senate,,DEM,Loretta Sanchez,498
-San Bernardino,UNI1529,U.S. Senate,,DEM,Kamala Harris,309
-San Bernardino,UNI1529,U.S. Senate,,DEM,Loretta Sanchez,469
-San Bernardino,UNI1530,U.S. Senate,,DEM,Kamala Harris,361
-San Bernardino,UNI1530,U.S. Senate,,DEM,Loretta Sanchez,531
-San Bernardino,UNI1531,U.S. Senate,,DEM,Kamala Harris,413
-San Bernardino,UNI1531,U.S. Senate,,DEM,Loretta Sanchez,630
-San Bernardino,UNI1532,U.S. Senate,,DEM,Kamala Harris,4
-San Bernardino,UNI1532,U.S. Senate,,DEM,Loretta Sanchez,13
-San Bernardino,UNI1566,U.S. Senate,,DEM,Kamala Harris,8
-San Bernardino,UNI1566,U.S. Senate,,DEM,Loretta Sanchez,1
-San Bernardino,UNI1567,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI1567,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI1578,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI1578,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI1579,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI1579,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI1580,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI1580,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI1581,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI1581,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI1582,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI1582,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI1583,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI1583,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI1584,U.S. Senate,,DEM,Kamala Harris,49
-San Bernardino,UNI1584,U.S. Senate,,DEM,Loretta Sanchez,18
-San Bernardino,UNI1585,U.S. Senate,,DEM,Kamala Harris,39
-San Bernardino,UNI1585,U.S. Senate,,DEM,Loretta Sanchez,33
-San Bernardino,UNI1586,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI1586,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI1587,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI1587,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI1588,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI1588,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI1589,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI1589,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI1590,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI1590,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI1591,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI1591,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI1592,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI1592,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI1593,U.S. Senate,,DEM,Kamala Harris,34
-San Bernardino,UNI1593,U.S. Senate,,DEM,Loretta Sanchez,25
-San Bernardino,UNI1594,U.S. Senate,,DEM,Kamala Harris,1
-San Bernardino,UNI1594,U.S. Senate,,DEM,Loretta Sanchez,1
-San Bernardino,UNI1595,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI1595,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI1596,U.S. Senate,,DEM,Kamala Harris,6
-San Bernardino,UNI1596,U.S. Senate,,DEM,Loretta Sanchez,2
-San Bernardino,UNI1597,U.S. Senate,,DEM,Kamala Harris,387
-San Bernardino,UNI1597,U.S. Senate,,DEM,Loretta Sanchez,236
-San Bernardino,UNI1598,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI1598,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI1599,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI1599,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI1600,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI1600,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI1601,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI1601,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI1602,U.S. Senate,,DEM,Kamala Harris,1
-San Bernardino,UNI1602,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI1603,U.S. Senate,,DEM,Kamala Harris,15
-San Bernardino,UNI1603,U.S. Senate,,DEM,Loretta Sanchez,15
-San Bernardino,UNI1608,U.S. Senate,,DEM,Kamala Harris,149
-San Bernardino,UNI1608,U.S. Senate,,DEM,Loretta Sanchez,131
-San Bernardino,UNI1610,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI1610,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI1611,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI1611,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI1612,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI1612,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI1613,U.S. Senate,,DEM,Kamala Harris,1
-San Bernardino,UNI1613,U.S. Senate,,DEM,Loretta Sanchez,11
-San Bernardino,UNI1614,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI1614,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI1615,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI1615,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI1616,U.S. Senate,,DEM,Kamala Harris,126
-San Bernardino,UNI1616,U.S. Senate,,DEM,Loretta Sanchez,135
-San Bernardino,UNI1623,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI1623,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI1624,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI1624,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI1627,U.S. Senate,,DEM,Kamala Harris,36
-San Bernardino,UNI1627,U.S. Senate,,DEM,Loretta Sanchez,28
-San Bernardino,UNI1628,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI1628,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI1630,U.S. Senate,,DEM,Kamala Harris,2
-San Bernardino,UNI1630,U.S. Senate,,DEM,Loretta Sanchez,4
-San Bernardino,UNI1637,U.S. Senate,,DEM,Kamala Harris,19
-San Bernardino,UNI1637,U.S. Senate,,DEM,Loretta Sanchez,29
-San Bernardino,UNI1638,U.S. Senate,,DEM,Kamala Harris,41
-San Bernardino,UNI1638,U.S. Senate,,DEM,Loretta Sanchez,21
-San Bernardino,UNI1645,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI1645,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI1646,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI1646,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI1647,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI1647,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI1648,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI1648,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI1649,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI1649,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI1650,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI1650,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI1651,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI1651,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI1652,U.S. Senate,,DEM,Kamala Harris,2
-San Bernardino,UNI1652,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI1653,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI1653,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI1666,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI1666,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI1673,U.S. Senate,,DEM,Kamala Harris,30
-San Bernardino,UNI1673,U.S. Senate,,DEM,Loretta Sanchez,25
-San Bernardino,UNI1676,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI1676,U.S. Senate,,DEM,Loretta Sanchez,4
-San Bernardino,UNI1677,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI1677,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI1678,U.S. Senate,,DEM,Kamala Harris,206
-San Bernardino,UNI1678,U.S. Senate,,DEM,Loretta Sanchez,130
-San Bernardino,UNI1679,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI1679,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI1680,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI1680,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI1681,U.S. Senate,,DEM,Kamala Harris,3
-San Bernardino,UNI1681,U.S. Senate,,DEM,Loretta Sanchez,4
-San Bernardino,UNI1682,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI1682,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI1683,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI1683,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI1684,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI1684,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI1685,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI1685,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI1686,U.S. Senate,,DEM,Kamala Harris,23
-San Bernardino,UNI1686,U.S. Senate,,DEM,Loretta Sanchez,26
-San Bernardino,UNI1687,U.S. Senate,,DEM,Kamala Harris,33
-San Bernardino,UNI1687,U.S. Senate,,DEM,Loretta Sanchez,11
-San Bernardino,UNI1688,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI1688,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI1689,U.S. Senate,,DEM,Kamala Harris,13
-San Bernardino,UNI1689,U.S. Senate,,DEM,Loretta Sanchez,4
-San Bernardino,UNI1690,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI1690,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI1691,U.S. Senate,,DEM,Kamala Harris,5
-San Bernardino,UNI1691,U.S. Senate,,DEM,Loretta Sanchez,3
-San Bernardino,UNI1692,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI1692,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI1693,U.S. Senate,,DEM,Kamala Harris,2
-San Bernardino,UNI1693,U.S. Senate,,DEM,Loretta Sanchez,1
-San Bernardino,UNI1694,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI1694,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI1697,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI1697,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI1698,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI1698,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI1699,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI1699,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI1700,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI1700,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI1701,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI1701,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI1702,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI1702,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI1703,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI1703,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI1704,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI1704,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI1705,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI1705,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI1706,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI1706,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI1708,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI1708,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI1709,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI1709,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI1710,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI1710,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI1711,U.S. Senate,,DEM,Kamala Harris,10
-San Bernardino,UNI1711,U.S. Senate,,DEM,Loretta Sanchez,23
-San Bernardino,UNI1712,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI1712,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI1713,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI1713,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI1714,U.S. Senate,,DEM,Kamala Harris,2
-San Bernardino,UNI1714,U.S. Senate,,DEM,Loretta Sanchez,2
-San Bernardino,UNI1725,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI1725,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI1726,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI1726,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI1727,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI1727,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI1728,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI1728,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI1729,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI1729,U.S. Senate,,DEM,Loretta Sanchez,1
-San Bernardino,UNI1733,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI1733,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI1734,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI1734,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI1775,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI1775,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI1780,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI1780,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI1781,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI1781,U.S. Senate,,DEM,Loretta Sanchez,2
-San Bernardino,UNI1782,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI1782,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UNI1783,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UNI1783,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UPL0836,U.S. Senate,,DEM,Kamala Harris,73
-San Bernardino,UPL0836,U.S. Senate,,DEM,Loretta Sanchez,53
-San Bernardino,UPL0837,U.S. Senate,,DEM,Kamala Harris,110
-San Bernardino,UPL0837,U.S. Senate,,DEM,Loretta Sanchez,55
-San Bernardino,UPL0841,U.S. Senate,,DEM,Kamala Harris,780
-San Bernardino,UPL0841,U.S. Senate,,DEM,Loretta Sanchez,519
-San Bernardino,UPL0842,U.S. Senate,,DEM,Kamala Harris,819
-San Bernardino,UPL0842,U.S. Senate,,DEM,Loretta Sanchez,571
-San Bernardino,UPL0843,U.S. Senate,,DEM,Kamala Harris,639
-San Bernardino,UPL0843,U.S. Senate,,DEM,Loretta Sanchez,426
-San Bernardino,UPL0844,U.S. Senate,,DEM,Kamala Harris,435
-San Bernardino,UPL0844,U.S. Senate,,DEM,Loretta Sanchez,352
-San Bernardino,UPL0845,U.S. Senate,,DEM,Kamala Harris,415
-San Bernardino,UPL0845,U.S. Senate,,DEM,Loretta Sanchez,334
-San Bernardino,UPL0846,U.S. Senate,,DEM,Kamala Harris,338
-San Bernardino,UPL0846,U.S. Senate,,DEM,Loretta Sanchez,249
-San Bernardino,UPL0847,U.S. Senate,,DEM,Kamala Harris,785
-San Bernardino,UPL0847,U.S. Senate,,DEM,Loretta Sanchez,535
-San Bernardino,UPL0848,U.S. Senate,,DEM,Kamala Harris,70
-San Bernardino,UPL0848,U.S. Senate,,DEM,Loretta Sanchez,61
-San Bernardino,UPL0849,U.S. Senate,,DEM,Kamala Harris,706
-San Bernardino,UPL0849,U.S. Senate,,DEM,Loretta Sanchez,561
-San Bernardino,UPL0850,U.S. Senate,,DEM,Kamala Harris,727
-San Bernardino,UPL0850,U.S. Senate,,DEM,Loretta Sanchez,572
-San Bernardino,UPL0851,U.S. Senate,,DEM,Kamala Harris,689
-San Bernardino,UPL0851,U.S. Senate,,DEM,Loretta Sanchez,592
-San Bernardino,UPL0852,U.S. Senate,,DEM,Kamala Harris,519
-San Bernardino,UPL0852,U.S. Senate,,DEM,Loretta Sanchez,395
-San Bernardino,UPL0853,U.S. Senate,,DEM,Kamala Harris,696
-San Bernardino,UPL0853,U.S. Senate,,DEM,Loretta Sanchez,438
-San Bernardino,UPL0854,U.S. Senate,,DEM,Kamala Harris,68
-San Bernardino,UPL0854,U.S. Senate,,DEM,Loretta Sanchez,35
-San Bernardino,UPL0855,U.S. Senate,,DEM,Kamala Harris,133
-San Bernardino,UPL0855,U.S. Senate,,DEM,Loretta Sanchez,138
-San Bernardino,UPL1275,U.S. Senate,,DEM,Kamala Harris,12
-San Bernardino,UPL1275,U.S. Senate,,DEM,Loretta Sanchez,18
-San Bernardino,UPL1276,U.S. Senate,,DEM,Kamala Harris,631
-San Bernardino,UPL1276,U.S. Senate,,DEM,Loretta Sanchez,497
-San Bernardino,UPL1277,U.S. Senate,,DEM,Kamala Harris,415
-San Bernardino,UPL1277,U.S. Senate,,DEM,Loretta Sanchez,321
-San Bernardino,UPL1278,U.S. Senate,,DEM,Kamala Harris,17
-San Bernardino,UPL1278,U.S. Senate,,DEM,Loretta Sanchez,6
-San Bernardino,UPL1279,U.S. Senate,,DEM,Kamala Harris,5
-San Bernardino,UPL1279,U.S. Senate,,DEM,Loretta Sanchez,2
-San Bernardino,UPL1280,U.S. Senate,,DEM,Kamala Harris,136
-San Bernardino,UPL1280,U.S. Senate,,DEM,Loretta Sanchez,118
-San Bernardino,UPL1281,U.S. Senate,,DEM,Kamala Harris,371
-San Bernardino,UPL1281,U.S. Senate,,DEM,Loretta Sanchez,309
-San Bernardino,UPL1282,U.S. Senate,,DEM,Kamala Harris,386
-San Bernardino,UPL1282,U.S. Senate,,DEM,Loretta Sanchez,293
-San Bernardino,UPL1283,U.S. Senate,,DEM,Kamala Harris,496
-San Bernardino,UPL1283,U.S. Senate,,DEM,Loretta Sanchez,458
-San Bernardino,UPL1284,U.S. Senate,,DEM,Kamala Harris,3
-San Bernardino,UPL1284,U.S. Senate,,DEM,Loretta Sanchez,11
-San Bernardino,UPL1285,U.S. Senate,,DEM,Kamala Harris,19
-San Bernardino,UPL1285,U.S. Senate,,DEM,Loretta Sanchez,11
-San Bernardino,UPL1286,U.S. Senate,,DEM,Kamala Harris,621
-San Bernardino,UPL1286,U.S. Senate,,DEM,Loretta Sanchez,567
-San Bernardino,UPL1287,U.S. Senate,,DEM,Kamala Harris,533
-San Bernardino,UPL1287,U.S. Senate,,DEM,Loretta Sanchez,502
-San Bernardino,UPL1288,U.S. Senate,,DEM,Kamala Harris,511
-San Bernardino,UPL1288,U.S. Senate,,DEM,Loretta Sanchez,483
-San Bernardino,UPL1289,U.S. Senate,,DEM,Kamala Harris,572
-San Bernardino,UPL1289,U.S. Senate,,DEM,Loretta Sanchez,548
-San Bernardino,UPL1290,U.S. Senate,,DEM,Kamala Harris,578
-San Bernardino,UPL1290,U.S. Senate,,DEM,Loretta Sanchez,475
-San Bernardino,UPL1291,U.S. Senate,,DEM,Kamala Harris,830
-San Bernardino,UPL1291,U.S. Senate,,DEM,Loretta Sanchez,602
-San Bernardino,UPL1292,U.S. Senate,,DEM,Kamala Harris,772
-San Bernardino,UPL1292,U.S. Senate,,DEM,Loretta Sanchez,555
-San Bernardino,UPL1293,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UPL1293,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UPL1294,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UPL1294,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UPL1460,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UPL1460,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UPL1522,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UPL1522,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UPL1523,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UPL1523,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,UPL1524,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,UPL1524,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,VIC0368,U.S. Senate,,DEM,Kamala Harris,163
-San Bernardino,VIC0368,U.S. Senate,,DEM,Loretta Sanchez,141
-San Bernardino,VIC0369,U.S. Senate,,DEM,Kamala Harris,478
-San Bernardino,VIC0369,U.S. Senate,,DEM,Loretta Sanchez,451
-San Bernardino,VIC0377,U.S. Senate,,DEM,Kamala Harris,476
-San Bernardino,VIC0377,U.S. Senate,,DEM,Loretta Sanchez,399
-San Bernardino,VIC0378,U.S. Senate,,DEM,Kamala Harris,385
-San Bernardino,VIC0378,U.S. Senate,,DEM,Loretta Sanchez,282
-San Bernardino,VIC0379,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,VIC0379,U.S. Senate,,DEM,Loretta Sanchez,2
-San Bernardino,VIC0418,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,VIC0418,U.S. Senate,,DEM,Loretta Sanchez,1
-San Bernardino,VIC0419,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,VIC0419,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,VIC0420,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,VIC0420,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,VIC0421,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,VIC0421,U.S. Senate,,DEM,Loretta Sanchez,5
-San Bernardino,VIC0422,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,VIC0422,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,VIC0423,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,VIC0423,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,VIC0424,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,VIC0424,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,VIC0425,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,VIC0425,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,VIC0426,U.S. Senate,,DEM,Kamala Harris,73
-San Bernardino,VIC0426,U.S. Senate,,DEM,Loretta Sanchez,32
-San Bernardino,VIC0427,U.S. Senate,,DEM,Kamala Harris,303
-San Bernardino,VIC0427,U.S. Senate,,DEM,Loretta Sanchez,299
-San Bernardino,VIC0428,U.S. Senate,,DEM,Kamala Harris,334
-San Bernardino,VIC0428,U.S. Senate,,DEM,Loretta Sanchez,319
-San Bernardino,VIC0429,U.S. Senate,,DEM,Kamala Harris,54
-San Bernardino,VIC0429,U.S. Senate,,DEM,Loretta Sanchez,41
-San Bernardino,VIC0430,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,VIC0430,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,VIC0431,U.S. Senate,,DEM,Kamala Harris,326
-San Bernardino,VIC0431,U.S. Senate,,DEM,Loretta Sanchez,290
-San Bernardino,VIC0432,U.S. Senate,,DEM,Kamala Harris,591
-San Bernardino,VIC0432,U.S. Senate,,DEM,Loretta Sanchez,569
-San Bernardino,VIC0433,U.S. Senate,,DEM,Kamala Harris,360
-San Bernardino,VIC0433,U.S. Senate,,DEM,Loretta Sanchez,331
-San Bernardino,VIC0434,U.S. Senate,,DEM,Kamala Harris,359
-San Bernardino,VIC0434,U.S. Senate,,DEM,Loretta Sanchez,375
-San Bernardino,VIC0435,U.S. Senate,,DEM,Kamala Harris,494
-San Bernardino,VIC0435,U.S. Senate,,DEM,Loretta Sanchez,373
-San Bernardino,VIC0436,U.S. Senate,,DEM,Kamala Harris,532
-San Bernardino,VIC0436,U.S. Senate,,DEM,Loretta Sanchez,406
-San Bernardino,VIC0437,U.S. Senate,,DEM,Kamala Harris,672
-San Bernardino,VIC0437,U.S. Senate,,DEM,Loretta Sanchez,544
-San Bernardino,VIC0438,U.S. Senate,,DEM,Kamala Harris,512
-San Bernardino,VIC0438,U.S. Senate,,DEM,Loretta Sanchez,377
-San Bernardino,VIC0439,U.S. Senate,,DEM,Kamala Harris,94
-San Bernardino,VIC0439,U.S. Senate,,DEM,Loretta Sanchez,73
-San Bernardino,VIC0440,U.S. Senate,,DEM,Kamala Harris,261
-San Bernardino,VIC0440,U.S. Senate,,DEM,Loretta Sanchez,275
-San Bernardino,VIC0441,U.S. Senate,,DEM,Kamala Harris,10
-San Bernardino,VIC0441,U.S. Senate,,DEM,Loretta Sanchez,7
-San Bernardino,VIC0442,U.S. Senate,,DEM,Kamala Harris,270
-San Bernardino,VIC0442,U.S. Senate,,DEM,Loretta Sanchez,275
-San Bernardino,VIC0443,U.S. Senate,,DEM,Kamala Harris,297
-San Bernardino,VIC0443,U.S. Senate,,DEM,Loretta Sanchez,260
-San Bernardino,VIC0444,U.S. Senate,,DEM,Kamala Harris,512
-San Bernardino,VIC0444,U.S. Senate,,DEM,Loretta Sanchez,440
-San Bernardino,VIC0445,U.S. Senate,,DEM,Kamala Harris,374
-San Bernardino,VIC0445,U.S. Senate,,DEM,Loretta Sanchez,342
-San Bernardino,VIC0446,U.S. Senate,,DEM,Kamala Harris,602
-San Bernardino,VIC0446,U.S. Senate,,DEM,Loretta Sanchez,482
-San Bernardino,VIC0447,U.S. Senate,,DEM,Kamala Harris,428
-San Bernardino,VIC0447,U.S. Senate,,DEM,Loretta Sanchez,381
-San Bernardino,VIC0448,U.S. Senate,,DEM,Kamala Harris,7
-San Bernardino,VIC0448,U.S. Senate,,DEM,Loretta Sanchez,7
-San Bernardino,VIC0449,U.S. Senate,,DEM,Kamala Harris,272
-San Bernardino,VIC0449,U.S. Senate,,DEM,Loretta Sanchez,230
-San Bernardino,VIC0450,U.S. Senate,,DEM,Kamala Harris,459
-San Bernardino,VIC0450,U.S. Senate,,DEM,Loretta Sanchez,365
-San Bernardino,VIC0451,U.S. Senate,,DEM,Kamala Harris,481
-San Bernardino,VIC0451,U.S. Senate,,DEM,Loretta Sanchez,456
-San Bernardino,VIC0452,U.S. Senate,,DEM,Kamala Harris,479
-San Bernardino,VIC0452,U.S. Senate,,DEM,Loretta Sanchez,405
-San Bernardino,VIC0453,U.S. Senate,,DEM,Kamala Harris,522
-San Bernardino,VIC0453,U.S. Senate,,DEM,Loretta Sanchez,369
-San Bernardino,VIC0454,U.S. Senate,,DEM,Kamala Harris,552
-San Bernardino,VIC0454,U.S. Senate,,DEM,Loretta Sanchez,383
-San Bernardino,VIC0455,U.S. Senate,,DEM,Kamala Harris,433
-San Bernardino,VIC0455,U.S. Senate,,DEM,Loretta Sanchez,368
-San Bernardino,VIC0456,U.S. Senate,,DEM,Kamala Harris,216
-San Bernardino,VIC0456,U.S. Senate,,DEM,Loretta Sanchez,198
-San Bernardino,VIC0457,U.S. Senate,,DEM,Kamala Harris,410
-San Bernardino,VIC0457,U.S. Senate,,DEM,Loretta Sanchez,434
-San Bernardino,VIC0458,U.S. Senate,,DEM,Kamala Harris,641
-San Bernardino,VIC0458,U.S. Senate,,DEM,Loretta Sanchez,511
-San Bernardino,VIC0459,U.S. Senate,,DEM,Kamala Harris,15
-San Bernardino,VIC0459,U.S. Senate,,DEM,Loretta Sanchez,13
-San Bernardino,VIC0460,U.S. Senate,,DEM,Kamala Harris,657
-San Bernardino,VIC0460,U.S. Senate,,DEM,Loretta Sanchez,478
-San Bernardino,VIC1604,U.S. Senate,,DEM,Kamala Harris,193
-San Bernardino,VIC1604,U.S. Senate,,DEM,Loretta Sanchez,161
-San Bernardino,VIC1605,U.S. Senate,,DEM,Kamala Harris,138
-San Bernardino,VIC1605,U.S. Senate,,DEM,Loretta Sanchez,152
-San Bernardino,VIC1617,U.S. Senate,,DEM,Kamala Harris,5
-San Bernardino,VIC1617,U.S. Senate,,DEM,Loretta Sanchez,5
-San Bernardino,VIC1618,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,VIC1618,U.S. Senate,,DEM,Loretta Sanchez,1
-San Bernardino,YU10781,U.S. Senate,,DEM,Kamala Harris,1
-San Bernardino,YU10781,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,YU10800,U.S. Senate,,DEM,Kamala Harris,573
-San Bernardino,YU10800,U.S. Senate,,DEM,Loretta Sanchez,392
-San Bernardino,YU10802,U.S. Senate,,DEM,Kamala Harris,662
-San Bernardino,YU10802,U.S. Senate,,DEM,Loretta Sanchez,484
-San Bernardino,YU10803,U.S. Senate,,DEM,Kamala Harris,400
-San Bernardino,YU10803,U.S. Senate,,DEM,Loretta Sanchez,365
-San Bernardino,YU10809,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,YU10809,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,YU10810,U.S. Senate,,DEM,Kamala Harris,332
-San Bernardino,YU10810,U.S. Senate,,DEM,Loretta Sanchez,266
-San Bernardino,YU10815,U.S. Senate,,DEM,Kamala Harris,4
-San Bernardino,YU10815,U.S. Senate,,DEM,Loretta Sanchez,3
-San Bernardino,YU10825,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,YU10825,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,YU10826,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,YU10826,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,YU10829,U.S. Senate,,DEM,Kamala Harris,138
-San Bernardino,YU10829,U.S. Senate,,DEM,Loretta Sanchez,109
-San Bernardino,YU20801,U.S. Senate,,DEM,Kamala Harris,3
-San Bernardino,YU20801,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,YU20804,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,YU20804,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,YU20805,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,YU20805,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,YU20811,U.S. Senate,,DEM,Kamala Harris,378
-San Bernardino,YU20811,U.S. Senate,,DEM,Loretta Sanchez,255
-San Bernardino,YU20812,U.S. Senate,,DEM,Kamala Harris,395
-San Bernardino,YU20812,U.S. Senate,,DEM,Loretta Sanchez,297
-San Bernardino,YU20817,U.S. Senate,,DEM,Kamala Harris,157
-San Bernardino,YU20817,U.S. Senate,,DEM,Loretta Sanchez,120
-San Bernardino,YU20821,U.S. Senate,,DEM,Kamala Harris,613
-San Bernardino,YU20821,U.S. Senate,,DEM,Loretta Sanchez,502
-San Bernardino,YU20827,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,YU20827,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,YU20828,U.S. Senate,,DEM,Kamala Harris,1
-San Bernardino,YU20828,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,YU21779,U.S. Senate,,DEM,Kamala Harris,376
-San Bernardino,YU21779,U.S. Senate,,DEM,Loretta Sanchez,293
-San Bernardino,YU30813,U.S. Senate,,DEM,Kamala Harris,832
-San Bernardino,YU30813,U.S. Senate,,DEM,Loretta Sanchez,670
-San Bernardino,YU31777,U.S. Senate,,DEM,Kamala Harris,275
-San Bernardino,YU31777,U.S. Senate,,DEM,Loretta Sanchez,158
-San Bernardino,YU31778,U.S. Senate,,DEM,Kamala Harris,429
-San Bernardino,YU31778,U.S. Senate,,DEM,Loretta Sanchez,361
-San Bernardino,YU40806,U.S. Senate,,DEM,Kamala Harris,610
-San Bernardino,YU40806,U.S. Senate,,DEM,Loretta Sanchez,454
-San Bernardino,YU40807,U.S. Senate,,DEM,Kamala Harris,627
-San Bernardino,YU40807,U.S. Senate,,DEM,Loretta Sanchez,541
-San Bernardino,YU40819,U.S. Senate,,DEM,Kamala Harris,336
-San Bernardino,YU40819,U.S. Senate,,DEM,Loretta Sanchez,238
-San Bernardino,YU40824,U.S. Senate,,DEM,Kamala Harris,297
-San Bernardino,YU40824,U.S. Senate,,DEM,Loretta Sanchez,226
-San Bernardino,YU50814,U.S. Senate,,DEM,Kamala Harris,67
-San Bernardino,YU50814,U.S. Senate,,DEM,Loretta Sanchez,60
-San Bernardino,YU50816,U.S. Senate,,DEM,Kamala Harris,697
-San Bernardino,YU50816,U.S. Senate,,DEM,Loretta Sanchez,570
-San Bernardino,YU50818,U.S. Senate,,DEM,Kamala Harris,669
-San Bernardino,YU50818,U.S. Senate,,DEM,Loretta Sanchez,521
-San Bernardino,YU50820,U.S. Senate,,DEM,Kamala Harris,569
-San Bernardino,YU50820,U.S. Senate,,DEM,Loretta Sanchez,514
-San Bernardino,YU50822,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,YU50822,U.S. Senate,,DEM,Loretta Sanchez,2
-San Bernardino,YU50823,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,YU50823,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,YU50830,U.S. Senate,,DEM,Kamala Harris,149
-San Bernardino,YU50830,U.S. Senate,,DEM,Loretta Sanchez,98
-San Bernardino,YU50831,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,YU50831,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,YU50832,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,YU50832,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,YU50833,U.S. Senate,,DEM,Kamala Harris,2
-San Bernardino,YU50833,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,YU51776,U.S. Senate,,DEM,Kamala Harris,1
-San Bernardino,YU51776,U.S. Senate,,DEM,Loretta Sanchez,1
-San Bernardino,YUV0265,U.S. Senate,,DEM,Kamala Harris,282
-San Bernardino,YUV0265,U.S. Senate,,DEM,Loretta Sanchez,205
-San Bernardino,YUV0266,U.S. Senate,,DEM,Kamala Harris,415
-San Bernardino,YUV0266,U.S. Senate,,DEM,Loretta Sanchez,262
-San Bernardino,YUV0267,U.S. Senate,,DEM,Kamala Harris,3
-San Bernardino,YUV0267,U.S. Senate,,DEM,Loretta Sanchez,1
-San Bernardino,YUV0268,U.S. Senate,,DEM,Kamala Harris,390
-San Bernardino,YUV0268,U.S. Senate,,DEM,Loretta Sanchez,252
-San Bernardino,YUV0269,U.S. Senate,,DEM,Kamala Harris,0
-San Bernardino,YUV0269,U.S. Senate,,DEM,Loretta Sanchez,0
-San Bernardino,YUV0270,U.S. Senate,,DEM,Kamala Harris,14
-San Bernardino,YUV0270,U.S. Senate,,DEM,Loretta Sanchez,11
-San Bernardino,YUV0271,U.S. Senate,,DEM,Kamala Harris,594
-San Bernardino,YUV0271,U.S. Senate,,DEM,Loretta Sanchez,419
-San Bernardino,YUV0272,U.S. Senate,,DEM,Kamala Harris,517
-San Bernardino,YUV0272,U.S. Senate,,DEM,Loretta Sanchez,310
-San Bernardino,YUV0273,U.S. Senate,,DEM,Kamala Harris,13
-San Bernardino,YUV0273,U.S. Senate,,DEM,Loretta Sanchez,17
-San Bernardino,YUV0274,U.S. Senate,,DEM,Kamala Harris,657
-San Bernardino,YUV0274,U.S. Senate,,DEM,Loretta Sanchez,511
-San Bernardino,YUV0275,U.S. Senate,,DEM,Kamala Harris,643
-San Bernardino,YUV0275,U.S. Senate,,DEM,Loretta Sanchez,443
+San Bernardino,ADE0110,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,ADE0110,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,ADE0111,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,ADE0111,U.S. Senate,,DEM,Loretta L. Sanchez,1
+San Bernardino,ADE0380,U.S. Senate,,DEM,Kamala D. Harris,307
+San Bernardino,ADE0380,U.S. Senate,,DEM,Loretta L. Sanchez,346
+San Bernardino,ADE0381,U.S. Senate,,DEM,Kamala D. Harris,394
+San Bernardino,ADE0381,U.S. Senate,,DEM,Loretta L. Sanchez,331
+San Bernardino,ADE0382,U.S. Senate,,DEM,Kamala D. Harris,480
+San Bernardino,ADE0382,U.S. Senate,,DEM,Loretta L. Sanchez,426
+San Bernardino,ADE0383,U.S. Senate,,DEM,Kamala D. Harris,600
+San Bernardino,ADE0383,U.S. Senate,,DEM,Loretta L. Sanchez,552
+San Bernardino,ADE0384,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,ADE0384,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,ADE0385,U.S. Senate,,DEM,Kamala D. Harris,1
+San Bernardino,ADE0385,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,ADE0386,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,ADE0386,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,ADE0387,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,ADE0387,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,ADE0388,U.S. Senate,,DEM,Kamala D. Harris,9
+San Bernardino,ADE0388,U.S. Senate,,DEM,Loretta L. Sanchez,2
+San Bernardino,ADE0389,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,ADE0389,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,ADE0390,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,ADE0390,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,ADE0391,U.S. Senate,,DEM,Kamala D. Harris,72
+San Bernardino,ADE0391,U.S. Senate,,DEM,Loretta L. Sanchez,86
+San Bernardino,ADE0392,U.S. Senate,,DEM,Kamala D. Harris,612
+San Bernardino,ADE0392,U.S. Senate,,DEM,Loretta L. Sanchez,623
+San Bernardino,ADE0393,U.S. Senate,,DEM,Kamala D. Harris,421
+San Bernardino,ADE0393,U.S. Senate,,DEM,Loretta L. Sanchez,424
+San Bernardino,ADE0394,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,ADE0394,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,ADE0395,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,ADE0395,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,ADE0396,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,ADE0396,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,ADE0397,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,ADE0397,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,APP0001,U.S. Senate,,DEM,Kamala D. Harris,5
+San Bernardino,APP0001,U.S. Senate,,DEM,Loretta L. Sanchez,3
+San Bernardino,APP0296,U.S. Senate,,DEM,Kamala D. Harris,12
+San Bernardino,APP0296,U.S. Senate,,DEM,Loretta L. Sanchez,3
+San Bernardino,APP0297,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,APP0297,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,APP0298,U.S. Senate,,DEM,Kamala D. Harris,132
+San Bernardino,APP0298,U.S. Senate,,DEM,Loretta L. Sanchez,163
+San Bernardino,APP0299,U.S. Senate,,DEM,Kamala D. Harris,203
+San Bernardino,APP0299,U.S. Senate,,DEM,Loretta L. Sanchez,161
+San Bernardino,APP0300,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,APP0300,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,APP0301,U.S. Senate,,DEM,Kamala D. Harris,550
+San Bernardino,APP0301,U.S. Senate,,DEM,Loretta L. Sanchez,446
+San Bernardino,APP0302,U.S. Senate,,DEM,Kamala D. Harris,442
+San Bernardino,APP0302,U.S. Senate,,DEM,Loretta L. Sanchez,419
+San Bernardino,APP0303,U.S. Senate,,DEM,Kamala D. Harris,526
+San Bernardino,APP0303,U.S. Senate,,DEM,Loretta L. Sanchez,429
+San Bernardino,APP0304,U.S. Senate,,DEM,Kamala D. Harris,518
+San Bernardino,APP0304,U.S. Senate,,DEM,Loretta L. Sanchez,476
+San Bernardino,APP0305,U.S. Senate,,DEM,Kamala D. Harris,473
+San Bernardino,APP0305,U.S. Senate,,DEM,Loretta L. Sanchez,425
+San Bernardino,APP0306,U.S. Senate,,DEM,Kamala D. Harris,489
+San Bernardino,APP0306,U.S. Senate,,DEM,Loretta L. Sanchez,449
+San Bernardino,APP0307,U.S. Senate,,DEM,Kamala D. Harris,343
+San Bernardino,APP0307,U.S. Senate,,DEM,Loretta L. Sanchez,362
+San Bernardino,APP0308,U.S. Senate,,DEM,Kamala D. Harris,444
+San Bernardino,APP0308,U.S. Senate,,DEM,Loretta L. Sanchez,315
+San Bernardino,APP0309,U.S. Senate,,DEM,Kamala D. Harris,510
+San Bernardino,APP0309,U.S. Senate,,DEM,Loretta L. Sanchez,506
+San Bernardino,APP0310,U.S. Senate,,DEM,Kamala D. Harris,402
+San Bernardino,APP0310,U.S. Senate,,DEM,Loretta L. Sanchez,348
+San Bernardino,APP0311,U.S. Senate,,DEM,Kamala D. Harris,573
+San Bernardino,APP0311,U.S. Senate,,DEM,Loretta L. Sanchez,577
+San Bernardino,APP0312,U.S. Senate,,DEM,Kamala D. Harris,530
+San Bernardino,APP0312,U.S. Senate,,DEM,Loretta L. Sanchez,403
+San Bernardino,APP0313,U.S. Senate,,DEM,Kamala D. Harris,566
+San Bernardino,APP0313,U.S. Senate,,DEM,Loretta L. Sanchez,450
+San Bernardino,APP0314,U.S. Senate,,DEM,Kamala D. Harris,453
+San Bernardino,APP0314,U.S. Senate,,DEM,Loretta L. Sanchez,324
+San Bernardino,APP0315,U.S. Senate,,DEM,Kamala D. Harris,398
+San Bernardino,APP0315,U.S. Senate,,DEM,Loretta L. Sanchez,295
+San Bernardino,APP0316,U.S. Senate,,DEM,Kamala D. Harris,424
+San Bernardino,APP0316,U.S. Senate,,DEM,Loretta L. Sanchez,376
+San Bernardino,APP0317,U.S. Senate,,DEM,Kamala D. Harris,380
+San Bernardino,APP0317,U.S. Senate,,DEM,Loretta L. Sanchez,366
+San Bernardino,APP0318,U.S. Senate,,DEM,Kamala D. Harris,384
+San Bernardino,APP0318,U.S. Senate,,DEM,Loretta L. Sanchez,317
+San Bernardino,APP0319,U.S. Senate,,DEM,Kamala D. Harris,344
+San Bernardino,APP0319,U.S. Senate,,DEM,Loretta L. Sanchez,315
+San Bernardino,APP0320,U.S. Senate,,DEM,Kamala D. Harris,1275
+San Bernardino,APP0320,U.S. Senate,,DEM,Loretta L. Sanchez,835
+San Bernardino,APP0321,U.S. Senate,,DEM,Kamala D. Harris,144
+San Bernardino,APP0321,U.S. Senate,,DEM,Loretta L. Sanchez,124
+San Bernardino,APP0322,U.S. Senate,,DEM,Kamala D. Harris,450
+San Bernardino,APP0322,U.S. Senate,,DEM,Loretta L. Sanchez,438
+San Bernardino,APP0323,U.S. Senate,,DEM,Kamala D. Harris,294
+San Bernardino,APP0323,U.S. Senate,,DEM,Loretta L. Sanchez,264
+San Bernardino,APP0324,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,APP0324,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,APP0326,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,APP0326,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,APP0327,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,APP0327,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,APP0328,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,APP0328,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,APP0398,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,APP0398,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,APP1609,U.S. Senate,,DEM,Kamala D. Harris,337
+San Bernardino,APP1609,U.S. Senate,,DEM,Loretta L. Sanchez,305
+San Bernardino,BAR0132,U.S. Senate,,DEM,Kamala D. Harris,138
+San Bernardino,BAR0132,U.S. Senate,,DEM,Loretta L. Sanchez,141
+San Bernardino,BAR0133,U.S. Senate,,DEM,Kamala D. Harris,1
+San Bernardino,BAR0133,U.S. Senate,,DEM,Loretta L. Sanchez,4
+San Bernardino,BAR0134,U.S. Senate,,DEM,Kamala D. Harris,10
+San Bernardino,BAR0134,U.S. Senate,,DEM,Loretta L. Sanchez,10
+San Bernardino,BAR0135,U.S. Senate,,DEM,Kamala D. Harris,251
+San Bernardino,BAR0135,U.S. Senate,,DEM,Loretta L. Sanchez,297
+San Bernardino,BAR0136,U.S. Senate,,DEM,Kamala D. Harris,272
+San Bernardino,BAR0136,U.S. Senate,,DEM,Loretta L. Sanchez,287
+San Bernardino,BAR0137,U.S. Senate,,DEM,Kamala D. Harris,444
+San Bernardino,BAR0137,U.S. Senate,,DEM,Loretta L. Sanchez,444
+San Bernardino,BAR0138,U.S. Senate,,DEM,Kamala D. Harris,409
+San Bernardino,BAR0138,U.S. Senate,,DEM,Loretta L. Sanchez,349
+San Bernardino,BAR0139,U.S. Senate,,DEM,Kamala D. Harris,530
+San Bernardino,BAR0139,U.S. Senate,,DEM,Loretta L. Sanchez,471
+San Bernardino,BAR0140,U.S. Senate,,DEM,Kamala D. Harris,424
+San Bernardino,BAR0140,U.S. Senate,,DEM,Loretta L. Sanchez,402
+San Bernardino,BAR0141,U.S. Senate,,DEM,Kamala D. Harris,8
+San Bernardino,BAR0141,U.S. Senate,,DEM,Loretta L. Sanchez,8
+San Bernardino,BAR0142,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,BAR0142,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,BAR0143,U.S. Senate,,DEM,Kamala D. Harris,6
+San Bernardino,BAR0143,U.S. Senate,,DEM,Loretta L. Sanchez,5
+San Bernardino,BAR0144,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,BAR0144,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,BAR0179,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,BAR0179,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,BIG0572,U.S. Senate,,DEM,Kamala D. Harris,233
+San Bernardino,BIG0572,U.S. Senate,,DEM,Loretta L. Sanchez,125
+San Bernardino,BIG0573,U.S. Senate,,DEM,Kamala D. Harris,251
+San Bernardino,BIG0573,U.S. Senate,,DEM,Loretta L. Sanchez,172
+San Bernardino,BIG0574,U.S. Senate,,DEM,Kamala D. Harris,377
+San Bernardino,BIG0574,U.S. Senate,,DEM,Loretta L. Sanchez,253
+San Bernardino,BIG0575,U.S. Senate,,DEM,Kamala D. Harris,160
+San Bernardino,BIG0575,U.S. Senate,,DEM,Loretta L. Sanchez,97
+San Bernardino,BIG0576,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,BIG0576,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,BIG1744,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,BIG1744,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,BIG1745,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,BIG1745,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,BIG1746,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,BIG1746,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,BIG1747,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,BIG1747,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,BIG1748,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,BIG1748,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,BIG1749,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,BIG1749,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,BIG1750,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,BIG1750,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,BIG1751,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,BIG1751,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,BIG1752,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,BIG1752,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,BIG1753,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,BIG1753,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,BIG1754,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,BIG1754,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,BIG1755,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,BIG1755,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,BIG1756,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,BIG1756,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,BIG1757,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,BIG1757,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,BIG1758,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,BIG1758,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,BIG1759,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,BIG1759,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,BIG1760,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,BIG1760,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,BIG1761,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,BIG1761,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,BIG1762,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,BIG1762,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,BIG1763,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,BIG1763,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,CHH1461,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,CHH1461,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,CHH1462,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,CHH1462,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,CHH1463,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,CHH1463,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,CHH1464,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,CHH1464,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,CHH1535,U.S. Senate,,DEM,Kamala D. Harris,566
+San Bernardino,CHH1535,U.S. Senate,,DEM,Loretta L. Sanchez,399
+San Bernardino,CHH1536,U.S. Senate,,DEM,Kamala D. Harris,588
+San Bernardino,CHH1536,U.S. Senate,,DEM,Loretta L. Sanchez,473
+San Bernardino,CHH1537,U.S. Senate,,DEM,Kamala D. Harris,658
+San Bernardino,CHH1537,U.S. Senate,,DEM,Loretta L. Sanchez,448
+San Bernardino,CHH1538,U.S. Senate,,DEM,Kamala D. Harris,667
+San Bernardino,CHH1538,U.S. Senate,,DEM,Loretta L. Sanchez,391
+San Bernardino,CHH1539,U.S. Senate,,DEM,Kamala D. Harris,494
+San Bernardino,CHH1539,U.S. Senate,,DEM,Loretta L. Sanchez,385
+San Bernardino,CHH1540,U.S. Senate,,DEM,Kamala D. Harris,504
+San Bernardino,CHH1540,U.S. Senate,,DEM,Loretta L. Sanchez,496
+San Bernardino,CHH1541,U.S. Senate,,DEM,Kamala D. Harris,476
+San Bernardino,CHH1541,U.S. Senate,,DEM,Loretta L. Sanchez,529
+San Bernardino,CHH1542,U.S. Senate,,DEM,Kamala D. Harris,626
+San Bernardino,CHH1542,U.S. Senate,,DEM,Loretta L. Sanchez,612
+San Bernardino,CHH1543,U.S. Senate,,DEM,Kamala D. Harris,711
+San Bernardino,CHH1543,U.S. Senate,,DEM,Loretta L. Sanchez,616
+San Bernardino,CHH1544,U.S. Senate,,DEM,Kamala D. Harris,603
+San Bernardino,CHH1544,U.S. Senate,,DEM,Loretta L. Sanchez,491
+San Bernardino,CHH1545,U.S. Senate,,DEM,Kamala D. Harris,512
+San Bernardino,CHH1545,U.S. Senate,,DEM,Loretta L. Sanchez,420
+San Bernardino,CHH1546,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,CHH1546,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,CHH1547,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,CHH1547,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,CHH1548,U.S. Senate,,DEM,Kamala D. Harris,619
+San Bernardino,CHH1548,U.S. Senate,,DEM,Loretta L. Sanchez,462
+San Bernardino,CHH1549,U.S. Senate,,DEM,Kamala D. Harris,642
+San Bernardino,CHH1549,U.S. Senate,,DEM,Loretta L. Sanchez,426
+San Bernardino,CHH1550,U.S. Senate,,DEM,Kamala D. Harris,500
+San Bernardino,CHH1550,U.S. Senate,,DEM,Loretta L. Sanchez,314
+San Bernardino,CHH1551,U.S. Senate,,DEM,Kamala D. Harris,681
+San Bernardino,CHH1551,U.S. Senate,,DEM,Loretta L. Sanchez,480
+San Bernardino,CHH1552,U.S. Senate,,DEM,Kamala D. Harris,719
+San Bernardino,CHH1552,U.S. Senate,,DEM,Loretta L. Sanchez,555
+San Bernardino,CHH1553,U.S. Senate,,DEM,Kamala D. Harris,610
+San Bernardino,CHH1553,U.S. Senate,,DEM,Loretta L. Sanchez,455
+San Bernardino,CHH1554,U.S. Senate,,DEM,Kamala D. Harris,599
+San Bernardino,CHH1554,U.S. Senate,,DEM,Loretta L. Sanchez,445
+San Bernardino,CHH1555,U.S. Senate,,DEM,Kamala D. Harris,647
+San Bernardino,CHH1555,U.S. Senate,,DEM,Loretta L. Sanchez,405
+San Bernardino,CHH1556,U.S. Senate,,DEM,Kamala D. Harris,636
+San Bernardino,CHH1556,U.S. Senate,,DEM,Loretta L. Sanchez,407
+San Bernardino,CHH1557,U.S. Senate,,DEM,Kamala D. Harris,573
+San Bernardino,CHH1557,U.S. Senate,,DEM,Loretta L. Sanchez,372
+San Bernardino,CHH1558,U.S. Senate,,DEM,Kamala D. Harris,663
+San Bernardino,CHH1558,U.S. Senate,,DEM,Loretta L. Sanchez,426
+San Bernardino,CHH1559,U.S. Senate,,DEM,Kamala D. Harris,685
+San Bernardino,CHH1559,U.S. Senate,,DEM,Loretta L. Sanchez,434
+San Bernardino,CHH1560,U.S. Senate,,DEM,Kamala D. Harris,412
+San Bernardino,CHH1560,U.S. Senate,,DEM,Loretta L. Sanchez,327
+San Bernardino,CN11465,U.S. Senate,,DEM,Kamala D. Harris,21
+San Bernardino,CN11465,U.S. Senate,,DEM,Loretta L. Sanchez,18
+San Bernardino,CN11466,U.S. Senate,,DEM,Kamala D. Harris,109
+San Bernardino,CN11466,U.S. Senate,,DEM,Loretta L. Sanchez,119
+San Bernardino,CN11467,U.S. Senate,,DEM,Kamala D. Harris,117
+San Bernardino,CN11467,U.S. Senate,,DEM,Loretta L. Sanchez,81
+San Bernardino,CN11468,U.S. Senate,,DEM,Kamala D. Harris,172
+San Bernardino,CN11468,U.S. Senate,,DEM,Loretta L. Sanchez,140
+San Bernardino,CN11469,U.S. Senate,,DEM,Kamala D. Harris,85
+San Bernardino,CN11469,U.S. Senate,,DEM,Loretta L. Sanchez,64
+San Bernardino,CN11470,U.S. Senate,,DEM,Kamala D. Harris,96
+San Bernardino,CN11470,U.S. Senate,,DEM,Loretta L. Sanchez,90
+San Bernardino,CN11471,U.S. Senate,,DEM,Kamala D. Harris,396
+San Bernardino,CN11471,U.S. Senate,,DEM,Loretta L. Sanchez,426
+San Bernardino,CN11484,U.S. Senate,,DEM,Kamala D. Harris,4
+San Bernardino,CN11484,U.S. Senate,,DEM,Loretta L. Sanchez,18
+San Bernardino,CN11485,U.S. Senate,,DEM,Kamala D. Harris,196
+San Bernardino,CN11485,U.S. Senate,,DEM,Loretta L. Sanchez,200
+San Bernardino,CN11486,U.S. Senate,,DEM,Kamala D. Harris,7
+San Bernardino,CN11486,U.S. Senate,,DEM,Loretta L. Sanchez,1
+San Bernardino,CN11487,U.S. Senate,,DEM,Kamala D. Harris,701
+San Bernardino,CN11487,U.S. Senate,,DEM,Loretta L. Sanchez,633
+San Bernardino,CN11490,U.S. Senate,,DEM,Kamala D. Harris,446
+San Bernardino,CN11490,U.S. Senate,,DEM,Loretta L. Sanchez,468
+San Bernardino,CN11774,U.S. Senate,,DEM,Kamala D. Harris,173
+San Bernardino,CN11774,U.S. Senate,,DEM,Loretta L. Sanchez,262
+San Bernardino,CN11789,U.S. Senate,,DEM,Kamala D. Harris,47
+San Bernardino,CN11789,U.S. Senate,,DEM,Loretta L. Sanchez,76
+San Bernardino,CN21488,U.S. Senate,,DEM,Kamala D. Harris,209
+San Bernardino,CN21488,U.S. Senate,,DEM,Loretta L. Sanchez,200
+San Bernardino,CN21489,U.S. Senate,,DEM,Kamala D. Harris,229
+San Bernardino,CN21489,U.S. Senate,,DEM,Loretta L. Sanchez,117
+San Bernardino,CN21492,U.S. Senate,,DEM,Kamala D. Harris,453
+San Bernardino,CN21492,U.S. Senate,,DEM,Loretta L. Sanchez,406
+San Bernardino,CN21495,U.S. Senate,,DEM,Kamala D. Harris,52
+San Bernardino,CN21495,U.S. Senate,,DEM,Loretta L. Sanchez,61
+San Bernardino,CN21496,U.S. Senate,,DEM,Kamala D. Harris,560
+San Bernardino,CN21496,U.S. Senate,,DEM,Loretta L. Sanchez,435
+San Bernardino,CN21497,U.S. Senate,,DEM,Kamala D. Harris,526
+San Bernardino,CN21497,U.S. Senate,,DEM,Loretta L. Sanchez,419
+San Bernardino,CN21498,U.S. Senate,,DEM,Kamala D. Harris,579
+San Bernardino,CN21498,U.S. Senate,,DEM,Loretta L. Sanchez,435
+San Bernardino,CN21499,U.S. Senate,,DEM,Kamala D. Harris,508
+San Bernardino,CN21499,U.S. Senate,,DEM,Loretta L. Sanchez,435
+San Bernardino,CN21500,U.S. Senate,,DEM,Kamala D. Harris,504
+San Bernardino,CN21500,U.S. Senate,,DEM,Loretta L. Sanchez,455
+San Bernardino,CN31388,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,CN31388,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,CN31478,U.S. Senate,,DEM,Kamala D. Harris,350
+San Bernardino,CN31478,U.S. Senate,,DEM,Loretta L. Sanchez,335
+San Bernardino,CN31479,U.S. Senate,,DEM,Kamala D. Harris,1029
+San Bernardino,CN31479,U.S. Senate,,DEM,Loretta L. Sanchez,658
+San Bernardino,CN31491,U.S. Senate,,DEM,Kamala D. Harris,438
+San Bernardino,CN31491,U.S. Senate,,DEM,Loretta L. Sanchez,381
+San Bernardino,CN31493,U.S. Senate,,DEM,Kamala D. Harris,230
+San Bernardino,CN31493,U.S. Senate,,DEM,Loretta L. Sanchez,389
+San Bernardino,CN31494,U.S. Senate,,DEM,Kamala D. Harris,503
+San Bernardino,CN31494,U.S. Senate,,DEM,Loretta L. Sanchez,528
+San Bernardino,CN31501,U.S. Senate,,DEM,Kamala D. Harris,526
+San Bernardino,CN31501,U.S. Senate,,DEM,Loretta L. Sanchez,419
+San Bernardino,CN41472,U.S. Senate,,DEM,Kamala D. Harris,489
+San Bernardino,CN41472,U.S. Senate,,DEM,Loretta L. Sanchez,405
+San Bernardino,CN41473,U.S. Senate,,DEM,Kamala D. Harris,556
+San Bernardino,CN41473,U.S. Senate,,DEM,Loretta L. Sanchez,501
+San Bernardino,CN41474,U.S. Senate,,DEM,Kamala D. Harris,482
+San Bernardino,CN41474,U.S. Senate,,DEM,Loretta L. Sanchez,418
+San Bernardino,CN41475,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,CN41475,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,CN41476,U.S. Senate,,DEM,Kamala D. Harris,423
+San Bernardino,CN41476,U.S. Senate,,DEM,Loretta L. Sanchez,373
+San Bernardino,CN41477,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,CN41477,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,CN41480,U.S. Senate,,DEM,Kamala D. Harris,1212
+San Bernardino,CN41480,U.S. Senate,,DEM,Loretta L. Sanchez,808
+San Bernardino,CN41481,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,CN41481,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,CN41482,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,CN41482,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,CN41483,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,CN41483,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,CN41534,U.S. Senate,,DEM,Kamala D. Harris,104
+San Bernardino,CN41534,U.S. Senate,,DEM,Loretta L. Sanchez,78
+San Bernardino,CN41561,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,CN41561,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,CN41562,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,CN41562,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,CN41563,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,CN41563,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,CN41564,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,CN41564,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,CN41565,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,CN41565,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,CN41773,U.S. Senate,,DEM,Kamala D. Harris,45
+San Bernardino,CN41773,U.S. Senate,,DEM,Loretta L. Sanchez,56
+San Bernardino,CO10920,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,CO10920,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,CO10921,U.S. Senate,,DEM,Kamala D. Harris,2
+San Bernardino,CO10921,U.S. Senate,,DEM,Loretta L. Sanchez,1
+San Bernardino,CO10922,U.S. Senate,,DEM,Kamala D. Harris,182
+San Bernardino,CO10922,U.S. Senate,,DEM,Loretta L. Sanchez,200
+San Bernardino,CO10923,U.S. Senate,,DEM,Kamala D. Harris,3
+San Bernardino,CO10923,U.S. Senate,,DEM,Loretta L. Sanchez,1
+San Bernardino,CO10924,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,CO10924,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,CO10925,U.S. Senate,,DEM,Kamala D. Harris,2
+San Bernardino,CO10925,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,CO10926,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,CO10926,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,CO10955,U.S. Senate,,DEM,Kamala D. Harris,193
+San Bernardino,CO10955,U.S. Senate,,DEM,Loretta L. Sanchez,227
+San Bernardino,CO10956,U.S. Senate,,DEM,Kamala D. Harris,381
+San Bernardino,CO10956,U.S. Senate,,DEM,Loretta L. Sanchez,489
+San Bernardino,CO10957,U.S. Senate,,DEM,Kamala D. Harris,264
+San Bernardino,CO10957,U.S. Senate,,DEM,Loretta L. Sanchez,255
+San Bernardino,CO10958,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,CO10958,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,CO20927,U.S. Senate,,DEM,Kamala D. Harris,407
+San Bernardino,CO20927,U.S. Senate,,DEM,Loretta L. Sanchez,475
+San Bernardino,CO20928,U.S. Senate,,DEM,Kamala D. Harris,297
+San Bernardino,CO20928,U.S. Senate,,DEM,Loretta L. Sanchez,406
+San Bernardino,CO20929,U.S. Senate,,DEM,Kamala D. Harris,224
+San Bernardino,CO20929,U.S. Senate,,DEM,Loretta L. Sanchez,290
+San Bernardino,CO20959,U.S. Senate,,DEM,Kamala D. Harris,17
+San Bernardino,CO20959,U.S. Senate,,DEM,Loretta L. Sanchez,12
+San Bernardino,CO20998,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,CO20998,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,CO30930,U.S. Senate,,DEM,Kamala D. Harris,372
+San Bernardino,CO30930,U.S. Senate,,DEM,Loretta L. Sanchez,596
+San Bernardino,CO30931,U.S. Senate,,DEM,Kamala D. Harris,372
+San Bernardino,CO30931,U.S. Senate,,DEM,Loretta L. Sanchez,492
+San Bernardino,CO30999,U.S. Senate,,DEM,Kamala D. Harris,2
+San Bernardino,CO30999,U.S. Senate,,DEM,Loretta L. Sanchez,7
+San Bernardino,CO31000,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,CO31000,U.S. Senate,,DEM,Loretta L. Sanchez,1
+San Bernardino,CO40932,U.S. Senate,,DEM,Kamala D. Harris,271
+San Bernardino,CO40932,U.S. Senate,,DEM,Loretta L. Sanchez,370
+San Bernardino,CO40933,U.S. Senate,,DEM,Kamala D. Harris,292
+San Bernardino,CO40933,U.S. Senate,,DEM,Loretta L. Sanchez,374
+San Bernardino,CO40934,U.S. Senate,,DEM,Kamala D. Harris,250
+San Bernardino,CO40934,U.S. Senate,,DEM,Loretta L. Sanchez,373
+San Bernardino,CO50893,U.S. Senate,,DEM,Kamala D. Harris,541
+San Bernardino,CO50893,U.S. Senate,,DEM,Loretta L. Sanchez,469
+San Bernardino,CO50894,U.S. Senate,,DEM,Kamala D. Harris,367
+San Bernardino,CO50894,U.S. Senate,,DEM,Loretta L. Sanchez,281
+San Bernardino,CO50895,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,CO50895,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,CO50896,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,CO50896,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,CO50897,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,CO50897,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,CO50898,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,CO50898,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,CO50899,U.S. Senate,,DEM,Kamala D. Harris,8
+San Bernardino,CO50899,U.S. Senate,,DEM,Loretta L. Sanchez,1
+San Bernardino,CO50900,U.S. Senate,,DEM,Kamala D. Harris,303
+San Bernardino,CO50900,U.S. Senate,,DEM,Loretta L. Sanchez,216
+San Bernardino,CO50901,U.S. Senate,,DEM,Kamala D. Harris,257
+San Bernardino,CO50901,U.S. Senate,,DEM,Loretta L. Sanchez,182
+San Bernardino,CO50902,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,CO50902,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,CO50935,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,CO50935,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,CO60903,U.S. Senate,,DEM,Kamala D. Harris,1
+San Bernardino,CO60903,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,CO60904,U.S. Senate,,DEM,Kamala D. Harris,2
+San Bernardino,CO60904,U.S. Senate,,DEM,Loretta L. Sanchez,5
+San Bernardino,CO60905,U.S. Senate,,DEM,Kamala D. Harris,194
+San Bernardino,CO60905,U.S. Senate,,DEM,Loretta L. Sanchez,110
+San Bernardino,CO60936,U.S. Senate,,DEM,Kamala D. Harris,314
+San Bernardino,CO60936,U.S. Senate,,DEM,Loretta L. Sanchez,354
+San Bernardino,CO60937,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,CO60937,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,CO60938,U.S. Senate,,DEM,Kamala D. Harris,484
+San Bernardino,CO60938,U.S. Senate,,DEM,Loretta L. Sanchez,340
+San Bernardino,CO60939,U.S. Senate,,DEM,Kamala D. Harris,12
+San Bernardino,CO60939,U.S. Senate,,DEM,Loretta L. Sanchez,39
+San Bernardino,CO61001,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,CO61001,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,CO61644,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,CO61644,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,FON0881,U.S. Senate,,DEM,Kamala D. Harris,6
+San Bernardino,FON0881,U.S. Senate,,DEM,Loretta L. Sanchez,14
+San Bernardino,FON0882,U.S. Senate,,DEM,Kamala D. Harris,524
+San Bernardino,FON0882,U.S. Senate,,DEM,Loretta L. Sanchez,407
+San Bernardino,FON0883,U.S. Senate,,DEM,Kamala D. Harris,678
+San Bernardino,FON0883,U.S. Senate,,DEM,Loretta L. Sanchez,486
+San Bernardino,FON0884,U.S. Senate,,DEM,Kamala D. Harris,464
+San Bernardino,FON0884,U.S. Senate,,DEM,Loretta L. Sanchez,368
+San Bernardino,FON0885,U.S. Senate,,DEM,Kamala D. Harris,398
+San Bernardino,FON0885,U.S. Senate,,DEM,Loretta L. Sanchez,275
+San Bernardino,FON0886,U.S. Senate,,DEM,Kamala D. Harris,414
+San Bernardino,FON0886,U.S. Senate,,DEM,Loretta L. Sanchez,217
+San Bernardino,FON0887,U.S. Senate,,DEM,Kamala D. Harris,40
+San Bernardino,FON0887,U.S. Senate,,DEM,Loretta L. Sanchez,39
+San Bernardino,FON0888,U.S. Senate,,DEM,Kamala D. Harris,176
+San Bernardino,FON0888,U.S. Senate,,DEM,Loretta L. Sanchez,97
+San Bernardino,FON0889,U.S. Senate,,DEM,Kamala D. Harris,92
+San Bernardino,FON0889,U.S. Senate,,DEM,Loretta L. Sanchez,98
+San Bernardino,FON0890,U.S. Senate,,DEM,Kamala D. Harris,581
+San Bernardino,FON0890,U.S. Senate,,DEM,Loretta L. Sanchez,451
+San Bernardino,FON0891,U.S. Senate,,DEM,Kamala D. Harris,517
+San Bernardino,FON0891,U.S. Senate,,DEM,Loretta L. Sanchez,360
+San Bernardino,FON0892,U.S. Senate,,DEM,Kamala D. Harris,622
+San Bernardino,FON0892,U.S. Senate,,DEM,Loretta L. Sanchez,431
+San Bernardino,FON0952,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,FON0952,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,FON0960,U.S. Senate,,DEM,Kamala D. Harris,69
+San Bernardino,FON0960,U.S. Senate,,DEM,Loretta L. Sanchez,32
+San Bernardino,FON1295,U.S. Senate,,DEM,Kamala D. Harris,1
+San Bernardino,FON1295,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,FON1296,U.S. Senate,,DEM,Kamala D. Harris,570
+San Bernardino,FON1296,U.S. Senate,,DEM,Loretta L. Sanchez,506
+San Bernardino,FON1297,U.S. Senate,,DEM,Kamala D. Harris,571
+San Bernardino,FON1297,U.S. Senate,,DEM,Loretta L. Sanchez,463
+San Bernardino,FON1298,U.S. Senate,,DEM,Kamala D. Harris,522
+San Bernardino,FON1298,U.S. Senate,,DEM,Loretta L. Sanchez,481
+San Bernardino,FON1299,U.S. Senate,,DEM,Kamala D. Harris,261
+San Bernardino,FON1299,U.S. Senate,,DEM,Loretta L. Sanchez,234
+San Bernardino,FON1300,U.S. Senate,,DEM,Kamala D. Harris,649
+San Bernardino,FON1300,U.S. Senate,,DEM,Loretta L. Sanchez,434
+San Bernardino,FON1301,U.S. Senate,,DEM,Kamala D. Harris,599
+San Bernardino,FON1301,U.S. Senate,,DEM,Loretta L. Sanchez,506
+San Bernardino,FON1302,U.S. Senate,,DEM,Kamala D. Harris,575
+San Bernardino,FON1302,U.S. Senate,,DEM,Loretta L. Sanchez,397
+San Bernardino,FON1303,U.S. Senate,,DEM,Kamala D. Harris,630
+San Bernardino,FON1303,U.S. Senate,,DEM,Loretta L. Sanchez,380
+San Bernardino,FON1304,U.S. Senate,,DEM,Kamala D. Harris,557
+San Bernardino,FON1304,U.S. Senate,,DEM,Loretta L. Sanchez,401
+San Bernardino,FON1305,U.S. Senate,,DEM,Kamala D. Harris,631
+San Bernardino,FON1305,U.S. Senate,,DEM,Loretta L. Sanchez,430
+San Bernardino,FON1306,U.S. Senate,,DEM,Kamala D. Harris,679
+San Bernardino,FON1306,U.S. Senate,,DEM,Loretta L. Sanchez,491
+San Bernardino,FON1307,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,FON1307,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,FON1308,U.S. Senate,,DEM,Kamala D. Harris,772
+San Bernardino,FON1308,U.S. Senate,,DEM,Loretta L. Sanchez,677
+San Bernardino,FON1309,U.S. Senate,,DEM,Kamala D. Harris,804
+San Bernardino,FON1309,U.S. Senate,,DEM,Loretta L. Sanchez,658
+San Bernardino,FON1310,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,FON1310,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,FON1311,U.S. Senate,,DEM,Kamala D. Harris,337
+San Bernardino,FON1311,U.S. Senate,,DEM,Loretta L. Sanchez,441
+San Bernardino,FON1312,U.S. Senate,,DEM,Kamala D. Harris,255
+San Bernardino,FON1312,U.S. Senate,,DEM,Loretta L. Sanchez,391
+San Bernardino,FON1313,U.S. Senate,,DEM,Kamala D. Harris,404
+San Bernardino,FON1313,U.S. Senate,,DEM,Loretta L. Sanchez,611
+San Bernardino,FON1314,U.S. Senate,,DEM,Kamala D. Harris,454
+San Bernardino,FON1314,U.S. Senate,,DEM,Loretta L. Sanchez,584
+San Bernardino,FON1315,U.S. Senate,,DEM,Kamala D. Harris,629
+San Bernardino,FON1315,U.S. Senate,,DEM,Loretta L. Sanchez,597
+San Bernardino,FON1316,U.S. Senate,,DEM,Kamala D. Harris,634
+San Bernardino,FON1316,U.S. Senate,,DEM,Loretta L. Sanchez,560
+San Bernardino,FON1317,U.S. Senate,,DEM,Kamala D. Harris,50
+San Bernardino,FON1317,U.S. Senate,,DEM,Loretta L. Sanchez,70
+San Bernardino,FON1318,U.S. Senate,,DEM,Kamala D. Harris,429
+San Bernardino,FON1318,U.S. Senate,,DEM,Loretta L. Sanchez,595
+San Bernardino,FON1319,U.S. Senate,,DEM,Kamala D. Harris,354
+San Bernardino,FON1319,U.S. Senate,,DEM,Loretta L. Sanchez,635
+San Bernardino,FON1320,U.S. Senate,,DEM,Kamala D. Harris,171
+San Bernardino,FON1320,U.S. Senate,,DEM,Loretta L. Sanchez,210
+San Bernardino,FON1321,U.S. Senate,,DEM,Kamala D. Harris,254
+San Bernardino,FON1321,U.S. Senate,,DEM,Loretta L. Sanchez,357
+San Bernardino,FON1322,U.S. Senate,,DEM,Kamala D. Harris,320
+San Bernardino,FON1322,U.S. Senate,,DEM,Loretta L. Sanchez,523
+San Bernardino,FON1323,U.S. Senate,,DEM,Kamala D. Harris,449
+San Bernardino,FON1323,U.S. Senate,,DEM,Loretta L. Sanchez,623
+San Bernardino,FON1324,U.S. Senate,,DEM,Kamala D. Harris,246
+San Bernardino,FON1324,U.S. Senate,,DEM,Loretta L. Sanchez,343
+San Bernardino,FON1325,U.S. Senate,,DEM,Kamala D. Harris,465
+San Bernardino,FON1325,U.S. Senate,,DEM,Loretta L. Sanchez,571
+San Bernardino,FON1326,U.S. Senate,,DEM,Kamala D. Harris,473
+San Bernardino,FON1326,U.S. Senate,,DEM,Loretta L. Sanchez,672
+San Bernardino,FON1327,U.S. Senate,,DEM,Kamala D. Harris,524
+San Bernardino,FON1327,U.S. Senate,,DEM,Loretta L. Sanchez,604
+San Bernardino,FON1328,U.S. Senate,,DEM,Kamala D. Harris,484
+San Bernardino,FON1328,U.S. Senate,,DEM,Loretta L. Sanchez,583
+San Bernardino,FON1329,U.S. Senate,,DEM,Kamala D. Harris,2
+San Bernardino,FON1329,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,FON1330,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,FON1330,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,FON1331,U.S. Senate,,DEM,Kamala D. Harris,122
+San Bernardino,FON1331,U.S. Senate,,DEM,Loretta L. Sanchez,164
+San Bernardino,FON1332,U.S. Senate,,DEM,Kamala D. Harris,37
+San Bernardino,FON1332,U.S. Senate,,DEM,Loretta L. Sanchez,75
+San Bernardino,FON1333,U.S. Senate,,DEM,Kamala D. Harris,85
+San Bernardino,FON1333,U.S. Senate,,DEM,Loretta L. Sanchez,157
+San Bernardino,FON1334,U.S. Senate,,DEM,Kamala D. Harris,3
+San Bernardino,FON1334,U.S. Senate,,DEM,Loretta L. Sanchez,5
+San Bernardino,FON1335,U.S. Senate,,DEM,Kamala D. Harris,456
+San Bernardino,FON1335,U.S. Senate,,DEM,Loretta L. Sanchez,448
+San Bernardino,FON1336,U.S. Senate,,DEM,Kamala D. Harris,8
+San Bernardino,FON1336,U.S. Senate,,DEM,Loretta L. Sanchez,9
+San Bernardino,FON1337,U.S. Senate,,DEM,Kamala D. Harris,272
+San Bernardino,FON1337,U.S. Senate,,DEM,Loretta L. Sanchez,189
+San Bernardino,FON1360,U.S. Senate,,DEM,Kamala D. Harris,407
+San Bernardino,FON1360,U.S. Senate,,DEM,Loretta L. Sanchez,506
+San Bernardino,FON1361,U.S. Senate,,DEM,Kamala D. Harris,370
+San Bernardino,FON1361,U.S. Senate,,DEM,Loretta L. Sanchez,530
+San Bernardino,FON1362,U.S. Senate,,DEM,Kamala D. Harris,422
+San Bernardino,FON1362,U.S. Senate,,DEM,Loretta L. Sanchez,565
+San Bernardino,FON1363,U.S. Senate,,DEM,Kamala D. Harris,474
+San Bernardino,FON1363,U.S. Senate,,DEM,Loretta L. Sanchez,622
+San Bernardino,FON1364,U.S. Senate,,DEM,Kamala D. Harris,528
+San Bernardino,FON1364,U.S. Senate,,DEM,Loretta L. Sanchez,644
+San Bernardino,FON1365,U.S. Senate,,DEM,Kamala D. Harris,389
+San Bernardino,FON1365,U.S. Senate,,DEM,Loretta L. Sanchez,532
+San Bernardino,FON1366,U.S. Senate,,DEM,Kamala D. Harris,264
+San Bernardino,FON1366,U.S. Senate,,DEM,Loretta L. Sanchez,374
+San Bernardino,FON1367,U.S. Senate,,DEM,Kamala D. Harris,350
+San Bernardino,FON1367,U.S. Senate,,DEM,Loretta L. Sanchez,427
+San Bernardino,FON1368,U.S. Senate,,DEM,Kamala D. Harris,458
+San Bernardino,FON1368,U.S. Senate,,DEM,Loretta L. Sanchez,666
+San Bernardino,FON1369,U.S. Senate,,DEM,Kamala D. Harris,444
+San Bernardino,FON1369,U.S. Senate,,DEM,Loretta L. Sanchez,563
+San Bernardino,FON1370,U.S. Senate,,DEM,Kamala D. Harris,126
+San Bernardino,FON1370,U.S. Senate,,DEM,Loretta L. Sanchez,126
+San Bernardino,FON1371,U.S. Senate,,DEM,Kamala D. Harris,99
+San Bernardino,FON1371,U.S. Senate,,DEM,Loretta L. Sanchez,146
+San Bernardino,FON1375,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,FON1375,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,FON1376,U.S. Senate,,DEM,Kamala D. Harris,377
+San Bernardino,FON1376,U.S. Senate,,DEM,Loretta L. Sanchez,368
+San Bernardino,FON1533,U.S. Senate,,DEM,Kamala D. Harris,53
+San Bernardino,FON1533,U.S. Senate,,DEM,Loretta L. Sanchez,65
+San Bernardino,FON1575,U.S. Senate,,DEM,Kamala D. Harris,104
+San Bernardino,FON1575,U.S. Senate,,DEM,Loretta L. Sanchez,145
+San Bernardino,GRA0906,U.S. Senate,,DEM,Kamala D. Harris,106
+San Bernardino,GRA0906,U.S. Senate,,DEM,Loretta L. Sanchez,109
+San Bernardino,GRA0907,U.S. Senate,,DEM,Kamala D. Harris,637
+San Bernardino,GRA0907,U.S. Senate,,DEM,Loretta L. Sanchez,462
+San Bernardino,GRA0908,U.S. Senate,,DEM,Kamala D. Harris,631
+San Bernardino,GRA0908,U.S. Senate,,DEM,Loretta L. Sanchez,448
+San Bernardino,GRA0909,U.S. Senate,,DEM,Kamala D. Harris,547
+San Bernardino,GRA0909,U.S. Senate,,DEM,Loretta L. Sanchez,417
+San Bernardino,GRA0910,U.S. Senate,,DEM,Kamala D. Harris,522
+San Bernardino,GRA0910,U.S. Senate,,DEM,Loretta L. Sanchez,385
+San Bernardino,GRA0911,U.S. Senate,,DEM,Kamala D. Harris,16
+San Bernardino,GRA0911,U.S. Senate,,DEM,Loretta L. Sanchez,15
+San Bernardino,GRA0912,U.S. Senate,,DEM,Kamala D. Harris,5
+San Bernardino,GRA0912,U.S. Senate,,DEM,Loretta L. Sanchez,5
+San Bernardino,GRA0913,U.S. Senate,,DEM,Kamala D. Harris,7
+San Bernardino,GRA0913,U.S. Senate,,DEM,Loretta L. Sanchez,17
+San Bernardino,HES0325,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,HES0325,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,HES0329,U.S. Senate,,DEM,Kamala D. Harris,459
+San Bernardino,HES0329,U.S. Senate,,DEM,Loretta L. Sanchez,525
+San Bernardino,HES0330,U.S. Senate,,DEM,Kamala D. Harris,462
+San Bernardino,HES0330,U.S. Senate,,DEM,Loretta L. Sanchez,512
+San Bernardino,HES0331,U.S. Senate,,DEM,Kamala D. Harris,380
+San Bernardino,HES0331,U.S. Senate,,DEM,Loretta L. Sanchez,489
+San Bernardino,HES0332,U.S. Senate,,DEM,Kamala D. Harris,382
+San Bernardino,HES0332,U.S. Senate,,DEM,Loretta L. Sanchez,394
+San Bernardino,HES0333,U.S. Senate,,DEM,Kamala D. Harris,353
+San Bernardino,HES0333,U.S. Senate,,DEM,Loretta L. Sanchez,491
+San Bernardino,HES0334,U.S. Senate,,DEM,Kamala D. Harris,44
+San Bernardino,HES0334,U.S. Senate,,DEM,Loretta L. Sanchez,46
+San Bernardino,HES0335,U.S. Senate,,DEM,Kamala D. Harris,255
+San Bernardino,HES0335,U.S. Senate,,DEM,Loretta L. Sanchez,347
+San Bernardino,HES0336,U.S. Senate,,DEM,Kamala D. Harris,385
+San Bernardino,HES0336,U.S. Senate,,DEM,Loretta L. Sanchez,421
+San Bernardino,HES0337,U.S. Senate,,DEM,Kamala D. Harris,473
+San Bernardino,HES0337,U.S. Senate,,DEM,Loretta L. Sanchez,591
+San Bernardino,HES0338,U.S. Senate,,DEM,Kamala D. Harris,401
+San Bernardino,HES0338,U.S. Senate,,DEM,Loretta L. Sanchez,495
+San Bernardino,HES0339,U.S. Senate,,DEM,Kamala D. Harris,406
+San Bernardino,HES0339,U.S. Senate,,DEM,Loretta L. Sanchez,456
+San Bernardino,HES0340,U.S. Senate,,DEM,Kamala D. Harris,32
+San Bernardino,HES0340,U.S. Senate,,DEM,Loretta L. Sanchez,24
+San Bernardino,HES0341,U.S. Senate,,DEM,Kamala D. Harris,565
+San Bernardino,HES0341,U.S. Senate,,DEM,Loretta L. Sanchez,558
+San Bernardino,HES0342,U.S. Senate,,DEM,Kamala D. Harris,513
+San Bernardino,HES0342,U.S. Senate,,DEM,Loretta L. Sanchez,614
+San Bernardino,HES0343,U.S. Senate,,DEM,Kamala D. Harris,296
+San Bernardino,HES0343,U.S. Senate,,DEM,Loretta L. Sanchez,354
+San Bernardino,HES0344,U.S. Senate,,DEM,Kamala D. Harris,81
+San Bernardino,HES0344,U.S. Senate,,DEM,Loretta L. Sanchez,73
+San Bernardino,HES0345,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,HES0345,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,HES0346,U.S. Senate,,DEM,Kamala D. Harris,377
+San Bernardino,HES0346,U.S. Senate,,DEM,Loretta L. Sanchez,438
+San Bernardino,HES0347,U.S. Senate,,DEM,Kamala D. Harris,375
+San Bernardino,HES0347,U.S. Senate,,DEM,Loretta L. Sanchez,329
+San Bernardino,HES0348,U.S. Senate,,DEM,Kamala D. Harris,328
+San Bernardino,HES0348,U.S. Senate,,DEM,Loretta L. Sanchez,353
+San Bernardino,HES0349,U.S. Senate,,DEM,Kamala D. Harris,485
+San Bernardino,HES0349,U.S. Senate,,DEM,Loretta L. Sanchez,486
+San Bernardino,HES0350,U.S. Senate,,DEM,Kamala D. Harris,584
+San Bernardino,HES0350,U.S. Senate,,DEM,Loretta L. Sanchez,572
+San Bernardino,HES0351,U.S. Senate,,DEM,Kamala D. Harris,352
+San Bernardino,HES0351,U.S. Senate,,DEM,Loretta L. Sanchez,403
+San Bernardino,HES0352,U.S. Senate,,DEM,Kamala D. Harris,195
+San Bernardino,HES0352,U.S. Senate,,DEM,Loretta L. Sanchez,208
+San Bernardino,HES0353,U.S. Senate,,DEM,Kamala D. Harris,459
+San Bernardino,HES0353,U.S. Senate,,DEM,Loretta L. Sanchez,445
+San Bernardino,HES0354,U.S. Senate,,DEM,Kamala D. Harris,381
+San Bernardino,HES0354,U.S. Senate,,DEM,Loretta L. Sanchez,452
+San Bernardino,HES0355,U.S. Senate,,DEM,Kamala D. Harris,487
+San Bernardino,HES0355,U.S. Senate,,DEM,Loretta L. Sanchez,528
+San Bernardino,HES0356,U.S. Senate,,DEM,Kamala D. Harris,474
+San Bernardino,HES0356,U.S. Senate,,DEM,Loretta L. Sanchez,513
+San Bernardino,HES0357,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,HES0357,U.S. Senate,,DEM,Loretta L. Sanchez,1
+San Bernardino,HES0358,U.S. Senate,,DEM,Kamala D. Harris,1
+San Bernardino,HES0358,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,HES0370,U.S. Senate,,DEM,Kamala D. Harris,3
+San Bernardino,HES0370,U.S. Senate,,DEM,Loretta L. Sanchez,5
+San Bernardino,HES0371,U.S. Senate,,DEM,Kamala D. Harris,8
+San Bernardino,HES0371,U.S. Senate,,DEM,Loretta L. Sanchez,4
+San Bernardino,HES1606,U.S. Senate,,DEM,Kamala D. Harris,197
+San Bernardino,HES1606,U.S. Senate,,DEM,Loretta L. Sanchez,191
+San Bernardino,HES1607,U.S. Senate,,DEM,Kamala D. Harris,141
+San Bernardino,HES1607,U.S. Senate,,DEM,Loretta L. Sanchez,212
+San Bernardino,HI10750,U.S. Senate,,DEM,Kamala D. Harris,288
+San Bernardino,HI10750,U.S. Senate,,DEM,Loretta L. Sanchez,292
+San Bernardino,HI10751,U.S. Senate,,DEM,Kamala D. Harris,310
+San Bernardino,HI10751,U.S. Senate,,DEM,Loretta L. Sanchez,277
+San Bernardino,HI10752,U.S. Senate,,DEM,Kamala D. Harris,107
+San Bernardino,HI10752,U.S. Senate,,DEM,Loretta L. Sanchez,115
+San Bernardino,HI10753,U.S. Senate,,DEM,Kamala D. Harris,168
+San Bernardino,HI10753,U.S. Senate,,DEM,Loretta L. Sanchez,153
+San Bernardino,HI11156,U.S. Senate,,DEM,Kamala D. Harris,1
+San Bernardino,HI11156,U.S. Senate,,DEM,Loretta L. Sanchez,3
+San Bernardino,HI20746,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,HI20746,U.S. Senate,,DEM,Loretta L. Sanchez,6
+San Bernardino,HI20747,U.S. Senate,,DEM,Kamala D. Harris,200
+San Bernardino,HI20747,U.S. Senate,,DEM,Loretta L. Sanchez,135
+San Bernardino,HI21154,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,HI21154,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,HI21155,U.S. Senate,,DEM,Kamala D. Harris,5
+San Bernardino,HI21155,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,HI21639,U.S. Senate,,DEM,Kamala D. Harris,85
+San Bernardino,HI21639,U.S. Senate,,DEM,Loretta L. Sanchez,73
+San Bernardino,HI21770,U.S. Senate,,DEM,Kamala D. Harris,607
+San Bernardino,HI21770,U.S. Senate,,DEM,Loretta L. Sanchez,542
+San Bernardino,HI30748,U.S. Senate,,DEM,Kamala D. Harris,477
+San Bernardino,HI30748,U.S. Senate,,DEM,Loretta L. Sanchez,376
+San Bernardino,HI30754,U.S. Senate,,DEM,Kamala D. Harris,489
+San Bernardino,HI30754,U.S. Senate,,DEM,Loretta L. Sanchez,446
+San Bernardino,HI30755,U.S. Senate,,DEM,Kamala D. Harris,174
+San Bernardino,HI30755,U.S. Senate,,DEM,Loretta L. Sanchez,168
+San Bernardino,HI30757,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,HI30757,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,HI30758,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,HI30758,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,HI31765,U.S. Senate,,DEM,Kamala D. Harris,376
+San Bernardino,HI31765,U.S. Senate,,DEM,Loretta L. Sanchez,300
+San Bernardino,HI31766,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,HI31766,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,HI31767,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,HI31767,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,HI31768,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,HI31768,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,HI31769,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,HI31769,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,HI40719,U.S. Senate,,DEM,Kamala D. Harris,476
+San Bernardino,HI40719,U.S. Senate,,DEM,Loretta L. Sanchez,299
+San Bernardino,HI40721,U.S. Senate,,DEM,Kamala D. Harris,430
+San Bernardino,HI40721,U.S. Senate,,DEM,Loretta L. Sanchez,277
+San Bernardino,HI40722,U.S. Senate,,DEM,Kamala D. Harris,538
+San Bernardino,HI40722,U.S. Senate,,DEM,Loretta L. Sanchez,307
+San Bernardino,HI40727,U.S. Senate,,DEM,Kamala D. Harris,29
+San Bernardino,HI40727,U.S. Senate,,DEM,Loretta L. Sanchez,36
+San Bernardino,HI40728,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,HI40728,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,HI40729,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,HI40729,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,HI40749,U.S. Senate,,DEM,Kamala D. Harris,511
+San Bernardino,HI40749,U.S. Senate,,DEM,Loretta L. Sanchez,393
+San Bernardino,HI40756,U.S. Senate,,DEM,Kamala D. Harris,138
+San Bernardino,HI40756,U.S. Senate,,DEM,Loretta L. Sanchez,93
+San Bernardino,HI41622,U.S. Senate,,DEM,Kamala D. Harris,365
+San Bernardino,HI41622,U.S. Senate,,DEM,Loretta L. Sanchez,226
+San Bernardino,HI41764,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,HI41764,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,HI50604,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,HI50604,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,HI50720,U.S. Senate,,DEM,Kamala D. Harris,750
+San Bernardino,HI50720,U.S. Senate,,DEM,Loretta L. Sanchez,433
+San Bernardino,HI50723,U.S. Senate,,DEM,Kamala D. Harris,997
+San Bernardino,HI50723,U.S. Senate,,DEM,Loretta L. Sanchez,549
+San Bernardino,HI50724,U.S. Senate,,DEM,Kamala D. Harris,51
+San Bernardino,HI50724,U.S. Senate,,DEM,Loretta L. Sanchez,45
+San Bernardino,HI50725,U.S. Senate,,DEM,Kamala D. Harris,782
+San Bernardino,HI50725,U.S. Senate,,DEM,Loretta L. Sanchez,502
+San Bernardino,HI50726,U.S. Senate,,DEM,Kamala D. Harris,56
+San Bernardino,HI50726,U.S. Senate,,DEM,Loretta L. Sanchez,29
+San Bernardino,HI50730,U.S. Senate,,DEM,Kamala D. Harris,35
+San Bernardino,HI50730,U.S. Senate,,DEM,Loretta L. Sanchez,27
+San Bernardino,HI50731,U.S. Senate,,DEM,Kamala D. Harris,16
+San Bernardino,HI50731,U.S. Senate,,DEM,Loretta L. Sanchez,21
+San Bernardino,HI50732,U.S. Senate,,DEM,Kamala D. Harris,1
+San Bernardino,HI50732,U.S. Senate,,DEM,Loretta L. Sanchez,1
+San Bernardino,HI50733,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,HI50733,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,HI50734,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,HI50734,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,HI50735,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,HI50735,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,HI51695,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,HI51695,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,HI51696,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,HI51696,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,HI51771,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,HI51771,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,LOM1091,U.S. Senate,,DEM,Kamala D. Harris,325
+San Bernardino,LOM1091,U.S. Senate,,DEM,Loretta L. Sanchez,168
+San Bernardino,LOM1092,U.S. Senate,,DEM,Kamala D. Harris,6
+San Bernardino,LOM1092,U.S. Senate,,DEM,Loretta L. Sanchez,1
+San Bernardino,LOM1093,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,LOM1093,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,LOM1095,U.S. Senate,,DEM,Kamala D. Harris,669
+San Bernardino,LOM1095,U.S. Senate,,DEM,Loretta L. Sanchez,386
+San Bernardino,LOM1096,U.S. Senate,,DEM,Kamala D. Harris,599
+San Bernardino,LOM1096,U.S. Senate,,DEM,Loretta L. Sanchez,393
+San Bernardino,LOM1097,U.S. Senate,,DEM,Kamala D. Harris,193
+San Bernardino,LOM1097,U.S. Senate,,DEM,Loretta L. Sanchez,102
+San Bernardino,LOM1098,U.S. Senate,,DEM,Kamala D. Harris,876
+San Bernardino,LOM1098,U.S. Senate,,DEM,Loretta L. Sanchez,442
+San Bernardino,LOM1099,U.S. Senate,,DEM,Kamala D. Harris,67
+San Bernardino,LOM1099,U.S. Senate,,DEM,Loretta L. Sanchez,34
+San Bernardino,LOM1100,U.S. Senate,,DEM,Kamala D. Harris,650
+San Bernardino,LOM1100,U.S. Senate,,DEM,Loretta L. Sanchez,365
+San Bernardino,LOM1101,U.S. Senate,,DEM,Kamala D. Harris,658
+San Bernardino,LOM1101,U.S. Senate,,DEM,Loretta L. Sanchez,339
+San Bernardino,LOM1102,U.S. Senate,,DEM,Kamala D. Harris,73
+San Bernardino,LOM1102,U.S. Senate,,DEM,Loretta L. Sanchez,46
+San Bernardino,LOM1209,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,LOM1209,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,LOM1210,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,LOM1210,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,LOM1211,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,LOM1211,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,LOM1631,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,LOM1631,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,MON1389,U.S. Senate,,DEM,Kamala D. Harris,586
+San Bernardino,MON1389,U.S. Senate,,DEM,Loretta L. Sanchez,494
+San Bernardino,MON1390,U.S. Senate,,DEM,Kamala D. Harris,456
+San Bernardino,MON1390,U.S. Senate,,DEM,Loretta L. Sanchez,491
+San Bernardino,MON1391,U.S. Senate,,DEM,Kamala D. Harris,462
+San Bernardino,MON1391,U.S. Senate,,DEM,Loretta L. Sanchez,415
+San Bernardino,MON1392,U.S. Senate,,DEM,Kamala D. Harris,521
+San Bernardino,MON1392,U.S. Senate,,DEM,Loretta L. Sanchez,449
+San Bernardino,MON1393,U.S. Senate,,DEM,Kamala D. Harris,591
+San Bernardino,MON1393,U.S. Senate,,DEM,Loretta L. Sanchez,577
+San Bernardino,MON1394,U.S. Senate,,DEM,Kamala D. Harris,536
+San Bernardino,MON1394,U.S. Senate,,DEM,Loretta L. Sanchez,547
+San Bernardino,MON1395,U.S. Senate,,DEM,Kamala D. Harris,412
+San Bernardino,MON1395,U.S. Senate,,DEM,Loretta L. Sanchez,434
+San Bernardino,MON1396,U.S. Senate,,DEM,Kamala D. Harris,429
+San Bernardino,MON1396,U.S. Senate,,DEM,Loretta L. Sanchez,485
+San Bernardino,MON1397,U.S. Senate,,DEM,Kamala D. Harris,620
+San Bernardino,MON1397,U.S. Senate,,DEM,Loretta L. Sanchez,498
+San Bernardino,MON1521,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,MON1521,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,NEE0060,U.S. Senate,,DEM,Kamala D. Harris,134
+San Bernardino,NEE0060,U.S. Senate,,DEM,Loretta L. Sanchez,86
+San Bernardino,NEE0061,U.S. Senate,,DEM,Kamala D. Harris,450
+San Bernardino,NEE0061,U.S. Senate,,DEM,Loretta L. Sanchez,339
+San Bernardino,ONT1027,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,ONT1027,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,ONT1398,U.S. Senate,,DEM,Kamala D. Harris,429
+San Bernardino,ONT1398,U.S. Senate,,DEM,Loretta L. Sanchez,418
+San Bernardino,ONT1399,U.S. Senate,,DEM,Kamala D. Harris,320
+San Bernardino,ONT1399,U.S. Senate,,DEM,Loretta L. Sanchez,267
+San Bernardino,ONT1400,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,ONT1400,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,ONT1401,U.S. Senate,,DEM,Kamala D. Harris,392
+San Bernardino,ONT1401,U.S. Senate,,DEM,Loretta L. Sanchez,370
+San Bernardino,ONT1402,U.S. Senate,,DEM,Kamala D. Harris,583
+San Bernardino,ONT1402,U.S. Senate,,DEM,Loretta L. Sanchez,574
+San Bernardino,ONT1403,U.S. Senate,,DEM,Kamala D. Harris,633
+San Bernardino,ONT1403,U.S. Senate,,DEM,Loretta L. Sanchez,583
+San Bernardino,ONT1404,U.S. Senate,,DEM,Kamala D. Harris,341
+San Bernardino,ONT1404,U.S. Senate,,DEM,Loretta L. Sanchez,280
+San Bernardino,ONT1405,U.S. Senate,,DEM,Kamala D. Harris,669
+San Bernardino,ONT1405,U.S. Senate,,DEM,Loretta L. Sanchez,528
+San Bernardino,ONT1406,U.S. Senate,,DEM,Kamala D. Harris,527
+San Bernardino,ONT1406,U.S. Senate,,DEM,Loretta L. Sanchez,485
+San Bernardino,ONT1407,U.S. Senate,,DEM,Kamala D. Harris,236
+San Bernardino,ONT1407,U.S. Senate,,DEM,Loretta L. Sanchez,259
+San Bernardino,ONT1408,U.S. Senate,,DEM,Kamala D. Harris,49
+San Bernardino,ONT1408,U.S. Senate,,DEM,Loretta L. Sanchez,54
+San Bernardino,ONT1409,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,ONT1409,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,ONT1410,U.S. Senate,,DEM,Kamala D. Harris,421
+San Bernardino,ONT1410,U.S. Senate,,DEM,Loretta L. Sanchez,529
+San Bernardino,ONT1411,U.S. Senate,,DEM,Kamala D. Harris,341
+San Bernardino,ONT1411,U.S. Senate,,DEM,Loretta L. Sanchez,252
+San Bernardino,ONT1412,U.S. Senate,,DEM,Kamala D. Harris,400
+San Bernardino,ONT1412,U.S. Senate,,DEM,Loretta L. Sanchez,580
+San Bernardino,ONT1413,U.S. Senate,,DEM,Kamala D. Harris,162
+San Bernardino,ONT1413,U.S. Senate,,DEM,Loretta L. Sanchez,174
+San Bernardino,ONT1414,U.S. Senate,,DEM,Kamala D. Harris,469
+San Bernardino,ONT1414,U.S. Senate,,DEM,Loretta L. Sanchez,498
+San Bernardino,ONT1415,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,ONT1415,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,ONT1416,U.S. Senate,,DEM,Kamala D. Harris,311
+San Bernardino,ONT1416,U.S. Senate,,DEM,Loretta L. Sanchez,391
+San Bernardino,ONT1417,U.S. Senate,,DEM,Kamala D. Harris,4
+San Bernardino,ONT1417,U.S. Senate,,DEM,Loretta L. Sanchez,2
+San Bernardino,ONT1418,U.S. Senate,,DEM,Kamala D. Harris,389
+San Bernardino,ONT1418,U.S. Senate,,DEM,Loretta L. Sanchez,451
+San Bernardino,ONT1419,U.S. Senate,,DEM,Kamala D. Harris,239
+San Bernardino,ONT1419,U.S. Senate,,DEM,Loretta L. Sanchez,217
+San Bernardino,ONT1420,U.S. Senate,,DEM,Kamala D. Harris,420
+San Bernardino,ONT1420,U.S. Senate,,DEM,Loretta L. Sanchez,329
+San Bernardino,ONT1421,U.S. Senate,,DEM,Kamala D. Harris,385
+San Bernardino,ONT1421,U.S. Senate,,DEM,Loretta L. Sanchez,472
+San Bernardino,ONT1422,U.S. Senate,,DEM,Kamala D. Harris,541
+San Bernardino,ONT1422,U.S. Senate,,DEM,Loretta L. Sanchez,459
+San Bernardino,ONT1423,U.S. Senate,,DEM,Kamala D. Harris,5
+San Bernardino,ONT1423,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,ONT1424,U.S. Senate,,DEM,Kamala D. Harris,280
+San Bernardino,ONT1424,U.S. Senate,,DEM,Loretta L. Sanchez,252
+San Bernardino,ONT1425,U.S. Senate,,DEM,Kamala D. Harris,85
+San Bernardino,ONT1425,U.S. Senate,,DEM,Loretta L. Sanchez,25
+San Bernardino,ONT1426,U.S. Senate,,DEM,Kamala D. Harris,324
+San Bernardino,ONT1426,U.S. Senate,,DEM,Loretta L. Sanchez,301
+San Bernardino,ONT1427,U.S. Senate,,DEM,Kamala D. Harris,172
+San Bernardino,ONT1427,U.S. Senate,,DEM,Loretta L. Sanchez,216
+San Bernardino,ONT1428,U.S. Senate,,DEM,Kamala D. Harris,385
+San Bernardino,ONT1428,U.S. Senate,,DEM,Loretta L. Sanchez,587
+San Bernardino,ONT1429,U.S. Senate,,DEM,Kamala D. Harris,500
+San Bernardino,ONT1429,U.S. Senate,,DEM,Loretta L. Sanchez,428
+San Bernardino,ONT1430,U.S. Senate,,DEM,Kamala D. Harris,473
+San Bernardino,ONT1430,U.S. Senate,,DEM,Loretta L. Sanchez,457
+San Bernardino,ONT1431,U.S. Senate,,DEM,Kamala D. Harris,387
+San Bernardino,ONT1431,U.S. Senate,,DEM,Loretta L. Sanchez,497
+San Bernardino,ONT1432,U.S. Senate,,DEM,Kamala D. Harris,378
+San Bernardino,ONT1432,U.S. Senate,,DEM,Loretta L. Sanchez,555
+San Bernardino,ONT1433,U.S. Senate,,DEM,Kamala D. Harris,466
+San Bernardino,ONT1433,U.S. Senate,,DEM,Loretta L. Sanchez,530
+San Bernardino,ONT1434,U.S. Senate,,DEM,Kamala D. Harris,648
+San Bernardino,ONT1434,U.S. Senate,,DEM,Loretta L. Sanchez,554
+San Bernardino,ONT1435,U.S. Senate,,DEM,Kamala D. Harris,422
+San Bernardino,ONT1435,U.S. Senate,,DEM,Loretta L. Sanchez,391
+San Bernardino,ONT1436,U.S. Senate,,DEM,Kamala D. Harris,303
+San Bernardino,ONT1436,U.S. Senate,,DEM,Loretta L. Sanchez,328
+San Bernardino,ONT1437,U.S. Senate,,DEM,Kamala D. Harris,32
+San Bernardino,ONT1437,U.S. Senate,,DEM,Loretta L. Sanchez,25
+San Bernardino,ONT1438,U.S. Senate,,DEM,Kamala D. Harris,94
+San Bernardino,ONT1438,U.S. Senate,,DEM,Loretta L. Sanchez,40
+San Bernardino,ONT1439,U.S. Senate,,DEM,Kamala D. Harris,63
+San Bernardino,ONT1439,U.S. Senate,,DEM,Loretta L. Sanchez,50
+San Bernardino,ONT1440,U.S. Senate,,DEM,Kamala D. Harris,400
+San Bernardino,ONT1440,U.S. Senate,,DEM,Loretta L. Sanchez,284
+San Bernardino,ONT1441,U.S. Senate,,DEM,Kamala D. Harris,596
+San Bernardino,ONT1441,U.S. Senate,,DEM,Loretta L. Sanchez,365
+San Bernardino,ONT1442,U.S. Senate,,DEM,Kamala D. Harris,475
+San Bernardino,ONT1442,U.S. Senate,,DEM,Loretta L. Sanchez,524
+San Bernardino,ONT1443,U.S. Senate,,DEM,Kamala D. Harris,659
+San Bernardino,ONT1443,U.S. Senate,,DEM,Loretta L. Sanchez,517
+San Bernardino,ONT1444,U.S. Senate,,DEM,Kamala D. Harris,585
+San Bernardino,ONT1444,U.S. Senate,,DEM,Loretta L. Sanchez,476
+San Bernardino,ONT1445,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,ONT1445,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,ONT1446,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,ONT1446,U.S. Senate,,DEM,Loretta L. Sanchez,1
+San Bernardino,ONT1447,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,ONT1447,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,ONT1448,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,ONT1448,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,ONT1449,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,ONT1449,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,ONT1450,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,ONT1450,U.S. Senate,,DEM,Loretta L. Sanchez,1
+San Bernardino,ONT1451,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,ONT1451,U.S. Senate,,DEM,Loretta L. Sanchez,1
+San Bernardino,ONT1452,U.S. Senate,,DEM,Kamala D. Harris,810
+San Bernardino,ONT1452,U.S. Senate,,DEM,Loretta L. Sanchez,388
+San Bernardino,ONT1453,U.S. Senate,,DEM,Kamala D. Harris,56
+San Bernardino,ONT1453,U.S. Senate,,DEM,Loretta L. Sanchez,30
+San Bernardino,ONT1502,U.S. Senate,,DEM,Kamala D. Harris,2
+San Bernardino,ONT1502,U.S. Senate,,DEM,Loretta L. Sanchez,2
+San Bernardino,ONT1503,U.S. Senate,,DEM,Kamala D. Harris,34
+San Bernardino,ONT1503,U.S. Senate,,DEM,Loretta L. Sanchez,42
+San Bernardino,ONT1504,U.S. Senate,,DEM,Kamala D. Harris,107
+San Bernardino,ONT1504,U.S. Senate,,DEM,Loretta L. Sanchez,63
+San Bernardino,ONT1505,U.S. Senate,,DEM,Kamala D. Harris,555
+San Bernardino,ONT1505,U.S. Senate,,DEM,Loretta L. Sanchez,568
+San Bernardino,ONT1506,U.S. Senate,,DEM,Kamala D. Harris,538
+San Bernardino,ONT1506,U.S. Senate,,DEM,Loretta L. Sanchez,464
+San Bernardino,ONT1507,U.S. Senate,,DEM,Kamala D. Harris,507
+San Bernardino,ONT1507,U.S. Senate,,DEM,Loretta L. Sanchez,483
+San Bernardino,ONT1508,U.S. Senate,,DEM,Kamala D. Harris,400
+San Bernardino,ONT1508,U.S. Senate,,DEM,Loretta L. Sanchez,457
+San Bernardino,ONT1509,U.S. Senate,,DEM,Kamala D. Harris,14
+San Bernardino,ONT1509,U.S. Senate,,DEM,Loretta L. Sanchez,40
+San Bernardino,ONT1570,U.S. Senate,,DEM,Kamala D. Harris,216
+San Bernardino,ONT1570,U.S. Senate,,DEM,Loretta L. Sanchez,217
+San Bernardino,ONT1571,U.S. Senate,,DEM,Kamala D. Harris,447
+San Bernardino,ONT1571,U.S. Senate,,DEM,Loretta L. Sanchez,341
+San Bernardino,ONT1572,U.S. Senate,,DEM,Kamala D. Harris,183
+San Bernardino,ONT1572,U.S. Senate,,DEM,Loretta L. Sanchez,231
+San Bernardino,ONT1576,U.S. Senate,,DEM,Kamala D. Harris,71
+San Bernardino,ONT1576,U.S. Senate,,DEM,Loretta L. Sanchez,58
+San Bernardino,ONT1577,U.S. Senate,,DEM,Kamala D. Harris,71
+San Bernardino,ONT1577,U.S. Senate,,DEM,Loretta L. Sanchez,92
+San Bernardino,ONT1730,U.S. Senate,,DEM,Kamala D. Harris,166
+San Bernardino,ONT1730,U.S. Senate,,DEM,Loretta L. Sanchez,144
+San Bernardino,ONT1731,U.S. Senate,,DEM,Kamala D. Harris,473
+San Bernardino,ONT1731,U.S. Senate,,DEM,Loretta L. Sanchez,384
+San Bernardino,ONT1732,U.S. Senate,,DEM,Kamala D. Harris,226
+San Bernardino,ONT1732,U.S. Senate,,DEM,Loretta L. Sanchez,127
+San Bernardino,RAN0835,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,RAN0835,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,RAN1028,U.S. Senate,,DEM,Kamala D. Harris,538
+San Bernardino,RAN1028,U.S. Senate,,DEM,Loretta L. Sanchez,347
+San Bernardino,RAN1029,U.S. Senate,,DEM,Kamala D. Harris,563
+San Bernardino,RAN1029,U.S. Senate,,DEM,Loretta L. Sanchez,454
+San Bernardino,RAN1030,U.S. Senate,,DEM,Kamala D. Harris,603
+San Bernardino,RAN1030,U.S. Senate,,DEM,Loretta L. Sanchez,399
+San Bernardino,RAN1031,U.S. Senate,,DEM,Kamala D. Harris,764
+San Bernardino,RAN1031,U.S. Senate,,DEM,Loretta L. Sanchez,494
+San Bernardino,RAN1032,U.S. Senate,,DEM,Kamala D. Harris,666
+San Bernardino,RAN1032,U.S. Senate,,DEM,Loretta L. Sanchez,442
+San Bernardino,RAN1033,U.S. Senate,,DEM,Kamala D. Harris,609
+San Bernardino,RAN1033,U.S. Senate,,DEM,Loretta L. Sanchez,368
+San Bernardino,RAN1034,U.S. Senate,,DEM,Kamala D. Harris,617
+San Bernardino,RAN1034,U.S. Senate,,DEM,Loretta L. Sanchez,345
+San Bernardino,RAN1035,U.S. Senate,,DEM,Kamala D. Harris,198
+San Bernardino,RAN1035,U.S. Senate,,DEM,Loretta L. Sanchez,95
+San Bernardino,RAN1036,U.S. Senate,,DEM,Kamala D. Harris,475
+San Bernardino,RAN1036,U.S. Senate,,DEM,Loretta L. Sanchez,330
+San Bernardino,RAN1037,U.S. Senate,,DEM,Kamala D. Harris,381
+San Bernardino,RAN1037,U.S. Senate,,DEM,Loretta L. Sanchez,256
+San Bernardino,RAN1038,U.S. Senate,,DEM,Kamala D. Harris,522
+San Bernardino,RAN1038,U.S. Senate,,DEM,Loretta L. Sanchez,364
+San Bernardino,RAN1039,U.S. Senate,,DEM,Kamala D. Harris,310
+San Bernardino,RAN1039,U.S. Senate,,DEM,Loretta L. Sanchez,177
+San Bernardino,RAN1040,U.S. Senate,,DEM,Kamala D. Harris,465
+San Bernardino,RAN1040,U.S. Senate,,DEM,Loretta L. Sanchez,299
+San Bernardino,RAN1041,U.S. Senate,,DEM,Kamala D. Harris,846
+San Bernardino,RAN1041,U.S. Senate,,DEM,Loretta L. Sanchez,408
+San Bernardino,RAN1042,U.S. Senate,,DEM,Kamala D. Harris,711
+San Bernardino,RAN1042,U.S. Senate,,DEM,Loretta L. Sanchez,321
+San Bernardino,RAN1043,U.S. Senate,,DEM,Kamala D. Harris,632
+San Bernardino,RAN1043,U.S. Senate,,DEM,Loretta L. Sanchez,318
+San Bernardino,RAN1044,U.S. Senate,,DEM,Kamala D. Harris,741
+San Bernardino,RAN1044,U.S. Senate,,DEM,Loretta L. Sanchez,380
+San Bernardino,RAN1045,U.S. Senate,,DEM,Kamala D. Harris,747
+San Bernardino,RAN1045,U.S. Senate,,DEM,Loretta L. Sanchez,465
+San Bernardino,RAN1046,U.S. Senate,,DEM,Kamala D. Harris,591
+San Bernardino,RAN1046,U.S. Senate,,DEM,Loretta L. Sanchez,415
+San Bernardino,RAN1047,U.S. Senate,,DEM,Kamala D. Harris,704
+San Bernardino,RAN1047,U.S. Senate,,DEM,Loretta L. Sanchez,437
+San Bernardino,RAN1048,U.S. Senate,,DEM,Kamala D. Harris,551
+San Bernardino,RAN1048,U.S. Senate,,DEM,Loretta L. Sanchez,315
+San Bernardino,RAN1049,U.S. Senate,,DEM,Kamala D. Harris,517
+San Bernardino,RAN1049,U.S. Senate,,DEM,Loretta L. Sanchez,327
+San Bernardino,RAN1050,U.S. Senate,,DEM,Kamala D. Harris,355
+San Bernardino,RAN1050,U.S. Senate,,DEM,Loretta L. Sanchez,217
+San Bernardino,RAN1051,U.S. Senate,,DEM,Kamala D. Harris,685
+San Bernardino,RAN1051,U.S. Senate,,DEM,Loretta L. Sanchez,370
+San Bernardino,RAN1052,U.S. Senate,,DEM,Kamala D. Harris,321
+San Bernardino,RAN1052,U.S. Senate,,DEM,Loretta L. Sanchez,201
+San Bernardino,RAN1053,U.S. Senate,,DEM,Kamala D. Harris,365
+San Bernardino,RAN1053,U.S. Senate,,DEM,Loretta L. Sanchez,226
+San Bernardino,RAN1054,U.S. Senate,,DEM,Kamala D. Harris,356
+San Bernardino,RAN1054,U.S. Senate,,DEM,Loretta L. Sanchez,212
+San Bernardino,RAN1055,U.S. Senate,,DEM,Kamala D. Harris,747
+San Bernardino,RAN1055,U.S. Senate,,DEM,Loretta L. Sanchez,378
+San Bernardino,RAN1056,U.S. Senate,,DEM,Kamala D. Harris,924
+San Bernardino,RAN1056,U.S. Senate,,DEM,Loretta L. Sanchez,524
+San Bernardino,RAN1057,U.S. Senate,,DEM,Kamala D. Harris,626
+San Bernardino,RAN1057,U.S. Senate,,DEM,Loretta L. Sanchez,359
+San Bernardino,RAN1058,U.S. Senate,,DEM,Kamala D. Harris,665
+San Bernardino,RAN1058,U.S. Senate,,DEM,Loretta L. Sanchez,385
+San Bernardino,RAN1059,U.S. Senate,,DEM,Kamala D. Harris,464
+San Bernardino,RAN1059,U.S. Senate,,DEM,Loretta L. Sanchez,321
+San Bernardino,RAN1060,U.S. Senate,,DEM,Kamala D. Harris,584
+San Bernardino,RAN1060,U.S. Senate,,DEM,Loretta L. Sanchez,405
+San Bernardino,RAN1061,U.S. Senate,,DEM,Kamala D. Harris,579
+San Bernardino,RAN1061,U.S. Senate,,DEM,Loretta L. Sanchez,454
+San Bernardino,RAN1062,U.S. Senate,,DEM,Kamala D. Harris,627
+San Bernardino,RAN1062,U.S. Senate,,DEM,Loretta L. Sanchez,411
+San Bernardino,RAN1063,U.S. Senate,,DEM,Kamala D. Harris,300
+San Bernardino,RAN1063,U.S. Senate,,DEM,Loretta L. Sanchez,205
+San Bernardino,RAN1064,U.S. Senate,,DEM,Kamala D. Harris,569
+San Bernardino,RAN1064,U.S. Senate,,DEM,Loretta L. Sanchez,470
+San Bernardino,RAN1065,U.S. Senate,,DEM,Kamala D. Harris,612
+San Bernardino,RAN1065,U.S. Senate,,DEM,Loretta L. Sanchez,432
+San Bernardino,RAN1066,U.S. Senate,,DEM,Kamala D. Harris,704
+San Bernardino,RAN1066,U.S. Senate,,DEM,Loretta L. Sanchez,514
+San Bernardino,RAN1067,U.S. Senate,,DEM,Kamala D. Harris,474
+San Bernardino,RAN1067,U.S. Senate,,DEM,Loretta L. Sanchez,346
+San Bernardino,RAN1068,U.S. Senate,,DEM,Kamala D. Harris,764
+San Bernardino,RAN1068,U.S. Senate,,DEM,Loretta L. Sanchez,363
+San Bernardino,RAN1069,U.S. Senate,,DEM,Kamala D. Harris,720
+San Bernardino,RAN1069,U.S. Senate,,DEM,Loretta L. Sanchez,362
+San Bernardino,RAN1070,U.S. Senate,,DEM,Kamala D. Harris,583
+San Bernardino,RAN1070,U.S. Senate,,DEM,Loretta L. Sanchez,355
+San Bernardino,RAN1071,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,RAN1071,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,RAN1072,U.S. Senate,,DEM,Kamala D. Harris,461
+San Bernardino,RAN1072,U.S. Senate,,DEM,Loretta L. Sanchez,399
+San Bernardino,RAN1073,U.S. Senate,,DEM,Kamala D. Harris,148
+San Bernardino,RAN1073,U.S. Senate,,DEM,Loretta L. Sanchez,123
+San Bernardino,RAN1074,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,RAN1074,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,RAN1075,U.S. Senate,,DEM,Kamala D. Harris,613
+San Bernardino,RAN1075,U.S. Senate,,DEM,Loretta L. Sanchez,244
+San Bernardino,RAN1076,U.S. Senate,,DEM,Kamala D. Harris,603
+San Bernardino,RAN1076,U.S. Senate,,DEM,Loretta L. Sanchez,499
+San Bernardino,RAN1077,U.S. Senate,,DEM,Kamala D. Harris,745
+San Bernardino,RAN1077,U.S. Senate,,DEM,Loretta L. Sanchez,463
+San Bernardino,RAN1078,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,RAN1078,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,RAN1079,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,RAN1079,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,RAN1080,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,RAN1080,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,RAN1081,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,RAN1081,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,RAN1082,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,RAN1082,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,RAN1083,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,RAN1083,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,RAN1084,U.S. Senate,,DEM,Kamala D. Harris,12
+San Bernardino,RAN1084,U.S. Senate,,DEM,Loretta L. Sanchez,19
+San Bernardino,RAN1086,U.S. Senate,,DEM,Kamala D. Harris,11
+San Bernardino,RAN1086,U.S. Senate,,DEM,Loretta L. Sanchez,11
+San Bernardino,RAN1260,U.S. Senate,,DEM,Kamala D. Harris,599
+San Bernardino,RAN1260,U.S. Senate,,DEM,Loretta L. Sanchez,461
+San Bernardino,RAN1261,U.S. Senate,,DEM,Kamala D. Harris,665
+San Bernardino,RAN1261,U.S. Senate,,DEM,Loretta L. Sanchez,481
+San Bernardino,RAN1262,U.S. Senate,,DEM,Kamala D. Harris,603
+San Bernardino,RAN1262,U.S. Senate,,DEM,Loretta L. Sanchez,458
+San Bernardino,RAN1263,U.S. Senate,,DEM,Kamala D. Harris,637
+San Bernardino,RAN1263,U.S. Senate,,DEM,Loretta L. Sanchez,479
+San Bernardino,RAN1264,U.S. Senate,,DEM,Kamala D. Harris,626
+San Bernardino,RAN1264,U.S. Senate,,DEM,Loretta L. Sanchez,480
+San Bernardino,RAN1265,U.S. Senate,,DEM,Kamala D. Harris,635
+San Bernardino,RAN1265,U.S. Senate,,DEM,Loretta L. Sanchez,499
+San Bernardino,RAN1266,U.S. Senate,,DEM,Kamala D. Harris,582
+San Bernardino,RAN1266,U.S. Senate,,DEM,Loretta L. Sanchez,416
+San Bernardino,RAN1267,U.S. Senate,,DEM,Kamala D. Harris,545
+San Bernardino,RAN1267,U.S. Senate,,DEM,Loretta L. Sanchez,427
+San Bernardino,RAN1272,U.S. Senate,,DEM,Kamala D. Harris,17
+San Bernardino,RAN1272,U.S. Senate,,DEM,Loretta L. Sanchez,7
+San Bernardino,RAN1454,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,RAN1454,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,RAN1455,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,RAN1455,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,RAN1456,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,RAN1456,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,RAN1568,U.S. Senate,,DEM,Kamala D. Harris,346
+San Bernardino,RAN1568,U.S. Senate,,DEM,Loretta L. Sanchez,174
+San Bernardino,RAN1569,U.S. Senate,,DEM,Kamala D. Harris,159
+San Bernardino,RAN1569,U.S. Senate,,DEM,Loretta L. Sanchez,83
+San Bernardino,RAN1573,U.S. Senate,,DEM,Kamala D. Harris,449
+San Bernardino,RAN1573,U.S. Senate,,DEM,Loretta L. Sanchez,256
+San Bernardino,RAN1574,U.S. Senate,,DEM,Kamala D. Harris,3
+San Bernardino,RAN1574,U.S. Senate,,DEM,Loretta L. Sanchez,5
+San Bernardino,RAN1735,U.S. Senate,,DEM,Kamala D. Harris,182
+San Bernardino,RAN1735,U.S. Senate,,DEM,Loretta L. Sanchez,107
+San Bernardino,RAN1736,U.S. Senate,,DEM,Kamala D. Harris,206
+San Bernardino,RAN1736,U.S. Senate,,DEM,Loretta L. Sanchez,137
+San Bernardino,RAN1737,U.S. Senate,,DEM,Kamala D. Harris,164
+San Bernardino,RAN1737,U.S. Senate,,DEM,Loretta L. Sanchez,125
+San Bernardino,RAN1738,U.S. Senate,,DEM,Kamala D. Harris,123
+San Bernardino,RAN1738,U.S. Senate,,DEM,Loretta L. Sanchez,65
+San Bernardino,RAN1739,U.S. Senate,,DEM,Kamala D. Harris,157
+San Bernardino,RAN1739,U.S. Senate,,DEM,Loretta L. Sanchez,149
+San Bernardino,RAN1740,U.S. Senate,,DEM,Kamala D. Harris,66
+San Bernardino,RAN1740,U.S. Senate,,DEM,Loretta L. Sanchez,60
+San Bernardino,RAN1741,U.S. Senate,,DEM,Kamala D. Harris,10
+San Bernardino,RAN1741,U.S. Senate,,DEM,Loretta L. Sanchez,12
+San Bernardino,RAN1742,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,RAN1742,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,RED0768,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,RED0768,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,RED0782,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,RED0782,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,RED1103,U.S. Senate,,DEM,Kamala D. Harris,674
+San Bernardino,RED1103,U.S. Senate,,DEM,Loretta L. Sanchez,362
+San Bernardino,RED1104,U.S. Senate,,DEM,Kamala D. Harris,360
+San Bernardino,RED1104,U.S. Senate,,DEM,Loretta L. Sanchez,219
+San Bernardino,RED1105,U.S. Senate,,DEM,Kamala D. Harris,501
+San Bernardino,RED1105,U.S. Senate,,DEM,Loretta L. Sanchez,399
+San Bernardino,RED1106,U.S. Senate,,DEM,Kamala D. Harris,525
+San Bernardino,RED1106,U.S. Senate,,DEM,Loretta L. Sanchez,474
+San Bernardino,RED1107,U.S. Senate,,DEM,Kamala D. Harris,719
+San Bernardino,RED1107,U.S. Senate,,DEM,Loretta L. Sanchez,402
+San Bernardino,RED1108,U.S. Senate,,DEM,Kamala D. Harris,492
+San Bernardino,RED1108,U.S. Senate,,DEM,Loretta L. Sanchez,377
+San Bernardino,RED1109,U.S. Senate,,DEM,Kamala D. Harris,554
+San Bernardino,RED1109,U.S. Senate,,DEM,Loretta L. Sanchez,389
+San Bernardino,RED1110,U.S. Senate,,DEM,Kamala D. Harris,220
+San Bernardino,RED1110,U.S. Senate,,DEM,Loretta L. Sanchez,275
+San Bernardino,RED1111,U.S. Senate,,DEM,Kamala D. Harris,463
+San Bernardino,RED1111,U.S. Senate,,DEM,Loretta L. Sanchez,283
+San Bernardino,RED1112,U.S. Senate,,DEM,Kamala D. Harris,659
+San Bernardino,RED1112,U.S. Senate,,DEM,Loretta L. Sanchez,395
+San Bernardino,RED1113,U.S. Senate,,DEM,Kamala D. Harris,567
+San Bernardino,RED1113,U.S. Senate,,DEM,Loretta L. Sanchez,347
+San Bernardino,RED1114,U.S. Senate,,DEM,Kamala D. Harris,23
+San Bernardino,RED1114,U.S. Senate,,DEM,Loretta L. Sanchez,17
+San Bernardino,RED1115,U.S. Senate,,DEM,Kamala D. Harris,603
+San Bernardino,RED1115,U.S. Senate,,DEM,Loretta L. Sanchez,359
+San Bernardino,RED1116,U.S. Senate,,DEM,Kamala D. Harris,404
+San Bernardino,RED1116,U.S. Senate,,DEM,Loretta L. Sanchez,229
+San Bernardino,RED1117,U.S. Senate,,DEM,Kamala D. Harris,393
+San Bernardino,RED1117,U.S. Senate,,DEM,Loretta L. Sanchez,213
+San Bernardino,RED1118,U.S. Senate,,DEM,Kamala D. Harris,758
+San Bernardino,RED1118,U.S. Senate,,DEM,Loretta L. Sanchez,443
+San Bernardino,RED1119,U.S. Senate,,DEM,Kamala D. Harris,776
+San Bernardino,RED1119,U.S. Senate,,DEM,Loretta L. Sanchez,402
+San Bernardino,RED1120,U.S. Senate,,DEM,Kamala D. Harris,672
+San Bernardino,RED1120,U.S. Senate,,DEM,Loretta L. Sanchez,348
+San Bernardino,RED1121,U.S. Senate,,DEM,Kamala D. Harris,785
+San Bernardino,RED1121,U.S. Senate,,DEM,Loretta L. Sanchez,402
+San Bernardino,RED1122,U.S. Senate,,DEM,Kamala D. Harris,628
+San Bernardino,RED1122,U.S. Senate,,DEM,Loretta L. Sanchez,310
+San Bernardino,RED1123,U.S. Senate,,DEM,Kamala D. Harris,555
+San Bernardino,RED1123,U.S. Senate,,DEM,Loretta L. Sanchez,277
+San Bernardino,RED1124,U.S. Senate,,DEM,Kamala D. Harris,642
+San Bernardino,RED1124,U.S. Senate,,DEM,Loretta L. Sanchez,390
+San Bernardino,RED1125,U.S. Senate,,DEM,Kamala D. Harris,642
+San Bernardino,RED1125,U.S. Senate,,DEM,Loretta L. Sanchez,408
+San Bernardino,RED1126,U.S. Senate,,DEM,Kamala D. Harris,438
+San Bernardino,RED1126,U.S. Senate,,DEM,Loretta L. Sanchez,310
+San Bernardino,RED1127,U.S. Senate,,DEM,Kamala D. Harris,625
+San Bernardino,RED1127,U.S. Senate,,DEM,Loretta L. Sanchez,410
+San Bernardino,RED1128,U.S. Senate,,DEM,Kamala D. Harris,241
+San Bernardino,RED1128,U.S. Senate,,DEM,Loretta L. Sanchez,133
+San Bernardino,RED1129,U.S. Senate,,DEM,Kamala D. Harris,511
+San Bernardino,RED1129,U.S. Senate,,DEM,Loretta L. Sanchez,304
+San Bernardino,RED1130,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,RED1130,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,RED1131,U.S. Senate,,DEM,Kamala D. Harris,22
+San Bernardino,RED1131,U.S. Senate,,DEM,Loretta L. Sanchez,20
+San Bernardino,RED1132,U.S. Senate,,DEM,Kamala D. Harris,1
+San Bernardino,RED1132,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,RED1133,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,RED1133,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,RED1134,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,RED1134,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,RED1135,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,RED1135,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,RED1136,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,RED1136,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,RED1137,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,RED1137,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,RED1138,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,RED1138,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,RED1139,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,RED1139,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,RED1140,U.S. Senate,,DEM,Kamala D. Harris,7
+San Bernardino,RED1140,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,RED1157,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,RED1157,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,RED1158,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,RED1158,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,RED1159,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,RED1159,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,RED1205,U.S. Senate,,DEM,Kamala D. Harris,68
+San Bernardino,RED1205,U.S. Senate,,DEM,Loretta L. Sanchez,52
+San Bernardino,RED1206,U.S. Senate,,DEM,Kamala D. Harris,18
+San Bernardino,RED1206,U.S. Senate,,DEM,Loretta L. Sanchez,14
+San Bernardino,RED1212,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,RED1212,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,RED1273,U.S. Senate,,DEM,Kamala D. Harris,2
+San Bernardino,RED1273,U.S. Senate,,DEM,Loretta L. Sanchez,2
+San Bernardino,RED1620,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,RED1620,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,RED1621,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,RED1621,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,RED1625,U.S. Senate,,DEM,Kamala D. Harris,349
+San Bernardino,RED1625,U.S. Senate,,DEM,Loretta L. Sanchez,251
+San Bernardino,RED1626,U.S. Senate,,DEM,Kamala D. Harris,371
+San Bernardino,RED1626,U.S. Senate,,DEM,Loretta L. Sanchez,265
+San Bernardino,RED1629,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,RED1629,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,RED1664,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,RED1664,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,RED1665,U.S. Senate,,DEM,Kamala D. Harris,2
+San Bernardino,RED1665,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,RED1667,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,RED1667,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,RED1668,U.S. Senate,,DEM,Kamala D. Harris,2
+San Bernardino,RED1668,U.S. Senate,,DEM,Loretta L. Sanchez,1
+San Bernardino,RED1707,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,RED1707,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,RIA0866,U.S. Senate,,DEM,Kamala D. Harris,6
+San Bernardino,RIA0866,U.S. Senate,,DEM,Loretta L. Sanchez,3
+San Bernardino,RIA0872,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,RIA0872,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,RIA0953,U.S. Senate,,DEM,Kamala D. Harris,348
+San Bernardino,RIA0953,U.S. Senate,,DEM,Loretta L. Sanchez,376
+San Bernardino,RIA0954,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,RIA0954,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,RIA0961,U.S. Senate,,DEM,Kamala D. Harris,699
+San Bernardino,RIA0961,U.S. Senate,,DEM,Loretta L. Sanchez,549
+San Bernardino,RIA0962,U.S. Senate,,DEM,Kamala D. Harris,551
+San Bernardino,RIA0962,U.S. Senate,,DEM,Loretta L. Sanchez,453
+San Bernardino,RIA0963,U.S. Senate,,DEM,Kamala D. Harris,590
+San Bernardino,RIA0963,U.S. Senate,,DEM,Loretta L. Sanchez,468
+San Bernardino,RIA0964,U.S. Senate,,DEM,Kamala D. Harris,592
+San Bernardino,RIA0964,U.S. Senate,,DEM,Loretta L. Sanchez,470
+San Bernardino,RIA0965,U.S. Senate,,DEM,Kamala D. Harris,611
+San Bernardino,RIA0965,U.S. Senate,,DEM,Loretta L. Sanchez,412
+San Bernardino,RIA0966,U.S. Senate,,DEM,Kamala D. Harris,294
+San Bernardino,RIA0966,U.S. Senate,,DEM,Loretta L. Sanchez,162
+San Bernardino,RIA0967,U.S. Senate,,DEM,Kamala D. Harris,673
+San Bernardino,RIA0967,U.S. Senate,,DEM,Loretta L. Sanchez,499
+San Bernardino,RIA0968,U.S. Senate,,DEM,Kamala D. Harris,533
+San Bernardino,RIA0968,U.S. Senate,,DEM,Loretta L. Sanchez,479
+San Bernardino,RIA0969,U.S. Senate,,DEM,Kamala D. Harris,501
+San Bernardino,RIA0969,U.S. Senate,,DEM,Loretta L. Sanchez,472
+San Bernardino,RIA0970,U.S. Senate,,DEM,Kamala D. Harris,598
+San Bernardino,RIA0970,U.S. Senate,,DEM,Loretta L. Sanchez,389
+San Bernardino,RIA0971,U.S. Senate,,DEM,Kamala D. Harris,373
+San Bernardino,RIA0971,U.S. Senate,,DEM,Loretta L. Sanchez,523
+San Bernardino,RIA0972,U.S. Senate,,DEM,Kamala D. Harris,464
+San Bernardino,RIA0972,U.S. Senate,,DEM,Loretta L. Sanchez,441
+San Bernardino,RIA0973,U.S. Senate,,DEM,Kamala D. Harris,378
+San Bernardino,RIA0973,U.S. Senate,,DEM,Loretta L. Sanchez,573
+San Bernardino,RIA0974,U.S. Senate,,DEM,Kamala D. Harris,495
+San Bernardino,RIA0974,U.S. Senate,,DEM,Loretta L. Sanchez,465
+San Bernardino,RIA0975,U.S. Senate,,DEM,Kamala D. Harris,487
+San Bernardino,RIA0975,U.S. Senate,,DEM,Loretta L. Sanchez,401
+San Bernardino,RIA0976,U.S. Senate,,DEM,Kamala D. Harris,491
+San Bernardino,RIA0976,U.S. Senate,,DEM,Loretta L. Sanchez,546
+San Bernardino,RIA0977,U.S. Senate,,DEM,Kamala D. Harris,59
+San Bernardino,RIA0977,U.S. Senate,,DEM,Loretta L. Sanchez,68
+San Bernardino,RIA0978,U.S. Senate,,DEM,Kamala D. Harris,1
+San Bernardino,RIA0978,U.S. Senate,,DEM,Loretta L. Sanchez,1
+San Bernardino,RIA0979,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,RIA0979,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,RIA0980,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,RIA0980,U.S. Senate,,DEM,Loretta L. Sanchez,1
+San Bernardino,RIA1338,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,RIA1338,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,RIA1339,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,RIA1339,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,RIA1340,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,RIA1340,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,RIA1341,U.S. Senate,,DEM,Kamala D. Harris,10
+San Bernardino,RIA1341,U.S. Senate,,DEM,Loretta L. Sanchez,10
+San Bernardino,RIA1342,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,RIA1342,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,RIA1343,U.S. Senate,,DEM,Kamala D. Harris,2
+San Bernardino,RIA1343,U.S. Senate,,DEM,Loretta L. Sanchez,2
+San Bernardino,RIA1344,U.S. Senate,,DEM,Kamala D. Harris,169
+San Bernardino,RIA1344,U.S. Senate,,DEM,Loretta L. Sanchez,260
+San Bernardino,RIA1345,U.S. Senate,,DEM,Kamala D. Harris,8
+San Bernardino,RIA1345,U.S. Senate,,DEM,Loretta L. Sanchez,11
+San Bernardino,RIA1346,U.S. Senate,,DEM,Kamala D. Harris,55
+San Bernardino,RIA1346,U.S. Senate,,DEM,Loretta L. Sanchez,41
+San Bernardino,RIA1347,U.S. Senate,,DEM,Kamala D. Harris,152
+San Bernardino,RIA1347,U.S. Senate,,DEM,Loretta L. Sanchez,191
+San Bernardino,RIA1372,U.S. Senate,,DEM,Kamala D. Harris,283
+San Bernardino,RIA1372,U.S. Senate,,DEM,Loretta L. Sanchez,296
+San Bernardino,RIA1373,U.S. Senate,,DEM,Kamala D. Harris,170
+San Bernardino,RIA1373,U.S. Senate,,DEM,Loretta L. Sanchez,188
+San Bernardino,RIA1374,U.S. Senate,,DEM,Kamala D. Harris,97
+San Bernardino,RIA1374,U.S. Senate,,DEM,Loretta L. Sanchez,82
+San Bernardino,RIA1377,U.S. Senate,,DEM,Kamala D. Harris,296
+San Bernardino,RIA1377,U.S. Senate,,DEM,Loretta L. Sanchez,436
+San Bernardino,RIA1378,U.S. Senate,,DEM,Kamala D. Harris,362
+San Bernardino,RIA1378,U.S. Senate,,DEM,Loretta L. Sanchez,415
+San Bernardino,RIA1379,U.S. Senate,,DEM,Kamala D. Harris,375
+San Bernardino,RIA1379,U.S. Senate,,DEM,Loretta L. Sanchez,434
+San Bernardino,RIA1380,U.S. Senate,,DEM,Kamala D. Harris,534
+San Bernardino,RIA1380,U.S. Senate,,DEM,Loretta L. Sanchez,563
+San Bernardino,RIA1381,U.S. Senate,,DEM,Kamala D. Harris,469
+San Bernardino,RIA1381,U.S. Senate,,DEM,Loretta L. Sanchez,610
+San Bernardino,RIA1382,U.S. Senate,,DEM,Kamala D. Harris,500
+San Bernardino,RIA1382,U.S. Senate,,DEM,Loretta L. Sanchez,604
+San Bernardino,RIA1383,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,RIA1383,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,RIA1384,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,RIA1384,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,RIA1385,U.S. Senate,,DEM,Kamala D. Harris,321
+San Bernardino,RIA1385,U.S. Senate,,DEM,Loretta L. Sanchez,328
+San Bernardino,RIA1640,U.S. Senate,,DEM,Kamala D. Harris,92
+San Bernardino,RIA1640,U.S. Senate,,DEM,Loretta L. Sanchez,153
+San Bernardino,RIA1641,U.S. Senate,,DEM,Kamala D. Harris,1
+San Bernardino,RIA1641,U.S. Senate,,DEM,Loretta L. Sanchez,1
+San Bernardino,RIA1642,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,RIA1642,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,RIA1643,U.S. Senate,,DEM,Kamala D. Harris,2
+San Bernardino,RIA1643,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,RIA1772,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,RIA1772,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,RIA1784,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,RIA1784,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,RIA1785,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,RIA1785,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,RIA1786,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,RIA1786,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,RIA1787,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,RIA1787,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,RIA1788,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,RIA1788,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,SB00696,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,SB00696,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,SB00697,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,SB00697,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,SB00863,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,SB00863,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,SB11002,U.S. Senate,,DEM,Kamala D. Harris,303
+San Bernardino,SB11002,U.S. Senate,,DEM,Loretta L. Sanchez,332
+San Bernardino,SB11003,U.S. Senate,,DEM,Kamala D. Harris,273
+San Bernardino,SB11003,U.S. Senate,,DEM,Loretta L. Sanchez,387
+San Bernardino,SB11004,U.S. Senate,,DEM,Kamala D. Harris,284
+San Bernardino,SB11004,U.S. Senate,,DEM,Loretta L. Sanchez,360
+San Bernardino,SB11005,U.S. Senate,,DEM,Kamala D. Harris,310
+San Bernardino,SB11005,U.S. Senate,,DEM,Loretta L. Sanchez,342
+San Bernardino,SB11006,U.S. Senate,,DEM,Kamala D. Harris,300
+San Bernardino,SB11006,U.S. Senate,,DEM,Loretta L. Sanchez,288
+San Bernardino,SB11160,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,SB11160,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,SB11161,U.S. Senate,,DEM,Kamala D. Harris,77
+San Bernardino,SB11161,U.S. Senate,,DEM,Loretta L. Sanchez,52
+San Bernardino,SB11162,U.S. Senate,,DEM,Kamala D. Harris,1
+San Bernardino,SB11162,U.S. Senate,,DEM,Loretta L. Sanchez,1
+San Bernardino,SB11163,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,SB11163,U.S. Senate,,DEM,Loretta L. Sanchez,2
+San Bernardino,SB11215,U.S. Senate,,DEM,Kamala D. Harris,5
+San Bernardino,SB11215,U.S. Senate,,DEM,Loretta L. Sanchez,16
+San Bernardino,SB11216,U.S. Senate,,DEM,Kamala D. Harris,47
+San Bernardino,SB11216,U.S. Senate,,DEM,Loretta L. Sanchez,48
+San Bernardino,SB11217,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,SB11217,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,SB11218,U.S. Senate,,DEM,Kamala D. Harris,50
+San Bernardino,SB11218,U.S. Senate,,DEM,Loretta L. Sanchez,76
+San Bernardino,SB11219,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,SB11219,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,SB11220,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,SB11220,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,SB11221,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,SB11221,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,SB11222,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,SB11222,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,SB11223,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,SB11223,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,SB11224,U.S. Senate,,DEM,Kamala D. Harris,94
+San Bernardino,SB11224,U.S. Senate,,DEM,Loretta L. Sanchez,78
+San Bernardino,SB11225,U.S. Senate,,DEM,Kamala D. Harris,131
+San Bernardino,SB11225,U.S. Senate,,DEM,Loretta L. Sanchez,94
+San Bernardino,SB11226,U.S. Senate,,DEM,Kamala D. Harris,3
+San Bernardino,SB11226,U.S. Senate,,DEM,Loretta L. Sanchez,1
+San Bernardino,SB11227,U.S. Senate,,DEM,Kamala D. Harris,1
+San Bernardino,SB11227,U.S. Senate,,DEM,Loretta L. Sanchez,1
+San Bernardino,SB11228,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,SB11228,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,SB11229,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,SB11229,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,SB11230,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,SB11230,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,SB11231,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,SB11231,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,SB11232,U.S. Senate,,DEM,Kamala D. Harris,21
+San Bernardino,SB11232,U.S. Senate,,DEM,Loretta L. Sanchez,12
+San Bernardino,SB11233,U.S. Senate,,DEM,Kamala D. Harris,144
+San Bernardino,SB11233,U.S. Senate,,DEM,Loretta L. Sanchez,164
+San Bernardino,SB11632,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,SB11632,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,SB11633,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,SB11633,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,SB11634,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,SB11634,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,SB11635,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,SB11635,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,SB11636,U.S. Senate,,DEM,Kamala D. Harris,1
+San Bernardino,SB11636,U.S. Senate,,DEM,Loretta L. Sanchez,1
+San Bernardino,SB11669,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,SB11669,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,SB11715,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,SB11715,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,SB11720,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,SB11720,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,SB11722,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,SB11722,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,SB21007,U.S. Senate,,DEM,Kamala D. Harris,69
+San Bernardino,SB21007,U.S. Senate,,DEM,Loretta L. Sanchez,94
+San Bernardino,SB21164,U.S. Senate,,DEM,Kamala D. Harris,124
+San Bernardino,SB21164,U.S. Senate,,DEM,Loretta L. Sanchez,86
+San Bernardino,SB21165,U.S. Senate,,DEM,Kamala D. Harris,169
+San Bernardino,SB21165,U.S. Senate,,DEM,Loretta L. Sanchez,181
+San Bernardino,SB21166,U.S. Senate,,DEM,Kamala D. Harris,259
+San Bernardino,SB21166,U.S. Senate,,DEM,Loretta L. Sanchez,202
+San Bernardino,SB21167,U.S. Senate,,DEM,Kamala D. Harris,21
+San Bernardino,SB21167,U.S. Senate,,DEM,Loretta L. Sanchez,36
+San Bernardino,SB21168,U.S. Senate,,DEM,Kamala D. Harris,23
+San Bernardino,SB21168,U.S. Senate,,DEM,Loretta L. Sanchez,21
+San Bernardino,SB21169,U.S. Senate,,DEM,Kamala D. Harris,41
+San Bernardino,SB21169,U.S. Senate,,DEM,Loretta L. Sanchez,17
+San Bernardino,SB21234,U.S. Senate,,DEM,Kamala D. Harris,504
+San Bernardino,SB21234,U.S. Senate,,DEM,Loretta L. Sanchez,452
+San Bernardino,SB21235,U.S. Senate,,DEM,Kamala D. Harris,300
+San Bernardino,SB21235,U.S. Senate,,DEM,Loretta L. Sanchez,271
+San Bernardino,SB21236,U.S. Senate,,DEM,Kamala D. Harris,369
+San Bernardino,SB21236,U.S. Senate,,DEM,Loretta L. Sanchez,298
+San Bernardino,SB21237,U.S. Senate,,DEM,Kamala D. Harris,389
+San Bernardino,SB21237,U.S. Senate,,DEM,Loretta L. Sanchez,358
+San Bernardino,SB21238,U.S. Senate,,DEM,Kamala D. Harris,379
+San Bernardino,SB21238,U.S. Senate,,DEM,Loretta L. Sanchez,398
+San Bernardino,SB21251,U.S. Senate,,DEM,Kamala D. Harris,3
+San Bernardino,SB21251,U.S. Senate,,DEM,Loretta L. Sanchez,4
+San Bernardino,SB21657,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,SB21657,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,SB21662,U.S. Senate,,DEM,Kamala D. Harris,144
+San Bernardino,SB21662,U.S. Senate,,DEM,Loretta L. Sanchez,95
+San Bernardino,SB30914,U.S. Senate,,DEM,Kamala D. Harris,307
+San Bernardino,SB30914,U.S. Senate,,DEM,Loretta L. Sanchez,229
+San Bernardino,SB30940,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,SB30940,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,SB30941,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,SB30941,U.S. Senate,,DEM,Loretta L. Sanchez,4
+San Bernardino,SB30942,U.S. Senate,,DEM,Kamala D. Harris,3
+San Bernardino,SB30942,U.S. Senate,,DEM,Loretta L. Sanchez,2
+San Bernardino,SB30943,U.S. Senate,,DEM,Kamala D. Harris,99
+San Bernardino,SB30943,U.S. Senate,,DEM,Loretta L. Sanchez,104
+San Bernardino,SB30944,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,SB30944,U.S. Senate,,DEM,Loretta L. Sanchez,2
+San Bernardino,SB30945,U.S. Senate,,DEM,Kamala D. Harris,5
+San Bernardino,SB30945,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,SB30946,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,SB30946,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,SB30947,U.S. Senate,,DEM,Kamala D. Harris,2
+San Bernardino,SB30947,U.S. Senate,,DEM,Loretta L. Sanchez,1
+San Bernardino,SB30981,U.S. Senate,,DEM,Kamala D. Harris,348
+San Bernardino,SB30981,U.S. Senate,,DEM,Loretta L. Sanchez,508
+San Bernardino,SB30982,U.S. Senate,,DEM,Kamala D. Harris,206
+San Bernardino,SB30982,U.S. Senate,,DEM,Loretta L. Sanchez,321
+San Bernardino,SB30983,U.S. Senate,,DEM,Kamala D. Harris,232
+San Bernardino,SB30983,U.S. Senate,,DEM,Loretta L. Sanchez,246
+San Bernardino,SB30984,U.S. Senate,,DEM,Kamala D. Harris,105
+San Bernardino,SB30984,U.S. Senate,,DEM,Loretta L. Sanchez,145
+San Bernardino,SB30985,U.S. Senate,,DEM,Kamala D. Harris,136
+San Bernardino,SB30985,U.S. Senate,,DEM,Loretta L. Sanchez,175
+San Bernardino,SB31008,U.S. Senate,,DEM,Kamala D. Harris,229
+San Bernardino,SB31008,U.S. Senate,,DEM,Loretta L. Sanchez,403
+San Bernardino,SB31009,U.S. Senate,,DEM,Kamala D. Harris,3
+San Bernardino,SB31009,U.S. Senate,,DEM,Loretta L. Sanchez,3
+San Bernardino,SB31010,U.S. Senate,,DEM,Kamala D. Harris,215
+San Bernardino,SB31010,U.S. Senate,,DEM,Loretta L. Sanchez,275
+San Bernardino,SB31011,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,SB31011,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,SB31012,U.S. Senate,,DEM,Kamala D. Harris,1
+San Bernardino,SB31012,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,SB31013,U.S. Senate,,DEM,Kamala D. Harris,33
+San Bernardino,SB31013,U.S. Senate,,DEM,Loretta L. Sanchez,29
+San Bernardino,SB31014,U.S. Senate,,DEM,Kamala D. Harris,33
+San Bernardino,SB31014,U.S. Senate,,DEM,Loretta L. Sanchez,44
+San Bernardino,SB31094,U.S. Senate,,DEM,Kamala D. Harris,188
+San Bernardino,SB31094,U.S. Senate,,DEM,Loretta L. Sanchez,130
+San Bernardino,SB31207,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,SB31207,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,SB31208,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,SB31208,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,SB31213,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,SB31213,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,SB31214,U.S. Senate,,DEM,Kamala D. Harris,556
+San Bernardino,SB31214,U.S. Senate,,DEM,Loretta L. Sanchez,442
+San Bernardino,SB31655,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,SB31655,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,SB31656,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,SB31656,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,SB31658,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,SB31658,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,SB31659,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,SB31659,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,SB31660,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,SB31660,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,SB31661,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,SB31661,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,SB31716,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,SB31716,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,SB31717,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,SB31717,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,SB31718,U.S. Senate,,DEM,Kamala D. Harris,34
+San Bernardino,SB31718,U.S. Senate,,DEM,Loretta L. Sanchez,38
+San Bernardino,SB31719,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,SB31719,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,SB31721,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,SB31721,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,SB40615,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,SB40615,U.S. Senate,,DEM,Loretta L. Sanchez,2
+San Bernardino,SB40616,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,SB40616,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,SB40617,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,SB40617,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,SB40618,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,SB40618,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,SB40637,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,SB40637,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,SB40638,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,SB40638,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,SB40710,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,SB40710,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,SB40712,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,SB40712,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,SB41141,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,SB41141,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,SB41142,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,SB41142,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,SB41170,U.S. Senate,,DEM,Kamala D. Harris,519
+San Bernardino,SB41170,U.S. Senate,,DEM,Loretta L. Sanchez,323
+San Bernardino,SB41171,U.S. Senate,,DEM,Kamala D. Harris,3
+San Bernardino,SB41171,U.S. Senate,,DEM,Loretta L. Sanchez,3
+San Bernardino,SB41172,U.S. Senate,,DEM,Kamala D. Harris,2
+San Bernardino,SB41172,U.S. Senate,,DEM,Loretta L. Sanchez,6
+San Bernardino,SB41173,U.S. Senate,,DEM,Kamala D. Harris,413
+San Bernardino,SB41173,U.S. Senate,,DEM,Loretta L. Sanchez,268
+San Bernardino,SB41174,U.S. Senate,,DEM,Kamala D. Harris,431
+San Bernardino,SB41174,U.S. Senate,,DEM,Loretta L. Sanchez,281
+San Bernardino,SB41175,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,SB41175,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,SB41176,U.S. Senate,,DEM,Kamala D. Harris,3
+San Bernardino,SB41176,U.S. Senate,,DEM,Loretta L. Sanchez,6
+San Bernardino,SB41177,U.S. Senate,,DEM,Kamala D. Harris,83
+San Bernardino,SB41177,U.S. Senate,,DEM,Loretta L. Sanchez,68
+San Bernardino,SB41178,U.S. Senate,,DEM,Kamala D. Harris,1
+San Bernardino,SB41178,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,SB41179,U.S. Senate,,DEM,Kamala D. Harris,160
+San Bernardino,SB41179,U.S. Senate,,DEM,Loretta L. Sanchez,111
+San Bernardino,SB41180,U.S. Senate,,DEM,Kamala D. Harris,442
+San Bernardino,SB41180,U.S. Senate,,DEM,Loretta L. Sanchez,247
+San Bernardino,SB41181,U.S. Senate,,DEM,Kamala D. Harris,33
+San Bernardino,SB41181,U.S. Senate,,DEM,Loretta L. Sanchez,8
+San Bernardino,SB41182,U.S. Senate,,DEM,Kamala D. Harris,100
+San Bernardino,SB41182,U.S. Senate,,DEM,Loretta L. Sanchez,54
+San Bernardino,SB41183,U.S. Senate,,DEM,Kamala D. Harris,284
+San Bernardino,SB41183,U.S. Senate,,DEM,Loretta L. Sanchez,160
+San Bernardino,SB41184,U.S. Senate,,DEM,Kamala D. Harris,30
+San Bernardino,SB41184,U.S. Senate,,DEM,Loretta L. Sanchez,25
+San Bernardino,SB41185,U.S. Senate,,DEM,Kamala D. Harris,84
+San Bernardino,SB41185,U.S. Senate,,DEM,Loretta L. Sanchez,47
+San Bernardino,SB41186,U.S. Senate,,DEM,Kamala D. Harris,459
+San Bernardino,SB41186,U.S. Senate,,DEM,Loretta L. Sanchez,327
+San Bernardino,SB41187,U.S. Senate,,DEM,Kamala D. Harris,53
+San Bernardino,SB41187,U.S. Senate,,DEM,Loretta L. Sanchez,32
+San Bernardino,SB41197,U.S. Senate,,DEM,Kamala D. Harris,75
+San Bernardino,SB41197,U.S. Senate,,DEM,Loretta L. Sanchez,36
+San Bernardino,SB41239,U.S. Senate,,DEM,Kamala D. Harris,618
+San Bernardino,SB41239,U.S. Senate,,DEM,Loretta L. Sanchez,461
+San Bernardino,SB41240,U.S. Senate,,DEM,Kamala D. Harris,522
+San Bernardino,SB41240,U.S. Senate,,DEM,Loretta L. Sanchez,398
+San Bernardino,SB41241,U.S. Senate,,DEM,Kamala D. Harris,602
+San Bernardino,SB41241,U.S. Senate,,DEM,Loretta L. Sanchez,438
+San Bernardino,SB41672,U.S. Senate,,DEM,Kamala D. Harris,48
+San Bernardino,SB41672,U.S. Senate,,DEM,Loretta L. Sanchez,31
+San Bernardino,SB41674,U.S. Senate,,DEM,Kamala D. Harris,1
+San Bernardino,SB41674,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,SB41675,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,SB41675,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,SB41723,U.S. Senate,,DEM,Kamala D. Harris,228
+San Bernardino,SB41723,U.S. Senate,,DEM,Loretta L. Sanchez,142
+San Bernardino,SB41724,U.S. Senate,,DEM,Kamala D. Harris,78
+San Bernardino,SB41724,U.S. Senate,,DEM,Loretta L. Sanchez,60
+San Bernardino,SB41743,U.S. Senate,,DEM,Kamala D. Harris,88
+San Bernardino,SB41743,U.S. Senate,,DEM,Loretta L. Sanchez,51
+San Bernardino,SB51085,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,SB51085,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,SB51087,U.S. Senate,,DEM,Kamala D. Harris,585
+San Bernardino,SB51087,U.S. Senate,,DEM,Loretta L. Sanchez,329
+San Bernardino,SB51088,U.S. Senate,,DEM,Kamala D. Harris,557
+San Bernardino,SB51088,U.S. Senate,,DEM,Loretta L. Sanchez,358
+San Bernardino,SB51089,U.S. Senate,,DEM,Kamala D. Harris,532
+San Bernardino,SB51089,U.S. Senate,,DEM,Loretta L. Sanchez,325
+San Bernardino,SB51090,U.S. Senate,,DEM,Kamala D. Harris,543
+San Bernardino,SB51090,U.S. Senate,,DEM,Loretta L. Sanchez,336
+San Bernardino,SB51242,U.S. Senate,,DEM,Kamala D. Harris,52
+San Bernardino,SB51242,U.S. Senate,,DEM,Loretta L. Sanchez,49
+San Bernardino,SB51243,U.S. Senate,,DEM,Kamala D. Harris,229
+San Bernardino,SB51243,U.S. Senate,,DEM,Loretta L. Sanchez,192
+San Bernardino,SB51244,U.S. Senate,,DEM,Kamala D. Harris,536
+San Bernardino,SB51244,U.S. Senate,,DEM,Loretta L. Sanchez,306
+San Bernardino,SB51245,U.S. Senate,,DEM,Kamala D. Harris,644
+San Bernardino,SB51245,U.S. Senate,,DEM,Loretta L. Sanchez,415
+San Bernardino,SB51246,U.S. Senate,,DEM,Kamala D. Harris,599
+San Bernardino,SB51246,U.S. Senate,,DEM,Loretta L. Sanchez,461
+San Bernardino,SB51247,U.S. Senate,,DEM,Kamala D. Harris,627
+San Bernardino,SB51247,U.S. Senate,,DEM,Loretta L. Sanchez,399
+San Bernardino,SB51248,U.S. Senate,,DEM,Kamala D. Harris,555
+San Bernardino,SB51248,U.S. Senate,,DEM,Loretta L. Sanchez,352
+San Bernardino,SB60873,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,SB60873,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,SB60986,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,SB60986,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,SB60987,U.S. Senate,,DEM,Kamala D. Harris,472
+San Bernardino,SB60987,U.S. Senate,,DEM,Loretta L. Sanchez,422
+San Bernardino,SB60988,U.S. Senate,,DEM,Kamala D. Harris,420
+San Bernardino,SB60988,U.S. Senate,,DEM,Loretta L. Sanchez,431
+San Bernardino,SB60989,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,SB60989,U.S. Senate,,DEM,Loretta L. Sanchez,1
+San Bernardino,SB61015,U.S. Senate,,DEM,Kamala D. Harris,383
+San Bernardino,SB61015,U.S. Senate,,DEM,Loretta L. Sanchez,295
+San Bernardino,SB61016,U.S. Senate,,DEM,Kamala D. Harris,498
+San Bernardino,SB61016,U.S. Senate,,DEM,Loretta L. Sanchez,381
+San Bernardino,SB61017,U.S. Senate,,DEM,Kamala D. Harris,376
+San Bernardino,SB61017,U.S. Senate,,DEM,Loretta L. Sanchez,408
+San Bernardino,SB61018,U.S. Senate,,DEM,Kamala D. Harris,1
+San Bernardino,SB61018,U.S. Senate,,DEM,Loretta L. Sanchez,3
+San Bernardino,SB61019,U.S. Senate,,DEM,Kamala D. Harris,208
+San Bernardino,SB61019,U.S. Senate,,DEM,Loretta L. Sanchez,193
+San Bernardino,SB61020,U.S. Senate,,DEM,Kamala D. Harris,107
+San Bernardino,SB61020,U.S. Senate,,DEM,Loretta L. Sanchez,112
+San Bernardino,SB61021,U.S. Senate,,DEM,Kamala D. Harris,40
+San Bernardino,SB61021,U.S. Senate,,DEM,Loretta L. Sanchez,14
+San Bernardino,SB61249,U.S. Senate,,DEM,Kamala D. Harris,218
+San Bernardino,SB61249,U.S. Senate,,DEM,Loretta L. Sanchez,266
+San Bernardino,SB61250,U.S. Senate,,DEM,Kamala D. Harris,325
+San Bernardino,SB61250,U.S. Senate,,DEM,Loretta L. Sanchez,293
+San Bernardino,SB61252,U.S. Senate,,DEM,Kamala D. Harris,13
+San Bernardino,SB61252,U.S. Senate,,DEM,Loretta L. Sanchez,6
+San Bernardino,SB61253,U.S. Senate,,DEM,Kamala D. Harris,9
+San Bernardino,SB61253,U.S. Senate,,DEM,Loretta L. Sanchez,15
+San Bernardino,SB61619,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,SB61619,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,SB61654,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,SB61654,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,SB61663,U.S. Senate,,DEM,Kamala D. Harris,28
+San Bernardino,SB61663,U.S. Senate,,DEM,Loretta L. Sanchez,38
+San Bernardino,SB71188,U.S. Senate,,DEM,Kamala D. Harris,526
+San Bernardino,SB71188,U.S. Senate,,DEM,Loretta L. Sanchez,361
+San Bernardino,SB71189,U.S. Senate,,DEM,Kamala D. Harris,168
+San Bernardino,SB71189,U.S. Senate,,DEM,Loretta L. Sanchez,164
+San Bernardino,SB71190,U.S. Senate,,DEM,Kamala D. Harris,499
+San Bernardino,SB71190,U.S. Senate,,DEM,Loretta L. Sanchez,408
+San Bernardino,SB71191,U.S. Senate,,DEM,Kamala D. Harris,61
+San Bernardino,SB71191,U.S. Senate,,DEM,Loretta L. Sanchez,62
+San Bernardino,SB71192,U.S. Senate,,DEM,Kamala D. Harris,185
+San Bernardino,SB71192,U.S. Senate,,DEM,Loretta L. Sanchez,129
+San Bernardino,SB71193,U.S. Senate,,DEM,Kamala D. Harris,139
+San Bernardino,SB71193,U.S. Senate,,DEM,Loretta L. Sanchez,107
+San Bernardino,SB71194,U.S. Senate,,DEM,Kamala D. Harris,2
+San Bernardino,SB71194,U.S. Senate,,DEM,Loretta L. Sanchez,2
+San Bernardino,SB71195,U.S. Senate,,DEM,Kamala D. Harris,207
+San Bernardino,SB71195,U.S. Senate,,DEM,Loretta L. Sanchez,158
+San Bernardino,SB71196,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,SB71196,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,SB71198,U.S. Senate,,DEM,Kamala D. Harris,192
+San Bernardino,SB71198,U.S. Senate,,DEM,Loretta L. Sanchez,139
+San Bernardino,SB71254,U.S. Senate,,DEM,Kamala D. Harris,558
+San Bernardino,SB71254,U.S. Senate,,DEM,Loretta L. Sanchez,406
+San Bernardino,SB71255,U.S. Senate,,DEM,Kamala D. Harris,565
+San Bernardino,SB71255,U.S. Senate,,DEM,Loretta L. Sanchez,387
+San Bernardino,SB71256,U.S. Senate,,DEM,Kamala D. Harris,389
+San Bernardino,SB71256,U.S. Senate,,DEM,Loretta L. Sanchez,381
+San Bernardino,SB71257,U.S. Senate,,DEM,Kamala D. Harris,346
+San Bernardino,SB71257,U.S. Senate,,DEM,Loretta L. Sanchez,233
+San Bernardino,SB71670,U.S. Senate,,DEM,Kamala D. Harris,98
+San Bernardino,SB71670,U.S. Senate,,DEM,Loretta L. Sanchez,48
+San Bernardino,SB71671,U.S. Senate,,DEM,Kamala D. Harris,8
+San Bernardino,SB71671,U.S. Senate,,DEM,Loretta L. Sanchez,4
+San Bernardino,TWE0210,U.S. Senate,,DEM,Kamala D. Harris,110
+San Bernardino,TWE0210,U.S. Senate,,DEM,Loretta L. Sanchez,94
+San Bernardino,TWE0211,U.S. Senate,,DEM,Kamala D. Harris,624
+San Bernardino,TWE0211,U.S. Senate,,DEM,Loretta L. Sanchez,399
+San Bernardino,TWE0212,U.S. Senate,,DEM,Kamala D. Harris,631
+San Bernardino,TWE0212,U.S. Senate,,DEM,Loretta L. Sanchez,379
+San Bernardino,TWE0213,U.S. Senate,,DEM,Kamala D. Harris,371
+San Bernardino,TWE0213,U.S. Senate,,DEM,Loretta L. Sanchez,224
+San Bernardino,TWE0214,U.S. Senate,,DEM,Kamala D. Harris,375
+San Bernardino,TWE0214,U.S. Senate,,DEM,Loretta L. Sanchez,237
+San Bernardino,TWE0215,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,TWE0215,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0002,U.S. Senate,,DEM,Kamala D. Harris,7
+San Bernardino,UNI0002,U.S. Senate,,DEM,Loretta L. Sanchez,4
+San Bernardino,UNI0003,U.S. Senate,,DEM,Kamala D. Harris,7
+San Bernardino,UNI0003,U.S. Senate,,DEM,Loretta L. Sanchez,7
+San Bernardino,UNI0004,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0004,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0005,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0005,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0006,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0006,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0007,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0007,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0008,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0008,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0009,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0009,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0010,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0010,U.S. Senate,,DEM,Loretta L. Sanchez,1
+San Bernardino,UNI0011,U.S. Senate,,DEM,Kamala D. Harris,332
+San Bernardino,UNI0011,U.S. Senate,,DEM,Loretta L. Sanchez,367
+San Bernardino,UNI0012,U.S. Senate,,DEM,Kamala D. Harris,113
+San Bernardino,UNI0012,U.S. Senate,,DEM,Loretta L. Sanchez,127
+San Bernardino,UNI0013,U.S. Senate,,DEM,Kamala D. Harris,92
+San Bernardino,UNI0013,U.S. Senate,,DEM,Loretta L. Sanchez,83
+San Bernardino,UNI0014,U.S. Senate,,DEM,Kamala D. Harris,216
+San Bernardino,UNI0014,U.S. Senate,,DEM,Loretta L. Sanchez,198
+San Bernardino,UNI0015,U.S. Senate,,DEM,Kamala D. Harris,91
+San Bernardino,UNI0015,U.S. Senate,,DEM,Loretta L. Sanchez,73
+San Bernardino,UNI0016,U.S. Senate,,DEM,Kamala D. Harris,44
+San Bernardino,UNI0016,U.S. Senate,,DEM,Loretta L. Sanchez,39
+San Bernardino,UNI0017,U.S. Senate,,DEM,Kamala D. Harris,112
+San Bernardino,UNI0017,U.S. Senate,,DEM,Loretta L. Sanchez,101
+San Bernardino,UNI0018,U.S. Senate,,DEM,Kamala D. Harris,80
+San Bernardino,UNI0018,U.S. Senate,,DEM,Loretta L. Sanchez,67
+San Bernardino,UNI0019,U.S. Senate,,DEM,Kamala D. Harris,32
+San Bernardino,UNI0019,U.S. Senate,,DEM,Loretta L. Sanchez,21
+San Bernardino,UNI0020,U.S. Senate,,DEM,Kamala D. Harris,38
+San Bernardino,UNI0020,U.S. Senate,,DEM,Loretta L. Sanchez,26
+San Bernardino,UNI0021,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0021,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0022,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0022,U.S. Senate,,DEM,Loretta L. Sanchez,2
+San Bernardino,UNI0023,U.S. Senate,,DEM,Kamala D. Harris,24
+San Bernardino,UNI0023,U.S. Senate,,DEM,Loretta L. Sanchez,32
+San Bernardino,UNI0024,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0024,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0025,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0025,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0026,U.S. Senate,,DEM,Kamala D. Harris,6
+San Bernardino,UNI0026,U.S. Senate,,DEM,Loretta L. Sanchez,3
+San Bernardino,UNI0027,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0027,U.S. Senate,,DEM,Loretta L. Sanchez,1
+San Bernardino,UNI0028,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0028,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0029,U.S. Senate,,DEM,Kamala D. Harris,6
+San Bernardino,UNI0029,U.S. Senate,,DEM,Loretta L. Sanchez,4
+San Bernardino,UNI0030,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0030,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0031,U.S. Senate,,DEM,Kamala D. Harris,104
+San Bernardino,UNI0031,U.S. Senate,,DEM,Loretta L. Sanchez,98
+San Bernardino,UNI0032,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0032,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0033,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0033,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0034,U.S. Senate,,DEM,Kamala D. Harris,11
+San Bernardino,UNI0034,U.S. Senate,,DEM,Loretta L. Sanchez,11
+San Bernardino,UNI0035,U.S. Senate,,DEM,Kamala D. Harris,18
+San Bernardino,UNI0035,U.S. Senate,,DEM,Loretta L. Sanchez,12
+San Bernardino,UNI0036,U.S. Senate,,DEM,Kamala D. Harris,9
+San Bernardino,UNI0036,U.S. Senate,,DEM,Loretta L. Sanchez,2
+San Bernardino,UNI0037,U.S. Senate,,DEM,Kamala D. Harris,5
+San Bernardino,UNI0037,U.S. Senate,,DEM,Loretta L. Sanchez,3
+San Bernardino,UNI0038,U.S. Senate,,DEM,Kamala D. Harris,2
+San Bernardino,UNI0038,U.S. Senate,,DEM,Loretta L. Sanchez,1
+San Bernardino,UNI0039,U.S. Senate,,DEM,Kamala D. Harris,315
+San Bernardino,UNI0039,U.S. Senate,,DEM,Loretta L. Sanchez,356
+San Bernardino,UNI0040,U.S. Senate,,DEM,Kamala D. Harris,10
+San Bernardino,UNI0040,U.S. Senate,,DEM,Loretta L. Sanchez,16
+San Bernardino,UNI0041,U.S. Senate,,DEM,Kamala D. Harris,24
+San Bernardino,UNI0041,U.S. Senate,,DEM,Loretta L. Sanchez,22
+San Bernardino,UNI0042,U.S. Senate,,DEM,Kamala D. Harris,216
+San Bernardino,UNI0042,U.S. Senate,,DEM,Loretta L. Sanchez,204
+San Bernardino,UNI0043,U.S. Senate,,DEM,Kamala D. Harris,52
+San Bernardino,UNI0043,U.S. Senate,,DEM,Loretta L. Sanchez,56
+San Bernardino,UNI0044,U.S. Senate,,DEM,Kamala D. Harris,71
+San Bernardino,UNI0044,U.S. Senate,,DEM,Loretta L. Sanchez,56
+San Bernardino,UNI0045,U.S. Senate,,DEM,Kamala D. Harris,13
+San Bernardino,UNI0045,U.S. Senate,,DEM,Loretta L. Sanchez,15
+San Bernardino,UNI0046,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0046,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0047,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0047,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0048,U.S. Senate,,DEM,Kamala D. Harris,1
+San Bernardino,UNI0048,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0049,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0049,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0050,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0050,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0051,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0051,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0052,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0052,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0053,U.S. Senate,,DEM,Kamala D. Harris,8
+San Bernardino,UNI0053,U.S. Senate,,DEM,Loretta L. Sanchez,8
+San Bernardino,UNI0054,U.S. Senate,,DEM,Kamala D. Harris,19
+San Bernardino,UNI0054,U.S. Senate,,DEM,Loretta L. Sanchez,27
+San Bernardino,UNI0055,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0055,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0056,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0056,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0057,U.S. Senate,,DEM,Kamala D. Harris,8
+San Bernardino,UNI0057,U.S. Senate,,DEM,Loretta L. Sanchez,1
+San Bernardino,UNI0058,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0058,U.S. Senate,,DEM,Loretta L. Sanchez,1
+San Bernardino,UNI0059,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0059,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0062,U.S. Senate,,DEM,Kamala D. Harris,15
+San Bernardino,UNI0062,U.S. Senate,,DEM,Loretta L. Sanchez,15
+San Bernardino,UNI0063,U.S. Senate,,DEM,Kamala D. Harris,105
+San Bernardino,UNI0063,U.S. Senate,,DEM,Loretta L. Sanchez,76
+San Bernardino,UNI0064,U.S. Senate,,DEM,Kamala D. Harris,1
+San Bernardino,UNI0064,U.S. Senate,,DEM,Loretta L. Sanchez,3
+San Bernardino,UNI0065,U.S. Senate,,DEM,Kamala D. Harris,7
+San Bernardino,UNI0065,U.S. Senate,,DEM,Loretta L. Sanchez,2
+San Bernardino,UNI0066,U.S. Senate,,DEM,Kamala D. Harris,58
+San Bernardino,UNI0066,U.S. Senate,,DEM,Loretta L. Sanchez,33
+San Bernardino,UNI0067,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0067,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0068,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0068,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0069,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0069,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0070,U.S. Senate,,DEM,Kamala D. Harris,8
+San Bernardino,UNI0070,U.S. Senate,,DEM,Loretta L. Sanchez,6
+San Bernardino,UNI0071,U.S. Senate,,DEM,Kamala D. Harris,4
+San Bernardino,UNI0071,U.S. Senate,,DEM,Loretta L. Sanchez,1
+San Bernardino,UNI0072,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0072,U.S. Senate,,DEM,Loretta L. Sanchez,1
+San Bernardino,UNI0073,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0073,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0074,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0074,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0075,U.S. Senate,,DEM,Kamala D. Harris,29
+San Bernardino,UNI0075,U.S. Senate,,DEM,Loretta L. Sanchez,30
+San Bernardino,UNI0076,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0076,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0077,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0077,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0078,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0078,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0079,U.S. Senate,,DEM,Kamala D. Harris,10
+San Bernardino,UNI0079,U.S. Senate,,DEM,Loretta L. Sanchez,12
+San Bernardino,UNI0080,U.S. Senate,,DEM,Kamala D. Harris,39
+San Bernardino,UNI0080,U.S. Senate,,DEM,Loretta L. Sanchez,35
+San Bernardino,UNI0081,U.S. Senate,,DEM,Kamala D. Harris,9
+San Bernardino,UNI0081,U.S. Senate,,DEM,Loretta L. Sanchez,5
+San Bernardino,UNI0082,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0082,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0083,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0083,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0084,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0084,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0085,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0085,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0086,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0086,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0087,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0087,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0088,U.S. Senate,,DEM,Kamala D. Harris,7
+San Bernardino,UNI0088,U.S. Senate,,DEM,Loretta L. Sanchez,3
+San Bernardino,UNI0089,U.S. Senate,,DEM,Kamala D. Harris,42
+San Bernardino,UNI0089,U.S. Senate,,DEM,Loretta L. Sanchez,57
+San Bernardino,UNI0090,U.S. Senate,,DEM,Kamala D. Harris,143
+San Bernardino,UNI0090,U.S. Senate,,DEM,Loretta L. Sanchez,140
+San Bernardino,UNI0091,U.S. Senate,,DEM,Kamala D. Harris,14
+San Bernardino,UNI0091,U.S. Senate,,DEM,Loretta L. Sanchez,9
+San Bernardino,UNI0092,U.S. Senate,,DEM,Kamala D. Harris,5
+San Bernardino,UNI0092,U.S. Senate,,DEM,Loretta L. Sanchez,1
+San Bernardino,UNI0093,U.S. Senate,,DEM,Kamala D. Harris,60
+San Bernardino,UNI0093,U.S. Senate,,DEM,Loretta L. Sanchez,58
+San Bernardino,UNI0094,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0094,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0095,U.S. Senate,,DEM,Kamala D. Harris,1
+San Bernardino,UNI0095,U.S. Senate,,DEM,Loretta L. Sanchez,1
+San Bernardino,UNI0096,U.S. Senate,,DEM,Kamala D. Harris,42
+San Bernardino,UNI0096,U.S. Senate,,DEM,Loretta L. Sanchez,23
+San Bernardino,UNI0097,U.S. Senate,,DEM,Kamala D. Harris,229
+San Bernardino,UNI0097,U.S. Senate,,DEM,Loretta L. Sanchez,179
+San Bernardino,UNI0098,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0098,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0099,U.S. Senate,,DEM,Kamala D. Harris,1
+San Bernardino,UNI0099,U.S. Senate,,DEM,Loretta L. Sanchez,2
+San Bernardino,UNI0100,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0100,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0101,U.S. Senate,,DEM,Kamala D. Harris,187
+San Bernardino,UNI0101,U.S. Senate,,DEM,Loretta L. Sanchez,128
+San Bernardino,UNI0102,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0102,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0103,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0103,U.S. Senate,,DEM,Loretta L. Sanchez,1
+San Bernardino,UNI0104,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0104,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0105,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0105,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0106,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0106,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0107,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0107,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0108,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0108,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0109,U.S. Senate,,DEM,Kamala D. Harris,198
+San Bernardino,UNI0109,U.S. Senate,,DEM,Loretta L. Sanchez,195
+San Bernardino,UNI0112,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0112,U.S. Senate,,DEM,Loretta L. Sanchez,6
+San Bernardino,UNI0113,U.S. Senate,,DEM,Kamala D. Harris,2
+San Bernardino,UNI0113,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0114,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0114,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0115,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0115,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0116,U.S. Senate,,DEM,Kamala D. Harris,1
+San Bernardino,UNI0116,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0117,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0117,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0118,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0118,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0119,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0119,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0120,U.S. Senate,,DEM,Kamala D. Harris,608
+San Bernardino,UNI0120,U.S. Senate,,DEM,Loretta L. Sanchez,504
+San Bernardino,UNI0121,U.S. Senate,,DEM,Kamala D. Harris,423
+San Bernardino,UNI0121,U.S. Senate,,DEM,Loretta L. Sanchez,401
+San Bernardino,UNI0122,U.S. Senate,,DEM,Kamala D. Harris,9
+San Bernardino,UNI0122,U.S. Senate,,DEM,Loretta L. Sanchez,8
+San Bernardino,UNI0123,U.S. Senate,,DEM,Kamala D. Harris,18
+San Bernardino,UNI0123,U.S. Senate,,DEM,Loretta L. Sanchez,24
+San Bernardino,UNI0124,U.S. Senate,,DEM,Kamala D. Harris,14
+San Bernardino,UNI0124,U.S. Senate,,DEM,Loretta L. Sanchez,19
+San Bernardino,UNI0125,U.S. Senate,,DEM,Kamala D. Harris,25
+San Bernardino,UNI0125,U.S. Senate,,DEM,Loretta L. Sanchez,25
+San Bernardino,UNI0126,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0126,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0127,U.S. Senate,,DEM,Kamala D. Harris,9
+San Bernardino,UNI0127,U.S. Senate,,DEM,Loretta L. Sanchez,11
+San Bernardino,UNI0128,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0128,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0129,U.S. Senate,,DEM,Kamala D. Harris,30
+San Bernardino,UNI0129,U.S. Senate,,DEM,Loretta L. Sanchez,27
+San Bernardino,UNI0130,U.S. Senate,,DEM,Kamala D. Harris,21
+San Bernardino,UNI0130,U.S. Senate,,DEM,Loretta L. Sanchez,23
+San Bernardino,UNI0131,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0131,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0145,U.S. Senate,,DEM,Kamala D. Harris,7
+San Bernardino,UNI0145,U.S. Senate,,DEM,Loretta L. Sanchez,3
+San Bernardino,UNI0146,U.S. Senate,,DEM,Kamala D. Harris,40
+San Bernardino,UNI0146,U.S. Senate,,DEM,Loretta L. Sanchez,26
+San Bernardino,UNI0147,U.S. Senate,,DEM,Kamala D. Harris,12
+San Bernardino,UNI0147,U.S. Senate,,DEM,Loretta L. Sanchez,12
+San Bernardino,UNI0148,U.S. Senate,,DEM,Kamala D. Harris,349
+San Bernardino,UNI0148,U.S. Senate,,DEM,Loretta L. Sanchez,329
+San Bernardino,UNI0149,U.S. Senate,,DEM,Kamala D. Harris,23
+San Bernardino,UNI0149,U.S. Senate,,DEM,Loretta L. Sanchez,22
+San Bernardino,UNI0150,U.S. Senate,,DEM,Kamala D. Harris,3
+San Bernardino,UNI0150,U.S. Senate,,DEM,Loretta L. Sanchez,2
+San Bernardino,UNI0151,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0151,U.S. Senate,,DEM,Loretta L. Sanchez,1
+San Bernardino,UNI0152,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0152,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0153,U.S. Senate,,DEM,Kamala D. Harris,130
+San Bernardino,UNI0153,U.S. Senate,,DEM,Loretta L. Sanchez,71
+San Bernardino,UNI0154,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0154,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0155,U.S. Senate,,DEM,Kamala D. Harris,222
+San Bernardino,UNI0155,U.S. Senate,,DEM,Loretta L. Sanchez,190
+San Bernardino,UNI0156,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0156,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0157,U.S. Senate,,DEM,Kamala D. Harris,529
+San Bernardino,UNI0157,U.S. Senate,,DEM,Loretta L. Sanchez,457
+San Bernardino,UNI0158,U.S. Senate,,DEM,Kamala D. Harris,72
+San Bernardino,UNI0158,U.S. Senate,,DEM,Loretta L. Sanchez,50
+San Bernardino,UNI0159,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0159,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0160,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0160,U.S. Senate,,DEM,Loretta L. Sanchez,1
+San Bernardino,UNI0161,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0161,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0162,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0162,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0163,U.S. Senate,,DEM,Kamala D. Harris,16
+San Bernardino,UNI0163,U.S. Senate,,DEM,Loretta L. Sanchez,3
+San Bernardino,UNI0164,U.S. Senate,,DEM,Kamala D. Harris,43
+San Bernardino,UNI0164,U.S. Senate,,DEM,Loretta L. Sanchez,50
+San Bernardino,UNI0165,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0165,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0166,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0166,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0167,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0167,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0168,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0168,U.S. Senate,,DEM,Loretta L. Sanchez,2
+San Bernardino,UNI0169,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0169,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0170,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0170,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0171,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0171,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0172,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0172,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0173,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0173,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0174,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0174,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0175,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0175,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0176,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0176,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0177,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0177,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0178,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0178,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0180,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0180,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0181,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0181,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0182,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0182,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0183,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0183,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0184,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0184,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0185,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0185,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0186,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0186,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0187,U.S. Senate,,DEM,Kamala D. Harris,6
+San Bernardino,UNI0187,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0188,U.S. Senate,,DEM,Kamala D. Harris,34
+San Bernardino,UNI0188,U.S. Senate,,DEM,Loretta L. Sanchez,16
+San Bernardino,UNI0189,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0189,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0190,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0190,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0191,U.S. Senate,,DEM,Kamala D. Harris,8
+San Bernardino,UNI0191,U.S. Senate,,DEM,Loretta L. Sanchez,3
+San Bernardino,UNI0192,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0192,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0193,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0193,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0194,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0194,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0195,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0195,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0196,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0196,U.S. Senate,,DEM,Loretta L. Sanchez,1
+San Bernardino,UNI0197,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0197,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0198,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0198,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0199,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0199,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0200,U.S. Senate,,DEM,Kamala D. Harris,9
+San Bernardino,UNI0200,U.S. Senate,,DEM,Loretta L. Sanchez,8
+San Bernardino,UNI0201,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0201,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0202,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0202,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0203,U.S. Senate,,DEM,Kamala D. Harris,170
+San Bernardino,UNI0203,U.S. Senate,,DEM,Loretta L. Sanchez,89
+San Bernardino,UNI0204,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0204,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0205,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0205,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0206,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0206,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0207,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0207,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0208,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0208,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0209,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0209,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0216,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0216,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0217,U.S. Senate,,DEM,Kamala D. Harris,22
+San Bernardino,UNI0217,U.S. Senate,,DEM,Loretta L. Sanchez,11
+San Bernardino,UNI0218,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0218,U.S. Senate,,DEM,Loretta L. Sanchez,1
+San Bernardino,UNI0219,U.S. Senate,,DEM,Kamala D. Harris,8
+San Bernardino,UNI0219,U.S. Senate,,DEM,Loretta L. Sanchez,2
+San Bernardino,UNI0220,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0220,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0221,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0221,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0222,U.S. Senate,,DEM,Kamala D. Harris,68
+San Bernardino,UNI0222,U.S. Senate,,DEM,Loretta L. Sanchez,34
+San Bernardino,UNI0223,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0223,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0224,U.S. Senate,,DEM,Kamala D. Harris,202
+San Bernardino,UNI0224,U.S. Senate,,DEM,Loretta L. Sanchez,135
+San Bernardino,UNI0225,U.S. Senate,,DEM,Kamala D. Harris,21
+San Bernardino,UNI0225,U.S. Senate,,DEM,Loretta L. Sanchez,10
+San Bernardino,UNI0226,U.S. Senate,,DEM,Kamala D. Harris,163
+San Bernardino,UNI0226,U.S. Senate,,DEM,Loretta L. Sanchez,88
+San Bernardino,UNI0227,U.S. Senate,,DEM,Kamala D. Harris,621
+San Bernardino,UNI0227,U.S. Senate,,DEM,Loretta L. Sanchez,301
+San Bernardino,UNI0228,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0228,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0229,U.S. Senate,,DEM,Kamala D. Harris,164
+San Bernardino,UNI0229,U.S. Senate,,DEM,Loretta L. Sanchez,109
+San Bernardino,UNI0230,U.S. Senate,,DEM,Kamala D. Harris,699
+San Bernardino,UNI0230,U.S. Senate,,DEM,Loretta L. Sanchez,322
+San Bernardino,UNI0231,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0231,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0232,U.S. Senate,,DEM,Kamala D. Harris,33
+San Bernardino,UNI0232,U.S. Senate,,DEM,Loretta L. Sanchez,16
+San Bernardino,UNI0233,U.S. Senate,,DEM,Kamala D. Harris,5
+San Bernardino,UNI0233,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0234,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0234,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0235,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0235,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0236,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0236,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0237,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0237,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0238,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0238,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0239,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0239,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0240,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0240,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0241,U.S. Senate,,DEM,Kamala D. Harris,4
+San Bernardino,UNI0241,U.S. Senate,,DEM,Loretta L. Sanchez,1
+San Bernardino,UNI0242,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0242,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0243,U.S. Senate,,DEM,Kamala D. Harris,1
+San Bernardino,UNI0243,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0244,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0244,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0245,U.S. Senate,,DEM,Kamala D. Harris,227
+San Bernardino,UNI0245,U.S. Senate,,DEM,Loretta L. Sanchez,118
+San Bernardino,UNI0246,U.S. Senate,,DEM,Kamala D. Harris,2
+San Bernardino,UNI0246,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0247,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0247,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0248,U.S. Senate,,DEM,Kamala D. Harris,167
+San Bernardino,UNI0248,U.S. Senate,,DEM,Loretta L. Sanchez,47
+San Bernardino,UNI0249,U.S. Senate,,DEM,Kamala D. Harris,224
+San Bernardino,UNI0249,U.S. Senate,,DEM,Loretta L. Sanchez,129
+San Bernardino,UNI0250,U.S. Senate,,DEM,Kamala D. Harris,3
+San Bernardino,UNI0250,U.S. Senate,,DEM,Loretta L. Sanchez,1
+San Bernardino,UNI0251,U.S. Senate,,DEM,Kamala D. Harris,124
+San Bernardino,UNI0251,U.S. Senate,,DEM,Loretta L. Sanchez,80
+San Bernardino,UNI0252,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0252,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0253,U.S. Senate,,DEM,Kamala D. Harris,6
+San Bernardino,UNI0253,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0254,U.S. Senate,,DEM,Kamala D. Harris,561
+San Bernardino,UNI0254,U.S. Senate,,DEM,Loretta L. Sanchez,357
+San Bernardino,UNI0255,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0255,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0256,U.S. Senate,,DEM,Kamala D. Harris,3
+San Bernardino,UNI0256,U.S. Senate,,DEM,Loretta L. Sanchez,3
+San Bernardino,UNI0257,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0257,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0258,U.S. Senate,,DEM,Kamala D. Harris,4
+San Bernardino,UNI0258,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0259,U.S. Senate,,DEM,Kamala D. Harris,637
+San Bernardino,UNI0259,U.S. Senate,,DEM,Loretta L. Sanchez,415
+San Bernardino,UNI0260,U.S. Senate,,DEM,Kamala D. Harris,54
+San Bernardino,UNI0260,U.S. Senate,,DEM,Loretta L. Sanchez,35
+San Bernardino,UNI0261,U.S. Senate,,DEM,Kamala D. Harris,5
+San Bernardino,UNI0261,U.S. Senate,,DEM,Loretta L. Sanchez,6
+San Bernardino,UNI0262,U.S. Senate,,DEM,Kamala D. Harris,2
+San Bernardino,UNI0262,U.S. Senate,,DEM,Loretta L. Sanchez,1
+San Bernardino,UNI0263,U.S. Senate,,DEM,Kamala D. Harris,3
+San Bernardino,UNI0263,U.S. Senate,,DEM,Loretta L. Sanchez,1
+San Bernardino,UNI0264,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0264,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0276,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0276,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0277,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0277,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0278,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0278,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0279,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0279,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0280,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0280,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0281,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0281,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0282,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0282,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0283,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0283,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0284,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0284,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0285,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0285,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0286,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0286,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0287,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0287,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0288,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0288,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0289,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0289,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0290,U.S. Senate,,DEM,Kamala D. Harris,8
+San Bernardino,UNI0290,U.S. Senate,,DEM,Loretta L. Sanchez,6
+San Bernardino,UNI0291,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0291,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0292,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0292,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0293,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0293,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0294,U.S. Senate,,DEM,Kamala D. Harris,1
+San Bernardino,UNI0294,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0295,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0295,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0359,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0359,U.S. Senate,,DEM,Loretta L. Sanchez,1
+San Bernardino,UNI0360,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0360,U.S. Senate,,DEM,Loretta L. Sanchez,2
+San Bernardino,UNI0361,U.S. Senate,,DEM,Kamala D. Harris,218
+San Bernardino,UNI0361,U.S. Senate,,DEM,Loretta L. Sanchez,200
+San Bernardino,UNI0362,U.S. Senate,,DEM,Kamala D. Harris,260
+San Bernardino,UNI0362,U.S. Senate,,DEM,Loretta L. Sanchez,258
+San Bernardino,UNI0363,U.S. Senate,,DEM,Kamala D. Harris,61
+San Bernardino,UNI0363,U.S. Senate,,DEM,Loretta L. Sanchez,80
+San Bernardino,UNI0364,U.S. Senate,,DEM,Kamala D. Harris,223
+San Bernardino,UNI0364,U.S. Senate,,DEM,Loretta L. Sanchez,192
+San Bernardino,UNI0365,U.S. Senate,,DEM,Kamala D. Harris,3
+San Bernardino,UNI0365,U.S. Senate,,DEM,Loretta L. Sanchez,5
+San Bernardino,UNI0366,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0366,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0367,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0367,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0372,U.S. Senate,,DEM,Kamala D. Harris,300
+San Bernardino,UNI0372,U.S. Senate,,DEM,Loretta L. Sanchez,260
+San Bernardino,UNI0373,U.S. Senate,,DEM,Kamala D. Harris,61
+San Bernardino,UNI0373,U.S. Senate,,DEM,Loretta L. Sanchez,61
+San Bernardino,UNI0374,U.S. Senate,,DEM,Kamala D. Harris,116
+San Bernardino,UNI0374,U.S. Senate,,DEM,Loretta L. Sanchez,120
+San Bernardino,UNI0375,U.S. Senate,,DEM,Kamala D. Harris,157
+San Bernardino,UNI0375,U.S. Senate,,DEM,Loretta L. Sanchez,164
+San Bernardino,UNI0376,U.S. Senate,,DEM,Kamala D. Harris,387
+San Bernardino,UNI0376,U.S. Senate,,DEM,Loretta L. Sanchez,324
+San Bernardino,UNI0399,U.S. Senate,,DEM,Kamala D. Harris,59
+San Bernardino,UNI0399,U.S. Senate,,DEM,Loretta L. Sanchez,79
+San Bernardino,UNI0400,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0400,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0401,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0401,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0402,U.S. Senate,,DEM,Kamala D. Harris,6
+San Bernardino,UNI0402,U.S. Senate,,DEM,Loretta L. Sanchez,7
+San Bernardino,UNI0403,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0403,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0404,U.S. Senate,,DEM,Kamala D. Harris,10
+San Bernardino,UNI0404,U.S. Senate,,DEM,Loretta L. Sanchez,6
+San Bernardino,UNI0405,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0405,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0406,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0406,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0407,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0407,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0408,U.S. Senate,,DEM,Kamala D. Harris,104
+San Bernardino,UNI0408,U.S. Senate,,DEM,Loretta L. Sanchez,94
+San Bernardino,UNI0409,U.S. Senate,,DEM,Kamala D. Harris,362
+San Bernardino,UNI0409,U.S. Senate,,DEM,Loretta L. Sanchez,402
+San Bernardino,UNI0410,U.S. Senate,,DEM,Kamala D. Harris,72
+San Bernardino,UNI0410,U.S. Senate,,DEM,Loretta L. Sanchez,64
+San Bernardino,UNI0411,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0411,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0412,U.S. Senate,,DEM,Kamala D. Harris,284
+San Bernardino,UNI0412,U.S. Senate,,DEM,Loretta L. Sanchez,224
+San Bernardino,UNI0413,U.S. Senate,,DEM,Kamala D. Harris,539
+San Bernardino,UNI0413,U.S. Senate,,DEM,Loretta L. Sanchez,416
+San Bernardino,UNI0414,U.S. Senate,,DEM,Kamala D. Harris,562
+San Bernardino,UNI0414,U.S. Senate,,DEM,Loretta L. Sanchez,476
+San Bernardino,UNI0415,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0415,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0416,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0416,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0417,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0417,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0461,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0461,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0462,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0462,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0463,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0463,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0464,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0464,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0465,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0465,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0466,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0466,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0467,U.S. Senate,,DEM,Kamala D. Harris,5
+San Bernardino,UNI0467,U.S. Senate,,DEM,Loretta L. Sanchez,5
+San Bernardino,UNI0468,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0468,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0469,U.S. Senate,,DEM,Kamala D. Harris,16
+San Bernardino,UNI0469,U.S. Senate,,DEM,Loretta L. Sanchez,27
+San Bernardino,UNI0470,U.S. Senate,,DEM,Kamala D. Harris,28
+San Bernardino,UNI0470,U.S. Senate,,DEM,Loretta L. Sanchez,15
+San Bernardino,UNI0471,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0471,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0472,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0472,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0473,U.S. Senate,,DEM,Kamala D. Harris,9
+San Bernardino,UNI0473,U.S. Senate,,DEM,Loretta L. Sanchez,10
+San Bernardino,UNI0474,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0474,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0475,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0475,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0476,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0476,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0477,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0477,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0478,U.S. Senate,,DEM,Kamala D. Harris,361
+San Bernardino,UNI0478,U.S. Senate,,DEM,Loretta L. Sanchez,361
+San Bernardino,UNI0479,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0479,U.S. Senate,,DEM,Loretta L. Sanchez,2
+San Bernardino,UNI0480,U.S. Senate,,DEM,Kamala D. Harris,540
+San Bernardino,UNI0480,U.S. Senate,,DEM,Loretta L. Sanchez,592
+San Bernardino,UNI0481,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0481,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0482,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0482,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0483,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0483,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0484,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0484,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0485,U.S. Senate,,DEM,Kamala D. Harris,95
+San Bernardino,UNI0485,U.S. Senate,,DEM,Loretta L. Sanchez,52
+San Bernardino,UNI0486,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0486,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0487,U.S. Senate,,DEM,Kamala D. Harris,215
+San Bernardino,UNI0487,U.S. Senate,,DEM,Loretta L. Sanchez,130
+San Bernardino,UNI0488,U.S. Senate,,DEM,Kamala D. Harris,132
+San Bernardino,UNI0488,U.S. Senate,,DEM,Loretta L. Sanchez,59
+San Bernardino,UNI0489,U.S. Senate,,DEM,Kamala D. Harris,402
+San Bernardino,UNI0489,U.S. Senate,,DEM,Loretta L. Sanchez,294
+San Bernardino,UNI0490,U.S. Senate,,DEM,Kamala D. Harris,185
+San Bernardino,UNI0490,U.S. Senate,,DEM,Loretta L. Sanchez,130
+San Bernardino,UNI0491,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0491,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0492,U.S. Senate,,DEM,Kamala D. Harris,1
+San Bernardino,UNI0492,U.S. Senate,,DEM,Loretta L. Sanchez,1
+San Bernardino,UNI0493,U.S. Senate,,DEM,Kamala D. Harris,1
+San Bernardino,UNI0493,U.S. Senate,,DEM,Loretta L. Sanchez,1
+San Bernardino,UNI0494,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0494,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0495,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0495,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0496,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0496,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0497,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0497,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0498,U.S. Senate,,DEM,Kamala D. Harris,2
+San Bernardino,UNI0498,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0499,U.S. Senate,,DEM,Kamala D. Harris,3
+San Bernardino,UNI0499,U.S. Senate,,DEM,Loretta L. Sanchez,5
+San Bernardino,UNI0500,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0500,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0501,U.S. Senate,,DEM,Kamala D. Harris,5
+San Bernardino,UNI0501,U.S. Senate,,DEM,Loretta L. Sanchez,2
+San Bernardino,UNI0502,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0502,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0503,U.S. Senate,,DEM,Kamala D. Harris,28
+San Bernardino,UNI0503,U.S. Senate,,DEM,Loretta L. Sanchez,24
+San Bernardino,UNI0504,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0504,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0505,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0505,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0506,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0506,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0507,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0507,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0508,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0508,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0509,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0509,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0510,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0510,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0511,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0511,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0512,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0512,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0513,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0513,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0514,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0514,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0515,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0515,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0516,U.S. Senate,,DEM,Kamala D. Harris,153
+San Bernardino,UNI0516,U.S. Senate,,DEM,Loretta L. Sanchez,104
+San Bernardino,UNI0517,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0517,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0518,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0518,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0519,U.S. Senate,,DEM,Kamala D. Harris,27
+San Bernardino,UNI0519,U.S. Senate,,DEM,Loretta L. Sanchez,6
+San Bernardino,UNI0520,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0520,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0521,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0521,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0522,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0522,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0523,U.S. Senate,,DEM,Kamala D. Harris,26
+San Bernardino,UNI0523,U.S. Senate,,DEM,Loretta L. Sanchez,10
+San Bernardino,UNI0524,U.S. Senate,,DEM,Kamala D. Harris,8
+San Bernardino,UNI0524,U.S. Senate,,DEM,Loretta L. Sanchez,5
+San Bernardino,UNI0525,U.S. Senate,,DEM,Kamala D. Harris,327
+San Bernardino,UNI0525,U.S. Senate,,DEM,Loretta L. Sanchez,254
+San Bernardino,UNI0526,U.S. Senate,,DEM,Kamala D. Harris,35
+San Bernardino,UNI0526,U.S. Senate,,DEM,Loretta L. Sanchez,32
+San Bernardino,UNI0527,U.S. Senate,,DEM,Kamala D. Harris,26
+San Bernardino,UNI0527,U.S. Senate,,DEM,Loretta L. Sanchez,28
+San Bernardino,UNI0528,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0528,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0529,U.S. Senate,,DEM,Kamala D. Harris,87
+San Bernardino,UNI0529,U.S. Senate,,DEM,Loretta L. Sanchez,57
+San Bernardino,UNI0530,U.S. Senate,,DEM,Kamala D. Harris,684
+San Bernardino,UNI0530,U.S. Senate,,DEM,Loretta L. Sanchez,506
+San Bernardino,UNI0531,U.S. Senate,,DEM,Kamala D. Harris,270
+San Bernardino,UNI0531,U.S. Senate,,DEM,Loretta L. Sanchez,174
+San Bernardino,UNI0532,U.S. Senate,,DEM,Kamala D. Harris,737
+San Bernardino,UNI0532,U.S. Senate,,DEM,Loretta L. Sanchez,479
+San Bernardino,UNI0533,U.S. Senate,,DEM,Kamala D. Harris,190
+San Bernardino,UNI0533,U.S. Senate,,DEM,Loretta L. Sanchez,92
+San Bernardino,UNI0534,U.S. Senate,,DEM,Kamala D. Harris,88
+San Bernardino,UNI0534,U.S. Senate,,DEM,Loretta L. Sanchez,68
+San Bernardino,UNI0535,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0535,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0536,U.S. Senate,,DEM,Kamala D. Harris,254
+San Bernardino,UNI0536,U.S. Senate,,DEM,Loretta L. Sanchez,136
+San Bernardino,UNI0537,U.S. Senate,,DEM,Kamala D. Harris,20
+San Bernardino,UNI0537,U.S. Senate,,DEM,Loretta L. Sanchez,18
+San Bernardino,UNI0538,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0538,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0539,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0539,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0540,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0540,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0541,U.S. Senate,,DEM,Kamala D. Harris,1
+San Bernardino,UNI0541,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0542,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0542,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0543,U.S. Senate,,DEM,Kamala D. Harris,226
+San Bernardino,UNI0543,U.S. Senate,,DEM,Loretta L. Sanchez,162
+San Bernardino,UNI0544,U.S. Senate,,DEM,Kamala D. Harris,76
+San Bernardino,UNI0544,U.S. Senate,,DEM,Loretta L. Sanchez,52
+San Bernardino,UNI0545,U.S. Senate,,DEM,Kamala D. Harris,11
+San Bernardino,UNI0545,U.S. Senate,,DEM,Loretta L. Sanchez,6
+San Bernardino,UNI0546,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0546,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0547,U.S. Senate,,DEM,Kamala D. Harris,1
+San Bernardino,UNI0547,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0548,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0548,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0549,U.S. Senate,,DEM,Kamala D. Harris,207
+San Bernardino,UNI0549,U.S. Senate,,DEM,Loretta L. Sanchez,162
+San Bernardino,UNI0550,U.S. Senate,,DEM,Kamala D. Harris,2
+San Bernardino,UNI0550,U.S. Senate,,DEM,Loretta L. Sanchez,1
+San Bernardino,UNI0551,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0551,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0552,U.S. Senate,,DEM,Kamala D. Harris,26
+San Bernardino,UNI0552,U.S. Senate,,DEM,Loretta L. Sanchez,18
+San Bernardino,UNI0553,U.S. Senate,,DEM,Kamala D. Harris,3
+San Bernardino,UNI0553,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0554,U.S. Senate,,DEM,Kamala D. Harris,21
+San Bernardino,UNI0554,U.S. Senate,,DEM,Loretta L. Sanchez,30
+San Bernardino,UNI0555,U.S. Senate,,DEM,Kamala D. Harris,1
+San Bernardino,UNI0555,U.S. Senate,,DEM,Loretta L. Sanchez,2
+San Bernardino,UNI0556,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0556,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0557,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0557,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0558,U.S. Senate,,DEM,Kamala D. Harris,351
+San Bernardino,UNI0558,U.S. Senate,,DEM,Loretta L. Sanchez,222
+San Bernardino,UNI0559,U.S. Senate,,DEM,Kamala D. Harris,388
+San Bernardino,UNI0559,U.S. Senate,,DEM,Loretta L. Sanchez,284
+San Bernardino,UNI0560,U.S. Senate,,DEM,Kamala D. Harris,429
+San Bernardino,UNI0560,U.S. Senate,,DEM,Loretta L. Sanchez,268
+San Bernardino,UNI0561,U.S. Senate,,DEM,Kamala D. Harris,2
+San Bernardino,UNI0561,U.S. Senate,,DEM,Loretta L. Sanchez,2
+San Bernardino,UNI0562,U.S. Senate,,DEM,Kamala D. Harris,20
+San Bernardino,UNI0562,U.S. Senate,,DEM,Loretta L. Sanchez,18
+San Bernardino,UNI0563,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0563,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0564,U.S. Senate,,DEM,Kamala D. Harris,9
+San Bernardino,UNI0564,U.S. Senate,,DEM,Loretta L. Sanchez,4
+San Bernardino,UNI0565,U.S. Senate,,DEM,Kamala D. Harris,53
+San Bernardino,UNI0565,U.S. Senate,,DEM,Loretta L. Sanchez,32
+San Bernardino,UNI0566,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0566,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0567,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0567,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0568,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0568,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0569,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0569,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0570,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0570,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0571,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0571,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0577,U.S. Senate,,DEM,Kamala D. Harris,148
+San Bernardino,UNI0577,U.S. Senate,,DEM,Loretta L. Sanchez,102
+San Bernardino,UNI0578,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0578,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0579,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0579,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0580,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0580,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0581,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0581,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0582,U.S. Senate,,DEM,Kamala D. Harris,23
+San Bernardino,UNI0582,U.S. Senate,,DEM,Loretta L. Sanchez,17
+San Bernardino,UNI0583,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0583,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0584,U.S. Senate,,DEM,Kamala D. Harris,1
+San Bernardino,UNI0584,U.S. Senate,,DEM,Loretta L. Sanchez,1
+San Bernardino,UNI0585,U.S. Senate,,DEM,Kamala D. Harris,294
+San Bernardino,UNI0585,U.S. Senate,,DEM,Loretta L. Sanchez,207
+San Bernardino,UNI0586,U.S. Senate,,DEM,Kamala D. Harris,42
+San Bernardino,UNI0586,U.S. Senate,,DEM,Loretta L. Sanchez,32
+San Bernardino,UNI0587,U.S. Senate,,DEM,Kamala D. Harris,565
+San Bernardino,UNI0587,U.S. Senate,,DEM,Loretta L. Sanchez,449
+San Bernardino,UNI0588,U.S. Senate,,DEM,Kamala D. Harris,272
+San Bernardino,UNI0588,U.S. Senate,,DEM,Loretta L. Sanchez,187
+San Bernardino,UNI0589,U.S. Senate,,DEM,Kamala D. Harris,425
+San Bernardino,UNI0589,U.S. Senate,,DEM,Loretta L. Sanchez,309
+San Bernardino,UNI0590,U.S. Senate,,DEM,Kamala D. Harris,172
+San Bernardino,UNI0590,U.S. Senate,,DEM,Loretta L. Sanchez,153
+San Bernardino,UNI0591,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0591,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0592,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0592,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0593,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0593,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0594,U.S. Senate,,DEM,Kamala D. Harris,94
+San Bernardino,UNI0594,U.S. Senate,,DEM,Loretta L. Sanchez,65
+San Bernardino,UNI0595,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0595,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0596,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0596,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0597,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0597,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0598,U.S. Senate,,DEM,Kamala D. Harris,2
+San Bernardino,UNI0598,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0599,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0599,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0600,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0600,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0601,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0601,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0602,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0602,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0603,U.S. Senate,,DEM,Kamala D. Harris,1
+San Bernardino,UNI0603,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0605,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0605,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0606,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0606,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0607,U.S. Senate,,DEM,Kamala D. Harris,244
+San Bernardino,UNI0607,U.S. Senate,,DEM,Loretta L. Sanchez,181
+San Bernardino,UNI0608,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0608,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0609,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0609,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0610,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0610,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0611,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0611,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0612,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0612,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0613,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0613,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0614,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0614,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0619,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0619,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0620,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0620,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0621,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0621,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0622,U.S. Senate,,DEM,Kamala D. Harris,4
+San Bernardino,UNI0622,U.S. Senate,,DEM,Loretta L. Sanchez,1
+San Bernardino,UNI0623,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0623,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0624,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0624,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0625,U.S. Senate,,DEM,Kamala D. Harris,7
+San Bernardino,UNI0625,U.S. Senate,,DEM,Loretta L. Sanchez,6
+San Bernardino,UNI0626,U.S. Senate,,DEM,Kamala D. Harris,3
+San Bernardino,UNI0626,U.S. Senate,,DEM,Loretta L. Sanchez,6
+San Bernardino,UNI0627,U.S. Senate,,DEM,Kamala D. Harris,4
+San Bernardino,UNI0627,U.S. Senate,,DEM,Loretta L. Sanchez,4
+San Bernardino,UNI0628,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0628,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0629,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0629,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0630,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0630,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0631,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0631,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0632,U.S. Senate,,DEM,Kamala D. Harris,52
+San Bernardino,UNI0632,U.S. Senate,,DEM,Loretta L. Sanchez,30
+San Bernardino,UNI0633,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0633,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0634,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0634,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0635,U.S. Senate,,DEM,Kamala D. Harris,1
+San Bernardino,UNI0635,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0636,U.S. Senate,,DEM,Kamala D. Harris,2
+San Bernardino,UNI0636,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0639,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0639,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0640,U.S. Senate,,DEM,Kamala D. Harris,16
+San Bernardino,UNI0640,U.S. Senate,,DEM,Loretta L. Sanchez,6
+San Bernardino,UNI0641,U.S. Senate,,DEM,Kamala D. Harris,2
+San Bernardino,UNI0641,U.S. Senate,,DEM,Loretta L. Sanchez,6
+San Bernardino,UNI0642,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0642,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0643,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0643,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0644,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0644,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0645,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0645,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0646,U.S. Senate,,DEM,Kamala D. Harris,6
+San Bernardino,UNI0646,U.S. Senate,,DEM,Loretta L. Sanchez,9
+San Bernardino,UNI0647,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0647,U.S. Senate,,DEM,Loretta L. Sanchez,2
+San Bernardino,UNI0648,U.S. Senate,,DEM,Kamala D. Harris,480
+San Bernardino,UNI0648,U.S. Senate,,DEM,Loretta L. Sanchez,449
+San Bernardino,UNI0649,U.S. Senate,,DEM,Kamala D. Harris,513
+San Bernardino,UNI0649,U.S. Senate,,DEM,Loretta L. Sanchez,469
+San Bernardino,UNI0650,U.S. Senate,,DEM,Kamala D. Harris,611
+San Bernardino,UNI0650,U.S. Senate,,DEM,Loretta L. Sanchez,491
+San Bernardino,UNI0651,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0651,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0652,U.S. Senate,,DEM,Kamala D. Harris,495
+San Bernardino,UNI0652,U.S. Senate,,DEM,Loretta L. Sanchez,429
+San Bernardino,UNI0653,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0653,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0654,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0654,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0655,U.S. Senate,,DEM,Kamala D. Harris,657
+San Bernardino,UNI0655,U.S. Senate,,DEM,Loretta L. Sanchez,445
+San Bernardino,UNI0656,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0656,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0657,U.S. Senate,,DEM,Kamala D. Harris,355
+San Bernardino,UNI0657,U.S. Senate,,DEM,Loretta L. Sanchez,200
+San Bernardino,UNI0658,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0658,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0659,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0659,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0660,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0660,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0661,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0661,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0662,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0662,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0663,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0663,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0664,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0664,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0665,U.S. Senate,,DEM,Kamala D. Harris,3
+San Bernardino,UNI0665,U.S. Senate,,DEM,Loretta L. Sanchez,1
+San Bernardino,UNI0666,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0666,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0667,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0667,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0668,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0668,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0669,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0669,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0670,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0670,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0671,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0671,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0672,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0672,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0673,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0673,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0674,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0674,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0675,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0675,U.S. Senate,,DEM,Loretta L. Sanchez,1
+San Bernardino,UNI0676,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0676,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0677,U.S. Senate,,DEM,Kamala D. Harris,74
+San Bernardino,UNI0677,U.S. Senate,,DEM,Loretta L. Sanchez,63
+San Bernardino,UNI0678,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0678,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0679,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0679,U.S. Senate,,DEM,Loretta L. Sanchez,2
+San Bernardino,UNI0680,U.S. Senate,,DEM,Kamala D. Harris,1
+San Bernardino,UNI0680,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0681,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0681,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0682,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0682,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0683,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0683,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0684,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0684,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0685,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0685,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0686,U.S. Senate,,DEM,Kamala D. Harris,18
+San Bernardino,UNI0686,U.S. Senate,,DEM,Loretta L. Sanchez,6
+San Bernardino,UNI0687,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0687,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0688,U.S. Senate,,DEM,Kamala D. Harris,76
+San Bernardino,UNI0688,U.S. Senate,,DEM,Loretta L. Sanchez,37
+San Bernardino,UNI0689,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0689,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0690,U.S. Senate,,DEM,Kamala D. Harris,1
+San Bernardino,UNI0690,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0691,U.S. Senate,,DEM,Kamala D. Harris,134
+San Bernardino,UNI0691,U.S. Senate,,DEM,Loretta L. Sanchez,116
+San Bernardino,UNI0692,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0692,U.S. Senate,,DEM,Loretta L. Sanchez,1
+San Bernardino,UNI0693,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0693,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0694,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0694,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0695,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0695,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0698,U.S. Senate,,DEM,Kamala D. Harris,10
+San Bernardino,UNI0698,U.S. Senate,,DEM,Loretta L. Sanchez,6
+San Bernardino,UNI0699,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0699,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0700,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0700,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0701,U.S. Senate,,DEM,Kamala D. Harris,280
+San Bernardino,UNI0701,U.S. Senate,,DEM,Loretta L. Sanchez,208
+San Bernardino,UNI0702,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0702,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0703,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0703,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0704,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0704,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0705,U.S. Senate,,DEM,Kamala D. Harris,3
+San Bernardino,UNI0705,U.S. Senate,,DEM,Loretta L. Sanchez,4
+San Bernardino,UNI0706,U.S. Senate,,DEM,Kamala D. Harris,7
+San Bernardino,UNI0706,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0707,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0707,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0708,U.S. Senate,,DEM,Kamala D. Harris,3
+San Bernardino,UNI0708,U.S. Senate,,DEM,Loretta L. Sanchez,1
+San Bernardino,UNI0709,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0709,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0711,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0711,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0713,U.S. Senate,,DEM,Kamala D. Harris,3
+San Bernardino,UNI0713,U.S. Senate,,DEM,Loretta L. Sanchez,4
+San Bernardino,UNI0714,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0714,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0715,U.S. Senate,,DEM,Kamala D. Harris,8
+San Bernardino,UNI0715,U.S. Senate,,DEM,Loretta L. Sanchez,7
+San Bernardino,UNI0716,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0716,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0717,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0717,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0718,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0718,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0736,U.S. Senate,,DEM,Kamala D. Harris,114
+San Bernardino,UNI0736,U.S. Senate,,DEM,Loretta L. Sanchez,83
+San Bernardino,UNI0737,U.S. Senate,,DEM,Kamala D. Harris,38
+San Bernardino,UNI0737,U.S. Senate,,DEM,Loretta L. Sanchez,22
+San Bernardino,UNI0738,U.S. Senate,,DEM,Kamala D. Harris,20
+San Bernardino,UNI0738,U.S. Senate,,DEM,Loretta L. Sanchez,15
+San Bernardino,UNI0739,U.S. Senate,,DEM,Kamala D. Harris,42
+San Bernardino,UNI0739,U.S. Senate,,DEM,Loretta L. Sanchez,38
+San Bernardino,UNI0740,U.S. Senate,,DEM,Kamala D. Harris,10
+San Bernardino,UNI0740,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0741,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0741,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0742,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0742,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0743,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0743,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0744,U.S. Senate,,DEM,Kamala D. Harris,1
+San Bernardino,UNI0744,U.S. Senate,,DEM,Loretta L. Sanchez,4
+San Bernardino,UNI0745,U.S. Senate,,DEM,Kamala D. Harris,3
+San Bernardino,UNI0745,U.S. Senate,,DEM,Loretta L. Sanchez,3
+San Bernardino,UNI0759,U.S. Senate,,DEM,Kamala D. Harris,21
+San Bernardino,UNI0759,U.S. Senate,,DEM,Loretta L. Sanchez,8
+San Bernardino,UNI0760,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0760,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0761,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0761,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0762,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0762,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0763,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0763,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0764,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0764,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0765,U.S. Senate,,DEM,Kamala D. Harris,1
+San Bernardino,UNI0765,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0766,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0766,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0767,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0767,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0769,U.S. Senate,,DEM,Kamala D. Harris,670
+San Bernardino,UNI0769,U.S. Senate,,DEM,Loretta L. Sanchez,425
+San Bernardino,UNI0770,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0770,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0771,U.S. Senate,,DEM,Kamala D. Harris,16
+San Bernardino,UNI0771,U.S. Senate,,DEM,Loretta L. Sanchez,23
+San Bernardino,UNI0772,U.S. Senate,,DEM,Kamala D. Harris,17
+San Bernardino,UNI0772,U.S. Senate,,DEM,Loretta L. Sanchez,10
+San Bernardino,UNI0773,U.S. Senate,,DEM,Kamala D. Harris,23
+San Bernardino,UNI0773,U.S. Senate,,DEM,Loretta L. Sanchez,14
+San Bernardino,UNI0774,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0774,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0775,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0775,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0776,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0776,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0777,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0777,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0778,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0778,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0779,U.S. Senate,,DEM,Kamala D. Harris,4
+San Bernardino,UNI0779,U.S. Senate,,DEM,Loretta L. Sanchez,2
+San Bernardino,UNI0780,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0780,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0783,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0783,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0784,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0784,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0785,U.S. Senate,,DEM,Kamala D. Harris,84
+San Bernardino,UNI0785,U.S. Senate,,DEM,Loretta L. Sanchez,55
+San Bernardino,UNI0786,U.S. Senate,,DEM,Kamala D. Harris,24
+San Bernardino,UNI0786,U.S. Senate,,DEM,Loretta L. Sanchez,21
+San Bernardino,UNI0787,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0787,U.S. Senate,,DEM,Loretta L. Sanchez,2
+San Bernardino,UNI0788,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0788,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0789,U.S. Senate,,DEM,Kamala D. Harris,2
+San Bernardino,UNI0789,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0790,U.S. Senate,,DEM,Kamala D. Harris,11
+San Bernardino,UNI0790,U.S. Senate,,DEM,Loretta L. Sanchez,9
+San Bernardino,UNI0791,U.S. Senate,,DEM,Kamala D. Harris,4
+San Bernardino,UNI0791,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0792,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0792,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0793,U.S. Senate,,DEM,Kamala D. Harris,5
+San Bernardino,UNI0793,U.S. Senate,,DEM,Loretta L. Sanchez,1
+San Bernardino,UNI0794,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0794,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0795,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0795,U.S. Senate,,DEM,Loretta L. Sanchez,4
+San Bernardino,UNI0796,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0796,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0797,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0797,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0798,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0798,U.S. Senate,,DEM,Loretta L. Sanchez,1
+San Bernardino,UNI0799,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0799,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0808,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0808,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0834,U.S. Senate,,DEM,Kamala D. Harris,61
+San Bernardino,UNI0834,U.S. Senate,,DEM,Loretta L. Sanchez,30
+San Bernardino,UNI0838,U.S. Senate,,DEM,Kamala D. Harris,4
+San Bernardino,UNI0838,U.S. Senate,,DEM,Loretta L. Sanchez,6
+San Bernardino,UNI0839,U.S. Senate,,DEM,Kamala D. Harris,429
+San Bernardino,UNI0839,U.S. Senate,,DEM,Loretta L. Sanchez,340
+San Bernardino,UNI0840,U.S. Senate,,DEM,Kamala D. Harris,383
+San Bernardino,UNI0840,U.S. Senate,,DEM,Loretta L. Sanchez,312
+San Bernardino,UNI0856,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0856,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0857,U.S. Senate,,DEM,Kamala D. Harris,12
+San Bernardino,UNI0857,U.S. Senate,,DEM,Loretta L. Sanchez,12
+San Bernardino,UNI0858,U.S. Senate,,DEM,Kamala D. Harris,2
+San Bernardino,UNI0858,U.S. Senate,,DEM,Loretta L. Sanchez,1
+San Bernardino,UNI0859,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0859,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0860,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0860,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0861,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0861,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0862,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0862,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0864,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0864,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0865,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0865,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0867,U.S. Senate,,DEM,Kamala D. Harris,499
+San Bernardino,UNI0867,U.S. Senate,,DEM,Loretta L. Sanchez,319
+San Bernardino,UNI0868,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0868,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0869,U.S. Senate,,DEM,Kamala D. Harris,163
+San Bernardino,UNI0869,U.S. Senate,,DEM,Loretta L. Sanchez,104
+San Bernardino,UNI0870,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0870,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0871,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0871,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0874,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0874,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0875,U.S. Senate,,DEM,Kamala D. Harris,15
+San Bernardino,UNI0875,U.S. Senate,,DEM,Loretta L. Sanchez,7
+San Bernardino,UNI0876,U.S. Senate,,DEM,Kamala D. Harris,22
+San Bernardino,UNI0876,U.S. Senate,,DEM,Loretta L. Sanchez,32
+San Bernardino,UNI0877,U.S. Senate,,DEM,Kamala D. Harris,660
+San Bernardino,UNI0877,U.S. Senate,,DEM,Loretta L. Sanchez,439
+San Bernardino,UNI0878,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0878,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0879,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0879,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0880,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0880,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0915,U.S. Senate,,DEM,Kamala D. Harris,34
+San Bernardino,UNI0915,U.S. Senate,,DEM,Loretta L. Sanchez,47
+San Bernardino,UNI0916,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0916,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0917,U.S. Senate,,DEM,Kamala D. Harris,7
+San Bernardino,UNI0917,U.S. Senate,,DEM,Loretta L. Sanchez,5
+San Bernardino,UNI0918,U.S. Senate,,DEM,Kamala D. Harris,3
+San Bernardino,UNI0918,U.S. Senate,,DEM,Loretta L. Sanchez,2
+San Bernardino,UNI0919,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0919,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0948,U.S. Senate,,DEM,Kamala D. Harris,227
+San Bernardino,UNI0948,U.S. Senate,,DEM,Loretta L. Sanchez,322
+San Bernardino,UNI0949,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0949,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0950,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0950,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0951,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0951,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0990,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0990,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0991,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0991,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI0992,U.S. Senate,,DEM,Kamala D. Harris,121
+San Bernardino,UNI0992,U.S. Senate,,DEM,Loretta L. Sanchez,136
+San Bernardino,UNI0993,U.S. Senate,,DEM,Kamala D. Harris,35
+San Bernardino,UNI0993,U.S. Senate,,DEM,Loretta L. Sanchez,51
+San Bernardino,UNI0994,U.S. Senate,,DEM,Kamala D. Harris,66
+San Bernardino,UNI0994,U.S. Senate,,DEM,Loretta L. Sanchez,47
+San Bernardino,UNI0995,U.S. Senate,,DEM,Kamala D. Harris,3
+San Bernardino,UNI0995,U.S. Senate,,DEM,Loretta L. Sanchez,1
+San Bernardino,UNI0996,U.S. Senate,,DEM,Kamala D. Harris,1
+San Bernardino,UNI0996,U.S. Senate,,DEM,Loretta L. Sanchez,3
+San Bernardino,UNI0997,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI0997,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI1022,U.S. Senate,,DEM,Kamala D. Harris,59
+San Bernardino,UNI1022,U.S. Senate,,DEM,Loretta L. Sanchez,82
+San Bernardino,UNI1023,U.S. Senate,,DEM,Kamala D. Harris,251
+San Bernardino,UNI1023,U.S. Senate,,DEM,Loretta L. Sanchez,379
+San Bernardino,UNI1024,U.S. Senate,,DEM,Kamala D. Harris,239
+San Bernardino,UNI1024,U.S. Senate,,DEM,Loretta L. Sanchez,345
+San Bernardino,UNI1025,U.S. Senate,,DEM,Kamala D. Harris,130
+San Bernardino,UNI1025,U.S. Senate,,DEM,Loretta L. Sanchez,188
+San Bernardino,UNI1026,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI1026,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI1143,U.S. Senate,,DEM,Kamala D. Harris,416
+San Bernardino,UNI1143,U.S. Senate,,DEM,Loretta L. Sanchez,260
+San Bernardino,UNI1144,U.S. Senate,,DEM,Kamala D. Harris,1
+San Bernardino,UNI1144,U.S. Senate,,DEM,Loretta L. Sanchez,1
+San Bernardino,UNI1145,U.S. Senate,,DEM,Kamala D. Harris,17
+San Bernardino,UNI1145,U.S. Senate,,DEM,Loretta L. Sanchez,11
+San Bernardino,UNI1146,U.S. Senate,,DEM,Kamala D. Harris,6
+San Bernardino,UNI1146,U.S. Senate,,DEM,Loretta L. Sanchez,5
+San Bernardino,UNI1147,U.S. Senate,,DEM,Kamala D. Harris,13
+San Bernardino,UNI1147,U.S. Senate,,DEM,Loretta L. Sanchez,3
+San Bernardino,UNI1148,U.S. Senate,,DEM,Kamala D. Harris,3
+San Bernardino,UNI1148,U.S. Senate,,DEM,Loretta L. Sanchez,3
+San Bernardino,UNI1149,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI1149,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI1150,U.S. Senate,,DEM,Kamala D. Harris,97
+San Bernardino,UNI1150,U.S. Senate,,DEM,Loretta L. Sanchez,17
+San Bernardino,UNI1151,U.S. Senate,,DEM,Kamala D. Harris,4
+San Bernardino,UNI1151,U.S. Senate,,DEM,Loretta L. Sanchez,3
+San Bernardino,UNI1152,U.S. Senate,,DEM,Kamala D. Harris,4
+San Bernardino,UNI1152,U.S. Senate,,DEM,Loretta L. Sanchez,5
+San Bernardino,UNI1153,U.S. Senate,,DEM,Kamala D. Harris,11
+San Bernardino,UNI1153,U.S. Senate,,DEM,Loretta L. Sanchez,8
+San Bernardino,UNI1199,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI1199,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI1200,U.S. Senate,,DEM,Kamala D. Harris,324
+San Bernardino,UNI1200,U.S. Senate,,DEM,Loretta L. Sanchez,252
+San Bernardino,UNI1201,U.S. Senate,,DEM,Kamala D. Harris,431
+San Bernardino,UNI1201,U.S. Senate,,DEM,Loretta L. Sanchez,326
+San Bernardino,UNI1202,U.S. Senate,,DEM,Kamala D. Harris,513
+San Bernardino,UNI1202,U.S. Senate,,DEM,Loretta L. Sanchez,420
+San Bernardino,UNI1203,U.S. Senate,,DEM,Kamala D. Harris,305
+San Bernardino,UNI1203,U.S. Senate,,DEM,Loretta L. Sanchez,278
+San Bernardino,UNI1204,U.S. Senate,,DEM,Kamala D. Harris,260
+San Bernardino,UNI1204,U.S. Senate,,DEM,Loretta L. Sanchez,233
+San Bernardino,UNI1258,U.S. Senate,,DEM,Kamala D. Harris,379
+San Bernardino,UNI1258,U.S. Senate,,DEM,Loretta L. Sanchez,341
+San Bernardino,UNI1259,U.S. Senate,,DEM,Kamala D. Harris,142
+San Bernardino,UNI1259,U.S. Senate,,DEM,Loretta L. Sanchez,146
+San Bernardino,UNI1268,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI1268,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI1269,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI1269,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI1270,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI1270,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI1271,U.S. Senate,,DEM,Kamala D. Harris,4
+San Bernardino,UNI1271,U.S. Senate,,DEM,Loretta L. Sanchez,3
+San Bernardino,UNI1274,U.S. Senate,,DEM,Kamala D. Harris,273
+San Bernardino,UNI1274,U.S. Senate,,DEM,Loretta L. Sanchez,204
+San Bernardino,UNI1348,U.S. Senate,,DEM,Kamala D. Harris,187
+San Bernardino,UNI1348,U.S. Senate,,DEM,Loretta L. Sanchez,206
+San Bernardino,UNI1349,U.S. Senate,,DEM,Kamala D. Harris,58
+San Bernardino,UNI1349,U.S. Senate,,DEM,Loretta L. Sanchez,76
+San Bernardino,UNI1350,U.S. Senate,,DEM,Kamala D. Harris,362
+San Bernardino,UNI1350,U.S. Senate,,DEM,Loretta L. Sanchez,554
+San Bernardino,UNI1351,U.S. Senate,,DEM,Kamala D. Harris,216
+San Bernardino,UNI1351,U.S. Senate,,DEM,Loretta L. Sanchez,359
+San Bernardino,UNI1352,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI1352,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI1353,U.S. Senate,,DEM,Kamala D. Harris,381
+San Bernardino,UNI1353,U.S. Senate,,DEM,Loretta L. Sanchez,544
+San Bernardino,UNI1354,U.S. Senate,,DEM,Kamala D. Harris,393
+San Bernardino,UNI1354,U.S. Senate,,DEM,Loretta L. Sanchez,580
+San Bernardino,UNI1355,U.S. Senate,,DEM,Kamala D. Harris,306
+San Bernardino,UNI1355,U.S. Senate,,DEM,Loretta L. Sanchez,594
+San Bernardino,UNI1356,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI1356,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI1357,U.S. Senate,,DEM,Kamala D. Harris,32
+San Bernardino,UNI1357,U.S. Senate,,DEM,Loretta L. Sanchez,63
+San Bernardino,UNI1358,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI1358,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI1359,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI1359,U.S. Senate,,DEM,Loretta L. Sanchez,2
+San Bernardino,UNI1386,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI1386,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI1387,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI1387,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI1457,U.S. Senate,,DEM,Kamala D. Harris,306
+San Bernardino,UNI1457,U.S. Senate,,DEM,Loretta L. Sanchez,444
+San Bernardino,UNI1458,U.S. Senate,,DEM,Kamala D. Harris,136
+San Bernardino,UNI1458,U.S. Senate,,DEM,Loretta L. Sanchez,148
+San Bernardino,UNI1459,U.S. Senate,,DEM,Kamala D. Harris,136
+San Bernardino,UNI1459,U.S. Senate,,DEM,Loretta L. Sanchez,182
+San Bernardino,UNI1510,U.S. Senate,,DEM,Kamala D. Harris,395
+San Bernardino,UNI1510,U.S. Senate,,DEM,Loretta L. Sanchez,469
+San Bernardino,UNI1511,U.S. Senate,,DEM,Kamala D. Harris,17
+San Bernardino,UNI1511,U.S. Senate,,DEM,Loretta L. Sanchez,14
+San Bernardino,UNI1512,U.S. Senate,,DEM,Kamala D. Harris,4
+San Bernardino,UNI1512,U.S. Senate,,DEM,Loretta L. Sanchez,4
+San Bernardino,UNI1513,U.S. Senate,,DEM,Kamala D. Harris,2
+San Bernardino,UNI1513,U.S. Senate,,DEM,Loretta L. Sanchez,2
+San Bernardino,UNI1514,U.S. Senate,,DEM,Kamala D. Harris,98
+San Bernardino,UNI1514,U.S. Senate,,DEM,Loretta L. Sanchez,68
+San Bernardino,UNI1515,U.S. Senate,,DEM,Kamala D. Harris,5
+San Bernardino,UNI1515,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI1516,U.S. Senate,,DEM,Kamala D. Harris,4
+San Bernardino,UNI1516,U.S. Senate,,DEM,Loretta L. Sanchez,6
+San Bernardino,UNI1517,U.S. Senate,,DEM,Kamala D. Harris,294
+San Bernardino,UNI1517,U.S. Senate,,DEM,Loretta L. Sanchez,290
+San Bernardino,UNI1518,U.S. Senate,,DEM,Kamala D. Harris,23
+San Bernardino,UNI1518,U.S. Senate,,DEM,Loretta L. Sanchez,12
+San Bernardino,UNI1519,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI1519,U.S. Senate,,DEM,Loretta L. Sanchez,1
+San Bernardino,UNI1520,U.S. Senate,,DEM,Kamala D. Harris,16
+San Bernardino,UNI1520,U.S. Senate,,DEM,Loretta L. Sanchez,26
+San Bernardino,UNI1525,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI1525,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI1526,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI1526,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI1527,U.S. Senate,,DEM,Kamala D. Harris,424
+San Bernardino,UNI1527,U.S. Senate,,DEM,Loretta L. Sanchez,530
+San Bernardino,UNI1528,U.S. Senate,,DEM,Kamala D. Harris,318
+San Bernardino,UNI1528,U.S. Senate,,DEM,Loretta L. Sanchez,498
+San Bernardino,UNI1529,U.S. Senate,,DEM,Kamala D. Harris,309
+San Bernardino,UNI1529,U.S. Senate,,DEM,Loretta L. Sanchez,469
+San Bernardino,UNI1530,U.S. Senate,,DEM,Kamala D. Harris,361
+San Bernardino,UNI1530,U.S. Senate,,DEM,Loretta L. Sanchez,531
+San Bernardino,UNI1531,U.S. Senate,,DEM,Kamala D. Harris,413
+San Bernardino,UNI1531,U.S. Senate,,DEM,Loretta L. Sanchez,630
+San Bernardino,UNI1532,U.S. Senate,,DEM,Kamala D. Harris,4
+San Bernardino,UNI1532,U.S. Senate,,DEM,Loretta L. Sanchez,13
+San Bernardino,UNI1566,U.S. Senate,,DEM,Kamala D. Harris,8
+San Bernardino,UNI1566,U.S. Senate,,DEM,Loretta L. Sanchez,1
+San Bernardino,UNI1567,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI1567,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI1578,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI1578,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI1579,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI1579,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI1580,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI1580,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI1581,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI1581,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI1582,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI1582,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI1583,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI1583,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI1584,U.S. Senate,,DEM,Kamala D. Harris,49
+San Bernardino,UNI1584,U.S. Senate,,DEM,Loretta L. Sanchez,18
+San Bernardino,UNI1585,U.S. Senate,,DEM,Kamala D. Harris,39
+San Bernardino,UNI1585,U.S. Senate,,DEM,Loretta L. Sanchez,33
+San Bernardino,UNI1586,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI1586,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI1587,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI1587,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI1588,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI1588,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI1589,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI1589,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI1590,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI1590,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI1591,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI1591,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI1592,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI1592,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI1593,U.S. Senate,,DEM,Kamala D. Harris,34
+San Bernardino,UNI1593,U.S. Senate,,DEM,Loretta L. Sanchez,25
+San Bernardino,UNI1594,U.S. Senate,,DEM,Kamala D. Harris,1
+San Bernardino,UNI1594,U.S. Senate,,DEM,Loretta L. Sanchez,1
+San Bernardino,UNI1595,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI1595,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI1596,U.S. Senate,,DEM,Kamala D. Harris,6
+San Bernardino,UNI1596,U.S. Senate,,DEM,Loretta L. Sanchez,2
+San Bernardino,UNI1597,U.S. Senate,,DEM,Kamala D. Harris,387
+San Bernardino,UNI1597,U.S. Senate,,DEM,Loretta L. Sanchez,236
+San Bernardino,UNI1598,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI1598,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI1599,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI1599,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI1600,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI1600,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI1601,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI1601,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI1602,U.S. Senate,,DEM,Kamala D. Harris,1
+San Bernardino,UNI1602,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI1603,U.S. Senate,,DEM,Kamala D. Harris,15
+San Bernardino,UNI1603,U.S. Senate,,DEM,Loretta L. Sanchez,15
+San Bernardino,UNI1608,U.S. Senate,,DEM,Kamala D. Harris,149
+San Bernardino,UNI1608,U.S. Senate,,DEM,Loretta L. Sanchez,131
+San Bernardino,UNI1610,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI1610,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI1611,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI1611,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI1612,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI1612,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI1613,U.S. Senate,,DEM,Kamala D. Harris,1
+San Bernardino,UNI1613,U.S. Senate,,DEM,Loretta L. Sanchez,11
+San Bernardino,UNI1614,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI1614,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI1615,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI1615,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI1616,U.S. Senate,,DEM,Kamala D. Harris,126
+San Bernardino,UNI1616,U.S. Senate,,DEM,Loretta L. Sanchez,135
+San Bernardino,UNI1623,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI1623,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI1624,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI1624,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI1627,U.S. Senate,,DEM,Kamala D. Harris,36
+San Bernardino,UNI1627,U.S. Senate,,DEM,Loretta L. Sanchez,28
+San Bernardino,UNI1628,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI1628,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI1630,U.S. Senate,,DEM,Kamala D. Harris,2
+San Bernardino,UNI1630,U.S. Senate,,DEM,Loretta L. Sanchez,4
+San Bernardino,UNI1637,U.S. Senate,,DEM,Kamala D. Harris,19
+San Bernardino,UNI1637,U.S. Senate,,DEM,Loretta L. Sanchez,29
+San Bernardino,UNI1638,U.S. Senate,,DEM,Kamala D. Harris,41
+San Bernardino,UNI1638,U.S. Senate,,DEM,Loretta L. Sanchez,21
+San Bernardino,UNI1645,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI1645,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI1646,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI1646,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI1647,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI1647,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI1648,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI1648,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI1649,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI1649,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI1650,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI1650,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI1651,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI1651,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI1652,U.S. Senate,,DEM,Kamala D. Harris,2
+San Bernardino,UNI1652,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI1653,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI1653,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI1666,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI1666,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI1673,U.S. Senate,,DEM,Kamala D. Harris,30
+San Bernardino,UNI1673,U.S. Senate,,DEM,Loretta L. Sanchez,25
+San Bernardino,UNI1676,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI1676,U.S. Senate,,DEM,Loretta L. Sanchez,4
+San Bernardino,UNI1677,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI1677,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI1678,U.S. Senate,,DEM,Kamala D. Harris,206
+San Bernardino,UNI1678,U.S. Senate,,DEM,Loretta L. Sanchez,130
+San Bernardino,UNI1679,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI1679,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI1680,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI1680,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI1681,U.S. Senate,,DEM,Kamala D. Harris,3
+San Bernardino,UNI1681,U.S. Senate,,DEM,Loretta L. Sanchez,4
+San Bernardino,UNI1682,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI1682,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI1683,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI1683,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI1684,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI1684,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI1685,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI1685,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI1686,U.S. Senate,,DEM,Kamala D. Harris,23
+San Bernardino,UNI1686,U.S. Senate,,DEM,Loretta L. Sanchez,26
+San Bernardino,UNI1687,U.S. Senate,,DEM,Kamala D. Harris,33
+San Bernardino,UNI1687,U.S. Senate,,DEM,Loretta L. Sanchez,11
+San Bernardino,UNI1688,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI1688,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI1689,U.S. Senate,,DEM,Kamala D. Harris,13
+San Bernardino,UNI1689,U.S. Senate,,DEM,Loretta L. Sanchez,4
+San Bernardino,UNI1690,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI1690,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI1691,U.S. Senate,,DEM,Kamala D. Harris,5
+San Bernardino,UNI1691,U.S. Senate,,DEM,Loretta L. Sanchez,3
+San Bernardino,UNI1692,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI1692,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI1693,U.S. Senate,,DEM,Kamala D. Harris,2
+San Bernardino,UNI1693,U.S. Senate,,DEM,Loretta L. Sanchez,1
+San Bernardino,UNI1694,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI1694,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI1697,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI1697,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI1698,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI1698,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI1699,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI1699,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI1700,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI1700,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI1701,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI1701,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI1702,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI1702,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI1703,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI1703,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI1704,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI1704,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI1705,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI1705,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI1706,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI1706,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI1708,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI1708,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI1709,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI1709,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI1710,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI1710,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI1711,U.S. Senate,,DEM,Kamala D. Harris,10
+San Bernardino,UNI1711,U.S. Senate,,DEM,Loretta L. Sanchez,23
+San Bernardino,UNI1712,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI1712,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI1713,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI1713,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI1714,U.S. Senate,,DEM,Kamala D. Harris,2
+San Bernardino,UNI1714,U.S. Senate,,DEM,Loretta L. Sanchez,2
+San Bernardino,UNI1725,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI1725,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI1726,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI1726,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI1727,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI1727,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI1728,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI1728,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI1729,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI1729,U.S. Senate,,DEM,Loretta L. Sanchez,1
+San Bernardino,UNI1733,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI1733,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI1734,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI1734,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI1775,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI1775,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI1780,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI1780,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI1781,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI1781,U.S. Senate,,DEM,Loretta L. Sanchez,2
+San Bernardino,UNI1782,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI1782,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UNI1783,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UNI1783,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UPL0836,U.S. Senate,,DEM,Kamala D. Harris,73
+San Bernardino,UPL0836,U.S. Senate,,DEM,Loretta L. Sanchez,53
+San Bernardino,UPL0837,U.S. Senate,,DEM,Kamala D. Harris,110
+San Bernardino,UPL0837,U.S. Senate,,DEM,Loretta L. Sanchez,55
+San Bernardino,UPL0841,U.S. Senate,,DEM,Kamala D. Harris,780
+San Bernardino,UPL0841,U.S. Senate,,DEM,Loretta L. Sanchez,519
+San Bernardino,UPL0842,U.S. Senate,,DEM,Kamala D. Harris,819
+San Bernardino,UPL0842,U.S. Senate,,DEM,Loretta L. Sanchez,571
+San Bernardino,UPL0843,U.S. Senate,,DEM,Kamala D. Harris,639
+San Bernardino,UPL0843,U.S. Senate,,DEM,Loretta L. Sanchez,426
+San Bernardino,UPL0844,U.S. Senate,,DEM,Kamala D. Harris,435
+San Bernardino,UPL0844,U.S. Senate,,DEM,Loretta L. Sanchez,352
+San Bernardino,UPL0845,U.S. Senate,,DEM,Kamala D. Harris,415
+San Bernardino,UPL0845,U.S. Senate,,DEM,Loretta L. Sanchez,334
+San Bernardino,UPL0846,U.S. Senate,,DEM,Kamala D. Harris,338
+San Bernardino,UPL0846,U.S. Senate,,DEM,Loretta L. Sanchez,249
+San Bernardino,UPL0847,U.S. Senate,,DEM,Kamala D. Harris,785
+San Bernardino,UPL0847,U.S. Senate,,DEM,Loretta L. Sanchez,535
+San Bernardino,UPL0848,U.S. Senate,,DEM,Kamala D. Harris,70
+San Bernardino,UPL0848,U.S. Senate,,DEM,Loretta L. Sanchez,61
+San Bernardino,UPL0849,U.S. Senate,,DEM,Kamala D. Harris,706
+San Bernardino,UPL0849,U.S. Senate,,DEM,Loretta L. Sanchez,561
+San Bernardino,UPL0850,U.S. Senate,,DEM,Kamala D. Harris,727
+San Bernardino,UPL0850,U.S. Senate,,DEM,Loretta L. Sanchez,572
+San Bernardino,UPL0851,U.S. Senate,,DEM,Kamala D. Harris,689
+San Bernardino,UPL0851,U.S. Senate,,DEM,Loretta L. Sanchez,592
+San Bernardino,UPL0852,U.S. Senate,,DEM,Kamala D. Harris,519
+San Bernardino,UPL0852,U.S. Senate,,DEM,Loretta L. Sanchez,395
+San Bernardino,UPL0853,U.S. Senate,,DEM,Kamala D. Harris,696
+San Bernardino,UPL0853,U.S. Senate,,DEM,Loretta L. Sanchez,438
+San Bernardino,UPL0854,U.S. Senate,,DEM,Kamala D. Harris,68
+San Bernardino,UPL0854,U.S. Senate,,DEM,Loretta L. Sanchez,35
+San Bernardino,UPL0855,U.S. Senate,,DEM,Kamala D. Harris,133
+San Bernardino,UPL0855,U.S. Senate,,DEM,Loretta L. Sanchez,138
+San Bernardino,UPL1275,U.S. Senate,,DEM,Kamala D. Harris,12
+San Bernardino,UPL1275,U.S. Senate,,DEM,Loretta L. Sanchez,18
+San Bernardino,UPL1276,U.S. Senate,,DEM,Kamala D. Harris,631
+San Bernardino,UPL1276,U.S. Senate,,DEM,Loretta L. Sanchez,497
+San Bernardino,UPL1277,U.S. Senate,,DEM,Kamala D. Harris,415
+San Bernardino,UPL1277,U.S. Senate,,DEM,Loretta L. Sanchez,321
+San Bernardino,UPL1278,U.S. Senate,,DEM,Kamala D. Harris,17
+San Bernardino,UPL1278,U.S. Senate,,DEM,Loretta L. Sanchez,6
+San Bernardino,UPL1279,U.S. Senate,,DEM,Kamala D. Harris,5
+San Bernardino,UPL1279,U.S. Senate,,DEM,Loretta L. Sanchez,2
+San Bernardino,UPL1280,U.S. Senate,,DEM,Kamala D. Harris,136
+San Bernardino,UPL1280,U.S. Senate,,DEM,Loretta L. Sanchez,118
+San Bernardino,UPL1281,U.S. Senate,,DEM,Kamala D. Harris,371
+San Bernardino,UPL1281,U.S. Senate,,DEM,Loretta L. Sanchez,309
+San Bernardino,UPL1282,U.S. Senate,,DEM,Kamala D. Harris,386
+San Bernardino,UPL1282,U.S. Senate,,DEM,Loretta L. Sanchez,293
+San Bernardino,UPL1283,U.S. Senate,,DEM,Kamala D. Harris,496
+San Bernardino,UPL1283,U.S. Senate,,DEM,Loretta L. Sanchez,458
+San Bernardino,UPL1284,U.S. Senate,,DEM,Kamala D. Harris,3
+San Bernardino,UPL1284,U.S. Senate,,DEM,Loretta L. Sanchez,11
+San Bernardino,UPL1285,U.S. Senate,,DEM,Kamala D. Harris,19
+San Bernardino,UPL1285,U.S. Senate,,DEM,Loretta L. Sanchez,11
+San Bernardino,UPL1286,U.S. Senate,,DEM,Kamala D. Harris,621
+San Bernardino,UPL1286,U.S. Senate,,DEM,Loretta L. Sanchez,567
+San Bernardino,UPL1287,U.S. Senate,,DEM,Kamala D. Harris,533
+San Bernardino,UPL1287,U.S. Senate,,DEM,Loretta L. Sanchez,502
+San Bernardino,UPL1288,U.S. Senate,,DEM,Kamala D. Harris,511
+San Bernardino,UPL1288,U.S. Senate,,DEM,Loretta L. Sanchez,483
+San Bernardino,UPL1289,U.S. Senate,,DEM,Kamala D. Harris,572
+San Bernardino,UPL1289,U.S. Senate,,DEM,Loretta L. Sanchez,548
+San Bernardino,UPL1290,U.S. Senate,,DEM,Kamala D. Harris,578
+San Bernardino,UPL1290,U.S. Senate,,DEM,Loretta L. Sanchez,475
+San Bernardino,UPL1291,U.S. Senate,,DEM,Kamala D. Harris,830
+San Bernardino,UPL1291,U.S. Senate,,DEM,Loretta L. Sanchez,602
+San Bernardino,UPL1292,U.S. Senate,,DEM,Kamala D. Harris,772
+San Bernardino,UPL1292,U.S. Senate,,DEM,Loretta L. Sanchez,555
+San Bernardino,UPL1293,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UPL1293,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UPL1294,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UPL1294,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UPL1460,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UPL1460,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UPL1522,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UPL1522,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UPL1523,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UPL1523,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,UPL1524,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,UPL1524,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,VIC0368,U.S. Senate,,DEM,Kamala D. Harris,163
+San Bernardino,VIC0368,U.S. Senate,,DEM,Loretta L. Sanchez,141
+San Bernardino,VIC0369,U.S. Senate,,DEM,Kamala D. Harris,478
+San Bernardino,VIC0369,U.S. Senate,,DEM,Loretta L. Sanchez,451
+San Bernardino,VIC0377,U.S. Senate,,DEM,Kamala D. Harris,476
+San Bernardino,VIC0377,U.S. Senate,,DEM,Loretta L. Sanchez,399
+San Bernardino,VIC0378,U.S. Senate,,DEM,Kamala D. Harris,385
+San Bernardino,VIC0378,U.S. Senate,,DEM,Loretta L. Sanchez,282
+San Bernardino,VIC0379,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,VIC0379,U.S. Senate,,DEM,Loretta L. Sanchez,2
+San Bernardino,VIC0418,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,VIC0418,U.S. Senate,,DEM,Loretta L. Sanchez,1
+San Bernardino,VIC0419,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,VIC0419,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,VIC0420,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,VIC0420,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,VIC0421,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,VIC0421,U.S. Senate,,DEM,Loretta L. Sanchez,5
+San Bernardino,VIC0422,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,VIC0422,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,VIC0423,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,VIC0423,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,VIC0424,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,VIC0424,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,VIC0425,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,VIC0425,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,VIC0426,U.S. Senate,,DEM,Kamala D. Harris,73
+San Bernardino,VIC0426,U.S. Senate,,DEM,Loretta L. Sanchez,32
+San Bernardino,VIC0427,U.S. Senate,,DEM,Kamala D. Harris,303
+San Bernardino,VIC0427,U.S. Senate,,DEM,Loretta L. Sanchez,299
+San Bernardino,VIC0428,U.S. Senate,,DEM,Kamala D. Harris,334
+San Bernardino,VIC0428,U.S. Senate,,DEM,Loretta L. Sanchez,319
+San Bernardino,VIC0429,U.S. Senate,,DEM,Kamala D. Harris,54
+San Bernardino,VIC0429,U.S. Senate,,DEM,Loretta L. Sanchez,41
+San Bernardino,VIC0430,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,VIC0430,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,VIC0431,U.S. Senate,,DEM,Kamala D. Harris,326
+San Bernardino,VIC0431,U.S. Senate,,DEM,Loretta L. Sanchez,290
+San Bernardino,VIC0432,U.S. Senate,,DEM,Kamala D. Harris,591
+San Bernardino,VIC0432,U.S. Senate,,DEM,Loretta L. Sanchez,569
+San Bernardino,VIC0433,U.S. Senate,,DEM,Kamala D. Harris,360
+San Bernardino,VIC0433,U.S. Senate,,DEM,Loretta L. Sanchez,331
+San Bernardino,VIC0434,U.S. Senate,,DEM,Kamala D. Harris,359
+San Bernardino,VIC0434,U.S. Senate,,DEM,Loretta L. Sanchez,375
+San Bernardino,VIC0435,U.S. Senate,,DEM,Kamala D. Harris,494
+San Bernardino,VIC0435,U.S. Senate,,DEM,Loretta L. Sanchez,373
+San Bernardino,VIC0436,U.S. Senate,,DEM,Kamala D. Harris,532
+San Bernardino,VIC0436,U.S. Senate,,DEM,Loretta L. Sanchez,406
+San Bernardino,VIC0437,U.S. Senate,,DEM,Kamala D. Harris,672
+San Bernardino,VIC0437,U.S. Senate,,DEM,Loretta L. Sanchez,544
+San Bernardino,VIC0438,U.S. Senate,,DEM,Kamala D. Harris,512
+San Bernardino,VIC0438,U.S. Senate,,DEM,Loretta L. Sanchez,377
+San Bernardino,VIC0439,U.S. Senate,,DEM,Kamala D. Harris,94
+San Bernardino,VIC0439,U.S. Senate,,DEM,Loretta L. Sanchez,73
+San Bernardino,VIC0440,U.S. Senate,,DEM,Kamala D. Harris,261
+San Bernardino,VIC0440,U.S. Senate,,DEM,Loretta L. Sanchez,275
+San Bernardino,VIC0441,U.S. Senate,,DEM,Kamala D. Harris,10
+San Bernardino,VIC0441,U.S. Senate,,DEM,Loretta L. Sanchez,7
+San Bernardino,VIC0442,U.S. Senate,,DEM,Kamala D. Harris,270
+San Bernardino,VIC0442,U.S. Senate,,DEM,Loretta L. Sanchez,275
+San Bernardino,VIC0443,U.S. Senate,,DEM,Kamala D. Harris,297
+San Bernardino,VIC0443,U.S. Senate,,DEM,Loretta L. Sanchez,260
+San Bernardino,VIC0444,U.S. Senate,,DEM,Kamala D. Harris,512
+San Bernardino,VIC0444,U.S. Senate,,DEM,Loretta L. Sanchez,440
+San Bernardino,VIC0445,U.S. Senate,,DEM,Kamala D. Harris,374
+San Bernardino,VIC0445,U.S. Senate,,DEM,Loretta L. Sanchez,342
+San Bernardino,VIC0446,U.S. Senate,,DEM,Kamala D. Harris,602
+San Bernardino,VIC0446,U.S. Senate,,DEM,Loretta L. Sanchez,482
+San Bernardino,VIC0447,U.S. Senate,,DEM,Kamala D. Harris,428
+San Bernardino,VIC0447,U.S. Senate,,DEM,Loretta L. Sanchez,381
+San Bernardino,VIC0448,U.S. Senate,,DEM,Kamala D. Harris,7
+San Bernardino,VIC0448,U.S. Senate,,DEM,Loretta L. Sanchez,7
+San Bernardino,VIC0449,U.S. Senate,,DEM,Kamala D. Harris,272
+San Bernardino,VIC0449,U.S. Senate,,DEM,Loretta L. Sanchez,230
+San Bernardino,VIC0450,U.S. Senate,,DEM,Kamala D. Harris,459
+San Bernardino,VIC0450,U.S. Senate,,DEM,Loretta L. Sanchez,365
+San Bernardino,VIC0451,U.S. Senate,,DEM,Kamala D. Harris,481
+San Bernardino,VIC0451,U.S. Senate,,DEM,Loretta L. Sanchez,456
+San Bernardino,VIC0452,U.S. Senate,,DEM,Kamala D. Harris,479
+San Bernardino,VIC0452,U.S. Senate,,DEM,Loretta L. Sanchez,405
+San Bernardino,VIC0453,U.S. Senate,,DEM,Kamala D. Harris,522
+San Bernardino,VIC0453,U.S. Senate,,DEM,Loretta L. Sanchez,369
+San Bernardino,VIC0454,U.S. Senate,,DEM,Kamala D. Harris,552
+San Bernardino,VIC0454,U.S. Senate,,DEM,Loretta L. Sanchez,383
+San Bernardino,VIC0455,U.S. Senate,,DEM,Kamala D. Harris,433
+San Bernardino,VIC0455,U.S. Senate,,DEM,Loretta L. Sanchez,368
+San Bernardino,VIC0456,U.S. Senate,,DEM,Kamala D. Harris,216
+San Bernardino,VIC0456,U.S. Senate,,DEM,Loretta L. Sanchez,198
+San Bernardino,VIC0457,U.S. Senate,,DEM,Kamala D. Harris,410
+San Bernardino,VIC0457,U.S. Senate,,DEM,Loretta L. Sanchez,434
+San Bernardino,VIC0458,U.S. Senate,,DEM,Kamala D. Harris,641
+San Bernardino,VIC0458,U.S. Senate,,DEM,Loretta L. Sanchez,511
+San Bernardino,VIC0459,U.S. Senate,,DEM,Kamala D. Harris,15
+San Bernardino,VIC0459,U.S. Senate,,DEM,Loretta L. Sanchez,13
+San Bernardino,VIC0460,U.S. Senate,,DEM,Kamala D. Harris,657
+San Bernardino,VIC0460,U.S. Senate,,DEM,Loretta L. Sanchez,478
+San Bernardino,VIC1604,U.S. Senate,,DEM,Kamala D. Harris,193
+San Bernardino,VIC1604,U.S. Senate,,DEM,Loretta L. Sanchez,161
+San Bernardino,VIC1605,U.S. Senate,,DEM,Kamala D. Harris,138
+San Bernardino,VIC1605,U.S. Senate,,DEM,Loretta L. Sanchez,152
+San Bernardino,VIC1617,U.S. Senate,,DEM,Kamala D. Harris,5
+San Bernardino,VIC1617,U.S. Senate,,DEM,Loretta L. Sanchez,5
+San Bernardino,VIC1618,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,VIC1618,U.S. Senate,,DEM,Loretta L. Sanchez,1
+San Bernardino,YU10781,U.S. Senate,,DEM,Kamala D. Harris,1
+San Bernardino,YU10781,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,YU10800,U.S. Senate,,DEM,Kamala D. Harris,573
+San Bernardino,YU10800,U.S. Senate,,DEM,Loretta L. Sanchez,392
+San Bernardino,YU10802,U.S. Senate,,DEM,Kamala D. Harris,662
+San Bernardino,YU10802,U.S. Senate,,DEM,Loretta L. Sanchez,484
+San Bernardino,YU10803,U.S. Senate,,DEM,Kamala D. Harris,400
+San Bernardino,YU10803,U.S. Senate,,DEM,Loretta L. Sanchez,365
+San Bernardino,YU10809,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,YU10809,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,YU10810,U.S. Senate,,DEM,Kamala D. Harris,332
+San Bernardino,YU10810,U.S. Senate,,DEM,Loretta L. Sanchez,266
+San Bernardino,YU10815,U.S. Senate,,DEM,Kamala D. Harris,4
+San Bernardino,YU10815,U.S. Senate,,DEM,Loretta L. Sanchez,3
+San Bernardino,YU10825,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,YU10825,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,YU10826,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,YU10826,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,YU10829,U.S. Senate,,DEM,Kamala D. Harris,138
+San Bernardino,YU10829,U.S. Senate,,DEM,Loretta L. Sanchez,109
+San Bernardino,YU20801,U.S. Senate,,DEM,Kamala D. Harris,3
+San Bernardino,YU20801,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,YU20804,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,YU20804,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,YU20805,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,YU20805,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,YU20811,U.S. Senate,,DEM,Kamala D. Harris,378
+San Bernardino,YU20811,U.S. Senate,,DEM,Loretta L. Sanchez,255
+San Bernardino,YU20812,U.S. Senate,,DEM,Kamala D. Harris,395
+San Bernardino,YU20812,U.S. Senate,,DEM,Loretta L. Sanchez,297
+San Bernardino,YU20817,U.S. Senate,,DEM,Kamala D. Harris,157
+San Bernardino,YU20817,U.S. Senate,,DEM,Loretta L. Sanchez,120
+San Bernardino,YU20821,U.S. Senate,,DEM,Kamala D. Harris,613
+San Bernardino,YU20821,U.S. Senate,,DEM,Loretta L. Sanchez,502
+San Bernardino,YU20827,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,YU20827,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,YU20828,U.S. Senate,,DEM,Kamala D. Harris,1
+San Bernardino,YU20828,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,YU21779,U.S. Senate,,DEM,Kamala D. Harris,376
+San Bernardino,YU21779,U.S. Senate,,DEM,Loretta L. Sanchez,293
+San Bernardino,YU30813,U.S. Senate,,DEM,Kamala D. Harris,832
+San Bernardino,YU30813,U.S. Senate,,DEM,Loretta L. Sanchez,670
+San Bernardino,YU31777,U.S. Senate,,DEM,Kamala D. Harris,275
+San Bernardino,YU31777,U.S. Senate,,DEM,Loretta L. Sanchez,158
+San Bernardino,YU31778,U.S. Senate,,DEM,Kamala D. Harris,429
+San Bernardino,YU31778,U.S. Senate,,DEM,Loretta L. Sanchez,361
+San Bernardino,YU40806,U.S. Senate,,DEM,Kamala D. Harris,610
+San Bernardino,YU40806,U.S. Senate,,DEM,Loretta L. Sanchez,454
+San Bernardino,YU40807,U.S. Senate,,DEM,Kamala D. Harris,627
+San Bernardino,YU40807,U.S. Senate,,DEM,Loretta L. Sanchez,541
+San Bernardino,YU40819,U.S. Senate,,DEM,Kamala D. Harris,336
+San Bernardino,YU40819,U.S. Senate,,DEM,Loretta L. Sanchez,238
+San Bernardino,YU40824,U.S. Senate,,DEM,Kamala D. Harris,297
+San Bernardino,YU40824,U.S. Senate,,DEM,Loretta L. Sanchez,226
+San Bernardino,YU50814,U.S. Senate,,DEM,Kamala D. Harris,67
+San Bernardino,YU50814,U.S. Senate,,DEM,Loretta L. Sanchez,60
+San Bernardino,YU50816,U.S. Senate,,DEM,Kamala D. Harris,697
+San Bernardino,YU50816,U.S. Senate,,DEM,Loretta L. Sanchez,570
+San Bernardino,YU50818,U.S. Senate,,DEM,Kamala D. Harris,669
+San Bernardino,YU50818,U.S. Senate,,DEM,Loretta L. Sanchez,521
+San Bernardino,YU50820,U.S. Senate,,DEM,Kamala D. Harris,569
+San Bernardino,YU50820,U.S. Senate,,DEM,Loretta L. Sanchez,514
+San Bernardino,YU50822,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,YU50822,U.S. Senate,,DEM,Loretta L. Sanchez,2
+San Bernardino,YU50823,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,YU50823,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,YU50830,U.S. Senate,,DEM,Kamala D. Harris,149
+San Bernardino,YU50830,U.S. Senate,,DEM,Loretta L. Sanchez,98
+San Bernardino,YU50831,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,YU50831,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,YU50832,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,YU50832,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,YU50833,U.S. Senate,,DEM,Kamala D. Harris,2
+San Bernardino,YU50833,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,YU51776,U.S. Senate,,DEM,Kamala D. Harris,1
+San Bernardino,YU51776,U.S. Senate,,DEM,Loretta L. Sanchez,1
+San Bernardino,YUV0265,U.S. Senate,,DEM,Kamala D. Harris,282
+San Bernardino,YUV0265,U.S. Senate,,DEM,Loretta L. Sanchez,205
+San Bernardino,YUV0266,U.S. Senate,,DEM,Kamala D. Harris,415
+San Bernardino,YUV0266,U.S. Senate,,DEM,Loretta L. Sanchez,262
+San Bernardino,YUV0267,U.S. Senate,,DEM,Kamala D. Harris,3
+San Bernardino,YUV0267,U.S. Senate,,DEM,Loretta L. Sanchez,1
+San Bernardino,YUV0268,U.S. Senate,,DEM,Kamala D. Harris,390
+San Bernardino,YUV0268,U.S. Senate,,DEM,Loretta L. Sanchez,252
+San Bernardino,YUV0269,U.S. Senate,,DEM,Kamala D. Harris,0
+San Bernardino,YUV0269,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Bernardino,YUV0270,U.S. Senate,,DEM,Kamala D. Harris,14
+San Bernardino,YUV0270,U.S. Senate,,DEM,Loretta L. Sanchez,11
+San Bernardino,YUV0271,U.S. Senate,,DEM,Kamala D. Harris,594
+San Bernardino,YUV0271,U.S. Senate,,DEM,Loretta L. Sanchez,419
+San Bernardino,YUV0272,U.S. Senate,,DEM,Kamala D. Harris,517
+San Bernardino,YUV0272,U.S. Senate,,DEM,Loretta L. Sanchez,310
+San Bernardino,YUV0273,U.S. Senate,,DEM,Kamala D. Harris,13
+San Bernardino,YUV0273,U.S. Senate,,DEM,Loretta L. Sanchez,17
+San Bernardino,YUV0274,U.S. Senate,,DEM,Kamala D. Harris,657
+San Bernardino,YUV0274,U.S. Senate,,DEM,Loretta L. Sanchez,511
+San Bernardino,YUV0275,U.S. Senate,,DEM,Kamala D. Harris,643
+San Bernardino,YUV0275,U.S. Senate,,DEM,Loretta L. Sanchez,443

--- a/2016/20161108__ca__general__san_francisco__precinct.csv
+++ b/2016/20161108__ca__general__san_francisco__precinct.csv
@@ -23879,1197 +23879,1197 @@ San Francisco,9901,Proposition 67,,N/A,Yes,0
 San Francisco,9901,Proposition 67,,N/A,No,0
 San Francisco,9902,Proposition 67,,N/A,Yes,0
 San Francisco,9902,Proposition 67,,N/A,No,0
-San Francisco,1101,U.S. Senate,,DEM,Kamala Harris,300
-San Francisco,1101,U.S. Senate,,DEM,Loretta Sanchez,105
-San Francisco,1102,U.S. Senate,,DEM,Kamala Harris,529
-San Francisco,1102,U.S. Senate,,DEM,Loretta Sanchez,215
-San Francisco,1103,U.S. Senate,,DEM,Kamala Harris,480
-San Francisco,1103,U.S. Senate,,DEM,Loretta Sanchez,229
-San Francisco,1104/1105,U.S. Senate,,DEM,Kamala Harris,487
-San Francisco,1104/1105,U.S. Senate,,DEM,Loretta Sanchez,207
-San Francisco,1106,U.S. Senate,,DEM,Kamala Harris,409
-San Francisco,1106,U.S. Senate,,DEM,Loretta Sanchez,116
-San Francisco,1107,U.S. Senate,,DEM,Kamala Harris,340
-San Francisco,1107,U.S. Senate,,DEM,Loretta Sanchez,108
-San Francisco,1108,U.S. Senate,,DEM,Kamala Harris,547
-San Francisco,1108,U.S. Senate,,DEM,Loretta Sanchez,130
-San Francisco,1109,U.S. Senate,,DEM,Kamala Harris,422
-San Francisco,1109,U.S. Senate,,DEM,Loretta Sanchez,134
-San Francisco,1111,U.S. Senate,,DEM,Kamala Harris,430
-San Francisco,1111,U.S. Senate,,DEM,Loretta Sanchez,185
-San Francisco,1112,U.S. Senate,,DEM,Kamala Harris,347
-San Francisco,1112,U.S. Senate,,DEM,Loretta Sanchez,136
-San Francisco,1113,U.S. Senate,,DEM,Kamala Harris,341
-San Francisco,1113,U.S. Senate,,DEM,Loretta Sanchez,147
-San Francisco,1114,U.S. Senate,,DEM,Kamala Harris,444
-San Francisco,1114,U.S. Senate,,DEM,Loretta Sanchez,195
-San Francisco,1115,U.S. Senate,,DEM,Kamala Harris,469
-San Francisco,1115,U.S. Senate,,DEM,Loretta Sanchez,161
-San Francisco,1116,U.S. Senate,,DEM,Kamala Harris,417
-San Francisco,1116,U.S. Senate,,DEM,Loretta Sanchez,147
-San Francisco,1117,U.S. Senate,,DEM,Kamala Harris,416
-San Francisco,1117,U.S. Senate,,DEM,Loretta Sanchez,150
-San Francisco,1118,U.S. Senate,,DEM,Kamala Harris,521
-San Francisco,1118,U.S. Senate,,DEM,Loretta Sanchez,194
-San Francisco,1119,U.S. Senate,,DEM,Kamala Harris,370
-San Francisco,1119,U.S. Senate,,DEM,Loretta Sanchez,142
-San Francisco,1121,U.S. Senate,,DEM,Kamala Harris,292
-San Francisco,1121,U.S. Senate,,DEM,Loretta Sanchez,148
-San Francisco,1122,U.S. Senate,,DEM,Kamala Harris,283
-San Francisco,1122,U.S. Senate,,DEM,Loretta Sanchez,134
-San Francisco,1123,U.S. Senate,,DEM,Kamala Harris,411
-San Francisco,1123,U.S. Senate,,DEM,Loretta Sanchez,164
-San Francisco,1124,U.S. Senate,,DEM,Kamala Harris,361
-San Francisco,1124,U.S. Senate,,DEM,Loretta Sanchez,145
-San Francisco,1125,U.S. Senate,,DEM,Kamala Harris,454
-San Francisco,1125,U.S. Senate,,DEM,Loretta Sanchez,217
-San Francisco,1126,U.S. Senate,,DEM,Kamala Harris,427
-San Francisco,1126,U.S. Senate,,DEM,Loretta Sanchez,196
-San Francisco,1127,U.S. Senate,,DEM,Kamala Harris,420
-San Francisco,1127,U.S. Senate,,DEM,Loretta Sanchez,176
-San Francisco,1128,U.S. Senate,,DEM,Kamala Harris,397
-San Francisco,1128,U.S. Senate,,DEM,Loretta Sanchez,196
-San Francisco,1129,U.S. Senate,,DEM,Kamala Harris,386
-San Francisco,1129,U.S. Senate,,DEM,Loretta Sanchez,216
-San Francisco,1131,U.S. Senate,,DEM,Kamala Harris,314
-San Francisco,1131,U.S. Senate,,DEM,Loretta Sanchez,178
-San Francisco,1132,U.S. Senate,,DEM,Kamala Harris,416
-San Francisco,1132,U.S. Senate,,DEM,Loretta Sanchez,190
-San Francisco,1133,U.S. Senate,,DEM,Kamala Harris,428
-San Francisco,1133,U.S. Senate,,DEM,Loretta Sanchez,148
-San Francisco,1134,U.S. Senate,,DEM,Kamala Harris,357
-San Francisco,1134,U.S. Senate,,DEM,Loretta Sanchez,157
-San Francisco,1135,U.S. Senate,,DEM,Kamala Harris,257
-San Francisco,1135,U.S. Senate,,DEM,Loretta Sanchez,119
-San Francisco,1136,U.S. Senate,,DEM,Kamala Harris,412
-San Francisco,1136,U.S. Senate,,DEM,Loretta Sanchez,168
-San Francisco,1141,U.S. Senate,,DEM,Kamala Harris,552
-San Francisco,1141,U.S. Senate,,DEM,Loretta Sanchez,182
-San Francisco,1142,U.S. Senate,,DEM,Kamala Harris,382
-San Francisco,1142,U.S. Senate,,DEM,Loretta Sanchez,203
-San Francisco,1143,U.S. Senate,,DEM,Kamala Harris,468
-San Francisco,1143,U.S. Senate,,DEM,Loretta Sanchez,230
-San Francisco,1144,U.S. Senate,,DEM,Kamala Harris,421
-San Francisco,1144,U.S. Senate,,DEM,Loretta Sanchez,219
-San Francisco,1145,U.S. Senate,,DEM,Kamala Harris,541
-San Francisco,1145,U.S. Senate,,DEM,Loretta Sanchez,159
-San Francisco,1146,U.S. Senate,,DEM,Kamala Harris,474
-San Francisco,1146,U.S. Senate,,DEM,Loretta Sanchez,231
-San Francisco,1147,U.S. Senate,,DEM,Kamala Harris,445
-San Francisco,1147,U.S. Senate,,DEM,Loretta Sanchez,208
-San Francisco,1148,U.S. Senate,,DEM,Kamala Harris,411
-San Francisco,1148,U.S. Senate,,DEM,Loretta Sanchez,221
-San Francisco,1149,U.S. Senate,,DEM,Kamala Harris,450
-San Francisco,1149,U.S. Senate,,DEM,Loretta Sanchez,215
-San Francisco,1151,U.S. Senate,,DEM,Kamala Harris,0
-San Francisco,1151,U.S. Senate,,DEM,Loretta Sanchez,0
-San Francisco,1152,U.S. Senate,,DEM,Kamala Harris,393
-San Francisco,1152,U.S. Senate,,DEM,Loretta Sanchez,201
-San Francisco,1153,U.S. Senate,,DEM,Kamala Harris,447
-San Francisco,1153,U.S. Senate,,DEM,Loretta Sanchez,193
-San Francisco,1154,U.S. Senate,,DEM,Kamala Harris,0
-San Francisco,1154,U.S. Senate,,DEM,Loretta Sanchez,0
-San Francisco,7001,U.S. Senate,,DEM,Kamala Harris,400
-San Francisco,7001,U.S. Senate,,DEM,Loretta Sanchez,97
-San Francisco,7002,U.S. Senate,,DEM,Kamala Harris,667
-San Francisco,7002,U.S. Senate,,DEM,Loretta Sanchez,184
-San Francisco,7003,U.S. Senate,,DEM,Kamala Harris,651
-San Francisco,7003,U.S. Senate,,DEM,Loretta Sanchez,123
-San Francisco,7004,U.S. Senate,,DEM,Kamala Harris,615
-San Francisco,7004,U.S. Senate,,DEM,Loretta Sanchez,106
-San Francisco,7005,U.S. Senate,,DEM,Kamala Harris,590
-San Francisco,7005,U.S. Senate,,DEM,Loretta Sanchez,101
-San Francisco,7006,U.S. Senate,,DEM,Kamala Harris,589
-San Francisco,7006,U.S. Senate,,DEM,Loretta Sanchez,135
-San Francisco,7007,U.S. Senate,,DEM,Kamala Harris,668
-San Francisco,7007,U.S. Senate,,DEM,Loretta Sanchez,133
-San Francisco,7008,U.S. Senate,,DEM,Kamala Harris,627
-San Francisco,7008,U.S. Senate,,DEM,Loretta Sanchez,133
-San Francisco,7009,U.S. Senate,,DEM,Kamala Harris,529
-San Francisco,7009,U.S. Senate,,DEM,Loretta Sanchez,137
-San Francisco,7011,U.S. Senate,,DEM,Kamala Harris,454
-San Francisco,7011,U.S. Senate,,DEM,Loretta Sanchez,119
-San Francisco,7012,U.S. Senate,,DEM,Kamala Harris,689
-San Francisco,7012,U.S. Senate,,DEM,Loretta Sanchez,144
-San Francisco,7013,U.S. Senate,,DEM,Kamala Harris,472
-San Francisco,7013,U.S. Senate,,DEM,Loretta Sanchez,102
-San Francisco,7014,U.S. Senate,,DEM,Kamala Harris,705
-San Francisco,7014,U.S. Senate,,DEM,Loretta Sanchez,134
-San Francisco,7015,U.S. Senate,,DEM,Kamala Harris,56
-San Francisco,7015,U.S. Senate,,DEM,Loretta Sanchez,18
-San Francisco,7016,U.S. Senate,,DEM,Kamala Harris,369
-San Francisco,7016,U.S. Senate,,DEM,Loretta Sanchez,155
-San Francisco,7017,U.S. Senate,,DEM,Kamala Harris,363
-San Francisco,7017,U.S. Senate,,DEM,Loretta Sanchez,78
-San Francisco,7018,U.S. Senate,,DEM,Kamala Harris,408
-San Francisco,7018,U.S. Senate,,DEM,Loretta Sanchez,176
-San Francisco,7019,U.S. Senate,,DEM,Kamala Harris,500
-San Francisco,7019,U.S. Senate,,DEM,Loretta Sanchez,130
-San Francisco,7021,U.S. Senate,,DEM,Kamala Harris,456
-San Francisco,7021,U.S. Senate,,DEM,Loretta Sanchez,122
-San Francisco,7022,U.S. Senate,,DEM,Kamala Harris,495
-San Francisco,7022,U.S. Senate,,DEM,Loretta Sanchez,116
-San Francisco,7023,U.S. Senate,,DEM,Kamala Harris,524
-San Francisco,7023,U.S. Senate,,DEM,Loretta Sanchez,91
-San Francisco,7024,U.S. Senate,,DEM,Kamala Harris,91
-San Francisco,7024,U.S. Senate,,DEM,Loretta Sanchez,22
-San Francisco,7025,U.S. Senate,,DEM,Kamala Harris,195
-San Francisco,7025,U.S. Senate,,DEM,Loretta Sanchez,55
-San Francisco,7026,U.S. Senate,,DEM,Kamala Harris,393
-San Francisco,7026,U.S. Senate,,DEM,Loretta Sanchez,191
-San Francisco,7027,U.S. Senate,,DEM,Kamala Harris,383
-San Francisco,7027,U.S. Senate,,DEM,Loretta Sanchez,130
-San Francisco,7028,U.S. Senate,,DEM,Kamala Harris,398
-San Francisco,7028,U.S. Senate,,DEM,Loretta Sanchez,104
-San Francisco,7029,U.S. Senate,,DEM,Kamala Harris,403
-San Francisco,7029,U.S. Senate,,DEM,Loretta Sanchez,83
-San Francisco,7030,U.S. Senate,,DEM,Kamala Harris,310
-San Francisco,7030,U.S. Senate,,DEM,Loretta Sanchez,156
-San Francisco,7031,U.S. Senate,,DEM,Kamala Harris,246
-San Francisco,7031,U.S. Senate,,DEM,Loretta Sanchez,95
-San Francisco,7032,U.S. Senate,,DEM,Kamala Harris,388
-San Francisco,7032,U.S. Senate,,DEM,Loretta Sanchez,156
-San Francisco,7033,U.S. Senate,,DEM,Kamala Harris,367
-San Francisco,7033,U.S. Senate,,DEM,Loretta Sanchez,131
-San Francisco,7034,U.S. Senate,,DEM,Kamala Harris,394
-San Francisco,7034,U.S. Senate,,DEM,Loretta Sanchez,89
-San Francisco,7035,U.S. Senate,,DEM,Kamala Harris,257
-San Francisco,7035,U.S. Senate,,DEM,Loretta Sanchez,51
-San Francisco,7036,U.S. Senate,,DEM,Kamala Harris,345
-San Francisco,7036,U.S. Senate,,DEM,Loretta Sanchez,189
-San Francisco,7037,U.S. Senate,,DEM,Kamala Harris,232
-San Francisco,7037,U.S. Senate,,DEM,Loretta Sanchez,90
-San Francisco,7038,U.S. Senate,,DEM,Kamala Harris,362
-San Francisco,7038,U.S. Senate,,DEM,Loretta Sanchez,160
-San Francisco,7039,U.S. Senate,,DEM,Kamala Harris,351
-San Francisco,7039,U.S. Senate,,DEM,Loretta Sanchez,195
-San Francisco,7041,U.S. Senate,,DEM,Kamala Harris,21
-San Francisco,7041,U.S. Senate,,DEM,Loretta Sanchez,9
-San Francisco,7042,U.S. Senate,,DEM,Kamala Harris,330
-San Francisco,7042,U.S. Senate,,DEM,Loretta Sanchez,136
-San Francisco,7043,U.S. Senate,,DEM,Kamala Harris,408
-San Francisco,7043,U.S. Senate,,DEM,Loretta Sanchez,166
-San Francisco,7044,U.S. Senate,,DEM,Kamala Harris,276
-San Francisco,7044,U.S. Senate,,DEM,Loretta Sanchez,91
-San Francisco,7045,U.S. Senate,,DEM,Kamala Harris,281
-San Francisco,7045,U.S. Senate,,DEM,Loretta Sanchez,170
-San Francisco,7046,U.S. Senate,,DEM,Kamala Harris,188
-San Francisco,7046,U.S. Senate,,DEM,Loretta Sanchez,91
-San Francisco,7047,U.S. Senate,,DEM,Kamala Harris,346
-San Francisco,7047,U.S. Senate,,DEM,Loretta Sanchez,189
-San Francisco,7048,U.S. Senate,,DEM,Kamala Harris,318
-San Francisco,7048,U.S. Senate,,DEM,Loretta Sanchez,143
-San Francisco,7049,U.S. Senate,,DEM,Kamala Harris,297
-San Francisco,7049,U.S. Senate,,DEM,Loretta Sanchez,156
-San Francisco,7051,U.S. Senate,,DEM,Kamala Harris,324
-San Francisco,7051,U.S. Senate,,DEM,Loretta Sanchez,186
-San Francisco,7052,U.S. Senate,,DEM,Kamala Harris,393
-San Francisco,7052,U.S. Senate,,DEM,Loretta Sanchez,182
-San Francisco,7053,U.S. Senate,,DEM,Kamala Harris,285
-San Francisco,7053,U.S. Senate,,DEM,Loretta Sanchez,116
-San Francisco,7054,U.S. Senate,,DEM,Kamala Harris,483
-San Francisco,7054,U.S. Senate,,DEM,Loretta Sanchez,142
-San Francisco,7101,U.S. Senate,,DEM,Kamala Harris,100
-San Francisco,7101,U.S. Senate,,DEM,Loretta Sanchez,15
-San Francisco,7201,U.S. Senate,,DEM,Kamala Harris,580
-San Francisco,7201,U.S. Senate,,DEM,Loretta Sanchez,161
-San Francisco,7202,U.S. Senate,,DEM,Kamala Harris,513
-San Francisco,7202,U.S. Senate,,DEM,Loretta Sanchez,139
-San Francisco,7203,U.S. Senate,,DEM,Kamala Harris,541
-San Francisco,7203,U.S. Senate,,DEM,Loretta Sanchez,187
-San Francisco,7204,U.S. Senate,,DEM,Kamala Harris,587
-San Francisco,7204,U.S. Senate,,DEM,Loretta Sanchez,152
-San Francisco,7205,U.S. Senate,,DEM,Kamala Harris,580
-San Francisco,7205,U.S. Senate,,DEM,Loretta Sanchez,135
-San Francisco,7206,U.S. Senate,,DEM,Kamala Harris,249
-San Francisco,7206,U.S. Senate,,DEM,Loretta Sanchez,60
-San Francisco,7207,U.S. Senate,,DEM,Kamala Harris,413
-San Francisco,7207,U.S. Senate,,DEM,Loretta Sanchez,85
-San Francisco,7208,U.S. Senate,,DEM,Kamala Harris,359
-San Francisco,7208,U.S. Senate,,DEM,Loretta Sanchez,91
-San Francisco,7209,U.S. Senate,,DEM,Kamala Harris,357
-San Francisco,7209,U.S. Senate,,DEM,Loretta Sanchez,77
-San Francisco,7301,U.S. Senate,,DEM,Kamala Harris,476
-San Francisco,7301,U.S. Senate,,DEM,Loretta Sanchez,203
-San Francisco,7302,U.S. Senate,,DEM,Kamala Harris,461
-San Francisco,7302,U.S. Senate,,DEM,Loretta Sanchez,170
-San Francisco,7303,U.S. Senate,,DEM,Kamala Harris,561
-San Francisco,7303,U.S. Senate,,DEM,Loretta Sanchez,178
-San Francisco,7304,U.S. Senate,,DEM,Kamala Harris,567
-San Francisco,7304,U.S. Senate,,DEM,Loretta Sanchez,160
-San Francisco,7305,U.S. Senate,,DEM,Kamala Harris,533
-San Francisco,7305,U.S. Senate,,DEM,Loretta Sanchez,155
-San Francisco,7306,U.S. Senate,,DEM,Kamala Harris,597
-San Francisco,7306,U.S. Senate,,DEM,Loretta Sanchez,163
-San Francisco,7307,U.S. Senate,,DEM,Kamala Harris,468
-San Francisco,7307,U.S. Senate,,DEM,Loretta Sanchez,119
-San Francisco,7308,U.S. Senate,,DEM,Kamala Harris,402
-San Francisco,7308,U.S. Senate,,DEM,Loretta Sanchez,94
-San Francisco,7309,U.S. Senate,,DEM,Kamala Harris,497
-San Francisco,7309,U.S. Senate,,DEM,Loretta Sanchez,164
-San Francisco,7311,U.S. Senate,,DEM,Kamala Harris,579
-San Francisco,7311,U.S. Senate,,DEM,Loretta Sanchez,151
-San Francisco,7312,U.S. Senate,,DEM,Kamala Harris,527
-San Francisco,7312,U.S. Senate,,DEM,Loretta Sanchez,150
-San Francisco,7313,U.S. Senate,,DEM,Kamala Harris,515
-San Francisco,7313,U.S. Senate,,DEM,Loretta Sanchez,173
-San Francisco,7314,U.S. Senate,,DEM,Kamala Harris,258
-San Francisco,7314,U.S. Senate,,DEM,Loretta Sanchez,147
-San Francisco,7315,U.S. Senate,,DEM,Kamala Harris,373
-San Francisco,7315,U.S. Senate,,DEM,Loretta Sanchez,132
-San Francisco,7316,U.S. Senate,,DEM,Kamala Harris,413
-San Francisco,7316,U.S. Senate,,DEM,Loretta Sanchez,147
-San Francisco,7317,U.S. Senate,,DEM,Kamala Harris,486
-San Francisco,7317,U.S. Senate,,DEM,Loretta Sanchez,169
-San Francisco,7318,U.S. Senate,,DEM,Kamala Harris,429
-San Francisco,7318,U.S. Senate,,DEM,Loretta Sanchez,146
-San Francisco,7319,U.S. Senate,,DEM,Kamala Harris,602
-San Francisco,7319,U.S. Senate,,DEM,Loretta Sanchez,179
-San Francisco,7321,U.S. Senate,,DEM,Kamala Harris,295
-San Francisco,7321,U.S. Senate,,DEM,Loretta Sanchez,124
-San Francisco,7322,U.S. Senate,,DEM,Kamala Harris,244
-San Francisco,7322,U.S. Senate,,DEM,Loretta Sanchez,164
-San Francisco,7323,U.S. Senate,,DEM,Kamala Harris,463
-San Francisco,7323,U.S. Senate,,DEM,Loretta Sanchez,158
-San Francisco,7324,U.S. Senate,,DEM,Kamala Harris,355
-San Francisco,7324,U.S. Senate,,DEM,Loretta Sanchez,145
-San Francisco,7325,U.S. Senate,,DEM,Kamala Harris,499
-San Francisco,7325,U.S. Senate,,DEM,Loretta Sanchez,162
-San Francisco,7326,U.S. Senate,,DEM,Kamala Harris,478
-San Francisco,7326,U.S. Senate,,DEM,Loretta Sanchez,161
-San Francisco,7327,U.S. Senate,,DEM,Kamala Harris,206
-San Francisco,7327,U.S. Senate,,DEM,Loretta Sanchez,146
-San Francisco,7328,U.S. Senate,,DEM,Kamala Harris,289
-San Francisco,7328,U.S. Senate,,DEM,Loretta Sanchez,202
-San Francisco,7329,U.S. Senate,,DEM,Kamala Harris,284
-San Francisco,7329,U.S. Senate,,DEM,Loretta Sanchez,105
-San Francisco,7331,U.S. Senate,,DEM,Kamala Harris,507
-San Francisco,7331,U.S. Senate,,DEM,Loretta Sanchez,171
-San Francisco,7332,U.S. Senate,,DEM,Kamala Harris,473
-San Francisco,7332,U.S. Senate,,DEM,Loretta Sanchez,155
-San Francisco,7333,U.S. Senate,,DEM,Kamala Harris,578
-San Francisco,7333,U.S. Senate,,DEM,Loretta Sanchez,187
-San Francisco,7334,U.S. Senate,,DEM,Kamala Harris,494
-San Francisco,7334,U.S. Senate,,DEM,Loretta Sanchez,170
-San Francisco,7335,U.S. Senate,,DEM,Kamala Harris,590
-San Francisco,7335,U.S. Senate,,DEM,Loretta Sanchez,192
-San Francisco,7336,U.S. Senate,,DEM,Kamala Harris,609
-San Francisco,7336,U.S. Senate,,DEM,Loretta Sanchez,172
-San Francisco,7337,U.S. Senate,,DEM,Kamala Harris,510
-San Francisco,7337,U.S. Senate,,DEM,Loretta Sanchez,142
-San Francisco,7338,U.S. Senate,,DEM,Kamala Harris,368
-San Francisco,7338,U.S. Senate,,DEM,Loretta Sanchez,203
-San Francisco,7339,U.S. Senate,,DEM,Kamala Harris,301
-San Francisco,7339,U.S. Senate,,DEM,Loretta Sanchez,127
-San Francisco,7341,U.S. Senate,,DEM,Kamala Harris,525
-San Francisco,7341,U.S. Senate,,DEM,Loretta Sanchez,136
-San Francisco,7342,U.S. Senate,,DEM,Kamala Harris,538
-San Francisco,7342,U.S. Senate,,DEM,Loretta Sanchez,169
-San Francisco,7343,U.S. Senate,,DEM,Kamala Harris,425
-San Francisco,7343,U.S. Senate,,DEM,Loretta Sanchez,114
-San Francisco,7344,U.S. Senate,,DEM,Kamala Harris,622
-San Francisco,7344,U.S. Senate,,DEM,Loretta Sanchez,184
-San Francisco,7345,U.S. Senate,,DEM,Kamala Harris,603
-San Francisco,7345,U.S. Senate,,DEM,Loretta Sanchez,189
-San Francisco,7346,U.S. Senate,,DEM,Kamala Harris,502
-San Francisco,7346,U.S. Senate,,DEM,Loretta Sanchez,180
-San Francisco,7347,U.S. Senate,,DEM,Kamala Harris,568
-San Francisco,7347,U.S. Senate,,DEM,Loretta Sanchez,192
-San Francisco,7348,U.S. Senate,,DEM,Kamala Harris,409
-San Francisco,7348,U.S. Senate,,DEM,Loretta Sanchez,152
-San Francisco,7349,U.S. Senate,,DEM,Kamala Harris,470
-San Francisco,7349,U.S. Senate,,DEM,Loretta Sanchez,195
-San Francisco,7501,U.S. Senate,,DEM,Kamala Harris,374
-San Francisco,7501,U.S. Senate,,DEM,Loretta Sanchez,90
-San Francisco,7502,U.S. Senate,,DEM,Kamala Harris,475
-San Francisco,7502,U.S. Senate,,DEM,Loretta Sanchez,138
-San Francisco,7503,U.S. Senate,,DEM,Kamala Harris,472
-San Francisco,7503,U.S. Senate,,DEM,Loretta Sanchez,132
-San Francisco,7504,U.S. Senate,,DEM,Kamala Harris,252
-San Francisco,7504,U.S. Senate,,DEM,Loretta Sanchez,97
-San Francisco,7505,U.S. Senate,,DEM,Kamala Harris,545
-San Francisco,7505,U.S. Senate,,DEM,Loretta Sanchez,145
-San Francisco,7506,U.S. Senate,,DEM,Kamala Harris,551
-San Francisco,7506,U.S. Senate,,DEM,Loretta Sanchez,155
-San Francisco,7507,U.S. Senate,,DEM,Kamala Harris,449
-San Francisco,7507,U.S. Senate,,DEM,Loretta Sanchez,127
-San Francisco,7508,U.S. Senate,,DEM,Kamala Harris,423
-San Francisco,7508,U.S. Senate,,DEM,Loretta Sanchez,128
-San Francisco,7509/7511,U.S. Senate,,DEM,Kamala Harris,590
-San Francisco,7509/7511,U.S. Senate,,DEM,Loretta Sanchez,162
-San Francisco,7512,U.S. Senate,,DEM,Kamala Harris,323
-San Francisco,7512,U.S. Senate,,DEM,Loretta Sanchez,92
-San Francisco,7513,U.S. Senate,,DEM,Kamala Harris,415
-San Francisco,7513,U.S. Senate,,DEM,Loretta Sanchez,110
-San Francisco,7514,U.S. Senate,,DEM,Kamala Harris,396
-San Francisco,7514,U.S. Senate,,DEM,Loretta Sanchez,96
-San Francisco,7515,U.S. Senate,,DEM,Kamala Harris,506
-San Francisco,7515,U.S. Senate,,DEM,Loretta Sanchez,116
-San Francisco,7516,U.S. Senate,,DEM,Kamala Harris,528
-San Francisco,7516,U.S. Senate,,DEM,Loretta Sanchez,152
-San Francisco,7517,U.S. Senate,,DEM,Kamala Harris,631
-San Francisco,7517,U.S. Senate,,DEM,Loretta Sanchez,134
-San Francisco,7518,U.S. Senate,,DEM,Kamala Harris,669
-San Francisco,7518,U.S. Senate,,DEM,Loretta Sanchez,123
-San Francisco,7519,U.S. Senate,,DEM,Kamala Harris,524
-San Francisco,7519,U.S. Senate,,DEM,Loretta Sanchez,83
-San Francisco,7521,U.S. Senate,,DEM,Kamala Harris,577
-San Francisco,7521,U.S. Senate,,DEM,Loretta Sanchez,85
-San Francisco,7522,U.S. Senate,,DEM,Kamala Harris,600
-San Francisco,7522,U.S. Senate,,DEM,Loretta Sanchez,91
-San Francisco,7523,U.S. Senate,,DEM,Kamala Harris,552
-San Francisco,7523,U.S. Senate,,DEM,Loretta Sanchez,85
-San Francisco,7524,U.S. Senate,,DEM,Kamala Harris,413
-San Francisco,7524,U.S. Senate,,DEM,Loretta Sanchez,80
-San Francisco,7525,U.S. Senate,,DEM,Kamala Harris,502
-San Francisco,7525,U.S. Senate,,DEM,Loretta Sanchez,84
-San Francisco,7526,U.S. Senate,,DEM,Kamala Harris,659
-San Francisco,7526,U.S. Senate,,DEM,Loretta Sanchez,127
-San Francisco,7527/7528,U.S. Senate,,DEM,Kamala Harris,421
-San Francisco,7527/7528,U.S. Senate,,DEM,Loretta Sanchez,131
-San Francisco,7529,U.S. Senate,,DEM,Kamala Harris,662
-San Francisco,7529,U.S. Senate,,DEM,Loretta Sanchez,115
-San Francisco,7531,U.S. Senate,,DEM,Kamala Harris,627
-San Francisco,7531,U.S. Senate,,DEM,Loretta Sanchez,106
-San Francisco,7532,U.S. Senate,,DEM,Kamala Harris,531
-San Francisco,7532,U.S. Senate,,DEM,Loretta Sanchez,139
-San Francisco,7533,U.S. Senate,,DEM,Kamala Harris,694
-San Francisco,7533,U.S. Senate,,DEM,Loretta Sanchez,139
-San Francisco,7534,U.S. Senate,,DEM,Kamala Harris,592
-San Francisco,7534,U.S. Senate,,DEM,Loretta Sanchez,111
-San Francisco,7535,U.S. Senate,,DEM,Kamala Harris,546
-San Francisco,7535,U.S. Senate,,DEM,Loretta Sanchez,122
-San Francisco,7536,U.S. Senate,,DEM,Kamala Harris,612
-San Francisco,7536,U.S. Senate,,DEM,Loretta Sanchez,96
-San Francisco,7537,U.S. Senate,,DEM,Kamala Harris,529
-San Francisco,7537,U.S. Senate,,DEM,Loretta Sanchez,85
-San Francisco,7538,U.S. Senate,,DEM,Kamala Harris,576
-San Francisco,7538,U.S. Senate,,DEM,Loretta Sanchez,92
-San Francisco,7539,U.S. Senate,,DEM,Kamala Harris,671
-San Francisco,7539,U.S. Senate,,DEM,Loretta Sanchez,87
-San Francisco,7541,U.S. Senate,,DEM,Kamala Harris,567
-San Francisco,7541,U.S. Senate,,DEM,Loretta Sanchez,98
-San Francisco,7542,U.S. Senate,,DEM,Kamala Harris,608
-San Francisco,7542,U.S. Senate,,DEM,Loretta Sanchez,93
-San Francisco,7543,U.S. Senate,,DEM,Kamala Harris,642
-San Francisco,7543,U.S. Senate,,DEM,Loretta Sanchez,100
-San Francisco,7544,U.S. Senate,,DEM,Kamala Harris,630
-San Francisco,7544,U.S. Senate,,DEM,Loretta Sanchez,119
-San Francisco,7545,U.S. Senate,,DEM,Kamala Harris,618
-San Francisco,7545,U.S. Senate,,DEM,Loretta Sanchez,123
-San Francisco,7546,U.S. Senate,,DEM,Kamala Harris,638
-San Francisco,7546,U.S. Senate,,DEM,Loretta Sanchez,117
-San Francisco,7547,U.S. Senate,,DEM,Kamala Harris,609
-San Francisco,7547,U.S. Senate,,DEM,Loretta Sanchez,126
-San Francisco,7548,U.S. Senate,,DEM,Kamala Harris,709
-San Francisco,7548,U.S. Senate,,DEM,Loretta Sanchez,100
-San Francisco,7549,U.S. Senate,,DEM,Kamala Harris,555
-San Francisco,7549,U.S. Senate,,DEM,Loretta Sanchez,92
-San Francisco,7551,U.S. Senate,,DEM,Kamala Harris,521
-San Francisco,7551,U.S. Senate,,DEM,Loretta Sanchez,79
-San Francisco,7552,U.S. Senate,,DEM,Kamala Harris,547
-San Francisco,7552,U.S. Senate,,DEM,Loretta Sanchez,74
-San Francisco,7553,U.S. Senate,,DEM,Kamala Harris,130
-San Francisco,7553,U.S. Senate,,DEM,Loretta Sanchez,14
-San Francisco,7554,U.S. Senate,,DEM,Kamala Harris,606
-San Francisco,7554,U.S. Senate,,DEM,Loretta Sanchez,103
-San Francisco,7555,U.S. Senate,,DEM,Kamala Harris,693
-San Francisco,7555,U.S. Senate,,DEM,Loretta Sanchez,107
-San Francisco,7556/7557,U.S. Senate,,DEM,Kamala Harris,723
-San Francisco,7556/7557,U.S. Senate,,DEM,Loretta Sanchez,109
-San Francisco,7601,U.S. Senate,,DEM,Kamala Harris,376
-San Francisco,7601,U.S. Senate,,DEM,Loretta Sanchez,140
-San Francisco,7602,U.S. Senate,,DEM,Kamala Harris,451
-San Francisco,7602,U.S. Senate,,DEM,Loretta Sanchez,162
-San Francisco,7603,U.S. Senate,,DEM,Kamala Harris,475
-San Francisco,7603,U.S. Senate,,DEM,Loretta Sanchez,155
-San Francisco,7604,U.S. Senate,,DEM,Kamala Harris,444
-San Francisco,7604,U.S. Senate,,DEM,Loretta Sanchez,156
-San Francisco,7605,U.S. Senate,,DEM,Kamala Harris,265
-San Francisco,7605,U.S. Senate,,DEM,Loretta Sanchez,108
-San Francisco,7606,U.S. Senate,,DEM,Kamala Harris,391
-San Francisco,7606,U.S. Senate,,DEM,Loretta Sanchez,170
-San Francisco,7607,U.S. Senate,,DEM,Kamala Harris,462
-San Francisco,7607,U.S. Senate,,DEM,Loretta Sanchez,179
-San Francisco,7608,U.S. Senate,,DEM,Kamala Harris,131
-San Francisco,7608,U.S. Senate,,DEM,Loretta Sanchez,85
-San Francisco,7609,U.S. Senate,,DEM,Kamala Harris,334
-San Francisco,7609,U.S. Senate,,DEM,Loretta Sanchez,134
-San Francisco,7611,U.S. Senate,,DEM,Kamala Harris,293
-San Francisco,7611,U.S. Senate,,DEM,Loretta Sanchez,109
-San Francisco,7612,U.S. Senate,,DEM,Kamala Harris,259
-San Francisco,7612,U.S. Senate,,DEM,Loretta Sanchez,96
-San Francisco,7613,U.S. Senate,,DEM,Kamala Harris,395
-San Francisco,7613,U.S. Senate,,DEM,Loretta Sanchez,158
-San Francisco,7614,U.S. Senate,,DEM,Kamala Harris,546
-San Francisco,7614,U.S. Senate,,DEM,Loretta Sanchez,174
-San Francisco,7615,U.S. Senate,,DEM,Kamala Harris,294
-San Francisco,7615,U.S. Senate,,DEM,Loretta Sanchez,157
-San Francisco,7616,U.S. Senate,,DEM,Kamala Harris,545
-San Francisco,7616,U.S. Senate,,DEM,Loretta Sanchez,163
-San Francisco,7617,U.S. Senate,,DEM,Kamala Harris,315
-San Francisco,7617,U.S. Senate,,DEM,Loretta Sanchez,125
-San Francisco,7618,U.S. Senate,,DEM,Kamala Harris,495
-San Francisco,7618,U.S. Senate,,DEM,Loretta Sanchez,125
-San Francisco,7619,U.S. Senate,,DEM,Kamala Harris,969
-San Francisco,7619,U.S. Senate,,DEM,Loretta Sanchez,354
-San Francisco,7621,U.S. Senate,,DEM,Kamala Harris,544
-San Francisco,7621,U.S. Senate,,DEM,Loretta Sanchez,148
-San Francisco,7622,U.S. Senate,,DEM,Kamala Harris,311
-San Francisco,7622,U.S. Senate,,DEM,Loretta Sanchez,124
-San Francisco,7623,U.S. Senate,,DEM,Kamala Harris,299
-San Francisco,7623,U.S. Senate,,DEM,Loretta Sanchez,112
-San Francisco,7624,U.S. Senate,,DEM,Kamala Harris,362
-San Francisco,7624,U.S. Senate,,DEM,Loretta Sanchez,134
-San Francisco,7625,U.S. Senate,,DEM,Kamala Harris,311
-San Francisco,7625,U.S. Senate,,DEM,Loretta Sanchez,196
-San Francisco,7626,U.S. Senate,,DEM,Kamala Harris,697
-San Francisco,7626,U.S. Senate,,DEM,Loretta Sanchez,203
-San Francisco,7627,U.S. Senate,,DEM,Kamala Harris,881
-San Francisco,7627,U.S. Senate,,DEM,Loretta Sanchez,279
-San Francisco,7628,U.S. Senate,,DEM,Kamala Harris,519
-San Francisco,7628,U.S. Senate,,DEM,Loretta Sanchez,134
-San Francisco,7629,U.S. Senate,,DEM,Kamala Harris,404
-San Francisco,7629,U.S. Senate,,DEM,Loretta Sanchez,110
-San Francisco,7631,U.S. Senate,,DEM,Kamala Harris,616
-San Francisco,7631,U.S. Senate,,DEM,Loretta Sanchez,193
-San Francisco,7632,U.S. Senate,,DEM,Kamala Harris,403
-San Francisco,7632,U.S. Senate,,DEM,Loretta Sanchez,86
-San Francisco,7633,U.S. Senate,,DEM,Kamala Harris,352
-San Francisco,7633,U.S. Senate,,DEM,Loretta Sanchez,143
-San Francisco,7634,U.S. Senate,,DEM,Kamala Harris,457
-San Francisco,7634,U.S. Senate,,DEM,Loretta Sanchez,160
-San Francisco,7635,U.S. Senate,,DEM,Kamala Harris,425
-San Francisco,7635,U.S. Senate,,DEM,Loretta Sanchez,135
-San Francisco,7636,U.S. Senate,,DEM,Kamala Harris,541
-San Francisco,7636,U.S. Senate,,DEM,Loretta Sanchez,143
-San Francisco,7637,U.S. Senate,,DEM,Kamala Harris,740
-San Francisco,7637,U.S. Senate,,DEM,Loretta Sanchez,234
-San Francisco,7638,U.S. Senate,,DEM,Kamala Harris,796
-San Francisco,7638,U.S. Senate,,DEM,Loretta Sanchez,183
-San Francisco,7639,U.S. Senate,,DEM,Kamala Harris,609
-San Francisco,7639,U.S. Senate,,DEM,Loretta Sanchez,160
-San Francisco,7641,U.S. Senate,,DEM,Kamala Harris,576
-San Francisco,7641,U.S. Senate,,DEM,Loretta Sanchez,150
-San Francisco,7642,U.S. Senate,,DEM,Kamala Harris,593
-San Francisco,7642,U.S. Senate,,DEM,Loretta Sanchez,124
-San Francisco,7643,U.S. Senate,,DEM,Kamala Harris,502
-San Francisco,7643,U.S. Senate,,DEM,Loretta Sanchez,149
-San Francisco,7644,U.S. Senate,,DEM,Kamala Harris,622
-San Francisco,7644,U.S. Senate,,DEM,Loretta Sanchez,175
-San Francisco,7645,U.S. Senate,,DEM,Kamala Harris,387
-San Francisco,7645,U.S. Senate,,DEM,Loretta Sanchez,115
-San Francisco,7646,U.S. Senate,,DEM,Kamala Harris,1297
-San Francisco,7646,U.S. Senate,,DEM,Loretta Sanchez,363
-San Francisco,7647,U.S. Senate,,DEM,Kamala Harris,387
-San Francisco,7647,U.S. Senate,,DEM,Loretta Sanchez,154
-San Francisco,7648,U.S. Senate,,DEM,Kamala Harris,2
-San Francisco,7648,U.S. Senate,,DEM,Loretta Sanchez,1
-San Francisco,7701,U.S. Senate,,DEM,Kamala Harris,650
-San Francisco,7701,U.S. Senate,,DEM,Loretta Sanchez,172
-San Francisco,7702,U.S. Senate,,DEM,Kamala Harris,458
-San Francisco,7702,U.S. Senate,,DEM,Loretta Sanchez,134
-San Francisco,7703,U.S. Senate,,DEM,Kamala Harris,63
-San Francisco,7703,U.S. Senate,,DEM,Loretta Sanchez,23
-San Francisco,7704,U.S. Senate,,DEM,Kamala Harris,623
-San Francisco,7704,U.S. Senate,,DEM,Loretta Sanchez,171
-San Francisco,7705,U.S. Senate,,DEM,Kamala Harris,340
-San Francisco,7705,U.S. Senate,,DEM,Loretta Sanchez,109
-San Francisco,7706,U.S. Senate,,DEM,Kamala Harris,572
-San Francisco,7706,U.S. Senate,,DEM,Loretta Sanchez,139
-San Francisco,7707,U.S. Senate,,DEM,Kamala Harris,578
-San Francisco,7707,U.S. Senate,,DEM,Loretta Sanchez,142
-San Francisco,7708,U.S. Senate,,DEM,Kamala Harris,590
-San Francisco,7708,U.S. Senate,,DEM,Loretta Sanchez,127
-San Francisco,7709,U.S. Senate,,DEM,Kamala Harris,252
-San Francisco,7709,U.S. Senate,,DEM,Loretta Sanchez,64
-San Francisco,7711,U.S. Senate,,DEM,Kamala Harris,503
-San Francisco,7711,U.S. Senate,,DEM,Loretta Sanchez,114
-San Francisco,7712,U.S. Senate,,DEM,Kamala Harris,381
-San Francisco,7712,U.S. Senate,,DEM,Loretta Sanchez,84
-San Francisco,7801,U.S. Senate,,DEM,Kamala Harris,787
-San Francisco,7801,U.S. Senate,,DEM,Loretta Sanchez,111
-San Francisco,7802,U.S. Senate,,DEM,Kamala Harris,590
-San Francisco,7802,U.S. Senate,,DEM,Loretta Sanchez,67
-San Francisco,7803,U.S. Senate,,DEM,Kamala Harris,628
-San Francisco,7803,U.S. Senate,,DEM,Loretta Sanchez,97
-San Francisco,7804,U.S. Senate,,DEM,Kamala Harris,697
-San Francisco,7804,U.S. Senate,,DEM,Loretta Sanchez,110
-San Francisco,7805,U.S. Senate,,DEM,Kamala Harris,605
-San Francisco,7805,U.S. Senate,,DEM,Loretta Sanchez,110
-San Francisco,7806,U.S. Senate,,DEM,Kamala Harris,558
-San Francisco,7806,U.S. Senate,,DEM,Loretta Sanchez,64
-San Francisco,7807,U.S. Senate,,DEM,Kamala Harris,554
-San Francisco,7807,U.S. Senate,,DEM,Loretta Sanchez,82
-San Francisco,7808,U.S. Senate,,DEM,Kamala Harris,454
-San Francisco,7808,U.S. Senate,,DEM,Loretta Sanchez,72
-San Francisco,7809,U.S. Senate,,DEM,Kamala Harris,813
-San Francisco,7809,U.S. Senate,,DEM,Loretta Sanchez,171
-San Francisco,7811,U.S. Senate,,DEM,Kamala Harris,532
-San Francisco,7811,U.S. Senate,,DEM,Loretta Sanchez,101
-San Francisco,7812,U.S. Senate,,DEM,Kamala Harris,576
-San Francisco,7812,U.S. Senate,,DEM,Loretta Sanchez,110
-San Francisco,7813,U.S. Senate,,DEM,Kamala Harris,740
-San Francisco,7813,U.S. Senate,,DEM,Loretta Sanchez,129
-San Francisco,7814,U.S. Senate,,DEM,Kamala Harris,431
-San Francisco,7814,U.S. Senate,,DEM,Loretta Sanchez,170
-San Francisco,7815,U.S. Senate,,DEM,Kamala Harris,710
-San Francisco,7815,U.S. Senate,,DEM,Loretta Sanchez,100
-San Francisco,7816,U.S. Senate,,DEM,Kamala Harris,703
-San Francisco,7816,U.S. Senate,,DEM,Loretta Sanchez,78
-San Francisco,7817,U.S. Senate,,DEM,Kamala Harris,584
-San Francisco,7817,U.S. Senate,,DEM,Loretta Sanchez,89
-San Francisco,7818,U.S. Senate,,DEM,Kamala Harris,614
-San Francisco,7818,U.S. Senate,,DEM,Loretta Sanchez,124
-San Francisco,7819,U.S. Senate,,DEM,Kamala Harris,512
-San Francisco,7819,U.S. Senate,,DEM,Loretta Sanchez,112
-San Francisco,7821,U.S. Senate,,DEM,Kamala Harris,744
-San Francisco,7821,U.S. Senate,,DEM,Loretta Sanchez,120
-San Francisco,7822,U.S. Senate,,DEM,Kamala Harris,615
-San Francisco,7822,U.S. Senate,,DEM,Loretta Sanchez,104
-San Francisco,7823,U.S. Senate,,DEM,Kamala Harris,661
-San Francisco,7823,U.S. Senate,,DEM,Loretta Sanchez,100
-San Francisco,7824,U.S. Senate,,DEM,Kamala Harris,529
-San Francisco,7824,U.S. Senate,,DEM,Loretta Sanchez,91
-San Francisco,7825,U.S. Senate,,DEM,Kamala Harris,422
-San Francisco,7825,U.S. Senate,,DEM,Loretta Sanchez,60
-San Francisco,7826,U.S. Senate,,DEM,Kamala Harris,519
-San Francisco,7826,U.S. Senate,,DEM,Loretta Sanchez,65
-San Francisco,7827,U.S. Senate,,DEM,Kamala Harris,559
-San Francisco,7827,U.S. Senate,,DEM,Loretta Sanchez,120
-San Francisco,7828,U.S. Senate,,DEM,Kamala Harris,702
-San Francisco,7828,U.S. Senate,,DEM,Loretta Sanchez,138
-San Francisco,7829,U.S. Senate,,DEM,Kamala Harris,677
-San Francisco,7829,U.S. Senate,,DEM,Loretta Sanchez,122
-San Francisco,7831,U.S. Senate,,DEM,Kamala Harris,686
-San Francisco,7831,U.S. Senate,,DEM,Loretta Sanchez,75
-San Francisco,7832,U.S. Senate,,DEM,Kamala Harris,610
-San Francisco,7832,U.S. Senate,,DEM,Loretta Sanchez,98
-San Francisco,7833,U.S. Senate,,DEM,Kamala Harris,586
-San Francisco,7833,U.S. Senate,,DEM,Loretta Sanchez,69
-San Francisco,7834,U.S. Senate,,DEM,Kamala Harris,614
-San Francisco,7834,U.S. Senate,,DEM,Loretta Sanchez,98
-San Francisco,7835,U.S. Senate,,DEM,Kamala Harris,593
-San Francisco,7835,U.S. Senate,,DEM,Loretta Sanchez,123
-San Francisco,7836,U.S. Senate,,DEM,Kamala Harris,708
-San Francisco,7836,U.S. Senate,,DEM,Loretta Sanchez,126
-San Francisco,7837,U.S. Senate,,DEM,Kamala Harris,673
-San Francisco,7837,U.S. Senate,,DEM,Loretta Sanchez,104
-San Francisco,7838,U.S. Senate,,DEM,Kamala Harris,688
-San Francisco,7838,U.S. Senate,,DEM,Loretta Sanchez,96
-San Francisco,7839,U.S. Senate,,DEM,Kamala Harris,626
-San Francisco,7839,U.S. Senate,,DEM,Loretta Sanchez,97
-San Francisco,7841,U.S. Senate,,DEM,Kamala Harris,679
-San Francisco,7841,U.S. Senate,,DEM,Loretta Sanchez,87
-San Francisco,7842,U.S. Senate,,DEM,Kamala Harris,685
-San Francisco,7842,U.S. Senate,,DEM,Loretta Sanchez,109
-San Francisco,7843,U.S. Senate,,DEM,Kamala Harris,507
-San Francisco,7843,U.S. Senate,,DEM,Loretta Sanchez,112
-San Francisco,7844,U.S. Senate,,DEM,Kamala Harris,448
-San Francisco,7844,U.S. Senate,,DEM,Loretta Sanchez,83
-San Francisco,7845,U.S. Senate,,DEM,Kamala Harris,658
-San Francisco,7845,U.S. Senate,,DEM,Loretta Sanchez,89
-San Francisco,7846,U.S. Senate,,DEM,Kamala Harris,654
-San Francisco,7846,U.S. Senate,,DEM,Loretta Sanchez,102
-San Francisco,7847,U.S. Senate,,DEM,Kamala Harris,654
-San Francisco,7847,U.S. Senate,,DEM,Loretta Sanchez,121
-San Francisco,7848,U.S. Senate,,DEM,Kamala Harris,643
-San Francisco,7848,U.S. Senate,,DEM,Loretta Sanchez,114
-San Francisco,7849,U.S. Senate,,DEM,Kamala Harris,690
-San Francisco,7849,U.S. Senate,,DEM,Loretta Sanchez,115
-San Francisco,7851,U.S. Senate,,DEM,Kamala Harris,338
-San Francisco,7851,U.S. Senate,,DEM,Loretta Sanchez,86
-San Francisco,7852,U.S. Senate,,DEM,Kamala Harris,444
-San Francisco,7852,U.S. Senate,,DEM,Loretta Sanchez,99
-San Francisco,7853,U.S. Senate,,DEM,Kamala Harris,605
-San Francisco,7853,U.S. Senate,,DEM,Loretta Sanchez,112
-San Francisco,7854,U.S. Senate,,DEM,Kamala Harris,639
-San Francisco,7854,U.S. Senate,,DEM,Loretta Sanchez,112
-San Francisco,7855,U.S. Senate,,DEM,Kamala Harris,672
-San Francisco,7855,U.S. Senate,,DEM,Loretta Sanchez,126
-San Francisco,7856,U.S. Senate,,DEM,Kamala Harris,601
-San Francisco,7856,U.S. Senate,,DEM,Loretta Sanchez,101
-San Francisco,7857,U.S. Senate,,DEM,Kamala Harris,653
-San Francisco,7857,U.S. Senate,,DEM,Loretta Sanchez,128
-San Francisco,7858,U.S. Senate,,DEM,Kamala Harris,518
-San Francisco,7858,U.S. Senate,,DEM,Loretta Sanchez,93
-San Francisco,7859,U.S. Senate,,DEM,Kamala Harris,656
-San Francisco,7859,U.S. Senate,,DEM,Loretta Sanchez,103
-San Francisco,7861,U.S. Senate,,DEM,Kamala Harris,596
-San Francisco,7861,U.S. Senate,,DEM,Loretta Sanchez,127
-San Francisco,7862,U.S. Senate,,DEM,Kamala Harris,655
-San Francisco,7862,U.S. Senate,,DEM,Loretta Sanchez,103
-San Francisco,7863,U.S. Senate,,DEM,Kamala Harris,606
-San Francisco,7863,U.S. Senate,,DEM,Loretta Sanchez,141
-San Francisco,7864,U.S. Senate,,DEM,Kamala Harris,544
-San Francisco,7864,U.S. Senate,,DEM,Loretta Sanchez,104
-San Francisco,7865,U.S. Senate,,DEM,Kamala Harris,569
-San Francisco,7865,U.S. Senate,,DEM,Loretta Sanchez,114
-San Francisco,7866,U.S. Senate,,DEM,Kamala Harris,549
-San Francisco,7866,U.S. Senate,,DEM,Loretta Sanchez,119
-San Francisco,7867,U.S. Senate,,DEM,Kamala Harris,635
-San Francisco,7867,U.S. Senate,,DEM,Loretta Sanchez,130
-San Francisco,7868,U.S. Senate,,DEM,Kamala Harris,602
-San Francisco,7868,U.S. Senate,,DEM,Loretta Sanchez,112
-San Francisco,7869,U.S. Senate,,DEM,Kamala Harris,622
-San Francisco,7869,U.S. Senate,,DEM,Loretta Sanchez,121
-San Francisco,7871,U.S. Senate,,DEM,Kamala Harris,635
-San Francisco,7871,U.S. Senate,,DEM,Loretta Sanchez,119
-San Francisco,7872,U.S. Senate,,DEM,Kamala Harris,665
-San Francisco,7872,U.S. Senate,,DEM,Loretta Sanchez,103
-San Francisco,7873,U.S. Senate,,DEM,Kamala Harris,633
-San Francisco,7873,U.S. Senate,,DEM,Loretta Sanchez,106
-San Francisco,7874,U.S. Senate,,DEM,Kamala Harris,279
-San Francisco,7874,U.S. Senate,,DEM,Loretta Sanchez,93
-San Francisco,7875,U.S. Senate,,DEM,Kamala Harris,347
-San Francisco,7875,U.S. Senate,,DEM,Loretta Sanchez,129
-San Francisco,7901,U.S. Senate,,DEM,Kamala Harris,642
-San Francisco,7901,U.S. Senate,,DEM,Loretta Sanchez,212
-San Francisco,7902,U.S. Senate,,DEM,Kamala Harris,595
-San Francisco,7902,U.S. Senate,,DEM,Loretta Sanchez,176
-San Francisco,7903,U.S. Senate,,DEM,Kamala Harris,418
-San Francisco,7903,U.S. Senate,,DEM,Loretta Sanchez,167
-San Francisco,7904,U.S. Senate,,DEM,Kamala Harris,480
-San Francisco,7904,U.S. Senate,,DEM,Loretta Sanchez,149
-San Francisco,7905,U.S. Senate,,DEM,Kamala Harris,542
-San Francisco,7905,U.S. Senate,,DEM,Loretta Sanchez,127
-San Francisco,7906,U.S. Senate,,DEM,Kamala Harris,499
-San Francisco,7906,U.S. Senate,,DEM,Loretta Sanchez,107
-San Francisco,7907,U.S. Senate,,DEM,Kamala Harris,597
-San Francisco,7907,U.S. Senate,,DEM,Loretta Sanchez,156
-San Francisco,7908,U.S. Senate,,DEM,Kamala Harris,578
-San Francisco,7908,U.S. Senate,,DEM,Loretta Sanchez,208
-San Francisco,7909,U.S. Senate,,DEM,Kamala Harris,477
-San Francisco,7909,U.S. Senate,,DEM,Loretta Sanchez,105
-San Francisco,7911,U.S. Senate,,DEM,Kamala Harris,511
-San Francisco,7911,U.S. Senate,,DEM,Loretta Sanchez,165
-San Francisco,7912,U.S. Senate,,DEM,Kamala Harris,615
-San Francisco,7912,U.S. Senate,,DEM,Loretta Sanchez,161
-San Francisco,7913,U.S. Senate,,DEM,Kamala Harris,566
-San Francisco,7913,U.S. Senate,,DEM,Loretta Sanchez,174
-San Francisco,7914,U.S. Senate,,DEM,Kamala Harris,544
-San Francisco,7914,U.S. Senate,,DEM,Loretta Sanchez,151
-San Francisco,7915,U.S. Senate,,DEM,Kamala Harris,528
-San Francisco,7915,U.S. Senate,,DEM,Loretta Sanchez,143
-San Francisco,7916,U.S. Senate,,DEM,Kamala Harris,591
-San Francisco,7916,U.S. Senate,,DEM,Loretta Sanchez,120
-San Francisco,7917,U.S. Senate,,DEM,Kamala Harris,601
-San Francisco,7917,U.S. Senate,,DEM,Loretta Sanchez,197
-San Francisco,7918,U.S. Senate,,DEM,Kamala Harris,513
-San Francisco,7918,U.S. Senate,,DEM,Loretta Sanchez,131
-San Francisco,7919,U.S. Senate,,DEM,Kamala Harris,531
-San Francisco,7919,U.S. Senate,,DEM,Loretta Sanchez,163
-San Francisco,7921,U.S. Senate,,DEM,Kamala Harris,462
-San Francisco,7921,U.S. Senate,,DEM,Loretta Sanchez,182
-San Francisco,7922,U.S. Senate,,DEM,Kamala Harris,512
-San Francisco,7922,U.S. Senate,,DEM,Loretta Sanchez,136
-San Francisco,7923,U.S. Senate,,DEM,Kamala Harris,515
-San Francisco,7923,U.S. Senate,,DEM,Loretta Sanchez,125
-San Francisco,7924,U.S. Senate,,DEM,Kamala Harris,463
-San Francisco,7924,U.S. Senate,,DEM,Loretta Sanchez,166
-San Francisco,7925,U.S. Senate,,DEM,Kamala Harris,358
-San Francisco,7925,U.S. Senate,,DEM,Loretta Sanchez,83
-San Francisco,7926,U.S. Senate,,DEM,Kamala Harris,519
-San Francisco,7926,U.S. Senate,,DEM,Loretta Sanchez,128
-San Francisco,7927,U.S. Senate,,DEM,Kamala Harris,535
-San Francisco,7927,U.S. Senate,,DEM,Loretta Sanchez,97
-San Francisco,7928,U.S. Senate,,DEM,Kamala Harris,689
-San Francisco,7928,U.S. Senate,,DEM,Loretta Sanchez,110
-San Francisco,7929,U.S. Senate,,DEM,Kamala Harris,641
-San Francisco,7929,U.S. Senate,,DEM,Loretta Sanchez,90
-San Francisco,7931,U.S. Senate,,DEM,Kamala Harris,556
-San Francisco,7931,U.S. Senate,,DEM,Loretta Sanchez,93
-San Francisco,7932,U.S. Senate,,DEM,Kamala Harris,396
-San Francisco,7932,U.S. Senate,,DEM,Loretta Sanchez,59
-San Francisco,7933,U.S. Senate,,DEM,Kamala Harris,4
-San Francisco,7933,U.S. Senate,,DEM,Loretta Sanchez,2
-San Francisco,7934,U.S. Senate,,DEM,Kamala Harris,611
-San Francisco,7934,U.S. Senate,,DEM,Loretta Sanchez,108
-San Francisco,7935,U.S. Senate,,DEM,Kamala Harris,702
-San Francisco,7935,U.S. Senate,,DEM,Loretta Sanchez,104
-San Francisco,7936,U.S. Senate,,DEM,Kamala Harris,637
-San Francisco,7936,U.S. Senate,,DEM,Loretta Sanchez,89
-San Francisco,7937,U.S. Senate,,DEM,Kamala Harris,612
-San Francisco,7937,U.S. Senate,,DEM,Loretta Sanchez,111
-San Francisco,7938,U.S. Senate,,DEM,Kamala Harris,461
-San Francisco,7938,U.S. Senate,,DEM,Loretta Sanchez,129
-San Francisco,7939,U.S. Senate,,DEM,Kamala Harris,476
-San Francisco,7939,U.S. Senate,,DEM,Loretta Sanchez,83
-San Francisco,7941,U.S. Senate,,DEM,Kamala Harris,513
-San Francisco,7941,U.S. Senate,,DEM,Loretta Sanchez,88
-San Francisco,7942,U.S. Senate,,DEM,Kamala Harris,560
-San Francisco,7942,U.S. Senate,,DEM,Loretta Sanchez,141
-San Francisco,7943,U.S. Senate,,DEM,Kamala Harris,563
-San Francisco,7943,U.S. Senate,,DEM,Loretta Sanchez,152
-San Francisco,7944,U.S. Senate,,DEM,Kamala Harris,541
-San Francisco,7944,U.S. Senate,,DEM,Loretta Sanchez,117
-San Francisco,7945,U.S. Senate,,DEM,Kamala Harris,483
-San Francisco,7945,U.S. Senate,,DEM,Loretta Sanchez,123
-San Francisco,7946,U.S. Senate,,DEM,Kamala Harris,424
-San Francisco,7946,U.S. Senate,,DEM,Loretta Sanchez,205
-San Francisco,7947,U.S. Senate,,DEM,Kamala Harris,429
-San Francisco,7947,U.S. Senate,,DEM,Loretta Sanchez,193
-San Francisco,7948,U.S. Senate,,DEM,Kamala Harris,466
-San Francisco,7948,U.S. Senate,,DEM,Loretta Sanchez,163
-San Francisco,7949,U.S. Senate,,DEM,Kamala Harris,253
-San Francisco,7949,U.S. Senate,,DEM,Loretta Sanchez,117
-San Francisco,7951,U.S. Senate,,DEM,Kamala Harris,346
-San Francisco,7951,U.S. Senate,,DEM,Loretta Sanchez,186
-San Francisco,7952,U.S. Senate,,DEM,Kamala Harris,384
-San Francisco,7952,U.S. Senate,,DEM,Loretta Sanchez,194
-San Francisco,7953,U.S. Senate,,DEM,Kamala Harris,426
-San Francisco,7953,U.S. Senate,,DEM,Loretta Sanchez,192
-San Francisco,7954,U.S. Senate,,DEM,Kamala Harris,0
-San Francisco,7954,U.S. Senate,,DEM,Loretta Sanchez,0
-San Francisco,7955,U.S. Senate,,DEM,Kamala Harris,403
-San Francisco,7955,U.S. Senate,,DEM,Loretta Sanchez,189
-San Francisco,7956,U.S. Senate,,DEM,Kamala Harris,313
-San Francisco,7956,U.S. Senate,,DEM,Loretta Sanchez,174
-San Francisco,7957,U.S. Senate,,DEM,Kamala Harris,374
-San Francisco,7957,U.S. Senate,,DEM,Loretta Sanchez,97
-San Francisco,7958,U.S. Senate,,DEM,Kamala Harris,116
-San Francisco,7958,U.S. Senate,,DEM,Loretta Sanchez,57
-San Francisco,9001,U.S. Senate,,DEM,Kamala Harris,138
-San Francisco,9001,U.S. Senate,,DEM,Loretta Sanchez,45
-San Francisco,9101,U.S. Senate,,DEM,Kamala Harris,502
-San Francisco,9101,U.S. Senate,,DEM,Loretta Sanchez,159
-San Francisco,9102,U.S. Senate,,DEM,Kamala Harris,553
-San Francisco,9102,U.S. Senate,,DEM,Loretta Sanchez,172
-San Francisco,9103,U.S. Senate,,DEM,Kamala Harris,525
-San Francisco,9103,U.S. Senate,,DEM,Loretta Sanchez,154
-San Francisco,9104,U.S. Senate,,DEM,Kamala Harris,543
-San Francisco,9104,U.S. Senate,,DEM,Loretta Sanchez,156
-San Francisco,9105,U.S. Senate,,DEM,Kamala Harris,558
-San Francisco,9105,U.S. Senate,,DEM,Loretta Sanchez,163
-San Francisco,9106,U.S. Senate,,DEM,Kamala Harris,593
-San Francisco,9106,U.S. Senate,,DEM,Loretta Sanchez,147
-San Francisco,9107,U.S. Senate,,DEM,Kamala Harris,442
-San Francisco,9107,U.S. Senate,,DEM,Loretta Sanchez,144
-San Francisco,9108,U.S. Senate,,DEM,Kamala Harris,467
-San Francisco,9108,U.S. Senate,,DEM,Loretta Sanchez,144
-San Francisco,9109,U.S. Senate,,DEM,Kamala Harris,524
-San Francisco,9109,U.S. Senate,,DEM,Loretta Sanchez,146
-San Francisco,9111,U.S. Senate,,DEM,Kamala Harris,424
-San Francisco,9111,U.S. Senate,,DEM,Loretta Sanchez,122
-San Francisco,9112,U.S. Senate,,DEM,Kamala Harris,562
-San Francisco,9112,U.S. Senate,,DEM,Loretta Sanchez,139
-San Francisco,9113,U.S. Senate,,DEM,Kamala Harris,634
-San Francisco,9113,U.S. Senate,,DEM,Loretta Sanchez,157
-San Francisco,9114,U.S. Senate,,DEM,Kamala Harris,518
-San Francisco,9114,U.S. Senate,,DEM,Loretta Sanchez,137
-San Francisco,9115,U.S. Senate,,DEM,Kamala Harris,531
-San Francisco,9115,U.S. Senate,,DEM,Loretta Sanchez,138
-San Francisco,9116,U.S. Senate,,DEM,Kamala Harris,566
-San Francisco,9116,U.S. Senate,,DEM,Loretta Sanchez,156
-San Francisco,9117,U.S. Senate,,DEM,Kamala Harris,490
-San Francisco,9117,U.S. Senate,,DEM,Loretta Sanchez,113
-San Francisco,9118,U.S. Senate,,DEM,Kamala Harris,469
-San Francisco,9118,U.S. Senate,,DEM,Loretta Sanchez,177
-San Francisco,9119,U.S. Senate,,DEM,Kamala Harris,490
-San Francisco,9119,U.S. Senate,,DEM,Loretta Sanchez,156
-San Francisco,9121,U.S. Senate,,DEM,Kamala Harris,494
-San Francisco,9121,U.S. Senate,,DEM,Loretta Sanchez,174
-San Francisco,9122,U.S. Senate,,DEM,Kamala Harris,503
-San Francisco,9122,U.S. Senate,,DEM,Loretta Sanchez,167
-San Francisco,9123,U.S. Senate,,DEM,Kamala Harris,489
-San Francisco,9123,U.S. Senate,,DEM,Loretta Sanchez,153
-San Francisco,9124,U.S. Senate,,DEM,Kamala Harris,472
-San Francisco,9124,U.S. Senate,,DEM,Loretta Sanchez,165
-San Francisco,9125,U.S. Senate,,DEM,Kamala Harris,511
-San Francisco,9125,U.S. Senate,,DEM,Loretta Sanchez,136
-San Francisco,9126,U.S. Senate,,DEM,Kamala Harris,538
-San Francisco,9126,U.S. Senate,,DEM,Loretta Sanchez,187
-San Francisco,9127,U.S. Senate,,DEM,Kamala Harris,552
-San Francisco,9127,U.S. Senate,,DEM,Loretta Sanchez,171
-San Francisco,9128,U.S. Senate,,DEM,Kamala Harris,504
-San Francisco,9128,U.S. Senate,,DEM,Loretta Sanchez,137
-San Francisco,9129,U.S. Senate,,DEM,Kamala Harris,430
-San Francisco,9129,U.S. Senate,,DEM,Loretta Sanchez,124
-San Francisco,9131,U.S. Senate,,DEM,Kamala Harris,459
-San Francisco,9131,U.S. Senate,,DEM,Loretta Sanchez,121
-San Francisco,9132,U.S. Senate,,DEM,Kamala Harris,487
-San Francisco,9132,U.S. Senate,,DEM,Loretta Sanchez,127
-San Francisco,9133,U.S. Senate,,DEM,Kamala Harris,617
-San Francisco,9133,U.S. Senate,,DEM,Loretta Sanchez,172
-San Francisco,9134,U.S. Senate,,DEM,Kamala Harris,511
-San Francisco,9134,U.S. Senate,,DEM,Loretta Sanchez,144
-San Francisco,9135,U.S. Senate,,DEM,Kamala Harris,429
-San Francisco,9135,U.S. Senate,,DEM,Loretta Sanchez,125
-San Francisco,9136,U.S. Senate,,DEM,Kamala Harris,557
-San Francisco,9136,U.S. Senate,,DEM,Loretta Sanchez,148
-San Francisco,9137,U.S. Senate,,DEM,Kamala Harris,516
-San Francisco,9137,U.S. Senate,,DEM,Loretta Sanchez,173
-San Francisco,9138,U.S. Senate,,DEM,Kamala Harris,517
-San Francisco,9138,U.S. Senate,,DEM,Loretta Sanchez,159
-San Francisco,9139,U.S. Senate,,DEM,Kamala Harris,552
-San Francisco,9139,U.S. Senate,,DEM,Loretta Sanchez,175
-San Francisco,9141,U.S. Senate,,DEM,Kamala Harris,532
-San Francisco,9141,U.S. Senate,,DEM,Loretta Sanchez,163
-San Francisco,9142,U.S. Senate,,DEM,Kamala Harris,566
-San Francisco,9142,U.S. Senate,,DEM,Loretta Sanchez,173
-San Francisco,9143,U.S. Senate,,DEM,Kamala Harris,495
-San Francisco,9143,U.S. Senate,,DEM,Loretta Sanchez,153
-San Francisco,9144,U.S. Senate,,DEM,Kamala Harris,580
-San Francisco,9144,U.S. Senate,,DEM,Loretta Sanchez,155
-San Francisco,9145,U.S. Senate,,DEM,Kamala Harris,548
-San Francisco,9145,U.S. Senate,,DEM,Loretta Sanchez,128
-San Francisco,9146,U.S. Senate,,DEM,Kamala Harris,575
-San Francisco,9146,U.S. Senate,,DEM,Loretta Sanchez,141
-San Francisco,9147,U.S. Senate,,DEM,Kamala Harris,575
-San Francisco,9147,U.S. Senate,,DEM,Loretta Sanchez,142
-San Francisco,9148,U.S. Senate,,DEM,Kamala Harris,621
-San Francisco,9148,U.S. Senate,,DEM,Loretta Sanchez,149
-San Francisco,9149,U.S. Senate,,DEM,Kamala Harris,623
-San Francisco,9149,U.S. Senate,,DEM,Loretta Sanchez,129
-San Francisco,9151,U.S. Senate,,DEM,Kamala Harris,489
-San Francisco,9151,U.S. Senate,,DEM,Loretta Sanchez,136
-San Francisco,9152,U.S. Senate,,DEM,Kamala Harris,371
-San Francisco,9152,U.S. Senate,,DEM,Loretta Sanchez,171
-San Francisco,9201,U.S. Senate,,DEM,Kamala Harris,642
-San Francisco,9201,U.S. Senate,,DEM,Loretta Sanchez,164
-San Francisco,9202,U.S. Senate,,DEM,Kamala Harris,587
-San Francisco,9202,U.S. Senate,,DEM,Loretta Sanchez,127
-San Francisco,9203,U.S. Senate,,DEM,Kamala Harris,532
-San Francisco,9203,U.S. Senate,,DEM,Loretta Sanchez,169
-San Francisco,9204,U.S. Senate,,DEM,Kamala Harris,460
-San Francisco,9204,U.S. Senate,,DEM,Loretta Sanchez,154
-San Francisco,9205,U.S. Senate,,DEM,Kamala Harris,425
-San Francisco,9205,U.S. Senate,,DEM,Loretta Sanchez,129
-San Francisco,9206,U.S. Senate,,DEM,Kamala Harris,509
-San Francisco,9206,U.S. Senate,,DEM,Loretta Sanchez,182
-San Francisco,9207,U.S. Senate,,DEM,Kamala Harris,531
-San Francisco,9207,U.S. Senate,,DEM,Loretta Sanchez,165
-San Francisco,9208,U.S. Senate,,DEM,Kamala Harris,573
-San Francisco,9208,U.S. Senate,,DEM,Loretta Sanchez,178
-San Francisco,9209,U.S. Senate,,DEM,Kamala Harris,398
-San Francisco,9209,U.S. Senate,,DEM,Loretta Sanchez,145
-San Francisco,9211,U.S. Senate,,DEM,Kamala Harris,488
-San Francisco,9211,U.S. Senate,,DEM,Loretta Sanchez,152
-San Francisco,9212,U.S. Senate,,DEM,Kamala Harris,447
-San Francisco,9212,U.S. Senate,,DEM,Loretta Sanchez,153
-San Francisco,9213,U.S. Senate,,DEM,Kamala Harris,555
-San Francisco,9213,U.S. Senate,,DEM,Loretta Sanchez,154
-San Francisco,9214,U.S. Senate,,DEM,Kamala Harris,376
-San Francisco,9214,U.S. Senate,,DEM,Loretta Sanchez,97
-San Francisco,9215,U.S. Senate,,DEM,Kamala Harris,378
-San Francisco,9215,U.S. Senate,,DEM,Loretta Sanchez,102
-San Francisco,9216,U.S. Senate,,DEM,Kamala Harris,470
-San Francisco,9216,U.S. Senate,,DEM,Loretta Sanchez,141
-San Francisco,9217,U.S. Senate,,DEM,Kamala Harris,437
-San Francisco,9217,U.S. Senate,,DEM,Loretta Sanchez,125
-San Francisco,9218,U.S. Senate,,DEM,Kamala Harris,468
-San Francisco,9218,U.S. Senate,,DEM,Loretta Sanchez,142
-San Francisco,9219,U.S. Senate,,DEM,Kamala Harris,466
-San Francisco,9219,U.S. Senate,,DEM,Loretta Sanchez,132
-San Francisco,9221,U.S. Senate,,DEM,Kamala Harris,444
-San Francisco,9221,U.S. Senate,,DEM,Loretta Sanchez,112
-San Francisco,9222,U.S. Senate,,DEM,Kamala Harris,541
-San Francisco,9222,U.S. Senate,,DEM,Loretta Sanchez,153
-San Francisco,9223,U.S. Senate,,DEM,Kamala Harris,353
-San Francisco,9223,U.S. Senate,,DEM,Loretta Sanchez,126
-San Francisco,9224,U.S. Senate,,DEM,Kamala Harris,583
-San Francisco,9224,U.S. Senate,,DEM,Loretta Sanchez,161
-San Francisco,9225,U.S. Senate,,DEM,Kamala Harris,584
-San Francisco,9225,U.S. Senate,,DEM,Loretta Sanchez,197
-San Francisco,9226,U.S. Senate,,DEM,Kamala Harris,547
-San Francisco,9226,U.S. Senate,,DEM,Loretta Sanchez,163
-San Francisco,9227,U.S. Senate,,DEM,Kamala Harris,470
-San Francisco,9227,U.S. Senate,,DEM,Loretta Sanchez,116
-San Francisco,9228,U.S. Senate,,DEM,Kamala Harris,461
-San Francisco,9228,U.S. Senate,,DEM,Loretta Sanchez,138
-San Francisco,9229,U.S. Senate,,DEM,Kamala Harris,415
-San Francisco,9229,U.S. Senate,,DEM,Loretta Sanchez,90
-San Francisco,9231,U.S. Senate,,DEM,Kamala Harris,659
-San Francisco,9231,U.S. Senate,,DEM,Loretta Sanchez,126
-San Francisco,9232,U.S. Senate,,DEM,Kamala Harris,530
-San Francisco,9232,U.S. Senate,,DEM,Loretta Sanchez,96
-San Francisco,9233,U.S. Senate,,DEM,Kamala Harris,525
-San Francisco,9233,U.S. Senate,,DEM,Loretta Sanchez,118
-San Francisco,9234,U.S. Senate,,DEM,Kamala Harris,468
-San Francisco,9234,U.S. Senate,,DEM,Loretta Sanchez,120
-San Francisco,9235,U.S. Senate,,DEM,Kamala Harris,564
-San Francisco,9235,U.S. Senate,,DEM,Loretta Sanchez,157
-San Francisco,9236,U.S. Senate,,DEM,Kamala Harris,432
-San Francisco,9236,U.S. Senate,,DEM,Loretta Sanchez,100
-San Francisco,9237,U.S. Senate,,DEM,Kamala Harris,596
-San Francisco,9237,U.S. Senate,,DEM,Loretta Sanchez,127
-San Francisco,9238,U.S. Senate,,DEM,Kamala Harris,536
-San Francisco,9238,U.S. Senate,,DEM,Loretta Sanchez,151
-San Francisco,9239,U.S. Senate,,DEM,Kamala Harris,588
-San Francisco,9239,U.S. Senate,,DEM,Loretta Sanchez,147
-San Francisco,9241,U.S. Senate,,DEM,Kamala Harris,627
-San Francisco,9241,U.S. Senate,,DEM,Loretta Sanchez,154
-San Francisco,9242,U.S. Senate,,DEM,Kamala Harris,619
-San Francisco,9242,U.S. Senate,,DEM,Loretta Sanchez,152
-San Francisco,9243,U.S. Senate,,DEM,Kamala Harris,413
-San Francisco,9243,U.S. Senate,,DEM,Loretta Sanchez,64
-San Francisco,9244,U.S. Senate,,DEM,Kamala Harris,567
-San Francisco,9244,U.S. Senate,,DEM,Loretta Sanchez,149
-San Francisco,9245,U.S. Senate,,DEM,Kamala Harris,456
-San Francisco,9245,U.S. Senate,,DEM,Loretta Sanchez,96
-San Francisco,9246,U.S. Senate,,DEM,Kamala Harris,589
-San Francisco,9246,U.S. Senate,,DEM,Loretta Sanchez,144
-San Francisco,9247,U.S. Senate,,DEM,Kamala Harris,624
-San Francisco,9247,U.S. Senate,,DEM,Loretta Sanchez,152
-San Francisco,9248,U.S. Senate,,DEM,Kamala Harris,589
-San Francisco,9248,U.S. Senate,,DEM,Loretta Sanchez,136
-San Francisco,9249,U.S. Senate,,DEM,Kamala Harris,584
-San Francisco,9249,U.S. Senate,,DEM,Loretta Sanchez,131
-San Francisco,9251,U.S. Senate,,DEM,Kamala Harris,630
-San Francisco,9251,U.S. Senate,,DEM,Loretta Sanchez,142
-San Francisco,9252,U.S. Senate,,DEM,Kamala Harris,553
-San Francisco,9252,U.S. Senate,,DEM,Loretta Sanchez,181
-San Francisco,9253,U.S. Senate,,DEM,Kamala Harris,463
-San Francisco,9253,U.S. Senate,,DEM,Loretta Sanchez,136
-San Francisco,9254,U.S. Senate,,DEM,Kamala Harris,646
-San Francisco,9254,U.S. Senate,,DEM,Loretta Sanchez,126
-San Francisco,9255,U.S. Senate,,DEM,Kamala Harris,349
-San Francisco,9255,U.S. Senate,,DEM,Loretta Sanchez,89
-San Francisco,9256,U.S. Senate,,DEM,Kamala Harris,237
-San Francisco,9256,U.S. Senate,,DEM,Loretta Sanchez,57
-San Francisco,9257,U.S. Senate,,DEM,Kamala Harris,203
-San Francisco,9257,U.S. Senate,,DEM,Loretta Sanchez,53
-San Francisco,9258,U.S. Senate,,DEM,Kamala Harris,441
-San Francisco,9258,U.S. Senate,,DEM,Loretta Sanchez,121
-San Francisco,9401,U.S. Senate,,DEM,Kamala Harris,552
-San Francisco,9401,U.S. Senate,,DEM,Loretta Sanchez,168
-San Francisco,9402,U.S. Senate,,DEM,Kamala Harris,512
-San Francisco,9402,U.S. Senate,,DEM,Loretta Sanchez,192
-San Francisco,9403,U.S. Senate,,DEM,Kamala Harris,498
-San Francisco,9403,U.S. Senate,,DEM,Loretta Sanchez,155
-San Francisco,9404,U.S. Senate,,DEM,Kamala Harris,505
-San Francisco,9404,U.S. Senate,,DEM,Loretta Sanchez,146
-San Francisco,9405,U.S. Senate,,DEM,Kamala Harris,444
-San Francisco,9405,U.S. Senate,,DEM,Loretta Sanchez,159
-San Francisco,9406,U.S. Senate,,DEM,Kamala Harris,551
-San Francisco,9406,U.S. Senate,,DEM,Loretta Sanchez,140
-San Francisco,9407,U.S. Senate,,DEM,Kamala Harris,461
-San Francisco,9407,U.S. Senate,,DEM,Loretta Sanchez,153
-San Francisco,9408,U.S. Senate,,DEM,Kamala Harris,480
-San Francisco,9408,U.S. Senate,,DEM,Loretta Sanchez,134
-San Francisco,9409,U.S. Senate,,DEM,Kamala Harris,373
-San Francisco,9409,U.S. Senate,,DEM,Loretta Sanchez,90
-San Francisco,9411,U.S. Senate,,DEM,Kamala Harris,560
-San Francisco,9411,U.S. Senate,,DEM,Loretta Sanchez,164
-San Francisco,9412,U.S. Senate,,DEM,Kamala Harris,450
-San Francisco,9412,U.S. Senate,,DEM,Loretta Sanchez,168
-San Francisco,9413,U.S. Senate,,DEM,Kamala Harris,478
-San Francisco,9413,U.S. Senate,,DEM,Loretta Sanchez,152
-San Francisco,9414,U.S. Senate,,DEM,Kamala Harris,464
-San Francisco,9414,U.S. Senate,,DEM,Loretta Sanchez,167
-San Francisco,9415,U.S. Senate,,DEM,Kamala Harris,396
-San Francisco,9415,U.S. Senate,,DEM,Loretta Sanchez,132
-San Francisco,9416,U.S. Senate,,DEM,Kamala Harris,544
-San Francisco,9416,U.S. Senate,,DEM,Loretta Sanchez,170
-San Francisco,9417,U.S. Senate,,DEM,Kamala Harris,346
-San Francisco,9417,U.S. Senate,,DEM,Loretta Sanchez,169
-San Francisco,9418,U.S. Senate,,DEM,Kamala Harris,403
-San Francisco,9418,U.S. Senate,,DEM,Loretta Sanchez,134
-San Francisco,9419,U.S. Senate,,DEM,Kamala Harris,443
-San Francisco,9419,U.S. Senate,,DEM,Loretta Sanchez,136
-San Francisco,9421,U.S. Senate,,DEM,Kamala Harris,456
-San Francisco,9421,U.S. Senate,,DEM,Loretta Sanchez,147
-San Francisco,9422,U.S. Senate,,DEM,Kamala Harris,589
-San Francisco,9422,U.S. Senate,,DEM,Loretta Sanchez,163
-San Francisco,9423,U.S. Senate,,DEM,Kamala Harris,493
-San Francisco,9423,U.S. Senate,,DEM,Loretta Sanchez,132
-San Francisco,9424,U.S. Senate,,DEM,Kamala Harris,479
-San Francisco,9424,U.S. Senate,,DEM,Loretta Sanchez,156
-San Francisco,9425,U.S. Senate,,DEM,Kamala Harris,450
-San Francisco,9425,U.S. Senate,,DEM,Loretta Sanchez,181
-San Francisco,9426,U.S. Senate,,DEM,Kamala Harris,401
-San Francisco,9426,U.S. Senate,,DEM,Loretta Sanchez,153
-San Francisco,9427,U.S. Senate,,DEM,Kamala Harris,416
-San Francisco,9427,U.S. Senate,,DEM,Loretta Sanchez,190
-San Francisco,9428,U.S. Senate,,DEM,Kamala Harris,474
-San Francisco,9428,U.S. Senate,,DEM,Loretta Sanchez,170
-San Francisco,9429,U.S. Senate,,DEM,Kamala Harris,418
-San Francisco,9429,U.S. Senate,,DEM,Loretta Sanchez,169
-San Francisco,9431,U.S. Senate,,DEM,Kamala Harris,487
-San Francisco,9431,U.S. Senate,,DEM,Loretta Sanchez,198
-San Francisco,9432,U.S. Senate,,DEM,Kamala Harris,456
-San Francisco,9432,U.S. Senate,,DEM,Loretta Sanchez,141
-San Francisco,9433,U.S. Senate,,DEM,Kamala Harris,470
-San Francisco,9433,U.S. Senate,,DEM,Loretta Sanchez,170
-San Francisco,9434,U.S. Senate,,DEM,Kamala Harris,538
-San Francisco,9434,U.S. Senate,,DEM,Loretta Sanchez,172
-San Francisco,9435,U.S. Senate,,DEM,Kamala Harris,468
-San Francisco,9435,U.S. Senate,,DEM,Loretta Sanchez,178
-San Francisco,9436,U.S. Senate,,DEM,Kamala Harris,473
-San Francisco,9436,U.S. Senate,,DEM,Loretta Sanchez,184
-San Francisco,9437,U.S. Senate,,DEM,Kamala Harris,416
-San Francisco,9437,U.S. Senate,,DEM,Loretta Sanchez,191
-San Francisco,9438,U.S. Senate,,DEM,Kamala Harris,483
-San Francisco,9438,U.S. Senate,,DEM,Loretta Sanchez,181
-San Francisco,9439,U.S. Senate,,DEM,Kamala Harris,432
-San Francisco,9439,U.S. Senate,,DEM,Loretta Sanchez,165
-San Francisco,9441,U.S. Senate,,DEM,Kamala Harris,520
-San Francisco,9441,U.S. Senate,,DEM,Loretta Sanchez,175
-San Francisco,9442,U.S. Senate,,DEM,Kamala Harris,491
-San Francisco,9442,U.S. Senate,,DEM,Loretta Sanchez,181
-San Francisco,9443,U.S. Senate,,DEM,Kamala Harris,473
-San Francisco,9443,U.S. Senate,,DEM,Loretta Sanchez,165
-San Francisco,9444,U.S. Senate,,DEM,Kamala Harris,420
-San Francisco,9444,U.S. Senate,,DEM,Loretta Sanchez,172
-San Francisco,9445,U.S. Senate,,DEM,Kamala Harris,461
-San Francisco,9445,U.S. Senate,,DEM,Loretta Sanchez,186
-San Francisco,9446,U.S. Senate,,DEM,Kamala Harris,554
-San Francisco,9446,U.S. Senate,,DEM,Loretta Sanchez,225
-San Francisco,9447,U.S. Senate,,DEM,Kamala Harris,492
-San Francisco,9447,U.S. Senate,,DEM,Loretta Sanchez,161
-San Francisco,9448,U.S. Senate,,DEM,Kamala Harris,438
-San Francisco,9448,U.S. Senate,,DEM,Loretta Sanchez,187
-San Francisco,9449,U.S. Senate,,DEM,Kamala Harris,400
-San Francisco,9449,U.S. Senate,,DEM,Loretta Sanchez,141
-San Francisco,9451,U.S. Senate,,DEM,Kamala Harris,210
-San Francisco,9451,U.S. Senate,,DEM,Loretta Sanchez,119
-San Francisco,9452,U.S. Senate,,DEM,Kamala Harris,458
-San Francisco,9452,U.S. Senate,,DEM,Loretta Sanchez,147
-San Francisco,9453,U.S. Senate,,DEM,Kamala Harris,248
-San Francisco,9453,U.S. Senate,,DEM,Loretta Sanchez,112
-San Francisco,9501,U.S. Senate,,DEM,Kamala Harris,89
-San Francisco,9501,U.S. Senate,,DEM,Loretta Sanchez,26
-San Francisco,9502,U.S. Senate,,DEM,Kamala Harris,153
-San Francisco,9502,U.S. Senate,,DEM,Loretta Sanchez,33
-San Francisco,9503/9504,U.S. Senate,,DEM,Kamala Harris,481
-San Francisco,9503/9504,U.S. Senate,,DEM,Loretta Sanchez,104
-San Francisco,9505,U.S. Senate,,DEM,Kamala Harris,474
-San Francisco,9505,U.S. Senate,,DEM,Loretta Sanchez,84
-San Francisco,9506,U.S. Senate,,DEM,Kamala Harris,449
-San Francisco,9506,U.S. Senate,,DEM,Loretta Sanchez,99
-San Francisco,9507,U.S. Senate,,DEM,Kamala Harris,505
-San Francisco,9507,U.S. Senate,,DEM,Loretta Sanchez,87
-San Francisco,9508,U.S. Senate,,DEM,Kamala Harris,581
-San Francisco,9508,U.S. Senate,,DEM,Loretta Sanchez,76
-San Francisco,9509,U.S. Senate,,DEM,Kamala Harris,498
-San Francisco,9509,U.S. Senate,,DEM,Loretta Sanchez,93
-San Francisco,9511,U.S. Senate,,DEM,Kamala Harris,397
-San Francisco,9511,U.S. Senate,,DEM,Loretta Sanchez,69
-San Francisco,9512,U.S. Senate,,DEM,Kamala Harris,530
-San Francisco,9512,U.S. Senate,,DEM,Loretta Sanchez,109
-San Francisco,9513,U.S. Senate,,DEM,Kamala Harris,615
-San Francisco,9513,U.S. Senate,,DEM,Loretta Sanchez,99
-San Francisco,9514/9522,U.S. Senate,,DEM,Kamala Harris,632
-San Francisco,9514/9522,U.S. Senate,,DEM,Loretta Sanchez,115
-San Francisco,9515,U.S. Senate,,DEM,Kamala Harris,474
-San Francisco,9515,U.S. Senate,,DEM,Loretta Sanchez,98
-San Francisco,9516,U.S. Senate,,DEM,Kamala Harris,534
-San Francisco,9516,U.S. Senate,,DEM,Loretta Sanchez,136
-San Francisco,9517,U.S. Senate,,DEM,Kamala Harris,525
-San Francisco,9517,U.S. Senate,,DEM,Loretta Sanchez,116
-San Francisco,9518,U.S. Senate,,DEM,Kamala Harris,524
-San Francisco,9518,U.S. Senate,,DEM,Loretta Sanchez,112
-San Francisco,9519,U.S. Senate,,DEM,Kamala Harris,595
-San Francisco,9519,U.S. Senate,,DEM,Loretta Sanchez,117
-San Francisco,9521,U.S. Senate,,DEM,Kamala Harris,613
-San Francisco,9521,U.S. Senate,,DEM,Loretta Sanchez,121
-San Francisco,9701,U.S. Senate,,DEM,Kamala Harris,385
-San Francisco,9701,U.S. Senate,,DEM,Loretta Sanchez,104
-San Francisco,9702,U.S. Senate,,DEM,Kamala Harris,481
-San Francisco,9702,U.S. Senate,,DEM,Loretta Sanchez,84
-San Francisco,9703,U.S. Senate,,DEM,Kamala Harris,541
-San Francisco,9703,U.S. Senate,,DEM,Loretta Sanchez,177
-San Francisco,9704,U.S. Senate,,DEM,Kamala Harris,620
-San Francisco,9704,U.S. Senate,,DEM,Loretta Sanchez,141
-San Francisco,9705,U.S. Senate,,DEM,Kamala Harris,615
-San Francisco,9705,U.S. Senate,,DEM,Loretta Sanchez,129
-San Francisco,9706,U.S. Senate,,DEM,Kamala Harris,39
-San Francisco,9706,U.S. Senate,,DEM,Loretta Sanchez,8
-San Francisco,9707,U.S. Senate,,DEM,Kamala Harris,475
-San Francisco,9707,U.S. Senate,,DEM,Loretta Sanchez,132
-San Francisco,9708,U.S. Senate,,DEM,Kamala Harris,594
-San Francisco,9708,U.S. Senate,,DEM,Loretta Sanchez,142
-San Francisco,9709,U.S. Senate,,DEM,Kamala Harris,553
-San Francisco,9709,U.S. Senate,,DEM,Loretta Sanchez,177
-San Francisco,9711,U.S. Senate,,DEM,Kamala Harris,413
-San Francisco,9711,U.S. Senate,,DEM,Loretta Sanchez,113
-San Francisco,9712,U.S. Senate,,DEM,Kamala Harris,396
-San Francisco,9712,U.S. Senate,,DEM,Loretta Sanchez,121
-San Francisco,9713,U.S. Senate,,DEM,Kamala Harris,535
-San Francisco,9713,U.S. Senate,,DEM,Loretta Sanchez,158
-San Francisco,9714,U.S. Senate,,DEM,Kamala Harris,572
-San Francisco,9714,U.S. Senate,,DEM,Loretta Sanchez,148
-San Francisco,9715,U.S. Senate,,DEM,Kamala Harris,372
-San Francisco,9715,U.S. Senate,,DEM,Loretta Sanchez,93
-San Francisco,9716,U.S. Senate,,DEM,Kamala Harris,499
-San Francisco,9716,U.S. Senate,,DEM,Loretta Sanchez,181
-San Francisco,9717,U.S. Senate,,DEM,Kamala Harris,555
-San Francisco,9717,U.S. Senate,,DEM,Loretta Sanchez,193
-San Francisco,9718,U.S. Senate,,DEM,Kamala Harris,511
-San Francisco,9718,U.S. Senate,,DEM,Loretta Sanchez,179
-San Francisco,9719,U.S. Senate,,DEM,Kamala Harris,522
-San Francisco,9719,U.S. Senate,,DEM,Loretta Sanchez,154
-San Francisco,9721,U.S. Senate,,DEM,Kamala Harris,378
-San Francisco,9721,U.S. Senate,,DEM,Loretta Sanchez,133
-San Francisco,9722,U.S. Senate,,DEM,Kamala Harris,345
-San Francisco,9722,U.S. Senate,,DEM,Loretta Sanchez,130
-San Francisco,9723,U.S. Senate,,DEM,Kamala Harris,241
-San Francisco,9723,U.S. Senate,,DEM,Loretta Sanchez,98
-San Francisco,9724,U.S. Senate,,DEM,Kamala Harris,496
-San Francisco,9724,U.S. Senate,,DEM,Loretta Sanchez,210
-San Francisco,9725,U.S. Senate,,DEM,Kamala Harris,474
-San Francisco,9725,U.S. Senate,,DEM,Loretta Sanchez,190
-San Francisco,9726,U.S. Senate,,DEM,Kamala Harris,344
-San Francisco,9726,U.S. Senate,,DEM,Loretta Sanchez,178
-San Francisco,9727,U.S. Senate,,DEM,Kamala Harris,261
-San Francisco,9727,U.S. Senate,,DEM,Loretta Sanchez,91
-San Francisco,9728,U.S. Senate,,DEM,Kamala Harris,513
-San Francisco,9728,U.S. Senate,,DEM,Loretta Sanchez,185
-San Francisco,9729,U.S. Senate,,DEM,Kamala Harris,486
-San Francisco,9729,U.S. Senate,,DEM,Loretta Sanchez,143
-San Francisco,9731,U.S. Senate,,DEM,Kamala Harris,324
-San Francisco,9731,U.S. Senate,,DEM,Loretta Sanchez,106
-San Francisco,9732,U.S. Senate,,DEM,Kamala Harris,50
-San Francisco,9732,U.S. Senate,,DEM,Loretta Sanchez,18
-San Francisco,9733,U.S. Senate,,DEM,Kamala Harris,156
-San Francisco,9733,U.S. Senate,,DEM,Loretta Sanchez,31
-San Francisco,9734,U.S. Senate,,DEM,Kamala Harris,366
-San Francisco,9734,U.S. Senate,,DEM,Loretta Sanchez,117
-San Francisco,9735,U.S. Senate,,DEM,Kamala Harris,476
-San Francisco,9735,U.S. Senate,,DEM,Loretta Sanchez,140
-San Francisco,9736,U.S. Senate,,DEM,Kamala Harris,468
-San Francisco,9736,U.S. Senate,,DEM,Loretta Sanchez,126
-San Francisco,9737,U.S. Senate,,DEM,Kamala Harris,542
-San Francisco,9737,U.S. Senate,,DEM,Loretta Sanchez,118
-San Francisco,9738,U.S. Senate,,DEM,Kamala Harris,421
-San Francisco,9738,U.S. Senate,,DEM,Loretta Sanchez,172
-San Francisco,9739,U.S. Senate,,DEM,Kamala Harris,384
-San Francisco,9739,U.S. Senate,,DEM,Loretta Sanchez,194
-San Francisco,9741,U.S. Senate,,DEM,Kamala Harris,288
-San Francisco,9741,U.S. Senate,,DEM,Loretta Sanchez,276
-San Francisco,9742,U.S. Senate,,DEM,Kamala Harris,339
-San Francisco,9742,U.S. Senate,,DEM,Loretta Sanchez,113
-San Francisco,9743,U.S. Senate,,DEM,Kamala Harris,581
-San Francisco,9743,U.S. Senate,,DEM,Loretta Sanchez,223
-San Francisco,9744,U.S. Senate,,DEM,Kamala Harris,439
-San Francisco,9744,U.S. Senate,,DEM,Loretta Sanchez,217
-San Francisco,9745,U.S. Senate,,DEM,Kamala Harris,453
-San Francisco,9745,U.S. Senate,,DEM,Loretta Sanchez,223
-San Francisco,9746,U.S. Senate,,DEM,Kamala Harris,516
-San Francisco,9746,U.S. Senate,,DEM,Loretta Sanchez,160
-San Francisco,9747,U.S. Senate,,DEM,Kamala Harris,534
-San Francisco,9747,U.S. Senate,,DEM,Loretta Sanchez,177
-San Francisco,9748,U.S. Senate,,DEM,Kamala Harris,542
-San Francisco,9748,U.S. Senate,,DEM,Loretta Sanchez,166
-San Francisco,9749,U.S. Senate,,DEM,Kamala Harris,414
-San Francisco,9749,U.S. Senate,,DEM,Loretta Sanchez,180
-San Francisco,9751,U.S. Senate,,DEM,Kamala Harris,611
-San Francisco,9751,U.S. Senate,,DEM,Loretta Sanchez,196
-San Francisco,9752,U.S. Senate,,DEM,Kamala Harris,432
-San Francisco,9752,U.S. Senate,,DEM,Loretta Sanchez,138
-San Francisco,9753,U.S. Senate,,DEM,Kamala Harris,419
-San Francisco,9753,U.S. Senate,,DEM,Loretta Sanchez,155
-San Francisco,9754,U.S. Senate,,DEM,Kamala Harris,481
-San Francisco,9754,U.S. Senate,,DEM,Loretta Sanchez,109
-San Francisco,9755,U.S. Senate,,DEM,Kamala Harris,315
-San Francisco,9755,U.S. Senate,,DEM,Loretta Sanchez,117
-San Francisco,9756,U.S. Senate,,DEM,Kamala Harris,467
-San Francisco,9756,U.S. Senate,,DEM,Loretta Sanchez,202
-San Francisco,9801,U.S. Senate,,DEM,Kamala Harris,220
-San Francisco,9801,U.S. Senate,,DEM,Loretta Sanchez,90
-San Francisco,9900,U.S. Senate,,DEM,Kamala Harris,0
-San Francisco,9900,U.S. Senate,,DEM,Loretta Sanchez,0
-San Francisco,9901,U.S. Senate,,DEM,Kamala Harris,0
-San Francisco,9901,U.S. Senate,,DEM,Loretta Sanchez,0
-San Francisco,9902,U.S. Senate,,DEM,Kamala Harris,0
-San Francisco,9902,U.S. Senate,,DEM,Loretta Sanchez,0
+San Francisco,1101,U.S. Senate,,DEM,Kamala D. Harris,300
+San Francisco,1101,U.S. Senate,,DEM,Loretta L. Sanchez,105
+San Francisco,1102,U.S. Senate,,DEM,Kamala D. Harris,529
+San Francisco,1102,U.S. Senate,,DEM,Loretta L. Sanchez,215
+San Francisco,1103,U.S. Senate,,DEM,Kamala D. Harris,480
+San Francisco,1103,U.S. Senate,,DEM,Loretta L. Sanchez,229
+San Francisco,1104/1105,U.S. Senate,,DEM,Kamala D. Harris,487
+San Francisco,1104/1105,U.S. Senate,,DEM,Loretta L. Sanchez,207
+San Francisco,1106,U.S. Senate,,DEM,Kamala D. Harris,409
+San Francisco,1106,U.S. Senate,,DEM,Loretta L. Sanchez,116
+San Francisco,1107,U.S. Senate,,DEM,Kamala D. Harris,340
+San Francisco,1107,U.S. Senate,,DEM,Loretta L. Sanchez,108
+San Francisco,1108,U.S. Senate,,DEM,Kamala D. Harris,547
+San Francisco,1108,U.S. Senate,,DEM,Loretta L. Sanchez,130
+San Francisco,1109,U.S. Senate,,DEM,Kamala D. Harris,422
+San Francisco,1109,U.S. Senate,,DEM,Loretta L. Sanchez,134
+San Francisco,1111,U.S. Senate,,DEM,Kamala D. Harris,430
+San Francisco,1111,U.S. Senate,,DEM,Loretta L. Sanchez,185
+San Francisco,1112,U.S. Senate,,DEM,Kamala D. Harris,347
+San Francisco,1112,U.S. Senate,,DEM,Loretta L. Sanchez,136
+San Francisco,1113,U.S. Senate,,DEM,Kamala D. Harris,341
+San Francisco,1113,U.S. Senate,,DEM,Loretta L. Sanchez,147
+San Francisco,1114,U.S. Senate,,DEM,Kamala D. Harris,444
+San Francisco,1114,U.S. Senate,,DEM,Loretta L. Sanchez,195
+San Francisco,1115,U.S. Senate,,DEM,Kamala D. Harris,469
+San Francisco,1115,U.S. Senate,,DEM,Loretta L. Sanchez,161
+San Francisco,1116,U.S. Senate,,DEM,Kamala D. Harris,417
+San Francisco,1116,U.S. Senate,,DEM,Loretta L. Sanchez,147
+San Francisco,1117,U.S. Senate,,DEM,Kamala D. Harris,416
+San Francisco,1117,U.S. Senate,,DEM,Loretta L. Sanchez,150
+San Francisco,1118,U.S. Senate,,DEM,Kamala D. Harris,521
+San Francisco,1118,U.S. Senate,,DEM,Loretta L. Sanchez,194
+San Francisco,1119,U.S. Senate,,DEM,Kamala D. Harris,370
+San Francisco,1119,U.S. Senate,,DEM,Loretta L. Sanchez,142
+San Francisco,1121,U.S. Senate,,DEM,Kamala D. Harris,292
+San Francisco,1121,U.S. Senate,,DEM,Loretta L. Sanchez,148
+San Francisco,1122,U.S. Senate,,DEM,Kamala D. Harris,283
+San Francisco,1122,U.S. Senate,,DEM,Loretta L. Sanchez,134
+San Francisco,1123,U.S. Senate,,DEM,Kamala D. Harris,411
+San Francisco,1123,U.S. Senate,,DEM,Loretta L. Sanchez,164
+San Francisco,1124,U.S. Senate,,DEM,Kamala D. Harris,361
+San Francisco,1124,U.S. Senate,,DEM,Loretta L. Sanchez,145
+San Francisco,1125,U.S. Senate,,DEM,Kamala D. Harris,454
+San Francisco,1125,U.S. Senate,,DEM,Loretta L. Sanchez,217
+San Francisco,1126,U.S. Senate,,DEM,Kamala D. Harris,427
+San Francisco,1126,U.S. Senate,,DEM,Loretta L. Sanchez,196
+San Francisco,1127,U.S. Senate,,DEM,Kamala D. Harris,420
+San Francisco,1127,U.S. Senate,,DEM,Loretta L. Sanchez,176
+San Francisco,1128,U.S. Senate,,DEM,Kamala D. Harris,397
+San Francisco,1128,U.S. Senate,,DEM,Loretta L. Sanchez,196
+San Francisco,1129,U.S. Senate,,DEM,Kamala D. Harris,386
+San Francisco,1129,U.S. Senate,,DEM,Loretta L. Sanchez,216
+San Francisco,1131,U.S. Senate,,DEM,Kamala D. Harris,314
+San Francisco,1131,U.S. Senate,,DEM,Loretta L. Sanchez,178
+San Francisco,1132,U.S. Senate,,DEM,Kamala D. Harris,416
+San Francisco,1132,U.S. Senate,,DEM,Loretta L. Sanchez,190
+San Francisco,1133,U.S. Senate,,DEM,Kamala D. Harris,428
+San Francisco,1133,U.S. Senate,,DEM,Loretta L. Sanchez,148
+San Francisco,1134,U.S. Senate,,DEM,Kamala D. Harris,357
+San Francisco,1134,U.S. Senate,,DEM,Loretta L. Sanchez,157
+San Francisco,1135,U.S. Senate,,DEM,Kamala D. Harris,257
+San Francisco,1135,U.S. Senate,,DEM,Loretta L. Sanchez,119
+San Francisco,1136,U.S. Senate,,DEM,Kamala D. Harris,412
+San Francisco,1136,U.S. Senate,,DEM,Loretta L. Sanchez,168
+San Francisco,1141,U.S. Senate,,DEM,Kamala D. Harris,552
+San Francisco,1141,U.S. Senate,,DEM,Loretta L. Sanchez,182
+San Francisco,1142,U.S. Senate,,DEM,Kamala D. Harris,382
+San Francisco,1142,U.S. Senate,,DEM,Loretta L. Sanchez,203
+San Francisco,1143,U.S. Senate,,DEM,Kamala D. Harris,468
+San Francisco,1143,U.S. Senate,,DEM,Loretta L. Sanchez,230
+San Francisco,1144,U.S. Senate,,DEM,Kamala D. Harris,421
+San Francisco,1144,U.S. Senate,,DEM,Loretta L. Sanchez,219
+San Francisco,1145,U.S. Senate,,DEM,Kamala D. Harris,541
+San Francisco,1145,U.S. Senate,,DEM,Loretta L. Sanchez,159
+San Francisco,1146,U.S. Senate,,DEM,Kamala D. Harris,474
+San Francisco,1146,U.S. Senate,,DEM,Loretta L. Sanchez,231
+San Francisco,1147,U.S. Senate,,DEM,Kamala D. Harris,445
+San Francisco,1147,U.S. Senate,,DEM,Loretta L. Sanchez,208
+San Francisco,1148,U.S. Senate,,DEM,Kamala D. Harris,411
+San Francisco,1148,U.S. Senate,,DEM,Loretta L. Sanchez,221
+San Francisco,1149,U.S. Senate,,DEM,Kamala D. Harris,450
+San Francisco,1149,U.S. Senate,,DEM,Loretta L. Sanchez,215
+San Francisco,1151,U.S. Senate,,DEM,Kamala D. Harris,0
+San Francisco,1151,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Francisco,1152,U.S. Senate,,DEM,Kamala D. Harris,393
+San Francisco,1152,U.S. Senate,,DEM,Loretta L. Sanchez,201
+San Francisco,1153,U.S. Senate,,DEM,Kamala D. Harris,447
+San Francisco,1153,U.S. Senate,,DEM,Loretta L. Sanchez,193
+San Francisco,1154,U.S. Senate,,DEM,Kamala D. Harris,0
+San Francisco,1154,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Francisco,7001,U.S. Senate,,DEM,Kamala D. Harris,400
+San Francisco,7001,U.S. Senate,,DEM,Loretta L. Sanchez,97
+San Francisco,7002,U.S. Senate,,DEM,Kamala D. Harris,667
+San Francisco,7002,U.S. Senate,,DEM,Loretta L. Sanchez,184
+San Francisco,7003,U.S. Senate,,DEM,Kamala D. Harris,651
+San Francisco,7003,U.S. Senate,,DEM,Loretta L. Sanchez,123
+San Francisco,7004,U.S. Senate,,DEM,Kamala D. Harris,615
+San Francisco,7004,U.S. Senate,,DEM,Loretta L. Sanchez,106
+San Francisco,7005,U.S. Senate,,DEM,Kamala D. Harris,590
+San Francisco,7005,U.S. Senate,,DEM,Loretta L. Sanchez,101
+San Francisco,7006,U.S. Senate,,DEM,Kamala D. Harris,589
+San Francisco,7006,U.S. Senate,,DEM,Loretta L. Sanchez,135
+San Francisco,7007,U.S. Senate,,DEM,Kamala D. Harris,668
+San Francisco,7007,U.S. Senate,,DEM,Loretta L. Sanchez,133
+San Francisco,7008,U.S. Senate,,DEM,Kamala D. Harris,627
+San Francisco,7008,U.S. Senate,,DEM,Loretta L. Sanchez,133
+San Francisco,7009,U.S. Senate,,DEM,Kamala D. Harris,529
+San Francisco,7009,U.S. Senate,,DEM,Loretta L. Sanchez,137
+San Francisco,7011,U.S. Senate,,DEM,Kamala D. Harris,454
+San Francisco,7011,U.S. Senate,,DEM,Loretta L. Sanchez,119
+San Francisco,7012,U.S. Senate,,DEM,Kamala D. Harris,689
+San Francisco,7012,U.S. Senate,,DEM,Loretta L. Sanchez,144
+San Francisco,7013,U.S. Senate,,DEM,Kamala D. Harris,472
+San Francisco,7013,U.S. Senate,,DEM,Loretta L. Sanchez,102
+San Francisco,7014,U.S. Senate,,DEM,Kamala D. Harris,705
+San Francisco,7014,U.S. Senate,,DEM,Loretta L. Sanchez,134
+San Francisco,7015,U.S. Senate,,DEM,Kamala D. Harris,56
+San Francisco,7015,U.S. Senate,,DEM,Loretta L. Sanchez,18
+San Francisco,7016,U.S. Senate,,DEM,Kamala D. Harris,369
+San Francisco,7016,U.S. Senate,,DEM,Loretta L. Sanchez,155
+San Francisco,7017,U.S. Senate,,DEM,Kamala D. Harris,363
+San Francisco,7017,U.S. Senate,,DEM,Loretta L. Sanchez,78
+San Francisco,7018,U.S. Senate,,DEM,Kamala D. Harris,408
+San Francisco,7018,U.S. Senate,,DEM,Loretta L. Sanchez,176
+San Francisco,7019,U.S. Senate,,DEM,Kamala D. Harris,500
+San Francisco,7019,U.S. Senate,,DEM,Loretta L. Sanchez,130
+San Francisco,7021,U.S. Senate,,DEM,Kamala D. Harris,456
+San Francisco,7021,U.S. Senate,,DEM,Loretta L. Sanchez,122
+San Francisco,7022,U.S. Senate,,DEM,Kamala D. Harris,495
+San Francisco,7022,U.S. Senate,,DEM,Loretta L. Sanchez,116
+San Francisco,7023,U.S. Senate,,DEM,Kamala D. Harris,524
+San Francisco,7023,U.S. Senate,,DEM,Loretta L. Sanchez,91
+San Francisco,7024,U.S. Senate,,DEM,Kamala D. Harris,91
+San Francisco,7024,U.S. Senate,,DEM,Loretta L. Sanchez,22
+San Francisco,7025,U.S. Senate,,DEM,Kamala D. Harris,195
+San Francisco,7025,U.S. Senate,,DEM,Loretta L. Sanchez,55
+San Francisco,7026,U.S. Senate,,DEM,Kamala D. Harris,393
+San Francisco,7026,U.S. Senate,,DEM,Loretta L. Sanchez,191
+San Francisco,7027,U.S. Senate,,DEM,Kamala D. Harris,383
+San Francisco,7027,U.S. Senate,,DEM,Loretta L. Sanchez,130
+San Francisco,7028,U.S. Senate,,DEM,Kamala D. Harris,398
+San Francisco,7028,U.S. Senate,,DEM,Loretta L. Sanchez,104
+San Francisco,7029,U.S. Senate,,DEM,Kamala D. Harris,403
+San Francisco,7029,U.S. Senate,,DEM,Loretta L. Sanchez,83
+San Francisco,7030,U.S. Senate,,DEM,Kamala D. Harris,310
+San Francisco,7030,U.S. Senate,,DEM,Loretta L. Sanchez,156
+San Francisco,7031,U.S. Senate,,DEM,Kamala D. Harris,246
+San Francisco,7031,U.S. Senate,,DEM,Loretta L. Sanchez,95
+San Francisco,7032,U.S. Senate,,DEM,Kamala D. Harris,388
+San Francisco,7032,U.S. Senate,,DEM,Loretta L. Sanchez,156
+San Francisco,7033,U.S. Senate,,DEM,Kamala D. Harris,367
+San Francisco,7033,U.S. Senate,,DEM,Loretta L. Sanchez,131
+San Francisco,7034,U.S. Senate,,DEM,Kamala D. Harris,394
+San Francisco,7034,U.S. Senate,,DEM,Loretta L. Sanchez,89
+San Francisco,7035,U.S. Senate,,DEM,Kamala D. Harris,257
+San Francisco,7035,U.S. Senate,,DEM,Loretta L. Sanchez,51
+San Francisco,7036,U.S. Senate,,DEM,Kamala D. Harris,345
+San Francisco,7036,U.S. Senate,,DEM,Loretta L. Sanchez,189
+San Francisco,7037,U.S. Senate,,DEM,Kamala D. Harris,232
+San Francisco,7037,U.S. Senate,,DEM,Loretta L. Sanchez,90
+San Francisco,7038,U.S. Senate,,DEM,Kamala D. Harris,362
+San Francisco,7038,U.S. Senate,,DEM,Loretta L. Sanchez,160
+San Francisco,7039,U.S. Senate,,DEM,Kamala D. Harris,351
+San Francisco,7039,U.S. Senate,,DEM,Loretta L. Sanchez,195
+San Francisco,7041,U.S. Senate,,DEM,Kamala D. Harris,21
+San Francisco,7041,U.S. Senate,,DEM,Loretta L. Sanchez,9
+San Francisco,7042,U.S. Senate,,DEM,Kamala D. Harris,330
+San Francisco,7042,U.S. Senate,,DEM,Loretta L. Sanchez,136
+San Francisco,7043,U.S. Senate,,DEM,Kamala D. Harris,408
+San Francisco,7043,U.S. Senate,,DEM,Loretta L. Sanchez,166
+San Francisco,7044,U.S. Senate,,DEM,Kamala D. Harris,276
+San Francisco,7044,U.S. Senate,,DEM,Loretta L. Sanchez,91
+San Francisco,7045,U.S. Senate,,DEM,Kamala D. Harris,281
+San Francisco,7045,U.S. Senate,,DEM,Loretta L. Sanchez,170
+San Francisco,7046,U.S. Senate,,DEM,Kamala D. Harris,188
+San Francisco,7046,U.S. Senate,,DEM,Loretta L. Sanchez,91
+San Francisco,7047,U.S. Senate,,DEM,Kamala D. Harris,346
+San Francisco,7047,U.S. Senate,,DEM,Loretta L. Sanchez,189
+San Francisco,7048,U.S. Senate,,DEM,Kamala D. Harris,318
+San Francisco,7048,U.S. Senate,,DEM,Loretta L. Sanchez,143
+San Francisco,7049,U.S. Senate,,DEM,Kamala D. Harris,297
+San Francisco,7049,U.S. Senate,,DEM,Loretta L. Sanchez,156
+San Francisco,7051,U.S. Senate,,DEM,Kamala D. Harris,324
+San Francisco,7051,U.S. Senate,,DEM,Loretta L. Sanchez,186
+San Francisco,7052,U.S. Senate,,DEM,Kamala D. Harris,393
+San Francisco,7052,U.S. Senate,,DEM,Loretta L. Sanchez,182
+San Francisco,7053,U.S. Senate,,DEM,Kamala D. Harris,285
+San Francisco,7053,U.S. Senate,,DEM,Loretta L. Sanchez,116
+San Francisco,7054,U.S. Senate,,DEM,Kamala D. Harris,483
+San Francisco,7054,U.S. Senate,,DEM,Loretta L. Sanchez,142
+San Francisco,7101,U.S. Senate,,DEM,Kamala D. Harris,100
+San Francisco,7101,U.S. Senate,,DEM,Loretta L. Sanchez,15
+San Francisco,7201,U.S. Senate,,DEM,Kamala D. Harris,580
+San Francisco,7201,U.S. Senate,,DEM,Loretta L. Sanchez,161
+San Francisco,7202,U.S. Senate,,DEM,Kamala D. Harris,513
+San Francisco,7202,U.S. Senate,,DEM,Loretta L. Sanchez,139
+San Francisco,7203,U.S. Senate,,DEM,Kamala D. Harris,541
+San Francisco,7203,U.S. Senate,,DEM,Loretta L. Sanchez,187
+San Francisco,7204,U.S. Senate,,DEM,Kamala D. Harris,587
+San Francisco,7204,U.S. Senate,,DEM,Loretta L. Sanchez,152
+San Francisco,7205,U.S. Senate,,DEM,Kamala D. Harris,580
+San Francisco,7205,U.S. Senate,,DEM,Loretta L. Sanchez,135
+San Francisco,7206,U.S. Senate,,DEM,Kamala D. Harris,249
+San Francisco,7206,U.S. Senate,,DEM,Loretta L. Sanchez,60
+San Francisco,7207,U.S. Senate,,DEM,Kamala D. Harris,413
+San Francisco,7207,U.S. Senate,,DEM,Loretta L. Sanchez,85
+San Francisco,7208,U.S. Senate,,DEM,Kamala D. Harris,359
+San Francisco,7208,U.S. Senate,,DEM,Loretta L. Sanchez,91
+San Francisco,7209,U.S. Senate,,DEM,Kamala D. Harris,357
+San Francisco,7209,U.S. Senate,,DEM,Loretta L. Sanchez,77
+San Francisco,7301,U.S. Senate,,DEM,Kamala D. Harris,476
+San Francisco,7301,U.S. Senate,,DEM,Loretta L. Sanchez,203
+San Francisco,7302,U.S. Senate,,DEM,Kamala D. Harris,461
+San Francisco,7302,U.S. Senate,,DEM,Loretta L. Sanchez,170
+San Francisco,7303,U.S. Senate,,DEM,Kamala D. Harris,561
+San Francisco,7303,U.S. Senate,,DEM,Loretta L. Sanchez,178
+San Francisco,7304,U.S. Senate,,DEM,Kamala D. Harris,567
+San Francisco,7304,U.S. Senate,,DEM,Loretta L. Sanchez,160
+San Francisco,7305,U.S. Senate,,DEM,Kamala D. Harris,533
+San Francisco,7305,U.S. Senate,,DEM,Loretta L. Sanchez,155
+San Francisco,7306,U.S. Senate,,DEM,Kamala D. Harris,597
+San Francisco,7306,U.S. Senate,,DEM,Loretta L. Sanchez,163
+San Francisco,7307,U.S. Senate,,DEM,Kamala D. Harris,468
+San Francisco,7307,U.S. Senate,,DEM,Loretta L. Sanchez,119
+San Francisco,7308,U.S. Senate,,DEM,Kamala D. Harris,402
+San Francisco,7308,U.S. Senate,,DEM,Loretta L. Sanchez,94
+San Francisco,7309,U.S. Senate,,DEM,Kamala D. Harris,497
+San Francisco,7309,U.S. Senate,,DEM,Loretta L. Sanchez,164
+San Francisco,7311,U.S. Senate,,DEM,Kamala D. Harris,579
+San Francisco,7311,U.S. Senate,,DEM,Loretta L. Sanchez,151
+San Francisco,7312,U.S. Senate,,DEM,Kamala D. Harris,527
+San Francisco,7312,U.S. Senate,,DEM,Loretta L. Sanchez,150
+San Francisco,7313,U.S. Senate,,DEM,Kamala D. Harris,515
+San Francisco,7313,U.S. Senate,,DEM,Loretta L. Sanchez,173
+San Francisco,7314,U.S. Senate,,DEM,Kamala D. Harris,258
+San Francisco,7314,U.S. Senate,,DEM,Loretta L. Sanchez,147
+San Francisco,7315,U.S. Senate,,DEM,Kamala D. Harris,373
+San Francisco,7315,U.S. Senate,,DEM,Loretta L. Sanchez,132
+San Francisco,7316,U.S. Senate,,DEM,Kamala D. Harris,413
+San Francisco,7316,U.S. Senate,,DEM,Loretta L. Sanchez,147
+San Francisco,7317,U.S. Senate,,DEM,Kamala D. Harris,486
+San Francisco,7317,U.S. Senate,,DEM,Loretta L. Sanchez,169
+San Francisco,7318,U.S. Senate,,DEM,Kamala D. Harris,429
+San Francisco,7318,U.S. Senate,,DEM,Loretta L. Sanchez,146
+San Francisco,7319,U.S. Senate,,DEM,Kamala D. Harris,602
+San Francisco,7319,U.S. Senate,,DEM,Loretta L. Sanchez,179
+San Francisco,7321,U.S. Senate,,DEM,Kamala D. Harris,295
+San Francisco,7321,U.S. Senate,,DEM,Loretta L. Sanchez,124
+San Francisco,7322,U.S. Senate,,DEM,Kamala D. Harris,244
+San Francisco,7322,U.S. Senate,,DEM,Loretta L. Sanchez,164
+San Francisco,7323,U.S. Senate,,DEM,Kamala D. Harris,463
+San Francisco,7323,U.S. Senate,,DEM,Loretta L. Sanchez,158
+San Francisco,7324,U.S. Senate,,DEM,Kamala D. Harris,355
+San Francisco,7324,U.S. Senate,,DEM,Loretta L. Sanchez,145
+San Francisco,7325,U.S. Senate,,DEM,Kamala D. Harris,499
+San Francisco,7325,U.S. Senate,,DEM,Loretta L. Sanchez,162
+San Francisco,7326,U.S. Senate,,DEM,Kamala D. Harris,478
+San Francisco,7326,U.S. Senate,,DEM,Loretta L. Sanchez,161
+San Francisco,7327,U.S. Senate,,DEM,Kamala D. Harris,206
+San Francisco,7327,U.S. Senate,,DEM,Loretta L. Sanchez,146
+San Francisco,7328,U.S. Senate,,DEM,Kamala D. Harris,289
+San Francisco,7328,U.S. Senate,,DEM,Loretta L. Sanchez,202
+San Francisco,7329,U.S. Senate,,DEM,Kamala D. Harris,284
+San Francisco,7329,U.S. Senate,,DEM,Loretta L. Sanchez,105
+San Francisco,7331,U.S. Senate,,DEM,Kamala D. Harris,507
+San Francisco,7331,U.S. Senate,,DEM,Loretta L. Sanchez,171
+San Francisco,7332,U.S. Senate,,DEM,Kamala D. Harris,473
+San Francisco,7332,U.S. Senate,,DEM,Loretta L. Sanchez,155
+San Francisco,7333,U.S. Senate,,DEM,Kamala D. Harris,578
+San Francisco,7333,U.S. Senate,,DEM,Loretta L. Sanchez,187
+San Francisco,7334,U.S. Senate,,DEM,Kamala D. Harris,494
+San Francisco,7334,U.S. Senate,,DEM,Loretta L. Sanchez,170
+San Francisco,7335,U.S. Senate,,DEM,Kamala D. Harris,590
+San Francisco,7335,U.S. Senate,,DEM,Loretta L. Sanchez,192
+San Francisco,7336,U.S. Senate,,DEM,Kamala D. Harris,609
+San Francisco,7336,U.S. Senate,,DEM,Loretta L. Sanchez,172
+San Francisco,7337,U.S. Senate,,DEM,Kamala D. Harris,510
+San Francisco,7337,U.S. Senate,,DEM,Loretta L. Sanchez,142
+San Francisco,7338,U.S. Senate,,DEM,Kamala D. Harris,368
+San Francisco,7338,U.S. Senate,,DEM,Loretta L. Sanchez,203
+San Francisco,7339,U.S. Senate,,DEM,Kamala D. Harris,301
+San Francisco,7339,U.S. Senate,,DEM,Loretta L. Sanchez,127
+San Francisco,7341,U.S. Senate,,DEM,Kamala D. Harris,525
+San Francisco,7341,U.S. Senate,,DEM,Loretta L. Sanchez,136
+San Francisco,7342,U.S. Senate,,DEM,Kamala D. Harris,538
+San Francisco,7342,U.S. Senate,,DEM,Loretta L. Sanchez,169
+San Francisco,7343,U.S. Senate,,DEM,Kamala D. Harris,425
+San Francisco,7343,U.S. Senate,,DEM,Loretta L. Sanchez,114
+San Francisco,7344,U.S. Senate,,DEM,Kamala D. Harris,622
+San Francisco,7344,U.S. Senate,,DEM,Loretta L. Sanchez,184
+San Francisco,7345,U.S. Senate,,DEM,Kamala D. Harris,603
+San Francisco,7345,U.S. Senate,,DEM,Loretta L. Sanchez,189
+San Francisco,7346,U.S. Senate,,DEM,Kamala D. Harris,502
+San Francisco,7346,U.S. Senate,,DEM,Loretta L. Sanchez,180
+San Francisco,7347,U.S. Senate,,DEM,Kamala D. Harris,568
+San Francisco,7347,U.S. Senate,,DEM,Loretta L. Sanchez,192
+San Francisco,7348,U.S. Senate,,DEM,Kamala D. Harris,409
+San Francisco,7348,U.S. Senate,,DEM,Loretta L. Sanchez,152
+San Francisco,7349,U.S. Senate,,DEM,Kamala D. Harris,470
+San Francisco,7349,U.S. Senate,,DEM,Loretta L. Sanchez,195
+San Francisco,7501,U.S. Senate,,DEM,Kamala D. Harris,374
+San Francisco,7501,U.S. Senate,,DEM,Loretta L. Sanchez,90
+San Francisco,7502,U.S. Senate,,DEM,Kamala D. Harris,475
+San Francisco,7502,U.S. Senate,,DEM,Loretta L. Sanchez,138
+San Francisco,7503,U.S. Senate,,DEM,Kamala D. Harris,472
+San Francisco,7503,U.S. Senate,,DEM,Loretta L. Sanchez,132
+San Francisco,7504,U.S. Senate,,DEM,Kamala D. Harris,252
+San Francisco,7504,U.S. Senate,,DEM,Loretta L. Sanchez,97
+San Francisco,7505,U.S. Senate,,DEM,Kamala D. Harris,545
+San Francisco,7505,U.S. Senate,,DEM,Loretta L. Sanchez,145
+San Francisco,7506,U.S. Senate,,DEM,Kamala D. Harris,551
+San Francisco,7506,U.S. Senate,,DEM,Loretta L. Sanchez,155
+San Francisco,7507,U.S. Senate,,DEM,Kamala D. Harris,449
+San Francisco,7507,U.S. Senate,,DEM,Loretta L. Sanchez,127
+San Francisco,7508,U.S. Senate,,DEM,Kamala D. Harris,423
+San Francisco,7508,U.S. Senate,,DEM,Loretta L. Sanchez,128
+San Francisco,7509/7511,U.S. Senate,,DEM,Kamala D. Harris,590
+San Francisco,7509/7511,U.S. Senate,,DEM,Loretta L. Sanchez,162
+San Francisco,7512,U.S. Senate,,DEM,Kamala D. Harris,323
+San Francisco,7512,U.S. Senate,,DEM,Loretta L. Sanchez,92
+San Francisco,7513,U.S. Senate,,DEM,Kamala D. Harris,415
+San Francisco,7513,U.S. Senate,,DEM,Loretta L. Sanchez,110
+San Francisco,7514,U.S. Senate,,DEM,Kamala D. Harris,396
+San Francisco,7514,U.S. Senate,,DEM,Loretta L. Sanchez,96
+San Francisco,7515,U.S. Senate,,DEM,Kamala D. Harris,506
+San Francisco,7515,U.S. Senate,,DEM,Loretta L. Sanchez,116
+San Francisco,7516,U.S. Senate,,DEM,Kamala D. Harris,528
+San Francisco,7516,U.S. Senate,,DEM,Loretta L. Sanchez,152
+San Francisco,7517,U.S. Senate,,DEM,Kamala D. Harris,631
+San Francisco,7517,U.S. Senate,,DEM,Loretta L. Sanchez,134
+San Francisco,7518,U.S. Senate,,DEM,Kamala D. Harris,669
+San Francisco,7518,U.S. Senate,,DEM,Loretta L. Sanchez,123
+San Francisco,7519,U.S. Senate,,DEM,Kamala D. Harris,524
+San Francisco,7519,U.S. Senate,,DEM,Loretta L. Sanchez,83
+San Francisco,7521,U.S. Senate,,DEM,Kamala D. Harris,577
+San Francisco,7521,U.S. Senate,,DEM,Loretta L. Sanchez,85
+San Francisco,7522,U.S. Senate,,DEM,Kamala D. Harris,600
+San Francisco,7522,U.S. Senate,,DEM,Loretta L. Sanchez,91
+San Francisco,7523,U.S. Senate,,DEM,Kamala D. Harris,552
+San Francisco,7523,U.S. Senate,,DEM,Loretta L. Sanchez,85
+San Francisco,7524,U.S. Senate,,DEM,Kamala D. Harris,413
+San Francisco,7524,U.S. Senate,,DEM,Loretta L. Sanchez,80
+San Francisco,7525,U.S. Senate,,DEM,Kamala D. Harris,502
+San Francisco,7525,U.S. Senate,,DEM,Loretta L. Sanchez,84
+San Francisco,7526,U.S. Senate,,DEM,Kamala D. Harris,659
+San Francisco,7526,U.S. Senate,,DEM,Loretta L. Sanchez,127
+San Francisco,7527/7528,U.S. Senate,,DEM,Kamala D. Harris,421
+San Francisco,7527/7528,U.S. Senate,,DEM,Loretta L. Sanchez,131
+San Francisco,7529,U.S. Senate,,DEM,Kamala D. Harris,662
+San Francisco,7529,U.S. Senate,,DEM,Loretta L. Sanchez,115
+San Francisco,7531,U.S. Senate,,DEM,Kamala D. Harris,627
+San Francisco,7531,U.S. Senate,,DEM,Loretta L. Sanchez,106
+San Francisco,7532,U.S. Senate,,DEM,Kamala D. Harris,531
+San Francisco,7532,U.S. Senate,,DEM,Loretta L. Sanchez,139
+San Francisco,7533,U.S. Senate,,DEM,Kamala D. Harris,694
+San Francisco,7533,U.S. Senate,,DEM,Loretta L. Sanchez,139
+San Francisco,7534,U.S. Senate,,DEM,Kamala D. Harris,592
+San Francisco,7534,U.S. Senate,,DEM,Loretta L. Sanchez,111
+San Francisco,7535,U.S. Senate,,DEM,Kamala D. Harris,546
+San Francisco,7535,U.S. Senate,,DEM,Loretta L. Sanchez,122
+San Francisco,7536,U.S. Senate,,DEM,Kamala D. Harris,612
+San Francisco,7536,U.S. Senate,,DEM,Loretta L. Sanchez,96
+San Francisco,7537,U.S. Senate,,DEM,Kamala D. Harris,529
+San Francisco,7537,U.S. Senate,,DEM,Loretta L. Sanchez,85
+San Francisco,7538,U.S. Senate,,DEM,Kamala D. Harris,576
+San Francisco,7538,U.S. Senate,,DEM,Loretta L. Sanchez,92
+San Francisco,7539,U.S. Senate,,DEM,Kamala D. Harris,671
+San Francisco,7539,U.S. Senate,,DEM,Loretta L. Sanchez,87
+San Francisco,7541,U.S. Senate,,DEM,Kamala D. Harris,567
+San Francisco,7541,U.S. Senate,,DEM,Loretta L. Sanchez,98
+San Francisco,7542,U.S. Senate,,DEM,Kamala D. Harris,608
+San Francisco,7542,U.S. Senate,,DEM,Loretta L. Sanchez,93
+San Francisco,7543,U.S. Senate,,DEM,Kamala D. Harris,642
+San Francisco,7543,U.S. Senate,,DEM,Loretta L. Sanchez,100
+San Francisco,7544,U.S. Senate,,DEM,Kamala D. Harris,630
+San Francisco,7544,U.S. Senate,,DEM,Loretta L. Sanchez,119
+San Francisco,7545,U.S. Senate,,DEM,Kamala D. Harris,618
+San Francisco,7545,U.S. Senate,,DEM,Loretta L. Sanchez,123
+San Francisco,7546,U.S. Senate,,DEM,Kamala D. Harris,638
+San Francisco,7546,U.S. Senate,,DEM,Loretta L. Sanchez,117
+San Francisco,7547,U.S. Senate,,DEM,Kamala D. Harris,609
+San Francisco,7547,U.S. Senate,,DEM,Loretta L. Sanchez,126
+San Francisco,7548,U.S. Senate,,DEM,Kamala D. Harris,709
+San Francisco,7548,U.S. Senate,,DEM,Loretta L. Sanchez,100
+San Francisco,7549,U.S. Senate,,DEM,Kamala D. Harris,555
+San Francisco,7549,U.S. Senate,,DEM,Loretta L. Sanchez,92
+San Francisco,7551,U.S. Senate,,DEM,Kamala D. Harris,521
+San Francisco,7551,U.S. Senate,,DEM,Loretta L. Sanchez,79
+San Francisco,7552,U.S. Senate,,DEM,Kamala D. Harris,547
+San Francisco,7552,U.S. Senate,,DEM,Loretta L. Sanchez,74
+San Francisco,7553,U.S. Senate,,DEM,Kamala D. Harris,130
+San Francisco,7553,U.S. Senate,,DEM,Loretta L. Sanchez,14
+San Francisco,7554,U.S. Senate,,DEM,Kamala D. Harris,606
+San Francisco,7554,U.S. Senate,,DEM,Loretta L. Sanchez,103
+San Francisco,7555,U.S. Senate,,DEM,Kamala D. Harris,693
+San Francisco,7555,U.S. Senate,,DEM,Loretta L. Sanchez,107
+San Francisco,7556/7557,U.S. Senate,,DEM,Kamala D. Harris,723
+San Francisco,7556/7557,U.S. Senate,,DEM,Loretta L. Sanchez,109
+San Francisco,7601,U.S. Senate,,DEM,Kamala D. Harris,376
+San Francisco,7601,U.S. Senate,,DEM,Loretta L. Sanchez,140
+San Francisco,7602,U.S. Senate,,DEM,Kamala D. Harris,451
+San Francisco,7602,U.S. Senate,,DEM,Loretta L. Sanchez,162
+San Francisco,7603,U.S. Senate,,DEM,Kamala D. Harris,475
+San Francisco,7603,U.S. Senate,,DEM,Loretta L. Sanchez,155
+San Francisco,7604,U.S. Senate,,DEM,Kamala D. Harris,444
+San Francisco,7604,U.S. Senate,,DEM,Loretta L. Sanchez,156
+San Francisco,7605,U.S. Senate,,DEM,Kamala D. Harris,265
+San Francisco,7605,U.S. Senate,,DEM,Loretta L. Sanchez,108
+San Francisco,7606,U.S. Senate,,DEM,Kamala D. Harris,391
+San Francisco,7606,U.S. Senate,,DEM,Loretta L. Sanchez,170
+San Francisco,7607,U.S. Senate,,DEM,Kamala D. Harris,462
+San Francisco,7607,U.S. Senate,,DEM,Loretta L. Sanchez,179
+San Francisco,7608,U.S. Senate,,DEM,Kamala D. Harris,131
+San Francisco,7608,U.S. Senate,,DEM,Loretta L. Sanchez,85
+San Francisco,7609,U.S. Senate,,DEM,Kamala D. Harris,334
+San Francisco,7609,U.S. Senate,,DEM,Loretta L. Sanchez,134
+San Francisco,7611,U.S. Senate,,DEM,Kamala D. Harris,293
+San Francisco,7611,U.S. Senate,,DEM,Loretta L. Sanchez,109
+San Francisco,7612,U.S. Senate,,DEM,Kamala D. Harris,259
+San Francisco,7612,U.S. Senate,,DEM,Loretta L. Sanchez,96
+San Francisco,7613,U.S. Senate,,DEM,Kamala D. Harris,395
+San Francisco,7613,U.S. Senate,,DEM,Loretta L. Sanchez,158
+San Francisco,7614,U.S. Senate,,DEM,Kamala D. Harris,546
+San Francisco,7614,U.S. Senate,,DEM,Loretta L. Sanchez,174
+San Francisco,7615,U.S. Senate,,DEM,Kamala D. Harris,294
+San Francisco,7615,U.S. Senate,,DEM,Loretta L. Sanchez,157
+San Francisco,7616,U.S. Senate,,DEM,Kamala D. Harris,545
+San Francisco,7616,U.S. Senate,,DEM,Loretta L. Sanchez,163
+San Francisco,7617,U.S. Senate,,DEM,Kamala D. Harris,315
+San Francisco,7617,U.S. Senate,,DEM,Loretta L. Sanchez,125
+San Francisco,7618,U.S. Senate,,DEM,Kamala D. Harris,495
+San Francisco,7618,U.S. Senate,,DEM,Loretta L. Sanchez,125
+San Francisco,7619,U.S. Senate,,DEM,Kamala D. Harris,969
+San Francisco,7619,U.S. Senate,,DEM,Loretta L. Sanchez,354
+San Francisco,7621,U.S. Senate,,DEM,Kamala D. Harris,544
+San Francisco,7621,U.S. Senate,,DEM,Loretta L. Sanchez,148
+San Francisco,7622,U.S. Senate,,DEM,Kamala D. Harris,311
+San Francisco,7622,U.S. Senate,,DEM,Loretta L. Sanchez,124
+San Francisco,7623,U.S. Senate,,DEM,Kamala D. Harris,299
+San Francisco,7623,U.S. Senate,,DEM,Loretta L. Sanchez,112
+San Francisco,7624,U.S. Senate,,DEM,Kamala D. Harris,362
+San Francisco,7624,U.S. Senate,,DEM,Loretta L. Sanchez,134
+San Francisco,7625,U.S. Senate,,DEM,Kamala D. Harris,311
+San Francisco,7625,U.S. Senate,,DEM,Loretta L. Sanchez,196
+San Francisco,7626,U.S. Senate,,DEM,Kamala D. Harris,697
+San Francisco,7626,U.S. Senate,,DEM,Loretta L. Sanchez,203
+San Francisco,7627,U.S. Senate,,DEM,Kamala D. Harris,881
+San Francisco,7627,U.S. Senate,,DEM,Loretta L. Sanchez,279
+San Francisco,7628,U.S. Senate,,DEM,Kamala D. Harris,519
+San Francisco,7628,U.S. Senate,,DEM,Loretta L. Sanchez,134
+San Francisco,7629,U.S. Senate,,DEM,Kamala D. Harris,404
+San Francisco,7629,U.S. Senate,,DEM,Loretta L. Sanchez,110
+San Francisco,7631,U.S. Senate,,DEM,Kamala D. Harris,616
+San Francisco,7631,U.S. Senate,,DEM,Loretta L. Sanchez,193
+San Francisco,7632,U.S. Senate,,DEM,Kamala D. Harris,403
+San Francisco,7632,U.S. Senate,,DEM,Loretta L. Sanchez,86
+San Francisco,7633,U.S. Senate,,DEM,Kamala D. Harris,352
+San Francisco,7633,U.S. Senate,,DEM,Loretta L. Sanchez,143
+San Francisco,7634,U.S. Senate,,DEM,Kamala D. Harris,457
+San Francisco,7634,U.S. Senate,,DEM,Loretta L. Sanchez,160
+San Francisco,7635,U.S. Senate,,DEM,Kamala D. Harris,425
+San Francisco,7635,U.S. Senate,,DEM,Loretta L. Sanchez,135
+San Francisco,7636,U.S. Senate,,DEM,Kamala D. Harris,541
+San Francisco,7636,U.S. Senate,,DEM,Loretta L. Sanchez,143
+San Francisco,7637,U.S. Senate,,DEM,Kamala D. Harris,740
+San Francisco,7637,U.S. Senate,,DEM,Loretta L. Sanchez,234
+San Francisco,7638,U.S. Senate,,DEM,Kamala D. Harris,796
+San Francisco,7638,U.S. Senate,,DEM,Loretta L. Sanchez,183
+San Francisco,7639,U.S. Senate,,DEM,Kamala D. Harris,609
+San Francisco,7639,U.S. Senate,,DEM,Loretta L. Sanchez,160
+San Francisco,7641,U.S. Senate,,DEM,Kamala D. Harris,576
+San Francisco,7641,U.S. Senate,,DEM,Loretta L. Sanchez,150
+San Francisco,7642,U.S. Senate,,DEM,Kamala D. Harris,593
+San Francisco,7642,U.S. Senate,,DEM,Loretta L. Sanchez,124
+San Francisco,7643,U.S. Senate,,DEM,Kamala D. Harris,502
+San Francisco,7643,U.S. Senate,,DEM,Loretta L. Sanchez,149
+San Francisco,7644,U.S. Senate,,DEM,Kamala D. Harris,622
+San Francisco,7644,U.S. Senate,,DEM,Loretta L. Sanchez,175
+San Francisco,7645,U.S. Senate,,DEM,Kamala D. Harris,387
+San Francisco,7645,U.S. Senate,,DEM,Loretta L. Sanchez,115
+San Francisco,7646,U.S. Senate,,DEM,Kamala D. Harris,1297
+San Francisco,7646,U.S. Senate,,DEM,Loretta L. Sanchez,363
+San Francisco,7647,U.S. Senate,,DEM,Kamala D. Harris,387
+San Francisco,7647,U.S. Senate,,DEM,Loretta L. Sanchez,154
+San Francisco,7648,U.S. Senate,,DEM,Kamala D. Harris,2
+San Francisco,7648,U.S. Senate,,DEM,Loretta L. Sanchez,1
+San Francisco,7701,U.S. Senate,,DEM,Kamala D. Harris,650
+San Francisco,7701,U.S. Senate,,DEM,Loretta L. Sanchez,172
+San Francisco,7702,U.S. Senate,,DEM,Kamala D. Harris,458
+San Francisco,7702,U.S. Senate,,DEM,Loretta L. Sanchez,134
+San Francisco,7703,U.S. Senate,,DEM,Kamala D. Harris,63
+San Francisco,7703,U.S. Senate,,DEM,Loretta L. Sanchez,23
+San Francisco,7704,U.S. Senate,,DEM,Kamala D. Harris,623
+San Francisco,7704,U.S. Senate,,DEM,Loretta L. Sanchez,171
+San Francisco,7705,U.S. Senate,,DEM,Kamala D. Harris,340
+San Francisco,7705,U.S. Senate,,DEM,Loretta L. Sanchez,109
+San Francisco,7706,U.S. Senate,,DEM,Kamala D. Harris,572
+San Francisco,7706,U.S. Senate,,DEM,Loretta L. Sanchez,139
+San Francisco,7707,U.S. Senate,,DEM,Kamala D. Harris,578
+San Francisco,7707,U.S. Senate,,DEM,Loretta L. Sanchez,142
+San Francisco,7708,U.S. Senate,,DEM,Kamala D. Harris,590
+San Francisco,7708,U.S. Senate,,DEM,Loretta L. Sanchez,127
+San Francisco,7709,U.S. Senate,,DEM,Kamala D. Harris,252
+San Francisco,7709,U.S. Senate,,DEM,Loretta L. Sanchez,64
+San Francisco,7711,U.S. Senate,,DEM,Kamala D. Harris,503
+San Francisco,7711,U.S. Senate,,DEM,Loretta L. Sanchez,114
+San Francisco,7712,U.S. Senate,,DEM,Kamala D. Harris,381
+San Francisco,7712,U.S. Senate,,DEM,Loretta L. Sanchez,84
+San Francisco,7801,U.S. Senate,,DEM,Kamala D. Harris,787
+San Francisco,7801,U.S. Senate,,DEM,Loretta L. Sanchez,111
+San Francisco,7802,U.S. Senate,,DEM,Kamala D. Harris,590
+San Francisco,7802,U.S. Senate,,DEM,Loretta L. Sanchez,67
+San Francisco,7803,U.S. Senate,,DEM,Kamala D. Harris,628
+San Francisco,7803,U.S. Senate,,DEM,Loretta L. Sanchez,97
+San Francisco,7804,U.S. Senate,,DEM,Kamala D. Harris,697
+San Francisco,7804,U.S. Senate,,DEM,Loretta L. Sanchez,110
+San Francisco,7805,U.S. Senate,,DEM,Kamala D. Harris,605
+San Francisco,7805,U.S. Senate,,DEM,Loretta L. Sanchez,110
+San Francisco,7806,U.S. Senate,,DEM,Kamala D. Harris,558
+San Francisco,7806,U.S. Senate,,DEM,Loretta L. Sanchez,64
+San Francisco,7807,U.S. Senate,,DEM,Kamala D. Harris,554
+San Francisco,7807,U.S. Senate,,DEM,Loretta L. Sanchez,82
+San Francisco,7808,U.S. Senate,,DEM,Kamala D. Harris,454
+San Francisco,7808,U.S. Senate,,DEM,Loretta L. Sanchez,72
+San Francisco,7809,U.S. Senate,,DEM,Kamala D. Harris,813
+San Francisco,7809,U.S. Senate,,DEM,Loretta L. Sanchez,171
+San Francisco,7811,U.S. Senate,,DEM,Kamala D. Harris,532
+San Francisco,7811,U.S. Senate,,DEM,Loretta L. Sanchez,101
+San Francisco,7812,U.S. Senate,,DEM,Kamala D. Harris,576
+San Francisco,7812,U.S. Senate,,DEM,Loretta L. Sanchez,110
+San Francisco,7813,U.S. Senate,,DEM,Kamala D. Harris,740
+San Francisco,7813,U.S. Senate,,DEM,Loretta L. Sanchez,129
+San Francisco,7814,U.S. Senate,,DEM,Kamala D. Harris,431
+San Francisco,7814,U.S. Senate,,DEM,Loretta L. Sanchez,170
+San Francisco,7815,U.S. Senate,,DEM,Kamala D. Harris,710
+San Francisco,7815,U.S. Senate,,DEM,Loretta L. Sanchez,100
+San Francisco,7816,U.S. Senate,,DEM,Kamala D. Harris,703
+San Francisco,7816,U.S. Senate,,DEM,Loretta L. Sanchez,78
+San Francisco,7817,U.S. Senate,,DEM,Kamala D. Harris,584
+San Francisco,7817,U.S. Senate,,DEM,Loretta L. Sanchez,89
+San Francisco,7818,U.S. Senate,,DEM,Kamala D. Harris,614
+San Francisco,7818,U.S. Senate,,DEM,Loretta L. Sanchez,124
+San Francisco,7819,U.S. Senate,,DEM,Kamala D. Harris,512
+San Francisco,7819,U.S. Senate,,DEM,Loretta L. Sanchez,112
+San Francisco,7821,U.S. Senate,,DEM,Kamala D. Harris,744
+San Francisco,7821,U.S. Senate,,DEM,Loretta L. Sanchez,120
+San Francisco,7822,U.S. Senate,,DEM,Kamala D. Harris,615
+San Francisco,7822,U.S. Senate,,DEM,Loretta L. Sanchez,104
+San Francisco,7823,U.S. Senate,,DEM,Kamala D. Harris,661
+San Francisco,7823,U.S. Senate,,DEM,Loretta L. Sanchez,100
+San Francisco,7824,U.S. Senate,,DEM,Kamala D. Harris,529
+San Francisco,7824,U.S. Senate,,DEM,Loretta L. Sanchez,91
+San Francisco,7825,U.S. Senate,,DEM,Kamala D. Harris,422
+San Francisco,7825,U.S. Senate,,DEM,Loretta L. Sanchez,60
+San Francisco,7826,U.S. Senate,,DEM,Kamala D. Harris,519
+San Francisco,7826,U.S. Senate,,DEM,Loretta L. Sanchez,65
+San Francisco,7827,U.S. Senate,,DEM,Kamala D. Harris,559
+San Francisco,7827,U.S. Senate,,DEM,Loretta L. Sanchez,120
+San Francisco,7828,U.S. Senate,,DEM,Kamala D. Harris,702
+San Francisco,7828,U.S. Senate,,DEM,Loretta L. Sanchez,138
+San Francisco,7829,U.S. Senate,,DEM,Kamala D. Harris,677
+San Francisco,7829,U.S. Senate,,DEM,Loretta L. Sanchez,122
+San Francisco,7831,U.S. Senate,,DEM,Kamala D. Harris,686
+San Francisco,7831,U.S. Senate,,DEM,Loretta L. Sanchez,75
+San Francisco,7832,U.S. Senate,,DEM,Kamala D. Harris,610
+San Francisco,7832,U.S. Senate,,DEM,Loretta L. Sanchez,98
+San Francisco,7833,U.S. Senate,,DEM,Kamala D. Harris,586
+San Francisco,7833,U.S. Senate,,DEM,Loretta L. Sanchez,69
+San Francisco,7834,U.S. Senate,,DEM,Kamala D. Harris,614
+San Francisco,7834,U.S. Senate,,DEM,Loretta L. Sanchez,98
+San Francisco,7835,U.S. Senate,,DEM,Kamala D. Harris,593
+San Francisco,7835,U.S. Senate,,DEM,Loretta L. Sanchez,123
+San Francisco,7836,U.S. Senate,,DEM,Kamala D. Harris,708
+San Francisco,7836,U.S. Senate,,DEM,Loretta L. Sanchez,126
+San Francisco,7837,U.S. Senate,,DEM,Kamala D. Harris,673
+San Francisco,7837,U.S. Senate,,DEM,Loretta L. Sanchez,104
+San Francisco,7838,U.S. Senate,,DEM,Kamala D. Harris,688
+San Francisco,7838,U.S. Senate,,DEM,Loretta L. Sanchez,96
+San Francisco,7839,U.S. Senate,,DEM,Kamala D. Harris,626
+San Francisco,7839,U.S. Senate,,DEM,Loretta L. Sanchez,97
+San Francisco,7841,U.S. Senate,,DEM,Kamala D. Harris,679
+San Francisco,7841,U.S. Senate,,DEM,Loretta L. Sanchez,87
+San Francisco,7842,U.S. Senate,,DEM,Kamala D. Harris,685
+San Francisco,7842,U.S. Senate,,DEM,Loretta L. Sanchez,109
+San Francisco,7843,U.S. Senate,,DEM,Kamala D. Harris,507
+San Francisco,7843,U.S. Senate,,DEM,Loretta L. Sanchez,112
+San Francisco,7844,U.S. Senate,,DEM,Kamala D. Harris,448
+San Francisco,7844,U.S. Senate,,DEM,Loretta L. Sanchez,83
+San Francisco,7845,U.S. Senate,,DEM,Kamala D. Harris,658
+San Francisco,7845,U.S. Senate,,DEM,Loretta L. Sanchez,89
+San Francisco,7846,U.S. Senate,,DEM,Kamala D. Harris,654
+San Francisco,7846,U.S. Senate,,DEM,Loretta L. Sanchez,102
+San Francisco,7847,U.S. Senate,,DEM,Kamala D. Harris,654
+San Francisco,7847,U.S. Senate,,DEM,Loretta L. Sanchez,121
+San Francisco,7848,U.S. Senate,,DEM,Kamala D. Harris,643
+San Francisco,7848,U.S. Senate,,DEM,Loretta L. Sanchez,114
+San Francisco,7849,U.S. Senate,,DEM,Kamala D. Harris,690
+San Francisco,7849,U.S. Senate,,DEM,Loretta L. Sanchez,115
+San Francisco,7851,U.S. Senate,,DEM,Kamala D. Harris,338
+San Francisco,7851,U.S. Senate,,DEM,Loretta L. Sanchez,86
+San Francisco,7852,U.S. Senate,,DEM,Kamala D. Harris,444
+San Francisco,7852,U.S. Senate,,DEM,Loretta L. Sanchez,99
+San Francisco,7853,U.S. Senate,,DEM,Kamala D. Harris,605
+San Francisco,7853,U.S. Senate,,DEM,Loretta L. Sanchez,112
+San Francisco,7854,U.S. Senate,,DEM,Kamala D. Harris,639
+San Francisco,7854,U.S. Senate,,DEM,Loretta L. Sanchez,112
+San Francisco,7855,U.S. Senate,,DEM,Kamala D. Harris,672
+San Francisco,7855,U.S. Senate,,DEM,Loretta L. Sanchez,126
+San Francisco,7856,U.S. Senate,,DEM,Kamala D. Harris,601
+San Francisco,7856,U.S. Senate,,DEM,Loretta L. Sanchez,101
+San Francisco,7857,U.S. Senate,,DEM,Kamala D. Harris,653
+San Francisco,7857,U.S. Senate,,DEM,Loretta L. Sanchez,128
+San Francisco,7858,U.S. Senate,,DEM,Kamala D. Harris,518
+San Francisco,7858,U.S. Senate,,DEM,Loretta L. Sanchez,93
+San Francisco,7859,U.S. Senate,,DEM,Kamala D. Harris,656
+San Francisco,7859,U.S. Senate,,DEM,Loretta L. Sanchez,103
+San Francisco,7861,U.S. Senate,,DEM,Kamala D. Harris,596
+San Francisco,7861,U.S. Senate,,DEM,Loretta L. Sanchez,127
+San Francisco,7862,U.S. Senate,,DEM,Kamala D. Harris,655
+San Francisco,7862,U.S. Senate,,DEM,Loretta L. Sanchez,103
+San Francisco,7863,U.S. Senate,,DEM,Kamala D. Harris,606
+San Francisco,7863,U.S. Senate,,DEM,Loretta L. Sanchez,141
+San Francisco,7864,U.S. Senate,,DEM,Kamala D. Harris,544
+San Francisco,7864,U.S. Senate,,DEM,Loretta L. Sanchez,104
+San Francisco,7865,U.S. Senate,,DEM,Kamala D. Harris,569
+San Francisco,7865,U.S. Senate,,DEM,Loretta L. Sanchez,114
+San Francisco,7866,U.S. Senate,,DEM,Kamala D. Harris,549
+San Francisco,7866,U.S. Senate,,DEM,Loretta L. Sanchez,119
+San Francisco,7867,U.S. Senate,,DEM,Kamala D. Harris,635
+San Francisco,7867,U.S. Senate,,DEM,Loretta L. Sanchez,130
+San Francisco,7868,U.S. Senate,,DEM,Kamala D. Harris,602
+San Francisco,7868,U.S. Senate,,DEM,Loretta L. Sanchez,112
+San Francisco,7869,U.S. Senate,,DEM,Kamala D. Harris,622
+San Francisco,7869,U.S. Senate,,DEM,Loretta L. Sanchez,121
+San Francisco,7871,U.S. Senate,,DEM,Kamala D. Harris,635
+San Francisco,7871,U.S. Senate,,DEM,Loretta L. Sanchez,119
+San Francisco,7872,U.S. Senate,,DEM,Kamala D. Harris,665
+San Francisco,7872,U.S. Senate,,DEM,Loretta L. Sanchez,103
+San Francisco,7873,U.S. Senate,,DEM,Kamala D. Harris,633
+San Francisco,7873,U.S. Senate,,DEM,Loretta L. Sanchez,106
+San Francisco,7874,U.S. Senate,,DEM,Kamala D. Harris,279
+San Francisco,7874,U.S. Senate,,DEM,Loretta L. Sanchez,93
+San Francisco,7875,U.S. Senate,,DEM,Kamala D. Harris,347
+San Francisco,7875,U.S. Senate,,DEM,Loretta L. Sanchez,129
+San Francisco,7901,U.S. Senate,,DEM,Kamala D. Harris,642
+San Francisco,7901,U.S. Senate,,DEM,Loretta L. Sanchez,212
+San Francisco,7902,U.S. Senate,,DEM,Kamala D. Harris,595
+San Francisco,7902,U.S. Senate,,DEM,Loretta L. Sanchez,176
+San Francisco,7903,U.S. Senate,,DEM,Kamala D. Harris,418
+San Francisco,7903,U.S. Senate,,DEM,Loretta L. Sanchez,167
+San Francisco,7904,U.S. Senate,,DEM,Kamala D. Harris,480
+San Francisco,7904,U.S. Senate,,DEM,Loretta L. Sanchez,149
+San Francisco,7905,U.S. Senate,,DEM,Kamala D. Harris,542
+San Francisco,7905,U.S. Senate,,DEM,Loretta L. Sanchez,127
+San Francisco,7906,U.S. Senate,,DEM,Kamala D. Harris,499
+San Francisco,7906,U.S. Senate,,DEM,Loretta L. Sanchez,107
+San Francisco,7907,U.S. Senate,,DEM,Kamala D. Harris,597
+San Francisco,7907,U.S. Senate,,DEM,Loretta L. Sanchez,156
+San Francisco,7908,U.S. Senate,,DEM,Kamala D. Harris,578
+San Francisco,7908,U.S. Senate,,DEM,Loretta L. Sanchez,208
+San Francisco,7909,U.S. Senate,,DEM,Kamala D. Harris,477
+San Francisco,7909,U.S. Senate,,DEM,Loretta L. Sanchez,105
+San Francisco,7911,U.S. Senate,,DEM,Kamala D. Harris,511
+San Francisco,7911,U.S. Senate,,DEM,Loretta L. Sanchez,165
+San Francisco,7912,U.S. Senate,,DEM,Kamala D. Harris,615
+San Francisco,7912,U.S. Senate,,DEM,Loretta L. Sanchez,161
+San Francisco,7913,U.S. Senate,,DEM,Kamala D. Harris,566
+San Francisco,7913,U.S. Senate,,DEM,Loretta L. Sanchez,174
+San Francisco,7914,U.S. Senate,,DEM,Kamala D. Harris,544
+San Francisco,7914,U.S. Senate,,DEM,Loretta L. Sanchez,151
+San Francisco,7915,U.S. Senate,,DEM,Kamala D. Harris,528
+San Francisco,7915,U.S. Senate,,DEM,Loretta L. Sanchez,143
+San Francisco,7916,U.S. Senate,,DEM,Kamala D. Harris,591
+San Francisco,7916,U.S. Senate,,DEM,Loretta L. Sanchez,120
+San Francisco,7917,U.S. Senate,,DEM,Kamala D. Harris,601
+San Francisco,7917,U.S. Senate,,DEM,Loretta L. Sanchez,197
+San Francisco,7918,U.S. Senate,,DEM,Kamala D. Harris,513
+San Francisco,7918,U.S. Senate,,DEM,Loretta L. Sanchez,131
+San Francisco,7919,U.S. Senate,,DEM,Kamala D. Harris,531
+San Francisco,7919,U.S. Senate,,DEM,Loretta L. Sanchez,163
+San Francisco,7921,U.S. Senate,,DEM,Kamala D. Harris,462
+San Francisco,7921,U.S. Senate,,DEM,Loretta L. Sanchez,182
+San Francisco,7922,U.S. Senate,,DEM,Kamala D. Harris,512
+San Francisco,7922,U.S. Senate,,DEM,Loretta L. Sanchez,136
+San Francisco,7923,U.S. Senate,,DEM,Kamala D. Harris,515
+San Francisco,7923,U.S. Senate,,DEM,Loretta L. Sanchez,125
+San Francisco,7924,U.S. Senate,,DEM,Kamala D. Harris,463
+San Francisco,7924,U.S. Senate,,DEM,Loretta L. Sanchez,166
+San Francisco,7925,U.S. Senate,,DEM,Kamala D. Harris,358
+San Francisco,7925,U.S. Senate,,DEM,Loretta L. Sanchez,83
+San Francisco,7926,U.S. Senate,,DEM,Kamala D. Harris,519
+San Francisco,7926,U.S. Senate,,DEM,Loretta L. Sanchez,128
+San Francisco,7927,U.S. Senate,,DEM,Kamala D. Harris,535
+San Francisco,7927,U.S. Senate,,DEM,Loretta L. Sanchez,97
+San Francisco,7928,U.S. Senate,,DEM,Kamala D. Harris,689
+San Francisco,7928,U.S. Senate,,DEM,Loretta L. Sanchez,110
+San Francisco,7929,U.S. Senate,,DEM,Kamala D. Harris,641
+San Francisco,7929,U.S. Senate,,DEM,Loretta L. Sanchez,90
+San Francisco,7931,U.S. Senate,,DEM,Kamala D. Harris,556
+San Francisco,7931,U.S. Senate,,DEM,Loretta L. Sanchez,93
+San Francisco,7932,U.S. Senate,,DEM,Kamala D. Harris,396
+San Francisco,7932,U.S. Senate,,DEM,Loretta L. Sanchez,59
+San Francisco,7933,U.S. Senate,,DEM,Kamala D. Harris,4
+San Francisco,7933,U.S. Senate,,DEM,Loretta L. Sanchez,2
+San Francisco,7934,U.S. Senate,,DEM,Kamala D. Harris,611
+San Francisco,7934,U.S. Senate,,DEM,Loretta L. Sanchez,108
+San Francisco,7935,U.S. Senate,,DEM,Kamala D. Harris,702
+San Francisco,7935,U.S. Senate,,DEM,Loretta L. Sanchez,104
+San Francisco,7936,U.S. Senate,,DEM,Kamala D. Harris,637
+San Francisco,7936,U.S. Senate,,DEM,Loretta L. Sanchez,89
+San Francisco,7937,U.S. Senate,,DEM,Kamala D. Harris,612
+San Francisco,7937,U.S. Senate,,DEM,Loretta L. Sanchez,111
+San Francisco,7938,U.S. Senate,,DEM,Kamala D. Harris,461
+San Francisco,7938,U.S. Senate,,DEM,Loretta L. Sanchez,129
+San Francisco,7939,U.S. Senate,,DEM,Kamala D. Harris,476
+San Francisco,7939,U.S. Senate,,DEM,Loretta L. Sanchez,83
+San Francisco,7941,U.S. Senate,,DEM,Kamala D. Harris,513
+San Francisco,7941,U.S. Senate,,DEM,Loretta L. Sanchez,88
+San Francisco,7942,U.S. Senate,,DEM,Kamala D. Harris,560
+San Francisco,7942,U.S. Senate,,DEM,Loretta L. Sanchez,141
+San Francisco,7943,U.S. Senate,,DEM,Kamala D. Harris,563
+San Francisco,7943,U.S. Senate,,DEM,Loretta L. Sanchez,152
+San Francisco,7944,U.S. Senate,,DEM,Kamala D. Harris,541
+San Francisco,7944,U.S. Senate,,DEM,Loretta L. Sanchez,117
+San Francisco,7945,U.S. Senate,,DEM,Kamala D. Harris,483
+San Francisco,7945,U.S. Senate,,DEM,Loretta L. Sanchez,123
+San Francisco,7946,U.S. Senate,,DEM,Kamala D. Harris,424
+San Francisco,7946,U.S. Senate,,DEM,Loretta L. Sanchez,205
+San Francisco,7947,U.S. Senate,,DEM,Kamala D. Harris,429
+San Francisco,7947,U.S. Senate,,DEM,Loretta L. Sanchez,193
+San Francisco,7948,U.S. Senate,,DEM,Kamala D. Harris,466
+San Francisco,7948,U.S. Senate,,DEM,Loretta L. Sanchez,163
+San Francisco,7949,U.S. Senate,,DEM,Kamala D. Harris,253
+San Francisco,7949,U.S. Senate,,DEM,Loretta L. Sanchez,117
+San Francisco,7951,U.S. Senate,,DEM,Kamala D. Harris,346
+San Francisco,7951,U.S. Senate,,DEM,Loretta L. Sanchez,186
+San Francisco,7952,U.S. Senate,,DEM,Kamala D. Harris,384
+San Francisco,7952,U.S. Senate,,DEM,Loretta L. Sanchez,194
+San Francisco,7953,U.S. Senate,,DEM,Kamala D. Harris,426
+San Francisco,7953,U.S. Senate,,DEM,Loretta L. Sanchez,192
+San Francisco,7954,U.S. Senate,,DEM,Kamala D. Harris,0
+San Francisco,7954,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Francisco,7955,U.S. Senate,,DEM,Kamala D. Harris,403
+San Francisco,7955,U.S. Senate,,DEM,Loretta L. Sanchez,189
+San Francisco,7956,U.S. Senate,,DEM,Kamala D. Harris,313
+San Francisco,7956,U.S. Senate,,DEM,Loretta L. Sanchez,174
+San Francisco,7957,U.S. Senate,,DEM,Kamala D. Harris,374
+San Francisco,7957,U.S. Senate,,DEM,Loretta L. Sanchez,97
+San Francisco,7958,U.S. Senate,,DEM,Kamala D. Harris,116
+San Francisco,7958,U.S. Senate,,DEM,Loretta L. Sanchez,57
+San Francisco,9001,U.S. Senate,,DEM,Kamala D. Harris,138
+San Francisco,9001,U.S. Senate,,DEM,Loretta L. Sanchez,45
+San Francisco,9101,U.S. Senate,,DEM,Kamala D. Harris,502
+San Francisco,9101,U.S. Senate,,DEM,Loretta L. Sanchez,159
+San Francisco,9102,U.S. Senate,,DEM,Kamala D. Harris,553
+San Francisco,9102,U.S. Senate,,DEM,Loretta L. Sanchez,172
+San Francisco,9103,U.S. Senate,,DEM,Kamala D. Harris,525
+San Francisco,9103,U.S. Senate,,DEM,Loretta L. Sanchez,154
+San Francisco,9104,U.S. Senate,,DEM,Kamala D. Harris,543
+San Francisco,9104,U.S. Senate,,DEM,Loretta L. Sanchez,156
+San Francisco,9105,U.S. Senate,,DEM,Kamala D. Harris,558
+San Francisco,9105,U.S. Senate,,DEM,Loretta L. Sanchez,163
+San Francisco,9106,U.S. Senate,,DEM,Kamala D. Harris,593
+San Francisco,9106,U.S. Senate,,DEM,Loretta L. Sanchez,147
+San Francisco,9107,U.S. Senate,,DEM,Kamala D. Harris,442
+San Francisco,9107,U.S. Senate,,DEM,Loretta L. Sanchez,144
+San Francisco,9108,U.S. Senate,,DEM,Kamala D. Harris,467
+San Francisco,9108,U.S. Senate,,DEM,Loretta L. Sanchez,144
+San Francisco,9109,U.S. Senate,,DEM,Kamala D. Harris,524
+San Francisco,9109,U.S. Senate,,DEM,Loretta L. Sanchez,146
+San Francisco,9111,U.S. Senate,,DEM,Kamala D. Harris,424
+San Francisco,9111,U.S. Senate,,DEM,Loretta L. Sanchez,122
+San Francisco,9112,U.S. Senate,,DEM,Kamala D. Harris,562
+San Francisco,9112,U.S. Senate,,DEM,Loretta L. Sanchez,139
+San Francisco,9113,U.S. Senate,,DEM,Kamala D. Harris,634
+San Francisco,9113,U.S. Senate,,DEM,Loretta L. Sanchez,157
+San Francisco,9114,U.S. Senate,,DEM,Kamala D. Harris,518
+San Francisco,9114,U.S. Senate,,DEM,Loretta L. Sanchez,137
+San Francisco,9115,U.S. Senate,,DEM,Kamala D. Harris,531
+San Francisco,9115,U.S. Senate,,DEM,Loretta L. Sanchez,138
+San Francisco,9116,U.S. Senate,,DEM,Kamala D. Harris,566
+San Francisco,9116,U.S. Senate,,DEM,Loretta L. Sanchez,156
+San Francisco,9117,U.S. Senate,,DEM,Kamala D. Harris,490
+San Francisco,9117,U.S. Senate,,DEM,Loretta L. Sanchez,113
+San Francisco,9118,U.S. Senate,,DEM,Kamala D. Harris,469
+San Francisco,9118,U.S. Senate,,DEM,Loretta L. Sanchez,177
+San Francisco,9119,U.S. Senate,,DEM,Kamala D. Harris,490
+San Francisco,9119,U.S. Senate,,DEM,Loretta L. Sanchez,156
+San Francisco,9121,U.S. Senate,,DEM,Kamala D. Harris,494
+San Francisco,9121,U.S. Senate,,DEM,Loretta L. Sanchez,174
+San Francisco,9122,U.S. Senate,,DEM,Kamala D. Harris,503
+San Francisco,9122,U.S. Senate,,DEM,Loretta L. Sanchez,167
+San Francisco,9123,U.S. Senate,,DEM,Kamala D. Harris,489
+San Francisco,9123,U.S. Senate,,DEM,Loretta L. Sanchez,153
+San Francisco,9124,U.S. Senate,,DEM,Kamala D. Harris,472
+San Francisco,9124,U.S. Senate,,DEM,Loretta L. Sanchez,165
+San Francisco,9125,U.S. Senate,,DEM,Kamala D. Harris,511
+San Francisco,9125,U.S. Senate,,DEM,Loretta L. Sanchez,136
+San Francisco,9126,U.S. Senate,,DEM,Kamala D. Harris,538
+San Francisco,9126,U.S. Senate,,DEM,Loretta L. Sanchez,187
+San Francisco,9127,U.S. Senate,,DEM,Kamala D. Harris,552
+San Francisco,9127,U.S. Senate,,DEM,Loretta L. Sanchez,171
+San Francisco,9128,U.S. Senate,,DEM,Kamala D. Harris,504
+San Francisco,9128,U.S. Senate,,DEM,Loretta L. Sanchez,137
+San Francisco,9129,U.S. Senate,,DEM,Kamala D. Harris,430
+San Francisco,9129,U.S. Senate,,DEM,Loretta L. Sanchez,124
+San Francisco,9131,U.S. Senate,,DEM,Kamala D. Harris,459
+San Francisco,9131,U.S. Senate,,DEM,Loretta L. Sanchez,121
+San Francisco,9132,U.S. Senate,,DEM,Kamala D. Harris,487
+San Francisco,9132,U.S. Senate,,DEM,Loretta L. Sanchez,127
+San Francisco,9133,U.S. Senate,,DEM,Kamala D. Harris,617
+San Francisco,9133,U.S. Senate,,DEM,Loretta L. Sanchez,172
+San Francisco,9134,U.S. Senate,,DEM,Kamala D. Harris,511
+San Francisco,9134,U.S. Senate,,DEM,Loretta L. Sanchez,144
+San Francisco,9135,U.S. Senate,,DEM,Kamala D. Harris,429
+San Francisco,9135,U.S. Senate,,DEM,Loretta L. Sanchez,125
+San Francisco,9136,U.S. Senate,,DEM,Kamala D. Harris,557
+San Francisco,9136,U.S. Senate,,DEM,Loretta L. Sanchez,148
+San Francisco,9137,U.S. Senate,,DEM,Kamala D. Harris,516
+San Francisco,9137,U.S. Senate,,DEM,Loretta L. Sanchez,173
+San Francisco,9138,U.S. Senate,,DEM,Kamala D. Harris,517
+San Francisco,9138,U.S. Senate,,DEM,Loretta L. Sanchez,159
+San Francisco,9139,U.S. Senate,,DEM,Kamala D. Harris,552
+San Francisco,9139,U.S. Senate,,DEM,Loretta L. Sanchez,175
+San Francisco,9141,U.S. Senate,,DEM,Kamala D. Harris,532
+San Francisco,9141,U.S. Senate,,DEM,Loretta L. Sanchez,163
+San Francisco,9142,U.S. Senate,,DEM,Kamala D. Harris,566
+San Francisco,9142,U.S. Senate,,DEM,Loretta L. Sanchez,173
+San Francisco,9143,U.S. Senate,,DEM,Kamala D. Harris,495
+San Francisco,9143,U.S. Senate,,DEM,Loretta L. Sanchez,153
+San Francisco,9144,U.S. Senate,,DEM,Kamala D. Harris,580
+San Francisco,9144,U.S. Senate,,DEM,Loretta L. Sanchez,155
+San Francisco,9145,U.S. Senate,,DEM,Kamala D. Harris,548
+San Francisco,9145,U.S. Senate,,DEM,Loretta L. Sanchez,128
+San Francisco,9146,U.S. Senate,,DEM,Kamala D. Harris,575
+San Francisco,9146,U.S. Senate,,DEM,Loretta L. Sanchez,141
+San Francisco,9147,U.S. Senate,,DEM,Kamala D. Harris,575
+San Francisco,9147,U.S. Senate,,DEM,Loretta L. Sanchez,142
+San Francisco,9148,U.S. Senate,,DEM,Kamala D. Harris,621
+San Francisco,9148,U.S. Senate,,DEM,Loretta L. Sanchez,149
+San Francisco,9149,U.S. Senate,,DEM,Kamala D. Harris,623
+San Francisco,9149,U.S. Senate,,DEM,Loretta L. Sanchez,129
+San Francisco,9151,U.S. Senate,,DEM,Kamala D. Harris,489
+San Francisco,9151,U.S. Senate,,DEM,Loretta L. Sanchez,136
+San Francisco,9152,U.S. Senate,,DEM,Kamala D. Harris,371
+San Francisco,9152,U.S. Senate,,DEM,Loretta L. Sanchez,171
+San Francisco,9201,U.S. Senate,,DEM,Kamala D. Harris,642
+San Francisco,9201,U.S. Senate,,DEM,Loretta L. Sanchez,164
+San Francisco,9202,U.S. Senate,,DEM,Kamala D. Harris,587
+San Francisco,9202,U.S. Senate,,DEM,Loretta L. Sanchez,127
+San Francisco,9203,U.S. Senate,,DEM,Kamala D. Harris,532
+San Francisco,9203,U.S. Senate,,DEM,Loretta L. Sanchez,169
+San Francisco,9204,U.S. Senate,,DEM,Kamala D. Harris,460
+San Francisco,9204,U.S. Senate,,DEM,Loretta L. Sanchez,154
+San Francisco,9205,U.S. Senate,,DEM,Kamala D. Harris,425
+San Francisco,9205,U.S. Senate,,DEM,Loretta L. Sanchez,129
+San Francisco,9206,U.S. Senate,,DEM,Kamala D. Harris,509
+San Francisco,9206,U.S. Senate,,DEM,Loretta L. Sanchez,182
+San Francisco,9207,U.S. Senate,,DEM,Kamala D. Harris,531
+San Francisco,9207,U.S. Senate,,DEM,Loretta L. Sanchez,165
+San Francisco,9208,U.S. Senate,,DEM,Kamala D. Harris,573
+San Francisco,9208,U.S. Senate,,DEM,Loretta L. Sanchez,178
+San Francisco,9209,U.S. Senate,,DEM,Kamala D. Harris,398
+San Francisco,9209,U.S. Senate,,DEM,Loretta L. Sanchez,145
+San Francisco,9211,U.S. Senate,,DEM,Kamala D. Harris,488
+San Francisco,9211,U.S. Senate,,DEM,Loretta L. Sanchez,152
+San Francisco,9212,U.S. Senate,,DEM,Kamala D. Harris,447
+San Francisco,9212,U.S. Senate,,DEM,Loretta L. Sanchez,153
+San Francisco,9213,U.S. Senate,,DEM,Kamala D. Harris,555
+San Francisco,9213,U.S. Senate,,DEM,Loretta L. Sanchez,154
+San Francisco,9214,U.S. Senate,,DEM,Kamala D. Harris,376
+San Francisco,9214,U.S. Senate,,DEM,Loretta L. Sanchez,97
+San Francisco,9215,U.S. Senate,,DEM,Kamala D. Harris,378
+San Francisco,9215,U.S. Senate,,DEM,Loretta L. Sanchez,102
+San Francisco,9216,U.S. Senate,,DEM,Kamala D. Harris,470
+San Francisco,9216,U.S. Senate,,DEM,Loretta L. Sanchez,141
+San Francisco,9217,U.S. Senate,,DEM,Kamala D. Harris,437
+San Francisco,9217,U.S. Senate,,DEM,Loretta L. Sanchez,125
+San Francisco,9218,U.S. Senate,,DEM,Kamala D. Harris,468
+San Francisco,9218,U.S. Senate,,DEM,Loretta L. Sanchez,142
+San Francisco,9219,U.S. Senate,,DEM,Kamala D. Harris,466
+San Francisco,9219,U.S. Senate,,DEM,Loretta L. Sanchez,132
+San Francisco,9221,U.S. Senate,,DEM,Kamala D. Harris,444
+San Francisco,9221,U.S. Senate,,DEM,Loretta L. Sanchez,112
+San Francisco,9222,U.S. Senate,,DEM,Kamala D. Harris,541
+San Francisco,9222,U.S. Senate,,DEM,Loretta L. Sanchez,153
+San Francisco,9223,U.S. Senate,,DEM,Kamala D. Harris,353
+San Francisco,9223,U.S. Senate,,DEM,Loretta L. Sanchez,126
+San Francisco,9224,U.S. Senate,,DEM,Kamala D. Harris,583
+San Francisco,9224,U.S. Senate,,DEM,Loretta L. Sanchez,161
+San Francisco,9225,U.S. Senate,,DEM,Kamala D. Harris,584
+San Francisco,9225,U.S. Senate,,DEM,Loretta L. Sanchez,197
+San Francisco,9226,U.S. Senate,,DEM,Kamala D. Harris,547
+San Francisco,9226,U.S. Senate,,DEM,Loretta L. Sanchez,163
+San Francisco,9227,U.S. Senate,,DEM,Kamala D. Harris,470
+San Francisco,9227,U.S. Senate,,DEM,Loretta L. Sanchez,116
+San Francisco,9228,U.S. Senate,,DEM,Kamala D. Harris,461
+San Francisco,9228,U.S. Senate,,DEM,Loretta L. Sanchez,138
+San Francisco,9229,U.S. Senate,,DEM,Kamala D. Harris,415
+San Francisco,9229,U.S. Senate,,DEM,Loretta L. Sanchez,90
+San Francisco,9231,U.S. Senate,,DEM,Kamala D. Harris,659
+San Francisco,9231,U.S. Senate,,DEM,Loretta L. Sanchez,126
+San Francisco,9232,U.S. Senate,,DEM,Kamala D. Harris,530
+San Francisco,9232,U.S. Senate,,DEM,Loretta L. Sanchez,96
+San Francisco,9233,U.S. Senate,,DEM,Kamala D. Harris,525
+San Francisco,9233,U.S. Senate,,DEM,Loretta L. Sanchez,118
+San Francisco,9234,U.S. Senate,,DEM,Kamala D. Harris,468
+San Francisco,9234,U.S. Senate,,DEM,Loretta L. Sanchez,120
+San Francisco,9235,U.S. Senate,,DEM,Kamala D. Harris,564
+San Francisco,9235,U.S. Senate,,DEM,Loretta L. Sanchez,157
+San Francisco,9236,U.S. Senate,,DEM,Kamala D. Harris,432
+San Francisco,9236,U.S. Senate,,DEM,Loretta L. Sanchez,100
+San Francisco,9237,U.S. Senate,,DEM,Kamala D. Harris,596
+San Francisco,9237,U.S. Senate,,DEM,Loretta L. Sanchez,127
+San Francisco,9238,U.S. Senate,,DEM,Kamala D. Harris,536
+San Francisco,9238,U.S. Senate,,DEM,Loretta L. Sanchez,151
+San Francisco,9239,U.S. Senate,,DEM,Kamala D. Harris,588
+San Francisco,9239,U.S. Senate,,DEM,Loretta L. Sanchez,147
+San Francisco,9241,U.S. Senate,,DEM,Kamala D. Harris,627
+San Francisco,9241,U.S. Senate,,DEM,Loretta L. Sanchez,154
+San Francisco,9242,U.S. Senate,,DEM,Kamala D. Harris,619
+San Francisco,9242,U.S. Senate,,DEM,Loretta L. Sanchez,152
+San Francisco,9243,U.S. Senate,,DEM,Kamala D. Harris,413
+San Francisco,9243,U.S. Senate,,DEM,Loretta L. Sanchez,64
+San Francisco,9244,U.S. Senate,,DEM,Kamala D. Harris,567
+San Francisco,9244,U.S. Senate,,DEM,Loretta L. Sanchez,149
+San Francisco,9245,U.S. Senate,,DEM,Kamala D. Harris,456
+San Francisco,9245,U.S. Senate,,DEM,Loretta L. Sanchez,96
+San Francisco,9246,U.S. Senate,,DEM,Kamala D. Harris,589
+San Francisco,9246,U.S. Senate,,DEM,Loretta L. Sanchez,144
+San Francisco,9247,U.S. Senate,,DEM,Kamala D. Harris,624
+San Francisco,9247,U.S. Senate,,DEM,Loretta L. Sanchez,152
+San Francisco,9248,U.S. Senate,,DEM,Kamala D. Harris,589
+San Francisco,9248,U.S. Senate,,DEM,Loretta L. Sanchez,136
+San Francisco,9249,U.S. Senate,,DEM,Kamala D. Harris,584
+San Francisco,9249,U.S. Senate,,DEM,Loretta L. Sanchez,131
+San Francisco,9251,U.S. Senate,,DEM,Kamala D. Harris,630
+San Francisco,9251,U.S. Senate,,DEM,Loretta L. Sanchez,142
+San Francisco,9252,U.S. Senate,,DEM,Kamala D. Harris,553
+San Francisco,9252,U.S. Senate,,DEM,Loretta L. Sanchez,181
+San Francisco,9253,U.S. Senate,,DEM,Kamala D. Harris,463
+San Francisco,9253,U.S. Senate,,DEM,Loretta L. Sanchez,136
+San Francisco,9254,U.S. Senate,,DEM,Kamala D. Harris,646
+San Francisco,9254,U.S. Senate,,DEM,Loretta L. Sanchez,126
+San Francisco,9255,U.S. Senate,,DEM,Kamala D. Harris,349
+San Francisco,9255,U.S. Senate,,DEM,Loretta L. Sanchez,89
+San Francisco,9256,U.S. Senate,,DEM,Kamala D. Harris,237
+San Francisco,9256,U.S. Senate,,DEM,Loretta L. Sanchez,57
+San Francisco,9257,U.S. Senate,,DEM,Kamala D. Harris,203
+San Francisco,9257,U.S. Senate,,DEM,Loretta L. Sanchez,53
+San Francisco,9258,U.S. Senate,,DEM,Kamala D. Harris,441
+San Francisco,9258,U.S. Senate,,DEM,Loretta L. Sanchez,121
+San Francisco,9401,U.S. Senate,,DEM,Kamala D. Harris,552
+San Francisco,9401,U.S. Senate,,DEM,Loretta L. Sanchez,168
+San Francisco,9402,U.S. Senate,,DEM,Kamala D. Harris,512
+San Francisco,9402,U.S. Senate,,DEM,Loretta L. Sanchez,192
+San Francisco,9403,U.S. Senate,,DEM,Kamala D. Harris,498
+San Francisco,9403,U.S. Senate,,DEM,Loretta L. Sanchez,155
+San Francisco,9404,U.S. Senate,,DEM,Kamala D. Harris,505
+San Francisco,9404,U.S. Senate,,DEM,Loretta L. Sanchez,146
+San Francisco,9405,U.S. Senate,,DEM,Kamala D. Harris,444
+San Francisco,9405,U.S. Senate,,DEM,Loretta L. Sanchez,159
+San Francisco,9406,U.S. Senate,,DEM,Kamala D. Harris,551
+San Francisco,9406,U.S. Senate,,DEM,Loretta L. Sanchez,140
+San Francisco,9407,U.S. Senate,,DEM,Kamala D. Harris,461
+San Francisco,9407,U.S. Senate,,DEM,Loretta L. Sanchez,153
+San Francisco,9408,U.S. Senate,,DEM,Kamala D. Harris,480
+San Francisco,9408,U.S. Senate,,DEM,Loretta L. Sanchez,134
+San Francisco,9409,U.S. Senate,,DEM,Kamala D. Harris,373
+San Francisco,9409,U.S. Senate,,DEM,Loretta L. Sanchez,90
+San Francisco,9411,U.S. Senate,,DEM,Kamala D. Harris,560
+San Francisco,9411,U.S. Senate,,DEM,Loretta L. Sanchez,164
+San Francisco,9412,U.S. Senate,,DEM,Kamala D. Harris,450
+San Francisco,9412,U.S. Senate,,DEM,Loretta L. Sanchez,168
+San Francisco,9413,U.S. Senate,,DEM,Kamala D. Harris,478
+San Francisco,9413,U.S. Senate,,DEM,Loretta L. Sanchez,152
+San Francisco,9414,U.S. Senate,,DEM,Kamala D. Harris,464
+San Francisco,9414,U.S. Senate,,DEM,Loretta L. Sanchez,167
+San Francisco,9415,U.S. Senate,,DEM,Kamala D. Harris,396
+San Francisco,9415,U.S. Senate,,DEM,Loretta L. Sanchez,132
+San Francisco,9416,U.S. Senate,,DEM,Kamala D. Harris,544
+San Francisco,9416,U.S. Senate,,DEM,Loretta L. Sanchez,170
+San Francisco,9417,U.S. Senate,,DEM,Kamala D. Harris,346
+San Francisco,9417,U.S. Senate,,DEM,Loretta L. Sanchez,169
+San Francisco,9418,U.S. Senate,,DEM,Kamala D. Harris,403
+San Francisco,9418,U.S. Senate,,DEM,Loretta L. Sanchez,134
+San Francisco,9419,U.S. Senate,,DEM,Kamala D. Harris,443
+San Francisco,9419,U.S. Senate,,DEM,Loretta L. Sanchez,136
+San Francisco,9421,U.S. Senate,,DEM,Kamala D. Harris,456
+San Francisco,9421,U.S. Senate,,DEM,Loretta L. Sanchez,147
+San Francisco,9422,U.S. Senate,,DEM,Kamala D. Harris,589
+San Francisco,9422,U.S. Senate,,DEM,Loretta L. Sanchez,163
+San Francisco,9423,U.S. Senate,,DEM,Kamala D. Harris,493
+San Francisco,9423,U.S. Senate,,DEM,Loretta L. Sanchez,132
+San Francisco,9424,U.S. Senate,,DEM,Kamala D. Harris,479
+San Francisco,9424,U.S. Senate,,DEM,Loretta L. Sanchez,156
+San Francisco,9425,U.S. Senate,,DEM,Kamala D. Harris,450
+San Francisco,9425,U.S. Senate,,DEM,Loretta L. Sanchez,181
+San Francisco,9426,U.S. Senate,,DEM,Kamala D. Harris,401
+San Francisco,9426,U.S. Senate,,DEM,Loretta L. Sanchez,153
+San Francisco,9427,U.S. Senate,,DEM,Kamala D. Harris,416
+San Francisco,9427,U.S. Senate,,DEM,Loretta L. Sanchez,190
+San Francisco,9428,U.S. Senate,,DEM,Kamala D. Harris,474
+San Francisco,9428,U.S. Senate,,DEM,Loretta L. Sanchez,170
+San Francisco,9429,U.S. Senate,,DEM,Kamala D. Harris,418
+San Francisco,9429,U.S. Senate,,DEM,Loretta L. Sanchez,169
+San Francisco,9431,U.S. Senate,,DEM,Kamala D. Harris,487
+San Francisco,9431,U.S. Senate,,DEM,Loretta L. Sanchez,198
+San Francisco,9432,U.S. Senate,,DEM,Kamala D. Harris,456
+San Francisco,9432,U.S. Senate,,DEM,Loretta L. Sanchez,141
+San Francisco,9433,U.S. Senate,,DEM,Kamala D. Harris,470
+San Francisco,9433,U.S. Senate,,DEM,Loretta L. Sanchez,170
+San Francisco,9434,U.S. Senate,,DEM,Kamala D. Harris,538
+San Francisco,9434,U.S. Senate,,DEM,Loretta L. Sanchez,172
+San Francisco,9435,U.S. Senate,,DEM,Kamala D. Harris,468
+San Francisco,9435,U.S. Senate,,DEM,Loretta L. Sanchez,178
+San Francisco,9436,U.S. Senate,,DEM,Kamala D. Harris,473
+San Francisco,9436,U.S. Senate,,DEM,Loretta L. Sanchez,184
+San Francisco,9437,U.S. Senate,,DEM,Kamala D. Harris,416
+San Francisco,9437,U.S. Senate,,DEM,Loretta L. Sanchez,191
+San Francisco,9438,U.S. Senate,,DEM,Kamala D. Harris,483
+San Francisco,9438,U.S. Senate,,DEM,Loretta L. Sanchez,181
+San Francisco,9439,U.S. Senate,,DEM,Kamala D. Harris,432
+San Francisco,9439,U.S. Senate,,DEM,Loretta L. Sanchez,165
+San Francisco,9441,U.S. Senate,,DEM,Kamala D. Harris,520
+San Francisco,9441,U.S. Senate,,DEM,Loretta L. Sanchez,175
+San Francisco,9442,U.S. Senate,,DEM,Kamala D. Harris,491
+San Francisco,9442,U.S. Senate,,DEM,Loretta L. Sanchez,181
+San Francisco,9443,U.S. Senate,,DEM,Kamala D. Harris,473
+San Francisco,9443,U.S. Senate,,DEM,Loretta L. Sanchez,165
+San Francisco,9444,U.S. Senate,,DEM,Kamala D. Harris,420
+San Francisco,9444,U.S. Senate,,DEM,Loretta L. Sanchez,172
+San Francisco,9445,U.S. Senate,,DEM,Kamala D. Harris,461
+San Francisco,9445,U.S. Senate,,DEM,Loretta L. Sanchez,186
+San Francisco,9446,U.S. Senate,,DEM,Kamala D. Harris,554
+San Francisco,9446,U.S. Senate,,DEM,Loretta L. Sanchez,225
+San Francisco,9447,U.S. Senate,,DEM,Kamala D. Harris,492
+San Francisco,9447,U.S. Senate,,DEM,Loretta L. Sanchez,161
+San Francisco,9448,U.S. Senate,,DEM,Kamala D. Harris,438
+San Francisco,9448,U.S. Senate,,DEM,Loretta L. Sanchez,187
+San Francisco,9449,U.S. Senate,,DEM,Kamala D. Harris,400
+San Francisco,9449,U.S. Senate,,DEM,Loretta L. Sanchez,141
+San Francisco,9451,U.S. Senate,,DEM,Kamala D. Harris,210
+San Francisco,9451,U.S. Senate,,DEM,Loretta L. Sanchez,119
+San Francisco,9452,U.S. Senate,,DEM,Kamala D. Harris,458
+San Francisco,9452,U.S. Senate,,DEM,Loretta L. Sanchez,147
+San Francisco,9453,U.S. Senate,,DEM,Kamala D. Harris,248
+San Francisco,9453,U.S. Senate,,DEM,Loretta L. Sanchez,112
+San Francisco,9501,U.S. Senate,,DEM,Kamala D. Harris,89
+San Francisco,9501,U.S. Senate,,DEM,Loretta L. Sanchez,26
+San Francisco,9502,U.S. Senate,,DEM,Kamala D. Harris,153
+San Francisco,9502,U.S. Senate,,DEM,Loretta L. Sanchez,33
+San Francisco,9503/9504,U.S. Senate,,DEM,Kamala D. Harris,481
+San Francisco,9503/9504,U.S. Senate,,DEM,Loretta L. Sanchez,104
+San Francisco,9505,U.S. Senate,,DEM,Kamala D. Harris,474
+San Francisco,9505,U.S. Senate,,DEM,Loretta L. Sanchez,84
+San Francisco,9506,U.S. Senate,,DEM,Kamala D. Harris,449
+San Francisco,9506,U.S. Senate,,DEM,Loretta L. Sanchez,99
+San Francisco,9507,U.S. Senate,,DEM,Kamala D. Harris,505
+San Francisco,9507,U.S. Senate,,DEM,Loretta L. Sanchez,87
+San Francisco,9508,U.S. Senate,,DEM,Kamala D. Harris,581
+San Francisco,9508,U.S. Senate,,DEM,Loretta L. Sanchez,76
+San Francisco,9509,U.S. Senate,,DEM,Kamala D. Harris,498
+San Francisco,9509,U.S. Senate,,DEM,Loretta L. Sanchez,93
+San Francisco,9511,U.S. Senate,,DEM,Kamala D. Harris,397
+San Francisco,9511,U.S. Senate,,DEM,Loretta L. Sanchez,69
+San Francisco,9512,U.S. Senate,,DEM,Kamala D. Harris,530
+San Francisco,9512,U.S. Senate,,DEM,Loretta L. Sanchez,109
+San Francisco,9513,U.S. Senate,,DEM,Kamala D. Harris,615
+San Francisco,9513,U.S. Senate,,DEM,Loretta L. Sanchez,99
+San Francisco,9514/9522,U.S. Senate,,DEM,Kamala D. Harris,632
+San Francisco,9514/9522,U.S. Senate,,DEM,Loretta L. Sanchez,115
+San Francisco,9515,U.S. Senate,,DEM,Kamala D. Harris,474
+San Francisco,9515,U.S. Senate,,DEM,Loretta L. Sanchez,98
+San Francisco,9516,U.S. Senate,,DEM,Kamala D. Harris,534
+San Francisco,9516,U.S. Senate,,DEM,Loretta L. Sanchez,136
+San Francisco,9517,U.S. Senate,,DEM,Kamala D. Harris,525
+San Francisco,9517,U.S. Senate,,DEM,Loretta L. Sanchez,116
+San Francisco,9518,U.S. Senate,,DEM,Kamala D. Harris,524
+San Francisco,9518,U.S. Senate,,DEM,Loretta L. Sanchez,112
+San Francisco,9519,U.S. Senate,,DEM,Kamala D. Harris,595
+San Francisco,9519,U.S. Senate,,DEM,Loretta L. Sanchez,117
+San Francisco,9521,U.S. Senate,,DEM,Kamala D. Harris,613
+San Francisco,9521,U.S. Senate,,DEM,Loretta L. Sanchez,121
+San Francisco,9701,U.S. Senate,,DEM,Kamala D. Harris,385
+San Francisco,9701,U.S. Senate,,DEM,Loretta L. Sanchez,104
+San Francisco,9702,U.S. Senate,,DEM,Kamala D. Harris,481
+San Francisco,9702,U.S. Senate,,DEM,Loretta L. Sanchez,84
+San Francisco,9703,U.S. Senate,,DEM,Kamala D. Harris,541
+San Francisco,9703,U.S. Senate,,DEM,Loretta L. Sanchez,177
+San Francisco,9704,U.S. Senate,,DEM,Kamala D. Harris,620
+San Francisco,9704,U.S. Senate,,DEM,Loretta L. Sanchez,141
+San Francisco,9705,U.S. Senate,,DEM,Kamala D. Harris,615
+San Francisco,9705,U.S. Senate,,DEM,Loretta L. Sanchez,129
+San Francisco,9706,U.S. Senate,,DEM,Kamala D. Harris,39
+San Francisco,9706,U.S. Senate,,DEM,Loretta L. Sanchez,8
+San Francisco,9707,U.S. Senate,,DEM,Kamala D. Harris,475
+San Francisco,9707,U.S. Senate,,DEM,Loretta L. Sanchez,132
+San Francisco,9708,U.S. Senate,,DEM,Kamala D. Harris,594
+San Francisco,9708,U.S. Senate,,DEM,Loretta L. Sanchez,142
+San Francisco,9709,U.S. Senate,,DEM,Kamala D. Harris,553
+San Francisco,9709,U.S. Senate,,DEM,Loretta L. Sanchez,177
+San Francisco,9711,U.S. Senate,,DEM,Kamala D. Harris,413
+San Francisco,9711,U.S. Senate,,DEM,Loretta L. Sanchez,113
+San Francisco,9712,U.S. Senate,,DEM,Kamala D. Harris,396
+San Francisco,9712,U.S. Senate,,DEM,Loretta L. Sanchez,121
+San Francisco,9713,U.S. Senate,,DEM,Kamala D. Harris,535
+San Francisco,9713,U.S. Senate,,DEM,Loretta L. Sanchez,158
+San Francisco,9714,U.S. Senate,,DEM,Kamala D. Harris,572
+San Francisco,9714,U.S. Senate,,DEM,Loretta L. Sanchez,148
+San Francisco,9715,U.S. Senate,,DEM,Kamala D. Harris,372
+San Francisco,9715,U.S. Senate,,DEM,Loretta L. Sanchez,93
+San Francisco,9716,U.S. Senate,,DEM,Kamala D. Harris,499
+San Francisco,9716,U.S. Senate,,DEM,Loretta L. Sanchez,181
+San Francisco,9717,U.S. Senate,,DEM,Kamala D. Harris,555
+San Francisco,9717,U.S. Senate,,DEM,Loretta L. Sanchez,193
+San Francisco,9718,U.S. Senate,,DEM,Kamala D. Harris,511
+San Francisco,9718,U.S. Senate,,DEM,Loretta L. Sanchez,179
+San Francisco,9719,U.S. Senate,,DEM,Kamala D. Harris,522
+San Francisco,9719,U.S. Senate,,DEM,Loretta L. Sanchez,154
+San Francisco,9721,U.S. Senate,,DEM,Kamala D. Harris,378
+San Francisco,9721,U.S. Senate,,DEM,Loretta L. Sanchez,133
+San Francisco,9722,U.S. Senate,,DEM,Kamala D. Harris,345
+San Francisco,9722,U.S. Senate,,DEM,Loretta L. Sanchez,130
+San Francisco,9723,U.S. Senate,,DEM,Kamala D. Harris,241
+San Francisco,9723,U.S. Senate,,DEM,Loretta L. Sanchez,98
+San Francisco,9724,U.S. Senate,,DEM,Kamala D. Harris,496
+San Francisco,9724,U.S. Senate,,DEM,Loretta L. Sanchez,210
+San Francisco,9725,U.S. Senate,,DEM,Kamala D. Harris,474
+San Francisco,9725,U.S. Senate,,DEM,Loretta L. Sanchez,190
+San Francisco,9726,U.S. Senate,,DEM,Kamala D. Harris,344
+San Francisco,9726,U.S. Senate,,DEM,Loretta L. Sanchez,178
+San Francisco,9727,U.S. Senate,,DEM,Kamala D. Harris,261
+San Francisco,9727,U.S. Senate,,DEM,Loretta L. Sanchez,91
+San Francisco,9728,U.S. Senate,,DEM,Kamala D. Harris,513
+San Francisco,9728,U.S. Senate,,DEM,Loretta L. Sanchez,185
+San Francisco,9729,U.S. Senate,,DEM,Kamala D. Harris,486
+San Francisco,9729,U.S. Senate,,DEM,Loretta L. Sanchez,143
+San Francisco,9731,U.S. Senate,,DEM,Kamala D. Harris,324
+San Francisco,9731,U.S. Senate,,DEM,Loretta L. Sanchez,106
+San Francisco,9732,U.S. Senate,,DEM,Kamala D. Harris,50
+San Francisco,9732,U.S. Senate,,DEM,Loretta L. Sanchez,18
+San Francisco,9733,U.S. Senate,,DEM,Kamala D. Harris,156
+San Francisco,9733,U.S. Senate,,DEM,Loretta L. Sanchez,31
+San Francisco,9734,U.S. Senate,,DEM,Kamala D. Harris,366
+San Francisco,9734,U.S. Senate,,DEM,Loretta L. Sanchez,117
+San Francisco,9735,U.S. Senate,,DEM,Kamala D. Harris,476
+San Francisco,9735,U.S. Senate,,DEM,Loretta L. Sanchez,140
+San Francisco,9736,U.S. Senate,,DEM,Kamala D. Harris,468
+San Francisco,9736,U.S. Senate,,DEM,Loretta L. Sanchez,126
+San Francisco,9737,U.S. Senate,,DEM,Kamala D. Harris,542
+San Francisco,9737,U.S. Senate,,DEM,Loretta L. Sanchez,118
+San Francisco,9738,U.S. Senate,,DEM,Kamala D. Harris,421
+San Francisco,9738,U.S. Senate,,DEM,Loretta L. Sanchez,172
+San Francisco,9739,U.S. Senate,,DEM,Kamala D. Harris,384
+San Francisco,9739,U.S. Senate,,DEM,Loretta L. Sanchez,194
+San Francisco,9741,U.S. Senate,,DEM,Kamala D. Harris,288
+San Francisco,9741,U.S. Senate,,DEM,Loretta L. Sanchez,276
+San Francisco,9742,U.S. Senate,,DEM,Kamala D. Harris,339
+San Francisco,9742,U.S. Senate,,DEM,Loretta L. Sanchez,113
+San Francisco,9743,U.S. Senate,,DEM,Kamala D. Harris,581
+San Francisco,9743,U.S. Senate,,DEM,Loretta L. Sanchez,223
+San Francisco,9744,U.S. Senate,,DEM,Kamala D. Harris,439
+San Francisco,9744,U.S. Senate,,DEM,Loretta L. Sanchez,217
+San Francisco,9745,U.S. Senate,,DEM,Kamala D. Harris,453
+San Francisco,9745,U.S. Senate,,DEM,Loretta L. Sanchez,223
+San Francisco,9746,U.S. Senate,,DEM,Kamala D. Harris,516
+San Francisco,9746,U.S. Senate,,DEM,Loretta L. Sanchez,160
+San Francisco,9747,U.S. Senate,,DEM,Kamala D. Harris,534
+San Francisco,9747,U.S. Senate,,DEM,Loretta L. Sanchez,177
+San Francisco,9748,U.S. Senate,,DEM,Kamala D. Harris,542
+San Francisco,9748,U.S. Senate,,DEM,Loretta L. Sanchez,166
+San Francisco,9749,U.S. Senate,,DEM,Kamala D. Harris,414
+San Francisco,9749,U.S. Senate,,DEM,Loretta L. Sanchez,180
+San Francisco,9751,U.S. Senate,,DEM,Kamala D. Harris,611
+San Francisco,9751,U.S. Senate,,DEM,Loretta L. Sanchez,196
+San Francisco,9752,U.S. Senate,,DEM,Kamala D. Harris,432
+San Francisco,9752,U.S. Senate,,DEM,Loretta L. Sanchez,138
+San Francisco,9753,U.S. Senate,,DEM,Kamala D. Harris,419
+San Francisco,9753,U.S. Senate,,DEM,Loretta L. Sanchez,155
+San Francisco,9754,U.S. Senate,,DEM,Kamala D. Harris,481
+San Francisco,9754,U.S. Senate,,DEM,Loretta L. Sanchez,109
+San Francisco,9755,U.S. Senate,,DEM,Kamala D. Harris,315
+San Francisco,9755,U.S. Senate,,DEM,Loretta L. Sanchez,117
+San Francisco,9756,U.S. Senate,,DEM,Kamala D. Harris,467
+San Francisco,9756,U.S. Senate,,DEM,Loretta L. Sanchez,202
+San Francisco,9801,U.S. Senate,,DEM,Kamala D. Harris,220
+San Francisco,9801,U.S. Senate,,DEM,Loretta L. Sanchez,90
+San Francisco,9900,U.S. Senate,,DEM,Kamala D. Harris,0
+San Francisco,9900,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Francisco,9901,U.S. Senate,,DEM,Kamala D. Harris,0
+San Francisco,9901,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Francisco,9902,U.S. Senate,,DEM,Kamala D. Harris,0
+San Francisco,9902,U.S. Senate,,DEM,Loretta L. Sanchez,0

--- a/2016/20161108__ca__general__san_joaquin__precinct.csv
+++ b/2016/20161108__ca__general__san_joaquin__precinct.csv
@@ -19999,1003 +19999,1003 @@ San Joaquin,945062,Proposition 67,,N/A,Yes,0
 San Joaquin,945062,Proposition 67,,N/A,No,0
 San Joaquin,945063,Proposition 67,,N/A,Yes,8
 San Joaquin,945063,Proposition 67,,N/A,No,3
-San Joaquin,11101,U.S. Senate,,DEM,Kamala Harris,106
-San Joaquin,11101,U.S. Senate,,DEM,Loretta Sanchez,124
-San Joaquin,11102,U.S. Senate,,DEM,Kamala Harris,180
-San Joaquin,11102,U.S. Senate,,DEM,Loretta Sanchez,224
-San Joaquin,11103,U.S. Senate,,DEM,Kamala Harris,211
-San Joaquin,11103,U.S. Senate,,DEM,Loretta Sanchez,196
-San Joaquin,11104,U.S. Senate,,DEM,Kamala Harris,349
-San Joaquin,11104,U.S. Senate,,DEM,Loretta Sanchez,459
-San Joaquin,11105,U.S. Senate,,DEM,Kamala Harris,179
-San Joaquin,11105,U.S. Senate,,DEM,Loretta Sanchez,148
-San Joaquin,11107,U.S. Senate,,DEM,Kamala Harris,170
-San Joaquin,11107,U.S. Senate,,DEM,Loretta Sanchez,187
-San Joaquin,11108,U.S. Senate,,DEM,Kamala Harris,126
-San Joaquin,11108,U.S. Senate,,DEM,Loretta Sanchez,201
-San Joaquin,11109,U.S. Senate,,DEM,Kamala Harris,156
-San Joaquin,11109,U.S. Senate,,DEM,Loretta Sanchez,237
-San Joaquin,11110,U.S. Senate,,DEM,Kamala Harris,238
-San Joaquin,11110,U.S. Senate,,DEM,Loretta Sanchez,187
-San Joaquin,11111,U.S. Senate,,DEM,Kamala Harris,438
-San Joaquin,11111,U.S. Senate,,DEM,Loretta Sanchez,332
-San Joaquin,11112,U.S. Senate,,DEM,Kamala Harris,112
-San Joaquin,11112,U.S. Senate,,DEM,Loretta Sanchez,201
-San Joaquin,11114,U.S. Senate,,DEM,Kamala Harris,462
-San Joaquin,11114,U.S. Senate,,DEM,Loretta Sanchez,293
-San Joaquin,11115,U.S. Senate,,DEM,Kamala Harris,325
-San Joaquin,11115,U.S. Senate,,DEM,Loretta Sanchez,311
-San Joaquin,11116,U.S. Senate,,DEM,Kamala Harris,339
-San Joaquin,11116,U.S. Senate,,DEM,Loretta Sanchez,403
-San Joaquin,11117,U.S. Senate,,DEM,Kamala Harris,388
-San Joaquin,11117,U.S. Senate,,DEM,Loretta Sanchez,285
-San Joaquin,11118,U.S. Senate,,DEM,Kamala Harris,484
-San Joaquin,11118,U.S. Senate,,DEM,Loretta Sanchez,325
-San Joaquin,11119,U.S. Senate,,DEM,Kamala Harris,53
-San Joaquin,11119,U.S. Senate,,DEM,Loretta Sanchez,68
-San Joaquin,11120,U.S. Senate,,DEM,Kamala Harris,291
-San Joaquin,11120,U.S. Senate,,DEM,Loretta Sanchez,436
-San Joaquin,11121,U.S. Senate,,DEM,Kamala Harris,462
-San Joaquin,11121,U.S. Senate,,DEM,Loretta Sanchez,313
-San Joaquin,11122,U.S. Senate,,DEM,Kamala Harris,334
-San Joaquin,11122,U.S. Senate,,DEM,Loretta Sanchez,428
-San Joaquin,11124,U.S. Senate,,DEM,Kamala Harris,182
-San Joaquin,11124,U.S. Senate,,DEM,Loretta Sanchez,204
-San Joaquin,11125,U.S. Senate,,DEM,Kamala Harris,602
-San Joaquin,11125,U.S. Senate,,DEM,Loretta Sanchez,304
-San Joaquin,11127,U.S. Senate,,DEM,Kamala Harris,327
-San Joaquin,11127,U.S. Senate,,DEM,Loretta Sanchez,518
-San Joaquin,11130,U.S. Senate,,DEM,Kamala Harris,125
-San Joaquin,11130,U.S. Senate,,DEM,Loretta Sanchez,95
-San Joaquin,11134,U.S. Senate,,DEM,Kamala Harris,215
-San Joaquin,11134,U.S. Senate,,DEM,Loretta Sanchez,173
-San Joaquin,11137,U.S. Senate,,DEM,Kamala Harris,247
-San Joaquin,11137,U.S. Senate,,DEM,Loretta Sanchez,225
-San Joaquin,11140,U.S. Senate,,DEM,Kamala Harris,112
-San Joaquin,11140,U.S. Senate,,DEM,Loretta Sanchez,192
-San Joaquin,11142,U.S. Senate,,DEM,Kamala Harris,559
-San Joaquin,11142,U.S. Senate,,DEM,Loretta Sanchez,390
-San Joaquin,11146,U.S. Senate,,DEM,Kamala Harris,332
-San Joaquin,11146,U.S. Senate,,DEM,Loretta Sanchez,213
-San Joaquin,11147,U.S. Senate,,DEM,Kamala Harris,222
-San Joaquin,11147,U.S. Senate,,DEM,Loretta Sanchez,210
-San Joaquin,11149,U.S. Senate,,DEM,Kamala Harris,454
-San Joaquin,11149,U.S. Senate,,DEM,Loretta Sanchez,266
-San Joaquin,11151,U.S. Senate,,DEM,Kamala Harris,330
-San Joaquin,11151,U.S. Senate,,DEM,Loretta Sanchez,297
-San Joaquin,11152,U.S. Senate,,DEM,Kamala Harris,394
-San Joaquin,11152,U.S. Senate,,DEM,Loretta Sanchez,248
-San Joaquin,11155,U.S. Senate,,DEM,Kamala Harris,130
-San Joaquin,11155,U.S. Senate,,DEM,Loretta Sanchez,187
-San Joaquin,11157,U.S. Senate,,DEM,Kamala Harris,260
-San Joaquin,11157,U.S. Senate,,DEM,Loretta Sanchez,291
-San Joaquin,11158,U.S. Senate,,DEM,Kamala Harris,251
-San Joaquin,11158,U.S. Senate,,DEM,Loretta Sanchez,233
-San Joaquin,11164,U.S. Senate,,DEM,Kamala Harris,251
-San Joaquin,11164,U.S. Senate,,DEM,Loretta Sanchez,286
-San Joaquin,11168,U.S. Senate,,DEM,Kamala Harris,293
-San Joaquin,11168,U.S. Senate,,DEM,Loretta Sanchez,283
-San Joaquin,11169,U.S. Senate,,DEM,Kamala Harris,545
-San Joaquin,11169,U.S. Senate,,DEM,Loretta Sanchez,458
-San Joaquin,11201,U.S. Senate,,DEM,Kamala Harris,585
-San Joaquin,11201,U.S. Senate,,DEM,Loretta Sanchez,269
-San Joaquin,11203,U.S. Senate,,DEM,Kamala Harris,585
-San Joaquin,11203,U.S. Senate,,DEM,Loretta Sanchez,278
-San Joaquin,11205,U.S. Senate,,DEM,Kamala Harris,199
-San Joaquin,11205,U.S. Senate,,DEM,Loretta Sanchez,111
-San Joaquin,11206,U.S. Senate,,DEM,Kamala Harris,544
-San Joaquin,11206,U.S. Senate,,DEM,Loretta Sanchez,321
-San Joaquin,11208,U.S. Senate,,DEM,Kamala Harris,393
-San Joaquin,11208,U.S. Senate,,DEM,Loretta Sanchez,291
-San Joaquin,11209,U.S. Senate,,DEM,Kamala Harris,353
-San Joaquin,11209,U.S. Senate,,DEM,Loretta Sanchez,159
-San Joaquin,11211,U.S. Senate,,DEM,Kamala Harris,487
-San Joaquin,11211,U.S. Senate,,DEM,Loretta Sanchez,273
-San Joaquin,11212,U.S. Senate,,DEM,Kamala Harris,195
-San Joaquin,11212,U.S. Senate,,DEM,Loretta Sanchez,151
-San Joaquin,11214,U.S. Senate,,DEM,Kamala Harris,343
-San Joaquin,11214,U.S. Senate,,DEM,Loretta Sanchez,255
-San Joaquin,11215,U.S. Senate,,DEM,Kamala Harris,320
-San Joaquin,11215,U.S. Senate,,DEM,Loretta Sanchez,202
-San Joaquin,11216,U.S. Senate,,DEM,Kamala Harris,163
-San Joaquin,11216,U.S. Senate,,DEM,Loretta Sanchez,136
-San Joaquin,11217,U.S. Senate,,DEM,Kamala Harris,696
-San Joaquin,11217,U.S. Senate,,DEM,Loretta Sanchez,306
-San Joaquin,11218,U.S. Senate,,DEM,Kamala Harris,274
-San Joaquin,11218,U.S. Senate,,DEM,Loretta Sanchez,190
-San Joaquin,11219,U.S. Senate,,DEM,Kamala Harris,516
-San Joaquin,11219,U.S. Senate,,DEM,Loretta Sanchez,245
-San Joaquin,11220,U.S. Senate,,DEM,Kamala Harris,188
-San Joaquin,11220,U.S. Senate,,DEM,Loretta Sanchez,129
-San Joaquin,11221,U.S. Senate,,DEM,Kamala Harris,357
-San Joaquin,11221,U.S. Senate,,DEM,Loretta Sanchez,190
-San Joaquin,11224,U.S. Senate,,DEM,Kamala Harris,345
-San Joaquin,11224,U.S. Senate,,DEM,Loretta Sanchez,256
-San Joaquin,11226,U.S. Senate,,DEM,Kamala Harris,456
-San Joaquin,11226,U.S. Senate,,DEM,Loretta Sanchez,351
-San Joaquin,11227,U.S. Senate,,DEM,Kamala Harris,234
-San Joaquin,11227,U.S. Senate,,DEM,Loretta Sanchez,175
-San Joaquin,11228,U.S. Senate,,DEM,Kamala Harris,213
-San Joaquin,11228,U.S. Senate,,DEM,Loretta Sanchez,140
-San Joaquin,11229,U.S. Senate,,DEM,Kamala Harris,625
-San Joaquin,11229,U.S. Senate,,DEM,Loretta Sanchez,335
-San Joaquin,11230,U.S. Senate,,DEM,Kamala Harris,303
-San Joaquin,11230,U.S. Senate,,DEM,Loretta Sanchez,190
-San Joaquin,11232,U.S. Senate,,DEM,Kamala Harris,433
-San Joaquin,11232,U.S. Senate,,DEM,Loretta Sanchez,346
-San Joaquin,11233,U.S. Senate,,DEM,Kamala Harris,250
-San Joaquin,11233,U.S. Senate,,DEM,Loretta Sanchez,125
-San Joaquin,11235,U.S. Senate,,DEM,Kamala Harris,174
-San Joaquin,11235,U.S. Senate,,DEM,Loretta Sanchez,141
-San Joaquin,11237,U.S. Senate,,DEM,Kamala Harris,280
-San Joaquin,11237,U.S. Senate,,DEM,Loretta Sanchez,234
-San Joaquin,11238,U.S. Senate,,DEM,Kamala Harris,623
-San Joaquin,11238,U.S. Senate,,DEM,Loretta Sanchez,431
-San Joaquin,11241,U.S. Senate,,DEM,Kamala Harris,435
-San Joaquin,11241,U.S. Senate,,DEM,Loretta Sanchez,215
-San Joaquin,11242,U.S. Senate,,DEM,Kamala Harris,514
-San Joaquin,11242,U.S. Senate,,DEM,Loretta Sanchez,308
-San Joaquin,11243,U.S. Senate,,DEM,Kamala Harris,507
-San Joaquin,11243,U.S. Senate,,DEM,Loretta Sanchez,301
-San Joaquin,11245,U.S. Senate,,DEM,Kamala Harris,390
-San Joaquin,11245,U.S. Senate,,DEM,Loretta Sanchez,208
-San Joaquin,11249,U.S. Senate,,DEM,Kamala Harris,474
-San Joaquin,11249,U.S. Senate,,DEM,Loretta Sanchez,332
-San Joaquin,11251,U.S. Senate,,DEM,Kamala Harris,332
-San Joaquin,11251,U.S. Senate,,DEM,Loretta Sanchez,239
-San Joaquin,11253,U.S. Senate,,DEM,Kamala Harris,446
-San Joaquin,11253,U.S. Senate,,DEM,Loretta Sanchez,271
-San Joaquin,11254,U.S. Senate,,DEM,Kamala Harris,332
-San Joaquin,11254,U.S. Senate,,DEM,Loretta Sanchez,273
-San Joaquin,11255,U.S. Senate,,DEM,Kamala Harris,455
-San Joaquin,11255,U.S. Senate,,DEM,Loretta Sanchez,303
-San Joaquin,11256,U.S. Senate,,DEM,Kamala Harris,310
-San Joaquin,11256,U.S. Senate,,DEM,Loretta Sanchez,231
-San Joaquin,11258,U.S. Senate,,DEM,Kamala Harris,552
-San Joaquin,11258,U.S. Senate,,DEM,Loretta Sanchez,392
-San Joaquin,11259,U.S. Senate,,DEM,Kamala Harris,251
-San Joaquin,11259,U.S. Senate,,DEM,Loretta Sanchez,126
-San Joaquin,11263,U.S. Senate,,DEM,Kamala Harris,244
-San Joaquin,11263,U.S. Senate,,DEM,Loretta Sanchez,241
-San Joaquin,11265,U.S. Senate,,DEM,Kamala Harris,228
-San Joaquin,11265,U.S. Senate,,DEM,Loretta Sanchez,121
-San Joaquin,11266,U.S. Senate,,DEM,Kamala Harris,440
-San Joaquin,11266,U.S. Senate,,DEM,Loretta Sanchez,344
-San Joaquin,11270,U.S. Senate,,DEM,Kamala Harris,352
-San Joaquin,11270,U.S. Senate,,DEM,Loretta Sanchez,311
-San Joaquin,11271,U.S. Senate,,DEM,Kamala Harris,263
-San Joaquin,11271,U.S. Senate,,DEM,Loretta Sanchez,241
-San Joaquin,11272,U.S. Senate,,DEM,Kamala Harris,631
-San Joaquin,11272,U.S. Senate,,DEM,Loretta Sanchez,509
-San Joaquin,11274,U.S. Senate,,DEM,Kamala Harris,147
-San Joaquin,11274,U.S. Senate,,DEM,Loretta Sanchez,136
-San Joaquin,11275,U.S. Senate,,DEM,Kamala Harris,405
-San Joaquin,11275,U.S. Senate,,DEM,Loretta Sanchez,313
-San Joaquin,11278,U.S. Senate,,DEM,Kamala Harris,185
-San Joaquin,11278,U.S. Senate,,DEM,Loretta Sanchez,178
-San Joaquin,11302,U.S. Senate,,DEM,Kamala Harris,391
-San Joaquin,11302,U.S. Senate,,DEM,Loretta Sanchez,318
-San Joaquin,11303,U.S. Senate,,DEM,Kamala Harris,531
-San Joaquin,11303,U.S. Senate,,DEM,Loretta Sanchez,322
-San Joaquin,11304,U.S. Senate,,DEM,Kamala Harris,372
-San Joaquin,11304,U.S. Senate,,DEM,Loretta Sanchez,200
-San Joaquin,11305,U.S. Senate,,DEM,Kamala Harris,748
-San Joaquin,11305,U.S. Senate,,DEM,Loretta Sanchez,382
-San Joaquin,11306,U.S. Senate,,DEM,Kamala Harris,260
-San Joaquin,11306,U.S. Senate,,DEM,Loretta Sanchez,187
-San Joaquin,11307,U.S. Senate,,DEM,Kamala Harris,312
-San Joaquin,11307,U.S. Senate,,DEM,Loretta Sanchez,235
-San Joaquin,11308,U.S. Senate,,DEM,Kamala Harris,511
-San Joaquin,11308,U.S. Senate,,DEM,Loretta Sanchez,257
-San Joaquin,11309,U.S. Senate,,DEM,Kamala Harris,395
-San Joaquin,11309,U.S. Senate,,DEM,Loretta Sanchez,220
-San Joaquin,11310,U.S. Senate,,DEM,Kamala Harris,275
-San Joaquin,11310,U.S. Senate,,DEM,Loretta Sanchez,189
-San Joaquin,11311,U.S. Senate,,DEM,Kamala Harris,330
-San Joaquin,11311,U.S. Senate,,DEM,Loretta Sanchez,174
-San Joaquin,11312,U.S. Senate,,DEM,Kamala Harris,575
-San Joaquin,11312,U.S. Senate,,DEM,Loretta Sanchez,321
-San Joaquin,11314,U.S. Senate,,DEM,Kamala Harris,522
-San Joaquin,11314,U.S. Senate,,DEM,Loretta Sanchez,267
-San Joaquin,11315,U.S. Senate,,DEM,Kamala Harris,409
-San Joaquin,11315,U.S. Senate,,DEM,Loretta Sanchez,313
-San Joaquin,11316,U.S. Senate,,DEM,Kamala Harris,223
-San Joaquin,11316,U.S. Senate,,DEM,Loretta Sanchez,163
-San Joaquin,11317,U.S. Senate,,DEM,Kamala Harris,206
-San Joaquin,11317,U.S. Senate,,DEM,Loretta Sanchez,166
-San Joaquin,11319,U.S. Senate,,DEM,Kamala Harris,141
-San Joaquin,11319,U.S. Senate,,DEM,Loretta Sanchez,124
-San Joaquin,11320,U.S. Senate,,DEM,Kamala Harris,591
-San Joaquin,11320,U.S. Senate,,DEM,Loretta Sanchez,358
-San Joaquin,11321,U.S. Senate,,DEM,Kamala Harris,590
-San Joaquin,11321,U.S. Senate,,DEM,Loretta Sanchez,380
-San Joaquin,11322,U.S. Senate,,DEM,Kamala Harris,398
-San Joaquin,11322,U.S. Senate,,DEM,Loretta Sanchez,289
-San Joaquin,11323,U.S. Senate,,DEM,Kamala Harris,490
-San Joaquin,11323,U.S. Senate,,DEM,Loretta Sanchez,312
-San Joaquin,11324,U.S. Senate,,DEM,Kamala Harris,367
-San Joaquin,11324,U.S. Senate,,DEM,Loretta Sanchez,219
-San Joaquin,11325,U.S. Senate,,DEM,Kamala Harris,682
-San Joaquin,11325,U.S. Senate,,DEM,Loretta Sanchez,370
-San Joaquin,11326,U.S. Senate,,DEM,Kamala Harris,235
-San Joaquin,11326,U.S. Senate,,DEM,Loretta Sanchez,171
-San Joaquin,11327,U.S. Senate,,DEM,Kamala Harris,582
-San Joaquin,11327,U.S. Senate,,DEM,Loretta Sanchez,444
-San Joaquin,11332,U.S. Senate,,DEM,Kamala Harris,631
-San Joaquin,11332,U.S. Senate,,DEM,Loretta Sanchez,404
-San Joaquin,11333,U.S. Senate,,DEM,Kamala Harris,272
-San Joaquin,11333,U.S. Senate,,DEM,Loretta Sanchez,186
-San Joaquin,11335,U.S. Senate,,DEM,Kamala Harris,562
-San Joaquin,11335,U.S. Senate,,DEM,Loretta Sanchez,343
-San Joaquin,11338,U.S. Senate,,DEM,Kamala Harris,414
-San Joaquin,11338,U.S. Senate,,DEM,Loretta Sanchez,292
-San Joaquin,11342,U.S. Senate,,DEM,Kamala Harris,244
-San Joaquin,11342,U.S. Senate,,DEM,Loretta Sanchez,110
-San Joaquin,11343,U.S. Senate,,DEM,Kamala Harris,270
-San Joaquin,11343,U.S. Senate,,DEM,Loretta Sanchez,158
-San Joaquin,11345,U.S. Senate,,DEM,Kamala Harris,279
-San Joaquin,11345,U.S. Senate,,DEM,Loretta Sanchez,162
-San Joaquin,11346,U.S. Senate,,DEM,Kamala Harris,273
-San Joaquin,11346,U.S. Senate,,DEM,Loretta Sanchez,182
-San Joaquin,11348,U.S. Senate,,DEM,Kamala Harris,339
-San Joaquin,11348,U.S. Senate,,DEM,Loretta Sanchez,208
-San Joaquin,33501,U.S. Senate,,DEM,Kamala Harris,291
-San Joaquin,33501,U.S. Senate,,DEM,Loretta Sanchez,303
-San Joaquin,33502,U.S. Senate,,DEM,Kamala Harris,497
-San Joaquin,33502,U.S. Senate,,DEM,Loretta Sanchez,304
-San Joaquin,33503,U.S. Senate,,DEM,Kamala Harris,328
-San Joaquin,33503,U.S. Senate,,DEM,Loretta Sanchez,243
-San Joaquin,33504,U.S. Senate,,DEM,Kamala Harris,366
-San Joaquin,33504,U.S. Senate,,DEM,Loretta Sanchez,371
-San Joaquin,33505,U.S. Senate,,DEM,Kamala Harris,482
-San Joaquin,33505,U.S. Senate,,DEM,Loretta Sanchez,473
-San Joaquin,33507,U.S. Senate,,DEM,Kamala Harris,448
-San Joaquin,33507,U.S. Senate,,DEM,Loretta Sanchez,392
-San Joaquin,33509,U.S. Senate,,DEM,Kamala Harris,573
-San Joaquin,33509,U.S. Senate,,DEM,Loretta Sanchez,533
-San Joaquin,33512,U.S. Senate,,DEM,Kamala Harris,192
-San Joaquin,33512,U.S. Senate,,DEM,Loretta Sanchez,189
-San Joaquin,33513,U.S. Senate,,DEM,Kamala Harris,138
-San Joaquin,33513,U.S. Senate,,DEM,Loretta Sanchez,143
-San Joaquin,33514,U.S. Senate,,DEM,Kamala Harris,483
-San Joaquin,33514,U.S. Senate,,DEM,Loretta Sanchez,297
-San Joaquin,33515,U.S. Senate,,DEM,Kamala Harris,328
-San Joaquin,33515,U.S. Senate,,DEM,Loretta Sanchez,211
-San Joaquin,33517,U.S. Senate,,DEM,Kamala Harris,299
-San Joaquin,33517,U.S. Senate,,DEM,Loretta Sanchez,226
-San Joaquin,33518,U.S. Senate,,DEM,Kamala Harris,366
-San Joaquin,33518,U.S. Senate,,DEM,Loretta Sanchez,309
-San Joaquin,33520,U.S. Senate,,DEM,Kamala Harris,604
-San Joaquin,33520,U.S. Senate,,DEM,Loretta Sanchez,479
-San Joaquin,33522,U.S. Senate,,DEM,Kamala Harris,362
-San Joaquin,33522,U.S. Senate,,DEM,Loretta Sanchez,313
-San Joaquin,33523,U.S. Senate,,DEM,Kamala Harris,355
-San Joaquin,33523,U.S. Senate,,DEM,Loretta Sanchez,335
-San Joaquin,33524,U.S. Senate,,DEM,Kamala Harris,327
-San Joaquin,33524,U.S. Senate,,DEM,Loretta Sanchez,245
-San Joaquin,33525,U.S. Senate,,DEM,Kamala Harris,561
-San Joaquin,33525,U.S. Senate,,DEM,Loretta Sanchez,349
-San Joaquin,33527,U.S. Senate,,DEM,Kamala Harris,287
-San Joaquin,33527,U.S. Senate,,DEM,Loretta Sanchez,244
-San Joaquin,33529,U.S. Senate,,DEM,Kamala Harris,263
-San Joaquin,33529,U.S. Senate,,DEM,Loretta Sanchez,181
-San Joaquin,33530,U.S. Senate,,DEM,Kamala Harris,318
-San Joaquin,33530,U.S. Senate,,DEM,Loretta Sanchez,212
-San Joaquin,33532,U.S. Senate,,DEM,Kamala Harris,372
-San Joaquin,33532,U.S. Senate,,DEM,Loretta Sanchez,309
-San Joaquin,33533,U.S. Senate,,DEM,Kamala Harris,247
-San Joaquin,33533,U.S. Senate,,DEM,Loretta Sanchez,198
-San Joaquin,33534,U.S. Senate,,DEM,Kamala Harris,435
-San Joaquin,33534,U.S. Senate,,DEM,Loretta Sanchez,341
-San Joaquin,33535,U.S. Senate,,DEM,Kamala Harris,384
-San Joaquin,33535,U.S. Senate,,DEM,Loretta Sanchez,266
-San Joaquin,33537,U.S. Senate,,DEM,Kamala Harris,205
-San Joaquin,33537,U.S. Senate,,DEM,Loretta Sanchez,172
-San Joaquin,33540,U.S. Senate,,DEM,Kamala Harris,666
-San Joaquin,33540,U.S. Senate,,DEM,Loretta Sanchez,470
-San Joaquin,33542,U.S. Senate,,DEM,Kamala Harris,374
-San Joaquin,33542,U.S. Senate,,DEM,Loretta Sanchez,235
-San Joaquin,33543,U.S. Senate,,DEM,Kamala Harris,367
-San Joaquin,33543,U.S. Senate,,DEM,Loretta Sanchez,214
-San Joaquin,33545,U.S. Senate,,DEM,Kamala Harris,387
-San Joaquin,33545,U.S. Senate,,DEM,Loretta Sanchez,247
-San Joaquin,33546,U.S. Senate,,DEM,Kamala Harris,745
-San Joaquin,33546,U.S. Senate,,DEM,Loretta Sanchez,469
-San Joaquin,33547,U.S. Senate,,DEM,Kamala Harris,374
-San Joaquin,33547,U.S. Senate,,DEM,Loretta Sanchez,266
-San Joaquin,33548,U.S. Senate,,DEM,Kamala Harris,216
-San Joaquin,33548,U.S. Senate,,DEM,Loretta Sanchez,150
-San Joaquin,33551,U.S. Senate,,DEM,Kamala Harris,424
-San Joaquin,33551,U.S. Senate,,DEM,Loretta Sanchez,266
-San Joaquin,33552,U.S. Senate,,DEM,Kamala Harris,517
-San Joaquin,33552,U.S. Senate,,DEM,Loretta Sanchez,361
-San Joaquin,33554,U.S. Senate,,DEM,Kamala Harris,432
-San Joaquin,33554,U.S. Senate,,DEM,Loretta Sanchez,258
-San Joaquin,42401,U.S. Senate,,DEM,Kamala Harris,373
-San Joaquin,42401,U.S. Senate,,DEM,Loretta Sanchez,233
-San Joaquin,42402,U.S. Senate,,DEM,Kamala Harris,485
-San Joaquin,42402,U.S. Senate,,DEM,Loretta Sanchez,293
-San Joaquin,42403,U.S. Senate,,DEM,Kamala Harris,270
-San Joaquin,42403,U.S. Senate,,DEM,Loretta Sanchez,375
-San Joaquin,42404,U.S. Senate,,DEM,Kamala Harris,457
-San Joaquin,42404,U.S. Senate,,DEM,Loretta Sanchez,408
-San Joaquin,42405,U.S. Senate,,DEM,Kamala Harris,354
-San Joaquin,42405,U.S. Senate,,DEM,Loretta Sanchez,363
-San Joaquin,42406,U.S. Senate,,DEM,Kamala Harris,647
-San Joaquin,42406,U.S. Senate,,DEM,Loretta Sanchez,413
-San Joaquin,42407,U.S. Senate,,DEM,Kamala Harris,356
-San Joaquin,42407,U.S. Senate,,DEM,Loretta Sanchez,231
-San Joaquin,42408,U.S. Senate,,DEM,Kamala Harris,403
-San Joaquin,42408,U.S. Senate,,DEM,Loretta Sanchez,287
-San Joaquin,42410,U.S. Senate,,DEM,Kamala Harris,252
-San Joaquin,42410,U.S. Senate,,DEM,Loretta Sanchez,140
-San Joaquin,42411,U.S. Senate,,DEM,Kamala Harris,301
-San Joaquin,42411,U.S. Senate,,DEM,Loretta Sanchez,145
-San Joaquin,42412,U.S. Senate,,DEM,Kamala Harris,233
-San Joaquin,42412,U.S. Senate,,DEM,Loretta Sanchez,143
-San Joaquin,42413,U.S. Senate,,DEM,Kamala Harris,447
-San Joaquin,42413,U.S. Senate,,DEM,Loretta Sanchez,270
-San Joaquin,42414,U.S. Senate,,DEM,Kamala Harris,222
-San Joaquin,42414,U.S. Senate,,DEM,Loretta Sanchez,224
-San Joaquin,42416,U.S. Senate,,DEM,Kamala Harris,357
-San Joaquin,42416,U.S. Senate,,DEM,Loretta Sanchez,201
-San Joaquin,42417,U.S. Senate,,DEM,Kamala Harris,224
-San Joaquin,42417,U.S. Senate,,DEM,Loretta Sanchez,155
-San Joaquin,42418,U.S. Senate,,DEM,Kamala Harris,480
-San Joaquin,42418,U.S. Senate,,DEM,Loretta Sanchez,320
-San Joaquin,42419,U.S. Senate,,DEM,Kamala Harris,308
-San Joaquin,42419,U.S. Senate,,DEM,Loretta Sanchez,238
-San Joaquin,42420,U.S. Senate,,DEM,Kamala Harris,163
-San Joaquin,42420,U.S. Senate,,DEM,Loretta Sanchez,130
-San Joaquin,42421,U.S. Senate,,DEM,Kamala Harris,371
-San Joaquin,42421,U.S. Senate,,DEM,Loretta Sanchez,209
-San Joaquin,42422,U.S. Senate,,DEM,Kamala Harris,212
-San Joaquin,42422,U.S. Senate,,DEM,Loretta Sanchez,122
-San Joaquin,42423,U.S. Senate,,DEM,Kamala Harris,424
-San Joaquin,42423,U.S. Senate,,DEM,Loretta Sanchez,263
-San Joaquin,42424,U.S. Senate,,DEM,Kamala Harris,265
-San Joaquin,42424,U.S. Senate,,DEM,Loretta Sanchez,196
-San Joaquin,42426,U.S. Senate,,DEM,Kamala Harris,373
-San Joaquin,42426,U.S. Senate,,DEM,Loretta Sanchez,274
-San Joaquin,42430,U.S. Senate,,DEM,Kamala Harris,199
-San Joaquin,42430,U.S. Senate,,DEM,Loretta Sanchez,141
-San Joaquin,42432,U.S. Senate,,DEM,Kamala Harris,349
-San Joaquin,42432,U.S. Senate,,DEM,Loretta Sanchez,230
-San Joaquin,42433,U.S. Senate,,DEM,Kamala Harris,264
-San Joaquin,42433,U.S. Senate,,DEM,Loretta Sanchez,164
-San Joaquin,42437,U.S. Senate,,DEM,Kamala Harris,162
-San Joaquin,42437,U.S. Senate,,DEM,Loretta Sanchez,255
-San Joaquin,42439,U.S. Senate,,DEM,Kamala Harris,350
-San Joaquin,42439,U.S. Senate,,DEM,Loretta Sanchez,204
-San Joaquin,42441,U.S. Senate,,DEM,Kamala Harris,360
-San Joaquin,42441,U.S. Senate,,DEM,Loretta Sanchez,223
-San Joaquin,42444,U.S. Senate,,DEM,Kamala Harris,191
-San Joaquin,42444,U.S. Senate,,DEM,Loretta Sanchez,239
-San Joaquin,42446,U.S. Senate,,DEM,Kamala Harris,299
-San Joaquin,42446,U.S. Senate,,DEM,Loretta Sanchez,236
-San Joaquin,42449,U.S. Senate,,DEM,Kamala Harris,325
-San Joaquin,42449,U.S. Senate,,DEM,Loretta Sanchez,230
-San Joaquin,54301,U.S. Senate,,DEM,Kamala Harris,563
-San Joaquin,54301,U.S. Senate,,DEM,Loretta Sanchez,346
-San Joaquin,54302,U.S. Senate,,DEM,Kamala Harris,513
-San Joaquin,54302,U.S. Senate,,DEM,Loretta Sanchez,426
-San Joaquin,54304,U.S. Senate,,DEM,Kamala Harris,272
-San Joaquin,54304,U.S. Senate,,DEM,Loretta Sanchez,235
-San Joaquin,54305,U.S. Senate,,DEM,Kamala Harris,293
-San Joaquin,54305,U.S. Senate,,DEM,Loretta Sanchez,226
-San Joaquin,54306,U.S. Senate,,DEM,Kamala Harris,283
-San Joaquin,54306,U.S. Senate,,DEM,Loretta Sanchez,177
-San Joaquin,54307,U.S. Senate,,DEM,Kamala Harris,411
-San Joaquin,54307,U.S. Senate,,DEM,Loretta Sanchez,316
-San Joaquin,54310,U.S. Senate,,DEM,Kamala Harris,415
-San Joaquin,54310,U.S. Senate,,DEM,Loretta Sanchez,376
-San Joaquin,54311,U.S. Senate,,DEM,Kamala Harris,462
-San Joaquin,54311,U.S. Senate,,DEM,Loretta Sanchez,387
-San Joaquin,54312,U.S. Senate,,DEM,Kamala Harris,122
-San Joaquin,54312,U.S. Senate,,DEM,Loretta Sanchez,68
-San Joaquin,54313,U.S. Senate,,DEM,Kamala Harris,231
-San Joaquin,54313,U.S. Senate,,DEM,Loretta Sanchez,155
-San Joaquin,54314,U.S. Senate,,DEM,Kamala Harris,483
-San Joaquin,54314,U.S. Senate,,DEM,Loretta Sanchez,407
-San Joaquin,54318,U.S. Senate,,DEM,Kamala Harris,934
-San Joaquin,54318,U.S. Senate,,DEM,Loretta Sanchez,394
-San Joaquin,54320,U.S. Senate,,DEM,Kamala Harris,299
-San Joaquin,54320,U.S. Senate,,DEM,Loretta Sanchez,249
-San Joaquin,54321,U.S. Senate,,DEM,Kamala Harris,259
-San Joaquin,54321,U.S. Senate,,DEM,Loretta Sanchez,258
-San Joaquin,54322,U.S. Senate,,DEM,Kamala Harris,445
-San Joaquin,54322,U.S. Senate,,DEM,Loretta Sanchez,346
-San Joaquin,54323,U.S. Senate,,DEM,Kamala Harris,106
-San Joaquin,54323,U.S. Senate,,DEM,Loretta Sanchez,76
-San Joaquin,54324,U.S. Senate,,DEM,Kamala Harris,283
-San Joaquin,54324,U.S. Senate,,DEM,Loretta Sanchez,195
-San Joaquin,54325,U.S. Senate,,DEM,Kamala Harris,637
-San Joaquin,54325,U.S. Senate,,DEM,Loretta Sanchez,419
-San Joaquin,54327,U.S. Senate,,DEM,Kamala Harris,378
-San Joaquin,54327,U.S. Senate,,DEM,Loretta Sanchez,236
-San Joaquin,54501,U.S. Senate,,DEM,Kamala Harris,267
-San Joaquin,54501,U.S. Senate,,DEM,Loretta Sanchez,254
-San Joaquin,54502,U.S. Senate,,DEM,Kamala Harris,304
-San Joaquin,54502,U.S. Senate,,DEM,Loretta Sanchez,261
-San Joaquin,54503,U.S. Senate,,DEM,Kamala Harris,333
-San Joaquin,54503,U.S. Senate,,DEM,Loretta Sanchez,213
-San Joaquin,54504,U.S. Senate,,DEM,Kamala Harris,236
-San Joaquin,54504,U.S. Senate,,DEM,Loretta Sanchez,211
-San Joaquin,54505,U.S. Senate,,DEM,Kamala Harris,529
-San Joaquin,54505,U.S. Senate,,DEM,Loretta Sanchez,405
-San Joaquin,54508,U.S. Senate,,DEM,Kamala Harris,448
-San Joaquin,54508,U.S. Senate,,DEM,Loretta Sanchez,296
-San Joaquin,54509,U.S. Senate,,DEM,Kamala Harris,209
-San Joaquin,54509,U.S. Senate,,DEM,Loretta Sanchez,145
-San Joaquin,54510,U.S. Senate,,DEM,Kamala Harris,471
-San Joaquin,54510,U.S. Senate,,DEM,Loretta Sanchez,318
-San Joaquin,54511,U.S. Senate,,DEM,Kamala Harris,251
-San Joaquin,54511,U.S. Senate,,DEM,Loretta Sanchez,171
-San Joaquin,54512,U.S. Senate,,DEM,Kamala Harris,261
-San Joaquin,54512,U.S. Senate,,DEM,Loretta Sanchez,197
-San Joaquin,54514,U.S. Senate,,DEM,Kamala Harris,419
-San Joaquin,54514,U.S. Senate,,DEM,Loretta Sanchez,227
-San Joaquin,54515,U.S. Senate,,DEM,Kamala Harris,394
-San Joaquin,54515,U.S. Senate,,DEM,Loretta Sanchez,327
-San Joaquin,54520,U.S. Senate,,DEM,Kamala Harris,324
-San Joaquin,54520,U.S. Senate,,DEM,Loretta Sanchez,199
-San Joaquin,54521,U.S. Senate,,DEM,Kamala Harris,341
-San Joaquin,54521,U.S. Senate,,DEM,Loretta Sanchez,209
-San Joaquin,54522,U.S. Senate,,DEM,Kamala Harris,255
-San Joaquin,54522,U.S. Senate,,DEM,Loretta Sanchez,175
-San Joaquin,54523,U.S. Senate,,DEM,Kamala Harris,168
-San Joaquin,54523,U.S. Senate,,DEM,Loretta Sanchez,122
-San Joaquin,64401,U.S. Senate,,DEM,Kamala Harris,142
-San Joaquin,64401,U.S. Senate,,DEM,Loretta Sanchez,101
-San Joaquin,64402,U.S. Senate,,DEM,Kamala Harris,275
-San Joaquin,64402,U.S. Senate,,DEM,Loretta Sanchez,198
-San Joaquin,64403,U.S. Senate,,DEM,Kamala Harris,229
-San Joaquin,64403,U.S. Senate,,DEM,Loretta Sanchez,149
-San Joaquin,64404,U.S. Senate,,DEM,Kamala Harris,217
-San Joaquin,64404,U.S. Senate,,DEM,Loretta Sanchez,148
-San Joaquin,64405,U.S. Senate,,DEM,Kamala Harris,139
-San Joaquin,64405,U.S. Senate,,DEM,Loretta Sanchez,135
-San Joaquin,64406,U.S. Senate,,DEM,Kamala Harris,190
-San Joaquin,64406,U.S. Senate,,DEM,Loretta Sanchez,114
-San Joaquin,74401,U.S. Senate,,DEM,Kamala Harris,423
-San Joaquin,74401,U.S. Senate,,DEM,Loretta Sanchez,274
-San Joaquin,74402,U.S. Senate,,DEM,Kamala Harris,455
-San Joaquin,74402,U.S. Senate,,DEM,Loretta Sanchez,333
-San Joaquin,74404,U.S. Senate,,DEM,Kamala Harris,175
-San Joaquin,74404,U.S. Senate,,DEM,Loretta Sanchez,160
-San Joaquin,74405,U.S. Senate,,DEM,Kamala Harris,220
-San Joaquin,74405,U.S. Senate,,DEM,Loretta Sanchez,158
-San Joaquin,74406,U.S. Senate,,DEM,Kamala Harris,264
-San Joaquin,74406,U.S. Senate,,DEM,Loretta Sanchez,160
-San Joaquin,74407,U.S. Senate,,DEM,Kamala Harris,202
-San Joaquin,74407,U.S. Senate,,DEM,Loretta Sanchez,144
-San Joaquin,74408,U.S. Senate,,DEM,Kamala Harris,329
-San Joaquin,74408,U.S. Senate,,DEM,Loretta Sanchez,239
-San Joaquin,74410,U.S. Senate,,DEM,Kamala Harris,339
-San Joaquin,74410,U.S. Senate,,DEM,Loretta Sanchez,204
-San Joaquin,74411,U.S. Senate,,DEM,Kamala Harris,244
-San Joaquin,74411,U.S. Senate,,DEM,Loretta Sanchez,160
-San Joaquin,74412,U.S. Senate,,DEM,Kamala Harris,275
-San Joaquin,74412,U.S. Senate,,DEM,Loretta Sanchez,192
-San Joaquin,84301,U.S. Senate,,DEM,Kamala Harris,360
-San Joaquin,84301,U.S. Senate,,DEM,Loretta Sanchez,262
-San Joaquin,84302,U.S. Senate,,DEM,Kamala Harris,403
-San Joaquin,84302,U.S. Senate,,DEM,Loretta Sanchez,402
-San Joaquin,84303,U.S. Senate,,DEM,Kamala Harris,415
-San Joaquin,84303,U.S. Senate,,DEM,Loretta Sanchez,185
-San Joaquin,84305,U.S. Senate,,DEM,Kamala Harris,200
-San Joaquin,84305,U.S. Senate,,DEM,Loretta Sanchez,200
-San Joaquin,84306,U.S. Senate,,DEM,Kamala Harris,256
-San Joaquin,84306,U.S. Senate,,DEM,Loretta Sanchez,143
-San Joaquin,84307,U.S. Senate,,DEM,Kamala Harris,265
-San Joaquin,84307,U.S. Senate,,DEM,Loretta Sanchez,282
-San Joaquin,84309,U.S. Senate,,DEM,Kamala Harris,420
-San Joaquin,84309,U.S. Senate,,DEM,Loretta Sanchez,217
-San Joaquin,84310,U.S. Senate,,DEM,Kamala Harris,339
-San Joaquin,84310,U.S. Senate,,DEM,Loretta Sanchez,290
-San Joaquin,84312,U.S. Senate,,DEM,Kamala Harris,565
-San Joaquin,84312,U.S. Senate,,DEM,Loretta Sanchez,275
-San Joaquin,84501,U.S. Senate,,DEM,Kamala Harris,226
-San Joaquin,84501,U.S. Senate,,DEM,Loretta Sanchez,123
-San Joaquin,91101,U.S. Senate,,DEM,Kamala Harris,103
-San Joaquin,91101,U.S. Senate,,DEM,Loretta Sanchez,147
-San Joaquin,91102,U.S. Senate,,DEM,Kamala Harris,86
-San Joaquin,91102,U.S. Senate,,DEM,Loretta Sanchez,94
-San Joaquin,91103,U.S. Senate,,DEM,Kamala Harris,48
-San Joaquin,91103,U.S. Senate,,DEM,Loretta Sanchez,91
-San Joaquin,91105,U.S. Senate,,DEM,Kamala Harris,65
-San Joaquin,91105,U.S. Senate,,DEM,Loretta Sanchez,152
-San Joaquin,91107,U.S. Senate,,DEM,Kamala Harris,216
-San Joaquin,91107,U.S. Senate,,DEM,Loretta Sanchez,373
-San Joaquin,91111,U.S. Senate,,DEM,Kamala Harris,447
-San Joaquin,91111,U.S. Senate,,DEM,Loretta Sanchez,303
-San Joaquin,91113,U.S. Senate,,DEM,Kamala Harris,191
-San Joaquin,91113,U.S. Senate,,DEM,Loretta Sanchez,249
-San Joaquin,91114,U.S. Senate,,DEM,Kamala Harris,257
-San Joaquin,91114,U.S. Senate,,DEM,Loretta Sanchez,202
-San Joaquin,91115,U.S. Senate,,DEM,Kamala Harris,396
-San Joaquin,91115,U.S. Senate,,DEM,Loretta Sanchez,288
-San Joaquin,91121,U.S. Senate,,DEM,Kamala Harris,87
-San Joaquin,91121,U.S. Senate,,DEM,Loretta Sanchez,72
-San Joaquin,91204,U.S. Senate,,DEM,Kamala Harris,163
-San Joaquin,91204,U.S. Senate,,DEM,Loretta Sanchez,143
-San Joaquin,91205,U.S. Senate,,DEM,Kamala Harris,119
-San Joaquin,91205,U.S. Senate,,DEM,Loretta Sanchez,99
-San Joaquin,91206,U.S. Senate,,DEM,Kamala Harris,89
-San Joaquin,91206,U.S. Senate,,DEM,Loretta Sanchez,120
-San Joaquin,91207,U.S. Senate,,DEM,Kamala Harris,184
-San Joaquin,91207,U.S. Senate,,DEM,Loretta Sanchez,259
-San Joaquin,91208,U.S. Senate,,DEM,Kamala Harris,113
-San Joaquin,91208,U.S. Senate,,DEM,Loretta Sanchez,88
-San Joaquin,91209,U.S. Senate,,DEM,Kamala Harris,483
-San Joaquin,91209,U.S. Senate,,DEM,Loretta Sanchez,303
-San Joaquin,91211,U.S. Senate,,DEM,Kamala Harris,429
-San Joaquin,91211,U.S. Senate,,DEM,Loretta Sanchez,216
-San Joaquin,91213,U.S. Senate,,DEM,Kamala Harris,119
-San Joaquin,91213,U.S. Senate,,DEM,Loretta Sanchez,84
-San Joaquin,91216,U.S. Senate,,DEM,Kamala Harris,203
-San Joaquin,91216,U.S. Senate,,DEM,Loretta Sanchez,255
-San Joaquin,91217,U.S. Senate,,DEM,Kamala Harris,149
-San Joaquin,91217,U.S. Senate,,DEM,Loretta Sanchez,246
-San Joaquin,91218,U.S. Senate,,DEM,Kamala Harris,145
-San Joaquin,91218,U.S. Senate,,DEM,Loretta Sanchez,201
-San Joaquin,91219,U.S. Senate,,DEM,Kamala Harris,212
-San Joaquin,91219,U.S. Senate,,DEM,Loretta Sanchez,300
-San Joaquin,91225,U.S. Senate,,DEM,Kamala Harris,94
-San Joaquin,91225,U.S. Senate,,DEM,Loretta Sanchez,126
-San Joaquin,91227,U.S. Senate,,DEM,Kamala Harris,158
-San Joaquin,91227,U.S. Senate,,DEM,Loretta Sanchez,117
-San Joaquin,91301,U.S. Senate,,DEM,Kamala Harris,397
-San Joaquin,91301,U.S. Senate,,DEM,Loretta Sanchez,263
-San Joaquin,91303,U.S. Senate,,DEM,Kamala Harris,447
-San Joaquin,91303,U.S. Senate,,DEM,Loretta Sanchez,353
-San Joaquin,91305,U.S. Senate,,DEM,Kamala Harris,247
-San Joaquin,91305,U.S. Senate,,DEM,Loretta Sanchez,212
-San Joaquin,91402,U.S. Senate,,DEM,Kamala Harris,474
-San Joaquin,91402,U.S. Senate,,DEM,Loretta Sanchez,294
-San Joaquin,91404,U.S. Senate,,DEM,Kamala Harris,238
-San Joaquin,91404,U.S. Senate,,DEM,Loretta Sanchez,154
-San Joaquin,91405,U.S. Senate,,DEM,Kamala Harris,282
-San Joaquin,91405,U.S. Senate,,DEM,Loretta Sanchez,202
-San Joaquin,91407,U.S. Senate,,DEM,Kamala Harris,246
-San Joaquin,91407,U.S. Senate,,DEM,Loretta Sanchez,203
-San Joaquin,91408,U.S. Senate,,DEM,Kamala Harris,203
-San Joaquin,91408,U.S. Senate,,DEM,Loretta Sanchez,120
-San Joaquin,91409,U.S. Senate,,DEM,Kamala Harris,318
-San Joaquin,91409,U.S. Senate,,DEM,Loretta Sanchez,218
-San Joaquin,91411,U.S. Senate,,DEM,Kamala Harris,325
-San Joaquin,91411,U.S. Senate,,DEM,Loretta Sanchez,187
-San Joaquin,91412,U.S. Senate,,DEM,Kamala Harris,253
-San Joaquin,91412,U.S. Senate,,DEM,Loretta Sanchez,120
-San Joaquin,91414,U.S. Senate,,DEM,Kamala Harris,245
-San Joaquin,91414,U.S. Senate,,DEM,Loretta Sanchez,202
-San Joaquin,91415,U.S. Senate,,DEM,Kamala Harris,279
-San Joaquin,91415,U.S. Senate,,DEM,Loretta Sanchez,196
-San Joaquin,92401,U.S. Senate,,DEM,Kamala Harris,187
-San Joaquin,92401,U.S. Senate,,DEM,Loretta Sanchez,117
-San Joaquin,92402,U.S. Senate,,DEM,Kamala Harris,283
-San Joaquin,92402,U.S. Senate,,DEM,Loretta Sanchez,214
-San Joaquin,92403,U.S. Senate,,DEM,Kamala Harris,122
-San Joaquin,92403,U.S. Senate,,DEM,Loretta Sanchez,84
-San Joaquin,92404,U.S. Senate,,DEM,Kamala Harris,376
-San Joaquin,92404,U.S. Senate,,DEM,Loretta Sanchez,262
-San Joaquin,92405,U.S. Senate,,DEM,Kamala Harris,97
-San Joaquin,92405,U.S. Senate,,DEM,Loretta Sanchez,75
-San Joaquin,92406,U.S. Senate,,DEM,Kamala Harris,513
-San Joaquin,92406,U.S. Senate,,DEM,Loretta Sanchez,298
-San Joaquin,92407,U.S. Senate,,DEM,Kamala Harris,203
-San Joaquin,92407,U.S. Senate,,DEM,Loretta Sanchez,96
-San Joaquin,92408,U.S. Senate,,DEM,Kamala Harris,451
-San Joaquin,92408,U.S. Senate,,DEM,Loretta Sanchez,336
-San Joaquin,92409,U.S. Senate,,DEM,Kamala Harris,263
-San Joaquin,92409,U.S. Senate,,DEM,Loretta Sanchez,279
-San Joaquin,92410,U.S. Senate,,DEM,Kamala Harris,222
-San Joaquin,92410,U.S. Senate,,DEM,Loretta Sanchez,165
-San Joaquin,92411,U.S. Senate,,DEM,Kamala Harris,303
-San Joaquin,92411,U.S. Senate,,DEM,Loretta Sanchez,240
-San Joaquin,92412,U.S. Senate,,DEM,Kamala Harris,186
-San Joaquin,92412,U.S. Senate,,DEM,Loretta Sanchez,139
-San Joaquin,92413,U.S. Senate,,DEM,Kamala Harris,89
-San Joaquin,92413,U.S. Senate,,DEM,Loretta Sanchez,82
-San Joaquin,92414,U.S. Senate,,DEM,Kamala Harris,141
-San Joaquin,92414,U.S. Senate,,DEM,Loretta Sanchez,142
-San Joaquin,92416,U.S. Senate,,DEM,Kamala Harris,212
-San Joaquin,92416,U.S. Senate,,DEM,Loretta Sanchez,145
-San Joaquin,92418,U.S. Senate,,DEM,Kamala Harris,310
-San Joaquin,92418,U.S. Senate,,DEM,Loretta Sanchez,198
-San Joaquin,92419,U.S. Senate,,DEM,Kamala Harris,354
-San Joaquin,92419,U.S. Senate,,DEM,Loretta Sanchez,241
-San Joaquin,92420,U.S. Senate,,DEM,Kamala Harris,312
-San Joaquin,92420,U.S. Senate,,DEM,Loretta Sanchez,219
-San Joaquin,92422,U.S. Senate,,DEM,Kamala Harris,119
-San Joaquin,92422,U.S. Senate,,DEM,Loretta Sanchez,87
-San Joaquin,92424,U.S. Senate,,DEM,Kamala Harris,226
-San Joaquin,92424,U.S. Senate,,DEM,Loretta Sanchez,145
-San Joaquin,92432,U.S. Senate,,DEM,Kamala Harris,148
-San Joaquin,92432,U.S. Senate,,DEM,Loretta Sanchez,94
-San Joaquin,93501,U.S. Senate,,DEM,Kamala Harris,607
-San Joaquin,93501,U.S. Senate,,DEM,Loretta Sanchez,370
-San Joaquin,93502,U.S. Senate,,DEM,Kamala Harris,198
-San Joaquin,93502,U.S. Senate,,DEM,Loretta Sanchez,104
-San Joaquin,93503,U.S. Senate,,DEM,Kamala Harris,124
-San Joaquin,93503,U.S. Senate,,DEM,Loretta Sanchez,124
-San Joaquin,93504,U.S. Senate,,DEM,Kamala Harris,150
-San Joaquin,93504,U.S. Senate,,DEM,Loretta Sanchez,147
-San Joaquin,93505,U.S. Senate,,DEM,Kamala Harris,233
-San Joaquin,93505,U.S. Senate,,DEM,Loretta Sanchez,212
-San Joaquin,93511,U.S. Senate,,DEM,Kamala Harris,603
-San Joaquin,93511,U.S. Senate,,DEM,Loretta Sanchez,271
-San Joaquin,93521,U.S. Senate,,DEM,Kamala Harris,467
-San Joaquin,93521,U.S. Senate,,DEM,Loretta Sanchez,203
-San Joaquin,93522,U.S. Senate,,DEM,Kamala Harris,493
-San Joaquin,93522,U.S. Senate,,DEM,Loretta Sanchez,206
-San Joaquin,93523,U.S. Senate,,DEM,Kamala Harris,421
-San Joaquin,93523,U.S. Senate,,DEM,Loretta Sanchez,257
-San Joaquin,93524,U.S. Senate,,DEM,Kamala Harris,129
-San Joaquin,93524,U.S. Senate,,DEM,Loretta Sanchez,89
-San Joaquin,93531,U.S. Senate,,DEM,Kamala Harris,648
-San Joaquin,93531,U.S. Senate,,DEM,Loretta Sanchez,342
-San Joaquin,94101,U.S. Senate,,DEM,Kamala Harris,216
-San Joaquin,94101,U.S. Senate,,DEM,Loretta Sanchez,328
-San Joaquin,94309,U.S. Senate,,DEM,Kamala Harris,293
-San Joaquin,94309,U.S. Senate,,DEM,Loretta Sanchez,147
-San Joaquin,94310,U.S. Senate,,DEM,Kamala Harris,96
-San Joaquin,94310,U.S. Senate,,DEM,Loretta Sanchez,82
-San Joaquin,94402,U.S. Senate,,DEM,Kamala Harris,112
-San Joaquin,94402,U.S. Senate,,DEM,Loretta Sanchez,69
-San Joaquin,94403,U.S. Senate,,DEM,Kamala Harris,140
-San Joaquin,94403,U.S. Senate,,DEM,Loretta Sanchez,100
-San Joaquin,94405,U.S. Senate,,DEM,Kamala Harris,173
-San Joaquin,94405,U.S. Senate,,DEM,Loretta Sanchez,140
-San Joaquin,94408,U.S. Senate,,DEM,Kamala Harris,397
-San Joaquin,94408,U.S. Senate,,DEM,Loretta Sanchez,299
-San Joaquin,94410,U.S. Senate,,DEM,Kamala Harris,158
-San Joaquin,94410,U.S. Senate,,DEM,Loretta Sanchez,85
-San Joaquin,94501,U.S. Senate,,DEM,Kamala Harris,219
-San Joaquin,94501,U.S. Senate,,DEM,Loretta Sanchez,114
-San Joaquin,94503,U.S. Senate,,DEM,Kamala Harris,100
-San Joaquin,94503,U.S. Senate,,DEM,Loretta Sanchez,80
-San Joaquin,94504,U.S. Senate,,DEM,Kamala Harris,198
-San Joaquin,94504,U.S. Senate,,DEM,Loretta Sanchez,132
-San Joaquin,111120,U.S. Senate,,DEM,Kamala Harris,21
-San Joaquin,111120,U.S. Senate,,DEM,Loretta Sanchez,10
-San Joaquin,111130,U.S. Senate,,DEM,Kamala Harris,62
-San Joaquin,111130,U.S. Senate,,DEM,Loretta Sanchez,59
-San Joaquin,111190,U.S. Senate,,DEM,Kamala Harris,65
-San Joaquin,111190,U.S. Senate,,DEM,Loretta Sanchez,46
-San Joaquin,111230,U.S. Senate,,DEM,Kamala Harris,63
-San Joaquin,111230,U.S. Senate,,DEM,Loretta Sanchez,96
-San Joaquin,111310,U.S. Senate,,DEM,Kamala Harris,3
-San Joaquin,111310,U.S. Senate,,DEM,Loretta Sanchez,3
-San Joaquin,111311,U.S. Senate,,DEM,Kamala Harris,0
-San Joaquin,111311,U.S. Senate,,DEM,Loretta Sanchez,0
-San Joaquin,111320,U.S. Senate,,DEM,Kamala Harris,0
-San Joaquin,111320,U.S. Senate,,DEM,Loretta Sanchez,0
-San Joaquin,111410,U.S. Senate,,DEM,Kamala Harris,0
-San Joaquin,111410,U.S. Senate,,DEM,Loretta Sanchez,0
-San Joaquin,111430,U.S. Senate,,DEM,Kamala Harris,0
-San Joaquin,111430,U.S. Senate,,DEM,Loretta Sanchez,0
-San Joaquin,111431,U.S. Senate,,DEM,Kamala Harris,0
-San Joaquin,111431,U.S. Senate,,DEM,Loretta Sanchez,0
-San Joaquin,111440,U.S. Senate,,DEM,Kamala Harris,0
-San Joaquin,111440,U.S. Senate,,DEM,Loretta Sanchez,1
-San Joaquin,111441,U.S. Senate,,DEM,Kamala Harris,0
-San Joaquin,111441,U.S. Senate,,DEM,Loretta Sanchez,3
-San Joaquin,111510,U.S. Senate,,DEM,Kamala Harris,27
-San Joaquin,111510,U.S. Senate,,DEM,Loretta Sanchez,36
-San Joaquin,111530,U.S. Senate,,DEM,Kamala Harris,76
-San Joaquin,111530,U.S. Senate,,DEM,Loretta Sanchez,61
-San Joaquin,111750,U.S. Senate,,DEM,Kamala Harris,3
-San Joaquin,111750,U.S. Senate,,DEM,Loretta Sanchez,8
-San Joaquin,111751,U.S. Senate,,DEM,Kamala Harris,0
-San Joaquin,111751,U.S. Senate,,DEM,Loretta Sanchez,1
-San Joaquin,112330,U.S. Senate,,DEM,Kamala Harris,83
-San Joaquin,112330,U.S. Senate,,DEM,Loretta Sanchez,47
-San Joaquin,112600,U.S. Senate,,DEM,Kamala Harris,46
-San Joaquin,112600,U.S. Senate,,DEM,Loretta Sanchez,39
-San Joaquin,113010,U.S. Senate,,DEM,Kamala Harris,4
-San Joaquin,113010,U.S. Senate,,DEM,Loretta Sanchez,0
-San Joaquin,113130,U.S. Senate,,DEM,Kamala Harris,18
-San Joaquin,113130,U.S. Senate,,DEM,Loretta Sanchez,3
-San Joaquin,113310,U.S. Senate,,DEM,Kamala Harris,120
-San Joaquin,113310,U.S. Senate,,DEM,Loretta Sanchez,58
-San Joaquin,113420,U.S. Senate,,DEM,Kamala Harris,0
-San Joaquin,113420,U.S. Senate,,DEM,Loretta Sanchez,0
-San Joaquin,113430,U.S. Senate,,DEM,Kamala Harris,45
-San Joaquin,113430,U.S. Senate,,DEM,Loretta Sanchez,16
-San Joaquin,113900,U.S. Senate,,DEM,Kamala Harris,0
-San Joaquin,113900,U.S. Senate,,DEM,Loretta Sanchez,0
-San Joaquin,335070,U.S. Senate,,DEM,Kamala Harris,8
-San Joaquin,335070,U.S. Senate,,DEM,Loretta Sanchez,1
-San Joaquin,335071,U.S. Senate,,DEM,Kamala Harris,1
-San Joaquin,335071,U.S. Senate,,DEM,Loretta Sanchez,3
-San Joaquin,335120,U.S. Senate,,DEM,Kamala Harris,0
-San Joaquin,335120,U.S. Senate,,DEM,Loretta Sanchez,0
-San Joaquin,335280,U.S. Senate,,DEM,Kamala Harris,0
-San Joaquin,335280,U.S. Senate,,DEM,Loretta Sanchez,4
-San Joaquin,335310,U.S. Senate,,DEM,Kamala Harris,1
-San Joaquin,335310,U.S. Senate,,DEM,Loretta Sanchez,0
-San Joaquin,335311,U.S. Senate,,DEM,Kamala Harris,2
-San Joaquin,335311,U.S. Senate,,DEM,Loretta Sanchez,2
-San Joaquin,335440,U.S. Senate,,DEM,Kamala Harris,8
-San Joaquin,335440,U.S. Senate,,DEM,Loretta Sanchez,0
-San Joaquin,335540,U.S. Senate,,DEM,Kamala Harris,91
-San Joaquin,335540,U.S. Senate,,DEM,Loretta Sanchez,54
-San Joaquin,335550,U.S. Senate,,DEM,Kamala Harris,2
-San Joaquin,335550,U.S. Senate,,DEM,Loretta Sanchez,0
-San Joaquin,335560,U.S. Senate,,DEM,Kamala Harris,0
-San Joaquin,335560,U.S. Senate,,DEM,Loretta Sanchez,0
-San Joaquin,424360,U.S. Senate,,DEM,Kamala Harris,0
-San Joaquin,424360,U.S. Senate,,DEM,Loretta Sanchez,0
-San Joaquin,424500,U.S. Senate,,DEM,Kamala Harris,3
-San Joaquin,424500,U.S. Senate,,DEM,Loretta Sanchez,3
-San Joaquin,543040,U.S. Senate,,DEM,Kamala Harris,14
-San Joaquin,543040,U.S. Senate,,DEM,Loretta Sanchez,9
-San Joaquin,543080,U.S. Senate,,DEM,Kamala Harris,0
-San Joaquin,543080,U.S. Senate,,DEM,Loretta Sanchez,0
-San Joaquin,543090,U.S. Senate,,DEM,Kamala Harris,103
-San Joaquin,543090,U.S. Senate,,DEM,Loretta Sanchez,90
-San Joaquin,543280,U.S. Senate,,DEM,Kamala Harris,2
-San Joaquin,543280,U.S. Senate,,DEM,Loretta Sanchez,0
-San Joaquin,545060,U.S. Senate,,DEM,Kamala Harris,7
-San Joaquin,545060,U.S. Senate,,DEM,Loretta Sanchez,8
-San Joaquin,545061,U.S. Senate,,DEM,Kamala Harris,2
-San Joaquin,545061,U.S. Senate,,DEM,Loretta Sanchez,0
-San Joaquin,545070,U.S. Senate,,DEM,Kamala Harris,19
-San Joaquin,545070,U.S. Senate,,DEM,Loretta Sanchez,12
-San Joaquin,545200,U.S. Senate,,DEM,Kamala Harris,172
-San Joaquin,545200,U.S. Senate,,DEM,Loretta Sanchez,101
-San Joaquin,545201,U.S. Senate,,DEM,Kamala Harris,7
-San Joaquin,545201,U.S. Senate,,DEM,Loretta Sanchez,1
-San Joaquin,644010,U.S. Senate,,DEM,Kamala Harris,93
-San Joaquin,644010,U.S. Senate,,DEM,Loretta Sanchez,54
-San Joaquin,644050,U.S. Senate,,DEM,Kamala Harris,70
-San Joaquin,644050,U.S. Senate,,DEM,Loretta Sanchez,38
-San Joaquin,644060,U.S. Senate,,DEM,Kamala Harris,8
-San Joaquin,644060,U.S. Senate,,DEM,Loretta Sanchez,9
-San Joaquin,835010,U.S. Senate,,DEM,Kamala Harris,0
-San Joaquin,835010,U.S. Senate,,DEM,Loretta Sanchez,0
-San Joaquin,843080,U.S. Senate,,DEM,Kamala Harris,4
-San Joaquin,843080,U.S. Senate,,DEM,Loretta Sanchez,15
-San Joaquin,843110,U.S. Senate,,DEM,Kamala Harris,2
-San Joaquin,843110,U.S. Senate,,DEM,Loretta Sanchez,2
-San Joaquin,845020,U.S. Senate,,DEM,Kamala Harris,0
-San Joaquin,845020,U.S. Senate,,DEM,Loretta Sanchez,0
-San Joaquin,845030,U.S. Senate,,DEM,Kamala Harris,3
-San Joaquin,845030,U.S. Senate,,DEM,Loretta Sanchez,1
-San Joaquin,911040,U.S. Senate,,DEM,Kamala Harris,59
-San Joaquin,911040,U.S. Senate,,DEM,Loretta Sanchez,56
-San Joaquin,911050,U.S. Senate,,DEM,Kamala Harris,24
-San Joaquin,911050,U.S. Senate,,DEM,Loretta Sanchez,15
-San Joaquin,911060,U.S. Senate,,DEM,Kamala Harris,78
-San Joaquin,911060,U.S. Senate,,DEM,Loretta Sanchez,58
-San Joaquin,911080,U.S. Senate,,DEM,Kamala Harris,9
-San Joaquin,911080,U.S. Senate,,DEM,Loretta Sanchez,7
-San Joaquin,911100,U.S. Senate,,DEM,Kamala Harris,8
-San Joaquin,911100,U.S. Senate,,DEM,Loretta Sanchez,13
-San Joaquin,911101,U.S. Senate,,DEM,Kamala Harris,2
-San Joaquin,911101,U.S. Senate,,DEM,Loretta Sanchez,8
-San Joaquin,911130,U.S. Senate,,DEM,Kamala Harris,2
-San Joaquin,911130,U.S. Senate,,DEM,Loretta Sanchez,4
-San Joaquin,911200,U.S. Senate,,DEM,Kamala Harris,30
-San Joaquin,911200,U.S. Senate,,DEM,Loretta Sanchez,33
-San Joaquin,911210,U.S. Senate,,DEM,Kamala Harris,25
-San Joaquin,911210,U.S. Senate,,DEM,Loretta Sanchez,20
-San Joaquin,911900,U.S. Senate,,DEM,Kamala Harris,0
-San Joaquin,911900,U.S. Senate,,DEM,Loretta Sanchez,0
-San Joaquin,912010,U.S. Senate,,DEM,Kamala Harris,24
-San Joaquin,912010,U.S. Senate,,DEM,Loretta Sanchez,15
-San Joaquin,912020,U.S. Senate,,DEM,Kamala Harris,1
-San Joaquin,912020,U.S. Senate,,DEM,Loretta Sanchez,3
-San Joaquin,912030,U.S. Senate,,DEM,Kamala Harris,101
-San Joaquin,912030,U.S. Senate,,DEM,Loretta Sanchez,51
-San Joaquin,912031,U.S. Senate,,DEM,Kamala Harris,31
-San Joaquin,912031,U.S. Senate,,DEM,Loretta Sanchez,19
-San Joaquin,912060,U.S. Senate,,DEM,Kamala Harris,9
-San Joaquin,912060,U.S. Senate,,DEM,Loretta Sanchez,12
-San Joaquin,912090,U.S. Senate,,DEM,Kamala Harris,79
-San Joaquin,912090,U.S. Senate,,DEM,Loretta Sanchez,38
-San Joaquin,912140,U.S. Senate,,DEM,Kamala Harris,6
-San Joaquin,912140,U.S. Senate,,DEM,Loretta Sanchez,8
-San Joaquin,912160,U.S. Senate,,DEM,Kamala Harris,0
-San Joaquin,912160,U.S. Senate,,DEM,Loretta Sanchez,0
-San Joaquin,912210,U.S. Senate,,DEM,Kamala Harris,1
-San Joaquin,912210,U.S. Senate,,DEM,Loretta Sanchez,1
-San Joaquin,912211,U.S. Senate,,DEM,Kamala Harris,68
-San Joaquin,912211,U.S. Senate,,DEM,Loretta Sanchez,78
-San Joaquin,912260,U.S. Senate,,DEM,Kamala Harris,0
-San Joaquin,912260,U.S. Senate,,DEM,Loretta Sanchez,0
-San Joaquin,913040,U.S. Senate,,DEM,Kamala Harris,1
-San Joaquin,913040,U.S. Senate,,DEM,Loretta Sanchez,5
-San Joaquin,913050,U.S. Senate,,DEM,Kamala Harris,1
-San Joaquin,913050,U.S. Senate,,DEM,Loretta Sanchez,2
-San Joaquin,913070,U.S. Senate,,DEM,Kamala Harris,48
-San Joaquin,913070,U.S. Senate,,DEM,Loretta Sanchez,29
-San Joaquin,913071,U.S. Senate,,DEM,Kamala Harris,42
-San Joaquin,913071,U.S. Senate,,DEM,Loretta Sanchez,21
-San Joaquin,913080,U.S. Senate,,DEM,Kamala Harris,69
-San Joaquin,913080,U.S. Senate,,DEM,Loretta Sanchez,28
-San Joaquin,913090,U.S. Senate,,DEM,Kamala Harris,43
-San Joaquin,913090,U.S. Senate,,DEM,Loretta Sanchez,36
-San Joaquin,914010,U.S. Senate,,DEM,Kamala Harris,84
-San Joaquin,914010,U.S. Senate,,DEM,Loretta Sanchez,49
-San Joaquin,914060,U.S. Senate,,DEM,Kamala Harris,31
-San Joaquin,914060,U.S. Senate,,DEM,Loretta Sanchez,27
-San Joaquin,914080,U.S. Senate,,DEM,Kamala Harris,37
-San Joaquin,914080,U.S. Senate,,DEM,Loretta Sanchez,18
-San Joaquin,914100,U.S. Senate,,DEM,Kamala Harris,77
-San Joaquin,914100,U.S. Senate,,DEM,Loretta Sanchez,35
-San Joaquin,914130,U.S. Senate,,DEM,Kamala Harris,13
-San Joaquin,914130,U.S. Senate,,DEM,Loretta Sanchez,2
-San Joaquin,914131,U.S. Senate,,DEM,Kamala Harris,8
-San Joaquin,914131,U.S. Senate,,DEM,Loretta Sanchez,2
-San Joaquin,914170,U.S. Senate,,DEM,Kamala Harris,29
-San Joaquin,914170,U.S. Senate,,DEM,Loretta Sanchez,17
-San Joaquin,914180,U.S. Senate,,DEM,Kamala Harris,29
-San Joaquin,914180,U.S. Senate,,DEM,Loretta Sanchez,24
-San Joaquin,914181,U.S. Senate,,DEM,Kamala Harris,14
-San Joaquin,914181,U.S. Senate,,DEM,Loretta Sanchez,12
-San Joaquin,923010,U.S. Senate,,DEM,Kamala Harris,8
-San Joaquin,923010,U.S. Senate,,DEM,Loretta Sanchez,4
-San Joaquin,924010,U.S. Senate,,DEM,Kamala Harris,55
-San Joaquin,924010,U.S. Senate,,DEM,Loretta Sanchez,39
-San Joaquin,924020,U.S. Senate,,DEM,Kamala Harris,50
-San Joaquin,924020,U.S. Senate,,DEM,Loretta Sanchez,22
-San Joaquin,924060,U.S. Senate,,DEM,Kamala Harris,15
-San Joaquin,924060,U.S. Senate,,DEM,Loretta Sanchez,5
-San Joaquin,924140,U.S. Senate,,DEM,Kamala Harris,16
-San Joaquin,924140,U.S. Senate,,DEM,Loretta Sanchez,19
-San Joaquin,924170,U.S. Senate,,DEM,Kamala Harris,83
-San Joaquin,924170,U.S. Senate,,DEM,Loretta Sanchez,60
-San Joaquin,924250,U.S. Senate,,DEM,Kamala Harris,1
-San Joaquin,924250,U.S. Senate,,DEM,Loretta Sanchez,10
-San Joaquin,924260,U.S. Senate,,DEM,Kamala Harris,5
-San Joaquin,924260,U.S. Senate,,DEM,Loretta Sanchez,9
-San Joaquin,924280,U.S. Senate,,DEM,Kamala Harris,2
-San Joaquin,924280,U.S. Senate,,DEM,Loretta Sanchez,2
-San Joaquin,924330,U.S. Senate,,DEM,Kamala Harris,18
-San Joaquin,924330,U.S. Senate,,DEM,Loretta Sanchez,18
-San Joaquin,924331,U.S. Senate,,DEM,Kamala Harris,67
-San Joaquin,924331,U.S. Senate,,DEM,Loretta Sanchez,67
-San Joaquin,933010,U.S. Senate,,DEM,Kamala Harris,32
-San Joaquin,933010,U.S. Senate,,DEM,Loretta Sanchez,25
-San Joaquin,933020,U.S. Senate,,DEM,Kamala Harris,48
-San Joaquin,933020,U.S. Senate,,DEM,Loretta Sanchez,53
-San Joaquin,933030,U.S. Senate,,DEM,Kamala Harris,15
-San Joaquin,933030,U.S. Senate,,DEM,Loretta Sanchez,14
-San Joaquin,933031,U.S. Senate,,DEM,Kamala Harris,1
-San Joaquin,933031,U.S. Senate,,DEM,Loretta Sanchez,0
-San Joaquin,935030,U.S. Senate,,DEM,Kamala Harris,42
-San Joaquin,935030,U.S. Senate,,DEM,Loretta Sanchez,48
-San Joaquin,935040,U.S. Senate,,DEM,Kamala Harris,10
-San Joaquin,935040,U.S. Senate,,DEM,Loretta Sanchez,4
-San Joaquin,935070,U.S. Senate,,DEM,Kamala Harris,49
-San Joaquin,935070,U.S. Senate,,DEM,Loretta Sanchez,32
-San Joaquin,935080,U.S. Senate,,DEM,Kamala Harris,80
-San Joaquin,935080,U.S. Senate,,DEM,Loretta Sanchez,56
-San Joaquin,935090,U.S. Senate,,DEM,Kamala Harris,7
-San Joaquin,935090,U.S. Senate,,DEM,Loretta Sanchez,10
-San Joaquin,935100,U.S. Senate,,DEM,Kamala Harris,63
-San Joaquin,935100,U.S. Senate,,DEM,Loretta Sanchez,58
-San Joaquin,935110,U.S. Senate,,DEM,Kamala Harris,22
-San Joaquin,935110,U.S. Senate,,DEM,Loretta Sanchez,16
-San Joaquin,935120,U.S. Senate,,DEM,Kamala Harris,4
-San Joaquin,935120,U.S. Senate,,DEM,Loretta Sanchez,11
-San Joaquin,935130,U.S. Senate,,DEM,Kamala Harris,10
-San Joaquin,935130,U.S. Senate,,DEM,Loretta Sanchez,5
-San Joaquin,935150,U.S. Senate,,DEM,Kamala Harris,76
-San Joaquin,935150,U.S. Senate,,DEM,Loretta Sanchez,53
-San Joaquin,935250,U.S. Senate,,DEM,Kamala Harris,0
-San Joaquin,935250,U.S. Senate,,DEM,Loretta Sanchez,0
-San Joaquin,935260,U.S. Senate,,DEM,Kamala Harris,2
-San Joaquin,935260,U.S. Senate,,DEM,Loretta Sanchez,3
-San Joaquin,935261,U.S. Senate,,DEM,Kamala Harris,18
-San Joaquin,935261,U.S. Senate,,DEM,Loretta Sanchez,21
-San Joaquin,935270,U.S. Senate,,DEM,Kamala Harris,2
-San Joaquin,935270,U.S. Senate,,DEM,Loretta Sanchez,24
-San Joaquin,935280,U.S. Senate,,DEM,Kamala Harris,1
-San Joaquin,935280,U.S. Senate,,DEM,Loretta Sanchez,0
-San Joaquin,935290,U.S. Senate,,DEM,Kamala Harris,4
-San Joaquin,935290,U.S. Senate,,DEM,Loretta Sanchez,4
-San Joaquin,935300,U.S. Senate,,DEM,Kamala Harris,3
-San Joaquin,935300,U.S. Senate,,DEM,Loretta Sanchez,3
-San Joaquin,935301,U.S. Senate,,DEM,Kamala Harris,0
-San Joaquin,935301,U.S. Senate,,DEM,Loretta Sanchez,0
-San Joaquin,941020,U.S. Senate,,DEM,Kamala Harris,0
-San Joaquin,941020,U.S. Senate,,DEM,Loretta Sanchez,1
-San Joaquin,941021,U.S. Senate,,DEM,Kamala Harris,0
-San Joaquin,941021,U.S. Senate,,DEM,Loretta Sanchez,0
-San Joaquin,941030,U.S. Senate,,DEM,Kamala Harris,22
-San Joaquin,941030,U.S. Senate,,DEM,Loretta Sanchez,11
-San Joaquin,941040,U.S. Senate,,DEM,Kamala Harris,12
-San Joaquin,941040,U.S. Senate,,DEM,Loretta Sanchez,17
-San Joaquin,941050,U.S. Senate,,DEM,Kamala Harris,43
-San Joaquin,941050,U.S. Senate,,DEM,Loretta Sanchez,60
-San Joaquin,941060,U.S. Senate,,DEM,Kamala Harris,31
-San Joaquin,941060,U.S. Senate,,DEM,Loretta Sanchez,24
-San Joaquin,941070,U.S. Senate,,DEM,Kamala Harris,57
-San Joaquin,941070,U.S. Senate,,DEM,Loretta Sanchez,62
-San Joaquin,941100,U.S. Senate,,DEM,Kamala Harris,2
-San Joaquin,941100,U.S. Senate,,DEM,Loretta Sanchez,7
-San Joaquin,941101,U.S. Senate,,DEM,Kamala Harris,4
-San Joaquin,941101,U.S. Senate,,DEM,Loretta Sanchez,3
-San Joaquin,941110,U.S. Senate,,DEM,Kamala Harris,5
-San Joaquin,941110,U.S. Senate,,DEM,Loretta Sanchez,4
-San Joaquin,941111,U.S. Senate,,DEM,Kamala Harris,0
-San Joaquin,941111,U.S. Senate,,DEM,Loretta Sanchez,0
-San Joaquin,941120,U.S. Senate,,DEM,Kamala Harris,40
-San Joaquin,941120,U.S. Senate,,DEM,Loretta Sanchez,49
-San Joaquin,943010,U.S. Senate,,DEM,Kamala Harris,28
-San Joaquin,943010,U.S. Senate,,DEM,Loretta Sanchez,18
-San Joaquin,943020,U.S. Senate,,DEM,Kamala Harris,52
-San Joaquin,943020,U.S. Senate,,DEM,Loretta Sanchez,34
-San Joaquin,943021,U.S. Senate,,DEM,Kamala Harris,49
-San Joaquin,943021,U.S. Senate,,DEM,Loretta Sanchez,20
-San Joaquin,943030,U.S. Senate,,DEM,Kamala Harris,72
-San Joaquin,943030,U.S. Senate,,DEM,Loretta Sanchez,57
-San Joaquin,943040,U.S. Senate,,DEM,Kamala Harris,36
-San Joaquin,943040,U.S. Senate,,DEM,Loretta Sanchez,12
-San Joaquin,943050,U.S. Senate,,DEM,Kamala Harris,97
-San Joaquin,943050,U.S. Senate,,DEM,Loretta Sanchez,75
-San Joaquin,943051,U.S. Senate,,DEM,Kamala Harris,4
-San Joaquin,943051,U.S. Senate,,DEM,Loretta Sanchez,3
-San Joaquin,943052,U.S. Senate,,DEM,Kamala Harris,52
-San Joaquin,943052,U.S. Senate,,DEM,Loretta Sanchez,37
-San Joaquin,943070,U.S. Senate,,DEM,Kamala Harris,15
-San Joaquin,943070,U.S. Senate,,DEM,Loretta Sanchez,21
-San Joaquin,943080,U.S. Senate,,DEM,Kamala Harris,49
-San Joaquin,943080,U.S. Senate,,DEM,Loretta Sanchez,30
-San Joaquin,943090,U.S. Senate,,DEM,Kamala Harris,0
-San Joaquin,943090,U.S. Senate,,DEM,Loretta Sanchez,0
-San Joaquin,943100,U.S. Senate,,DEM,Kamala Harris,2
-San Joaquin,943100,U.S. Senate,,DEM,Loretta Sanchez,0
-San Joaquin,943110,U.S. Senate,,DEM,Kamala Harris,0
-San Joaquin,943110,U.S. Senate,,DEM,Loretta Sanchez,0
-San Joaquin,943130,U.S. Senate,,DEM,Kamala Harris,15
-San Joaquin,943130,U.S. Senate,,DEM,Loretta Sanchez,13
-San Joaquin,944010,U.S. Senate,,DEM,Kamala Harris,10
-San Joaquin,944010,U.S. Senate,,DEM,Loretta Sanchez,16
-San Joaquin,944020,U.S. Senate,,DEM,Kamala Harris,5
-San Joaquin,944020,U.S. Senate,,DEM,Loretta Sanchez,2
-San Joaquin,944021,U.S. Senate,,DEM,Kamala Harris,2
-San Joaquin,944021,U.S. Senate,,DEM,Loretta Sanchez,0
-San Joaquin,944040,U.S. Senate,,DEM,Kamala Harris,11
-San Joaquin,944040,U.S. Senate,,DEM,Loretta Sanchez,28
-San Joaquin,944041,U.S. Senate,,DEM,Kamala Harris,71
-San Joaquin,944041,U.S. Senate,,DEM,Loretta Sanchez,51
-San Joaquin,944050,U.S. Senate,,DEM,Kamala Harris,59
-San Joaquin,944050,U.S. Senate,,DEM,Loretta Sanchez,72
-San Joaquin,944060,U.S. Senate,,DEM,Kamala Harris,73
-San Joaquin,944060,U.S. Senate,,DEM,Loretta Sanchez,47
-San Joaquin,944061,U.S. Senate,,DEM,Kamala Harris,62
-San Joaquin,944061,U.S. Senate,,DEM,Loretta Sanchez,39
-San Joaquin,944070,U.S. Senate,,DEM,Kamala Harris,43
-San Joaquin,944070,U.S. Senate,,DEM,Loretta Sanchez,51
-San Joaquin,944090,U.S. Senate,,DEM,Kamala Harris,78
-San Joaquin,944090,U.S. Senate,,DEM,Loretta Sanchez,73
-San Joaquin,944091,U.S. Senate,,DEM,Kamala Harris,27
-San Joaquin,944091,U.S. Senate,,DEM,Loretta Sanchez,26
-San Joaquin,944130,U.S. Senate,,DEM,Kamala Harris,11
-San Joaquin,944130,U.S. Senate,,DEM,Loretta Sanchez,12
-San Joaquin,945020,U.S. Senate,,DEM,Kamala Harris,0
-San Joaquin,945020,U.S. Senate,,DEM,Loretta Sanchez,0
-San Joaquin,945030,U.S. Senate,,DEM,Kamala Harris,1
-San Joaquin,945030,U.S. Senate,,DEM,Loretta Sanchez,0
-San Joaquin,945031,U.S. Senate,,DEM,Kamala Harris,2
-San Joaquin,945031,U.S. Senate,,DEM,Loretta Sanchez,0
-San Joaquin,945032,U.S. Senate,,DEM,Kamala Harris,0
-San Joaquin,945032,U.S. Senate,,DEM,Loretta Sanchez,0
-San Joaquin,945040,U.S. Senate,,DEM,Kamala Harris,10
-San Joaquin,945040,U.S. Senate,,DEM,Loretta Sanchez,5
-San Joaquin,945050,U.S. Senate,,DEM,Kamala Harris,2
-San Joaquin,945050,U.S. Senate,,DEM,Loretta Sanchez,1
-San Joaquin,945051,U.S. Senate,,DEM,Kamala Harris,37
-San Joaquin,945051,U.S. Senate,,DEM,Loretta Sanchez,25
-San Joaquin,945060,U.S. Senate,,DEM,Kamala Harris,76
-San Joaquin,945060,U.S. Senate,,DEM,Loretta Sanchez,62
-San Joaquin,945061,U.S. Senate,,DEM,Kamala Harris,0
-San Joaquin,945061,U.S. Senate,,DEM,Loretta Sanchez,0
-San Joaquin,945062,U.S. Senate,,DEM,Kamala Harris,0
-San Joaquin,945062,U.S. Senate,,DEM,Loretta Sanchez,0
-San Joaquin,945063,U.S. Senate,,DEM,Kamala Harris,8
-San Joaquin,945063,U.S. Senate,,DEM,Loretta Sanchez,2
+San Joaquin,11101,U.S. Senate,,DEM,Kamala D. Harris,106
+San Joaquin,11101,U.S. Senate,,DEM,Loretta L. Sanchez,124
+San Joaquin,11102,U.S. Senate,,DEM,Kamala D. Harris,180
+San Joaquin,11102,U.S. Senate,,DEM,Loretta L. Sanchez,224
+San Joaquin,11103,U.S. Senate,,DEM,Kamala D. Harris,211
+San Joaquin,11103,U.S. Senate,,DEM,Loretta L. Sanchez,196
+San Joaquin,11104,U.S. Senate,,DEM,Kamala D. Harris,349
+San Joaquin,11104,U.S. Senate,,DEM,Loretta L. Sanchez,459
+San Joaquin,11105,U.S. Senate,,DEM,Kamala D. Harris,179
+San Joaquin,11105,U.S. Senate,,DEM,Loretta L. Sanchez,148
+San Joaquin,11107,U.S. Senate,,DEM,Kamala D. Harris,170
+San Joaquin,11107,U.S. Senate,,DEM,Loretta L. Sanchez,187
+San Joaquin,11108,U.S. Senate,,DEM,Kamala D. Harris,126
+San Joaquin,11108,U.S. Senate,,DEM,Loretta L. Sanchez,201
+San Joaquin,11109,U.S. Senate,,DEM,Kamala D. Harris,156
+San Joaquin,11109,U.S. Senate,,DEM,Loretta L. Sanchez,237
+San Joaquin,11110,U.S. Senate,,DEM,Kamala D. Harris,238
+San Joaquin,11110,U.S. Senate,,DEM,Loretta L. Sanchez,187
+San Joaquin,11111,U.S. Senate,,DEM,Kamala D. Harris,438
+San Joaquin,11111,U.S. Senate,,DEM,Loretta L. Sanchez,332
+San Joaquin,11112,U.S. Senate,,DEM,Kamala D. Harris,112
+San Joaquin,11112,U.S. Senate,,DEM,Loretta L. Sanchez,201
+San Joaquin,11114,U.S. Senate,,DEM,Kamala D. Harris,462
+San Joaquin,11114,U.S. Senate,,DEM,Loretta L. Sanchez,293
+San Joaquin,11115,U.S. Senate,,DEM,Kamala D. Harris,325
+San Joaquin,11115,U.S. Senate,,DEM,Loretta L. Sanchez,311
+San Joaquin,11116,U.S. Senate,,DEM,Kamala D. Harris,339
+San Joaquin,11116,U.S. Senate,,DEM,Loretta L. Sanchez,403
+San Joaquin,11117,U.S. Senate,,DEM,Kamala D. Harris,388
+San Joaquin,11117,U.S. Senate,,DEM,Loretta L. Sanchez,285
+San Joaquin,11118,U.S. Senate,,DEM,Kamala D. Harris,484
+San Joaquin,11118,U.S. Senate,,DEM,Loretta L. Sanchez,325
+San Joaquin,11119,U.S. Senate,,DEM,Kamala D. Harris,53
+San Joaquin,11119,U.S. Senate,,DEM,Loretta L. Sanchez,68
+San Joaquin,11120,U.S. Senate,,DEM,Kamala D. Harris,291
+San Joaquin,11120,U.S. Senate,,DEM,Loretta L. Sanchez,436
+San Joaquin,11121,U.S. Senate,,DEM,Kamala D. Harris,462
+San Joaquin,11121,U.S. Senate,,DEM,Loretta L. Sanchez,313
+San Joaquin,11122,U.S. Senate,,DEM,Kamala D. Harris,334
+San Joaquin,11122,U.S. Senate,,DEM,Loretta L. Sanchez,428
+San Joaquin,11124,U.S. Senate,,DEM,Kamala D. Harris,182
+San Joaquin,11124,U.S. Senate,,DEM,Loretta L. Sanchez,204
+San Joaquin,11125,U.S. Senate,,DEM,Kamala D. Harris,602
+San Joaquin,11125,U.S. Senate,,DEM,Loretta L. Sanchez,304
+San Joaquin,11127,U.S. Senate,,DEM,Kamala D. Harris,327
+San Joaquin,11127,U.S. Senate,,DEM,Loretta L. Sanchez,518
+San Joaquin,11130,U.S. Senate,,DEM,Kamala D. Harris,125
+San Joaquin,11130,U.S. Senate,,DEM,Loretta L. Sanchez,95
+San Joaquin,11134,U.S. Senate,,DEM,Kamala D. Harris,215
+San Joaquin,11134,U.S. Senate,,DEM,Loretta L. Sanchez,173
+San Joaquin,11137,U.S. Senate,,DEM,Kamala D. Harris,247
+San Joaquin,11137,U.S. Senate,,DEM,Loretta L. Sanchez,225
+San Joaquin,11140,U.S. Senate,,DEM,Kamala D. Harris,112
+San Joaquin,11140,U.S. Senate,,DEM,Loretta L. Sanchez,192
+San Joaquin,11142,U.S. Senate,,DEM,Kamala D. Harris,559
+San Joaquin,11142,U.S. Senate,,DEM,Loretta L. Sanchez,390
+San Joaquin,11146,U.S. Senate,,DEM,Kamala D. Harris,332
+San Joaquin,11146,U.S. Senate,,DEM,Loretta L. Sanchez,213
+San Joaquin,11147,U.S. Senate,,DEM,Kamala D. Harris,222
+San Joaquin,11147,U.S. Senate,,DEM,Loretta L. Sanchez,210
+San Joaquin,11149,U.S. Senate,,DEM,Kamala D. Harris,454
+San Joaquin,11149,U.S. Senate,,DEM,Loretta L. Sanchez,266
+San Joaquin,11151,U.S. Senate,,DEM,Kamala D. Harris,330
+San Joaquin,11151,U.S. Senate,,DEM,Loretta L. Sanchez,297
+San Joaquin,11152,U.S. Senate,,DEM,Kamala D. Harris,394
+San Joaquin,11152,U.S. Senate,,DEM,Loretta L. Sanchez,248
+San Joaquin,11155,U.S. Senate,,DEM,Kamala D. Harris,130
+San Joaquin,11155,U.S. Senate,,DEM,Loretta L. Sanchez,187
+San Joaquin,11157,U.S. Senate,,DEM,Kamala D. Harris,260
+San Joaquin,11157,U.S. Senate,,DEM,Loretta L. Sanchez,291
+San Joaquin,11158,U.S. Senate,,DEM,Kamala D. Harris,251
+San Joaquin,11158,U.S. Senate,,DEM,Loretta L. Sanchez,233
+San Joaquin,11164,U.S. Senate,,DEM,Kamala D. Harris,251
+San Joaquin,11164,U.S. Senate,,DEM,Loretta L. Sanchez,286
+San Joaquin,11168,U.S. Senate,,DEM,Kamala D. Harris,293
+San Joaquin,11168,U.S. Senate,,DEM,Loretta L. Sanchez,283
+San Joaquin,11169,U.S. Senate,,DEM,Kamala D. Harris,545
+San Joaquin,11169,U.S. Senate,,DEM,Loretta L. Sanchez,458
+San Joaquin,11201,U.S. Senate,,DEM,Kamala D. Harris,585
+San Joaquin,11201,U.S. Senate,,DEM,Loretta L. Sanchez,269
+San Joaquin,11203,U.S. Senate,,DEM,Kamala D. Harris,585
+San Joaquin,11203,U.S. Senate,,DEM,Loretta L. Sanchez,278
+San Joaquin,11205,U.S. Senate,,DEM,Kamala D. Harris,199
+San Joaquin,11205,U.S. Senate,,DEM,Loretta L. Sanchez,111
+San Joaquin,11206,U.S. Senate,,DEM,Kamala D. Harris,544
+San Joaquin,11206,U.S. Senate,,DEM,Loretta L. Sanchez,321
+San Joaquin,11208,U.S. Senate,,DEM,Kamala D. Harris,393
+San Joaquin,11208,U.S. Senate,,DEM,Loretta L. Sanchez,291
+San Joaquin,11209,U.S. Senate,,DEM,Kamala D. Harris,353
+San Joaquin,11209,U.S. Senate,,DEM,Loretta L. Sanchez,159
+San Joaquin,11211,U.S. Senate,,DEM,Kamala D. Harris,487
+San Joaquin,11211,U.S. Senate,,DEM,Loretta L. Sanchez,273
+San Joaquin,11212,U.S. Senate,,DEM,Kamala D. Harris,195
+San Joaquin,11212,U.S. Senate,,DEM,Loretta L. Sanchez,151
+San Joaquin,11214,U.S. Senate,,DEM,Kamala D. Harris,343
+San Joaquin,11214,U.S. Senate,,DEM,Loretta L. Sanchez,255
+San Joaquin,11215,U.S. Senate,,DEM,Kamala D. Harris,320
+San Joaquin,11215,U.S. Senate,,DEM,Loretta L. Sanchez,202
+San Joaquin,11216,U.S. Senate,,DEM,Kamala D. Harris,163
+San Joaquin,11216,U.S. Senate,,DEM,Loretta L. Sanchez,136
+San Joaquin,11217,U.S. Senate,,DEM,Kamala D. Harris,696
+San Joaquin,11217,U.S. Senate,,DEM,Loretta L. Sanchez,306
+San Joaquin,11218,U.S. Senate,,DEM,Kamala D. Harris,274
+San Joaquin,11218,U.S. Senate,,DEM,Loretta L. Sanchez,190
+San Joaquin,11219,U.S. Senate,,DEM,Kamala D. Harris,516
+San Joaquin,11219,U.S. Senate,,DEM,Loretta L. Sanchez,245
+San Joaquin,11220,U.S. Senate,,DEM,Kamala D. Harris,188
+San Joaquin,11220,U.S. Senate,,DEM,Loretta L. Sanchez,129
+San Joaquin,11221,U.S. Senate,,DEM,Kamala D. Harris,357
+San Joaquin,11221,U.S. Senate,,DEM,Loretta L. Sanchez,190
+San Joaquin,11224,U.S. Senate,,DEM,Kamala D. Harris,345
+San Joaquin,11224,U.S. Senate,,DEM,Loretta L. Sanchez,256
+San Joaquin,11226,U.S. Senate,,DEM,Kamala D. Harris,456
+San Joaquin,11226,U.S. Senate,,DEM,Loretta L. Sanchez,351
+San Joaquin,11227,U.S. Senate,,DEM,Kamala D. Harris,234
+San Joaquin,11227,U.S. Senate,,DEM,Loretta L. Sanchez,175
+San Joaquin,11228,U.S. Senate,,DEM,Kamala D. Harris,213
+San Joaquin,11228,U.S. Senate,,DEM,Loretta L. Sanchez,140
+San Joaquin,11229,U.S. Senate,,DEM,Kamala D. Harris,625
+San Joaquin,11229,U.S. Senate,,DEM,Loretta L. Sanchez,335
+San Joaquin,11230,U.S. Senate,,DEM,Kamala D. Harris,303
+San Joaquin,11230,U.S. Senate,,DEM,Loretta L. Sanchez,190
+San Joaquin,11232,U.S. Senate,,DEM,Kamala D. Harris,433
+San Joaquin,11232,U.S. Senate,,DEM,Loretta L. Sanchez,346
+San Joaquin,11233,U.S. Senate,,DEM,Kamala D. Harris,250
+San Joaquin,11233,U.S. Senate,,DEM,Loretta L. Sanchez,125
+San Joaquin,11235,U.S. Senate,,DEM,Kamala D. Harris,174
+San Joaquin,11235,U.S. Senate,,DEM,Loretta L. Sanchez,141
+San Joaquin,11237,U.S. Senate,,DEM,Kamala D. Harris,280
+San Joaquin,11237,U.S. Senate,,DEM,Loretta L. Sanchez,234
+San Joaquin,11238,U.S. Senate,,DEM,Kamala D. Harris,623
+San Joaquin,11238,U.S. Senate,,DEM,Loretta L. Sanchez,431
+San Joaquin,11241,U.S. Senate,,DEM,Kamala D. Harris,435
+San Joaquin,11241,U.S. Senate,,DEM,Loretta L. Sanchez,215
+San Joaquin,11242,U.S. Senate,,DEM,Kamala D. Harris,514
+San Joaquin,11242,U.S. Senate,,DEM,Loretta L. Sanchez,308
+San Joaquin,11243,U.S. Senate,,DEM,Kamala D. Harris,507
+San Joaquin,11243,U.S. Senate,,DEM,Loretta L. Sanchez,301
+San Joaquin,11245,U.S. Senate,,DEM,Kamala D. Harris,390
+San Joaquin,11245,U.S. Senate,,DEM,Loretta L. Sanchez,208
+San Joaquin,11249,U.S. Senate,,DEM,Kamala D. Harris,474
+San Joaquin,11249,U.S. Senate,,DEM,Loretta L. Sanchez,332
+San Joaquin,11251,U.S. Senate,,DEM,Kamala D. Harris,332
+San Joaquin,11251,U.S. Senate,,DEM,Loretta L. Sanchez,239
+San Joaquin,11253,U.S. Senate,,DEM,Kamala D. Harris,446
+San Joaquin,11253,U.S. Senate,,DEM,Loretta L. Sanchez,271
+San Joaquin,11254,U.S. Senate,,DEM,Kamala D. Harris,332
+San Joaquin,11254,U.S. Senate,,DEM,Loretta L. Sanchez,273
+San Joaquin,11255,U.S. Senate,,DEM,Kamala D. Harris,455
+San Joaquin,11255,U.S. Senate,,DEM,Loretta L. Sanchez,303
+San Joaquin,11256,U.S. Senate,,DEM,Kamala D. Harris,310
+San Joaquin,11256,U.S. Senate,,DEM,Loretta L. Sanchez,231
+San Joaquin,11258,U.S. Senate,,DEM,Kamala D. Harris,552
+San Joaquin,11258,U.S. Senate,,DEM,Loretta L. Sanchez,392
+San Joaquin,11259,U.S. Senate,,DEM,Kamala D. Harris,251
+San Joaquin,11259,U.S. Senate,,DEM,Loretta L. Sanchez,126
+San Joaquin,11263,U.S. Senate,,DEM,Kamala D. Harris,244
+San Joaquin,11263,U.S. Senate,,DEM,Loretta L. Sanchez,241
+San Joaquin,11265,U.S. Senate,,DEM,Kamala D. Harris,228
+San Joaquin,11265,U.S. Senate,,DEM,Loretta L. Sanchez,121
+San Joaquin,11266,U.S. Senate,,DEM,Kamala D. Harris,440
+San Joaquin,11266,U.S. Senate,,DEM,Loretta L. Sanchez,344
+San Joaquin,11270,U.S. Senate,,DEM,Kamala D. Harris,352
+San Joaquin,11270,U.S. Senate,,DEM,Loretta L. Sanchez,311
+San Joaquin,11271,U.S. Senate,,DEM,Kamala D. Harris,263
+San Joaquin,11271,U.S. Senate,,DEM,Loretta L. Sanchez,241
+San Joaquin,11272,U.S. Senate,,DEM,Kamala D. Harris,631
+San Joaquin,11272,U.S. Senate,,DEM,Loretta L. Sanchez,509
+San Joaquin,11274,U.S. Senate,,DEM,Kamala D. Harris,147
+San Joaquin,11274,U.S. Senate,,DEM,Loretta L. Sanchez,136
+San Joaquin,11275,U.S. Senate,,DEM,Kamala D. Harris,405
+San Joaquin,11275,U.S. Senate,,DEM,Loretta L. Sanchez,313
+San Joaquin,11278,U.S. Senate,,DEM,Kamala D. Harris,185
+San Joaquin,11278,U.S. Senate,,DEM,Loretta L. Sanchez,178
+San Joaquin,11302,U.S. Senate,,DEM,Kamala D. Harris,391
+San Joaquin,11302,U.S. Senate,,DEM,Loretta L. Sanchez,318
+San Joaquin,11303,U.S. Senate,,DEM,Kamala D. Harris,531
+San Joaquin,11303,U.S. Senate,,DEM,Loretta L. Sanchez,322
+San Joaquin,11304,U.S. Senate,,DEM,Kamala D. Harris,372
+San Joaquin,11304,U.S. Senate,,DEM,Loretta L. Sanchez,200
+San Joaquin,11305,U.S. Senate,,DEM,Kamala D. Harris,748
+San Joaquin,11305,U.S. Senate,,DEM,Loretta L. Sanchez,382
+San Joaquin,11306,U.S. Senate,,DEM,Kamala D. Harris,260
+San Joaquin,11306,U.S. Senate,,DEM,Loretta L. Sanchez,187
+San Joaquin,11307,U.S. Senate,,DEM,Kamala D. Harris,312
+San Joaquin,11307,U.S. Senate,,DEM,Loretta L. Sanchez,235
+San Joaquin,11308,U.S. Senate,,DEM,Kamala D. Harris,511
+San Joaquin,11308,U.S. Senate,,DEM,Loretta L. Sanchez,257
+San Joaquin,11309,U.S. Senate,,DEM,Kamala D. Harris,395
+San Joaquin,11309,U.S. Senate,,DEM,Loretta L. Sanchez,220
+San Joaquin,11310,U.S. Senate,,DEM,Kamala D. Harris,275
+San Joaquin,11310,U.S. Senate,,DEM,Loretta L. Sanchez,189
+San Joaquin,11311,U.S. Senate,,DEM,Kamala D. Harris,330
+San Joaquin,11311,U.S. Senate,,DEM,Loretta L. Sanchez,174
+San Joaquin,11312,U.S. Senate,,DEM,Kamala D. Harris,575
+San Joaquin,11312,U.S. Senate,,DEM,Loretta L. Sanchez,321
+San Joaquin,11314,U.S. Senate,,DEM,Kamala D. Harris,522
+San Joaquin,11314,U.S. Senate,,DEM,Loretta L. Sanchez,267
+San Joaquin,11315,U.S. Senate,,DEM,Kamala D. Harris,409
+San Joaquin,11315,U.S. Senate,,DEM,Loretta L. Sanchez,313
+San Joaquin,11316,U.S. Senate,,DEM,Kamala D. Harris,223
+San Joaquin,11316,U.S. Senate,,DEM,Loretta L. Sanchez,163
+San Joaquin,11317,U.S. Senate,,DEM,Kamala D. Harris,206
+San Joaquin,11317,U.S. Senate,,DEM,Loretta L. Sanchez,166
+San Joaquin,11319,U.S. Senate,,DEM,Kamala D. Harris,141
+San Joaquin,11319,U.S. Senate,,DEM,Loretta L. Sanchez,124
+San Joaquin,11320,U.S. Senate,,DEM,Kamala D. Harris,591
+San Joaquin,11320,U.S. Senate,,DEM,Loretta L. Sanchez,358
+San Joaquin,11321,U.S. Senate,,DEM,Kamala D. Harris,590
+San Joaquin,11321,U.S. Senate,,DEM,Loretta L. Sanchez,380
+San Joaquin,11322,U.S. Senate,,DEM,Kamala D. Harris,398
+San Joaquin,11322,U.S. Senate,,DEM,Loretta L. Sanchez,289
+San Joaquin,11323,U.S. Senate,,DEM,Kamala D. Harris,490
+San Joaquin,11323,U.S. Senate,,DEM,Loretta L. Sanchez,312
+San Joaquin,11324,U.S. Senate,,DEM,Kamala D. Harris,367
+San Joaquin,11324,U.S. Senate,,DEM,Loretta L. Sanchez,219
+San Joaquin,11325,U.S. Senate,,DEM,Kamala D. Harris,682
+San Joaquin,11325,U.S. Senate,,DEM,Loretta L. Sanchez,370
+San Joaquin,11326,U.S. Senate,,DEM,Kamala D. Harris,235
+San Joaquin,11326,U.S. Senate,,DEM,Loretta L. Sanchez,171
+San Joaquin,11327,U.S. Senate,,DEM,Kamala D. Harris,582
+San Joaquin,11327,U.S. Senate,,DEM,Loretta L. Sanchez,444
+San Joaquin,11332,U.S. Senate,,DEM,Kamala D. Harris,631
+San Joaquin,11332,U.S. Senate,,DEM,Loretta L. Sanchez,404
+San Joaquin,11333,U.S. Senate,,DEM,Kamala D. Harris,272
+San Joaquin,11333,U.S. Senate,,DEM,Loretta L. Sanchez,186
+San Joaquin,11335,U.S. Senate,,DEM,Kamala D. Harris,562
+San Joaquin,11335,U.S. Senate,,DEM,Loretta L. Sanchez,343
+San Joaquin,11338,U.S. Senate,,DEM,Kamala D. Harris,414
+San Joaquin,11338,U.S. Senate,,DEM,Loretta L. Sanchez,292
+San Joaquin,11342,U.S. Senate,,DEM,Kamala D. Harris,244
+San Joaquin,11342,U.S. Senate,,DEM,Loretta L. Sanchez,110
+San Joaquin,11343,U.S. Senate,,DEM,Kamala D. Harris,270
+San Joaquin,11343,U.S. Senate,,DEM,Loretta L. Sanchez,158
+San Joaquin,11345,U.S. Senate,,DEM,Kamala D. Harris,279
+San Joaquin,11345,U.S. Senate,,DEM,Loretta L. Sanchez,162
+San Joaquin,11346,U.S. Senate,,DEM,Kamala D. Harris,273
+San Joaquin,11346,U.S. Senate,,DEM,Loretta L. Sanchez,182
+San Joaquin,11348,U.S. Senate,,DEM,Kamala D. Harris,339
+San Joaquin,11348,U.S. Senate,,DEM,Loretta L. Sanchez,208
+San Joaquin,33501,U.S. Senate,,DEM,Kamala D. Harris,291
+San Joaquin,33501,U.S. Senate,,DEM,Loretta L. Sanchez,303
+San Joaquin,33502,U.S. Senate,,DEM,Kamala D. Harris,497
+San Joaquin,33502,U.S. Senate,,DEM,Loretta L. Sanchez,304
+San Joaquin,33503,U.S. Senate,,DEM,Kamala D. Harris,328
+San Joaquin,33503,U.S. Senate,,DEM,Loretta L. Sanchez,243
+San Joaquin,33504,U.S. Senate,,DEM,Kamala D. Harris,366
+San Joaquin,33504,U.S. Senate,,DEM,Loretta L. Sanchez,371
+San Joaquin,33505,U.S. Senate,,DEM,Kamala D. Harris,482
+San Joaquin,33505,U.S. Senate,,DEM,Loretta L. Sanchez,473
+San Joaquin,33507,U.S. Senate,,DEM,Kamala D. Harris,448
+San Joaquin,33507,U.S. Senate,,DEM,Loretta L. Sanchez,392
+San Joaquin,33509,U.S. Senate,,DEM,Kamala D. Harris,573
+San Joaquin,33509,U.S. Senate,,DEM,Loretta L. Sanchez,533
+San Joaquin,33512,U.S. Senate,,DEM,Kamala D. Harris,192
+San Joaquin,33512,U.S. Senate,,DEM,Loretta L. Sanchez,189
+San Joaquin,33513,U.S. Senate,,DEM,Kamala D. Harris,138
+San Joaquin,33513,U.S. Senate,,DEM,Loretta L. Sanchez,143
+San Joaquin,33514,U.S. Senate,,DEM,Kamala D. Harris,483
+San Joaquin,33514,U.S. Senate,,DEM,Loretta L. Sanchez,297
+San Joaquin,33515,U.S. Senate,,DEM,Kamala D. Harris,328
+San Joaquin,33515,U.S. Senate,,DEM,Loretta L. Sanchez,211
+San Joaquin,33517,U.S. Senate,,DEM,Kamala D. Harris,299
+San Joaquin,33517,U.S. Senate,,DEM,Loretta L. Sanchez,226
+San Joaquin,33518,U.S. Senate,,DEM,Kamala D. Harris,366
+San Joaquin,33518,U.S. Senate,,DEM,Loretta L. Sanchez,309
+San Joaquin,33520,U.S. Senate,,DEM,Kamala D. Harris,604
+San Joaquin,33520,U.S. Senate,,DEM,Loretta L. Sanchez,479
+San Joaquin,33522,U.S. Senate,,DEM,Kamala D. Harris,362
+San Joaquin,33522,U.S. Senate,,DEM,Loretta L. Sanchez,313
+San Joaquin,33523,U.S. Senate,,DEM,Kamala D. Harris,355
+San Joaquin,33523,U.S. Senate,,DEM,Loretta L. Sanchez,335
+San Joaquin,33524,U.S. Senate,,DEM,Kamala D. Harris,327
+San Joaquin,33524,U.S. Senate,,DEM,Loretta L. Sanchez,245
+San Joaquin,33525,U.S. Senate,,DEM,Kamala D. Harris,561
+San Joaquin,33525,U.S. Senate,,DEM,Loretta L. Sanchez,349
+San Joaquin,33527,U.S. Senate,,DEM,Kamala D. Harris,287
+San Joaquin,33527,U.S. Senate,,DEM,Loretta L. Sanchez,244
+San Joaquin,33529,U.S. Senate,,DEM,Kamala D. Harris,263
+San Joaquin,33529,U.S. Senate,,DEM,Loretta L. Sanchez,181
+San Joaquin,33530,U.S. Senate,,DEM,Kamala D. Harris,318
+San Joaquin,33530,U.S. Senate,,DEM,Loretta L. Sanchez,212
+San Joaquin,33532,U.S. Senate,,DEM,Kamala D. Harris,372
+San Joaquin,33532,U.S. Senate,,DEM,Loretta L. Sanchez,309
+San Joaquin,33533,U.S. Senate,,DEM,Kamala D. Harris,247
+San Joaquin,33533,U.S. Senate,,DEM,Loretta L. Sanchez,198
+San Joaquin,33534,U.S. Senate,,DEM,Kamala D. Harris,435
+San Joaquin,33534,U.S. Senate,,DEM,Loretta L. Sanchez,341
+San Joaquin,33535,U.S. Senate,,DEM,Kamala D. Harris,384
+San Joaquin,33535,U.S. Senate,,DEM,Loretta L. Sanchez,266
+San Joaquin,33537,U.S. Senate,,DEM,Kamala D. Harris,205
+San Joaquin,33537,U.S. Senate,,DEM,Loretta L. Sanchez,172
+San Joaquin,33540,U.S. Senate,,DEM,Kamala D. Harris,666
+San Joaquin,33540,U.S. Senate,,DEM,Loretta L. Sanchez,470
+San Joaquin,33542,U.S. Senate,,DEM,Kamala D. Harris,374
+San Joaquin,33542,U.S. Senate,,DEM,Loretta L. Sanchez,235
+San Joaquin,33543,U.S. Senate,,DEM,Kamala D. Harris,367
+San Joaquin,33543,U.S. Senate,,DEM,Loretta L. Sanchez,214
+San Joaquin,33545,U.S. Senate,,DEM,Kamala D. Harris,387
+San Joaquin,33545,U.S. Senate,,DEM,Loretta L. Sanchez,247
+San Joaquin,33546,U.S. Senate,,DEM,Kamala D. Harris,745
+San Joaquin,33546,U.S. Senate,,DEM,Loretta L. Sanchez,469
+San Joaquin,33547,U.S. Senate,,DEM,Kamala D. Harris,374
+San Joaquin,33547,U.S. Senate,,DEM,Loretta L. Sanchez,266
+San Joaquin,33548,U.S. Senate,,DEM,Kamala D. Harris,216
+San Joaquin,33548,U.S. Senate,,DEM,Loretta L. Sanchez,150
+San Joaquin,33551,U.S. Senate,,DEM,Kamala D. Harris,424
+San Joaquin,33551,U.S. Senate,,DEM,Loretta L. Sanchez,266
+San Joaquin,33552,U.S. Senate,,DEM,Kamala D. Harris,517
+San Joaquin,33552,U.S. Senate,,DEM,Loretta L. Sanchez,361
+San Joaquin,33554,U.S. Senate,,DEM,Kamala D. Harris,432
+San Joaquin,33554,U.S. Senate,,DEM,Loretta L. Sanchez,258
+San Joaquin,42401,U.S. Senate,,DEM,Kamala D. Harris,373
+San Joaquin,42401,U.S. Senate,,DEM,Loretta L. Sanchez,233
+San Joaquin,42402,U.S. Senate,,DEM,Kamala D. Harris,485
+San Joaquin,42402,U.S. Senate,,DEM,Loretta L. Sanchez,293
+San Joaquin,42403,U.S. Senate,,DEM,Kamala D. Harris,270
+San Joaquin,42403,U.S. Senate,,DEM,Loretta L. Sanchez,375
+San Joaquin,42404,U.S. Senate,,DEM,Kamala D. Harris,457
+San Joaquin,42404,U.S. Senate,,DEM,Loretta L. Sanchez,408
+San Joaquin,42405,U.S. Senate,,DEM,Kamala D. Harris,354
+San Joaquin,42405,U.S. Senate,,DEM,Loretta L. Sanchez,363
+San Joaquin,42406,U.S. Senate,,DEM,Kamala D. Harris,647
+San Joaquin,42406,U.S. Senate,,DEM,Loretta L. Sanchez,413
+San Joaquin,42407,U.S. Senate,,DEM,Kamala D. Harris,356
+San Joaquin,42407,U.S. Senate,,DEM,Loretta L. Sanchez,231
+San Joaquin,42408,U.S. Senate,,DEM,Kamala D. Harris,403
+San Joaquin,42408,U.S. Senate,,DEM,Loretta L. Sanchez,287
+San Joaquin,42410,U.S. Senate,,DEM,Kamala D. Harris,252
+San Joaquin,42410,U.S. Senate,,DEM,Loretta L. Sanchez,140
+San Joaquin,42411,U.S. Senate,,DEM,Kamala D. Harris,301
+San Joaquin,42411,U.S. Senate,,DEM,Loretta L. Sanchez,145
+San Joaquin,42412,U.S. Senate,,DEM,Kamala D. Harris,233
+San Joaquin,42412,U.S. Senate,,DEM,Loretta L. Sanchez,143
+San Joaquin,42413,U.S. Senate,,DEM,Kamala D. Harris,447
+San Joaquin,42413,U.S. Senate,,DEM,Loretta L. Sanchez,270
+San Joaquin,42414,U.S. Senate,,DEM,Kamala D. Harris,222
+San Joaquin,42414,U.S. Senate,,DEM,Loretta L. Sanchez,224
+San Joaquin,42416,U.S. Senate,,DEM,Kamala D. Harris,357
+San Joaquin,42416,U.S. Senate,,DEM,Loretta L. Sanchez,201
+San Joaquin,42417,U.S. Senate,,DEM,Kamala D. Harris,224
+San Joaquin,42417,U.S. Senate,,DEM,Loretta L. Sanchez,155
+San Joaquin,42418,U.S. Senate,,DEM,Kamala D. Harris,480
+San Joaquin,42418,U.S. Senate,,DEM,Loretta L. Sanchez,320
+San Joaquin,42419,U.S. Senate,,DEM,Kamala D. Harris,308
+San Joaquin,42419,U.S. Senate,,DEM,Loretta L. Sanchez,238
+San Joaquin,42420,U.S. Senate,,DEM,Kamala D. Harris,163
+San Joaquin,42420,U.S. Senate,,DEM,Loretta L. Sanchez,130
+San Joaquin,42421,U.S. Senate,,DEM,Kamala D. Harris,371
+San Joaquin,42421,U.S. Senate,,DEM,Loretta L. Sanchez,209
+San Joaquin,42422,U.S. Senate,,DEM,Kamala D. Harris,212
+San Joaquin,42422,U.S. Senate,,DEM,Loretta L. Sanchez,122
+San Joaquin,42423,U.S. Senate,,DEM,Kamala D. Harris,424
+San Joaquin,42423,U.S. Senate,,DEM,Loretta L. Sanchez,263
+San Joaquin,42424,U.S. Senate,,DEM,Kamala D. Harris,265
+San Joaquin,42424,U.S. Senate,,DEM,Loretta L. Sanchez,196
+San Joaquin,42426,U.S. Senate,,DEM,Kamala D. Harris,373
+San Joaquin,42426,U.S. Senate,,DEM,Loretta L. Sanchez,274
+San Joaquin,42430,U.S. Senate,,DEM,Kamala D. Harris,199
+San Joaquin,42430,U.S. Senate,,DEM,Loretta L. Sanchez,141
+San Joaquin,42432,U.S. Senate,,DEM,Kamala D. Harris,349
+San Joaquin,42432,U.S. Senate,,DEM,Loretta L. Sanchez,230
+San Joaquin,42433,U.S. Senate,,DEM,Kamala D. Harris,264
+San Joaquin,42433,U.S. Senate,,DEM,Loretta L. Sanchez,164
+San Joaquin,42437,U.S. Senate,,DEM,Kamala D. Harris,162
+San Joaquin,42437,U.S. Senate,,DEM,Loretta L. Sanchez,255
+San Joaquin,42439,U.S. Senate,,DEM,Kamala D. Harris,350
+San Joaquin,42439,U.S. Senate,,DEM,Loretta L. Sanchez,204
+San Joaquin,42441,U.S. Senate,,DEM,Kamala D. Harris,360
+San Joaquin,42441,U.S. Senate,,DEM,Loretta L. Sanchez,223
+San Joaquin,42444,U.S. Senate,,DEM,Kamala D. Harris,191
+San Joaquin,42444,U.S. Senate,,DEM,Loretta L. Sanchez,239
+San Joaquin,42446,U.S. Senate,,DEM,Kamala D. Harris,299
+San Joaquin,42446,U.S. Senate,,DEM,Loretta L. Sanchez,236
+San Joaquin,42449,U.S. Senate,,DEM,Kamala D. Harris,325
+San Joaquin,42449,U.S. Senate,,DEM,Loretta L. Sanchez,230
+San Joaquin,54301,U.S. Senate,,DEM,Kamala D. Harris,563
+San Joaquin,54301,U.S. Senate,,DEM,Loretta L. Sanchez,346
+San Joaquin,54302,U.S. Senate,,DEM,Kamala D. Harris,513
+San Joaquin,54302,U.S. Senate,,DEM,Loretta L. Sanchez,426
+San Joaquin,54304,U.S. Senate,,DEM,Kamala D. Harris,272
+San Joaquin,54304,U.S. Senate,,DEM,Loretta L. Sanchez,235
+San Joaquin,54305,U.S. Senate,,DEM,Kamala D. Harris,293
+San Joaquin,54305,U.S. Senate,,DEM,Loretta L. Sanchez,226
+San Joaquin,54306,U.S. Senate,,DEM,Kamala D. Harris,283
+San Joaquin,54306,U.S. Senate,,DEM,Loretta L. Sanchez,177
+San Joaquin,54307,U.S. Senate,,DEM,Kamala D. Harris,411
+San Joaquin,54307,U.S. Senate,,DEM,Loretta L. Sanchez,316
+San Joaquin,54310,U.S. Senate,,DEM,Kamala D. Harris,415
+San Joaquin,54310,U.S. Senate,,DEM,Loretta L. Sanchez,376
+San Joaquin,54311,U.S. Senate,,DEM,Kamala D. Harris,462
+San Joaquin,54311,U.S. Senate,,DEM,Loretta L. Sanchez,387
+San Joaquin,54312,U.S. Senate,,DEM,Kamala D. Harris,122
+San Joaquin,54312,U.S. Senate,,DEM,Loretta L. Sanchez,68
+San Joaquin,54313,U.S. Senate,,DEM,Kamala D. Harris,231
+San Joaquin,54313,U.S. Senate,,DEM,Loretta L. Sanchez,155
+San Joaquin,54314,U.S. Senate,,DEM,Kamala D. Harris,483
+San Joaquin,54314,U.S. Senate,,DEM,Loretta L. Sanchez,407
+San Joaquin,54318,U.S. Senate,,DEM,Kamala D. Harris,934
+San Joaquin,54318,U.S. Senate,,DEM,Loretta L. Sanchez,394
+San Joaquin,54320,U.S. Senate,,DEM,Kamala D. Harris,299
+San Joaquin,54320,U.S. Senate,,DEM,Loretta L. Sanchez,249
+San Joaquin,54321,U.S. Senate,,DEM,Kamala D. Harris,259
+San Joaquin,54321,U.S. Senate,,DEM,Loretta L. Sanchez,258
+San Joaquin,54322,U.S. Senate,,DEM,Kamala D. Harris,445
+San Joaquin,54322,U.S. Senate,,DEM,Loretta L. Sanchez,346
+San Joaquin,54323,U.S. Senate,,DEM,Kamala D. Harris,106
+San Joaquin,54323,U.S. Senate,,DEM,Loretta L. Sanchez,76
+San Joaquin,54324,U.S. Senate,,DEM,Kamala D. Harris,283
+San Joaquin,54324,U.S. Senate,,DEM,Loretta L. Sanchez,195
+San Joaquin,54325,U.S. Senate,,DEM,Kamala D. Harris,637
+San Joaquin,54325,U.S. Senate,,DEM,Loretta L. Sanchez,419
+San Joaquin,54327,U.S. Senate,,DEM,Kamala D. Harris,378
+San Joaquin,54327,U.S. Senate,,DEM,Loretta L. Sanchez,236
+San Joaquin,54501,U.S. Senate,,DEM,Kamala D. Harris,267
+San Joaquin,54501,U.S. Senate,,DEM,Loretta L. Sanchez,254
+San Joaquin,54502,U.S. Senate,,DEM,Kamala D. Harris,304
+San Joaquin,54502,U.S. Senate,,DEM,Loretta L. Sanchez,261
+San Joaquin,54503,U.S. Senate,,DEM,Kamala D. Harris,333
+San Joaquin,54503,U.S. Senate,,DEM,Loretta L. Sanchez,213
+San Joaquin,54504,U.S. Senate,,DEM,Kamala D. Harris,236
+San Joaquin,54504,U.S. Senate,,DEM,Loretta L. Sanchez,211
+San Joaquin,54505,U.S. Senate,,DEM,Kamala D. Harris,529
+San Joaquin,54505,U.S. Senate,,DEM,Loretta L. Sanchez,405
+San Joaquin,54508,U.S. Senate,,DEM,Kamala D. Harris,448
+San Joaquin,54508,U.S. Senate,,DEM,Loretta L. Sanchez,296
+San Joaquin,54509,U.S. Senate,,DEM,Kamala D. Harris,209
+San Joaquin,54509,U.S. Senate,,DEM,Loretta L. Sanchez,145
+San Joaquin,54510,U.S. Senate,,DEM,Kamala D. Harris,471
+San Joaquin,54510,U.S. Senate,,DEM,Loretta L. Sanchez,318
+San Joaquin,54511,U.S. Senate,,DEM,Kamala D. Harris,251
+San Joaquin,54511,U.S. Senate,,DEM,Loretta L. Sanchez,171
+San Joaquin,54512,U.S. Senate,,DEM,Kamala D. Harris,261
+San Joaquin,54512,U.S. Senate,,DEM,Loretta L. Sanchez,197
+San Joaquin,54514,U.S. Senate,,DEM,Kamala D. Harris,419
+San Joaquin,54514,U.S. Senate,,DEM,Loretta L. Sanchez,227
+San Joaquin,54515,U.S. Senate,,DEM,Kamala D. Harris,394
+San Joaquin,54515,U.S. Senate,,DEM,Loretta L. Sanchez,327
+San Joaquin,54520,U.S. Senate,,DEM,Kamala D. Harris,324
+San Joaquin,54520,U.S. Senate,,DEM,Loretta L. Sanchez,199
+San Joaquin,54521,U.S. Senate,,DEM,Kamala D. Harris,341
+San Joaquin,54521,U.S. Senate,,DEM,Loretta L. Sanchez,209
+San Joaquin,54522,U.S. Senate,,DEM,Kamala D. Harris,255
+San Joaquin,54522,U.S. Senate,,DEM,Loretta L. Sanchez,175
+San Joaquin,54523,U.S. Senate,,DEM,Kamala D. Harris,168
+San Joaquin,54523,U.S. Senate,,DEM,Loretta L. Sanchez,122
+San Joaquin,64401,U.S. Senate,,DEM,Kamala D. Harris,142
+San Joaquin,64401,U.S. Senate,,DEM,Loretta L. Sanchez,101
+San Joaquin,64402,U.S. Senate,,DEM,Kamala D. Harris,275
+San Joaquin,64402,U.S. Senate,,DEM,Loretta L. Sanchez,198
+San Joaquin,64403,U.S. Senate,,DEM,Kamala D. Harris,229
+San Joaquin,64403,U.S. Senate,,DEM,Loretta L. Sanchez,149
+San Joaquin,64404,U.S. Senate,,DEM,Kamala D. Harris,217
+San Joaquin,64404,U.S. Senate,,DEM,Loretta L. Sanchez,148
+San Joaquin,64405,U.S. Senate,,DEM,Kamala D. Harris,139
+San Joaquin,64405,U.S. Senate,,DEM,Loretta L. Sanchez,135
+San Joaquin,64406,U.S. Senate,,DEM,Kamala D. Harris,190
+San Joaquin,64406,U.S. Senate,,DEM,Loretta L. Sanchez,114
+San Joaquin,74401,U.S. Senate,,DEM,Kamala D. Harris,423
+San Joaquin,74401,U.S. Senate,,DEM,Loretta L. Sanchez,274
+San Joaquin,74402,U.S. Senate,,DEM,Kamala D. Harris,455
+San Joaquin,74402,U.S. Senate,,DEM,Loretta L. Sanchez,333
+San Joaquin,74404,U.S. Senate,,DEM,Kamala D. Harris,175
+San Joaquin,74404,U.S. Senate,,DEM,Loretta L. Sanchez,160
+San Joaquin,74405,U.S. Senate,,DEM,Kamala D. Harris,220
+San Joaquin,74405,U.S. Senate,,DEM,Loretta L. Sanchez,158
+San Joaquin,74406,U.S. Senate,,DEM,Kamala D. Harris,264
+San Joaquin,74406,U.S. Senate,,DEM,Loretta L. Sanchez,160
+San Joaquin,74407,U.S. Senate,,DEM,Kamala D. Harris,202
+San Joaquin,74407,U.S. Senate,,DEM,Loretta L. Sanchez,144
+San Joaquin,74408,U.S. Senate,,DEM,Kamala D. Harris,329
+San Joaquin,74408,U.S. Senate,,DEM,Loretta L. Sanchez,239
+San Joaquin,74410,U.S. Senate,,DEM,Kamala D. Harris,339
+San Joaquin,74410,U.S. Senate,,DEM,Loretta L. Sanchez,204
+San Joaquin,74411,U.S. Senate,,DEM,Kamala D. Harris,244
+San Joaquin,74411,U.S. Senate,,DEM,Loretta L. Sanchez,160
+San Joaquin,74412,U.S. Senate,,DEM,Kamala D. Harris,275
+San Joaquin,74412,U.S. Senate,,DEM,Loretta L. Sanchez,192
+San Joaquin,84301,U.S. Senate,,DEM,Kamala D. Harris,360
+San Joaquin,84301,U.S. Senate,,DEM,Loretta L. Sanchez,262
+San Joaquin,84302,U.S. Senate,,DEM,Kamala D. Harris,403
+San Joaquin,84302,U.S. Senate,,DEM,Loretta L. Sanchez,402
+San Joaquin,84303,U.S. Senate,,DEM,Kamala D. Harris,415
+San Joaquin,84303,U.S. Senate,,DEM,Loretta L. Sanchez,185
+San Joaquin,84305,U.S. Senate,,DEM,Kamala D. Harris,200
+San Joaquin,84305,U.S. Senate,,DEM,Loretta L. Sanchez,200
+San Joaquin,84306,U.S. Senate,,DEM,Kamala D. Harris,256
+San Joaquin,84306,U.S. Senate,,DEM,Loretta L. Sanchez,143
+San Joaquin,84307,U.S. Senate,,DEM,Kamala D. Harris,265
+San Joaquin,84307,U.S. Senate,,DEM,Loretta L. Sanchez,282
+San Joaquin,84309,U.S. Senate,,DEM,Kamala D. Harris,420
+San Joaquin,84309,U.S. Senate,,DEM,Loretta L. Sanchez,217
+San Joaquin,84310,U.S. Senate,,DEM,Kamala D. Harris,339
+San Joaquin,84310,U.S. Senate,,DEM,Loretta L. Sanchez,290
+San Joaquin,84312,U.S. Senate,,DEM,Kamala D. Harris,565
+San Joaquin,84312,U.S. Senate,,DEM,Loretta L. Sanchez,275
+San Joaquin,84501,U.S. Senate,,DEM,Kamala D. Harris,226
+San Joaquin,84501,U.S. Senate,,DEM,Loretta L. Sanchez,123
+San Joaquin,91101,U.S. Senate,,DEM,Kamala D. Harris,103
+San Joaquin,91101,U.S. Senate,,DEM,Loretta L. Sanchez,147
+San Joaquin,91102,U.S. Senate,,DEM,Kamala D. Harris,86
+San Joaquin,91102,U.S. Senate,,DEM,Loretta L. Sanchez,94
+San Joaquin,91103,U.S. Senate,,DEM,Kamala D. Harris,48
+San Joaquin,91103,U.S. Senate,,DEM,Loretta L. Sanchez,91
+San Joaquin,91105,U.S. Senate,,DEM,Kamala D. Harris,65
+San Joaquin,91105,U.S. Senate,,DEM,Loretta L. Sanchez,152
+San Joaquin,91107,U.S. Senate,,DEM,Kamala D. Harris,216
+San Joaquin,91107,U.S. Senate,,DEM,Loretta L. Sanchez,373
+San Joaquin,91111,U.S. Senate,,DEM,Kamala D. Harris,447
+San Joaquin,91111,U.S. Senate,,DEM,Loretta L. Sanchez,303
+San Joaquin,91113,U.S. Senate,,DEM,Kamala D. Harris,191
+San Joaquin,91113,U.S. Senate,,DEM,Loretta L. Sanchez,249
+San Joaquin,91114,U.S. Senate,,DEM,Kamala D. Harris,257
+San Joaquin,91114,U.S. Senate,,DEM,Loretta L. Sanchez,202
+San Joaquin,91115,U.S. Senate,,DEM,Kamala D. Harris,396
+San Joaquin,91115,U.S. Senate,,DEM,Loretta L. Sanchez,288
+San Joaquin,91121,U.S. Senate,,DEM,Kamala D. Harris,87
+San Joaquin,91121,U.S. Senate,,DEM,Loretta L. Sanchez,72
+San Joaquin,91204,U.S. Senate,,DEM,Kamala D. Harris,163
+San Joaquin,91204,U.S. Senate,,DEM,Loretta L. Sanchez,143
+San Joaquin,91205,U.S. Senate,,DEM,Kamala D. Harris,119
+San Joaquin,91205,U.S. Senate,,DEM,Loretta L. Sanchez,99
+San Joaquin,91206,U.S. Senate,,DEM,Kamala D. Harris,89
+San Joaquin,91206,U.S. Senate,,DEM,Loretta L. Sanchez,120
+San Joaquin,91207,U.S. Senate,,DEM,Kamala D. Harris,184
+San Joaquin,91207,U.S. Senate,,DEM,Loretta L. Sanchez,259
+San Joaquin,91208,U.S. Senate,,DEM,Kamala D. Harris,113
+San Joaquin,91208,U.S. Senate,,DEM,Loretta L. Sanchez,88
+San Joaquin,91209,U.S. Senate,,DEM,Kamala D. Harris,483
+San Joaquin,91209,U.S. Senate,,DEM,Loretta L. Sanchez,303
+San Joaquin,91211,U.S. Senate,,DEM,Kamala D. Harris,429
+San Joaquin,91211,U.S. Senate,,DEM,Loretta L. Sanchez,216
+San Joaquin,91213,U.S. Senate,,DEM,Kamala D. Harris,119
+San Joaquin,91213,U.S. Senate,,DEM,Loretta L. Sanchez,84
+San Joaquin,91216,U.S. Senate,,DEM,Kamala D. Harris,203
+San Joaquin,91216,U.S. Senate,,DEM,Loretta L. Sanchez,255
+San Joaquin,91217,U.S. Senate,,DEM,Kamala D. Harris,149
+San Joaquin,91217,U.S. Senate,,DEM,Loretta L. Sanchez,246
+San Joaquin,91218,U.S. Senate,,DEM,Kamala D. Harris,145
+San Joaquin,91218,U.S. Senate,,DEM,Loretta L. Sanchez,201
+San Joaquin,91219,U.S. Senate,,DEM,Kamala D. Harris,212
+San Joaquin,91219,U.S. Senate,,DEM,Loretta L. Sanchez,300
+San Joaquin,91225,U.S. Senate,,DEM,Kamala D. Harris,94
+San Joaquin,91225,U.S. Senate,,DEM,Loretta L. Sanchez,126
+San Joaquin,91227,U.S. Senate,,DEM,Kamala D. Harris,158
+San Joaquin,91227,U.S. Senate,,DEM,Loretta L. Sanchez,117
+San Joaquin,91301,U.S. Senate,,DEM,Kamala D. Harris,397
+San Joaquin,91301,U.S. Senate,,DEM,Loretta L. Sanchez,263
+San Joaquin,91303,U.S. Senate,,DEM,Kamala D. Harris,447
+San Joaquin,91303,U.S. Senate,,DEM,Loretta L. Sanchez,353
+San Joaquin,91305,U.S. Senate,,DEM,Kamala D. Harris,247
+San Joaquin,91305,U.S. Senate,,DEM,Loretta L. Sanchez,212
+San Joaquin,91402,U.S. Senate,,DEM,Kamala D. Harris,474
+San Joaquin,91402,U.S. Senate,,DEM,Loretta L. Sanchez,294
+San Joaquin,91404,U.S. Senate,,DEM,Kamala D. Harris,238
+San Joaquin,91404,U.S. Senate,,DEM,Loretta L. Sanchez,154
+San Joaquin,91405,U.S. Senate,,DEM,Kamala D. Harris,282
+San Joaquin,91405,U.S. Senate,,DEM,Loretta L. Sanchez,202
+San Joaquin,91407,U.S. Senate,,DEM,Kamala D. Harris,246
+San Joaquin,91407,U.S. Senate,,DEM,Loretta L. Sanchez,203
+San Joaquin,91408,U.S. Senate,,DEM,Kamala D. Harris,203
+San Joaquin,91408,U.S. Senate,,DEM,Loretta L. Sanchez,120
+San Joaquin,91409,U.S. Senate,,DEM,Kamala D. Harris,318
+San Joaquin,91409,U.S. Senate,,DEM,Loretta L. Sanchez,218
+San Joaquin,91411,U.S. Senate,,DEM,Kamala D. Harris,325
+San Joaquin,91411,U.S. Senate,,DEM,Loretta L. Sanchez,187
+San Joaquin,91412,U.S. Senate,,DEM,Kamala D. Harris,253
+San Joaquin,91412,U.S. Senate,,DEM,Loretta L. Sanchez,120
+San Joaquin,91414,U.S. Senate,,DEM,Kamala D. Harris,245
+San Joaquin,91414,U.S. Senate,,DEM,Loretta L. Sanchez,202
+San Joaquin,91415,U.S. Senate,,DEM,Kamala D. Harris,279
+San Joaquin,91415,U.S. Senate,,DEM,Loretta L. Sanchez,196
+San Joaquin,92401,U.S. Senate,,DEM,Kamala D. Harris,187
+San Joaquin,92401,U.S. Senate,,DEM,Loretta L. Sanchez,117
+San Joaquin,92402,U.S. Senate,,DEM,Kamala D. Harris,283
+San Joaquin,92402,U.S. Senate,,DEM,Loretta L. Sanchez,214
+San Joaquin,92403,U.S. Senate,,DEM,Kamala D. Harris,122
+San Joaquin,92403,U.S. Senate,,DEM,Loretta L. Sanchez,84
+San Joaquin,92404,U.S. Senate,,DEM,Kamala D. Harris,376
+San Joaquin,92404,U.S. Senate,,DEM,Loretta L. Sanchez,262
+San Joaquin,92405,U.S. Senate,,DEM,Kamala D. Harris,97
+San Joaquin,92405,U.S. Senate,,DEM,Loretta L. Sanchez,75
+San Joaquin,92406,U.S. Senate,,DEM,Kamala D. Harris,513
+San Joaquin,92406,U.S. Senate,,DEM,Loretta L. Sanchez,298
+San Joaquin,92407,U.S. Senate,,DEM,Kamala D. Harris,203
+San Joaquin,92407,U.S. Senate,,DEM,Loretta L. Sanchez,96
+San Joaquin,92408,U.S. Senate,,DEM,Kamala D. Harris,451
+San Joaquin,92408,U.S. Senate,,DEM,Loretta L. Sanchez,336
+San Joaquin,92409,U.S. Senate,,DEM,Kamala D. Harris,263
+San Joaquin,92409,U.S. Senate,,DEM,Loretta L. Sanchez,279
+San Joaquin,92410,U.S. Senate,,DEM,Kamala D. Harris,222
+San Joaquin,92410,U.S. Senate,,DEM,Loretta L. Sanchez,165
+San Joaquin,92411,U.S. Senate,,DEM,Kamala D. Harris,303
+San Joaquin,92411,U.S. Senate,,DEM,Loretta L. Sanchez,240
+San Joaquin,92412,U.S. Senate,,DEM,Kamala D. Harris,186
+San Joaquin,92412,U.S. Senate,,DEM,Loretta L. Sanchez,139
+San Joaquin,92413,U.S. Senate,,DEM,Kamala D. Harris,89
+San Joaquin,92413,U.S. Senate,,DEM,Loretta L. Sanchez,82
+San Joaquin,92414,U.S. Senate,,DEM,Kamala D. Harris,141
+San Joaquin,92414,U.S. Senate,,DEM,Loretta L. Sanchez,142
+San Joaquin,92416,U.S. Senate,,DEM,Kamala D. Harris,212
+San Joaquin,92416,U.S. Senate,,DEM,Loretta L. Sanchez,145
+San Joaquin,92418,U.S. Senate,,DEM,Kamala D. Harris,310
+San Joaquin,92418,U.S. Senate,,DEM,Loretta L. Sanchez,198
+San Joaquin,92419,U.S. Senate,,DEM,Kamala D. Harris,354
+San Joaquin,92419,U.S. Senate,,DEM,Loretta L. Sanchez,241
+San Joaquin,92420,U.S. Senate,,DEM,Kamala D. Harris,312
+San Joaquin,92420,U.S. Senate,,DEM,Loretta L. Sanchez,219
+San Joaquin,92422,U.S. Senate,,DEM,Kamala D. Harris,119
+San Joaquin,92422,U.S. Senate,,DEM,Loretta L. Sanchez,87
+San Joaquin,92424,U.S. Senate,,DEM,Kamala D. Harris,226
+San Joaquin,92424,U.S. Senate,,DEM,Loretta L. Sanchez,145
+San Joaquin,92432,U.S. Senate,,DEM,Kamala D. Harris,148
+San Joaquin,92432,U.S. Senate,,DEM,Loretta L. Sanchez,94
+San Joaquin,93501,U.S. Senate,,DEM,Kamala D. Harris,607
+San Joaquin,93501,U.S. Senate,,DEM,Loretta L. Sanchez,370
+San Joaquin,93502,U.S. Senate,,DEM,Kamala D. Harris,198
+San Joaquin,93502,U.S. Senate,,DEM,Loretta L. Sanchez,104
+San Joaquin,93503,U.S. Senate,,DEM,Kamala D. Harris,124
+San Joaquin,93503,U.S. Senate,,DEM,Loretta L. Sanchez,124
+San Joaquin,93504,U.S. Senate,,DEM,Kamala D. Harris,150
+San Joaquin,93504,U.S. Senate,,DEM,Loretta L. Sanchez,147
+San Joaquin,93505,U.S. Senate,,DEM,Kamala D. Harris,233
+San Joaquin,93505,U.S. Senate,,DEM,Loretta L. Sanchez,212
+San Joaquin,93511,U.S. Senate,,DEM,Kamala D. Harris,603
+San Joaquin,93511,U.S. Senate,,DEM,Loretta L. Sanchez,271
+San Joaquin,93521,U.S. Senate,,DEM,Kamala D. Harris,467
+San Joaquin,93521,U.S. Senate,,DEM,Loretta L. Sanchez,203
+San Joaquin,93522,U.S. Senate,,DEM,Kamala D. Harris,493
+San Joaquin,93522,U.S. Senate,,DEM,Loretta L. Sanchez,206
+San Joaquin,93523,U.S. Senate,,DEM,Kamala D. Harris,421
+San Joaquin,93523,U.S. Senate,,DEM,Loretta L. Sanchez,257
+San Joaquin,93524,U.S. Senate,,DEM,Kamala D. Harris,129
+San Joaquin,93524,U.S. Senate,,DEM,Loretta L. Sanchez,89
+San Joaquin,93531,U.S. Senate,,DEM,Kamala D. Harris,648
+San Joaquin,93531,U.S. Senate,,DEM,Loretta L. Sanchez,342
+San Joaquin,94101,U.S. Senate,,DEM,Kamala D. Harris,216
+San Joaquin,94101,U.S. Senate,,DEM,Loretta L. Sanchez,328
+San Joaquin,94309,U.S. Senate,,DEM,Kamala D. Harris,293
+San Joaquin,94309,U.S. Senate,,DEM,Loretta L. Sanchez,147
+San Joaquin,94310,U.S. Senate,,DEM,Kamala D. Harris,96
+San Joaquin,94310,U.S. Senate,,DEM,Loretta L. Sanchez,82
+San Joaquin,94402,U.S. Senate,,DEM,Kamala D. Harris,112
+San Joaquin,94402,U.S. Senate,,DEM,Loretta L. Sanchez,69
+San Joaquin,94403,U.S. Senate,,DEM,Kamala D. Harris,140
+San Joaquin,94403,U.S. Senate,,DEM,Loretta L. Sanchez,100
+San Joaquin,94405,U.S. Senate,,DEM,Kamala D. Harris,173
+San Joaquin,94405,U.S. Senate,,DEM,Loretta L. Sanchez,140
+San Joaquin,94408,U.S. Senate,,DEM,Kamala D. Harris,397
+San Joaquin,94408,U.S. Senate,,DEM,Loretta L. Sanchez,299
+San Joaquin,94410,U.S. Senate,,DEM,Kamala D. Harris,158
+San Joaquin,94410,U.S. Senate,,DEM,Loretta L. Sanchez,85
+San Joaquin,94501,U.S. Senate,,DEM,Kamala D. Harris,219
+San Joaquin,94501,U.S. Senate,,DEM,Loretta L. Sanchez,114
+San Joaquin,94503,U.S. Senate,,DEM,Kamala D. Harris,100
+San Joaquin,94503,U.S. Senate,,DEM,Loretta L. Sanchez,80
+San Joaquin,94504,U.S. Senate,,DEM,Kamala D. Harris,198
+San Joaquin,94504,U.S. Senate,,DEM,Loretta L. Sanchez,132
+San Joaquin,111120,U.S. Senate,,DEM,Kamala D. Harris,21
+San Joaquin,111120,U.S. Senate,,DEM,Loretta L. Sanchez,10
+San Joaquin,111130,U.S. Senate,,DEM,Kamala D. Harris,62
+San Joaquin,111130,U.S. Senate,,DEM,Loretta L. Sanchez,59
+San Joaquin,111190,U.S. Senate,,DEM,Kamala D. Harris,65
+San Joaquin,111190,U.S. Senate,,DEM,Loretta L. Sanchez,46
+San Joaquin,111230,U.S. Senate,,DEM,Kamala D. Harris,63
+San Joaquin,111230,U.S. Senate,,DEM,Loretta L. Sanchez,96
+San Joaquin,111310,U.S. Senate,,DEM,Kamala D. Harris,3
+San Joaquin,111310,U.S. Senate,,DEM,Loretta L. Sanchez,3
+San Joaquin,111311,U.S. Senate,,DEM,Kamala D. Harris,0
+San Joaquin,111311,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Joaquin,111320,U.S. Senate,,DEM,Kamala D. Harris,0
+San Joaquin,111320,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Joaquin,111410,U.S. Senate,,DEM,Kamala D. Harris,0
+San Joaquin,111410,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Joaquin,111430,U.S. Senate,,DEM,Kamala D. Harris,0
+San Joaquin,111430,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Joaquin,111431,U.S. Senate,,DEM,Kamala D. Harris,0
+San Joaquin,111431,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Joaquin,111440,U.S. Senate,,DEM,Kamala D. Harris,0
+San Joaquin,111440,U.S. Senate,,DEM,Loretta L. Sanchez,1
+San Joaquin,111441,U.S. Senate,,DEM,Kamala D. Harris,0
+San Joaquin,111441,U.S. Senate,,DEM,Loretta L. Sanchez,3
+San Joaquin,111510,U.S. Senate,,DEM,Kamala D. Harris,27
+San Joaquin,111510,U.S. Senate,,DEM,Loretta L. Sanchez,36
+San Joaquin,111530,U.S. Senate,,DEM,Kamala D. Harris,76
+San Joaquin,111530,U.S. Senate,,DEM,Loretta L. Sanchez,61
+San Joaquin,111750,U.S. Senate,,DEM,Kamala D. Harris,3
+San Joaquin,111750,U.S. Senate,,DEM,Loretta L. Sanchez,8
+San Joaquin,111751,U.S. Senate,,DEM,Kamala D. Harris,0
+San Joaquin,111751,U.S. Senate,,DEM,Loretta L. Sanchez,1
+San Joaquin,112330,U.S. Senate,,DEM,Kamala D. Harris,83
+San Joaquin,112330,U.S. Senate,,DEM,Loretta L. Sanchez,47
+San Joaquin,112600,U.S. Senate,,DEM,Kamala D. Harris,46
+San Joaquin,112600,U.S. Senate,,DEM,Loretta L. Sanchez,39
+San Joaquin,113010,U.S. Senate,,DEM,Kamala D. Harris,4
+San Joaquin,113010,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Joaquin,113130,U.S. Senate,,DEM,Kamala D. Harris,18
+San Joaquin,113130,U.S. Senate,,DEM,Loretta L. Sanchez,3
+San Joaquin,113310,U.S. Senate,,DEM,Kamala D. Harris,120
+San Joaquin,113310,U.S. Senate,,DEM,Loretta L. Sanchez,58
+San Joaquin,113420,U.S. Senate,,DEM,Kamala D. Harris,0
+San Joaquin,113420,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Joaquin,113430,U.S. Senate,,DEM,Kamala D. Harris,45
+San Joaquin,113430,U.S. Senate,,DEM,Loretta L. Sanchez,16
+San Joaquin,113900,U.S. Senate,,DEM,Kamala D. Harris,0
+San Joaquin,113900,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Joaquin,335070,U.S. Senate,,DEM,Kamala D. Harris,8
+San Joaquin,335070,U.S. Senate,,DEM,Loretta L. Sanchez,1
+San Joaquin,335071,U.S. Senate,,DEM,Kamala D. Harris,1
+San Joaquin,335071,U.S. Senate,,DEM,Loretta L. Sanchez,3
+San Joaquin,335120,U.S. Senate,,DEM,Kamala D. Harris,0
+San Joaquin,335120,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Joaquin,335280,U.S. Senate,,DEM,Kamala D. Harris,0
+San Joaquin,335280,U.S. Senate,,DEM,Loretta L. Sanchez,4
+San Joaquin,335310,U.S. Senate,,DEM,Kamala D. Harris,1
+San Joaquin,335310,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Joaquin,335311,U.S. Senate,,DEM,Kamala D. Harris,2
+San Joaquin,335311,U.S. Senate,,DEM,Loretta L. Sanchez,2
+San Joaquin,335440,U.S. Senate,,DEM,Kamala D. Harris,8
+San Joaquin,335440,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Joaquin,335540,U.S. Senate,,DEM,Kamala D. Harris,91
+San Joaquin,335540,U.S. Senate,,DEM,Loretta L. Sanchez,54
+San Joaquin,335550,U.S. Senate,,DEM,Kamala D. Harris,2
+San Joaquin,335550,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Joaquin,335560,U.S. Senate,,DEM,Kamala D. Harris,0
+San Joaquin,335560,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Joaquin,424360,U.S. Senate,,DEM,Kamala D. Harris,0
+San Joaquin,424360,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Joaquin,424500,U.S. Senate,,DEM,Kamala D. Harris,3
+San Joaquin,424500,U.S. Senate,,DEM,Loretta L. Sanchez,3
+San Joaquin,543040,U.S. Senate,,DEM,Kamala D. Harris,14
+San Joaquin,543040,U.S. Senate,,DEM,Loretta L. Sanchez,9
+San Joaquin,543080,U.S. Senate,,DEM,Kamala D. Harris,0
+San Joaquin,543080,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Joaquin,543090,U.S. Senate,,DEM,Kamala D. Harris,103
+San Joaquin,543090,U.S. Senate,,DEM,Loretta L. Sanchez,90
+San Joaquin,543280,U.S. Senate,,DEM,Kamala D. Harris,2
+San Joaquin,543280,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Joaquin,545060,U.S. Senate,,DEM,Kamala D. Harris,7
+San Joaquin,545060,U.S. Senate,,DEM,Loretta L. Sanchez,8
+San Joaquin,545061,U.S. Senate,,DEM,Kamala D. Harris,2
+San Joaquin,545061,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Joaquin,545070,U.S. Senate,,DEM,Kamala D. Harris,19
+San Joaquin,545070,U.S. Senate,,DEM,Loretta L. Sanchez,12
+San Joaquin,545200,U.S. Senate,,DEM,Kamala D. Harris,172
+San Joaquin,545200,U.S. Senate,,DEM,Loretta L. Sanchez,101
+San Joaquin,545201,U.S. Senate,,DEM,Kamala D. Harris,7
+San Joaquin,545201,U.S. Senate,,DEM,Loretta L. Sanchez,1
+San Joaquin,644010,U.S. Senate,,DEM,Kamala D. Harris,93
+San Joaquin,644010,U.S. Senate,,DEM,Loretta L. Sanchez,54
+San Joaquin,644050,U.S. Senate,,DEM,Kamala D. Harris,70
+San Joaquin,644050,U.S. Senate,,DEM,Loretta L. Sanchez,38
+San Joaquin,644060,U.S. Senate,,DEM,Kamala D. Harris,8
+San Joaquin,644060,U.S. Senate,,DEM,Loretta L. Sanchez,9
+San Joaquin,835010,U.S. Senate,,DEM,Kamala D. Harris,0
+San Joaquin,835010,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Joaquin,843080,U.S. Senate,,DEM,Kamala D. Harris,4
+San Joaquin,843080,U.S. Senate,,DEM,Loretta L. Sanchez,15
+San Joaquin,843110,U.S. Senate,,DEM,Kamala D. Harris,2
+San Joaquin,843110,U.S. Senate,,DEM,Loretta L. Sanchez,2
+San Joaquin,845020,U.S. Senate,,DEM,Kamala D. Harris,0
+San Joaquin,845020,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Joaquin,845030,U.S. Senate,,DEM,Kamala D. Harris,3
+San Joaquin,845030,U.S. Senate,,DEM,Loretta L. Sanchez,1
+San Joaquin,911040,U.S. Senate,,DEM,Kamala D. Harris,59
+San Joaquin,911040,U.S. Senate,,DEM,Loretta L. Sanchez,56
+San Joaquin,911050,U.S. Senate,,DEM,Kamala D. Harris,24
+San Joaquin,911050,U.S. Senate,,DEM,Loretta L. Sanchez,15
+San Joaquin,911060,U.S. Senate,,DEM,Kamala D. Harris,78
+San Joaquin,911060,U.S. Senate,,DEM,Loretta L. Sanchez,58
+San Joaquin,911080,U.S. Senate,,DEM,Kamala D. Harris,9
+San Joaquin,911080,U.S. Senate,,DEM,Loretta L. Sanchez,7
+San Joaquin,911100,U.S. Senate,,DEM,Kamala D. Harris,8
+San Joaquin,911100,U.S. Senate,,DEM,Loretta L. Sanchez,13
+San Joaquin,911101,U.S. Senate,,DEM,Kamala D. Harris,2
+San Joaquin,911101,U.S. Senate,,DEM,Loretta L. Sanchez,8
+San Joaquin,911130,U.S. Senate,,DEM,Kamala D. Harris,2
+San Joaquin,911130,U.S. Senate,,DEM,Loretta L. Sanchez,4
+San Joaquin,911200,U.S. Senate,,DEM,Kamala D. Harris,30
+San Joaquin,911200,U.S. Senate,,DEM,Loretta L. Sanchez,33
+San Joaquin,911210,U.S. Senate,,DEM,Kamala D. Harris,25
+San Joaquin,911210,U.S. Senate,,DEM,Loretta L. Sanchez,20
+San Joaquin,911900,U.S. Senate,,DEM,Kamala D. Harris,0
+San Joaquin,911900,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Joaquin,912010,U.S. Senate,,DEM,Kamala D. Harris,24
+San Joaquin,912010,U.S. Senate,,DEM,Loretta L. Sanchez,15
+San Joaquin,912020,U.S. Senate,,DEM,Kamala D. Harris,1
+San Joaquin,912020,U.S. Senate,,DEM,Loretta L. Sanchez,3
+San Joaquin,912030,U.S. Senate,,DEM,Kamala D. Harris,101
+San Joaquin,912030,U.S. Senate,,DEM,Loretta L. Sanchez,51
+San Joaquin,912031,U.S. Senate,,DEM,Kamala D. Harris,31
+San Joaquin,912031,U.S. Senate,,DEM,Loretta L. Sanchez,19
+San Joaquin,912060,U.S. Senate,,DEM,Kamala D. Harris,9
+San Joaquin,912060,U.S. Senate,,DEM,Loretta L. Sanchez,12
+San Joaquin,912090,U.S. Senate,,DEM,Kamala D. Harris,79
+San Joaquin,912090,U.S. Senate,,DEM,Loretta L. Sanchez,38
+San Joaquin,912140,U.S. Senate,,DEM,Kamala D. Harris,6
+San Joaquin,912140,U.S. Senate,,DEM,Loretta L. Sanchez,8
+San Joaquin,912160,U.S. Senate,,DEM,Kamala D. Harris,0
+San Joaquin,912160,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Joaquin,912210,U.S. Senate,,DEM,Kamala D. Harris,1
+San Joaquin,912210,U.S. Senate,,DEM,Loretta L. Sanchez,1
+San Joaquin,912211,U.S. Senate,,DEM,Kamala D. Harris,68
+San Joaquin,912211,U.S. Senate,,DEM,Loretta L. Sanchez,78
+San Joaquin,912260,U.S. Senate,,DEM,Kamala D. Harris,0
+San Joaquin,912260,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Joaquin,913040,U.S. Senate,,DEM,Kamala D. Harris,1
+San Joaquin,913040,U.S. Senate,,DEM,Loretta L. Sanchez,5
+San Joaquin,913050,U.S. Senate,,DEM,Kamala D. Harris,1
+San Joaquin,913050,U.S. Senate,,DEM,Loretta L. Sanchez,2
+San Joaquin,913070,U.S. Senate,,DEM,Kamala D. Harris,48
+San Joaquin,913070,U.S. Senate,,DEM,Loretta L. Sanchez,29
+San Joaquin,913071,U.S. Senate,,DEM,Kamala D. Harris,42
+San Joaquin,913071,U.S. Senate,,DEM,Loretta L. Sanchez,21
+San Joaquin,913080,U.S. Senate,,DEM,Kamala D. Harris,69
+San Joaquin,913080,U.S. Senate,,DEM,Loretta L. Sanchez,28
+San Joaquin,913090,U.S. Senate,,DEM,Kamala D. Harris,43
+San Joaquin,913090,U.S. Senate,,DEM,Loretta L. Sanchez,36
+San Joaquin,914010,U.S. Senate,,DEM,Kamala D. Harris,84
+San Joaquin,914010,U.S. Senate,,DEM,Loretta L. Sanchez,49
+San Joaquin,914060,U.S. Senate,,DEM,Kamala D. Harris,31
+San Joaquin,914060,U.S. Senate,,DEM,Loretta L. Sanchez,27
+San Joaquin,914080,U.S. Senate,,DEM,Kamala D. Harris,37
+San Joaquin,914080,U.S. Senate,,DEM,Loretta L. Sanchez,18
+San Joaquin,914100,U.S. Senate,,DEM,Kamala D. Harris,77
+San Joaquin,914100,U.S. Senate,,DEM,Loretta L. Sanchez,35
+San Joaquin,914130,U.S. Senate,,DEM,Kamala D. Harris,13
+San Joaquin,914130,U.S. Senate,,DEM,Loretta L. Sanchez,2
+San Joaquin,914131,U.S. Senate,,DEM,Kamala D. Harris,8
+San Joaquin,914131,U.S. Senate,,DEM,Loretta L. Sanchez,2
+San Joaquin,914170,U.S. Senate,,DEM,Kamala D. Harris,29
+San Joaquin,914170,U.S. Senate,,DEM,Loretta L. Sanchez,17
+San Joaquin,914180,U.S. Senate,,DEM,Kamala D. Harris,29
+San Joaquin,914180,U.S. Senate,,DEM,Loretta L. Sanchez,24
+San Joaquin,914181,U.S. Senate,,DEM,Kamala D. Harris,14
+San Joaquin,914181,U.S. Senate,,DEM,Loretta L. Sanchez,12
+San Joaquin,923010,U.S. Senate,,DEM,Kamala D. Harris,8
+San Joaquin,923010,U.S. Senate,,DEM,Loretta L. Sanchez,4
+San Joaquin,924010,U.S. Senate,,DEM,Kamala D. Harris,55
+San Joaquin,924010,U.S. Senate,,DEM,Loretta L. Sanchez,39
+San Joaquin,924020,U.S. Senate,,DEM,Kamala D. Harris,50
+San Joaquin,924020,U.S. Senate,,DEM,Loretta L. Sanchez,22
+San Joaquin,924060,U.S. Senate,,DEM,Kamala D. Harris,15
+San Joaquin,924060,U.S. Senate,,DEM,Loretta L. Sanchez,5
+San Joaquin,924140,U.S. Senate,,DEM,Kamala D. Harris,16
+San Joaquin,924140,U.S. Senate,,DEM,Loretta L. Sanchez,19
+San Joaquin,924170,U.S. Senate,,DEM,Kamala D. Harris,83
+San Joaquin,924170,U.S. Senate,,DEM,Loretta L. Sanchez,60
+San Joaquin,924250,U.S. Senate,,DEM,Kamala D. Harris,1
+San Joaquin,924250,U.S. Senate,,DEM,Loretta L. Sanchez,10
+San Joaquin,924260,U.S. Senate,,DEM,Kamala D. Harris,5
+San Joaquin,924260,U.S. Senate,,DEM,Loretta L. Sanchez,9
+San Joaquin,924280,U.S. Senate,,DEM,Kamala D. Harris,2
+San Joaquin,924280,U.S. Senate,,DEM,Loretta L. Sanchez,2
+San Joaquin,924330,U.S. Senate,,DEM,Kamala D. Harris,18
+San Joaquin,924330,U.S. Senate,,DEM,Loretta L. Sanchez,18
+San Joaquin,924331,U.S. Senate,,DEM,Kamala D. Harris,67
+San Joaquin,924331,U.S. Senate,,DEM,Loretta L. Sanchez,67
+San Joaquin,933010,U.S. Senate,,DEM,Kamala D. Harris,32
+San Joaquin,933010,U.S. Senate,,DEM,Loretta L. Sanchez,25
+San Joaquin,933020,U.S. Senate,,DEM,Kamala D. Harris,48
+San Joaquin,933020,U.S. Senate,,DEM,Loretta L. Sanchez,53
+San Joaquin,933030,U.S. Senate,,DEM,Kamala D. Harris,15
+San Joaquin,933030,U.S. Senate,,DEM,Loretta L. Sanchez,14
+San Joaquin,933031,U.S. Senate,,DEM,Kamala D. Harris,1
+San Joaquin,933031,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Joaquin,935030,U.S. Senate,,DEM,Kamala D. Harris,42
+San Joaquin,935030,U.S. Senate,,DEM,Loretta L. Sanchez,48
+San Joaquin,935040,U.S. Senate,,DEM,Kamala D. Harris,10
+San Joaquin,935040,U.S. Senate,,DEM,Loretta L. Sanchez,4
+San Joaquin,935070,U.S. Senate,,DEM,Kamala D. Harris,49
+San Joaquin,935070,U.S. Senate,,DEM,Loretta L. Sanchez,32
+San Joaquin,935080,U.S. Senate,,DEM,Kamala D. Harris,80
+San Joaquin,935080,U.S. Senate,,DEM,Loretta L. Sanchez,56
+San Joaquin,935090,U.S. Senate,,DEM,Kamala D. Harris,7
+San Joaquin,935090,U.S. Senate,,DEM,Loretta L. Sanchez,10
+San Joaquin,935100,U.S. Senate,,DEM,Kamala D. Harris,63
+San Joaquin,935100,U.S. Senate,,DEM,Loretta L. Sanchez,58
+San Joaquin,935110,U.S. Senate,,DEM,Kamala D. Harris,22
+San Joaquin,935110,U.S. Senate,,DEM,Loretta L. Sanchez,16
+San Joaquin,935120,U.S. Senate,,DEM,Kamala D. Harris,4
+San Joaquin,935120,U.S. Senate,,DEM,Loretta L. Sanchez,11
+San Joaquin,935130,U.S. Senate,,DEM,Kamala D. Harris,10
+San Joaquin,935130,U.S. Senate,,DEM,Loretta L. Sanchez,5
+San Joaquin,935150,U.S. Senate,,DEM,Kamala D. Harris,76
+San Joaquin,935150,U.S. Senate,,DEM,Loretta L. Sanchez,53
+San Joaquin,935250,U.S. Senate,,DEM,Kamala D. Harris,0
+San Joaquin,935250,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Joaquin,935260,U.S. Senate,,DEM,Kamala D. Harris,2
+San Joaquin,935260,U.S. Senate,,DEM,Loretta L. Sanchez,3
+San Joaquin,935261,U.S. Senate,,DEM,Kamala D. Harris,18
+San Joaquin,935261,U.S. Senate,,DEM,Loretta L. Sanchez,21
+San Joaquin,935270,U.S. Senate,,DEM,Kamala D. Harris,2
+San Joaquin,935270,U.S. Senate,,DEM,Loretta L. Sanchez,24
+San Joaquin,935280,U.S. Senate,,DEM,Kamala D. Harris,1
+San Joaquin,935280,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Joaquin,935290,U.S. Senate,,DEM,Kamala D. Harris,4
+San Joaquin,935290,U.S. Senate,,DEM,Loretta L. Sanchez,4
+San Joaquin,935300,U.S. Senate,,DEM,Kamala D. Harris,3
+San Joaquin,935300,U.S. Senate,,DEM,Loretta L. Sanchez,3
+San Joaquin,935301,U.S. Senate,,DEM,Kamala D. Harris,0
+San Joaquin,935301,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Joaquin,941020,U.S. Senate,,DEM,Kamala D. Harris,0
+San Joaquin,941020,U.S. Senate,,DEM,Loretta L. Sanchez,1
+San Joaquin,941021,U.S. Senate,,DEM,Kamala D. Harris,0
+San Joaquin,941021,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Joaquin,941030,U.S. Senate,,DEM,Kamala D. Harris,22
+San Joaquin,941030,U.S. Senate,,DEM,Loretta L. Sanchez,11
+San Joaquin,941040,U.S. Senate,,DEM,Kamala D. Harris,12
+San Joaquin,941040,U.S. Senate,,DEM,Loretta L. Sanchez,17
+San Joaquin,941050,U.S. Senate,,DEM,Kamala D. Harris,43
+San Joaquin,941050,U.S. Senate,,DEM,Loretta L. Sanchez,60
+San Joaquin,941060,U.S. Senate,,DEM,Kamala D. Harris,31
+San Joaquin,941060,U.S. Senate,,DEM,Loretta L. Sanchez,24
+San Joaquin,941070,U.S. Senate,,DEM,Kamala D. Harris,57
+San Joaquin,941070,U.S. Senate,,DEM,Loretta L. Sanchez,62
+San Joaquin,941100,U.S. Senate,,DEM,Kamala D. Harris,2
+San Joaquin,941100,U.S. Senate,,DEM,Loretta L. Sanchez,7
+San Joaquin,941101,U.S. Senate,,DEM,Kamala D. Harris,4
+San Joaquin,941101,U.S. Senate,,DEM,Loretta L. Sanchez,3
+San Joaquin,941110,U.S. Senate,,DEM,Kamala D. Harris,5
+San Joaquin,941110,U.S. Senate,,DEM,Loretta L. Sanchez,4
+San Joaquin,941111,U.S. Senate,,DEM,Kamala D. Harris,0
+San Joaquin,941111,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Joaquin,941120,U.S. Senate,,DEM,Kamala D. Harris,40
+San Joaquin,941120,U.S. Senate,,DEM,Loretta L. Sanchez,49
+San Joaquin,943010,U.S. Senate,,DEM,Kamala D. Harris,28
+San Joaquin,943010,U.S. Senate,,DEM,Loretta L. Sanchez,18
+San Joaquin,943020,U.S. Senate,,DEM,Kamala D. Harris,52
+San Joaquin,943020,U.S. Senate,,DEM,Loretta L. Sanchez,34
+San Joaquin,943021,U.S. Senate,,DEM,Kamala D. Harris,49
+San Joaquin,943021,U.S. Senate,,DEM,Loretta L. Sanchez,20
+San Joaquin,943030,U.S. Senate,,DEM,Kamala D. Harris,72
+San Joaquin,943030,U.S. Senate,,DEM,Loretta L. Sanchez,57
+San Joaquin,943040,U.S. Senate,,DEM,Kamala D. Harris,36
+San Joaquin,943040,U.S. Senate,,DEM,Loretta L. Sanchez,12
+San Joaquin,943050,U.S. Senate,,DEM,Kamala D. Harris,97
+San Joaquin,943050,U.S. Senate,,DEM,Loretta L. Sanchez,75
+San Joaquin,943051,U.S. Senate,,DEM,Kamala D. Harris,4
+San Joaquin,943051,U.S. Senate,,DEM,Loretta L. Sanchez,3
+San Joaquin,943052,U.S. Senate,,DEM,Kamala D. Harris,52
+San Joaquin,943052,U.S. Senate,,DEM,Loretta L. Sanchez,37
+San Joaquin,943070,U.S. Senate,,DEM,Kamala D. Harris,15
+San Joaquin,943070,U.S. Senate,,DEM,Loretta L. Sanchez,21
+San Joaquin,943080,U.S. Senate,,DEM,Kamala D. Harris,49
+San Joaquin,943080,U.S. Senate,,DEM,Loretta L. Sanchez,30
+San Joaquin,943090,U.S. Senate,,DEM,Kamala D. Harris,0
+San Joaquin,943090,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Joaquin,943100,U.S. Senate,,DEM,Kamala D. Harris,2
+San Joaquin,943100,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Joaquin,943110,U.S. Senate,,DEM,Kamala D. Harris,0
+San Joaquin,943110,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Joaquin,943130,U.S. Senate,,DEM,Kamala D. Harris,15
+San Joaquin,943130,U.S. Senate,,DEM,Loretta L. Sanchez,13
+San Joaquin,944010,U.S. Senate,,DEM,Kamala D. Harris,10
+San Joaquin,944010,U.S. Senate,,DEM,Loretta L. Sanchez,16
+San Joaquin,944020,U.S. Senate,,DEM,Kamala D. Harris,5
+San Joaquin,944020,U.S. Senate,,DEM,Loretta L. Sanchez,2
+San Joaquin,944021,U.S. Senate,,DEM,Kamala D. Harris,2
+San Joaquin,944021,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Joaquin,944040,U.S. Senate,,DEM,Kamala D. Harris,11
+San Joaquin,944040,U.S. Senate,,DEM,Loretta L. Sanchez,28
+San Joaquin,944041,U.S. Senate,,DEM,Kamala D. Harris,71
+San Joaquin,944041,U.S. Senate,,DEM,Loretta L. Sanchez,51
+San Joaquin,944050,U.S. Senate,,DEM,Kamala D. Harris,59
+San Joaquin,944050,U.S. Senate,,DEM,Loretta L. Sanchez,72
+San Joaquin,944060,U.S. Senate,,DEM,Kamala D. Harris,73
+San Joaquin,944060,U.S. Senate,,DEM,Loretta L. Sanchez,47
+San Joaquin,944061,U.S. Senate,,DEM,Kamala D. Harris,62
+San Joaquin,944061,U.S. Senate,,DEM,Loretta L. Sanchez,39
+San Joaquin,944070,U.S. Senate,,DEM,Kamala D. Harris,43
+San Joaquin,944070,U.S. Senate,,DEM,Loretta L. Sanchez,51
+San Joaquin,944090,U.S. Senate,,DEM,Kamala D. Harris,78
+San Joaquin,944090,U.S. Senate,,DEM,Loretta L. Sanchez,73
+San Joaquin,944091,U.S. Senate,,DEM,Kamala D. Harris,27
+San Joaquin,944091,U.S. Senate,,DEM,Loretta L. Sanchez,26
+San Joaquin,944130,U.S. Senate,,DEM,Kamala D. Harris,11
+San Joaquin,944130,U.S. Senate,,DEM,Loretta L. Sanchez,12
+San Joaquin,945020,U.S. Senate,,DEM,Kamala D. Harris,0
+San Joaquin,945020,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Joaquin,945030,U.S. Senate,,DEM,Kamala D. Harris,1
+San Joaquin,945030,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Joaquin,945031,U.S. Senate,,DEM,Kamala D. Harris,2
+San Joaquin,945031,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Joaquin,945032,U.S. Senate,,DEM,Kamala D. Harris,0
+San Joaquin,945032,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Joaquin,945040,U.S. Senate,,DEM,Kamala D. Harris,10
+San Joaquin,945040,U.S. Senate,,DEM,Loretta L. Sanchez,5
+San Joaquin,945050,U.S. Senate,,DEM,Kamala D. Harris,2
+San Joaquin,945050,U.S. Senate,,DEM,Loretta L. Sanchez,1
+San Joaquin,945051,U.S. Senate,,DEM,Kamala D. Harris,37
+San Joaquin,945051,U.S. Senate,,DEM,Loretta L. Sanchez,25
+San Joaquin,945060,U.S. Senate,,DEM,Kamala D. Harris,76
+San Joaquin,945060,U.S. Senate,,DEM,Loretta L. Sanchez,62
+San Joaquin,945061,U.S. Senate,,DEM,Kamala D. Harris,0
+San Joaquin,945061,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Joaquin,945062,U.S. Senate,,DEM,Kamala D. Harris,0
+San Joaquin,945062,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Joaquin,945063,U.S. Senate,,DEM,Kamala D. Harris,8
+San Joaquin,945063,U.S. Senate,,DEM,Loretta L. Sanchez,2

--- a/2016/20161108__ca__general__san_luis_obispo__precinct.csv
+++ b/2016/20161108__ca__general__san_luis_obispo__precinct.csv
@@ -6399,323 +6399,323 @@ San Luis Obispo,MB7,Proposition 67,,N/A,Yes,56
 San Luis Obispo,MB7,Proposition 67,,N/A,No,62
 San Luis Obispo,MB9,Proposition 67,,N/A,Yes,0
 San Luis Obispo,MB9,Proposition 67,,N/A,No,0
-San Luis Obispo,CON101-01,U.S. Senate,,DEM,Kamala Harris,534
-San Luis Obispo,CON101-01,U.S. Senate,,DEM,Loretta Sanchez,445
-San Luis Obispo,CON102-02,U.S. Senate,,DEM,Kamala Harris,721
-San Luis Obispo,CON102-02,U.S. Senate,,DEM,Loretta Sanchez,462
-San Luis Obispo,CON103-03,U.S. Senate,,DEM,Kamala Harris,473
-San Luis Obispo,CON103-03,U.S. Senate,,DEM,Loretta Sanchez,320
-San Luis Obispo,CON104-04,U.S. Senate,,DEM,Kamala Harris,288
-San Luis Obispo,CON104-04,U.S. Senate,,DEM,Loretta Sanchez,225
-San Luis Obispo,CON105-05,U.S. Senate,,DEM,Kamala Harris,225
-San Luis Obispo,CON105-05,U.S. Senate,,DEM,Loretta Sanchez,180
-San Luis Obispo,CON106-06,U.S. Senate,,DEM,Kamala Harris,503
-San Luis Obispo,CON106-06,U.S. Senate,,DEM,Loretta Sanchez,359
-San Luis Obispo,CON107-07,U.S. Senate,,DEM,Kamala Harris,141
-San Luis Obispo,CON107-07,U.S. Senate,,DEM,Loretta Sanchez,177
-San Luis Obispo,CON108-04,U.S. Senate,,DEM,Kamala Harris,547
-San Luis Obispo,CON108-04,U.S. Senate,,DEM,Loretta Sanchez,394
-San Luis Obispo,CON109-05,U.S. Senate,,DEM,Kamala Harris,617
-San Luis Obispo,CON109-05,U.S. Senate,,DEM,Loretta Sanchez,380
-San Luis Obispo,CON110-05,U.S. Senate,,DEM,Kamala Harris,261
-San Luis Obispo,CON110-05,U.S. Senate,,DEM,Loretta Sanchez,232
-San Luis Obispo,CON111-08,U.S. Senate,,DEM,Kamala Harris,398
-San Luis Obispo,CON111-08,U.S. Senate,,DEM,Loretta Sanchez,236
-San Luis Obispo,CON112-08,U.S. Senate,,DEM,Kamala Harris,617
-San Luis Obispo,CON112-08,U.S. Senate,,DEM,Loretta Sanchez,386
-San Luis Obispo,CON113-09,U.S. Senate,,DEM,Kamala Harris,331
-San Luis Obispo,CON113-09,U.S. Senate,,DEM,Loretta Sanchez,221
-San Luis Obispo,CON114-10,U.S. Senate,,DEM,Kamala Harris,333
-San Luis Obispo,CON114-10,U.S. Senate,,DEM,Loretta Sanchez,229
-San Luis Obispo,CON115-06,U.S. Senate,,DEM,Kamala Harris,643
-San Luis Obispo,CON115-06,U.S. Senate,,DEM,Loretta Sanchez,439
-San Luis Obispo,CON116-11,U.S. Senate,,DEM,Kamala Harris,641
-San Luis Obispo,CON116-11,U.S. Senate,,DEM,Loretta Sanchez,487
-San Luis Obispo,CON117-06,U.S. Senate,,DEM,Kamala Harris,268
-San Luis Obispo,CON117-06,U.S. Senate,,DEM,Loretta Sanchez,220
-San Luis Obispo,CON118-11,U.S. Senate,,DEM,Kamala Harris,274
-San Luis Obispo,CON118-11,U.S. Senate,,DEM,Loretta Sanchez,258
-San Luis Obispo,CON119-12,U.S. Senate,,DEM,Kamala Harris,475
-San Luis Obispo,CON119-12,U.S. Senate,,DEM,Loretta Sanchez,331
-San Luis Obispo,CON120-12,U.S. Senate,,DEM,Kamala Harris,378
-San Luis Obispo,CON120-12,U.S. Senate,,DEM,Loretta Sanchez,242
-San Luis Obispo,CON121-13,U.S. Senate,,DEM,Kamala Harris,229
-San Luis Obispo,CON121-13,U.S. Senate,,DEM,Loretta Sanchez,189
-San Luis Obispo,CON122-13,U.S. Senate,,DEM,Kamala Harris,581
-San Luis Obispo,CON122-13,U.S. Senate,,DEM,Loretta Sanchez,411
-San Luis Obispo,CON123-14,U.S. Senate,,DEM,Kamala Harris,569
-San Luis Obispo,CON123-14,U.S. Senate,,DEM,Loretta Sanchez,354
-San Luis Obispo,CON124-14,U.S. Senate,,DEM,Kamala Harris,499
-San Luis Obispo,CON124-14,U.S. Senate,,DEM,Loretta Sanchez,313
-San Luis Obispo,CON201-15,U.S. Senate,,DEM,Kamala Harris,701
-San Luis Obispo,CON201-15,U.S. Senate,,DEM,Loretta Sanchez,338
-San Luis Obispo,CON202-15,U.S. Senate,,DEM,Kamala Harris,687
-San Luis Obispo,CON202-15,U.S. Senate,,DEM,Loretta Sanchez,294
-San Luis Obispo,CON203-15,U.S. Senate,,DEM,Kamala Harris,719
-San Luis Obispo,CON203-15,U.S. Senate,,DEM,Loretta Sanchez,248
-San Luis Obispo,CON204-15,U.S. Senate,,DEM,Kamala Harris,153
-San Luis Obispo,CON204-15,U.S. Senate,,DEM,Loretta Sanchez,108
-San Luis Obispo,CON205-16,U.S. Senate,,DEM,Kamala Harris,417
-San Luis Obispo,CON205-16,U.S. Senate,,DEM,Loretta Sanchez,227
-San Luis Obispo,CON206-16,U.S. Senate,,DEM,Kamala Harris,567
-San Luis Obispo,CON206-16,U.S. Senate,,DEM,Loretta Sanchez,277
-San Luis Obispo,CON207-17,U.S. Senate,,DEM,Kamala Harris,449
-San Luis Obispo,CON207-17,U.S. Senate,,DEM,Loretta Sanchez,213
-San Luis Obispo,CON208-17,U.S. Senate,,DEM,Kamala Harris,449
-San Luis Obispo,CON208-17,U.S. Senate,,DEM,Loretta Sanchez,224
-San Luis Obispo,CON209-17,U.S. Senate,,DEM,Kamala Harris,448
-San Luis Obispo,CON209-17,U.S. Senate,,DEM,Loretta Sanchez,188
-San Luis Obispo,CON210-18,U.S. Senate,,DEM,Kamala Harris,358
-San Luis Obispo,CON210-18,U.S. Senate,,DEM,Loretta Sanchez,167
-San Luis Obispo,CON211-19,U.S. Senate,,DEM,Kamala Harris,420
-San Luis Obispo,CON211-19,U.S. Senate,,DEM,Loretta Sanchez,258
-San Luis Obispo,CON212-19,U.S. Senate,,DEM,Kamala Harris,647
-San Luis Obispo,CON212-19,U.S. Senate,,DEM,Loretta Sanchez,304
-San Luis Obispo,CON213-19,U.S. Senate,,DEM,Kamala Harris,648
-San Luis Obispo,CON213-19,U.S. Senate,,DEM,Loretta Sanchez,285
-San Luis Obispo,CON214-20,U.S. Senate,,DEM,Kamala Harris,840
-San Luis Obispo,CON214-20,U.S. Senate,,DEM,Loretta Sanchez,347
-San Luis Obispo,CON215-21,U.S. Senate,,DEM,Kamala Harris,521
-San Luis Obispo,CON215-21,U.S. Senate,,DEM,Loretta Sanchez,177
-San Luis Obispo,CON216-22,U.S. Senate,,DEM,Kamala Harris,415
-San Luis Obispo,CON216-22,U.S. Senate,,DEM,Loretta Sanchez,154
-San Luis Obispo,CON217-22,U.S. Senate,,DEM,Kamala Harris,538
-San Luis Obispo,CON217-22,U.S. Senate,,DEM,Loretta Sanchez,240
-San Luis Obispo,CON218-23,U.S. Senate,,DEM,Kamala Harris,767
-San Luis Obispo,CON218-23,U.S. Senate,,DEM,Loretta Sanchez,321
-San Luis Obispo,CON219-24,U.S. Senate,,DEM,Kamala Harris,368
-San Luis Obispo,CON219-24,U.S. Senate,,DEM,Loretta Sanchez,124
-San Luis Obispo,CON220-25,U.S. Senate,,DEM,Kamala Harris,891
-San Luis Obispo,CON220-25,U.S. Senate,,DEM,Loretta Sanchez,362
-San Luis Obispo,CON221-26,U.S. Senate,,DEM,Kamala Harris,697
-San Luis Obispo,CON221-26,U.S. Senate,,DEM,Loretta Sanchez,258
-San Luis Obispo,CON222-27,U.S. Senate,,DEM,Kamala Harris,591
-San Luis Obispo,CON222-27,U.S. Senate,,DEM,Loretta Sanchez,225
-San Luis Obispo,CON223-27,U.S. Senate,,DEM,Kamala Harris,655
-San Luis Obispo,CON223-27,U.S. Senate,,DEM,Loretta Sanchez,275
-San Luis Obispo,CON224-28,U.S. Senate,,DEM,Kamala Harris,638
-San Luis Obispo,CON224-28,U.S. Senate,,DEM,Loretta Sanchez,233
-San Luis Obispo,CON225-29,U.S. Senate,,DEM,Kamala Harris,668
-San Luis Obispo,CON225-29,U.S. Senate,,DEM,Loretta Sanchez,391
-San Luis Obispo,CON226-30,U.S. Senate,,DEM,Kamala Harris,693
-San Luis Obispo,CON226-30,U.S. Senate,,DEM,Loretta Sanchez,574
-San Luis Obispo,CON301-31,U.S. Senate,,DEM,Kamala Harris,457
-San Luis Obispo,CON301-31,U.S. Senate,,DEM,Loretta Sanchez,187
-San Luis Obispo,CON302-32,U.S. Senate,,DEM,Kamala Harris,351
-San Luis Obispo,CON302-32,U.S. Senate,,DEM,Loretta Sanchez,194
-San Luis Obispo,CON303-33,U.S. Senate,,DEM,Kamala Harris,504
-San Luis Obispo,CON303-33,U.S. Senate,,DEM,Loretta Sanchez,245
-San Luis Obispo,CON304-34,U.S. Senate,,DEM,Kamala Harris,582
-San Luis Obispo,CON304-34,U.S. Senate,,DEM,Loretta Sanchez,237
-San Luis Obispo,CON305-35,U.S. Senate,,DEM,Kamala Harris,522
-San Luis Obispo,CON305-35,U.S. Senate,,DEM,Loretta Sanchez,221
-San Luis Obispo,CON306-36,U.S. Senate,,DEM,Kamala Harris,520
-San Luis Obispo,CON306-36,U.S. Senate,,DEM,Loretta Sanchez,146
-San Luis Obispo,CON307-37,U.S. Senate,,DEM,Kamala Harris,312
-San Luis Obispo,CON307-37,U.S. Senate,,DEM,Loretta Sanchez,176
-San Luis Obispo,CON308-36,U.S. Senate,,DEM,Kamala Harris,667
-San Luis Obispo,CON308-36,U.S. Senate,,DEM,Loretta Sanchez,231
-San Luis Obispo,CON309-38,U.S. Senate,,DEM,Kamala Harris,523
-San Luis Obispo,CON309-38,U.S. Senate,,DEM,Loretta Sanchez,174
-San Luis Obispo,CON310-38,U.S. Senate,,DEM,Kamala Harris,512
-San Luis Obispo,CON310-38,U.S. Senate,,DEM,Loretta Sanchez,166
-San Luis Obispo,CON311-35,U.S. Senate,,DEM,Kamala Harris,553
-San Luis Obispo,CON311-35,U.S. Senate,,DEM,Loretta Sanchez,193
-San Luis Obispo,CON312-39,U.S. Senate,,DEM,Kamala Harris,460
-San Luis Obispo,CON312-39,U.S. Senate,,DEM,Loretta Sanchez,250
-San Luis Obispo,CON313-39,U.S. Senate,,DEM,Kamala Harris,551
-San Luis Obispo,CON313-39,U.S. Senate,,DEM,Loretta Sanchez,230
-San Luis Obispo,CON314-40,U.S. Senate,,DEM,Kamala Harris,524
-San Luis Obispo,CON314-40,U.S. Senate,,DEM,Loretta Sanchez,198
-San Luis Obispo,CON315-40,U.S. Senate,,DEM,Kamala Harris,900
-San Luis Obispo,CON315-40,U.S. Senate,,DEM,Loretta Sanchez,338
-San Luis Obispo,CON316-41,U.S. Senate,,DEM,Kamala Harris,587
-San Luis Obispo,CON316-41,U.S. Senate,,DEM,Loretta Sanchez,229
-San Luis Obispo,CON317-42,U.S. Senate,,DEM,Kamala Harris,826
-San Luis Obispo,CON317-42,U.S. Senate,,DEM,Loretta Sanchez,333
-San Luis Obispo,CON318-43,U.S. Senate,,DEM,Kamala Harris,768
-San Luis Obispo,CON318-43,U.S. Senate,,DEM,Loretta Sanchez,332
-San Luis Obispo,CON319-43,U.S. Senate,,DEM,Kamala Harris,441
-San Luis Obispo,CON319-43,U.S. Senate,,DEM,Loretta Sanchez,192
-San Luis Obispo,CON320-44,U.S. Senate,,DEM,Kamala Harris,534
-San Luis Obispo,CON320-44,U.S. Senate,,DEM,Loretta Sanchez,269
-San Luis Obispo,CON321-44,U.S. Senate,,DEM,Kamala Harris,430
-San Luis Obispo,CON321-44,U.S. Senate,,DEM,Loretta Sanchez,178
-San Luis Obispo,CON322-44,U.S. Senate,,DEM,Kamala Harris,553
-San Luis Obispo,CON322-44,U.S. Senate,,DEM,Loretta Sanchez,274
-San Luis Obispo,CON323-45,U.S. Senate,,DEM,Kamala Harris,753
-San Luis Obispo,CON323-45,U.S. Senate,,DEM,Loretta Sanchez,417
-San Luis Obispo,CON324-45,U.S. Senate,,DEM,Kamala Harris,344
-San Luis Obispo,CON324-45,U.S. Senate,,DEM,Loretta Sanchez,193
-San Luis Obispo,CON325-46,U.S. Senate,,DEM,Kamala Harris,399
-San Luis Obispo,CON325-46,U.S. Senate,,DEM,Loretta Sanchez,210
-San Luis Obispo,CON326-47,U.S. Senate,,DEM,Kamala Harris,278
-San Luis Obispo,CON326-47,U.S. Senate,,DEM,Loretta Sanchez,230
-San Luis Obispo,CON327-48,U.S. Senate,,DEM,Kamala Harris,371
-San Luis Obispo,CON327-48,U.S. Senate,,DEM,Loretta Sanchez,253
-San Luis Obispo,CON328-49,U.S. Senate,,DEM,Kamala Harris,734
-San Luis Obispo,CON328-49,U.S. Senate,,DEM,Loretta Sanchez,377
-San Luis Obispo,CON329-50,U.S. Senate,,DEM,Kamala Harris,450
-San Luis Obispo,CON329-50,U.S. Senate,,DEM,Loretta Sanchez,235
-San Luis Obispo,CON330-50,U.S. Senate,,DEM,Kamala Harris,302
-San Luis Obispo,CON330-50,U.S. Senate,,DEM,Loretta Sanchez,147
-San Luis Obispo,CON401-50,U.S. Senate,,DEM,Kamala Harris,542
-San Luis Obispo,CON401-50,U.S. Senate,,DEM,Loretta Sanchez,201
-San Luis Obispo,CON402-50,U.S. Senate,,DEM,Kamala Harris,487
-San Luis Obispo,CON402-50,U.S. Senate,,DEM,Loretta Sanchez,228
-San Luis Obispo,CON403-51,U.S. Senate,,DEM,Kamala Harris,703
-San Luis Obispo,CON403-51,U.S. Senate,,DEM,Loretta Sanchez,259
-San Luis Obispo,CON404-51,U.S. Senate,,DEM,Kamala Harris,414
-San Luis Obispo,CON404-51,U.S. Senate,,DEM,Loretta Sanchez,189
-San Luis Obispo,CON405-52,U.S. Senate,,DEM,Kamala Harris,281
-San Luis Obispo,CON405-52,U.S. Senate,,DEM,Loretta Sanchez,133
-San Luis Obispo,CON406-53,U.S. Senate,,DEM,Kamala Harris,277
-San Luis Obispo,CON406-53,U.S. Senate,,DEM,Loretta Sanchez,115
-San Luis Obispo,CON407-54,U.S. Senate,,DEM,Kamala Harris,358
-San Luis Obispo,CON407-54,U.S. Senate,,DEM,Loretta Sanchez,185
-San Luis Obispo,CON408-54,U.S. Senate,,DEM,Kamala Harris,421
-San Luis Obispo,CON408-54,U.S. Senate,,DEM,Loretta Sanchez,198
-San Luis Obispo,CON409-46,U.S. Senate,,DEM,Kamala Harris,379
-San Luis Obispo,CON409-46,U.S. Senate,,DEM,Loretta Sanchez,217
-San Luis Obispo,CON410-55,U.S. Senate,,DEM,Kamala Harris,665
-San Luis Obispo,CON410-55,U.S. Senate,,DEM,Loretta Sanchez,310
-San Luis Obispo,CON411-49,U.S. Senate,,DEM,Kamala Harris,331
-San Luis Obispo,CON411-49,U.S. Senate,,DEM,Loretta Sanchez,198
-San Luis Obispo,CON412-56,U.S. Senate,,DEM,Kamala Harris,332
-San Luis Obispo,CON412-56,U.S. Senate,,DEM,Loretta Sanchez,186
-San Luis Obispo,CON413-50,U.S. Senate,,DEM,Kamala Harris,405
-San Luis Obispo,CON413-50,U.S. Senate,,DEM,Loretta Sanchez,237
-San Luis Obispo,CON414-52,U.S. Senate,,DEM,Kamala Harris,648
-San Luis Obispo,CON414-52,U.S. Senate,,DEM,Loretta Sanchez,361
-San Luis Obispo,CON415-57,U.S. Senate,,DEM,Kamala Harris,555
-San Luis Obispo,CON415-57,U.S. Senate,,DEM,Loretta Sanchez,309
-San Luis Obispo,CON416-57,U.S. Senate,,DEM,Kamala Harris,413
-San Luis Obispo,CON416-57,U.S. Senate,,DEM,Loretta Sanchez,278
-San Luis Obispo,CON417-58,U.S. Senate,,DEM,Kamala Harris,477
-San Luis Obispo,CON417-58,U.S. Senate,,DEM,Loretta Sanchez,417
-San Luis Obispo,CON418-59,U.S. Senate,,DEM,Kamala Harris,621
-San Luis Obispo,CON418-59,U.S. Senate,,DEM,Loretta Sanchez,328
-San Luis Obispo,CON419-60,U.S. Senate,,DEM,Kamala Harris,560
-San Luis Obispo,CON419-60,U.S. Senate,,DEM,Loretta Sanchez,413
-San Luis Obispo,CON420-60,U.S. Senate,,DEM,Kamala Harris,521
-San Luis Obispo,CON420-60,U.S. Senate,,DEM,Loretta Sanchez,446
-San Luis Obispo,CON421-61,U.S. Senate,,DEM,Kamala Harris,406
-San Luis Obispo,CON421-61,U.S. Senate,,DEM,Loretta Sanchez,484
-San Luis Obispo,CON422-61,U.S. Senate,,DEM,Kamala Harris,511
-San Luis Obispo,CON422-61,U.S. Senate,,DEM,Loretta Sanchez,285
-San Luis Obispo,CON423-59,U.S. Senate,,DEM,Kamala Harris,385
-San Luis Obispo,CON423-59,U.S. Senate,,DEM,Loretta Sanchez,237
-San Luis Obispo,CON424-62,U.S. Senate,,DEM,Kamala Harris,856
-San Luis Obispo,CON424-62,U.S. Senate,,DEM,Loretta Sanchez,432
-San Luis Obispo,CON425-63,U.S. Senate,,DEM,Kamala Harris,370
-San Luis Obispo,CON425-63,U.S. Senate,,DEM,Loretta Sanchez,207
-San Luis Obispo,CON426-63,U.S. Senate,,DEM,Kamala Harris,403
-San Luis Obispo,CON426-63,U.S. Senate,,DEM,Loretta Sanchez,336
-San Luis Obispo,CON427-64,U.S. Senate,,DEM,Kamala Harris,459
-San Luis Obispo,CON427-64,U.S. Senate,,DEM,Loretta Sanchez,398
-San Luis Obispo,CON501-65,U.S. Senate,,DEM,Kamala Harris,589
-San Luis Obispo,CON501-65,U.S. Senate,,DEM,Loretta Sanchez,287
-San Luis Obispo,CON502-65,U.S. Senate,,DEM,Kamala Harris,601
-San Luis Obispo,CON502-65,U.S. Senate,,DEM,Loretta Sanchez,308
-San Luis Obispo,CON503-66,U.S. Senate,,DEM,Kamala Harris,611
-San Luis Obispo,CON503-66,U.S. Senate,,DEM,Loretta Sanchez,302
-San Luis Obispo,CON504-66,U.S. Senate,,DEM,Kamala Harris,316
-San Luis Obispo,CON504-66,U.S. Senate,,DEM,Loretta Sanchez,213
-San Luis Obispo,CON505-66,U.S. Senate,,DEM,Kamala Harris,630
-San Luis Obispo,CON505-66,U.S. Senate,,DEM,Loretta Sanchez,300
-San Luis Obispo,CON506-66,U.S. Senate,,DEM,Kamala Harris,369
-San Luis Obispo,CON506-66,U.S. Senate,,DEM,Loretta Sanchez,174
-San Luis Obispo,CON507-67,U.S. Senate,,DEM,Kamala Harris,349
-San Luis Obispo,CON507-67,U.S. Senate,,DEM,Loretta Sanchez,207
-San Luis Obispo,CON508-65,U.S. Senate,,DEM,Kamala Harris,409
-San Luis Obispo,CON508-65,U.S. Senate,,DEM,Loretta Sanchez,182
-San Luis Obispo,CON509-65,U.S. Senate,,DEM,Kamala Harris,382
-San Luis Obispo,CON509-65,U.S. Senate,,DEM,Loretta Sanchez,233
-San Luis Obispo,CON510-68,U.S. Senate,,DEM,Kamala Harris,395
-San Luis Obispo,CON510-68,U.S. Senate,,DEM,Loretta Sanchez,188
-San Luis Obispo,CON511-68,U.S. Senate,,DEM,Kamala Harris,411
-San Luis Obispo,CON511-68,U.S. Senate,,DEM,Loretta Sanchez,220
-San Luis Obispo,CON512-69,U.S. Senate,,DEM,Kamala Harris,366
-San Luis Obispo,CON512-69,U.S. Senate,,DEM,Loretta Sanchez,209
-San Luis Obispo,CON513-69,U.S. Senate,,DEM,Kamala Harris,379
-San Luis Obispo,CON513-69,U.S. Senate,,DEM,Loretta Sanchez,247
-San Luis Obispo,CON514-67,U.S. Senate,,DEM,Kamala Harris,395
-San Luis Obispo,CON514-67,U.S. Senate,,DEM,Loretta Sanchez,238
-San Luis Obispo,CON515-70,U.S. Senate,,DEM,Kamala Harris,442
-San Luis Obispo,CON515-70,U.S. Senate,,DEM,Loretta Sanchez,276
-San Luis Obispo,CON516-71,U.S. Senate,,DEM,Kamala Harris,570
-San Luis Obispo,CON516-71,U.S. Senate,,DEM,Loretta Sanchez,373
-San Luis Obispo,CON517-71,U.S. Senate,,DEM,Kamala Harris,539
-San Luis Obispo,CON517-71,U.S. Senate,,DEM,Loretta Sanchez,311
-San Luis Obispo,CON518-14,U.S. Senate,,DEM,Kamala Harris,337
-San Luis Obispo,CON518-14,U.S. Senate,,DEM,Loretta Sanchez,244
-San Luis Obispo,CON519-03,U.S. Senate,,DEM,Kamala Harris,449
-San Luis Obispo,CON519-03,U.S. Senate,,DEM,Loretta Sanchez,295
-San Luis Obispo,CON520-06,U.S. Senate,,DEM,Kamala Harris,221
-San Luis Obispo,CON520-06,U.S. Senate,,DEM,Loretta Sanchez,177
-San Luis Obispo,CON521-72,U.S. Senate,,DEM,Kamala Harris,379
-San Luis Obispo,CON521-72,U.S. Senate,,DEM,Loretta Sanchez,226
-San Luis Obispo,CON522-73,U.S. Senate,,DEM,Kamala Harris,442
-San Luis Obispo,CON522-73,U.S. Senate,,DEM,Loretta Sanchez,242
-San Luis Obispo,CON523-73,U.S. Senate,,DEM,Kamala Harris,354
-San Luis Obispo,CON523-73,U.S. Senate,,DEM,Loretta Sanchez,196
-San Luis Obispo,CON524-74,U.S. Senate,,DEM,Kamala Harris,438
-San Luis Obispo,CON524-74,U.S. Senate,,DEM,Loretta Sanchez,186
-San Luis Obispo,CON525-75,U.S. Senate,,DEM,Kamala Harris,696
-San Luis Obispo,CON525-75,U.S. Senate,,DEM,Loretta Sanchez,335
-San Luis Obispo,CON526-75,U.S. Senate,,DEM,Kamala Harris,439
-San Luis Obispo,CON526-75,U.S. Senate,,DEM,Loretta Sanchez,158
-San Luis Obispo,CON527-76,U.S. Senate,,DEM,Kamala Harris,490
-San Luis Obispo,CON527-76,U.S. Senate,,DEM,Loretta Sanchez,262
-San Luis Obispo,CON528-76,U.S. Senate,,DEM,Kamala Harris,311
-San Luis Obispo,CON528-76,U.S. Senate,,DEM,Loretta Sanchez,214
-San Luis Obispo,CON529-76,U.S. Senate,,DEM,Kamala Harris,268
-San Luis Obispo,CON529-76,U.S. Senate,,DEM,Loretta Sanchez,163
-San Luis Obispo,CON530-74,U.S. Senate,,DEM,Kamala Harris,425
-San Luis Obispo,CON530-74,U.S. Senate,,DEM,Loretta Sanchez,208
-San Luis Obispo,MB10,U.S. Senate,,DEM,Kamala Harris,138
-San Luis Obispo,MB10,U.S. Senate,,DEM,Loretta Sanchez,72
-San Luis Obispo,MB16,U.S. Senate,,DEM,Kamala Harris,77
-San Luis Obispo,MB16,U.S. Senate,,DEM,Loretta Sanchez,51
-San Luis Obispo,MB17,U.S. Senate,,DEM,Kamala Harris,383
-San Luis Obispo,MB17,U.S. Senate,,DEM,Loretta Sanchez,339
-San Luis Obispo,MB18,U.S. Senate,,DEM,Kamala Harris,130
-San Luis Obispo,MB18,U.S. Senate,,DEM,Loretta Sanchez,85
-San Luis Obispo,MB19,U.S. Senate,,DEM,Kamala Harris,0
-San Luis Obispo,MB19,U.S. Senate,,DEM,Loretta Sanchez,0
-San Luis Obispo,MB20,U.S. Senate,,DEM,Kamala Harris,19
-San Luis Obispo,MB20,U.S. Senate,,DEM,Loretta Sanchez,11
-San Luis Obispo,MB22,U.S. Senate,,DEM,Kamala Harris,20
-San Luis Obispo,MB22,U.S. Senate,,DEM,Loretta Sanchez,15
-San Luis Obispo,MB30,U.S. Senate,,DEM,Kamala Harris,23
-San Luis Obispo,MB30,U.S. Senate,,DEM,Loretta Sanchez,6
-San Luis Obispo,MB31,U.S. Senate,,DEM,Kamala Harris,339
-San Luis Obispo,MB31,U.S. Senate,,DEM,Loretta Sanchez,185
-San Luis Obispo,MB33,U.S. Senate,,DEM,Kamala Harris,45
-San Luis Obispo,MB33,U.S. Senate,,DEM,Loretta Sanchez,33
-San Luis Obispo,MB34,U.S. Senate,,DEM,Kamala Harris,8
-San Luis Obispo,MB34,U.S. Senate,,DEM,Loretta Sanchez,7
-San Luis Obispo,MB36,U.S. Senate,,DEM,Kamala Harris,353
-San Luis Obispo,MB36,U.S. Senate,,DEM,Loretta Sanchez,162
-San Luis Obispo,MB37,U.S. Senate,,DEM,Kamala Harris,1
-San Luis Obispo,MB37,U.S. Senate,,DEM,Loretta Sanchez,2
-San Luis Obispo,MB38,U.S. Senate,,DEM,Kamala Harris,0
-San Luis Obispo,MB38,U.S. Senate,,DEM,Loretta Sanchez,0
-San Luis Obispo,MB39,U.S. Senate,,DEM,Kamala Harris,0
-San Luis Obispo,MB39,U.S. Senate,,DEM,Loretta Sanchez,0
-San Luis Obispo,MB40,U.S. Senate,,DEM,Kamala Harris,97
-San Luis Obispo,MB40,U.S. Senate,,DEM,Loretta Sanchez,37
-San Luis Obispo,MB41,U.S. Senate,,DEM,Kamala Harris,2
-San Luis Obispo,MB41,U.S. Senate,,DEM,Loretta Sanchez,0
-San Luis Obispo,MB46,U.S. Senate,,DEM,Kamala Harris,0
-San Luis Obispo,MB46,U.S. Senate,,DEM,Loretta Sanchez,0
-San Luis Obispo,MB47,U.S. Senate,,DEM,Kamala Harris,510
-San Luis Obispo,MB47,U.S. Senate,,DEM,Loretta Sanchez,293
-San Luis Obispo,MB48,U.S. Senate,,DEM,Kamala Harris,9
-San Luis Obispo,MB48,U.S. Senate,,DEM,Loretta Sanchez,2
-San Luis Obispo,MB5,U.S. Senate,,DEM,Kamala Harris,0
-San Luis Obispo,MB5,U.S. Senate,,DEM,Loretta Sanchez,0
-San Luis Obispo,MB7,U.S. Senate,,DEM,Kamala Harris,55
-San Luis Obispo,MB7,U.S. Senate,,DEM,Loretta Sanchez,37
-San Luis Obispo,MB9,U.S. Senate,,DEM,Kamala Harris,0
-San Luis Obispo,MB9,U.S. Senate,,DEM,Loretta Sanchez,0
+San Luis Obispo,CON101-01,U.S. Senate,,DEM,Kamala D. Harris,534
+San Luis Obispo,CON101-01,U.S. Senate,,DEM,Loretta L. Sanchez,445
+San Luis Obispo,CON102-02,U.S. Senate,,DEM,Kamala D. Harris,721
+San Luis Obispo,CON102-02,U.S. Senate,,DEM,Loretta L. Sanchez,462
+San Luis Obispo,CON103-03,U.S. Senate,,DEM,Kamala D. Harris,473
+San Luis Obispo,CON103-03,U.S. Senate,,DEM,Loretta L. Sanchez,320
+San Luis Obispo,CON104-04,U.S. Senate,,DEM,Kamala D. Harris,288
+San Luis Obispo,CON104-04,U.S. Senate,,DEM,Loretta L. Sanchez,225
+San Luis Obispo,CON105-05,U.S. Senate,,DEM,Kamala D. Harris,225
+San Luis Obispo,CON105-05,U.S. Senate,,DEM,Loretta L. Sanchez,180
+San Luis Obispo,CON106-06,U.S. Senate,,DEM,Kamala D. Harris,503
+San Luis Obispo,CON106-06,U.S. Senate,,DEM,Loretta L. Sanchez,359
+San Luis Obispo,CON107-07,U.S. Senate,,DEM,Kamala D. Harris,141
+San Luis Obispo,CON107-07,U.S. Senate,,DEM,Loretta L. Sanchez,177
+San Luis Obispo,CON108-04,U.S. Senate,,DEM,Kamala D. Harris,547
+San Luis Obispo,CON108-04,U.S. Senate,,DEM,Loretta L. Sanchez,394
+San Luis Obispo,CON109-05,U.S. Senate,,DEM,Kamala D. Harris,617
+San Luis Obispo,CON109-05,U.S. Senate,,DEM,Loretta L. Sanchez,380
+San Luis Obispo,CON110-05,U.S. Senate,,DEM,Kamala D. Harris,261
+San Luis Obispo,CON110-05,U.S. Senate,,DEM,Loretta L. Sanchez,232
+San Luis Obispo,CON111-08,U.S. Senate,,DEM,Kamala D. Harris,398
+San Luis Obispo,CON111-08,U.S. Senate,,DEM,Loretta L. Sanchez,236
+San Luis Obispo,CON112-08,U.S. Senate,,DEM,Kamala D. Harris,617
+San Luis Obispo,CON112-08,U.S. Senate,,DEM,Loretta L. Sanchez,386
+San Luis Obispo,CON113-09,U.S. Senate,,DEM,Kamala D. Harris,331
+San Luis Obispo,CON113-09,U.S. Senate,,DEM,Loretta L. Sanchez,221
+San Luis Obispo,CON114-10,U.S. Senate,,DEM,Kamala D. Harris,333
+San Luis Obispo,CON114-10,U.S. Senate,,DEM,Loretta L. Sanchez,229
+San Luis Obispo,CON115-06,U.S. Senate,,DEM,Kamala D. Harris,643
+San Luis Obispo,CON115-06,U.S. Senate,,DEM,Loretta L. Sanchez,439
+San Luis Obispo,CON116-11,U.S. Senate,,DEM,Kamala D. Harris,641
+San Luis Obispo,CON116-11,U.S. Senate,,DEM,Loretta L. Sanchez,487
+San Luis Obispo,CON117-06,U.S. Senate,,DEM,Kamala D. Harris,268
+San Luis Obispo,CON117-06,U.S. Senate,,DEM,Loretta L. Sanchez,220
+San Luis Obispo,CON118-11,U.S. Senate,,DEM,Kamala D. Harris,274
+San Luis Obispo,CON118-11,U.S. Senate,,DEM,Loretta L. Sanchez,258
+San Luis Obispo,CON119-12,U.S. Senate,,DEM,Kamala D. Harris,475
+San Luis Obispo,CON119-12,U.S. Senate,,DEM,Loretta L. Sanchez,331
+San Luis Obispo,CON120-12,U.S. Senate,,DEM,Kamala D. Harris,378
+San Luis Obispo,CON120-12,U.S. Senate,,DEM,Loretta L. Sanchez,242
+San Luis Obispo,CON121-13,U.S. Senate,,DEM,Kamala D. Harris,229
+San Luis Obispo,CON121-13,U.S. Senate,,DEM,Loretta L. Sanchez,189
+San Luis Obispo,CON122-13,U.S. Senate,,DEM,Kamala D. Harris,581
+San Luis Obispo,CON122-13,U.S. Senate,,DEM,Loretta L. Sanchez,411
+San Luis Obispo,CON123-14,U.S. Senate,,DEM,Kamala D. Harris,569
+San Luis Obispo,CON123-14,U.S. Senate,,DEM,Loretta L. Sanchez,354
+San Luis Obispo,CON124-14,U.S. Senate,,DEM,Kamala D. Harris,499
+San Luis Obispo,CON124-14,U.S. Senate,,DEM,Loretta L. Sanchez,313
+San Luis Obispo,CON201-15,U.S. Senate,,DEM,Kamala D. Harris,701
+San Luis Obispo,CON201-15,U.S. Senate,,DEM,Loretta L. Sanchez,338
+San Luis Obispo,CON202-15,U.S. Senate,,DEM,Kamala D. Harris,687
+San Luis Obispo,CON202-15,U.S. Senate,,DEM,Loretta L. Sanchez,294
+San Luis Obispo,CON203-15,U.S. Senate,,DEM,Kamala D. Harris,719
+San Luis Obispo,CON203-15,U.S. Senate,,DEM,Loretta L. Sanchez,248
+San Luis Obispo,CON204-15,U.S. Senate,,DEM,Kamala D. Harris,153
+San Luis Obispo,CON204-15,U.S. Senate,,DEM,Loretta L. Sanchez,108
+San Luis Obispo,CON205-16,U.S. Senate,,DEM,Kamala D. Harris,417
+San Luis Obispo,CON205-16,U.S. Senate,,DEM,Loretta L. Sanchez,227
+San Luis Obispo,CON206-16,U.S. Senate,,DEM,Kamala D. Harris,567
+San Luis Obispo,CON206-16,U.S. Senate,,DEM,Loretta L. Sanchez,277
+San Luis Obispo,CON207-17,U.S. Senate,,DEM,Kamala D. Harris,449
+San Luis Obispo,CON207-17,U.S. Senate,,DEM,Loretta L. Sanchez,213
+San Luis Obispo,CON208-17,U.S. Senate,,DEM,Kamala D. Harris,449
+San Luis Obispo,CON208-17,U.S. Senate,,DEM,Loretta L. Sanchez,224
+San Luis Obispo,CON209-17,U.S. Senate,,DEM,Kamala D. Harris,448
+San Luis Obispo,CON209-17,U.S. Senate,,DEM,Loretta L. Sanchez,188
+San Luis Obispo,CON210-18,U.S. Senate,,DEM,Kamala D. Harris,358
+San Luis Obispo,CON210-18,U.S. Senate,,DEM,Loretta L. Sanchez,167
+San Luis Obispo,CON211-19,U.S. Senate,,DEM,Kamala D. Harris,420
+San Luis Obispo,CON211-19,U.S. Senate,,DEM,Loretta L. Sanchez,258
+San Luis Obispo,CON212-19,U.S. Senate,,DEM,Kamala D. Harris,647
+San Luis Obispo,CON212-19,U.S. Senate,,DEM,Loretta L. Sanchez,304
+San Luis Obispo,CON213-19,U.S. Senate,,DEM,Kamala D. Harris,648
+San Luis Obispo,CON213-19,U.S. Senate,,DEM,Loretta L. Sanchez,285
+San Luis Obispo,CON214-20,U.S. Senate,,DEM,Kamala D. Harris,840
+San Luis Obispo,CON214-20,U.S. Senate,,DEM,Loretta L. Sanchez,347
+San Luis Obispo,CON215-21,U.S. Senate,,DEM,Kamala D. Harris,521
+San Luis Obispo,CON215-21,U.S. Senate,,DEM,Loretta L. Sanchez,177
+San Luis Obispo,CON216-22,U.S. Senate,,DEM,Kamala D. Harris,415
+San Luis Obispo,CON216-22,U.S. Senate,,DEM,Loretta L. Sanchez,154
+San Luis Obispo,CON217-22,U.S. Senate,,DEM,Kamala D. Harris,538
+San Luis Obispo,CON217-22,U.S. Senate,,DEM,Loretta L. Sanchez,240
+San Luis Obispo,CON218-23,U.S. Senate,,DEM,Kamala D. Harris,767
+San Luis Obispo,CON218-23,U.S. Senate,,DEM,Loretta L. Sanchez,321
+San Luis Obispo,CON219-24,U.S. Senate,,DEM,Kamala D. Harris,368
+San Luis Obispo,CON219-24,U.S. Senate,,DEM,Loretta L. Sanchez,124
+San Luis Obispo,CON220-25,U.S. Senate,,DEM,Kamala D. Harris,891
+San Luis Obispo,CON220-25,U.S. Senate,,DEM,Loretta L. Sanchez,362
+San Luis Obispo,CON221-26,U.S. Senate,,DEM,Kamala D. Harris,697
+San Luis Obispo,CON221-26,U.S. Senate,,DEM,Loretta L. Sanchez,258
+San Luis Obispo,CON222-27,U.S. Senate,,DEM,Kamala D. Harris,591
+San Luis Obispo,CON222-27,U.S. Senate,,DEM,Loretta L. Sanchez,225
+San Luis Obispo,CON223-27,U.S. Senate,,DEM,Kamala D. Harris,655
+San Luis Obispo,CON223-27,U.S. Senate,,DEM,Loretta L. Sanchez,275
+San Luis Obispo,CON224-28,U.S. Senate,,DEM,Kamala D. Harris,638
+San Luis Obispo,CON224-28,U.S. Senate,,DEM,Loretta L. Sanchez,233
+San Luis Obispo,CON225-29,U.S. Senate,,DEM,Kamala D. Harris,668
+San Luis Obispo,CON225-29,U.S. Senate,,DEM,Loretta L. Sanchez,391
+San Luis Obispo,CON226-30,U.S. Senate,,DEM,Kamala D. Harris,693
+San Luis Obispo,CON226-30,U.S. Senate,,DEM,Loretta L. Sanchez,574
+San Luis Obispo,CON301-31,U.S. Senate,,DEM,Kamala D. Harris,457
+San Luis Obispo,CON301-31,U.S. Senate,,DEM,Loretta L. Sanchez,187
+San Luis Obispo,CON302-32,U.S. Senate,,DEM,Kamala D. Harris,351
+San Luis Obispo,CON302-32,U.S. Senate,,DEM,Loretta L. Sanchez,194
+San Luis Obispo,CON303-33,U.S. Senate,,DEM,Kamala D. Harris,504
+San Luis Obispo,CON303-33,U.S. Senate,,DEM,Loretta L. Sanchez,245
+San Luis Obispo,CON304-34,U.S. Senate,,DEM,Kamala D. Harris,582
+San Luis Obispo,CON304-34,U.S. Senate,,DEM,Loretta L. Sanchez,237
+San Luis Obispo,CON305-35,U.S. Senate,,DEM,Kamala D. Harris,522
+San Luis Obispo,CON305-35,U.S. Senate,,DEM,Loretta L. Sanchez,221
+San Luis Obispo,CON306-36,U.S. Senate,,DEM,Kamala D. Harris,520
+San Luis Obispo,CON306-36,U.S. Senate,,DEM,Loretta L. Sanchez,146
+San Luis Obispo,CON307-37,U.S. Senate,,DEM,Kamala D. Harris,312
+San Luis Obispo,CON307-37,U.S. Senate,,DEM,Loretta L. Sanchez,176
+San Luis Obispo,CON308-36,U.S. Senate,,DEM,Kamala D. Harris,667
+San Luis Obispo,CON308-36,U.S. Senate,,DEM,Loretta L. Sanchez,231
+San Luis Obispo,CON309-38,U.S. Senate,,DEM,Kamala D. Harris,523
+San Luis Obispo,CON309-38,U.S. Senate,,DEM,Loretta L. Sanchez,174
+San Luis Obispo,CON310-38,U.S. Senate,,DEM,Kamala D. Harris,512
+San Luis Obispo,CON310-38,U.S. Senate,,DEM,Loretta L. Sanchez,166
+San Luis Obispo,CON311-35,U.S. Senate,,DEM,Kamala D. Harris,553
+San Luis Obispo,CON311-35,U.S. Senate,,DEM,Loretta L. Sanchez,193
+San Luis Obispo,CON312-39,U.S. Senate,,DEM,Kamala D. Harris,460
+San Luis Obispo,CON312-39,U.S. Senate,,DEM,Loretta L. Sanchez,250
+San Luis Obispo,CON313-39,U.S. Senate,,DEM,Kamala D. Harris,551
+San Luis Obispo,CON313-39,U.S. Senate,,DEM,Loretta L. Sanchez,230
+San Luis Obispo,CON314-40,U.S. Senate,,DEM,Kamala D. Harris,524
+San Luis Obispo,CON314-40,U.S. Senate,,DEM,Loretta L. Sanchez,198
+San Luis Obispo,CON315-40,U.S. Senate,,DEM,Kamala D. Harris,900
+San Luis Obispo,CON315-40,U.S. Senate,,DEM,Loretta L. Sanchez,338
+San Luis Obispo,CON316-41,U.S. Senate,,DEM,Kamala D. Harris,587
+San Luis Obispo,CON316-41,U.S. Senate,,DEM,Loretta L. Sanchez,229
+San Luis Obispo,CON317-42,U.S. Senate,,DEM,Kamala D. Harris,826
+San Luis Obispo,CON317-42,U.S. Senate,,DEM,Loretta L. Sanchez,333
+San Luis Obispo,CON318-43,U.S. Senate,,DEM,Kamala D. Harris,768
+San Luis Obispo,CON318-43,U.S. Senate,,DEM,Loretta L. Sanchez,332
+San Luis Obispo,CON319-43,U.S. Senate,,DEM,Kamala D. Harris,441
+San Luis Obispo,CON319-43,U.S. Senate,,DEM,Loretta L. Sanchez,192
+San Luis Obispo,CON320-44,U.S. Senate,,DEM,Kamala D. Harris,534
+San Luis Obispo,CON320-44,U.S. Senate,,DEM,Loretta L. Sanchez,269
+San Luis Obispo,CON321-44,U.S. Senate,,DEM,Kamala D. Harris,430
+San Luis Obispo,CON321-44,U.S. Senate,,DEM,Loretta L. Sanchez,178
+San Luis Obispo,CON322-44,U.S. Senate,,DEM,Kamala D. Harris,553
+San Luis Obispo,CON322-44,U.S. Senate,,DEM,Loretta L. Sanchez,274
+San Luis Obispo,CON323-45,U.S. Senate,,DEM,Kamala D. Harris,753
+San Luis Obispo,CON323-45,U.S. Senate,,DEM,Loretta L. Sanchez,417
+San Luis Obispo,CON324-45,U.S. Senate,,DEM,Kamala D. Harris,344
+San Luis Obispo,CON324-45,U.S. Senate,,DEM,Loretta L. Sanchez,193
+San Luis Obispo,CON325-46,U.S. Senate,,DEM,Kamala D. Harris,399
+San Luis Obispo,CON325-46,U.S. Senate,,DEM,Loretta L. Sanchez,210
+San Luis Obispo,CON326-47,U.S. Senate,,DEM,Kamala D. Harris,278
+San Luis Obispo,CON326-47,U.S. Senate,,DEM,Loretta L. Sanchez,230
+San Luis Obispo,CON327-48,U.S. Senate,,DEM,Kamala D. Harris,371
+San Luis Obispo,CON327-48,U.S. Senate,,DEM,Loretta L. Sanchez,253
+San Luis Obispo,CON328-49,U.S. Senate,,DEM,Kamala D. Harris,734
+San Luis Obispo,CON328-49,U.S. Senate,,DEM,Loretta L. Sanchez,377
+San Luis Obispo,CON329-50,U.S. Senate,,DEM,Kamala D. Harris,450
+San Luis Obispo,CON329-50,U.S. Senate,,DEM,Loretta L. Sanchez,235
+San Luis Obispo,CON330-50,U.S. Senate,,DEM,Kamala D. Harris,302
+San Luis Obispo,CON330-50,U.S. Senate,,DEM,Loretta L. Sanchez,147
+San Luis Obispo,CON401-50,U.S. Senate,,DEM,Kamala D. Harris,542
+San Luis Obispo,CON401-50,U.S. Senate,,DEM,Loretta L. Sanchez,201
+San Luis Obispo,CON402-50,U.S. Senate,,DEM,Kamala D. Harris,487
+San Luis Obispo,CON402-50,U.S. Senate,,DEM,Loretta L. Sanchez,228
+San Luis Obispo,CON403-51,U.S. Senate,,DEM,Kamala D. Harris,703
+San Luis Obispo,CON403-51,U.S. Senate,,DEM,Loretta L. Sanchez,259
+San Luis Obispo,CON404-51,U.S. Senate,,DEM,Kamala D. Harris,414
+San Luis Obispo,CON404-51,U.S. Senate,,DEM,Loretta L. Sanchez,189
+San Luis Obispo,CON405-52,U.S. Senate,,DEM,Kamala D. Harris,281
+San Luis Obispo,CON405-52,U.S. Senate,,DEM,Loretta L. Sanchez,133
+San Luis Obispo,CON406-53,U.S. Senate,,DEM,Kamala D. Harris,277
+San Luis Obispo,CON406-53,U.S. Senate,,DEM,Loretta L. Sanchez,115
+San Luis Obispo,CON407-54,U.S. Senate,,DEM,Kamala D. Harris,358
+San Luis Obispo,CON407-54,U.S. Senate,,DEM,Loretta L. Sanchez,185
+San Luis Obispo,CON408-54,U.S. Senate,,DEM,Kamala D. Harris,421
+San Luis Obispo,CON408-54,U.S. Senate,,DEM,Loretta L. Sanchez,198
+San Luis Obispo,CON409-46,U.S. Senate,,DEM,Kamala D. Harris,379
+San Luis Obispo,CON409-46,U.S. Senate,,DEM,Loretta L. Sanchez,217
+San Luis Obispo,CON410-55,U.S. Senate,,DEM,Kamala D. Harris,665
+San Luis Obispo,CON410-55,U.S. Senate,,DEM,Loretta L. Sanchez,310
+San Luis Obispo,CON411-49,U.S. Senate,,DEM,Kamala D. Harris,331
+San Luis Obispo,CON411-49,U.S. Senate,,DEM,Loretta L. Sanchez,198
+San Luis Obispo,CON412-56,U.S. Senate,,DEM,Kamala D. Harris,332
+San Luis Obispo,CON412-56,U.S. Senate,,DEM,Loretta L. Sanchez,186
+San Luis Obispo,CON413-50,U.S. Senate,,DEM,Kamala D. Harris,405
+San Luis Obispo,CON413-50,U.S. Senate,,DEM,Loretta L. Sanchez,237
+San Luis Obispo,CON414-52,U.S. Senate,,DEM,Kamala D. Harris,648
+San Luis Obispo,CON414-52,U.S. Senate,,DEM,Loretta L. Sanchez,361
+San Luis Obispo,CON415-57,U.S. Senate,,DEM,Kamala D. Harris,555
+San Luis Obispo,CON415-57,U.S. Senate,,DEM,Loretta L. Sanchez,309
+San Luis Obispo,CON416-57,U.S. Senate,,DEM,Kamala D. Harris,413
+San Luis Obispo,CON416-57,U.S. Senate,,DEM,Loretta L. Sanchez,278
+San Luis Obispo,CON417-58,U.S. Senate,,DEM,Kamala D. Harris,477
+San Luis Obispo,CON417-58,U.S. Senate,,DEM,Loretta L. Sanchez,417
+San Luis Obispo,CON418-59,U.S. Senate,,DEM,Kamala D. Harris,621
+San Luis Obispo,CON418-59,U.S. Senate,,DEM,Loretta L. Sanchez,328
+San Luis Obispo,CON419-60,U.S. Senate,,DEM,Kamala D. Harris,560
+San Luis Obispo,CON419-60,U.S. Senate,,DEM,Loretta L. Sanchez,413
+San Luis Obispo,CON420-60,U.S. Senate,,DEM,Kamala D. Harris,521
+San Luis Obispo,CON420-60,U.S. Senate,,DEM,Loretta L. Sanchez,446
+San Luis Obispo,CON421-61,U.S. Senate,,DEM,Kamala D. Harris,406
+San Luis Obispo,CON421-61,U.S. Senate,,DEM,Loretta L. Sanchez,484
+San Luis Obispo,CON422-61,U.S. Senate,,DEM,Kamala D. Harris,511
+San Luis Obispo,CON422-61,U.S. Senate,,DEM,Loretta L. Sanchez,285
+San Luis Obispo,CON423-59,U.S. Senate,,DEM,Kamala D. Harris,385
+San Luis Obispo,CON423-59,U.S. Senate,,DEM,Loretta L. Sanchez,237
+San Luis Obispo,CON424-62,U.S. Senate,,DEM,Kamala D. Harris,856
+San Luis Obispo,CON424-62,U.S. Senate,,DEM,Loretta L. Sanchez,432
+San Luis Obispo,CON425-63,U.S. Senate,,DEM,Kamala D. Harris,370
+San Luis Obispo,CON425-63,U.S. Senate,,DEM,Loretta L. Sanchez,207
+San Luis Obispo,CON426-63,U.S. Senate,,DEM,Kamala D. Harris,403
+San Luis Obispo,CON426-63,U.S. Senate,,DEM,Loretta L. Sanchez,336
+San Luis Obispo,CON427-64,U.S. Senate,,DEM,Kamala D. Harris,459
+San Luis Obispo,CON427-64,U.S. Senate,,DEM,Loretta L. Sanchez,398
+San Luis Obispo,CON501-65,U.S. Senate,,DEM,Kamala D. Harris,589
+San Luis Obispo,CON501-65,U.S. Senate,,DEM,Loretta L. Sanchez,287
+San Luis Obispo,CON502-65,U.S. Senate,,DEM,Kamala D. Harris,601
+San Luis Obispo,CON502-65,U.S. Senate,,DEM,Loretta L. Sanchez,308
+San Luis Obispo,CON503-66,U.S. Senate,,DEM,Kamala D. Harris,611
+San Luis Obispo,CON503-66,U.S. Senate,,DEM,Loretta L. Sanchez,302
+San Luis Obispo,CON504-66,U.S. Senate,,DEM,Kamala D. Harris,316
+San Luis Obispo,CON504-66,U.S. Senate,,DEM,Loretta L. Sanchez,213
+San Luis Obispo,CON505-66,U.S. Senate,,DEM,Kamala D. Harris,630
+San Luis Obispo,CON505-66,U.S. Senate,,DEM,Loretta L. Sanchez,300
+San Luis Obispo,CON506-66,U.S. Senate,,DEM,Kamala D. Harris,369
+San Luis Obispo,CON506-66,U.S. Senate,,DEM,Loretta L. Sanchez,174
+San Luis Obispo,CON507-67,U.S. Senate,,DEM,Kamala D. Harris,349
+San Luis Obispo,CON507-67,U.S. Senate,,DEM,Loretta L. Sanchez,207
+San Luis Obispo,CON508-65,U.S. Senate,,DEM,Kamala D. Harris,409
+San Luis Obispo,CON508-65,U.S. Senate,,DEM,Loretta L. Sanchez,182
+San Luis Obispo,CON509-65,U.S. Senate,,DEM,Kamala D. Harris,382
+San Luis Obispo,CON509-65,U.S. Senate,,DEM,Loretta L. Sanchez,233
+San Luis Obispo,CON510-68,U.S. Senate,,DEM,Kamala D. Harris,395
+San Luis Obispo,CON510-68,U.S. Senate,,DEM,Loretta L. Sanchez,188
+San Luis Obispo,CON511-68,U.S. Senate,,DEM,Kamala D. Harris,411
+San Luis Obispo,CON511-68,U.S. Senate,,DEM,Loretta L. Sanchez,220
+San Luis Obispo,CON512-69,U.S. Senate,,DEM,Kamala D. Harris,366
+San Luis Obispo,CON512-69,U.S. Senate,,DEM,Loretta L. Sanchez,209
+San Luis Obispo,CON513-69,U.S. Senate,,DEM,Kamala D. Harris,379
+San Luis Obispo,CON513-69,U.S. Senate,,DEM,Loretta L. Sanchez,247
+San Luis Obispo,CON514-67,U.S. Senate,,DEM,Kamala D. Harris,395
+San Luis Obispo,CON514-67,U.S. Senate,,DEM,Loretta L. Sanchez,238
+San Luis Obispo,CON515-70,U.S. Senate,,DEM,Kamala D. Harris,442
+San Luis Obispo,CON515-70,U.S. Senate,,DEM,Loretta L. Sanchez,276
+San Luis Obispo,CON516-71,U.S. Senate,,DEM,Kamala D. Harris,570
+San Luis Obispo,CON516-71,U.S. Senate,,DEM,Loretta L. Sanchez,373
+San Luis Obispo,CON517-71,U.S. Senate,,DEM,Kamala D. Harris,539
+San Luis Obispo,CON517-71,U.S. Senate,,DEM,Loretta L. Sanchez,311
+San Luis Obispo,CON518-14,U.S. Senate,,DEM,Kamala D. Harris,337
+San Luis Obispo,CON518-14,U.S. Senate,,DEM,Loretta L. Sanchez,244
+San Luis Obispo,CON519-03,U.S. Senate,,DEM,Kamala D. Harris,449
+San Luis Obispo,CON519-03,U.S. Senate,,DEM,Loretta L. Sanchez,295
+San Luis Obispo,CON520-06,U.S. Senate,,DEM,Kamala D. Harris,221
+San Luis Obispo,CON520-06,U.S. Senate,,DEM,Loretta L. Sanchez,177
+San Luis Obispo,CON521-72,U.S. Senate,,DEM,Kamala D. Harris,379
+San Luis Obispo,CON521-72,U.S. Senate,,DEM,Loretta L. Sanchez,226
+San Luis Obispo,CON522-73,U.S. Senate,,DEM,Kamala D. Harris,442
+San Luis Obispo,CON522-73,U.S. Senate,,DEM,Loretta L. Sanchez,242
+San Luis Obispo,CON523-73,U.S. Senate,,DEM,Kamala D. Harris,354
+San Luis Obispo,CON523-73,U.S. Senate,,DEM,Loretta L. Sanchez,196
+San Luis Obispo,CON524-74,U.S. Senate,,DEM,Kamala D. Harris,438
+San Luis Obispo,CON524-74,U.S. Senate,,DEM,Loretta L. Sanchez,186
+San Luis Obispo,CON525-75,U.S. Senate,,DEM,Kamala D. Harris,696
+San Luis Obispo,CON525-75,U.S. Senate,,DEM,Loretta L. Sanchez,335
+San Luis Obispo,CON526-75,U.S. Senate,,DEM,Kamala D. Harris,439
+San Luis Obispo,CON526-75,U.S. Senate,,DEM,Loretta L. Sanchez,158
+San Luis Obispo,CON527-76,U.S. Senate,,DEM,Kamala D. Harris,490
+San Luis Obispo,CON527-76,U.S. Senate,,DEM,Loretta L. Sanchez,262
+San Luis Obispo,CON528-76,U.S. Senate,,DEM,Kamala D. Harris,311
+San Luis Obispo,CON528-76,U.S. Senate,,DEM,Loretta L. Sanchez,214
+San Luis Obispo,CON529-76,U.S. Senate,,DEM,Kamala D. Harris,268
+San Luis Obispo,CON529-76,U.S. Senate,,DEM,Loretta L. Sanchez,163
+San Luis Obispo,CON530-74,U.S. Senate,,DEM,Kamala D. Harris,425
+San Luis Obispo,CON530-74,U.S. Senate,,DEM,Loretta L. Sanchez,208
+San Luis Obispo,MB10,U.S. Senate,,DEM,Kamala D. Harris,138
+San Luis Obispo,MB10,U.S. Senate,,DEM,Loretta L. Sanchez,72
+San Luis Obispo,MB16,U.S. Senate,,DEM,Kamala D. Harris,77
+San Luis Obispo,MB16,U.S. Senate,,DEM,Loretta L. Sanchez,51
+San Luis Obispo,MB17,U.S. Senate,,DEM,Kamala D. Harris,383
+San Luis Obispo,MB17,U.S. Senate,,DEM,Loretta L. Sanchez,339
+San Luis Obispo,MB18,U.S. Senate,,DEM,Kamala D. Harris,130
+San Luis Obispo,MB18,U.S. Senate,,DEM,Loretta L. Sanchez,85
+San Luis Obispo,MB19,U.S. Senate,,DEM,Kamala D. Harris,0
+San Luis Obispo,MB19,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Luis Obispo,MB20,U.S. Senate,,DEM,Kamala D. Harris,19
+San Luis Obispo,MB20,U.S. Senate,,DEM,Loretta L. Sanchez,11
+San Luis Obispo,MB22,U.S. Senate,,DEM,Kamala D. Harris,20
+San Luis Obispo,MB22,U.S. Senate,,DEM,Loretta L. Sanchez,15
+San Luis Obispo,MB30,U.S. Senate,,DEM,Kamala D. Harris,23
+San Luis Obispo,MB30,U.S. Senate,,DEM,Loretta L. Sanchez,6
+San Luis Obispo,MB31,U.S. Senate,,DEM,Kamala D. Harris,339
+San Luis Obispo,MB31,U.S. Senate,,DEM,Loretta L. Sanchez,185
+San Luis Obispo,MB33,U.S. Senate,,DEM,Kamala D. Harris,45
+San Luis Obispo,MB33,U.S. Senate,,DEM,Loretta L. Sanchez,33
+San Luis Obispo,MB34,U.S. Senate,,DEM,Kamala D. Harris,8
+San Luis Obispo,MB34,U.S. Senate,,DEM,Loretta L. Sanchez,7
+San Luis Obispo,MB36,U.S. Senate,,DEM,Kamala D. Harris,353
+San Luis Obispo,MB36,U.S. Senate,,DEM,Loretta L. Sanchez,162
+San Luis Obispo,MB37,U.S. Senate,,DEM,Kamala D. Harris,1
+San Luis Obispo,MB37,U.S. Senate,,DEM,Loretta L. Sanchez,2
+San Luis Obispo,MB38,U.S. Senate,,DEM,Kamala D. Harris,0
+San Luis Obispo,MB38,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Luis Obispo,MB39,U.S. Senate,,DEM,Kamala D. Harris,0
+San Luis Obispo,MB39,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Luis Obispo,MB40,U.S. Senate,,DEM,Kamala D. Harris,97
+San Luis Obispo,MB40,U.S. Senate,,DEM,Loretta L. Sanchez,37
+San Luis Obispo,MB41,U.S. Senate,,DEM,Kamala D. Harris,2
+San Luis Obispo,MB41,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Luis Obispo,MB46,U.S. Senate,,DEM,Kamala D. Harris,0
+San Luis Obispo,MB46,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Luis Obispo,MB47,U.S. Senate,,DEM,Kamala D. Harris,510
+San Luis Obispo,MB47,U.S. Senate,,DEM,Loretta L. Sanchez,293
+San Luis Obispo,MB48,U.S. Senate,,DEM,Kamala D. Harris,9
+San Luis Obispo,MB48,U.S. Senate,,DEM,Loretta L. Sanchez,2
+San Luis Obispo,MB5,U.S. Senate,,DEM,Kamala D. Harris,0
+San Luis Obispo,MB5,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Luis Obispo,MB7,U.S. Senate,,DEM,Kamala D. Harris,55
+San Luis Obispo,MB7,U.S. Senate,,DEM,Loretta L. Sanchez,37
+San Luis Obispo,MB9,U.S. Senate,,DEM,Kamala D. Harris,0
+San Luis Obispo,MB9,U.S. Senate,,DEM,Loretta L. Sanchez,0

--- a/2016/20161108__ca__general__san_mateo__precinct.csv
+++ b/2016/20161108__ca__general__san_mateo__precinct.csv
@@ -18719,939 +18719,939 @@ San Mateo,5906,Proposition 67,,N/A,Yes,0
 San Mateo,5906,Proposition 67,,N/A,No,0
 San Mateo,5907,Proposition 67,,N/A,Yes,0
 San Mateo,5907,Proposition 67,,N/A,No,0
-San Mateo,1001,U.S. Senate,,DEM,Kamala Harris,682
-San Mateo,1001,U.S. Senate,,DEM,Loretta Sanchez,227
-San Mateo,1002,U.S. Senate,,DEM,Kamala Harris,489
-San Mateo,1002,U.S. Senate,,DEM,Loretta Sanchez,156
-San Mateo,1003,U.S. Senate,,DEM,Kamala Harris,807
-San Mateo,1003,U.S. Senate,,DEM,Loretta Sanchez,309
-San Mateo,1005,U.S. Senate,,DEM,Kamala Harris,618
-San Mateo,1005,U.S. Senate,,DEM,Loretta Sanchez,222
-San Mateo,1007,U.S. Senate,,DEM,Kamala Harris,398
-San Mateo,1007,U.S. Senate,,DEM,Loretta Sanchez,170
-San Mateo,1008,U.S. Senate,,DEM,Kamala Harris,817
-San Mateo,1008,U.S. Senate,,DEM,Loretta Sanchez,303
-San Mateo,1009,U.S. Senate,,DEM,Kamala Harris,393
-San Mateo,1009,U.S. Senate,,DEM,Loretta Sanchez,126
-San Mateo,1011,U.S. Senate,,DEM,Kamala Harris,862
-San Mateo,1011,U.S. Senate,,DEM,Loretta Sanchez,309
-San Mateo,1013,U.S. Senate,,DEM,Kamala Harris,1003
-San Mateo,1013,U.S. Senate,,DEM,Loretta Sanchez,366
-San Mateo,1016,U.S. Senate,,DEM,Kamala Harris,1018
-San Mateo,1016,U.S. Senate,,DEM,Loretta Sanchez,287
-San Mateo,1017,U.S. Senate,,DEM,Kamala Harris,621
-San Mateo,1017,U.S. Senate,,DEM,Loretta Sanchez,200
-San Mateo,1019,U.S. Senate,,DEM,Kamala Harris,863
-San Mateo,1019,U.S. Senate,,DEM,Loretta Sanchez,316
-San Mateo,1021,U.S. Senate,,DEM,Kamala Harris,895
-San Mateo,1021,U.S. Senate,,DEM,Loretta Sanchez,360
-San Mateo,1201,U.S. Senate,,DEM,Kamala Harris,79
-San Mateo,1201,U.S. Senate,,DEM,Loretta Sanchez,37
-San Mateo,1202,U.S. Senate,,DEM,Kamala Harris,110
-San Mateo,1202,U.S. Senate,,DEM,Loretta Sanchez,57
-San Mateo,1203,U.S. Senate,,DEM,Kamala Harris,57
-San Mateo,1203,U.S. Senate,,DEM,Loretta Sanchez,21
-San Mateo,1204,U.S. Senate,,DEM,Kamala Harris,89
-San Mateo,1204,U.S. Senate,,DEM,Loretta Sanchez,46
-San Mateo,1205,U.S. Senate,,DEM,Kamala Harris,11
-San Mateo,1205,U.S. Senate,,DEM,Loretta Sanchez,2
-San Mateo,1206,U.S. Senate,,DEM,Kamala Harris,56
-San Mateo,1206,U.S. Senate,,DEM,Loretta Sanchez,25
-San Mateo,1302,U.S. Senate,,DEM,Kamala Harris,0
-San Mateo,1302,U.S. Senate,,DEM,Loretta Sanchez,0
-San Mateo,1303,U.S. Senate,,DEM,Kamala Harris,0
-San Mateo,1303,U.S. Senate,,DEM,Loretta Sanchez,0
-San Mateo,1304,U.S. Senate,,DEM,Kamala Harris,0
-San Mateo,1304,U.S. Senate,,DEM,Loretta Sanchez,0
-San Mateo,1401,U.S. Senate,,DEM,Kamala Harris,702
-San Mateo,1401,U.S. Senate,,DEM,Loretta Sanchez,329
-San Mateo,1402,U.S. Senate,,DEM,Kamala Harris,95
-San Mateo,1402,U.S. Senate,,DEM,Loretta Sanchez,44
-San Mateo,1403,U.S. Senate,,DEM,Kamala Harris,971
-San Mateo,1403,U.S. Senate,,DEM,Loretta Sanchez,440
-San Mateo,1406,U.S. Senate,,DEM,Kamala Harris,341
-San Mateo,1406,U.S. Senate,,DEM,Loretta Sanchez,146
-San Mateo,1407,U.S. Senate,,DEM,Kamala Harris,835
-San Mateo,1407,U.S. Senate,,DEM,Loretta Sanchez,325
-San Mateo,1409,U.S. Senate,,DEM,Kamala Harris,361
-San Mateo,1409,U.S. Senate,,DEM,Loretta Sanchez,174
-San Mateo,1410,U.S. Senate,,DEM,Kamala Harris,312
-San Mateo,1410,U.S. Senate,,DEM,Loretta Sanchez,93
-San Mateo,1501,U.S. Senate,,DEM,Kamala Harris,492
-San Mateo,1501,U.S. Senate,,DEM,Loretta Sanchez,213
-San Mateo,1502,U.S. Senate,,DEM,Kamala Harris,499
-San Mateo,1502,U.S. Senate,,DEM,Loretta Sanchez,199
-San Mateo,1503,U.S. Senate,,DEM,Kamala Harris,786
-San Mateo,1503,U.S. Senate,,DEM,Loretta Sanchez,323
-San Mateo,1506,U.S. Senate,,DEM,Kamala Harris,263
-San Mateo,1506,U.S. Senate,,DEM,Loretta Sanchez,113
-San Mateo,1507,U.S. Senate,,DEM,Kamala Harris,441
-San Mateo,1507,U.S. Senate,,DEM,Loretta Sanchez,176
-San Mateo,1508,U.S. Senate,,DEM,Kamala Harris,488
-San Mateo,1508,U.S. Senate,,DEM,Loretta Sanchez,197
-San Mateo,1509,U.S. Senate,,DEM,Kamala Harris,867
-San Mateo,1509,U.S. Senate,,DEM,Loretta Sanchez,341
-San Mateo,1511,U.S. Senate,,DEM,Kamala Harris,368
-San Mateo,1511,U.S. Senate,,DEM,Loretta Sanchez,122
-San Mateo,1512,U.S. Senate,,DEM,Kamala Harris,514
-San Mateo,1512,U.S. Senate,,DEM,Loretta Sanchez,241
-San Mateo,1514,U.S. Senate,,DEM,Kamala Harris,886
-San Mateo,1514,U.S. Senate,,DEM,Loretta Sanchez,399
-San Mateo,1516,U.S. Senate,,DEM,Kamala Harris,240
-San Mateo,1516,U.S. Senate,,DEM,Loretta Sanchez,94
-San Mateo,1601,U.S. Senate,,DEM,Kamala Harris,304
-San Mateo,1601,U.S. Senate,,DEM,Loretta Sanchez,242
-San Mateo,1602,U.S. Senate,,DEM,Kamala Harris,384
-San Mateo,1602,U.S. Senate,,DEM,Loretta Sanchez,227
-San Mateo,1603,U.S. Senate,,DEM,Kamala Harris,364
-San Mateo,1603,U.S. Senate,,DEM,Loretta Sanchez,249
-San Mateo,1604,U.S. Senate,,DEM,Kamala Harris,527
-San Mateo,1604,U.S. Senate,,DEM,Loretta Sanchez,278
-San Mateo,1605,U.S. Senate,,DEM,Kamala Harris,442
-San Mateo,1605,U.S. Senate,,DEM,Loretta Sanchez,257
-San Mateo,1606,U.S. Senate,,DEM,Kamala Harris,470
-San Mateo,1606,U.S. Senate,,DEM,Loretta Sanchez,214
-San Mateo,1607,U.S. Senate,,DEM,Kamala Harris,398
-San Mateo,1607,U.S. Senate,,DEM,Loretta Sanchez,175
-San Mateo,1608,U.S. Senate,,DEM,Kamala Harris,551
-San Mateo,1608,U.S. Senate,,DEM,Loretta Sanchez,261
-San Mateo,1610,U.S. Senate,,DEM,Kamala Harris,535
-San Mateo,1610,U.S. Senate,,DEM,Loretta Sanchez,214
-San Mateo,1612,U.S. Senate,,DEM,Kamala Harris,537
-San Mateo,1612,U.S. Senate,,DEM,Loretta Sanchez,219
-San Mateo,1613,U.S. Senate,,DEM,Kamala Harris,796
-San Mateo,1613,U.S. Senate,,DEM,Loretta Sanchez,283
-San Mateo,1614,U.S. Senate,,DEM,Kamala Harris,543
-San Mateo,1614,U.S. Senate,,DEM,Loretta Sanchez,224
-San Mateo,1617,U.S. Senate,,DEM,Kamala Harris,867
-San Mateo,1617,U.S. Senate,,DEM,Loretta Sanchez,389
-San Mateo,1619,U.S. Senate,,DEM,Kamala Harris,676
-San Mateo,1619,U.S. Senate,,DEM,Loretta Sanchez,298
-San Mateo,1701,U.S. Senate,,DEM,Kamala Harris,592
-San Mateo,1701,U.S. Senate,,DEM,Loretta Sanchez,199
-San Mateo,1703,U.S. Senate,,DEM,Kamala Harris,991
-San Mateo,1703,U.S. Senate,,DEM,Loretta Sanchez,235
-San Mateo,1705,U.S. Senate,,DEM,Kamala Harris,1
-San Mateo,1705,U.S. Senate,,DEM,Loretta Sanchez,0
-San Mateo,1706,U.S. Senate,,DEM,Kamala Harris,118
-San Mateo,1706,U.S. Senate,,DEM,Loretta Sanchez,35
-San Mateo,1801,U.S. Senate,,DEM,Kamala Harris,744
-San Mateo,1801,U.S. Senate,,DEM,Loretta Sanchez,436
-San Mateo,1802,U.S. Senate,,DEM,Kamala Harris,521
-San Mateo,1802,U.S. Senate,,DEM,Loretta Sanchez,217
-San Mateo,1803,U.S. Senate,,DEM,Kamala Harris,512
-San Mateo,1803,U.S. Senate,,DEM,Loretta Sanchez,234
-San Mateo,1806,U.S. Senate,,DEM,Kamala Harris,948
-San Mateo,1806,U.S. Senate,,DEM,Loretta Sanchez,429
-San Mateo,1807,U.S. Senate,,DEM,Kamala Harris,671
-San Mateo,1807,U.S. Senate,,DEM,Loretta Sanchez,323
-San Mateo,1810,U.S. Senate,,DEM,Kamala Harris,635
-San Mateo,1810,U.S. Senate,,DEM,Loretta Sanchez,408
-San Mateo,1813,U.S. Senate,,DEM,Kamala Harris,444
-San Mateo,1813,U.S. Senate,,DEM,Loretta Sanchez,265
-San Mateo,1814,U.S. Senate,,DEM,Kamala Harris,419
-San Mateo,1814,U.S. Senate,,DEM,Loretta Sanchez,296
-San Mateo,1815,U.S. Senate,,DEM,Kamala Harris,374
-San Mateo,1815,U.S. Senate,,DEM,Loretta Sanchez,221
-San Mateo,1816,U.S. Senate,,DEM,Kamala Harris,459
-San Mateo,1816,U.S. Senate,,DEM,Loretta Sanchez,236
-San Mateo,1818,U.S. Senate,,DEM,Kamala Harris,399
-San Mateo,1818,U.S. Senate,,DEM,Loretta Sanchez,259
-San Mateo,1819,U.S. Senate,,DEM,Kamala Harris,696
-San Mateo,1819,U.S. Senate,,DEM,Loretta Sanchez,379
-San Mateo,1820,U.S. Senate,,DEM,Kamala Harris,112
-San Mateo,1820,U.S. Senate,,DEM,Loretta Sanchez,49
-San Mateo,1821,U.S. Senate,,DEM,Kamala Harris,860
-San Mateo,1821,U.S. Senate,,DEM,Loretta Sanchez,376
-San Mateo,1824,U.S. Senate,,DEM,Kamala Harris,483
-San Mateo,1824,U.S. Senate,,DEM,Loretta Sanchez,236
-San Mateo,1833,U.S. Senate,,DEM,Kamala Harris,653
-San Mateo,1833,U.S. Senate,,DEM,Loretta Sanchez,291
-San Mateo,1835,U.S. Senate,,DEM,Kamala Harris,812
-San Mateo,1835,U.S. Senate,,DEM,Loretta Sanchez,384
-San Mateo,1837,U.S. Senate,,DEM,Kamala Harris,389
-San Mateo,1837,U.S. Senate,,DEM,Loretta Sanchez,191
-San Mateo,1838,U.S. Senate,,DEM,Kamala Harris,57
-San Mateo,1838,U.S. Senate,,DEM,Loretta Sanchez,24
-San Mateo,1902,U.S. Senate,,DEM,Kamala Harris,0
-San Mateo,1902,U.S. Senate,,DEM,Loretta Sanchez,0
-San Mateo,1903,U.S. Senate,,DEM,Kamala Harris,45
-San Mateo,1903,U.S. Senate,,DEM,Loretta Sanchez,26
-San Mateo,2101,U.S. Senate,,DEM,Kamala Harris,147
-San Mateo,2101,U.S. Senate,,DEM,Loretta Sanchez,60
-San Mateo,2104,U.S. Senate,,DEM,Kamala Harris,261
-San Mateo,2104,U.S. Senate,,DEM,Loretta Sanchez,105
-San Mateo,2106,U.S. Senate,,DEM,Kamala Harris,539
-San Mateo,2106,U.S. Senate,,DEM,Loretta Sanchez,163
-San Mateo,2107,U.S. Senate,,DEM,Kamala Harris,905
-San Mateo,2107,U.S. Senate,,DEM,Loretta Sanchez,272
-San Mateo,2110,U.S. Senate,,DEM,Kamala Harris,458
-San Mateo,2110,U.S. Senate,,DEM,Loretta Sanchez,114
-San Mateo,2111,U.S. Senate,,DEM,Kamala Harris,487
-San Mateo,2111,U.S. Senate,,DEM,Loretta Sanchez,154
-San Mateo,2112,U.S. Senate,,DEM,Kamala Harris,451
-San Mateo,2112,U.S. Senate,,DEM,Loretta Sanchez,157
-San Mateo,2113,U.S. Senate,,DEM,Kamala Harris,953
-San Mateo,2113,U.S. Senate,,DEM,Loretta Sanchez,291
-San Mateo,2115,U.S. Senate,,DEM,Kamala Harris,791
-San Mateo,2115,U.S. Senate,,DEM,Loretta Sanchez,270
-San Mateo,2117,U.S. Senate,,DEM,Kamala Harris,678
-San Mateo,2117,U.S. Senate,,DEM,Loretta Sanchez,252
-San Mateo,2122,U.S. Senate,,DEM,Kamala Harris,12
-San Mateo,2122,U.S. Senate,,DEM,Loretta Sanchez,2
-San Mateo,2131,U.S. Senate,,DEM,Kamala Harris,951
-San Mateo,2131,U.S. Senate,,DEM,Loretta Sanchez,321
-San Mateo,2133,U.S. Senate,,DEM,Kamala Harris,675
-San Mateo,2133,U.S. Senate,,DEM,Loretta Sanchez,230
-San Mateo,2201,U.S. Senate,,DEM,Kamala Harris,751
-San Mateo,2201,U.S. Senate,,DEM,Loretta Sanchez,232
-San Mateo,2203,U.S. Senate,,DEM,Kamala Harris,625
-San Mateo,2203,U.S. Senate,,DEM,Loretta Sanchez,251
-San Mateo,2204,U.S. Senate,,DEM,Kamala Harris,619
-San Mateo,2204,U.S. Senate,,DEM,Loretta Sanchez,222
-San Mateo,2205,U.S. Senate,,DEM,Kamala Harris,591
-San Mateo,2205,U.S. Senate,,DEM,Loretta Sanchez,221
-San Mateo,2207,U.S. Senate,,DEM,Kamala Harris,797
-San Mateo,2207,U.S. Senate,,DEM,Loretta Sanchez,264
-San Mateo,2210,U.S. Senate,,DEM,Kamala Harris,594
-San Mateo,2210,U.S. Senate,,DEM,Loretta Sanchez,204
-San Mateo,2212,U.S. Senate,,DEM,Kamala Harris,389
-San Mateo,2212,U.S. Senate,,DEM,Loretta Sanchez,89
-San Mateo,2214,U.S. Senate,,DEM,Kamala Harris,492
-San Mateo,2214,U.S. Senate,,DEM,Loretta Sanchez,159
-San Mateo,2215,U.S. Senate,,DEM,Kamala Harris,858
-San Mateo,2215,U.S. Senate,,DEM,Loretta Sanchez,269
-San Mateo,2217,U.S. Senate,,DEM,Kamala Harris,856
-San Mateo,2217,U.S. Senate,,DEM,Loretta Sanchez,228
-San Mateo,2221,U.S. Senate,,DEM,Kamala Harris,771
-San Mateo,2221,U.S. Senate,,DEM,Loretta Sanchez,272
-San Mateo,2222,U.S. Senate,,DEM,Kamala Harris,465
-San Mateo,2222,U.S. Senate,,DEM,Loretta Sanchez,172
-San Mateo,2224,U.S. Senate,,DEM,Kamala Harris,512
-San Mateo,2224,U.S. Senate,,DEM,Loretta Sanchez,143
-San Mateo,2225,U.S. Senate,,DEM,Kamala Harris,300
-San Mateo,2225,U.S. Senate,,DEM,Loretta Sanchez,107
-San Mateo,2601,U.S. Senate,,DEM,Kamala Harris,931
-San Mateo,2601,U.S. Senate,,DEM,Loretta Sanchez,502
-San Mateo,2603,U.S. Senate,,DEM,Kamala Harris,431
-San Mateo,2603,U.S. Senate,,DEM,Loretta Sanchez,183
-San Mateo,2604,U.S. Senate,,DEM,Kamala Harris,392
-San Mateo,2604,U.S. Senate,,DEM,Loretta Sanchez,223
-San Mateo,2605,U.S. Senate,,DEM,Kamala Harris,680
-San Mateo,2605,U.S. Senate,,DEM,Loretta Sanchez,395
-San Mateo,2607,U.S. Senate,,DEM,Kamala Harris,371
-San Mateo,2607,U.S. Senate,,DEM,Loretta Sanchez,154
-San Mateo,2608,U.S. Senate,,DEM,Kamala Harris,421
-San Mateo,2608,U.S. Senate,,DEM,Loretta Sanchez,211
-San Mateo,2609,U.S. Senate,,DEM,Kamala Harris,478
-San Mateo,2609,U.S. Senate,,DEM,Loretta Sanchez,169
-San Mateo,2610,U.S. Senate,,DEM,Kamala Harris,551
-San Mateo,2610,U.S. Senate,,DEM,Loretta Sanchez,180
-San Mateo,2611,U.S. Senate,,DEM,Kamala Harris,422
-San Mateo,2611,U.S. Senate,,DEM,Loretta Sanchez,181
-San Mateo,2612,U.S. Senate,,DEM,Kamala Harris,668
-San Mateo,2612,U.S. Senate,,DEM,Loretta Sanchez,297
-San Mateo,2614,U.S. Senate,,DEM,Kamala Harris,683
-San Mateo,2614,U.S. Senate,,DEM,Loretta Sanchez,247
-San Mateo,2616,U.S. Senate,,DEM,Kamala Harris,605
-San Mateo,2616,U.S. Senate,,DEM,Loretta Sanchez,298
-San Mateo,2618,U.S. Senate,,DEM,Kamala Harris,858
-San Mateo,2618,U.S. Senate,,DEM,Loretta Sanchez,399
-San Mateo,2620,U.S. Senate,,DEM,Kamala Harris,727
-San Mateo,2620,U.S. Senate,,DEM,Loretta Sanchez,257
-San Mateo,2621,U.S. Senate,,DEM,Kamala Harris,609
-San Mateo,2621,U.S. Senate,,DEM,Loretta Sanchez,216
-San Mateo,2622,U.S. Senate,,DEM,Kamala Harris,666
-San Mateo,2622,U.S. Senate,,DEM,Loretta Sanchez,257
-San Mateo,2624,U.S. Senate,,DEM,Kamala Harris,421
-San Mateo,2624,U.S. Senate,,DEM,Loretta Sanchez,128
-San Mateo,2625,U.S. Senate,,DEM,Kamala Harris,534
-San Mateo,2625,U.S. Senate,,DEM,Loretta Sanchez,221
-San Mateo,2626,U.S. Senate,,DEM,Kamala Harris,589
-San Mateo,2626,U.S. Senate,,DEM,Loretta Sanchez,211
-San Mateo,2627,U.S. Senate,,DEM,Kamala Harris,438
-San Mateo,2627,U.S. Senate,,DEM,Loretta Sanchez,163
-San Mateo,2628,U.S. Senate,,DEM,Kamala Harris,548
-San Mateo,2628,U.S. Senate,,DEM,Loretta Sanchez,246
-San Mateo,2629,U.S. Senate,,DEM,Kamala Harris,366
-San Mateo,2629,U.S. Senate,,DEM,Loretta Sanchez,203
-San Mateo,2630,U.S. Senate,,DEM,Kamala Harris,330
-San Mateo,2630,U.S. Senate,,DEM,Loretta Sanchez,159
-San Mateo,2631,U.S. Senate,,DEM,Kamala Harris,665
-San Mateo,2631,U.S. Senate,,DEM,Loretta Sanchez,288
-San Mateo,2633,U.S. Senate,,DEM,Kamala Harris,391
-San Mateo,2633,U.S. Senate,,DEM,Loretta Sanchez,169
-San Mateo,2634,U.S. Senate,,DEM,Kamala Harris,506
-San Mateo,2634,U.S. Senate,,DEM,Loretta Sanchez,207
-San Mateo,2636,U.S. Senate,,DEM,Kamala Harris,594
-San Mateo,2636,U.S. Senate,,DEM,Loretta Sanchez,202
-San Mateo,2637,U.S. Senate,,DEM,Kamala Harris,444
-San Mateo,2637,U.S. Senate,,DEM,Loretta Sanchez,156
-San Mateo,2638,U.S. Senate,,DEM,Kamala Harris,524
-San Mateo,2638,U.S. Senate,,DEM,Loretta Sanchez,175
-San Mateo,2639,U.S. Senate,,DEM,Kamala Harris,520
-San Mateo,2639,U.S. Senate,,DEM,Loretta Sanchez,181
-San Mateo,2644,U.S. Senate,,DEM,Kamala Harris,442
-San Mateo,2644,U.S. Senate,,DEM,Loretta Sanchez,169
-San Mateo,2646,U.S. Senate,,DEM,Kamala Harris,752
-San Mateo,2646,U.S. Senate,,DEM,Loretta Sanchez,257
-San Mateo,2648,U.S. Senate,,DEM,Kamala Harris,795
-San Mateo,2648,U.S. Senate,,DEM,Loretta Sanchez,286
-San Mateo,2650,U.S. Senate,,DEM,Kamala Harris,682
-San Mateo,2650,U.S. Senate,,DEM,Loretta Sanchez,246
-San Mateo,2651,U.S. Senate,,DEM,Kamala Harris,510
-San Mateo,2651,U.S. Senate,,DEM,Loretta Sanchez,210
-San Mateo,2652,U.S. Senate,,DEM,Kamala Harris,479
-San Mateo,2652,U.S. Senate,,DEM,Loretta Sanchez,166
-San Mateo,2653,U.S. Senate,,DEM,Kamala Harris,455
-San Mateo,2653,U.S. Senate,,DEM,Loretta Sanchez,163
-San Mateo,2654,U.S. Senate,,DEM,Kamala Harris,734
-San Mateo,2654,U.S. Senate,,DEM,Loretta Sanchez,269
-San Mateo,2655,U.S. Senate,,DEM,Kamala Harris,715
-San Mateo,2655,U.S. Senate,,DEM,Loretta Sanchez,327
-San Mateo,2657,U.S. Senate,,DEM,Kamala Harris,723
-San Mateo,2657,U.S. Senate,,DEM,Loretta Sanchez,255
-San Mateo,2658,U.S. Senate,,DEM,Kamala Harris,879
-San Mateo,2658,U.S. Senate,,DEM,Loretta Sanchez,326
-San Mateo,2662,U.S. Senate,,DEM,Kamala Harris,582
-San Mateo,2662,U.S. Senate,,DEM,Loretta Sanchez,217
-San Mateo,2663,U.S. Senate,,DEM,Kamala Harris,607
-San Mateo,2663,U.S. Senate,,DEM,Loretta Sanchez,226
-San Mateo,2664,U.S. Senate,,DEM,Kamala Harris,84
-San Mateo,2664,U.S. Senate,,DEM,Loretta Sanchez,42
-San Mateo,2667,U.S. Senate,,DEM,Kamala Harris,338
-San Mateo,2667,U.S. Senate,,DEM,Loretta Sanchez,126
-San Mateo,2668,U.S. Senate,,DEM,Kamala Harris,275
-San Mateo,2668,U.S. Senate,,DEM,Loretta Sanchez,93
-San Mateo,2670,U.S. Senate,,DEM,Kamala Harris,682
-San Mateo,2670,U.S. Senate,,DEM,Loretta Sanchez,290
-San Mateo,2671,U.S. Senate,,DEM,Kamala Harris,860
-San Mateo,2671,U.S. Senate,,DEM,Loretta Sanchez,318
-San Mateo,2675,U.S. Senate,,DEM,Kamala Harris,121
-San Mateo,2675,U.S. Senate,,DEM,Loretta Sanchez,42
-San Mateo,2676,U.S. Senate,,DEM,Kamala Harris,115
-San Mateo,2676,U.S. Senate,,DEM,Loretta Sanchez,37
-San Mateo,2677,U.S. Senate,,DEM,Kamala Harris,61
-San Mateo,2677,U.S. Senate,,DEM,Loretta Sanchez,19
-San Mateo,2678,U.S. Senate,,DEM,Kamala Harris,74
-San Mateo,2678,U.S. Senate,,DEM,Loretta Sanchez,31
-San Mateo,2679,U.S. Senate,,DEM,Kamala Harris,444
-San Mateo,2679,U.S. Senate,,DEM,Loretta Sanchez,180
-San Mateo,2701,U.S. Senate,,DEM,Kamala Harris,0
-San Mateo,2701,U.S. Senate,,DEM,Loretta Sanchez,0
-San Mateo,3001,U.S. Senate,,DEM,Kamala Harris,816
-San Mateo,3001,U.S. Senate,,DEM,Loretta Sanchez,361
-San Mateo,3004,U.S. Senate,,DEM,Kamala Harris,108
-San Mateo,3004,U.S. Senate,,DEM,Loretta Sanchez,52
-San Mateo,3005,U.S. Senate,,DEM,Kamala Harris,417
-San Mateo,3005,U.S. Senate,,DEM,Loretta Sanchez,198
-San Mateo,3006,U.S. Senate,,DEM,Kamala Harris,531
-San Mateo,3006,U.S. Senate,,DEM,Loretta Sanchez,184
-San Mateo,3008,U.S. Senate,,DEM,Kamala Harris,392
-San Mateo,3008,U.S. Senate,,DEM,Loretta Sanchez,169
-San Mateo,3009,U.S. Senate,,DEM,Kamala Harris,74
-San Mateo,3009,U.S. Senate,,DEM,Loretta Sanchez,50
-San Mateo,3010,U.S. Senate,,DEM,Kamala Harris,90
-San Mateo,3010,U.S. Senate,,DEM,Loretta Sanchez,16
-San Mateo,3102,U.S. Senate,,DEM,Kamala Harris,872
-San Mateo,3102,U.S. Senate,,DEM,Loretta Sanchez,354
-San Mateo,3123,U.S. Senate,,DEM,Kamala Harris,92
-San Mateo,3123,U.S. Senate,,DEM,Loretta Sanchez,32
-San Mateo,3135,U.S. Senate,,DEM,Kamala Harris,509
-San Mateo,3135,U.S. Senate,,DEM,Loretta Sanchez,178
-San Mateo,3201,U.S. Senate,,DEM,Kamala Harris,28
-San Mateo,3201,U.S. Senate,,DEM,Loretta Sanchez,22
-San Mateo,3202,U.S. Senate,,DEM,Kamala Harris,295
-San Mateo,3202,U.S. Senate,,DEM,Loretta Sanchez,98
-San Mateo,3203,U.S. Senate,,DEM,Kamala Harris,7
-San Mateo,3203,U.S. Senate,,DEM,Loretta Sanchez,2
-San Mateo,3204,U.S. Senate,,DEM,Kamala Harris,12
-San Mateo,3204,U.S. Senate,,DEM,Loretta Sanchez,4
-San Mateo,3210,U.S. Senate,,DEM,Kamala Harris,1
-San Mateo,3210,U.S. Senate,,DEM,Loretta Sanchez,1
-San Mateo,3211,U.S. Senate,,DEM,Kamala Harris,2
-San Mateo,3211,U.S. Senate,,DEM,Loretta Sanchez,0
-San Mateo,3213,U.S. Senate,,DEM,Kamala Harris,0
-San Mateo,3213,U.S. Senate,,DEM,Loretta Sanchez,0
-San Mateo,3214,U.S. Senate,,DEM,Kamala Harris,0
-San Mateo,3214,U.S. Senate,,DEM,Loretta Sanchez,0
-San Mateo,3301,U.S. Senate,,DEM,Kamala Harris,516
-San Mateo,3301,U.S. Senate,,DEM,Loretta Sanchez,173
-San Mateo,3303,U.S. Senate,,DEM,Kamala Harris,391
-San Mateo,3303,U.S. Senate,,DEM,Loretta Sanchez,138
-San Mateo,3304,U.S. Senate,,DEM,Kamala Harris,860
-San Mateo,3304,U.S. Senate,,DEM,Loretta Sanchez,269
-San Mateo,3306,U.S. Senate,,DEM,Kamala Harris,519
-San Mateo,3306,U.S. Senate,,DEM,Loretta Sanchez,147
-San Mateo,3307,U.S. Senate,,DEM,Kamala Harris,11
-San Mateo,3307,U.S. Senate,,DEM,Loretta Sanchez,4
-San Mateo,3310,U.S. Senate,,DEM,Kamala Harris,487
-San Mateo,3310,U.S. Senate,,DEM,Loretta Sanchez,155
-San Mateo,3311,U.S. Senate,,DEM,Kamala Harris,505
-San Mateo,3311,U.S. Senate,,DEM,Loretta Sanchez,149
-San Mateo,3312,U.S. Senate,,DEM,Kamala Harris,587
-San Mateo,3312,U.S. Senate,,DEM,Loretta Sanchez,210
-San Mateo,3313,U.S. Senate,,DEM,Kamala Harris,552
-San Mateo,3313,U.S. Senate,,DEM,Loretta Sanchez,197
-San Mateo,3314,U.S. Senate,,DEM,Kamala Harris,2
-San Mateo,3314,U.S. Senate,,DEM,Loretta Sanchez,1
-San Mateo,3316,U.S. Senate,,DEM,Kamala Harris,28
-San Mateo,3316,U.S. Senate,,DEM,Loretta Sanchez,13
-San Mateo,3320,U.S. Senate,,DEM,Kamala Harris,432
-San Mateo,3320,U.S. Senate,,DEM,Loretta Sanchez,145
-San Mateo,3321,U.S. Senate,,DEM,Kamala Harris,824
-San Mateo,3321,U.S. Senate,,DEM,Loretta Sanchez,409
-San Mateo,3323,U.S. Senate,,DEM,Kamala Harris,554
-San Mateo,3323,U.S. Senate,,DEM,Loretta Sanchez,251
-San Mateo,3324,U.S. Senate,,DEM,Kamala Harris,521
-San Mateo,3324,U.S. Senate,,DEM,Loretta Sanchez,186
-San Mateo,3325,U.S. Senate,,DEM,Kamala Harris,489
-San Mateo,3325,U.S. Senate,,DEM,Loretta Sanchez,222
-San Mateo,3326,U.S. Senate,,DEM,Kamala Harris,831
-San Mateo,3326,U.S. Senate,,DEM,Loretta Sanchez,316
-San Mateo,3330,U.S. Senate,,DEM,Kamala Harris,17
-San Mateo,3330,U.S. Senate,,DEM,Loretta Sanchez,10
-San Mateo,3331,U.S. Senate,,DEM,Kamala Harris,111
-San Mateo,3331,U.S. Senate,,DEM,Loretta Sanchez,140
-San Mateo,3340,U.S. Senate,,DEM,Kamala Harris,640
-San Mateo,3340,U.S. Senate,,DEM,Loretta Sanchez,204
-San Mateo,3350,U.S. Senate,,DEM,Kamala Harris,378
-San Mateo,3350,U.S. Senate,,DEM,Loretta Sanchez,188
-San Mateo,3360,U.S. Senate,,DEM,Kamala Harris,53
-San Mateo,3360,U.S. Senate,,DEM,Loretta Sanchez,22
-San Mateo,3361,U.S. Senate,,DEM,Kamala Harris,55
-San Mateo,3361,U.S. Senate,,DEM,Loretta Sanchez,8
-San Mateo,3370,U.S. Senate,,DEM,Kamala Harris,346
-San Mateo,3370,U.S. Senate,,DEM,Loretta Sanchez,96
-San Mateo,3371,U.S. Senate,,DEM,Kamala Harris,30
-San Mateo,3371,U.S. Senate,,DEM,Loretta Sanchez,13
-San Mateo,3372,U.S. Senate,,DEM,Kamala Harris,61
-San Mateo,3372,U.S. Senate,,DEM,Loretta Sanchez,14
-San Mateo,3375,U.S. Senate,,DEM,Kamala Harris,45
-San Mateo,3375,U.S. Senate,,DEM,Loretta Sanchez,7
-San Mateo,3376,U.S. Senate,,DEM,Kamala Harris,129
-San Mateo,3376,U.S. Senate,,DEM,Loretta Sanchez,44
-San Mateo,3377,U.S. Senate,,DEM,Kamala Harris,15
-San Mateo,3377,U.S. Senate,,DEM,Loretta Sanchez,8
-San Mateo,3380,U.S. Senate,,DEM,Kamala Harris,42
-San Mateo,3380,U.S. Senate,,DEM,Loretta Sanchez,19
-San Mateo,3401,U.S. Senate,,DEM,Kamala Harris,546
-San Mateo,3401,U.S. Senate,,DEM,Loretta Sanchez,129
-San Mateo,3402,U.S. Senate,,DEM,Kamala Harris,881
-San Mateo,3402,U.S. Senate,,DEM,Loretta Sanchez,219
-San Mateo,3406,U.S. Senate,,DEM,Kamala Harris,54
-San Mateo,3406,U.S. Senate,,DEM,Loretta Sanchez,14
-San Mateo,3407,U.S. Senate,,DEM,Kamala Harris,144
-San Mateo,3407,U.S. Senate,,DEM,Loretta Sanchez,28
-San Mateo,3408,U.S. Senate,,DEM,Kamala Harris,59
-San Mateo,3408,U.S. Senate,,DEM,Loretta Sanchez,21
-San Mateo,3409,U.S. Senate,,DEM,Kamala Harris,0
-San Mateo,3409,U.S. Senate,,DEM,Loretta Sanchez,0
-San Mateo,3410,U.S. Senate,,DEM,Kamala Harris,741
-San Mateo,3410,U.S. Senate,,DEM,Loretta Sanchez,165
-San Mateo,3412,U.S. Senate,,DEM,Kamala Harris,7
-San Mateo,3412,U.S. Senate,,DEM,Loretta Sanchez,14
-San Mateo,3420,U.S. Senate,,DEM,Kamala Harris,316
-San Mateo,3420,U.S. Senate,,DEM,Loretta Sanchez,89
-San Mateo,3421,U.S. Senate,,DEM,Kamala Harris,37
-San Mateo,3421,U.S. Senate,,DEM,Loretta Sanchez,9
-San Mateo,3450,U.S. Senate,,DEM,Kamala Harris,342
-San Mateo,3450,U.S. Senate,,DEM,Loretta Sanchez,123
-San Mateo,3451,U.S. Senate,,DEM,Kamala Harris,892
-San Mateo,3451,U.S. Senate,,DEM,Loretta Sanchez,222
-San Mateo,3452,U.S. Senate,,DEM,Kamala Harris,817
-San Mateo,3452,U.S. Senate,,DEM,Loretta Sanchez,195
-San Mateo,3455,U.S. Senate,,DEM,Kamala Harris,758
-San Mateo,3455,U.S. Senate,,DEM,Loretta Sanchez,243
-San Mateo,3457,U.S. Senate,,DEM,Kamala Harris,805
-San Mateo,3457,U.S. Senate,,DEM,Loretta Sanchez,205
-San Mateo,3459,U.S. Senate,,DEM,Kamala Harris,733
-San Mateo,3459,U.S. Senate,,DEM,Loretta Sanchez,176
-San Mateo,3460,U.S. Senate,,DEM,Kamala Harris,784
-San Mateo,3460,U.S. Senate,,DEM,Loretta Sanchez,240
-San Mateo,3463,U.S. Senate,,DEM,Kamala Harris,18
-San Mateo,3463,U.S. Senate,,DEM,Loretta Sanchez,3
-San Mateo,3464,U.S. Senate,,DEM,Kamala Harris,49
-San Mateo,3464,U.S. Senate,,DEM,Loretta Sanchez,9
-San Mateo,3480,U.S. Senate,,DEM,Kamala Harris,360
-San Mateo,3480,U.S. Senate,,DEM,Loretta Sanchez,92
-San Mateo,3501,U.S. Senate,,DEM,Kamala Harris,482
-San Mateo,3501,U.S. Senate,,DEM,Loretta Sanchez,191
-San Mateo,3502,U.S. Senate,,DEM,Kamala Harris,543
-San Mateo,3502,U.S. Senate,,DEM,Loretta Sanchez,220
-San Mateo,3503,U.S. Senate,,DEM,Kamala Harris,526
-San Mateo,3503,U.S. Senate,,DEM,Loretta Sanchez,241
-San Mateo,3504,U.S. Senate,,DEM,Kamala Harris,402
-San Mateo,3504,U.S. Senate,,DEM,Loretta Sanchez,165
-San Mateo,3505,U.S. Senate,,DEM,Kamala Harris,431
-San Mateo,3505,U.S. Senate,,DEM,Loretta Sanchez,218
-San Mateo,3506,U.S. Senate,,DEM,Kamala Harris,85
-San Mateo,3506,U.S. Senate,,DEM,Loretta Sanchez,18
-San Mateo,3507,U.S. Senate,,DEM,Kamala Harris,586
-San Mateo,3507,U.S. Senate,,DEM,Loretta Sanchez,219
-San Mateo,3508,U.S. Senate,,DEM,Kamala Harris,548
-San Mateo,3508,U.S. Senate,,DEM,Loretta Sanchez,210
-San Mateo,3509,U.S. Senate,,DEM,Kamala Harris,562
-San Mateo,3509,U.S. Senate,,DEM,Loretta Sanchez,244
-San Mateo,3510,U.S. Senate,,DEM,Kamala Harris,394
-San Mateo,3510,U.S. Senate,,DEM,Loretta Sanchez,152
-San Mateo,3512,U.S. Senate,,DEM,Kamala Harris,620
-San Mateo,3512,U.S. Senate,,DEM,Loretta Sanchez,243
-San Mateo,3513,U.S. Senate,,DEM,Kamala Harris,506
-San Mateo,3513,U.S. Senate,,DEM,Loretta Sanchez,192
-San Mateo,3515,U.S. Senate,,DEM,Kamala Harris,265
-San Mateo,3515,U.S. Senate,,DEM,Loretta Sanchez,111
-San Mateo,3516,U.S. Senate,,DEM,Kamala Harris,384
-San Mateo,3516,U.S. Senate,,DEM,Loretta Sanchez,110
-San Mateo,3517,U.S. Senate,,DEM,Kamala Harris,338
-San Mateo,3517,U.S. Senate,,DEM,Loretta Sanchez,143
-San Mateo,3518,U.S. Senate,,DEM,Kamala Harris,476
-San Mateo,3518,U.S. Senate,,DEM,Loretta Sanchez,204
-San Mateo,3519,U.S. Senate,,DEM,Kamala Harris,342
-San Mateo,3519,U.S. Senate,,DEM,Loretta Sanchez,156
-San Mateo,3520,U.S. Senate,,DEM,Kamala Harris,913
-San Mateo,3520,U.S. Senate,,DEM,Loretta Sanchez,397
-San Mateo,3522,U.S. Senate,,DEM,Kamala Harris,805
-San Mateo,3522,U.S. Senate,,DEM,Loretta Sanchez,288
-San Mateo,3523,U.S. Senate,,DEM,Kamala Harris,406
-San Mateo,3523,U.S. Senate,,DEM,Loretta Sanchez,143
-San Mateo,3524,U.S. Senate,,DEM,Kamala Harris,374
-San Mateo,3524,U.S. Senate,,DEM,Loretta Sanchez,153
-San Mateo,3525,U.S. Senate,,DEM,Kamala Harris,729
-San Mateo,3525,U.S. Senate,,DEM,Loretta Sanchez,316
-San Mateo,3528,U.S. Senate,,DEM,Kamala Harris,431
-San Mateo,3528,U.S. Senate,,DEM,Loretta Sanchez,176
-San Mateo,3529,U.S. Senate,,DEM,Kamala Harris,487
-San Mateo,3529,U.S. Senate,,DEM,Loretta Sanchez,195
-San Mateo,3530,U.S. Senate,,DEM,Kamala Harris,457
-San Mateo,3530,U.S. Senate,,DEM,Loretta Sanchez,184
-San Mateo,3531,U.S. Senate,,DEM,Kamala Harris,363
-San Mateo,3531,U.S. Senate,,DEM,Loretta Sanchez,156
-San Mateo,3532,U.S. Senate,,DEM,Kamala Harris,111
-San Mateo,3532,U.S. Senate,,DEM,Loretta Sanchez,30
-San Mateo,3533,U.S. Senate,,DEM,Kamala Harris,145
-San Mateo,3533,U.S. Senate,,DEM,Loretta Sanchez,53
-San Mateo,3540,U.S. Senate,,DEM,Kamala Harris,5
-San Mateo,3540,U.S. Senate,,DEM,Loretta Sanchez,2
-San Mateo,3541,U.S. Senate,,DEM,Kamala Harris,0
-San Mateo,3541,U.S. Senate,,DEM,Loretta Sanchez,0
-San Mateo,3542,U.S. Senate,,DEM,Kamala Harris,0
-San Mateo,3542,U.S. Senate,,DEM,Loretta Sanchez,0
-San Mateo,3543,U.S. Senate,,DEM,Kamala Harris,0
-San Mateo,3543,U.S. Senate,,DEM,Loretta Sanchez,0
-San Mateo,3601,U.S. Senate,,DEM,Kamala Harris,848
-San Mateo,3601,U.S. Senate,,DEM,Loretta Sanchez,259
-San Mateo,3602,U.S. Senate,,DEM,Kamala Harris,654
-San Mateo,3602,U.S. Senate,,DEM,Loretta Sanchez,238
-San Mateo,3605,U.S. Senate,,DEM,Kamala Harris,758
-San Mateo,3605,U.S. Senate,,DEM,Loretta Sanchez,232
-San Mateo,3607,U.S. Senate,,DEM,Kamala Harris,474
-San Mateo,3607,U.S. Senate,,DEM,Loretta Sanchez,165
-San Mateo,3608,U.S. Senate,,DEM,Kamala Harris,913
-San Mateo,3608,U.S. Senate,,DEM,Loretta Sanchez,285
-San Mateo,3610,U.S. Senate,,DEM,Kamala Harris,931
-San Mateo,3610,U.S. Senate,,DEM,Loretta Sanchez,293
-San Mateo,3612,U.S. Senate,,DEM,Kamala Harris,461
-San Mateo,3612,U.S. Senate,,DEM,Loretta Sanchez,185
-San Mateo,3613,U.S. Senate,,DEM,Kamala Harris,1404
-San Mateo,3613,U.S. Senate,,DEM,Loretta Sanchez,396
-San Mateo,3616,U.S. Senate,,DEM,Kamala Harris,829
-San Mateo,3616,U.S. Senate,,DEM,Loretta Sanchez,223
-San Mateo,3617,U.S. Senate,,DEM,Kamala Harris,839
-San Mateo,3617,U.S. Senate,,DEM,Loretta Sanchez,244
-San Mateo,3620,U.S. Senate,,DEM,Kamala Harris,780
-San Mateo,3620,U.S. Senate,,DEM,Loretta Sanchez,259
-San Mateo,3621,U.S. Senate,,DEM,Kamala Harris,821
-San Mateo,3621,U.S. Senate,,DEM,Loretta Sanchez,263
-San Mateo,3624,U.S. Senate,,DEM,Kamala Harris,742
-San Mateo,3624,U.S. Senate,,DEM,Loretta Sanchez,255
-San Mateo,3626,U.S. Senate,,DEM,Kamala Harris,317
-San Mateo,3626,U.S. Senate,,DEM,Loretta Sanchez,91
-San Mateo,3627,U.S. Senate,,DEM,Kamala Harris,54
-San Mateo,3627,U.S. Senate,,DEM,Loretta Sanchez,16
-San Mateo,3629,U.S. Senate,,DEM,Kamala Harris,1
-San Mateo,3629,U.S. Senate,,DEM,Loretta Sanchez,4
-San Mateo,3630,U.S. Senate,,DEM,Kamala Harris,8
-San Mateo,3630,U.S. Senate,,DEM,Loretta Sanchez,0
-San Mateo,3631,U.S. Senate,,DEM,Kamala Harris,56
-San Mateo,3631,U.S. Senate,,DEM,Loretta Sanchez,11
-San Mateo,3632,U.S. Senate,,DEM,Kamala Harris,5
-San Mateo,3632,U.S. Senate,,DEM,Loretta Sanchez,3
-San Mateo,3633,U.S. Senate,,DEM,Kamala Harris,64
-San Mateo,3633,U.S. Senate,,DEM,Loretta Sanchez,28
-San Mateo,3634,U.S. Senate,,DEM,Kamala Harris,16
-San Mateo,3634,U.S. Senate,,DEM,Loretta Sanchez,7
-San Mateo,3635,U.S. Senate,,DEM,Kamala Harris,19
-San Mateo,3635,U.S. Senate,,DEM,Loretta Sanchez,4
-San Mateo,3637,U.S. Senate,,DEM,Kamala Harris,2
-San Mateo,3637,U.S. Senate,,DEM,Loretta Sanchez,2
-San Mateo,3638,U.S. Senate,,DEM,Kamala Harris,130
-San Mateo,3638,U.S. Senate,,DEM,Loretta Sanchez,39
-San Mateo,3701,U.S. Senate,,DEM,Kamala Harris,602
-San Mateo,3701,U.S. Senate,,DEM,Loretta Sanchez,199
-San Mateo,3702,U.S. Senate,,DEM,Kamala Harris,584
-San Mateo,3702,U.S. Senate,,DEM,Loretta Sanchez,185
-San Mateo,3703,U.S. Senate,,DEM,Kamala Harris,368
-San Mateo,3703,U.S. Senate,,DEM,Loretta Sanchez,138
-San Mateo,3704,U.S. Senate,,DEM,Kamala Harris,6
-San Mateo,3704,U.S. Senate,,DEM,Loretta Sanchez,2
-San Mateo,3706,U.S. Senate,,DEM,Kamala Harris,80
-San Mateo,3706,U.S. Senate,,DEM,Loretta Sanchez,22
-San Mateo,3707,U.S. Senate,,DEM,Kamala Harris,29
-San Mateo,3707,U.S. Senate,,DEM,Loretta Sanchez,15
-San Mateo,3708,U.S. Senate,,DEM,Kamala Harris,53
-San Mateo,3708,U.S. Senate,,DEM,Loretta Sanchez,31
-San Mateo,3709,U.S. Senate,,DEM,Kamala Harris,136
-San Mateo,3709,U.S. Senate,,DEM,Loretta Sanchez,35
-San Mateo,3710,U.S. Senate,,DEM,Kamala Harris,315
-San Mateo,3710,U.S. Senate,,DEM,Loretta Sanchez,105
-San Mateo,3711,U.S. Senate,,DEM,Kamala Harris,2
-San Mateo,3711,U.S. Senate,,DEM,Loretta Sanchez,1
-San Mateo,3712,U.S. Senate,,DEM,Kamala Harris,37
-San Mateo,3712,U.S. Senate,,DEM,Loretta Sanchez,10
-San Mateo,3720,U.S. Senate,,DEM,Kamala Harris,416
-San Mateo,3720,U.S. Senate,,DEM,Loretta Sanchez,159
-San Mateo,3721,U.S. Senate,,DEM,Kamala Harris,448
-San Mateo,3721,U.S. Senate,,DEM,Loretta Sanchez,165
-San Mateo,3722,U.S. Senate,,DEM,Kamala Harris,372
-San Mateo,3722,U.S. Senate,,DEM,Loretta Sanchez,122
-San Mateo,3723,U.S. Senate,,DEM,Kamala Harris,10
-San Mateo,3723,U.S. Senate,,DEM,Loretta Sanchez,3
-San Mateo,3801,U.S. Senate,,DEM,Kamala Harris,232
-San Mateo,3801,U.S. Senate,,DEM,Loretta Sanchez,67
-San Mateo,3802,U.S. Senate,,DEM,Kamala Harris,925
-San Mateo,3802,U.S. Senate,,DEM,Loretta Sanchez,317
-San Mateo,3803,U.S. Senate,,DEM,Kamala Harris,121
-San Mateo,3803,U.S. Senate,,DEM,Loretta Sanchez,42
-San Mateo,3806,U.S. Senate,,DEM,Kamala Harris,441
-San Mateo,3806,U.S. Senate,,DEM,Loretta Sanchez,176
-San Mateo,3807,U.S. Senate,,DEM,Kamala Harris,46
-San Mateo,3807,U.S. Senate,,DEM,Loretta Sanchez,26
-San Mateo,3808,U.S. Senate,,DEM,Kamala Harris,248
-San Mateo,3808,U.S. Senate,,DEM,Loretta Sanchez,136
-San Mateo,3811,U.S. Senate,,DEM,Kamala Harris,30
-San Mateo,3811,U.S. Senate,,DEM,Loretta Sanchez,22
-San Mateo,3812,U.S. Senate,,DEM,Kamala Harris,72
-San Mateo,3812,U.S. Senate,,DEM,Loretta Sanchez,52
-San Mateo,3901,U.S. Senate,,DEM,Kamala Harris,741
-San Mateo,3901,U.S. Senate,,DEM,Loretta Sanchez,191
-San Mateo,3903,U.S. Senate,,DEM,Kamala Harris,655
-San Mateo,3903,U.S. Senate,,DEM,Loretta Sanchez,164
-San Mateo,3905,U.S. Senate,,DEM,Kamala Harris,650
-San Mateo,3905,U.S. Senate,,DEM,Loretta Sanchez,225
-San Mateo,4001,U.S. Senate,,DEM,Kamala Harris,289
-San Mateo,4001,U.S. Senate,,DEM,Loretta Sanchez,211
-San Mateo,4002,U.S. Senate,,DEM,Kamala Harris,244
-San Mateo,4002,U.S. Senate,,DEM,Loretta Sanchez,254
-San Mateo,4003,U.S. Senate,,DEM,Kamala Harris,244
-San Mateo,4003,U.S. Senate,,DEM,Loretta Sanchez,202
-San Mateo,4004,U.S. Senate,,DEM,Kamala Harris,245
-San Mateo,4004,U.S. Senate,,DEM,Loretta Sanchez,134
-San Mateo,4005,U.S. Senate,,DEM,Kamala Harris,302
-San Mateo,4005,U.S. Senate,,DEM,Loretta Sanchez,158
-San Mateo,4006,U.S. Senate,,DEM,Kamala Harris,299
-San Mateo,4006,U.S. Senate,,DEM,Loretta Sanchez,218
-San Mateo,4007,U.S. Senate,,DEM,Kamala Harris,403
-San Mateo,4007,U.S. Senate,,DEM,Loretta Sanchez,210
-San Mateo,4008,U.S. Senate,,DEM,Kamala Harris,307
-San Mateo,4008,U.S. Senate,,DEM,Loretta Sanchez,181
-San Mateo,4009,U.S. Senate,,DEM,Kamala Harris,316
-San Mateo,4009,U.S. Senate,,DEM,Loretta Sanchez,162
-San Mateo,4010,U.S. Senate,,DEM,Kamala Harris,250
-San Mateo,4010,U.S. Senate,,DEM,Loretta Sanchez,131
-San Mateo,4011,U.S. Senate,,DEM,Kamala Harris,474
-San Mateo,4011,U.S. Senate,,DEM,Loretta Sanchez,284
-San Mateo,4013,U.S. Senate,,DEM,Kamala Harris,0
-San Mateo,4013,U.S. Senate,,DEM,Loretta Sanchez,0
-San Mateo,4014,U.S. Senate,,DEM,Kamala Harris,375
-San Mateo,4014,U.S. Senate,,DEM,Loretta Sanchez,193
-San Mateo,4015,U.S. Senate,,DEM,Kamala Harris,191
-San Mateo,4015,U.S. Senate,,DEM,Loretta Sanchez,110
-San Mateo,4401,U.S. Senate,,DEM,Kamala Harris,445
-San Mateo,4401,U.S. Senate,,DEM,Loretta Sanchez,166
-San Mateo,4402,U.S. Senate,,DEM,Kamala Harris,418
-San Mateo,4402,U.S. Senate,,DEM,Loretta Sanchez,128
-San Mateo,4403,U.S. Senate,,DEM,Kamala Harris,345
-San Mateo,4403,U.S. Senate,,DEM,Loretta Sanchez,248
-San Mateo,4404,U.S. Senate,,DEM,Kamala Harris,550
-San Mateo,4404,U.S. Senate,,DEM,Loretta Sanchez,404
-San Mateo,4406,U.S. Senate,,DEM,Kamala Harris,30
-San Mateo,4406,U.S. Senate,,DEM,Loretta Sanchez,5
-San Mateo,4407,U.S. Senate,,DEM,Kamala Harris,1166
-San Mateo,4407,U.S. Senate,,DEM,Loretta Sanchez,325
-San Mateo,4409,U.S. Senate,,DEM,Kamala Harris,1059
-San Mateo,4409,U.S. Senate,,DEM,Loretta Sanchez,209
-San Mateo,4412,U.S. Senate,,DEM,Kamala Harris,731
-San Mateo,4412,U.S. Senate,,DEM,Loretta Sanchez,169
-San Mateo,4414,U.S. Senate,,DEM,Kamala Harris,282
-San Mateo,4414,U.S. Senate,,DEM,Loretta Sanchez,70
-San Mateo,4415,U.S. Senate,,DEM,Kamala Harris,375
-San Mateo,4415,U.S. Senate,,DEM,Loretta Sanchez,142
-San Mateo,4431,U.S. Senate,,DEM,Kamala Harris,28
-San Mateo,4431,U.S. Senate,,DEM,Loretta Sanchez,13
-San Mateo,4432,U.S. Senate,,DEM,Kamala Harris,2
-San Mateo,4432,U.S. Senate,,DEM,Loretta Sanchez,1
-San Mateo,4433,U.S. Senate,,DEM,Kamala Harris,152
-San Mateo,4433,U.S. Senate,,DEM,Loretta Sanchez,43
-San Mateo,4434,U.S. Senate,,DEM,Kamala Harris,0
-San Mateo,4434,U.S. Senate,,DEM,Loretta Sanchez,0
-San Mateo,4435,U.S. Senate,,DEM,Kamala Harris,2
-San Mateo,4435,U.S. Senate,,DEM,Loretta Sanchez,1
-San Mateo,4436,U.S. Senate,,DEM,Kamala Harris,14
-San Mateo,4436,U.S. Senate,,DEM,Loretta Sanchez,8
-San Mateo,4501,U.S. Senate,,DEM,Kamala Harris,225
-San Mateo,4501,U.S. Senate,,DEM,Loretta Sanchez,309
-San Mateo,4502,U.S. Senate,,DEM,Kamala Harris,319
-San Mateo,4502,U.S. Senate,,DEM,Loretta Sanchez,248
-San Mateo,4503,U.S. Senate,,DEM,Kamala Harris,218
-San Mateo,4503,U.S. Senate,,DEM,Loretta Sanchez,57
-San Mateo,4504,U.S. Senate,,DEM,Kamala Harris,366
-San Mateo,4504,U.S. Senate,,DEM,Loretta Sanchez,109
-San Mateo,4505,U.S. Senate,,DEM,Kamala Harris,353
-San Mateo,4505,U.S. Senate,,DEM,Loretta Sanchez,231
-San Mateo,4506,U.S. Senate,,DEM,Kamala Harris,368
-San Mateo,4506,U.S. Senate,,DEM,Loretta Sanchez,311
-San Mateo,4507,U.S. Senate,,DEM,Kamala Harris,60
-San Mateo,4507,U.S. Senate,,DEM,Loretta Sanchez,46
-San Mateo,4508,U.S. Senate,,DEM,Kamala Harris,62
-San Mateo,4508,U.S. Senate,,DEM,Loretta Sanchez,24
-San Mateo,4509,U.S. Senate,,DEM,Kamala Harris,120
-San Mateo,4509,U.S. Senate,,DEM,Loretta Sanchez,217
-San Mateo,4601,U.S. Senate,,DEM,Kamala Harris,383
-San Mateo,4601,U.S. Senate,,DEM,Loretta Sanchez,284
-San Mateo,4602,U.S. Senate,,DEM,Kamala Harris,449
-San Mateo,4602,U.S. Senate,,DEM,Loretta Sanchez,355
-San Mateo,4603,U.S. Senate,,DEM,Kamala Harris,206
-San Mateo,4603,U.S. Senate,,DEM,Loretta Sanchez,184
-San Mateo,4604,U.S. Senate,,DEM,Kamala Harris,618
-San Mateo,4604,U.S. Senate,,DEM,Loretta Sanchez,512
-San Mateo,4606,U.S. Senate,,DEM,Kamala Harris,884
-San Mateo,4606,U.S. Senate,,DEM,Loretta Sanchez,399
-San Mateo,4607,U.S. Senate,,DEM,Kamala Harris,446
-San Mateo,4607,U.S. Senate,,DEM,Loretta Sanchez,181
-San Mateo,4608,U.S. Senate,,DEM,Kamala Harris,501
-San Mateo,4608,U.S. Senate,,DEM,Loretta Sanchez,207
-San Mateo,4609,U.S. Senate,,DEM,Kamala Harris,593
-San Mateo,4609,U.S. Senate,,DEM,Loretta Sanchez,218
-San Mateo,4611,U.S. Senate,,DEM,Kamala Harris,395
-San Mateo,4611,U.S. Senate,,DEM,Loretta Sanchez,133
-San Mateo,4612,U.S. Senate,,DEM,Kamala Harris,944
-San Mateo,4612,U.S. Senate,,DEM,Loretta Sanchez,275
-San Mateo,4613,U.S. Senate,,DEM,Kamala Harris,799
-San Mateo,4613,U.S. Senate,,DEM,Loretta Sanchez,304
-San Mateo,4615,U.S. Senate,,DEM,Kamala Harris,444
-San Mateo,4615,U.S. Senate,,DEM,Loretta Sanchez,156
-San Mateo,4616,U.S. Senate,,DEM,Kamala Harris,819
-San Mateo,4616,U.S. Senate,,DEM,Loretta Sanchez,349
-San Mateo,4617,U.S. Senate,,DEM,Kamala Harris,354
-San Mateo,4617,U.S. Senate,,DEM,Loretta Sanchez,146
-San Mateo,4618,U.S. Senate,,DEM,Kamala Harris,835
-San Mateo,4618,U.S. Senate,,DEM,Loretta Sanchez,403
-San Mateo,4619,U.S. Senate,,DEM,Kamala Harris,306
-San Mateo,4619,U.S. Senate,,DEM,Loretta Sanchez,177
-San Mateo,4620,U.S. Senate,,DEM,Kamala Harris,502
-San Mateo,4620,U.S. Senate,,DEM,Loretta Sanchez,268
-San Mateo,4621,U.S. Senate,,DEM,Kamala Harris,445
-San Mateo,4621,U.S. Senate,,DEM,Loretta Sanchez,183
-San Mateo,4622,U.S. Senate,,DEM,Kamala Harris,619
-San Mateo,4622,U.S. Senate,,DEM,Loretta Sanchez,360
-San Mateo,4625,U.S. Senate,,DEM,Kamala Harris,431
-San Mateo,4625,U.S. Senate,,DEM,Loretta Sanchez,175
-San Mateo,4626,U.S. Senate,,DEM,Kamala Harris,457
-San Mateo,4626,U.S. Senate,,DEM,Loretta Sanchez,194
-San Mateo,4627,U.S. Senate,,DEM,Kamala Harris,884
-San Mateo,4627,U.S. Senate,,DEM,Loretta Sanchez,328
-San Mateo,4629,U.S. Senate,,DEM,Kamala Harris,382
-San Mateo,4629,U.S. Senate,,DEM,Loretta Sanchez,125
-San Mateo,4630,U.S. Senate,,DEM,Kamala Harris,432
-San Mateo,4630,U.S. Senate,,DEM,Loretta Sanchez,169
-San Mateo,4631,U.S. Senate,,DEM,Kamala Harris,444
-San Mateo,4631,U.S. Senate,,DEM,Loretta Sanchez,136
-San Mateo,4633,U.S. Senate,,DEM,Kamala Harris,745
-San Mateo,4633,U.S. Senate,,DEM,Loretta Sanchez,296
-San Mateo,4635,U.S. Senate,,DEM,Kamala Harris,507
-San Mateo,4635,U.S. Senate,,DEM,Loretta Sanchez,175
-San Mateo,4636,U.S. Senate,,DEM,Kamala Harris,91
-San Mateo,4636,U.S. Senate,,DEM,Loretta Sanchez,49
-San Mateo,4637,U.S. Senate,,DEM,Kamala Harris,241
-San Mateo,4637,U.S. Senate,,DEM,Loretta Sanchez,96
-San Mateo,4638,U.S. Senate,,DEM,Kamala Harris,804
-San Mateo,4638,U.S. Senate,,DEM,Loretta Sanchez,338
-San Mateo,4639,U.S. Senate,,DEM,Kamala Harris,432
-San Mateo,4639,U.S. Senate,,DEM,Loretta Sanchez,179
-San Mateo,4650,U.S. Senate,,DEM,Kamala Harris,115
-San Mateo,4650,U.S. Senate,,DEM,Loretta Sanchez,56
-San Mateo,4651,U.S. Senate,,DEM,Kamala Harris,43
-San Mateo,4651,U.S. Senate,,DEM,Loretta Sanchez,26
-San Mateo,4652,U.S. Senate,,DEM,Kamala Harris,53
-San Mateo,4652,U.S. Senate,,DEM,Loretta Sanchez,36
-San Mateo,4653,U.S. Senate,,DEM,Kamala Harris,73
-San Mateo,4653,U.S. Senate,,DEM,Loretta Sanchez,86
-San Mateo,4654,U.S. Senate,,DEM,Kamala Harris,0
-San Mateo,4654,U.S. Senate,,DEM,Loretta Sanchez,0
-San Mateo,4655,U.S. Senate,,DEM,Kamala Harris,3
-San Mateo,4655,U.S. Senate,,DEM,Loretta Sanchez,1
-San Mateo,4656,U.S. Senate,,DEM,Kamala Harris,146
-San Mateo,4656,U.S. Senate,,DEM,Loretta Sanchez,45
-San Mateo,4657,U.S. Senate,,DEM,Kamala Harris,88
-San Mateo,4657,U.S. Senate,,DEM,Loretta Sanchez,21
-San Mateo,4658,U.S. Senate,,DEM,Kamala Harris,21
-San Mateo,4658,U.S. Senate,,DEM,Loretta Sanchez,9
-San Mateo,4659,U.S. Senate,,DEM,Kamala Harris,22
-San Mateo,4659,U.S. Senate,,DEM,Loretta Sanchez,7
-San Mateo,4663,U.S. Senate,,DEM,Kamala Harris,54
-San Mateo,4663,U.S. Senate,,DEM,Loretta Sanchez,17
-San Mateo,4670,U.S. Senate,,DEM,Kamala Harris,0
-San Mateo,4670,U.S. Senate,,DEM,Loretta Sanchez,0
-San Mateo,4680,U.S. Senate,,DEM,Kamala Harris,785
-San Mateo,4680,U.S. Senate,,DEM,Loretta Sanchez,261
-San Mateo,4681,U.S. Senate,,DEM,Kamala Harris,995
-San Mateo,4681,U.S. Senate,,DEM,Loretta Sanchez,287
-San Mateo,4684,U.S. Senate,,DEM,Kamala Harris,531
-San Mateo,4684,U.S. Senate,,DEM,Loretta Sanchez,173
-San Mateo,4685,U.S. Senate,,DEM,Kamala Harris,602
-San Mateo,4685,U.S. Senate,,DEM,Loretta Sanchez,188
-San Mateo,4686,U.S. Senate,,DEM,Kamala Harris,888
-San Mateo,4686,U.S. Senate,,DEM,Loretta Sanchez,273
-San Mateo,4688,U.S. Senate,,DEM,Kamala Harris,0
-San Mateo,4688,U.S. Senate,,DEM,Loretta Sanchez,0
-San Mateo,4701,U.S. Senate,,DEM,Kamala Harris,120
-San Mateo,4701,U.S. Senate,,DEM,Loretta Sanchez,37
-San Mateo,4702,U.S. Senate,,DEM,Kamala Harris,49
-San Mateo,4702,U.S. Senate,,DEM,Loretta Sanchez,17
-San Mateo,4708,U.S. Senate,,DEM,Kamala Harris,78
-San Mateo,4708,U.S. Senate,,DEM,Loretta Sanchez,20
-San Mateo,4710,U.S. Senate,,DEM,Kamala Harris,4
-San Mateo,4710,U.S. Senate,,DEM,Loretta Sanchez,0
-San Mateo,5001,U.S. Senate,,DEM,Kamala Harris,477
-San Mateo,5001,U.S. Senate,,DEM,Loretta Sanchez,153
-San Mateo,5002,U.S. Senate,,DEM,Kamala Harris,580
-San Mateo,5002,U.S. Senate,,DEM,Loretta Sanchez,196
-San Mateo,5003,U.S. Senate,,DEM,Kamala Harris,454
-San Mateo,5003,U.S. Senate,,DEM,Loretta Sanchez,149
-San Mateo,5101,U.S. Senate,,DEM,Kamala Harris,813
-San Mateo,5101,U.S. Senate,,DEM,Loretta Sanchez,365
-San Mateo,5103,U.S. Senate,,DEM,Kamala Harris,603
-San Mateo,5103,U.S. Senate,,DEM,Loretta Sanchez,274
-San Mateo,5105,U.S. Senate,,DEM,Kamala Harris,18
-San Mateo,5105,U.S. Senate,,DEM,Loretta Sanchez,15
-San Mateo,5301,U.S. Senate,,DEM,Kamala Harris,315
-San Mateo,5301,U.S. Senate,,DEM,Loretta Sanchez,175
-San Mateo,5521,U.S. Senate,,DEM,Kamala Harris,513
-San Mateo,5521,U.S. Senate,,DEM,Loretta Sanchez,211
-San Mateo,5522,U.S. Senate,,DEM,Kamala Harris,488
-San Mateo,5522,U.S. Senate,,DEM,Loretta Sanchez,242
-San Mateo,5523,U.S. Senate,,DEM,Kamala Harris,8
-San Mateo,5523,U.S. Senate,,DEM,Loretta Sanchez,4
-San Mateo,5524,U.S. Senate,,DEM,Kamala Harris,462
-San Mateo,5524,U.S. Senate,,DEM,Loretta Sanchez,179
-San Mateo,5525,U.S. Senate,,DEM,Kamala Harris,757
-San Mateo,5525,U.S. Senate,,DEM,Loretta Sanchez,329
-San Mateo,5528,U.S. Senate,,DEM,Kamala Harris,826
-San Mateo,5528,U.S. Senate,,DEM,Loretta Sanchez,346
-San Mateo,5530,U.S. Senate,,DEM,Kamala Harris,121
-San Mateo,5530,U.S. Senate,,DEM,Loretta Sanchez,53
-San Mateo,5531,U.S. Senate,,DEM,Kamala Harris,18
-San Mateo,5531,U.S. Senate,,DEM,Loretta Sanchez,13
-San Mateo,5534,U.S. Senate,,DEM,Kamala Harris,58
-San Mateo,5534,U.S. Senate,,DEM,Loretta Sanchez,14
-San Mateo,5535,U.S. Senate,,DEM,Kamala Harris,0
-San Mateo,5535,U.S. Senate,,DEM,Loretta Sanchez,0
-San Mateo,5601,U.S. Senate,,DEM,Kamala Harris,593
-San Mateo,5601,U.S. Senate,,DEM,Loretta Sanchez,308
-San Mateo,5602,U.S. Senate,,DEM,Kamala Harris,393
-San Mateo,5602,U.S. Senate,,DEM,Loretta Sanchez,227
-San Mateo,5603,U.S. Senate,,DEM,Kamala Harris,526
-San Mateo,5603,U.S. Senate,,DEM,Loretta Sanchez,258
-San Mateo,5604,U.S. Senate,,DEM,Kamala Harris,614
-San Mateo,5604,U.S. Senate,,DEM,Loretta Sanchez,280
-San Mateo,5605,U.S. Senate,,DEM,Kamala Harris,579
-San Mateo,5605,U.S. Senate,,DEM,Loretta Sanchez,300
-San Mateo,5607,U.S. Senate,,DEM,Kamala Harris,355
-San Mateo,5607,U.S. Senate,,DEM,Loretta Sanchez,245
-San Mateo,5608,U.S. Senate,,DEM,Kamala Harris,365
-San Mateo,5608,U.S. Senate,,DEM,Loretta Sanchez,208
-San Mateo,5609,U.S. Senate,,DEM,Kamala Harris,817
-San Mateo,5609,U.S. Senate,,DEM,Loretta Sanchez,442
-San Mateo,5611,U.S. Senate,,DEM,Kamala Harris,768
-San Mateo,5611,U.S. Senate,,DEM,Loretta Sanchez,427
-San Mateo,5612,U.S. Senate,,DEM,Kamala Harris,857
-San Mateo,5612,U.S. Senate,,DEM,Loretta Sanchez,453
-San Mateo,5615,U.S. Senate,,DEM,Kamala Harris,732
-San Mateo,5615,U.S. Senate,,DEM,Loretta Sanchez,389
-San Mateo,5617,U.S. Senate,,DEM,Kamala Harris,816
-San Mateo,5617,U.S. Senate,,DEM,Loretta Sanchez,463
-San Mateo,5619,U.S. Senate,,DEM,Kamala Harris,276
-San Mateo,5619,U.S. Senate,,DEM,Loretta Sanchez,164
-San Mateo,5620,U.S. Senate,,DEM,Kamala Harris,657
-San Mateo,5620,U.S. Senate,,DEM,Loretta Sanchez,299
-San Mateo,5622,U.S. Senate,,DEM,Kamala Harris,329
-San Mateo,5622,U.S. Senate,,DEM,Loretta Sanchez,138
-San Mateo,5623,U.S. Senate,,DEM,Kamala Harris,742
-San Mateo,5623,U.S. Senate,,DEM,Loretta Sanchez,259
-San Mateo,5624,U.S. Senate,,DEM,Kamala Harris,808
-San Mateo,5624,U.S. Senate,,DEM,Loretta Sanchez,376
-San Mateo,5627,U.S. Senate,,DEM,Kamala Harris,448
-San Mateo,5627,U.S. Senate,,DEM,Loretta Sanchez,236
-San Mateo,5628,U.S. Senate,,DEM,Kamala Harris,271
-San Mateo,5628,U.S. Senate,,DEM,Loretta Sanchez,173
-San Mateo,5629,U.S. Senate,,DEM,Kamala Harris,350
-San Mateo,5629,U.S. Senate,,DEM,Loretta Sanchez,143
-San Mateo,5631,U.S. Senate,,DEM,Kamala Harris,739
-San Mateo,5631,U.S. Senate,,DEM,Loretta Sanchez,281
-San Mateo,5633,U.S. Senate,,DEM,Kamala Harris,791
-San Mateo,5633,U.S. Senate,,DEM,Loretta Sanchez,384
-San Mateo,5635,U.S. Senate,,DEM,Kamala Harris,1037
-San Mateo,5635,U.S. Senate,,DEM,Loretta Sanchez,505
-San Mateo,5636,U.S. Senate,,DEM,Kamala Harris,403
-San Mateo,5636,U.S. Senate,,DEM,Loretta Sanchez,193
-San Mateo,5639,U.S. Senate,,DEM,Kamala Harris,651
-San Mateo,5639,U.S. Senate,,DEM,Loretta Sanchez,289
-San Mateo,5641,U.S. Senate,,DEM,Kamala Harris,981
-San Mateo,5641,U.S. Senate,,DEM,Loretta Sanchez,399
-San Mateo,5644,U.S. Senate,,DEM,Kamala Harris,768
-San Mateo,5644,U.S. Senate,,DEM,Loretta Sanchez,343
-San Mateo,5646,U.S. Senate,,DEM,Kamala Harris,444
-San Mateo,5646,U.S. Senate,,DEM,Loretta Sanchez,181
-San Mateo,5647,U.S. Senate,,DEM,Kamala Harris,415
-San Mateo,5647,U.S. Senate,,DEM,Loretta Sanchez,188
-San Mateo,5648,U.S. Senate,,DEM,Kamala Harris,824
-San Mateo,5648,U.S. Senate,,DEM,Loretta Sanchez,344
-San Mateo,5650,U.S. Senate,,DEM,Kamala Harris,445
-San Mateo,5650,U.S. Senate,,DEM,Loretta Sanchez,201
-San Mateo,5651,U.S. Senate,,DEM,Kamala Harris,891
-San Mateo,5651,U.S. Senate,,DEM,Loretta Sanchez,424
-San Mateo,5656,U.S. Senate,,DEM,Kamala Harris,162
-San Mateo,5656,U.S. Senate,,DEM,Loretta Sanchez,118
-San Mateo,5701,U.S. Senate,,DEM,Kamala Harris,0
-San Mateo,5701,U.S. Senate,,DEM,Loretta Sanchez,0
-San Mateo,5809,U.S. Senate,,DEM,Kamala Harris,297
-San Mateo,5809,U.S. Senate,,DEM,Loretta Sanchez,134
-San Mateo,5816,U.S. Senate,,DEM,Kamala Harris,104
-San Mateo,5816,U.S. Senate,,DEM,Loretta Sanchez,37
-San Mateo,5822,U.S. Senate,,DEM,Kamala Harris,417
-San Mateo,5822,U.S. Senate,,DEM,Loretta Sanchez,204
-San Mateo,5823,U.S. Senate,,DEM,Kamala Harris,425
-San Mateo,5823,U.S. Senate,,DEM,Loretta Sanchez,202
-San Mateo,5825,U.S. Senate,,DEM,Kamala Harris,981
-San Mateo,5825,U.S. Senate,,DEM,Loretta Sanchez,371
-San Mateo,5827,U.S. Senate,,DEM,Kamala Harris,888
-San Mateo,5827,U.S. Senate,,DEM,Loretta Sanchez,342
-San Mateo,5829,U.S. Senate,,DEM,Kamala Harris,895
-San Mateo,5829,U.S. Senate,,DEM,Loretta Sanchez,332
-San Mateo,5832,U.S. Senate,,DEM,Kamala Harris,461
-San Mateo,5832,U.S. Senate,,DEM,Loretta Sanchez,165
-San Mateo,5901,U.S. Senate,,DEM,Kamala Harris,0
-San Mateo,5901,U.S. Senate,,DEM,Loretta Sanchez,0
-San Mateo,5902,U.S. Senate,,DEM,Kamala Harris,0
-San Mateo,5902,U.S. Senate,,DEM,Loretta Sanchez,0
-San Mateo,5903,U.S. Senate,,DEM,Kamala Harris,0
-San Mateo,5903,U.S. Senate,,DEM,Loretta Sanchez,0
-San Mateo,5904,U.S. Senate,,DEM,Kamala Harris,0
-San Mateo,5904,U.S. Senate,,DEM,Loretta Sanchez,0
-San Mateo,5905,U.S. Senate,,DEM,Kamala Harris,0
-San Mateo,5905,U.S. Senate,,DEM,Loretta Sanchez,0
-San Mateo,5906,U.S. Senate,,DEM,Kamala Harris,0
-San Mateo,5906,U.S. Senate,,DEM,Loretta Sanchez,0
-San Mateo,5907,U.S. Senate,,DEM,Kamala Harris,0
-San Mateo,5907,U.S. Senate,,DEM,Loretta Sanchez,0
+San Mateo,1001,U.S. Senate,,DEM,Kamala D. Harris,682
+San Mateo,1001,U.S. Senate,,DEM,Loretta L. Sanchez,227
+San Mateo,1002,U.S. Senate,,DEM,Kamala D. Harris,489
+San Mateo,1002,U.S. Senate,,DEM,Loretta L. Sanchez,156
+San Mateo,1003,U.S. Senate,,DEM,Kamala D. Harris,807
+San Mateo,1003,U.S. Senate,,DEM,Loretta L. Sanchez,309
+San Mateo,1005,U.S. Senate,,DEM,Kamala D. Harris,618
+San Mateo,1005,U.S. Senate,,DEM,Loretta L. Sanchez,222
+San Mateo,1007,U.S. Senate,,DEM,Kamala D. Harris,398
+San Mateo,1007,U.S. Senate,,DEM,Loretta L. Sanchez,170
+San Mateo,1008,U.S. Senate,,DEM,Kamala D. Harris,817
+San Mateo,1008,U.S. Senate,,DEM,Loretta L. Sanchez,303
+San Mateo,1009,U.S. Senate,,DEM,Kamala D. Harris,393
+San Mateo,1009,U.S. Senate,,DEM,Loretta L. Sanchez,126
+San Mateo,1011,U.S. Senate,,DEM,Kamala D. Harris,862
+San Mateo,1011,U.S. Senate,,DEM,Loretta L. Sanchez,309
+San Mateo,1013,U.S. Senate,,DEM,Kamala D. Harris,1003
+San Mateo,1013,U.S. Senate,,DEM,Loretta L. Sanchez,366
+San Mateo,1016,U.S. Senate,,DEM,Kamala D. Harris,1018
+San Mateo,1016,U.S. Senate,,DEM,Loretta L. Sanchez,287
+San Mateo,1017,U.S. Senate,,DEM,Kamala D. Harris,621
+San Mateo,1017,U.S. Senate,,DEM,Loretta L. Sanchez,200
+San Mateo,1019,U.S. Senate,,DEM,Kamala D. Harris,863
+San Mateo,1019,U.S. Senate,,DEM,Loretta L. Sanchez,316
+San Mateo,1021,U.S. Senate,,DEM,Kamala D. Harris,895
+San Mateo,1021,U.S. Senate,,DEM,Loretta L. Sanchez,360
+San Mateo,1201,U.S. Senate,,DEM,Kamala D. Harris,79
+San Mateo,1201,U.S. Senate,,DEM,Loretta L. Sanchez,37
+San Mateo,1202,U.S. Senate,,DEM,Kamala D. Harris,110
+San Mateo,1202,U.S. Senate,,DEM,Loretta L. Sanchez,57
+San Mateo,1203,U.S. Senate,,DEM,Kamala D. Harris,57
+San Mateo,1203,U.S. Senate,,DEM,Loretta L. Sanchez,21
+San Mateo,1204,U.S. Senate,,DEM,Kamala D. Harris,89
+San Mateo,1204,U.S. Senate,,DEM,Loretta L. Sanchez,46
+San Mateo,1205,U.S. Senate,,DEM,Kamala D. Harris,11
+San Mateo,1205,U.S. Senate,,DEM,Loretta L. Sanchez,2
+San Mateo,1206,U.S. Senate,,DEM,Kamala D. Harris,56
+San Mateo,1206,U.S. Senate,,DEM,Loretta L. Sanchez,25
+San Mateo,1302,U.S. Senate,,DEM,Kamala D. Harris,0
+San Mateo,1302,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Mateo,1303,U.S. Senate,,DEM,Kamala D. Harris,0
+San Mateo,1303,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Mateo,1304,U.S. Senate,,DEM,Kamala D. Harris,0
+San Mateo,1304,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Mateo,1401,U.S. Senate,,DEM,Kamala D. Harris,702
+San Mateo,1401,U.S. Senate,,DEM,Loretta L. Sanchez,329
+San Mateo,1402,U.S. Senate,,DEM,Kamala D. Harris,95
+San Mateo,1402,U.S. Senate,,DEM,Loretta L. Sanchez,44
+San Mateo,1403,U.S. Senate,,DEM,Kamala D. Harris,971
+San Mateo,1403,U.S. Senate,,DEM,Loretta L. Sanchez,440
+San Mateo,1406,U.S. Senate,,DEM,Kamala D. Harris,341
+San Mateo,1406,U.S. Senate,,DEM,Loretta L. Sanchez,146
+San Mateo,1407,U.S. Senate,,DEM,Kamala D. Harris,835
+San Mateo,1407,U.S. Senate,,DEM,Loretta L. Sanchez,325
+San Mateo,1409,U.S. Senate,,DEM,Kamala D. Harris,361
+San Mateo,1409,U.S. Senate,,DEM,Loretta L. Sanchez,174
+San Mateo,1410,U.S. Senate,,DEM,Kamala D. Harris,312
+San Mateo,1410,U.S. Senate,,DEM,Loretta L. Sanchez,93
+San Mateo,1501,U.S. Senate,,DEM,Kamala D. Harris,492
+San Mateo,1501,U.S. Senate,,DEM,Loretta L. Sanchez,213
+San Mateo,1502,U.S. Senate,,DEM,Kamala D. Harris,499
+San Mateo,1502,U.S. Senate,,DEM,Loretta L. Sanchez,199
+San Mateo,1503,U.S. Senate,,DEM,Kamala D. Harris,786
+San Mateo,1503,U.S. Senate,,DEM,Loretta L. Sanchez,323
+San Mateo,1506,U.S. Senate,,DEM,Kamala D. Harris,263
+San Mateo,1506,U.S. Senate,,DEM,Loretta L. Sanchez,113
+San Mateo,1507,U.S. Senate,,DEM,Kamala D. Harris,441
+San Mateo,1507,U.S. Senate,,DEM,Loretta L. Sanchez,176
+San Mateo,1508,U.S. Senate,,DEM,Kamala D. Harris,488
+San Mateo,1508,U.S. Senate,,DEM,Loretta L. Sanchez,197
+San Mateo,1509,U.S. Senate,,DEM,Kamala D. Harris,867
+San Mateo,1509,U.S. Senate,,DEM,Loretta L. Sanchez,341
+San Mateo,1511,U.S. Senate,,DEM,Kamala D. Harris,368
+San Mateo,1511,U.S. Senate,,DEM,Loretta L. Sanchez,122
+San Mateo,1512,U.S. Senate,,DEM,Kamala D. Harris,514
+San Mateo,1512,U.S. Senate,,DEM,Loretta L. Sanchez,241
+San Mateo,1514,U.S. Senate,,DEM,Kamala D. Harris,886
+San Mateo,1514,U.S. Senate,,DEM,Loretta L. Sanchez,399
+San Mateo,1516,U.S. Senate,,DEM,Kamala D. Harris,240
+San Mateo,1516,U.S. Senate,,DEM,Loretta L. Sanchez,94
+San Mateo,1601,U.S. Senate,,DEM,Kamala D. Harris,304
+San Mateo,1601,U.S. Senate,,DEM,Loretta L. Sanchez,242
+San Mateo,1602,U.S. Senate,,DEM,Kamala D. Harris,384
+San Mateo,1602,U.S. Senate,,DEM,Loretta L. Sanchez,227
+San Mateo,1603,U.S. Senate,,DEM,Kamala D. Harris,364
+San Mateo,1603,U.S. Senate,,DEM,Loretta L. Sanchez,249
+San Mateo,1604,U.S. Senate,,DEM,Kamala D. Harris,527
+San Mateo,1604,U.S. Senate,,DEM,Loretta L. Sanchez,278
+San Mateo,1605,U.S. Senate,,DEM,Kamala D. Harris,442
+San Mateo,1605,U.S. Senate,,DEM,Loretta L. Sanchez,257
+San Mateo,1606,U.S. Senate,,DEM,Kamala D. Harris,470
+San Mateo,1606,U.S. Senate,,DEM,Loretta L. Sanchez,214
+San Mateo,1607,U.S. Senate,,DEM,Kamala D. Harris,398
+San Mateo,1607,U.S. Senate,,DEM,Loretta L. Sanchez,175
+San Mateo,1608,U.S. Senate,,DEM,Kamala D. Harris,551
+San Mateo,1608,U.S. Senate,,DEM,Loretta L. Sanchez,261
+San Mateo,1610,U.S. Senate,,DEM,Kamala D. Harris,535
+San Mateo,1610,U.S. Senate,,DEM,Loretta L. Sanchez,214
+San Mateo,1612,U.S. Senate,,DEM,Kamala D. Harris,537
+San Mateo,1612,U.S. Senate,,DEM,Loretta L. Sanchez,219
+San Mateo,1613,U.S. Senate,,DEM,Kamala D. Harris,796
+San Mateo,1613,U.S. Senate,,DEM,Loretta L. Sanchez,283
+San Mateo,1614,U.S. Senate,,DEM,Kamala D. Harris,543
+San Mateo,1614,U.S. Senate,,DEM,Loretta L. Sanchez,224
+San Mateo,1617,U.S. Senate,,DEM,Kamala D. Harris,867
+San Mateo,1617,U.S. Senate,,DEM,Loretta L. Sanchez,389
+San Mateo,1619,U.S. Senate,,DEM,Kamala D. Harris,676
+San Mateo,1619,U.S. Senate,,DEM,Loretta L. Sanchez,298
+San Mateo,1701,U.S. Senate,,DEM,Kamala D. Harris,592
+San Mateo,1701,U.S. Senate,,DEM,Loretta L. Sanchez,199
+San Mateo,1703,U.S. Senate,,DEM,Kamala D. Harris,991
+San Mateo,1703,U.S. Senate,,DEM,Loretta L. Sanchez,235
+San Mateo,1705,U.S. Senate,,DEM,Kamala D. Harris,1
+San Mateo,1705,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Mateo,1706,U.S. Senate,,DEM,Kamala D. Harris,118
+San Mateo,1706,U.S. Senate,,DEM,Loretta L. Sanchez,35
+San Mateo,1801,U.S. Senate,,DEM,Kamala D. Harris,744
+San Mateo,1801,U.S. Senate,,DEM,Loretta L. Sanchez,436
+San Mateo,1802,U.S. Senate,,DEM,Kamala D. Harris,521
+San Mateo,1802,U.S. Senate,,DEM,Loretta L. Sanchez,217
+San Mateo,1803,U.S. Senate,,DEM,Kamala D. Harris,512
+San Mateo,1803,U.S. Senate,,DEM,Loretta L. Sanchez,234
+San Mateo,1806,U.S. Senate,,DEM,Kamala D. Harris,948
+San Mateo,1806,U.S. Senate,,DEM,Loretta L. Sanchez,429
+San Mateo,1807,U.S. Senate,,DEM,Kamala D. Harris,671
+San Mateo,1807,U.S. Senate,,DEM,Loretta L. Sanchez,323
+San Mateo,1810,U.S. Senate,,DEM,Kamala D. Harris,635
+San Mateo,1810,U.S. Senate,,DEM,Loretta L. Sanchez,408
+San Mateo,1813,U.S. Senate,,DEM,Kamala D. Harris,444
+San Mateo,1813,U.S. Senate,,DEM,Loretta L. Sanchez,265
+San Mateo,1814,U.S. Senate,,DEM,Kamala D. Harris,419
+San Mateo,1814,U.S. Senate,,DEM,Loretta L. Sanchez,296
+San Mateo,1815,U.S. Senate,,DEM,Kamala D. Harris,374
+San Mateo,1815,U.S. Senate,,DEM,Loretta L. Sanchez,221
+San Mateo,1816,U.S. Senate,,DEM,Kamala D. Harris,459
+San Mateo,1816,U.S. Senate,,DEM,Loretta L. Sanchez,236
+San Mateo,1818,U.S. Senate,,DEM,Kamala D. Harris,399
+San Mateo,1818,U.S. Senate,,DEM,Loretta L. Sanchez,259
+San Mateo,1819,U.S. Senate,,DEM,Kamala D. Harris,696
+San Mateo,1819,U.S. Senate,,DEM,Loretta L. Sanchez,379
+San Mateo,1820,U.S. Senate,,DEM,Kamala D. Harris,112
+San Mateo,1820,U.S. Senate,,DEM,Loretta L. Sanchez,49
+San Mateo,1821,U.S. Senate,,DEM,Kamala D. Harris,860
+San Mateo,1821,U.S. Senate,,DEM,Loretta L. Sanchez,376
+San Mateo,1824,U.S. Senate,,DEM,Kamala D. Harris,483
+San Mateo,1824,U.S. Senate,,DEM,Loretta L. Sanchez,236
+San Mateo,1833,U.S. Senate,,DEM,Kamala D. Harris,653
+San Mateo,1833,U.S. Senate,,DEM,Loretta L. Sanchez,291
+San Mateo,1835,U.S. Senate,,DEM,Kamala D. Harris,812
+San Mateo,1835,U.S. Senate,,DEM,Loretta L. Sanchez,384
+San Mateo,1837,U.S. Senate,,DEM,Kamala D. Harris,389
+San Mateo,1837,U.S. Senate,,DEM,Loretta L. Sanchez,191
+San Mateo,1838,U.S. Senate,,DEM,Kamala D. Harris,57
+San Mateo,1838,U.S. Senate,,DEM,Loretta L. Sanchez,24
+San Mateo,1902,U.S. Senate,,DEM,Kamala D. Harris,0
+San Mateo,1902,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Mateo,1903,U.S. Senate,,DEM,Kamala D. Harris,45
+San Mateo,1903,U.S. Senate,,DEM,Loretta L. Sanchez,26
+San Mateo,2101,U.S. Senate,,DEM,Kamala D. Harris,147
+San Mateo,2101,U.S. Senate,,DEM,Loretta L. Sanchez,60
+San Mateo,2104,U.S. Senate,,DEM,Kamala D. Harris,261
+San Mateo,2104,U.S. Senate,,DEM,Loretta L. Sanchez,105
+San Mateo,2106,U.S. Senate,,DEM,Kamala D. Harris,539
+San Mateo,2106,U.S. Senate,,DEM,Loretta L. Sanchez,163
+San Mateo,2107,U.S. Senate,,DEM,Kamala D. Harris,905
+San Mateo,2107,U.S. Senate,,DEM,Loretta L. Sanchez,272
+San Mateo,2110,U.S. Senate,,DEM,Kamala D. Harris,458
+San Mateo,2110,U.S. Senate,,DEM,Loretta L. Sanchez,114
+San Mateo,2111,U.S. Senate,,DEM,Kamala D. Harris,487
+San Mateo,2111,U.S. Senate,,DEM,Loretta L. Sanchez,154
+San Mateo,2112,U.S. Senate,,DEM,Kamala D. Harris,451
+San Mateo,2112,U.S. Senate,,DEM,Loretta L. Sanchez,157
+San Mateo,2113,U.S. Senate,,DEM,Kamala D. Harris,953
+San Mateo,2113,U.S. Senate,,DEM,Loretta L. Sanchez,291
+San Mateo,2115,U.S. Senate,,DEM,Kamala D. Harris,791
+San Mateo,2115,U.S. Senate,,DEM,Loretta L. Sanchez,270
+San Mateo,2117,U.S. Senate,,DEM,Kamala D. Harris,678
+San Mateo,2117,U.S. Senate,,DEM,Loretta L. Sanchez,252
+San Mateo,2122,U.S. Senate,,DEM,Kamala D. Harris,12
+San Mateo,2122,U.S. Senate,,DEM,Loretta L. Sanchez,2
+San Mateo,2131,U.S. Senate,,DEM,Kamala D. Harris,951
+San Mateo,2131,U.S. Senate,,DEM,Loretta L. Sanchez,321
+San Mateo,2133,U.S. Senate,,DEM,Kamala D. Harris,675
+San Mateo,2133,U.S. Senate,,DEM,Loretta L. Sanchez,230
+San Mateo,2201,U.S. Senate,,DEM,Kamala D. Harris,751
+San Mateo,2201,U.S. Senate,,DEM,Loretta L. Sanchez,232
+San Mateo,2203,U.S. Senate,,DEM,Kamala D. Harris,625
+San Mateo,2203,U.S. Senate,,DEM,Loretta L. Sanchez,251
+San Mateo,2204,U.S. Senate,,DEM,Kamala D. Harris,619
+San Mateo,2204,U.S. Senate,,DEM,Loretta L. Sanchez,222
+San Mateo,2205,U.S. Senate,,DEM,Kamala D. Harris,591
+San Mateo,2205,U.S. Senate,,DEM,Loretta L. Sanchez,221
+San Mateo,2207,U.S. Senate,,DEM,Kamala D. Harris,797
+San Mateo,2207,U.S. Senate,,DEM,Loretta L. Sanchez,264
+San Mateo,2210,U.S. Senate,,DEM,Kamala D. Harris,594
+San Mateo,2210,U.S. Senate,,DEM,Loretta L. Sanchez,204
+San Mateo,2212,U.S. Senate,,DEM,Kamala D. Harris,389
+San Mateo,2212,U.S. Senate,,DEM,Loretta L. Sanchez,89
+San Mateo,2214,U.S. Senate,,DEM,Kamala D. Harris,492
+San Mateo,2214,U.S. Senate,,DEM,Loretta L. Sanchez,159
+San Mateo,2215,U.S. Senate,,DEM,Kamala D. Harris,858
+San Mateo,2215,U.S. Senate,,DEM,Loretta L. Sanchez,269
+San Mateo,2217,U.S. Senate,,DEM,Kamala D. Harris,856
+San Mateo,2217,U.S. Senate,,DEM,Loretta L. Sanchez,228
+San Mateo,2221,U.S. Senate,,DEM,Kamala D. Harris,771
+San Mateo,2221,U.S. Senate,,DEM,Loretta L. Sanchez,272
+San Mateo,2222,U.S. Senate,,DEM,Kamala D. Harris,465
+San Mateo,2222,U.S. Senate,,DEM,Loretta L. Sanchez,172
+San Mateo,2224,U.S. Senate,,DEM,Kamala D. Harris,512
+San Mateo,2224,U.S. Senate,,DEM,Loretta L. Sanchez,143
+San Mateo,2225,U.S. Senate,,DEM,Kamala D. Harris,300
+San Mateo,2225,U.S. Senate,,DEM,Loretta L. Sanchez,107
+San Mateo,2601,U.S. Senate,,DEM,Kamala D. Harris,931
+San Mateo,2601,U.S. Senate,,DEM,Loretta L. Sanchez,502
+San Mateo,2603,U.S. Senate,,DEM,Kamala D. Harris,431
+San Mateo,2603,U.S. Senate,,DEM,Loretta L. Sanchez,183
+San Mateo,2604,U.S. Senate,,DEM,Kamala D. Harris,392
+San Mateo,2604,U.S. Senate,,DEM,Loretta L. Sanchez,223
+San Mateo,2605,U.S. Senate,,DEM,Kamala D. Harris,680
+San Mateo,2605,U.S. Senate,,DEM,Loretta L. Sanchez,395
+San Mateo,2607,U.S. Senate,,DEM,Kamala D. Harris,371
+San Mateo,2607,U.S. Senate,,DEM,Loretta L. Sanchez,154
+San Mateo,2608,U.S. Senate,,DEM,Kamala D. Harris,421
+San Mateo,2608,U.S. Senate,,DEM,Loretta L. Sanchez,211
+San Mateo,2609,U.S. Senate,,DEM,Kamala D. Harris,478
+San Mateo,2609,U.S. Senate,,DEM,Loretta L. Sanchez,169
+San Mateo,2610,U.S. Senate,,DEM,Kamala D. Harris,551
+San Mateo,2610,U.S. Senate,,DEM,Loretta L. Sanchez,180
+San Mateo,2611,U.S. Senate,,DEM,Kamala D. Harris,422
+San Mateo,2611,U.S. Senate,,DEM,Loretta L. Sanchez,181
+San Mateo,2612,U.S. Senate,,DEM,Kamala D. Harris,668
+San Mateo,2612,U.S. Senate,,DEM,Loretta L. Sanchez,297
+San Mateo,2614,U.S. Senate,,DEM,Kamala D. Harris,683
+San Mateo,2614,U.S. Senate,,DEM,Loretta L. Sanchez,247
+San Mateo,2616,U.S. Senate,,DEM,Kamala D. Harris,605
+San Mateo,2616,U.S. Senate,,DEM,Loretta L. Sanchez,298
+San Mateo,2618,U.S. Senate,,DEM,Kamala D. Harris,858
+San Mateo,2618,U.S. Senate,,DEM,Loretta L. Sanchez,399
+San Mateo,2620,U.S. Senate,,DEM,Kamala D. Harris,727
+San Mateo,2620,U.S. Senate,,DEM,Loretta L. Sanchez,257
+San Mateo,2621,U.S. Senate,,DEM,Kamala D. Harris,609
+San Mateo,2621,U.S. Senate,,DEM,Loretta L. Sanchez,216
+San Mateo,2622,U.S. Senate,,DEM,Kamala D. Harris,666
+San Mateo,2622,U.S. Senate,,DEM,Loretta L. Sanchez,257
+San Mateo,2624,U.S. Senate,,DEM,Kamala D. Harris,421
+San Mateo,2624,U.S. Senate,,DEM,Loretta L. Sanchez,128
+San Mateo,2625,U.S. Senate,,DEM,Kamala D. Harris,534
+San Mateo,2625,U.S. Senate,,DEM,Loretta L. Sanchez,221
+San Mateo,2626,U.S. Senate,,DEM,Kamala D. Harris,589
+San Mateo,2626,U.S. Senate,,DEM,Loretta L. Sanchez,211
+San Mateo,2627,U.S. Senate,,DEM,Kamala D. Harris,438
+San Mateo,2627,U.S. Senate,,DEM,Loretta L. Sanchez,163
+San Mateo,2628,U.S. Senate,,DEM,Kamala D. Harris,548
+San Mateo,2628,U.S. Senate,,DEM,Loretta L. Sanchez,246
+San Mateo,2629,U.S. Senate,,DEM,Kamala D. Harris,366
+San Mateo,2629,U.S. Senate,,DEM,Loretta L. Sanchez,203
+San Mateo,2630,U.S. Senate,,DEM,Kamala D. Harris,330
+San Mateo,2630,U.S. Senate,,DEM,Loretta L. Sanchez,159
+San Mateo,2631,U.S. Senate,,DEM,Kamala D. Harris,665
+San Mateo,2631,U.S. Senate,,DEM,Loretta L. Sanchez,288
+San Mateo,2633,U.S. Senate,,DEM,Kamala D. Harris,391
+San Mateo,2633,U.S. Senate,,DEM,Loretta L. Sanchez,169
+San Mateo,2634,U.S. Senate,,DEM,Kamala D. Harris,506
+San Mateo,2634,U.S. Senate,,DEM,Loretta L. Sanchez,207
+San Mateo,2636,U.S. Senate,,DEM,Kamala D. Harris,594
+San Mateo,2636,U.S. Senate,,DEM,Loretta L. Sanchez,202
+San Mateo,2637,U.S. Senate,,DEM,Kamala D. Harris,444
+San Mateo,2637,U.S. Senate,,DEM,Loretta L. Sanchez,156
+San Mateo,2638,U.S. Senate,,DEM,Kamala D. Harris,524
+San Mateo,2638,U.S. Senate,,DEM,Loretta L. Sanchez,175
+San Mateo,2639,U.S. Senate,,DEM,Kamala D. Harris,520
+San Mateo,2639,U.S. Senate,,DEM,Loretta L. Sanchez,181
+San Mateo,2644,U.S. Senate,,DEM,Kamala D. Harris,442
+San Mateo,2644,U.S. Senate,,DEM,Loretta L. Sanchez,169
+San Mateo,2646,U.S. Senate,,DEM,Kamala D. Harris,752
+San Mateo,2646,U.S. Senate,,DEM,Loretta L. Sanchez,257
+San Mateo,2648,U.S. Senate,,DEM,Kamala D. Harris,795
+San Mateo,2648,U.S. Senate,,DEM,Loretta L. Sanchez,286
+San Mateo,2650,U.S. Senate,,DEM,Kamala D. Harris,682
+San Mateo,2650,U.S. Senate,,DEM,Loretta L. Sanchez,246
+San Mateo,2651,U.S. Senate,,DEM,Kamala D. Harris,510
+San Mateo,2651,U.S. Senate,,DEM,Loretta L. Sanchez,210
+San Mateo,2652,U.S. Senate,,DEM,Kamala D. Harris,479
+San Mateo,2652,U.S. Senate,,DEM,Loretta L. Sanchez,166
+San Mateo,2653,U.S. Senate,,DEM,Kamala D. Harris,455
+San Mateo,2653,U.S. Senate,,DEM,Loretta L. Sanchez,163
+San Mateo,2654,U.S. Senate,,DEM,Kamala D. Harris,734
+San Mateo,2654,U.S. Senate,,DEM,Loretta L. Sanchez,269
+San Mateo,2655,U.S. Senate,,DEM,Kamala D. Harris,715
+San Mateo,2655,U.S. Senate,,DEM,Loretta L. Sanchez,327
+San Mateo,2657,U.S. Senate,,DEM,Kamala D. Harris,723
+San Mateo,2657,U.S. Senate,,DEM,Loretta L. Sanchez,255
+San Mateo,2658,U.S. Senate,,DEM,Kamala D. Harris,879
+San Mateo,2658,U.S. Senate,,DEM,Loretta L. Sanchez,326
+San Mateo,2662,U.S. Senate,,DEM,Kamala D. Harris,582
+San Mateo,2662,U.S. Senate,,DEM,Loretta L. Sanchez,217
+San Mateo,2663,U.S. Senate,,DEM,Kamala D. Harris,607
+San Mateo,2663,U.S. Senate,,DEM,Loretta L. Sanchez,226
+San Mateo,2664,U.S. Senate,,DEM,Kamala D. Harris,84
+San Mateo,2664,U.S. Senate,,DEM,Loretta L. Sanchez,42
+San Mateo,2667,U.S. Senate,,DEM,Kamala D. Harris,338
+San Mateo,2667,U.S. Senate,,DEM,Loretta L. Sanchez,126
+San Mateo,2668,U.S. Senate,,DEM,Kamala D. Harris,275
+San Mateo,2668,U.S. Senate,,DEM,Loretta L. Sanchez,93
+San Mateo,2670,U.S. Senate,,DEM,Kamala D. Harris,682
+San Mateo,2670,U.S. Senate,,DEM,Loretta L. Sanchez,290
+San Mateo,2671,U.S. Senate,,DEM,Kamala D. Harris,860
+San Mateo,2671,U.S. Senate,,DEM,Loretta L. Sanchez,318
+San Mateo,2675,U.S. Senate,,DEM,Kamala D. Harris,121
+San Mateo,2675,U.S. Senate,,DEM,Loretta L. Sanchez,42
+San Mateo,2676,U.S. Senate,,DEM,Kamala D. Harris,115
+San Mateo,2676,U.S. Senate,,DEM,Loretta L. Sanchez,37
+San Mateo,2677,U.S. Senate,,DEM,Kamala D. Harris,61
+San Mateo,2677,U.S. Senate,,DEM,Loretta L. Sanchez,19
+San Mateo,2678,U.S. Senate,,DEM,Kamala D. Harris,74
+San Mateo,2678,U.S. Senate,,DEM,Loretta L. Sanchez,31
+San Mateo,2679,U.S. Senate,,DEM,Kamala D. Harris,444
+San Mateo,2679,U.S. Senate,,DEM,Loretta L. Sanchez,180
+San Mateo,2701,U.S. Senate,,DEM,Kamala D. Harris,0
+San Mateo,2701,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Mateo,3001,U.S. Senate,,DEM,Kamala D. Harris,816
+San Mateo,3001,U.S. Senate,,DEM,Loretta L. Sanchez,361
+San Mateo,3004,U.S. Senate,,DEM,Kamala D. Harris,108
+San Mateo,3004,U.S. Senate,,DEM,Loretta L. Sanchez,52
+San Mateo,3005,U.S. Senate,,DEM,Kamala D. Harris,417
+San Mateo,3005,U.S. Senate,,DEM,Loretta L. Sanchez,198
+San Mateo,3006,U.S. Senate,,DEM,Kamala D. Harris,531
+San Mateo,3006,U.S. Senate,,DEM,Loretta L. Sanchez,184
+San Mateo,3008,U.S. Senate,,DEM,Kamala D. Harris,392
+San Mateo,3008,U.S. Senate,,DEM,Loretta L. Sanchez,169
+San Mateo,3009,U.S. Senate,,DEM,Kamala D. Harris,74
+San Mateo,3009,U.S. Senate,,DEM,Loretta L. Sanchez,50
+San Mateo,3010,U.S. Senate,,DEM,Kamala D. Harris,90
+San Mateo,3010,U.S. Senate,,DEM,Loretta L. Sanchez,16
+San Mateo,3102,U.S. Senate,,DEM,Kamala D. Harris,872
+San Mateo,3102,U.S. Senate,,DEM,Loretta L. Sanchez,354
+San Mateo,3123,U.S. Senate,,DEM,Kamala D. Harris,92
+San Mateo,3123,U.S. Senate,,DEM,Loretta L. Sanchez,32
+San Mateo,3135,U.S. Senate,,DEM,Kamala D. Harris,509
+San Mateo,3135,U.S. Senate,,DEM,Loretta L. Sanchez,178
+San Mateo,3201,U.S. Senate,,DEM,Kamala D. Harris,28
+San Mateo,3201,U.S. Senate,,DEM,Loretta L. Sanchez,22
+San Mateo,3202,U.S. Senate,,DEM,Kamala D. Harris,295
+San Mateo,3202,U.S. Senate,,DEM,Loretta L. Sanchez,98
+San Mateo,3203,U.S. Senate,,DEM,Kamala D. Harris,7
+San Mateo,3203,U.S. Senate,,DEM,Loretta L. Sanchez,2
+San Mateo,3204,U.S. Senate,,DEM,Kamala D. Harris,12
+San Mateo,3204,U.S. Senate,,DEM,Loretta L. Sanchez,4
+San Mateo,3210,U.S. Senate,,DEM,Kamala D. Harris,1
+San Mateo,3210,U.S. Senate,,DEM,Loretta L. Sanchez,1
+San Mateo,3211,U.S. Senate,,DEM,Kamala D. Harris,2
+San Mateo,3211,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Mateo,3213,U.S. Senate,,DEM,Kamala D. Harris,0
+San Mateo,3213,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Mateo,3214,U.S. Senate,,DEM,Kamala D. Harris,0
+San Mateo,3214,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Mateo,3301,U.S. Senate,,DEM,Kamala D. Harris,516
+San Mateo,3301,U.S. Senate,,DEM,Loretta L. Sanchez,173
+San Mateo,3303,U.S. Senate,,DEM,Kamala D. Harris,391
+San Mateo,3303,U.S. Senate,,DEM,Loretta L. Sanchez,138
+San Mateo,3304,U.S. Senate,,DEM,Kamala D. Harris,860
+San Mateo,3304,U.S. Senate,,DEM,Loretta L. Sanchez,269
+San Mateo,3306,U.S. Senate,,DEM,Kamala D. Harris,519
+San Mateo,3306,U.S. Senate,,DEM,Loretta L. Sanchez,147
+San Mateo,3307,U.S. Senate,,DEM,Kamala D. Harris,11
+San Mateo,3307,U.S. Senate,,DEM,Loretta L. Sanchez,4
+San Mateo,3310,U.S. Senate,,DEM,Kamala D. Harris,487
+San Mateo,3310,U.S. Senate,,DEM,Loretta L. Sanchez,155
+San Mateo,3311,U.S. Senate,,DEM,Kamala D. Harris,505
+San Mateo,3311,U.S. Senate,,DEM,Loretta L. Sanchez,149
+San Mateo,3312,U.S. Senate,,DEM,Kamala D. Harris,587
+San Mateo,3312,U.S. Senate,,DEM,Loretta L. Sanchez,210
+San Mateo,3313,U.S. Senate,,DEM,Kamala D. Harris,552
+San Mateo,3313,U.S. Senate,,DEM,Loretta L. Sanchez,197
+San Mateo,3314,U.S. Senate,,DEM,Kamala D. Harris,2
+San Mateo,3314,U.S. Senate,,DEM,Loretta L. Sanchez,1
+San Mateo,3316,U.S. Senate,,DEM,Kamala D. Harris,28
+San Mateo,3316,U.S. Senate,,DEM,Loretta L. Sanchez,13
+San Mateo,3320,U.S. Senate,,DEM,Kamala D. Harris,432
+San Mateo,3320,U.S. Senate,,DEM,Loretta L. Sanchez,145
+San Mateo,3321,U.S. Senate,,DEM,Kamala D. Harris,824
+San Mateo,3321,U.S. Senate,,DEM,Loretta L. Sanchez,409
+San Mateo,3323,U.S. Senate,,DEM,Kamala D. Harris,554
+San Mateo,3323,U.S. Senate,,DEM,Loretta L. Sanchez,251
+San Mateo,3324,U.S. Senate,,DEM,Kamala D. Harris,521
+San Mateo,3324,U.S. Senate,,DEM,Loretta L. Sanchez,186
+San Mateo,3325,U.S. Senate,,DEM,Kamala D. Harris,489
+San Mateo,3325,U.S. Senate,,DEM,Loretta L. Sanchez,222
+San Mateo,3326,U.S. Senate,,DEM,Kamala D. Harris,831
+San Mateo,3326,U.S. Senate,,DEM,Loretta L. Sanchez,316
+San Mateo,3330,U.S. Senate,,DEM,Kamala D. Harris,17
+San Mateo,3330,U.S. Senate,,DEM,Loretta L. Sanchez,10
+San Mateo,3331,U.S. Senate,,DEM,Kamala D. Harris,111
+San Mateo,3331,U.S. Senate,,DEM,Loretta L. Sanchez,140
+San Mateo,3340,U.S. Senate,,DEM,Kamala D. Harris,640
+San Mateo,3340,U.S. Senate,,DEM,Loretta L. Sanchez,204
+San Mateo,3350,U.S. Senate,,DEM,Kamala D. Harris,378
+San Mateo,3350,U.S. Senate,,DEM,Loretta L. Sanchez,188
+San Mateo,3360,U.S. Senate,,DEM,Kamala D. Harris,53
+San Mateo,3360,U.S. Senate,,DEM,Loretta L. Sanchez,22
+San Mateo,3361,U.S. Senate,,DEM,Kamala D. Harris,55
+San Mateo,3361,U.S. Senate,,DEM,Loretta L. Sanchez,8
+San Mateo,3370,U.S. Senate,,DEM,Kamala D. Harris,346
+San Mateo,3370,U.S. Senate,,DEM,Loretta L. Sanchez,96
+San Mateo,3371,U.S. Senate,,DEM,Kamala D. Harris,30
+San Mateo,3371,U.S. Senate,,DEM,Loretta L. Sanchez,13
+San Mateo,3372,U.S. Senate,,DEM,Kamala D. Harris,61
+San Mateo,3372,U.S. Senate,,DEM,Loretta L. Sanchez,14
+San Mateo,3375,U.S. Senate,,DEM,Kamala D. Harris,45
+San Mateo,3375,U.S. Senate,,DEM,Loretta L. Sanchez,7
+San Mateo,3376,U.S. Senate,,DEM,Kamala D. Harris,129
+San Mateo,3376,U.S. Senate,,DEM,Loretta L. Sanchez,44
+San Mateo,3377,U.S. Senate,,DEM,Kamala D. Harris,15
+San Mateo,3377,U.S. Senate,,DEM,Loretta L. Sanchez,8
+San Mateo,3380,U.S. Senate,,DEM,Kamala D. Harris,42
+San Mateo,3380,U.S. Senate,,DEM,Loretta L. Sanchez,19
+San Mateo,3401,U.S. Senate,,DEM,Kamala D. Harris,546
+San Mateo,3401,U.S. Senate,,DEM,Loretta L. Sanchez,129
+San Mateo,3402,U.S. Senate,,DEM,Kamala D. Harris,881
+San Mateo,3402,U.S. Senate,,DEM,Loretta L. Sanchez,219
+San Mateo,3406,U.S. Senate,,DEM,Kamala D. Harris,54
+San Mateo,3406,U.S. Senate,,DEM,Loretta L. Sanchez,14
+San Mateo,3407,U.S. Senate,,DEM,Kamala D. Harris,144
+San Mateo,3407,U.S. Senate,,DEM,Loretta L. Sanchez,28
+San Mateo,3408,U.S. Senate,,DEM,Kamala D. Harris,59
+San Mateo,3408,U.S. Senate,,DEM,Loretta L. Sanchez,21
+San Mateo,3409,U.S. Senate,,DEM,Kamala D. Harris,0
+San Mateo,3409,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Mateo,3410,U.S. Senate,,DEM,Kamala D. Harris,741
+San Mateo,3410,U.S. Senate,,DEM,Loretta L. Sanchez,165
+San Mateo,3412,U.S. Senate,,DEM,Kamala D. Harris,7
+San Mateo,3412,U.S. Senate,,DEM,Loretta L. Sanchez,14
+San Mateo,3420,U.S. Senate,,DEM,Kamala D. Harris,316
+San Mateo,3420,U.S. Senate,,DEM,Loretta L. Sanchez,89
+San Mateo,3421,U.S. Senate,,DEM,Kamala D. Harris,37
+San Mateo,3421,U.S. Senate,,DEM,Loretta L. Sanchez,9
+San Mateo,3450,U.S. Senate,,DEM,Kamala D. Harris,342
+San Mateo,3450,U.S. Senate,,DEM,Loretta L. Sanchez,123
+San Mateo,3451,U.S. Senate,,DEM,Kamala D. Harris,892
+San Mateo,3451,U.S. Senate,,DEM,Loretta L. Sanchez,222
+San Mateo,3452,U.S. Senate,,DEM,Kamala D. Harris,817
+San Mateo,3452,U.S. Senate,,DEM,Loretta L. Sanchez,195
+San Mateo,3455,U.S. Senate,,DEM,Kamala D. Harris,758
+San Mateo,3455,U.S. Senate,,DEM,Loretta L. Sanchez,243
+San Mateo,3457,U.S. Senate,,DEM,Kamala D. Harris,805
+San Mateo,3457,U.S. Senate,,DEM,Loretta L. Sanchez,205
+San Mateo,3459,U.S. Senate,,DEM,Kamala D. Harris,733
+San Mateo,3459,U.S. Senate,,DEM,Loretta L. Sanchez,176
+San Mateo,3460,U.S. Senate,,DEM,Kamala D. Harris,784
+San Mateo,3460,U.S. Senate,,DEM,Loretta L. Sanchez,240
+San Mateo,3463,U.S. Senate,,DEM,Kamala D. Harris,18
+San Mateo,3463,U.S. Senate,,DEM,Loretta L. Sanchez,3
+San Mateo,3464,U.S. Senate,,DEM,Kamala D. Harris,49
+San Mateo,3464,U.S. Senate,,DEM,Loretta L. Sanchez,9
+San Mateo,3480,U.S. Senate,,DEM,Kamala D. Harris,360
+San Mateo,3480,U.S. Senate,,DEM,Loretta L. Sanchez,92
+San Mateo,3501,U.S. Senate,,DEM,Kamala D. Harris,482
+San Mateo,3501,U.S. Senate,,DEM,Loretta L. Sanchez,191
+San Mateo,3502,U.S. Senate,,DEM,Kamala D. Harris,543
+San Mateo,3502,U.S. Senate,,DEM,Loretta L. Sanchez,220
+San Mateo,3503,U.S. Senate,,DEM,Kamala D. Harris,526
+San Mateo,3503,U.S. Senate,,DEM,Loretta L. Sanchez,241
+San Mateo,3504,U.S. Senate,,DEM,Kamala D. Harris,402
+San Mateo,3504,U.S. Senate,,DEM,Loretta L. Sanchez,165
+San Mateo,3505,U.S. Senate,,DEM,Kamala D. Harris,431
+San Mateo,3505,U.S. Senate,,DEM,Loretta L. Sanchez,218
+San Mateo,3506,U.S. Senate,,DEM,Kamala D. Harris,85
+San Mateo,3506,U.S. Senate,,DEM,Loretta L. Sanchez,18
+San Mateo,3507,U.S. Senate,,DEM,Kamala D. Harris,586
+San Mateo,3507,U.S. Senate,,DEM,Loretta L. Sanchez,219
+San Mateo,3508,U.S. Senate,,DEM,Kamala D. Harris,548
+San Mateo,3508,U.S. Senate,,DEM,Loretta L. Sanchez,210
+San Mateo,3509,U.S. Senate,,DEM,Kamala D. Harris,562
+San Mateo,3509,U.S. Senate,,DEM,Loretta L. Sanchez,244
+San Mateo,3510,U.S. Senate,,DEM,Kamala D. Harris,394
+San Mateo,3510,U.S. Senate,,DEM,Loretta L. Sanchez,152
+San Mateo,3512,U.S. Senate,,DEM,Kamala D. Harris,620
+San Mateo,3512,U.S. Senate,,DEM,Loretta L. Sanchez,243
+San Mateo,3513,U.S. Senate,,DEM,Kamala D. Harris,506
+San Mateo,3513,U.S. Senate,,DEM,Loretta L. Sanchez,192
+San Mateo,3515,U.S. Senate,,DEM,Kamala D. Harris,265
+San Mateo,3515,U.S. Senate,,DEM,Loretta L. Sanchez,111
+San Mateo,3516,U.S. Senate,,DEM,Kamala D. Harris,384
+San Mateo,3516,U.S. Senate,,DEM,Loretta L. Sanchez,110
+San Mateo,3517,U.S. Senate,,DEM,Kamala D. Harris,338
+San Mateo,3517,U.S. Senate,,DEM,Loretta L. Sanchez,143
+San Mateo,3518,U.S. Senate,,DEM,Kamala D. Harris,476
+San Mateo,3518,U.S. Senate,,DEM,Loretta L. Sanchez,204
+San Mateo,3519,U.S. Senate,,DEM,Kamala D. Harris,342
+San Mateo,3519,U.S. Senate,,DEM,Loretta L. Sanchez,156
+San Mateo,3520,U.S. Senate,,DEM,Kamala D. Harris,913
+San Mateo,3520,U.S. Senate,,DEM,Loretta L. Sanchez,397
+San Mateo,3522,U.S. Senate,,DEM,Kamala D. Harris,805
+San Mateo,3522,U.S. Senate,,DEM,Loretta L. Sanchez,288
+San Mateo,3523,U.S. Senate,,DEM,Kamala D. Harris,406
+San Mateo,3523,U.S. Senate,,DEM,Loretta L. Sanchez,143
+San Mateo,3524,U.S. Senate,,DEM,Kamala D. Harris,374
+San Mateo,3524,U.S. Senate,,DEM,Loretta L. Sanchez,153
+San Mateo,3525,U.S. Senate,,DEM,Kamala D. Harris,729
+San Mateo,3525,U.S. Senate,,DEM,Loretta L. Sanchez,316
+San Mateo,3528,U.S. Senate,,DEM,Kamala D. Harris,431
+San Mateo,3528,U.S. Senate,,DEM,Loretta L. Sanchez,176
+San Mateo,3529,U.S. Senate,,DEM,Kamala D. Harris,487
+San Mateo,3529,U.S. Senate,,DEM,Loretta L. Sanchez,195
+San Mateo,3530,U.S. Senate,,DEM,Kamala D. Harris,457
+San Mateo,3530,U.S. Senate,,DEM,Loretta L. Sanchez,184
+San Mateo,3531,U.S. Senate,,DEM,Kamala D. Harris,363
+San Mateo,3531,U.S. Senate,,DEM,Loretta L. Sanchez,156
+San Mateo,3532,U.S. Senate,,DEM,Kamala D. Harris,111
+San Mateo,3532,U.S. Senate,,DEM,Loretta L. Sanchez,30
+San Mateo,3533,U.S. Senate,,DEM,Kamala D. Harris,145
+San Mateo,3533,U.S. Senate,,DEM,Loretta L. Sanchez,53
+San Mateo,3540,U.S. Senate,,DEM,Kamala D. Harris,5
+San Mateo,3540,U.S. Senate,,DEM,Loretta L. Sanchez,2
+San Mateo,3541,U.S. Senate,,DEM,Kamala D. Harris,0
+San Mateo,3541,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Mateo,3542,U.S. Senate,,DEM,Kamala D. Harris,0
+San Mateo,3542,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Mateo,3543,U.S. Senate,,DEM,Kamala D. Harris,0
+San Mateo,3543,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Mateo,3601,U.S. Senate,,DEM,Kamala D. Harris,848
+San Mateo,3601,U.S. Senate,,DEM,Loretta L. Sanchez,259
+San Mateo,3602,U.S. Senate,,DEM,Kamala D. Harris,654
+San Mateo,3602,U.S. Senate,,DEM,Loretta L. Sanchez,238
+San Mateo,3605,U.S. Senate,,DEM,Kamala D. Harris,758
+San Mateo,3605,U.S. Senate,,DEM,Loretta L. Sanchez,232
+San Mateo,3607,U.S. Senate,,DEM,Kamala D. Harris,474
+San Mateo,3607,U.S. Senate,,DEM,Loretta L. Sanchez,165
+San Mateo,3608,U.S. Senate,,DEM,Kamala D. Harris,913
+San Mateo,3608,U.S. Senate,,DEM,Loretta L. Sanchez,285
+San Mateo,3610,U.S. Senate,,DEM,Kamala D. Harris,931
+San Mateo,3610,U.S. Senate,,DEM,Loretta L. Sanchez,293
+San Mateo,3612,U.S. Senate,,DEM,Kamala D. Harris,461
+San Mateo,3612,U.S. Senate,,DEM,Loretta L. Sanchez,185
+San Mateo,3613,U.S. Senate,,DEM,Kamala D. Harris,1404
+San Mateo,3613,U.S. Senate,,DEM,Loretta L. Sanchez,396
+San Mateo,3616,U.S. Senate,,DEM,Kamala D. Harris,829
+San Mateo,3616,U.S. Senate,,DEM,Loretta L. Sanchez,223
+San Mateo,3617,U.S. Senate,,DEM,Kamala D. Harris,839
+San Mateo,3617,U.S. Senate,,DEM,Loretta L. Sanchez,244
+San Mateo,3620,U.S. Senate,,DEM,Kamala D. Harris,780
+San Mateo,3620,U.S. Senate,,DEM,Loretta L. Sanchez,259
+San Mateo,3621,U.S. Senate,,DEM,Kamala D. Harris,821
+San Mateo,3621,U.S. Senate,,DEM,Loretta L. Sanchez,263
+San Mateo,3624,U.S. Senate,,DEM,Kamala D. Harris,742
+San Mateo,3624,U.S. Senate,,DEM,Loretta L. Sanchez,255
+San Mateo,3626,U.S. Senate,,DEM,Kamala D. Harris,317
+San Mateo,3626,U.S. Senate,,DEM,Loretta L. Sanchez,91
+San Mateo,3627,U.S. Senate,,DEM,Kamala D. Harris,54
+San Mateo,3627,U.S. Senate,,DEM,Loretta L. Sanchez,16
+San Mateo,3629,U.S. Senate,,DEM,Kamala D. Harris,1
+San Mateo,3629,U.S. Senate,,DEM,Loretta L. Sanchez,4
+San Mateo,3630,U.S. Senate,,DEM,Kamala D. Harris,8
+San Mateo,3630,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Mateo,3631,U.S. Senate,,DEM,Kamala D. Harris,56
+San Mateo,3631,U.S. Senate,,DEM,Loretta L. Sanchez,11
+San Mateo,3632,U.S. Senate,,DEM,Kamala D. Harris,5
+San Mateo,3632,U.S. Senate,,DEM,Loretta L. Sanchez,3
+San Mateo,3633,U.S. Senate,,DEM,Kamala D. Harris,64
+San Mateo,3633,U.S. Senate,,DEM,Loretta L. Sanchez,28
+San Mateo,3634,U.S. Senate,,DEM,Kamala D. Harris,16
+San Mateo,3634,U.S. Senate,,DEM,Loretta L. Sanchez,7
+San Mateo,3635,U.S. Senate,,DEM,Kamala D. Harris,19
+San Mateo,3635,U.S. Senate,,DEM,Loretta L. Sanchez,4
+San Mateo,3637,U.S. Senate,,DEM,Kamala D. Harris,2
+San Mateo,3637,U.S. Senate,,DEM,Loretta L. Sanchez,2
+San Mateo,3638,U.S. Senate,,DEM,Kamala D. Harris,130
+San Mateo,3638,U.S. Senate,,DEM,Loretta L. Sanchez,39
+San Mateo,3701,U.S. Senate,,DEM,Kamala D. Harris,602
+San Mateo,3701,U.S. Senate,,DEM,Loretta L. Sanchez,199
+San Mateo,3702,U.S. Senate,,DEM,Kamala D. Harris,584
+San Mateo,3702,U.S. Senate,,DEM,Loretta L. Sanchez,185
+San Mateo,3703,U.S. Senate,,DEM,Kamala D. Harris,368
+San Mateo,3703,U.S. Senate,,DEM,Loretta L. Sanchez,138
+San Mateo,3704,U.S. Senate,,DEM,Kamala D. Harris,6
+San Mateo,3704,U.S. Senate,,DEM,Loretta L. Sanchez,2
+San Mateo,3706,U.S. Senate,,DEM,Kamala D. Harris,80
+San Mateo,3706,U.S. Senate,,DEM,Loretta L. Sanchez,22
+San Mateo,3707,U.S. Senate,,DEM,Kamala D. Harris,29
+San Mateo,3707,U.S. Senate,,DEM,Loretta L. Sanchez,15
+San Mateo,3708,U.S. Senate,,DEM,Kamala D. Harris,53
+San Mateo,3708,U.S. Senate,,DEM,Loretta L. Sanchez,31
+San Mateo,3709,U.S. Senate,,DEM,Kamala D. Harris,136
+San Mateo,3709,U.S. Senate,,DEM,Loretta L. Sanchez,35
+San Mateo,3710,U.S. Senate,,DEM,Kamala D. Harris,315
+San Mateo,3710,U.S. Senate,,DEM,Loretta L. Sanchez,105
+San Mateo,3711,U.S. Senate,,DEM,Kamala D. Harris,2
+San Mateo,3711,U.S. Senate,,DEM,Loretta L. Sanchez,1
+San Mateo,3712,U.S. Senate,,DEM,Kamala D. Harris,37
+San Mateo,3712,U.S. Senate,,DEM,Loretta L. Sanchez,10
+San Mateo,3720,U.S. Senate,,DEM,Kamala D. Harris,416
+San Mateo,3720,U.S. Senate,,DEM,Loretta L. Sanchez,159
+San Mateo,3721,U.S. Senate,,DEM,Kamala D. Harris,448
+San Mateo,3721,U.S. Senate,,DEM,Loretta L. Sanchez,165
+San Mateo,3722,U.S. Senate,,DEM,Kamala D. Harris,372
+San Mateo,3722,U.S. Senate,,DEM,Loretta L. Sanchez,122
+San Mateo,3723,U.S. Senate,,DEM,Kamala D. Harris,10
+San Mateo,3723,U.S. Senate,,DEM,Loretta L. Sanchez,3
+San Mateo,3801,U.S. Senate,,DEM,Kamala D. Harris,232
+San Mateo,3801,U.S. Senate,,DEM,Loretta L. Sanchez,67
+San Mateo,3802,U.S. Senate,,DEM,Kamala D. Harris,925
+San Mateo,3802,U.S. Senate,,DEM,Loretta L. Sanchez,317
+San Mateo,3803,U.S. Senate,,DEM,Kamala D. Harris,121
+San Mateo,3803,U.S. Senate,,DEM,Loretta L. Sanchez,42
+San Mateo,3806,U.S. Senate,,DEM,Kamala D. Harris,441
+San Mateo,3806,U.S. Senate,,DEM,Loretta L. Sanchez,176
+San Mateo,3807,U.S. Senate,,DEM,Kamala D. Harris,46
+San Mateo,3807,U.S. Senate,,DEM,Loretta L. Sanchez,26
+San Mateo,3808,U.S. Senate,,DEM,Kamala D. Harris,248
+San Mateo,3808,U.S. Senate,,DEM,Loretta L. Sanchez,136
+San Mateo,3811,U.S. Senate,,DEM,Kamala D. Harris,30
+San Mateo,3811,U.S. Senate,,DEM,Loretta L. Sanchez,22
+San Mateo,3812,U.S. Senate,,DEM,Kamala D. Harris,72
+San Mateo,3812,U.S. Senate,,DEM,Loretta L. Sanchez,52
+San Mateo,3901,U.S. Senate,,DEM,Kamala D. Harris,741
+San Mateo,3901,U.S. Senate,,DEM,Loretta L. Sanchez,191
+San Mateo,3903,U.S. Senate,,DEM,Kamala D. Harris,655
+San Mateo,3903,U.S. Senate,,DEM,Loretta L. Sanchez,164
+San Mateo,3905,U.S. Senate,,DEM,Kamala D. Harris,650
+San Mateo,3905,U.S. Senate,,DEM,Loretta L. Sanchez,225
+San Mateo,4001,U.S. Senate,,DEM,Kamala D. Harris,289
+San Mateo,4001,U.S. Senate,,DEM,Loretta L. Sanchez,211
+San Mateo,4002,U.S. Senate,,DEM,Kamala D. Harris,244
+San Mateo,4002,U.S. Senate,,DEM,Loretta L. Sanchez,254
+San Mateo,4003,U.S. Senate,,DEM,Kamala D. Harris,244
+San Mateo,4003,U.S. Senate,,DEM,Loretta L. Sanchez,202
+San Mateo,4004,U.S. Senate,,DEM,Kamala D. Harris,245
+San Mateo,4004,U.S. Senate,,DEM,Loretta L. Sanchez,134
+San Mateo,4005,U.S. Senate,,DEM,Kamala D. Harris,302
+San Mateo,4005,U.S. Senate,,DEM,Loretta L. Sanchez,158
+San Mateo,4006,U.S. Senate,,DEM,Kamala D. Harris,299
+San Mateo,4006,U.S. Senate,,DEM,Loretta L. Sanchez,218
+San Mateo,4007,U.S. Senate,,DEM,Kamala D. Harris,403
+San Mateo,4007,U.S. Senate,,DEM,Loretta L. Sanchez,210
+San Mateo,4008,U.S. Senate,,DEM,Kamala D. Harris,307
+San Mateo,4008,U.S. Senate,,DEM,Loretta L. Sanchez,181
+San Mateo,4009,U.S. Senate,,DEM,Kamala D. Harris,316
+San Mateo,4009,U.S. Senate,,DEM,Loretta L. Sanchez,162
+San Mateo,4010,U.S. Senate,,DEM,Kamala D. Harris,250
+San Mateo,4010,U.S. Senate,,DEM,Loretta L. Sanchez,131
+San Mateo,4011,U.S. Senate,,DEM,Kamala D. Harris,474
+San Mateo,4011,U.S. Senate,,DEM,Loretta L. Sanchez,284
+San Mateo,4013,U.S. Senate,,DEM,Kamala D. Harris,0
+San Mateo,4013,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Mateo,4014,U.S. Senate,,DEM,Kamala D. Harris,375
+San Mateo,4014,U.S. Senate,,DEM,Loretta L. Sanchez,193
+San Mateo,4015,U.S. Senate,,DEM,Kamala D. Harris,191
+San Mateo,4015,U.S. Senate,,DEM,Loretta L. Sanchez,110
+San Mateo,4401,U.S. Senate,,DEM,Kamala D. Harris,445
+San Mateo,4401,U.S. Senate,,DEM,Loretta L. Sanchez,166
+San Mateo,4402,U.S. Senate,,DEM,Kamala D. Harris,418
+San Mateo,4402,U.S. Senate,,DEM,Loretta L. Sanchez,128
+San Mateo,4403,U.S. Senate,,DEM,Kamala D. Harris,345
+San Mateo,4403,U.S. Senate,,DEM,Loretta L. Sanchez,248
+San Mateo,4404,U.S. Senate,,DEM,Kamala D. Harris,550
+San Mateo,4404,U.S. Senate,,DEM,Loretta L. Sanchez,404
+San Mateo,4406,U.S. Senate,,DEM,Kamala D. Harris,30
+San Mateo,4406,U.S. Senate,,DEM,Loretta L. Sanchez,5
+San Mateo,4407,U.S. Senate,,DEM,Kamala D. Harris,1166
+San Mateo,4407,U.S. Senate,,DEM,Loretta L. Sanchez,325
+San Mateo,4409,U.S. Senate,,DEM,Kamala D. Harris,1059
+San Mateo,4409,U.S. Senate,,DEM,Loretta L. Sanchez,209
+San Mateo,4412,U.S. Senate,,DEM,Kamala D. Harris,731
+San Mateo,4412,U.S. Senate,,DEM,Loretta L. Sanchez,169
+San Mateo,4414,U.S. Senate,,DEM,Kamala D. Harris,282
+San Mateo,4414,U.S. Senate,,DEM,Loretta L. Sanchez,70
+San Mateo,4415,U.S. Senate,,DEM,Kamala D. Harris,375
+San Mateo,4415,U.S. Senate,,DEM,Loretta L. Sanchez,142
+San Mateo,4431,U.S. Senate,,DEM,Kamala D. Harris,28
+San Mateo,4431,U.S. Senate,,DEM,Loretta L. Sanchez,13
+San Mateo,4432,U.S. Senate,,DEM,Kamala D. Harris,2
+San Mateo,4432,U.S. Senate,,DEM,Loretta L. Sanchez,1
+San Mateo,4433,U.S. Senate,,DEM,Kamala D. Harris,152
+San Mateo,4433,U.S. Senate,,DEM,Loretta L. Sanchez,43
+San Mateo,4434,U.S. Senate,,DEM,Kamala D. Harris,0
+San Mateo,4434,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Mateo,4435,U.S. Senate,,DEM,Kamala D. Harris,2
+San Mateo,4435,U.S. Senate,,DEM,Loretta L. Sanchez,1
+San Mateo,4436,U.S. Senate,,DEM,Kamala D. Harris,14
+San Mateo,4436,U.S. Senate,,DEM,Loretta L. Sanchez,8
+San Mateo,4501,U.S. Senate,,DEM,Kamala D. Harris,225
+San Mateo,4501,U.S. Senate,,DEM,Loretta L. Sanchez,309
+San Mateo,4502,U.S. Senate,,DEM,Kamala D. Harris,319
+San Mateo,4502,U.S. Senate,,DEM,Loretta L. Sanchez,248
+San Mateo,4503,U.S. Senate,,DEM,Kamala D. Harris,218
+San Mateo,4503,U.S. Senate,,DEM,Loretta L. Sanchez,57
+San Mateo,4504,U.S. Senate,,DEM,Kamala D. Harris,366
+San Mateo,4504,U.S. Senate,,DEM,Loretta L. Sanchez,109
+San Mateo,4505,U.S. Senate,,DEM,Kamala D. Harris,353
+San Mateo,4505,U.S. Senate,,DEM,Loretta L. Sanchez,231
+San Mateo,4506,U.S. Senate,,DEM,Kamala D. Harris,368
+San Mateo,4506,U.S. Senate,,DEM,Loretta L. Sanchez,311
+San Mateo,4507,U.S. Senate,,DEM,Kamala D. Harris,60
+San Mateo,4507,U.S. Senate,,DEM,Loretta L. Sanchez,46
+San Mateo,4508,U.S. Senate,,DEM,Kamala D. Harris,62
+San Mateo,4508,U.S. Senate,,DEM,Loretta L. Sanchez,24
+San Mateo,4509,U.S. Senate,,DEM,Kamala D. Harris,120
+San Mateo,4509,U.S. Senate,,DEM,Loretta L. Sanchez,217
+San Mateo,4601,U.S. Senate,,DEM,Kamala D. Harris,383
+San Mateo,4601,U.S. Senate,,DEM,Loretta L. Sanchez,284
+San Mateo,4602,U.S. Senate,,DEM,Kamala D. Harris,449
+San Mateo,4602,U.S. Senate,,DEM,Loretta L. Sanchez,355
+San Mateo,4603,U.S. Senate,,DEM,Kamala D. Harris,206
+San Mateo,4603,U.S. Senate,,DEM,Loretta L. Sanchez,184
+San Mateo,4604,U.S. Senate,,DEM,Kamala D. Harris,618
+San Mateo,4604,U.S. Senate,,DEM,Loretta L. Sanchez,512
+San Mateo,4606,U.S. Senate,,DEM,Kamala D. Harris,884
+San Mateo,4606,U.S. Senate,,DEM,Loretta L. Sanchez,399
+San Mateo,4607,U.S. Senate,,DEM,Kamala D. Harris,446
+San Mateo,4607,U.S. Senate,,DEM,Loretta L. Sanchez,181
+San Mateo,4608,U.S. Senate,,DEM,Kamala D. Harris,501
+San Mateo,4608,U.S. Senate,,DEM,Loretta L. Sanchez,207
+San Mateo,4609,U.S. Senate,,DEM,Kamala D. Harris,593
+San Mateo,4609,U.S. Senate,,DEM,Loretta L. Sanchez,218
+San Mateo,4611,U.S. Senate,,DEM,Kamala D. Harris,395
+San Mateo,4611,U.S. Senate,,DEM,Loretta L. Sanchez,133
+San Mateo,4612,U.S. Senate,,DEM,Kamala D. Harris,944
+San Mateo,4612,U.S. Senate,,DEM,Loretta L. Sanchez,275
+San Mateo,4613,U.S. Senate,,DEM,Kamala D. Harris,799
+San Mateo,4613,U.S. Senate,,DEM,Loretta L. Sanchez,304
+San Mateo,4615,U.S. Senate,,DEM,Kamala D. Harris,444
+San Mateo,4615,U.S. Senate,,DEM,Loretta L. Sanchez,156
+San Mateo,4616,U.S. Senate,,DEM,Kamala D. Harris,819
+San Mateo,4616,U.S. Senate,,DEM,Loretta L. Sanchez,349
+San Mateo,4617,U.S. Senate,,DEM,Kamala D. Harris,354
+San Mateo,4617,U.S. Senate,,DEM,Loretta L. Sanchez,146
+San Mateo,4618,U.S. Senate,,DEM,Kamala D. Harris,835
+San Mateo,4618,U.S. Senate,,DEM,Loretta L. Sanchez,403
+San Mateo,4619,U.S. Senate,,DEM,Kamala D. Harris,306
+San Mateo,4619,U.S. Senate,,DEM,Loretta L. Sanchez,177
+San Mateo,4620,U.S. Senate,,DEM,Kamala D. Harris,502
+San Mateo,4620,U.S. Senate,,DEM,Loretta L. Sanchez,268
+San Mateo,4621,U.S. Senate,,DEM,Kamala D. Harris,445
+San Mateo,4621,U.S. Senate,,DEM,Loretta L. Sanchez,183
+San Mateo,4622,U.S. Senate,,DEM,Kamala D. Harris,619
+San Mateo,4622,U.S. Senate,,DEM,Loretta L. Sanchez,360
+San Mateo,4625,U.S. Senate,,DEM,Kamala D. Harris,431
+San Mateo,4625,U.S. Senate,,DEM,Loretta L. Sanchez,175
+San Mateo,4626,U.S. Senate,,DEM,Kamala D. Harris,457
+San Mateo,4626,U.S. Senate,,DEM,Loretta L. Sanchez,194
+San Mateo,4627,U.S. Senate,,DEM,Kamala D. Harris,884
+San Mateo,4627,U.S. Senate,,DEM,Loretta L. Sanchez,328
+San Mateo,4629,U.S. Senate,,DEM,Kamala D. Harris,382
+San Mateo,4629,U.S. Senate,,DEM,Loretta L. Sanchez,125
+San Mateo,4630,U.S. Senate,,DEM,Kamala D. Harris,432
+San Mateo,4630,U.S. Senate,,DEM,Loretta L. Sanchez,169
+San Mateo,4631,U.S. Senate,,DEM,Kamala D. Harris,444
+San Mateo,4631,U.S. Senate,,DEM,Loretta L. Sanchez,136
+San Mateo,4633,U.S. Senate,,DEM,Kamala D. Harris,745
+San Mateo,4633,U.S. Senate,,DEM,Loretta L. Sanchez,296
+San Mateo,4635,U.S. Senate,,DEM,Kamala D. Harris,507
+San Mateo,4635,U.S. Senate,,DEM,Loretta L. Sanchez,175
+San Mateo,4636,U.S. Senate,,DEM,Kamala D. Harris,91
+San Mateo,4636,U.S. Senate,,DEM,Loretta L. Sanchez,49
+San Mateo,4637,U.S. Senate,,DEM,Kamala D. Harris,241
+San Mateo,4637,U.S. Senate,,DEM,Loretta L. Sanchez,96
+San Mateo,4638,U.S. Senate,,DEM,Kamala D. Harris,804
+San Mateo,4638,U.S. Senate,,DEM,Loretta L. Sanchez,338
+San Mateo,4639,U.S. Senate,,DEM,Kamala D. Harris,432
+San Mateo,4639,U.S. Senate,,DEM,Loretta L. Sanchez,179
+San Mateo,4650,U.S. Senate,,DEM,Kamala D. Harris,115
+San Mateo,4650,U.S. Senate,,DEM,Loretta L. Sanchez,56
+San Mateo,4651,U.S. Senate,,DEM,Kamala D. Harris,43
+San Mateo,4651,U.S. Senate,,DEM,Loretta L. Sanchez,26
+San Mateo,4652,U.S. Senate,,DEM,Kamala D. Harris,53
+San Mateo,4652,U.S. Senate,,DEM,Loretta L. Sanchez,36
+San Mateo,4653,U.S. Senate,,DEM,Kamala D. Harris,73
+San Mateo,4653,U.S. Senate,,DEM,Loretta L. Sanchez,86
+San Mateo,4654,U.S. Senate,,DEM,Kamala D. Harris,0
+San Mateo,4654,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Mateo,4655,U.S. Senate,,DEM,Kamala D. Harris,3
+San Mateo,4655,U.S. Senate,,DEM,Loretta L. Sanchez,1
+San Mateo,4656,U.S. Senate,,DEM,Kamala D. Harris,146
+San Mateo,4656,U.S. Senate,,DEM,Loretta L. Sanchez,45
+San Mateo,4657,U.S. Senate,,DEM,Kamala D. Harris,88
+San Mateo,4657,U.S. Senate,,DEM,Loretta L. Sanchez,21
+San Mateo,4658,U.S. Senate,,DEM,Kamala D. Harris,21
+San Mateo,4658,U.S. Senate,,DEM,Loretta L. Sanchez,9
+San Mateo,4659,U.S. Senate,,DEM,Kamala D. Harris,22
+San Mateo,4659,U.S. Senate,,DEM,Loretta L. Sanchez,7
+San Mateo,4663,U.S. Senate,,DEM,Kamala D. Harris,54
+San Mateo,4663,U.S. Senate,,DEM,Loretta L. Sanchez,17
+San Mateo,4670,U.S. Senate,,DEM,Kamala D. Harris,0
+San Mateo,4670,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Mateo,4680,U.S. Senate,,DEM,Kamala D. Harris,785
+San Mateo,4680,U.S. Senate,,DEM,Loretta L. Sanchez,261
+San Mateo,4681,U.S. Senate,,DEM,Kamala D. Harris,995
+San Mateo,4681,U.S. Senate,,DEM,Loretta L. Sanchez,287
+San Mateo,4684,U.S. Senate,,DEM,Kamala D. Harris,531
+San Mateo,4684,U.S. Senate,,DEM,Loretta L. Sanchez,173
+San Mateo,4685,U.S. Senate,,DEM,Kamala D. Harris,602
+San Mateo,4685,U.S. Senate,,DEM,Loretta L. Sanchez,188
+San Mateo,4686,U.S. Senate,,DEM,Kamala D. Harris,888
+San Mateo,4686,U.S. Senate,,DEM,Loretta L. Sanchez,273
+San Mateo,4688,U.S. Senate,,DEM,Kamala D. Harris,0
+San Mateo,4688,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Mateo,4701,U.S. Senate,,DEM,Kamala D. Harris,120
+San Mateo,4701,U.S. Senate,,DEM,Loretta L. Sanchez,37
+San Mateo,4702,U.S. Senate,,DEM,Kamala D. Harris,49
+San Mateo,4702,U.S. Senate,,DEM,Loretta L. Sanchez,17
+San Mateo,4708,U.S. Senate,,DEM,Kamala D. Harris,78
+San Mateo,4708,U.S. Senate,,DEM,Loretta L. Sanchez,20
+San Mateo,4710,U.S. Senate,,DEM,Kamala D. Harris,4
+San Mateo,4710,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Mateo,5001,U.S. Senate,,DEM,Kamala D. Harris,477
+San Mateo,5001,U.S. Senate,,DEM,Loretta L. Sanchez,153
+San Mateo,5002,U.S. Senate,,DEM,Kamala D. Harris,580
+San Mateo,5002,U.S. Senate,,DEM,Loretta L. Sanchez,196
+San Mateo,5003,U.S. Senate,,DEM,Kamala D. Harris,454
+San Mateo,5003,U.S. Senate,,DEM,Loretta L. Sanchez,149
+San Mateo,5101,U.S. Senate,,DEM,Kamala D. Harris,813
+San Mateo,5101,U.S. Senate,,DEM,Loretta L. Sanchez,365
+San Mateo,5103,U.S. Senate,,DEM,Kamala D. Harris,603
+San Mateo,5103,U.S. Senate,,DEM,Loretta L. Sanchez,274
+San Mateo,5105,U.S. Senate,,DEM,Kamala D. Harris,18
+San Mateo,5105,U.S. Senate,,DEM,Loretta L. Sanchez,15
+San Mateo,5301,U.S. Senate,,DEM,Kamala D. Harris,315
+San Mateo,5301,U.S. Senate,,DEM,Loretta L. Sanchez,175
+San Mateo,5521,U.S. Senate,,DEM,Kamala D. Harris,513
+San Mateo,5521,U.S. Senate,,DEM,Loretta L. Sanchez,211
+San Mateo,5522,U.S. Senate,,DEM,Kamala D. Harris,488
+San Mateo,5522,U.S. Senate,,DEM,Loretta L. Sanchez,242
+San Mateo,5523,U.S. Senate,,DEM,Kamala D. Harris,8
+San Mateo,5523,U.S. Senate,,DEM,Loretta L. Sanchez,4
+San Mateo,5524,U.S. Senate,,DEM,Kamala D. Harris,462
+San Mateo,5524,U.S. Senate,,DEM,Loretta L. Sanchez,179
+San Mateo,5525,U.S. Senate,,DEM,Kamala D. Harris,757
+San Mateo,5525,U.S. Senate,,DEM,Loretta L. Sanchez,329
+San Mateo,5528,U.S. Senate,,DEM,Kamala D. Harris,826
+San Mateo,5528,U.S. Senate,,DEM,Loretta L. Sanchez,346
+San Mateo,5530,U.S. Senate,,DEM,Kamala D. Harris,121
+San Mateo,5530,U.S. Senate,,DEM,Loretta L. Sanchez,53
+San Mateo,5531,U.S. Senate,,DEM,Kamala D. Harris,18
+San Mateo,5531,U.S. Senate,,DEM,Loretta L. Sanchez,13
+San Mateo,5534,U.S. Senate,,DEM,Kamala D. Harris,58
+San Mateo,5534,U.S. Senate,,DEM,Loretta L. Sanchez,14
+San Mateo,5535,U.S. Senate,,DEM,Kamala D. Harris,0
+San Mateo,5535,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Mateo,5601,U.S. Senate,,DEM,Kamala D. Harris,593
+San Mateo,5601,U.S. Senate,,DEM,Loretta L. Sanchez,308
+San Mateo,5602,U.S. Senate,,DEM,Kamala D. Harris,393
+San Mateo,5602,U.S. Senate,,DEM,Loretta L. Sanchez,227
+San Mateo,5603,U.S. Senate,,DEM,Kamala D. Harris,526
+San Mateo,5603,U.S. Senate,,DEM,Loretta L. Sanchez,258
+San Mateo,5604,U.S. Senate,,DEM,Kamala D. Harris,614
+San Mateo,5604,U.S. Senate,,DEM,Loretta L. Sanchez,280
+San Mateo,5605,U.S. Senate,,DEM,Kamala D. Harris,579
+San Mateo,5605,U.S. Senate,,DEM,Loretta L. Sanchez,300
+San Mateo,5607,U.S. Senate,,DEM,Kamala D. Harris,355
+San Mateo,5607,U.S. Senate,,DEM,Loretta L. Sanchez,245
+San Mateo,5608,U.S. Senate,,DEM,Kamala D. Harris,365
+San Mateo,5608,U.S. Senate,,DEM,Loretta L. Sanchez,208
+San Mateo,5609,U.S. Senate,,DEM,Kamala D. Harris,817
+San Mateo,5609,U.S. Senate,,DEM,Loretta L. Sanchez,442
+San Mateo,5611,U.S. Senate,,DEM,Kamala D. Harris,768
+San Mateo,5611,U.S. Senate,,DEM,Loretta L. Sanchez,427
+San Mateo,5612,U.S. Senate,,DEM,Kamala D. Harris,857
+San Mateo,5612,U.S. Senate,,DEM,Loretta L. Sanchez,453
+San Mateo,5615,U.S. Senate,,DEM,Kamala D. Harris,732
+San Mateo,5615,U.S. Senate,,DEM,Loretta L. Sanchez,389
+San Mateo,5617,U.S. Senate,,DEM,Kamala D. Harris,816
+San Mateo,5617,U.S. Senate,,DEM,Loretta L. Sanchez,463
+San Mateo,5619,U.S. Senate,,DEM,Kamala D. Harris,276
+San Mateo,5619,U.S. Senate,,DEM,Loretta L. Sanchez,164
+San Mateo,5620,U.S. Senate,,DEM,Kamala D. Harris,657
+San Mateo,5620,U.S. Senate,,DEM,Loretta L. Sanchez,299
+San Mateo,5622,U.S. Senate,,DEM,Kamala D. Harris,329
+San Mateo,5622,U.S. Senate,,DEM,Loretta L. Sanchez,138
+San Mateo,5623,U.S. Senate,,DEM,Kamala D. Harris,742
+San Mateo,5623,U.S. Senate,,DEM,Loretta L. Sanchez,259
+San Mateo,5624,U.S. Senate,,DEM,Kamala D. Harris,808
+San Mateo,5624,U.S. Senate,,DEM,Loretta L. Sanchez,376
+San Mateo,5627,U.S. Senate,,DEM,Kamala D. Harris,448
+San Mateo,5627,U.S. Senate,,DEM,Loretta L. Sanchez,236
+San Mateo,5628,U.S. Senate,,DEM,Kamala D. Harris,271
+San Mateo,5628,U.S. Senate,,DEM,Loretta L. Sanchez,173
+San Mateo,5629,U.S. Senate,,DEM,Kamala D. Harris,350
+San Mateo,5629,U.S. Senate,,DEM,Loretta L. Sanchez,143
+San Mateo,5631,U.S. Senate,,DEM,Kamala D. Harris,739
+San Mateo,5631,U.S. Senate,,DEM,Loretta L. Sanchez,281
+San Mateo,5633,U.S. Senate,,DEM,Kamala D. Harris,791
+San Mateo,5633,U.S. Senate,,DEM,Loretta L. Sanchez,384
+San Mateo,5635,U.S. Senate,,DEM,Kamala D. Harris,1037
+San Mateo,5635,U.S. Senate,,DEM,Loretta L. Sanchez,505
+San Mateo,5636,U.S. Senate,,DEM,Kamala D. Harris,403
+San Mateo,5636,U.S. Senate,,DEM,Loretta L. Sanchez,193
+San Mateo,5639,U.S. Senate,,DEM,Kamala D. Harris,651
+San Mateo,5639,U.S. Senate,,DEM,Loretta L. Sanchez,289
+San Mateo,5641,U.S. Senate,,DEM,Kamala D. Harris,981
+San Mateo,5641,U.S. Senate,,DEM,Loretta L. Sanchez,399
+San Mateo,5644,U.S. Senate,,DEM,Kamala D. Harris,768
+San Mateo,5644,U.S. Senate,,DEM,Loretta L. Sanchez,343
+San Mateo,5646,U.S. Senate,,DEM,Kamala D. Harris,444
+San Mateo,5646,U.S. Senate,,DEM,Loretta L. Sanchez,181
+San Mateo,5647,U.S. Senate,,DEM,Kamala D. Harris,415
+San Mateo,5647,U.S. Senate,,DEM,Loretta L. Sanchez,188
+San Mateo,5648,U.S. Senate,,DEM,Kamala D. Harris,824
+San Mateo,5648,U.S. Senate,,DEM,Loretta L. Sanchez,344
+San Mateo,5650,U.S. Senate,,DEM,Kamala D. Harris,445
+San Mateo,5650,U.S. Senate,,DEM,Loretta L. Sanchez,201
+San Mateo,5651,U.S. Senate,,DEM,Kamala D. Harris,891
+San Mateo,5651,U.S. Senate,,DEM,Loretta L. Sanchez,424
+San Mateo,5656,U.S. Senate,,DEM,Kamala D. Harris,162
+San Mateo,5656,U.S. Senate,,DEM,Loretta L. Sanchez,118
+San Mateo,5701,U.S. Senate,,DEM,Kamala D. Harris,0
+San Mateo,5701,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Mateo,5809,U.S. Senate,,DEM,Kamala D. Harris,297
+San Mateo,5809,U.S. Senate,,DEM,Loretta L. Sanchez,134
+San Mateo,5816,U.S. Senate,,DEM,Kamala D. Harris,104
+San Mateo,5816,U.S. Senate,,DEM,Loretta L. Sanchez,37
+San Mateo,5822,U.S. Senate,,DEM,Kamala D. Harris,417
+San Mateo,5822,U.S. Senate,,DEM,Loretta L. Sanchez,204
+San Mateo,5823,U.S. Senate,,DEM,Kamala D. Harris,425
+San Mateo,5823,U.S. Senate,,DEM,Loretta L. Sanchez,202
+San Mateo,5825,U.S. Senate,,DEM,Kamala D. Harris,981
+San Mateo,5825,U.S. Senate,,DEM,Loretta L. Sanchez,371
+San Mateo,5827,U.S. Senate,,DEM,Kamala D. Harris,888
+San Mateo,5827,U.S. Senate,,DEM,Loretta L. Sanchez,342
+San Mateo,5829,U.S. Senate,,DEM,Kamala D. Harris,895
+San Mateo,5829,U.S. Senate,,DEM,Loretta L. Sanchez,332
+San Mateo,5832,U.S. Senate,,DEM,Kamala D. Harris,461
+San Mateo,5832,U.S. Senate,,DEM,Loretta L. Sanchez,165
+San Mateo,5901,U.S. Senate,,DEM,Kamala D. Harris,0
+San Mateo,5901,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Mateo,5902,U.S. Senate,,DEM,Kamala D. Harris,0
+San Mateo,5902,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Mateo,5903,U.S. Senate,,DEM,Kamala D. Harris,0
+San Mateo,5903,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Mateo,5904,U.S. Senate,,DEM,Kamala D. Harris,0
+San Mateo,5904,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Mateo,5905,U.S. Senate,,DEM,Kamala D. Harris,0
+San Mateo,5905,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Mateo,5906,U.S. Senate,,DEM,Kamala D. Harris,0
+San Mateo,5906,U.S. Senate,,DEM,Loretta L. Sanchez,0
+San Mateo,5907,U.S. Senate,,DEM,Kamala D. Harris,0
+San Mateo,5907,U.S. Senate,,DEM,Loretta L. Sanchez,0

--- a/2016/20161108__ca__general__santa_barbara__precinct.csv
+++ b/2016/20161108__ca__general__santa_barbara__precinct.csv
@@ -10359,521 +10359,521 @@ Santa Barbara,57-5420,Proposition 67,,N/A,Yes,436
 Santa Barbara,57-5420,Proposition 67,,N/A,No,462
 Santa Barbara,57-5774,Proposition 67,,N/A,Yes,98
 Santa Barbara,57-5774,Proposition 67,,N/A,No,92
-Santa Barbara,10-1002,U.S. Senate,,DEM,Kamala Harris,79
-Santa Barbara,10-1002,U.S. Senate,,DEM,Loretta Sanchez,39
-Santa Barbara,10-1003,U.S. Senate,,DEM,Kamala Harris,5
-Santa Barbara,10-1003,U.S. Senate,,DEM,Loretta Sanchez,3
-Santa Barbara,10-1004,U.S. Senate,,DEM,Kamala Harris,0
-Santa Barbara,10-1004,U.S. Senate,,DEM,Loretta Sanchez,0
-Santa Barbara,10-1005,U.S. Senate,,DEM,Kamala Harris,0
-Santa Barbara,10-1005,U.S. Senate,,DEM,Loretta Sanchez,0
-Santa Barbara,10-1006,U.S. Senate,,DEM,Kamala Harris,103
-Santa Barbara,10-1006,U.S. Senate,,DEM,Loretta Sanchez,20
-Santa Barbara,10-1007,U.S. Senate,,DEM,Kamala Harris,78
-Santa Barbara,10-1007,U.S. Senate,,DEM,Loretta Sanchez,37
-Santa Barbara,10-1008,U.S. Senate,,DEM,Kamala Harris,23
-Santa Barbara,10-1008,U.S. Senate,,DEM,Loretta Sanchez,11
-Santa Barbara,10-1009,U.S. Senate,,DEM,Kamala Harris,13
-Santa Barbara,10-1009,U.S. Senate,,DEM,Loretta Sanchez,3
-Santa Barbara,10-1010,U.S. Senate,,DEM,Kamala Harris,21
-Santa Barbara,10-1010,U.S. Senate,,DEM,Loretta Sanchez,10
-Santa Barbara,10-1011,U.S. Senate,,DEM,Kamala Harris,10
-Santa Barbara,10-1011,U.S. Senate,,DEM,Loretta Sanchez,1
-Santa Barbara,10-1012,U.S. Senate,,DEM,Kamala Harris,0
-Santa Barbara,10-1012,U.S. Senate,,DEM,Loretta Sanchez,0
-Santa Barbara,10-1013,U.S. Senate,,DEM,Kamala Harris,20
-Santa Barbara,10-1013,U.S. Senate,,DEM,Loretta Sanchez,29
-Santa Barbara,10-1014,U.S. Senate,,DEM,Kamala Harris,82
-Santa Barbara,10-1014,U.S. Senate,,DEM,Loretta Sanchez,68
-Santa Barbara,10-1510,U.S. Senate,,DEM,Kamala Harris,526
-Santa Barbara,10-1510,U.S. Senate,,DEM,Loretta Sanchez,315
-Santa Barbara,10-1520,U.S. Senate,,DEM,Kamala Harris,292
-Santa Barbara,10-1520,U.S. Senate,,DEM,Loretta Sanchez,177
-Santa Barbara,10-1530,U.S. Senate,,DEM,Kamala Harris,654
-Santa Barbara,10-1530,U.S. Senate,,DEM,Loretta Sanchez,286
-Santa Barbara,10-1560,U.S. Senate,,DEM,Kamala Harris,530
-Santa Barbara,10-1560,U.S. Senate,,DEM,Loretta Sanchez,257
-Santa Barbara,10-1570,U.S. Senate,,DEM,Kamala Harris,498
-Santa Barbara,10-1570,U.S. Senate,,DEM,Loretta Sanchez,308
-Santa Barbara,10-1580,U.S. Senate,,DEM,Kamala Harris,511
-Santa Barbara,10-1580,U.S. Senate,,DEM,Loretta Sanchez,271
-Santa Barbara,10-1590,U.S. Senate,,DEM,Kamala Harris,527
-Santa Barbara,10-1590,U.S. Senate,,DEM,Loretta Sanchez,261
-Santa Barbara,10-1610,U.S. Senate,,DEM,Kamala Harris,615
-Santa Barbara,10-1610,U.S. Senate,,DEM,Loretta Sanchez,279
-Santa Barbara,10-1630,U.S. Senate,,DEM,Kamala Harris,677
-Santa Barbara,10-1630,U.S. Senate,,DEM,Loretta Sanchez,206
-Santa Barbara,10-1640,U.S. Senate,,DEM,Kamala Harris,508
-Santa Barbara,10-1640,U.S. Senate,,DEM,Loretta Sanchez,152
-Santa Barbara,11-1010,U.S. Senate,,DEM,Kamala Harris,534
-Santa Barbara,11-1010,U.S. Senate,,DEM,Loretta Sanchez,357
-Santa Barbara,11-1020,U.S. Senate,,DEM,Kamala Harris,641
-Santa Barbara,11-1020,U.S. Senate,,DEM,Loretta Sanchez,331
-Santa Barbara,11-1030,U.S. Senate,,DEM,Kamala Harris,518
-Santa Barbara,11-1030,U.S. Senate,,DEM,Loretta Sanchez,343
-Santa Barbara,11-1040,U.S. Senate,,DEM,Kamala Harris,557
-Santa Barbara,11-1040,U.S. Senate,,DEM,Loretta Sanchez,413
-Santa Barbara,11-1070,U.S. Senate,,DEM,Kamala Harris,433
-Santa Barbara,11-1070,U.S. Senate,,DEM,Loretta Sanchez,349
-Santa Barbara,11-1080,U.S. Senate,,DEM,Kamala Harris,454
-Santa Barbara,11-1080,U.S. Senate,,DEM,Loretta Sanchez,352
-Santa Barbara,12-0020,U.S. Senate,,DEM,Kamala Harris,10
-Santa Barbara,12-0020,U.S. Senate,,DEM,Loretta Sanchez,6
-Santa Barbara,12-1110,U.S. Senate,,DEM,Kamala Harris,222
-Santa Barbara,12-1110,U.S. Senate,,DEM,Loretta Sanchez,155
-Santa Barbara,12-1120,U.S. Senate,,DEM,Kamala Harris,236
-Santa Barbara,12-1120,U.S. Senate,,DEM,Loretta Sanchez,151
-Santa Barbara,12-1130,U.S. Senate,,DEM,Kamala Harris,586
-Santa Barbara,12-1130,U.S. Senate,,DEM,Loretta Sanchez,527
-Santa Barbara,12-1170,U.S. Senate,,DEM,Kamala Harris,683
-Santa Barbara,12-1170,U.S. Senate,,DEM,Loretta Sanchez,460
-Santa Barbara,12-1180,U.S. Senate,,DEM,Kamala Harris,582
-Santa Barbara,12-1180,U.S. Senate,,DEM,Loretta Sanchez,299
-Santa Barbara,12-1190,U.S. Senate,,DEM,Kamala Harris,449
-Santa Barbara,12-1190,U.S. Senate,,DEM,Loretta Sanchez,165
-Santa Barbara,12-1210,U.S. Senate,,DEM,Kamala Harris,873
-Santa Barbara,12-1210,U.S. Senate,,DEM,Loretta Sanchez,412
-Santa Barbara,12-1216,U.S. Senate,,DEM,Kamala Harris,47
-Santa Barbara,12-1216,U.S. Senate,,DEM,Loretta Sanchez,19
-Santa Barbara,12-1218,U.S. Senate,,DEM,Kamala Harris,103
-Santa Barbara,12-1218,U.S. Senate,,DEM,Loretta Sanchez,51
-Santa Barbara,12-1219,U.S. Senate,,DEM,Kamala Harris,9
-Santa Barbara,12-1219,U.S. Senate,,DEM,Loretta Sanchez,7
-Santa Barbara,12-1220,U.S. Senate,,DEM,Kamala Harris,798
-Santa Barbara,12-1220,U.S. Senate,,DEM,Loretta Sanchez,330
-Santa Barbara,12-1230,U.S. Senate,,DEM,Kamala Harris,739
-Santa Barbara,12-1230,U.S. Senate,,DEM,Loretta Sanchez,320
-Santa Barbara,12-1240,U.S. Senate,,DEM,Kamala Harris,293
-Santa Barbara,12-1240,U.S. Senate,,DEM,Loretta Sanchez,183
-Santa Barbara,12-1260,U.S. Senate,,DEM,Kamala Harris,563
-Santa Barbara,12-1260,U.S. Senate,,DEM,Loretta Sanchez,418
-Santa Barbara,12-1280,U.S. Senate,,DEM,Kamala Harris,770
-Santa Barbara,12-1280,U.S. Senate,,DEM,Loretta Sanchez,260
-Santa Barbara,12-1290,U.S. Senate,,DEM,Kamala Harris,635
-Santa Barbara,12-1290,U.S. Senate,,DEM,Loretta Sanchez,214
-Santa Barbara,12-1310,U.S. Senate,,DEM,Kamala Harris,622
-Santa Barbara,12-1310,U.S. Senate,,DEM,Loretta Sanchez,429
-Santa Barbara,12-1320,U.S. Senate,,DEM,Kamala Harris,575
-Santa Barbara,12-1320,U.S. Senate,,DEM,Loretta Sanchez,490
-Santa Barbara,12-1340,U.S. Senate,,DEM,Kamala Harris,544
-Santa Barbara,12-1340,U.S. Senate,,DEM,Loretta Sanchez,544
-Santa Barbara,12-1370,U.S. Senate,,DEM,Kamala Harris,893
-Santa Barbara,12-1370,U.S. Senate,,DEM,Loretta Sanchez,401
-Santa Barbara,12-1380,U.S. Senate,,DEM,Kamala Harris,624
-Santa Barbara,12-1380,U.S. Senate,,DEM,Loretta Sanchez,303
-Santa Barbara,12-1390,U.S. Senate,,DEM,Kamala Harris,443
-Santa Barbara,12-1390,U.S. Senate,,DEM,Loretta Sanchez,151
-Santa Barbara,12-1430,U.S. Senate,,DEM,Kamala Harris,812
-Santa Barbara,12-1430,U.S. Senate,,DEM,Loretta Sanchez,290
-Santa Barbara,12-1440,U.S. Senate,,DEM,Kamala Harris,336
-Santa Barbara,12-1440,U.S. Senate,,DEM,Loretta Sanchez,154
-Santa Barbara,12-1460,U.S. Senate,,DEM,Kamala Harris,577
-Santa Barbara,12-1460,U.S. Senate,,DEM,Loretta Sanchez,219
-Santa Barbara,12-1470,U.S. Senate,,DEM,Kamala Harris,737
-Santa Barbara,12-1470,U.S. Senate,,DEM,Loretta Sanchez,333
-Santa Barbara,20-2005,U.S. Senate,,DEM,Kamala Harris,348
-Santa Barbara,20-2005,U.S. Senate,,DEM,Loretta Sanchez,114
-Santa Barbara,20-2009,U.S. Senate,,DEM,Kamala Harris,272
-Santa Barbara,20-2009,U.S. Senate,,DEM,Loretta Sanchez,182
-Santa Barbara,20-2010,U.S. Senate,,DEM,Kamala Harris,28
-Santa Barbara,20-2010,U.S. Senate,,DEM,Loretta Sanchez,2
-Santa Barbara,20-2011,U.S. Senate,,DEM,Kamala Harris,49
-Santa Barbara,20-2011,U.S. Senate,,DEM,Loretta Sanchez,29
-Santa Barbara,20-2021,U.S. Senate,,DEM,Kamala Harris,189
-Santa Barbara,20-2021,U.S. Senate,,DEM,Loretta Sanchez,93
-Santa Barbara,20-2022,U.S. Senate,,DEM,Kamala Harris,5
-Santa Barbara,20-2022,U.S. Senate,,DEM,Loretta Sanchez,1
-Santa Barbara,20-2530,U.S. Senate,,DEM,Kamala Harris,375
-Santa Barbara,20-2530,U.S. Senate,,DEM,Loretta Sanchez,140
-Santa Barbara,20-2540,U.S. Senate,,DEM,Kamala Harris,241
-Santa Barbara,20-2540,U.S. Senate,,DEM,Loretta Sanchez,124
-Santa Barbara,20-2560,U.S. Senate,,DEM,Kamala Harris,546
-Santa Barbara,20-2560,U.S. Senate,,DEM,Loretta Sanchez,374
-Santa Barbara,20-2570,U.S. Senate,,DEM,Kamala Harris,767
-Santa Barbara,20-2570,U.S. Senate,,DEM,Loretta Sanchez,333
-Santa Barbara,20-2580,U.S. Senate,,DEM,Kamala Harris,634
-Santa Barbara,20-2580,U.S. Senate,,DEM,Loretta Sanchez,334
-Santa Barbara,20-2610,U.S. Senate,,DEM,Kamala Harris,520
-Santa Barbara,20-2610,U.S. Senate,,DEM,Loretta Sanchez,301
-Santa Barbara,20-2620,U.S. Senate,,DEM,Kamala Harris,531
-Santa Barbara,20-2620,U.S. Senate,,DEM,Loretta Sanchez,300
-Santa Barbara,20-2630,U.S. Senate,,DEM,Kamala Harris,423
-Santa Barbara,20-2630,U.S. Senate,,DEM,Loretta Sanchez,251
-Santa Barbara,20-2640,U.S. Senate,,DEM,Kamala Harris,397
-Santa Barbara,20-2640,U.S. Senate,,DEM,Loretta Sanchez,263
-Santa Barbara,20-2660,U.S. Senate,,DEM,Kamala Harris,513
-Santa Barbara,20-2660,U.S. Senate,,DEM,Loretta Sanchez,324
-Santa Barbara,20-2710,U.S. Senate,,DEM,Kamala Harris,539
-Santa Barbara,20-2710,U.S. Senate,,DEM,Loretta Sanchez,294
-Santa Barbara,20-2720,U.S. Senate,,DEM,Kamala Harris,665
-Santa Barbara,20-2720,U.S. Senate,,DEM,Loretta Sanchez,391
-Santa Barbara,20-2730,U.S. Senate,,DEM,Kamala Harris,548
-Santa Barbara,20-2730,U.S. Senate,,DEM,Loretta Sanchez,287
-Santa Barbara,20-2740,U.S. Senate,,DEM,Kamala Harris,544
-Santa Barbara,20-2740,U.S. Senate,,DEM,Loretta Sanchez,282
-Santa Barbara,20-2760,U.S. Senate,,DEM,Kamala Harris,512
-Santa Barbara,20-2760,U.S. Senate,,DEM,Loretta Sanchez,266
-Santa Barbara,20-2770,U.S. Senate,,DEM,Kamala Harris,759
-Santa Barbara,20-2770,U.S. Senate,,DEM,Loretta Sanchez,393
-Santa Barbara,22-2010,U.S. Senate,,DEM,Kamala Harris,292
-Santa Barbara,22-2010,U.S. Senate,,DEM,Loretta Sanchez,135
-Santa Barbara,22-2020,U.S. Senate,,DEM,Kamala Harris,653
-Santa Barbara,22-2020,U.S. Senate,,DEM,Loretta Sanchez,300
-Santa Barbara,22-2030,U.S. Senate,,DEM,Kamala Harris,531
-Santa Barbara,22-2030,U.S. Senate,,DEM,Loretta Sanchez,279
-Santa Barbara,22-2040,U.S. Senate,,DEM,Kamala Harris,648
-Santa Barbara,22-2040,U.S. Senate,,DEM,Loretta Sanchez,257
-Santa Barbara,22-2070,U.S. Senate,,DEM,Kamala Harris,844
-Santa Barbara,22-2070,U.S. Senate,,DEM,Loretta Sanchez,379
-Santa Barbara,22-2080,U.S. Senate,,DEM,Kamala Harris,300
-Santa Barbara,22-2080,U.S. Senate,,DEM,Loretta Sanchez,177
-Santa Barbara,22-2090,U.S. Senate,,DEM,Kamala Harris,623
-Santa Barbara,22-2090,U.S. Senate,,DEM,Loretta Sanchez,255
-Santa Barbara,22-2110,U.S. Senate,,DEM,Kamala Harris,579
-Santa Barbara,22-2110,U.S. Senate,,DEM,Loretta Sanchez,257
-Santa Barbara,22-2120,U.S. Senate,,DEM,Kamala Harris,568
-Santa Barbara,22-2120,U.S. Senate,,DEM,Loretta Sanchez,233
-Santa Barbara,22-2130,U.S. Senate,,DEM,Kamala Harris,814
-Santa Barbara,22-2130,U.S. Senate,,DEM,Loretta Sanchez,331
-Santa Barbara,22-2160,U.S. Senate,,DEM,Kamala Harris,807
-Santa Barbara,22-2160,U.S. Senate,,DEM,Loretta Sanchez,339
-Santa Barbara,22-2180,U.S. Senate,,DEM,Kamala Harris,562
-Santa Barbara,22-2180,U.S. Senate,,DEM,Loretta Sanchez,316
-Santa Barbara,22-2190,U.S. Senate,,DEM,Kamala Harris,597
-Santa Barbara,22-2190,U.S. Senate,,DEM,Loretta Sanchez,241
-Santa Barbara,22-2210,U.S. Senate,,DEM,Kamala Harris,470
-Santa Barbara,22-2210,U.S. Senate,,DEM,Loretta Sanchez,274
-Santa Barbara,22-2217,U.S. Senate,,DEM,Kamala Harris,212
-Santa Barbara,22-2217,U.S. Senate,,DEM,Loretta Sanchez,167
-Santa Barbara,22-2220,U.S. Senate,,DEM,Kamala Harris,659
-Santa Barbara,22-2220,U.S. Senate,,DEM,Loretta Sanchez,279
-Santa Barbara,22-2224,U.S. Senate,,DEM,Kamala Harris,0
-Santa Barbara,22-2224,U.S. Senate,,DEM,Loretta Sanchez,0
-Santa Barbara,22-2225,U.S. Senate,,DEM,Kamala Harris,0
-Santa Barbara,22-2225,U.S. Senate,,DEM,Loretta Sanchez,0
-Santa Barbara,22-2230,U.S. Senate,,DEM,Kamala Harris,423
-Santa Barbara,22-2230,U.S. Senate,,DEM,Loretta Sanchez,194
-Santa Barbara,22-2240,U.S. Senate,,DEM,Kamala Harris,416
-Santa Barbara,22-2240,U.S. Senate,,DEM,Loretta Sanchez,180
-Santa Barbara,22-2260,U.S. Senate,,DEM,Kamala Harris,436
-Santa Barbara,22-2260,U.S. Senate,,DEM,Loretta Sanchez,182
-Santa Barbara,22-2280,U.S. Senate,,DEM,Kamala Harris,575
-Santa Barbara,22-2280,U.S. Senate,,DEM,Loretta Sanchez,330
-Santa Barbara,23-2310,U.S. Senate,,DEM,Kamala Harris,562
-Santa Barbara,23-2310,U.S. Senate,,DEM,Loretta Sanchez,304
-Santa Barbara,23-2320,U.S. Senate,,DEM,Kamala Harris,358
-Santa Barbara,23-2320,U.S. Senate,,DEM,Loretta Sanchez,390
-Santa Barbara,23-2326,U.S. Senate,,DEM,Kamala Harris,146
-Santa Barbara,23-2326,U.S. Senate,,DEM,Loretta Sanchez,63
-Santa Barbara,23-2327,U.S. Senate,,DEM,Kamala Harris,6
-Santa Barbara,23-2327,U.S. Senate,,DEM,Loretta Sanchez,1
-Santa Barbara,23-2330,U.S. Senate,,DEM,Kamala Harris,698
-Santa Barbara,23-2330,U.S. Senate,,DEM,Loretta Sanchez,362
-Santa Barbara,23-2360,U.S. Senate,,DEM,Kamala Harris,663
-Santa Barbara,23-2360,U.S. Senate,,DEM,Loretta Sanchez,384
-Santa Barbara,23-2370,U.S. Senate,,DEM,Kamala Harris,768
-Santa Barbara,23-2370,U.S. Senate,,DEM,Loretta Sanchez,356
-Santa Barbara,23-2380,U.S. Senate,,DEM,Kamala Harris,645
-Santa Barbara,23-2380,U.S. Senate,,DEM,Loretta Sanchez,403
-Santa Barbara,23-2420,U.S. Senate,,DEM,Kamala Harris,448
-Santa Barbara,23-2420,U.S. Senate,,DEM,Loretta Sanchez,272
-Santa Barbara,23-2430,U.S. Senate,,DEM,Kamala Harris,407
-Santa Barbara,23-2430,U.S. Senate,,DEM,Loretta Sanchez,297
-Santa Barbara,23-2440,U.S. Senate,,DEM,Kamala Harris,422
-Santa Barbara,23-2440,U.S. Senate,,DEM,Loretta Sanchez,294
-Santa Barbara,30-3028,U.S. Senate,,DEM,Kamala Harris,124
-Santa Barbara,30-3028,U.S. Senate,,DEM,Loretta Sanchez,45
-Santa Barbara,30-3031,U.S. Senate,,DEM,Kamala Harris,175
-Santa Barbara,30-3031,U.S. Senate,,DEM,Loretta Sanchez,79
-Santa Barbara,30-3032,U.S. Senate,,DEM,Kamala Harris,2
-Santa Barbara,30-3032,U.S. Senate,,DEM,Loretta Sanchez,1
-Santa Barbara,30-3033,U.S. Senate,,DEM,Kamala Harris,45
-Santa Barbara,30-3033,U.S. Senate,,DEM,Loretta Sanchez,24
-Santa Barbara,30-3034,U.S. Senate,,DEM,Kamala Harris,531
-Santa Barbara,30-3034,U.S. Senate,,DEM,Loretta Sanchez,380
-Santa Barbara,30-3035,U.S. Senate,,DEM,Kamala Harris,19
-Santa Barbara,30-3035,U.S. Senate,,DEM,Loretta Sanchez,8
-Santa Barbara,30-3036,U.S. Senate,,DEM,Kamala Harris,16
-Santa Barbara,30-3036,U.S. Senate,,DEM,Loretta Sanchez,12
-Santa Barbara,30-3037,U.S. Senate,,DEM,Kamala Harris,240
-Santa Barbara,30-3037,U.S. Senate,,DEM,Loretta Sanchez,172
-Santa Barbara,30-3038,U.S. Senate,,DEM,Kamala Harris,4
-Santa Barbara,30-3038,U.S. Senate,,DEM,Loretta Sanchez,4
-Santa Barbara,30-3039,U.S. Senate,,DEM,Kamala Harris,42
-Santa Barbara,30-3039,U.S. Senate,,DEM,Loretta Sanchez,48
-Santa Barbara,30-3040,U.S. Senate,,DEM,Kamala Harris,33
-Santa Barbara,30-3040,U.S. Senate,,DEM,Loretta Sanchez,36
-Santa Barbara,30-3044,U.S. Senate,,DEM,Kamala Harris,109
-Santa Barbara,30-3044,U.S. Senate,,DEM,Loretta Sanchez,81
-Santa Barbara,30-3045,U.S. Senate,,DEM,Kamala Harris,15
-Santa Barbara,30-3045,U.S. Senate,,DEM,Loretta Sanchez,19
-Santa Barbara,30-3046,U.S. Senate,,DEM,Kamala Harris,2
-Santa Barbara,30-3046,U.S. Senate,,DEM,Loretta Sanchez,2
-Santa Barbara,30-3047,U.S. Senate,,DEM,Kamala Harris,20
-Santa Barbara,30-3047,U.S. Senate,,DEM,Loretta Sanchez,35
-Santa Barbara,30-3048,U.S. Senate,,DEM,Kamala Harris,5
-Santa Barbara,30-3048,U.S. Senate,,DEM,Loretta Sanchez,7
-Santa Barbara,30-3110,U.S. Senate,,DEM,Kamala Harris,331
-Santa Barbara,30-3110,U.S. Senate,,DEM,Loretta Sanchez,265
-Santa Barbara,30-3120,U.S. Senate,,DEM,Kamala Harris,156
-Santa Barbara,30-3120,U.S. Senate,,DEM,Loretta Sanchez,148
-Santa Barbara,30-3130,U.S. Senate,,DEM,Kamala Harris,333
-Santa Barbara,30-3130,U.S. Senate,,DEM,Loretta Sanchez,311
-Santa Barbara,30-3140,U.S. Senate,,DEM,Kamala Harris,251
-Santa Barbara,30-3140,U.S. Senate,,DEM,Loretta Sanchez,278
-Santa Barbara,30-3160,U.S. Senate,,DEM,Kamala Harris,580
-Santa Barbara,30-3160,U.S. Senate,,DEM,Loretta Sanchez,366
-Santa Barbara,30-3170,U.S. Senate,,DEM,Kamala Harris,224
-Santa Barbara,30-3170,U.S. Senate,,DEM,Loretta Sanchez,213
-Santa Barbara,30-3180,U.S. Senate,,DEM,Kamala Harris,227
-Santa Barbara,30-3180,U.S. Senate,,DEM,Loretta Sanchez,248
-Santa Barbara,30-3190,U.S. Senate,,DEM,Kamala Harris,341
-Santa Barbara,30-3190,U.S. Senate,,DEM,Loretta Sanchez,154
-Santa Barbara,30-3260,U.S. Senate,,DEM,Kamala Harris,433
-Santa Barbara,30-3260,U.S. Senate,,DEM,Loretta Sanchez,230
-Santa Barbara,30-3270,U.S. Senate,,DEM,Kamala Harris,377
-Santa Barbara,30-3270,U.S. Senate,,DEM,Loretta Sanchez,265
-Santa Barbara,30-3280,U.S. Senate,,DEM,Kamala Harris,383
-Santa Barbara,30-3280,U.S. Senate,,DEM,Loretta Sanchez,248
-Santa Barbara,30-3290,U.S. Senate,,DEM,Kamala Harris,374
-Santa Barbara,30-3290,U.S. Senate,,DEM,Loretta Sanchez,251
-Santa Barbara,30-3310,U.S. Senate,,DEM,Kamala Harris,495
-Santa Barbara,30-3310,U.S. Senate,,DEM,Loretta Sanchez,284
-Santa Barbara,30-3320,U.S. Senate,,DEM,Kamala Harris,429
-Santa Barbara,30-3320,U.S. Senate,,DEM,Loretta Sanchez,306
-Santa Barbara,30-3330,U.S. Senate,,DEM,Kamala Harris,418
-Santa Barbara,30-3330,U.S. Senate,,DEM,Loretta Sanchez,309
-Santa Barbara,30-3340,U.S. Senate,,DEM,Kamala Harris,408
-Santa Barbara,30-3340,U.S. Senate,,DEM,Loretta Sanchez,219
-Santa Barbara,30-3360,U.S. Senate,,DEM,Kamala Harris,405
-Santa Barbara,30-3360,U.S. Senate,,DEM,Loretta Sanchez,224
-Santa Barbara,30-3370,U.S. Senate,,DEM,Kamala Harris,234
-Santa Barbara,30-3370,U.S. Senate,,DEM,Loretta Sanchez,172
-Santa Barbara,30-3530,U.S. Senate,,DEM,Kamala Harris,364
-Santa Barbara,30-3530,U.S. Senate,,DEM,Loretta Sanchez,237
-Santa Barbara,30-3610,U.S. Senate,,DEM,Kamala Harris,463
-Santa Barbara,30-3610,U.S. Senate,,DEM,Loretta Sanchez,278
-Santa Barbara,30-3620,U.S. Senate,,DEM,Kamala Harris,370
-Santa Barbara,30-3620,U.S. Senate,,DEM,Loretta Sanchez,265
-Santa Barbara,30-3630,U.S. Senate,,DEM,Kamala Harris,338
-Santa Barbara,30-3630,U.S. Senate,,DEM,Loretta Sanchez,275
-Santa Barbara,30-3640,U.S. Senate,,DEM,Kamala Harris,99
-Santa Barbara,30-3640,U.S. Senate,,DEM,Loretta Sanchez,42
-Santa Barbara,30-3670,U.S. Senate,,DEM,Kamala Harris,331
-Santa Barbara,30-3670,U.S. Senate,,DEM,Loretta Sanchez,196
-Santa Barbara,30-3810,U.S. Senate,,DEM,Kamala Harris,571
-Santa Barbara,30-3810,U.S. Senate,,DEM,Loretta Sanchez,463
-Santa Barbara,30-3820,U.S. Senate,,DEM,Kamala Harris,513
-Santa Barbara,30-3820,U.S. Senate,,DEM,Loretta Sanchez,386
-Santa Barbara,30-3830,U.S. Senate,,DEM,Kamala Harris,608
-Santa Barbara,30-3830,U.S. Senate,,DEM,Loretta Sanchez,388
-Santa Barbara,30-3840,U.S. Senate,,DEM,Kamala Harris,389
-Santa Barbara,30-3840,U.S. Senate,,DEM,Loretta Sanchez,252
-Santa Barbara,30-3860,U.S. Senate,,DEM,Kamala Harris,407
-Santa Barbara,30-3860,U.S. Senate,,DEM,Loretta Sanchez,326
-Santa Barbara,30-3880,U.S. Senate,,DEM,Kamala Harris,330
-Santa Barbara,30-3880,U.S. Senate,,DEM,Loretta Sanchez,294
-Santa Barbara,30-3910,U.S. Senate,,DEM,Kamala Harris,149
-Santa Barbara,30-3910,U.S. Senate,,DEM,Loretta Sanchez,264
-Santa Barbara,33-3010,U.S. Senate,,DEM,Kamala Harris,663
-Santa Barbara,33-3010,U.S. Senate,,DEM,Loretta Sanchez,343
-Santa Barbara,33-3020,U.S. Senate,,DEM,Kamala Harris,520
-Santa Barbara,33-3020,U.S. Senate,,DEM,Loretta Sanchez,296
-Santa Barbara,33-3030,U.S. Senate,,DEM,Kamala Harris,562
-Santa Barbara,33-3030,U.S. Senate,,DEM,Loretta Sanchez,297
-Santa Barbara,33-3040,U.S. Senate,,DEM,Kamala Harris,618
-Santa Barbara,33-3040,U.S. Senate,,DEM,Loretta Sanchez,276
-Santa Barbara,33-3060,U.S. Senate,,DEM,Kamala Harris,588
-Santa Barbara,33-3060,U.S. Senate,,DEM,Loretta Sanchez,361
-Santa Barbara,33-3349,U.S. Senate,,DEM,Kamala Harris,0
-Santa Barbara,33-3349,U.S. Senate,,DEM,Loretta Sanchez,0
-Santa Barbara,33-3350,U.S. Senate,,DEM,Kamala Harris,0
-Santa Barbara,33-3350,U.S. Senate,,DEM,Loretta Sanchez,0
-Santa Barbara,34-3080,U.S. Senate,,DEM,Kamala Harris,478
-Santa Barbara,34-3080,U.S. Senate,,DEM,Loretta Sanchez,361
-Santa Barbara,34-3090,U.S. Senate,,DEM,Kamala Harris,369
-Santa Barbara,34-3090,U.S. Senate,,DEM,Loretta Sanchez,201
-Santa Barbara,34-3110,U.S. Senate,,DEM,Kamala Harris,398
-Santa Barbara,34-3110,U.S. Senate,,DEM,Loretta Sanchez,289
-Santa Barbara,34-3451,U.S. Senate,,DEM,Kamala Harris,152
-Santa Barbara,34-3451,U.S. Senate,,DEM,Loretta Sanchez,78
-Santa Barbara,35-3120,U.S. Senate,,DEM,Kamala Harris,500
-Santa Barbara,35-3120,U.S. Senate,,DEM,Loretta Sanchez,406
-Santa Barbara,35-3130,U.S. Senate,,DEM,Kamala Harris,632
-Santa Barbara,35-3130,U.S. Senate,,DEM,Loretta Sanchez,418
-Santa Barbara,35-3552,U.S. Senate,,DEM,Kamala Harris,0
-Santa Barbara,35-3552,U.S. Senate,,DEM,Loretta Sanchez,1
-Santa Barbara,36-3653,U.S. Senate,,DEM,Kamala Harris,99
-Santa Barbara,36-3653,U.S. Senate,,DEM,Loretta Sanchez,87
-Santa Barbara,36-3654,U.S. Senate,,DEM,Kamala Harris,0
-Santa Barbara,36-3654,U.S. Senate,,DEM,Loretta Sanchez,0
-Santa Barbara,36-3655,U.S. Senate,,DEM,Kamala Harris,25
-Santa Barbara,36-3655,U.S. Senate,,DEM,Loretta Sanchez,13
-Santa Barbara,38-3170,U.S. Senate,,DEM,Kamala Harris,241
-Santa Barbara,38-3170,U.S. Senate,,DEM,Loretta Sanchez,469
-Santa Barbara,38-3180,U.S. Senate,,DEM,Kamala Harris,317
-Santa Barbara,38-3180,U.S. Senate,,DEM,Loretta Sanchez,518
-Santa Barbara,40-4057,U.S. Senate,,DEM,Kamala Harris,103
-Santa Barbara,40-4057,U.S. Senate,,DEM,Loretta Sanchez,84
-Santa Barbara,40-4058,U.S. Senate,,DEM,Kamala Harris,56
-Santa Barbara,40-4058,U.S. Senate,,DEM,Loretta Sanchez,37
-Santa Barbara,40-4059,U.S. Senate,,DEM,Kamala Harris,6
-Santa Barbara,40-4059,U.S. Senate,,DEM,Loretta Sanchez,9
-Santa Barbara,40-4060,U.S. Senate,,DEM,Kamala Harris,16
-Santa Barbara,40-4060,U.S. Senate,,DEM,Loretta Sanchez,8
-Santa Barbara,40-4061,U.S. Senate,,DEM,Kamala Harris,0
-Santa Barbara,40-4061,U.S. Senate,,DEM,Loretta Sanchez,0
-Santa Barbara,40-4062,U.S. Senate,,DEM,Kamala Harris,0
-Santa Barbara,40-4062,U.S. Senate,,DEM,Loretta Sanchez,0
-Santa Barbara,40-4063,U.S. Senate,,DEM,Kamala Harris,19
-Santa Barbara,40-4063,U.S. Senate,,DEM,Loretta Sanchez,5
-Santa Barbara,40-4064,U.S. Senate,,DEM,Kamala Harris,8
-Santa Barbara,40-4064,U.S. Senate,,DEM,Loretta Sanchez,12
-Santa Barbara,40-4065,U.S. Senate,,DEM,Kamala Harris,244
-Santa Barbara,40-4065,U.S. Senate,,DEM,Loretta Sanchez,177
-Santa Barbara,40-4066,U.S. Senate,,DEM,Kamala Harris,0
-Santa Barbara,40-4066,U.S. Senate,,DEM,Loretta Sanchez,0
-Santa Barbara,40-4067,U.S. Senate,,DEM,Kamala Harris,2
-Santa Barbara,40-4067,U.S. Senate,,DEM,Loretta Sanchez,7
-Santa Barbara,40-4068,U.S. Senate,,DEM,Kamala Harris,2
-Santa Barbara,40-4068,U.S. Senate,,DEM,Loretta Sanchez,5
-Santa Barbara,40-4069,U.S. Senate,,DEM,Kamala Harris,0
-Santa Barbara,40-4069,U.S. Senate,,DEM,Loretta Sanchez,9
-Santa Barbara,40-4610,U.S. Senate,,DEM,Kamala Harris,463
-Santa Barbara,40-4610,U.S. Senate,,DEM,Loretta Sanchez,321
-Santa Barbara,40-4620,U.S. Senate,,DEM,Kamala Harris,502
-Santa Barbara,40-4620,U.S. Senate,,DEM,Loretta Sanchez,399
-Santa Barbara,40-4630,U.S. Senate,,DEM,Kamala Harris,376
-Santa Barbara,40-4630,U.S. Senate,,DEM,Loretta Sanchez,320
-Santa Barbara,40-4640,U.S. Senate,,DEM,Kamala Harris,466
-Santa Barbara,40-4640,U.S. Senate,,DEM,Loretta Sanchez,333
-Santa Barbara,40-4660,U.S. Senate,,DEM,Kamala Harris,433
-Santa Barbara,40-4660,U.S. Senate,,DEM,Loretta Sanchez,318
-Santa Barbara,40-4670,U.S. Senate,,DEM,Kamala Harris,458
-Santa Barbara,40-4670,U.S. Senate,,DEM,Loretta Sanchez,366
-Santa Barbara,40-4710,U.S. Senate,,DEM,Kamala Harris,367
-Santa Barbara,40-4710,U.S. Senate,,DEM,Loretta Sanchez,344
-Santa Barbara,40-4720,U.S. Senate,,DEM,Kamala Harris,395
-Santa Barbara,40-4720,U.S. Senate,,DEM,Loretta Sanchez,288
-Santa Barbara,40-4730,U.S. Senate,,DEM,Kamala Harris,461
-Santa Barbara,40-4730,U.S. Senate,,DEM,Loretta Sanchez,356
-Santa Barbara,40-4740,U.S. Senate,,DEM,Kamala Harris,415
-Santa Barbara,40-4740,U.S. Senate,,DEM,Loretta Sanchez,296
-Santa Barbara,40-4760,U.S. Senate,,DEM,Kamala Harris,464
-Santa Barbara,40-4760,U.S. Senate,,DEM,Loretta Sanchez,329
-Santa Barbara,40-4770,U.S. Senate,,DEM,Kamala Harris,311
-Santa Barbara,40-4770,U.S. Senate,,DEM,Loretta Sanchez,286
-Santa Barbara,40-4780,U.S. Senate,,DEM,Kamala Harris,406
-Santa Barbara,40-4780,U.S. Senate,,DEM,Loretta Sanchez,328
-Santa Barbara,40-4810,U.S. Senate,,DEM,Kamala Harris,451
-Santa Barbara,40-4810,U.S. Senate,,DEM,Loretta Sanchez,323
-Santa Barbara,40-4820,U.S. Senate,,DEM,Kamala Harris,437
-Santa Barbara,40-4820,U.S. Senate,,DEM,Loretta Sanchez,350
-Santa Barbara,46-4010,U.S. Senate,,DEM,Kamala Harris,345
-Santa Barbara,46-4010,U.S. Senate,,DEM,Loretta Sanchez,331
-Santa Barbara,46-4020,U.S. Senate,,DEM,Kamala Harris,396
-Santa Barbara,46-4020,U.S. Senate,,DEM,Loretta Sanchez,356
-Santa Barbara,46-4030,U.S. Senate,,DEM,Kamala Harris,408
-Santa Barbara,46-4030,U.S. Senate,,DEM,Loretta Sanchez,370
-Santa Barbara,46-4040,U.S. Senate,,DEM,Kamala Harris,417
-Santa Barbara,46-4040,U.S. Senate,,DEM,Loretta Sanchez,351
-Santa Barbara,46-4060,U.S. Senate,,DEM,Kamala Harris,369
-Santa Barbara,46-4060,U.S. Senate,,DEM,Loretta Sanchez,338
-Santa Barbara,46-4080,U.S. Senate,,DEM,Kamala Harris,352
-Santa Barbara,46-4080,U.S. Senate,,DEM,Loretta Sanchez,493
-Santa Barbara,46-4090,U.S. Senate,,DEM,Kamala Harris,355
-Santa Barbara,46-4090,U.S. Senate,,DEM,Loretta Sanchez,453
-Santa Barbara,46-4110,U.S. Senate,,DEM,Kamala Harris,383
-Santa Barbara,46-4110,U.S. Senate,,DEM,Loretta Sanchez,421
-Santa Barbara,46-4120,U.S. Senate,,DEM,Kamala Harris,386
-Santa Barbara,46-4120,U.S. Senate,,DEM,Loretta Sanchez,356
-Santa Barbara,46-4130,U.S. Senate,,DEM,Kamala Harris,376
-Santa Barbara,46-4130,U.S. Senate,,DEM,Loretta Sanchez,365
-Santa Barbara,46-4140,U.S. Senate,,DEM,Kamala Harris,391
-Santa Barbara,46-4140,U.S. Senate,,DEM,Loretta Sanchez,467
-Santa Barbara,46-4160,U.S. Senate,,DEM,Kamala Harris,391
-Santa Barbara,46-4160,U.S. Senate,,DEM,Loretta Sanchez,366
-Santa Barbara,46-4170,U.S. Senate,,DEM,Kamala Harris,438
-Santa Barbara,46-4170,U.S. Senate,,DEM,Loretta Sanchez,317
-Santa Barbara,46-4180,U.S. Senate,,DEM,Kamala Harris,431
-Santa Barbara,46-4180,U.S. Senate,,DEM,Loretta Sanchez,393
-Santa Barbara,46-4670,U.S. Senate,,DEM,Kamala Harris,0
-Santa Barbara,46-4670,U.S. Senate,,DEM,Loretta Sanchez,1
-Santa Barbara,47-4220,U.S. Senate,,DEM,Kamala Harris,372
-Santa Barbara,47-4220,U.S. Senate,,DEM,Loretta Sanchez,292
-Santa Barbara,47-4230,U.S. Senate,,DEM,Kamala Harris,570
-Santa Barbara,47-4230,U.S. Senate,,DEM,Loretta Sanchez,483
-Santa Barbara,47-4270,U.S. Senate,,DEM,Kamala Harris,287
-Santa Barbara,47-4270,U.S. Senate,,DEM,Loretta Sanchez,391
-Santa Barbara,47-4280,U.S. Senate,,DEM,Kamala Harris,169
-Santa Barbara,47-4280,U.S. Senate,,DEM,Loretta Sanchez,398
-Santa Barbara,47-4771,U.S. Senate,,DEM,Kamala Harris,112
-Santa Barbara,47-4771,U.S. Senate,,DEM,Loretta Sanchez,117
-Santa Barbara,47-4773,U.S. Senate,,DEM,Kamala Harris,0
-Santa Barbara,47-4773,U.S. Senate,,DEM,Loretta Sanchez,0
-Santa Barbara,50-5012,U.S. Senate,,DEM,Kamala Harris,0
-Santa Barbara,50-5012,U.S. Senate,,DEM,Loretta Sanchez,0
-Santa Barbara,50-5014,U.S. Senate,,DEM,Kamala Harris,9
-Santa Barbara,50-5014,U.S. Senate,,DEM,Loretta Sanchez,7
-Santa Barbara,50-5064,U.S. Senate,,DEM,Kamala Harris,0
-Santa Barbara,50-5064,U.S. Senate,,DEM,Loretta Sanchez,0
-Santa Barbara,50-5066,U.S. Senate,,DEM,Kamala Harris,64
-Santa Barbara,50-5066,U.S. Senate,,DEM,Loretta Sanchez,58
-Santa Barbara,50-5067,U.S. Senate,,DEM,Kamala Harris,26
-Santa Barbara,50-5067,U.S. Senate,,DEM,Loretta Sanchez,19
-Santa Barbara,50-5068,U.S. Senate,,DEM,Kamala Harris,135
-Santa Barbara,50-5068,U.S. Senate,,DEM,Loretta Sanchez,124
-Santa Barbara,50-5069,U.S. Senate,,DEM,Kamala Harris,15
-Santa Barbara,50-5069,U.S. Senate,,DEM,Loretta Sanchez,31
-Santa Barbara,50-5075,U.S. Senate,,DEM,Kamala Harris,0
-Santa Barbara,50-5075,U.S. Senate,,DEM,Loretta Sanchez,0
-Santa Barbara,50-5076,U.S. Senate,,DEM,Kamala Harris,0
-Santa Barbara,50-5076,U.S. Senate,,DEM,Loretta Sanchez,0
-Santa Barbara,57-5010,U.S. Senate,,DEM,Kamala Harris,334
-Santa Barbara,57-5010,U.S. Senate,,DEM,Loretta Sanchez,248
-Santa Barbara,57-5020,U.S. Senate,,DEM,Kamala Harris,279
-Santa Barbara,57-5020,U.S. Senate,,DEM,Loretta Sanchez,255
-Santa Barbara,57-5030,U.S. Senate,,DEM,Kamala Harris,302
-Santa Barbara,57-5030,U.S. Senate,,DEM,Loretta Sanchez,293
-Santa Barbara,57-5040,U.S. Senate,,DEM,Kamala Harris,339
-Santa Barbara,57-5040,U.S. Senate,,DEM,Loretta Sanchez,548
-Santa Barbara,57-5060,U.S. Senate,,DEM,Kamala Harris,340
-Santa Barbara,57-5060,U.S. Senate,,DEM,Loretta Sanchez,313
-Santa Barbara,57-5070,U.S. Senate,,DEM,Kamala Harris,282
-Santa Barbara,57-5070,U.S. Senate,,DEM,Loretta Sanchez,227
-Santa Barbara,57-5080,U.S. Senate,,DEM,Kamala Harris,330
-Santa Barbara,57-5080,U.S. Senate,,DEM,Loretta Sanchez,391
-Santa Barbara,57-5110,U.S. Senate,,DEM,Kamala Harris,458
-Santa Barbara,57-5110,U.S. Senate,,DEM,Loretta Sanchez,538
-Santa Barbara,57-5210,U.S. Senate,,DEM,Kamala Harris,401
-Santa Barbara,57-5210,U.S. Senate,,DEM,Loretta Sanchez,341
-Santa Barbara,57-5220,U.S. Senate,,DEM,Kamala Harris,402
-Santa Barbara,57-5220,U.S. Senate,,DEM,Loretta Sanchez,345
-Santa Barbara,57-5230,U.S. Senate,,DEM,Kamala Harris,387
-Santa Barbara,57-5230,U.S. Senate,,DEM,Loretta Sanchez,398
-Santa Barbara,57-5240,U.S. Senate,,DEM,Kamala Harris,361
-Santa Barbara,57-5240,U.S. Senate,,DEM,Loretta Sanchez,352
-Santa Barbara,57-5260,U.S. Senate,,DEM,Kamala Harris,307
-Santa Barbara,57-5260,U.S. Senate,,DEM,Loretta Sanchez,345
-Santa Barbara,57-5310,U.S. Senate,,DEM,Kamala Harris,326
-Santa Barbara,57-5310,U.S. Senate,,DEM,Loretta Sanchez,362
-Santa Barbara,57-5320,U.S. Senate,,DEM,Kamala Harris,342
-Santa Barbara,57-5320,U.S. Senate,,DEM,Loretta Sanchez,387
-Santa Barbara,57-5330,U.S. Senate,,DEM,Kamala Harris,319
-Santa Barbara,57-5330,U.S. Senate,,DEM,Loretta Sanchez,461
-Santa Barbara,57-5340,U.S. Senate,,DEM,Kamala Harris,271
-Santa Barbara,57-5340,U.S. Senate,,DEM,Loretta Sanchez,559
-Santa Barbara,57-5360,U.S. Senate,,DEM,Kamala Harris,314
-Santa Barbara,57-5360,U.S. Senate,,DEM,Loretta Sanchez,651
-Santa Barbara,57-5370,U.S. Senate,,DEM,Kamala Harris,331
-Santa Barbara,57-5370,U.S. Senate,,DEM,Loretta Sanchez,507
-Santa Barbara,57-5380,U.S. Senate,,DEM,Kamala Harris,243
-Santa Barbara,57-5380,U.S. Senate,,DEM,Loretta Sanchez,489
-Santa Barbara,57-5390,U.S. Senate,,DEM,Kamala Harris,299
-Santa Barbara,57-5390,U.S. Senate,,DEM,Loretta Sanchez,389
-Santa Barbara,57-5410,U.S. Senate,,DEM,Kamala Harris,324
-Santa Barbara,57-5410,U.S. Senate,,DEM,Loretta Sanchez,431
-Santa Barbara,57-5420,U.S. Senate,,DEM,Kamala Harris,367
-Santa Barbara,57-5420,U.S. Senate,,DEM,Loretta Sanchez,447
-Santa Barbara,57-5774,U.S. Senate,,DEM,Kamala Harris,63
-Santa Barbara,57-5774,U.S. Senate,,DEM,Loretta Sanchez,108
+Santa Barbara,10-1002,U.S. Senate,,DEM,Kamala D. Harris,79
+Santa Barbara,10-1002,U.S. Senate,,DEM,Loretta L. Sanchez,39
+Santa Barbara,10-1003,U.S. Senate,,DEM,Kamala D. Harris,5
+Santa Barbara,10-1003,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Santa Barbara,10-1004,U.S. Senate,,DEM,Kamala D. Harris,0
+Santa Barbara,10-1004,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Santa Barbara,10-1005,U.S. Senate,,DEM,Kamala D. Harris,0
+Santa Barbara,10-1005,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Santa Barbara,10-1006,U.S. Senate,,DEM,Kamala D. Harris,103
+Santa Barbara,10-1006,U.S. Senate,,DEM,Loretta L. Sanchez,20
+Santa Barbara,10-1007,U.S. Senate,,DEM,Kamala D. Harris,78
+Santa Barbara,10-1007,U.S. Senate,,DEM,Loretta L. Sanchez,37
+Santa Barbara,10-1008,U.S. Senate,,DEM,Kamala D. Harris,23
+Santa Barbara,10-1008,U.S. Senate,,DEM,Loretta L. Sanchez,11
+Santa Barbara,10-1009,U.S. Senate,,DEM,Kamala D. Harris,13
+Santa Barbara,10-1009,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Santa Barbara,10-1010,U.S. Senate,,DEM,Kamala D. Harris,21
+Santa Barbara,10-1010,U.S. Senate,,DEM,Loretta L. Sanchez,10
+Santa Barbara,10-1011,U.S. Senate,,DEM,Kamala D. Harris,10
+Santa Barbara,10-1011,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Santa Barbara,10-1012,U.S. Senate,,DEM,Kamala D. Harris,0
+Santa Barbara,10-1012,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Santa Barbara,10-1013,U.S. Senate,,DEM,Kamala D. Harris,20
+Santa Barbara,10-1013,U.S. Senate,,DEM,Loretta L. Sanchez,29
+Santa Barbara,10-1014,U.S. Senate,,DEM,Kamala D. Harris,82
+Santa Barbara,10-1014,U.S. Senate,,DEM,Loretta L. Sanchez,68
+Santa Barbara,10-1510,U.S. Senate,,DEM,Kamala D. Harris,526
+Santa Barbara,10-1510,U.S. Senate,,DEM,Loretta L. Sanchez,315
+Santa Barbara,10-1520,U.S. Senate,,DEM,Kamala D. Harris,292
+Santa Barbara,10-1520,U.S. Senate,,DEM,Loretta L. Sanchez,177
+Santa Barbara,10-1530,U.S. Senate,,DEM,Kamala D. Harris,654
+Santa Barbara,10-1530,U.S. Senate,,DEM,Loretta L. Sanchez,286
+Santa Barbara,10-1560,U.S. Senate,,DEM,Kamala D. Harris,530
+Santa Barbara,10-1560,U.S. Senate,,DEM,Loretta L. Sanchez,257
+Santa Barbara,10-1570,U.S. Senate,,DEM,Kamala D. Harris,498
+Santa Barbara,10-1570,U.S. Senate,,DEM,Loretta L. Sanchez,308
+Santa Barbara,10-1580,U.S. Senate,,DEM,Kamala D. Harris,511
+Santa Barbara,10-1580,U.S. Senate,,DEM,Loretta L. Sanchez,271
+Santa Barbara,10-1590,U.S. Senate,,DEM,Kamala D. Harris,527
+Santa Barbara,10-1590,U.S. Senate,,DEM,Loretta L. Sanchez,261
+Santa Barbara,10-1610,U.S. Senate,,DEM,Kamala D. Harris,615
+Santa Barbara,10-1610,U.S. Senate,,DEM,Loretta L. Sanchez,279
+Santa Barbara,10-1630,U.S. Senate,,DEM,Kamala D. Harris,677
+Santa Barbara,10-1630,U.S. Senate,,DEM,Loretta L. Sanchez,206
+Santa Barbara,10-1640,U.S. Senate,,DEM,Kamala D. Harris,508
+Santa Barbara,10-1640,U.S. Senate,,DEM,Loretta L. Sanchez,152
+Santa Barbara,11-1010,U.S. Senate,,DEM,Kamala D. Harris,534
+Santa Barbara,11-1010,U.S. Senate,,DEM,Loretta L. Sanchez,357
+Santa Barbara,11-1020,U.S. Senate,,DEM,Kamala D. Harris,641
+Santa Barbara,11-1020,U.S. Senate,,DEM,Loretta L. Sanchez,331
+Santa Barbara,11-1030,U.S. Senate,,DEM,Kamala D. Harris,518
+Santa Barbara,11-1030,U.S. Senate,,DEM,Loretta L. Sanchez,343
+Santa Barbara,11-1040,U.S. Senate,,DEM,Kamala D. Harris,557
+Santa Barbara,11-1040,U.S. Senate,,DEM,Loretta L. Sanchez,413
+Santa Barbara,11-1070,U.S. Senate,,DEM,Kamala D. Harris,433
+Santa Barbara,11-1070,U.S. Senate,,DEM,Loretta L. Sanchez,349
+Santa Barbara,11-1080,U.S. Senate,,DEM,Kamala D. Harris,454
+Santa Barbara,11-1080,U.S. Senate,,DEM,Loretta L. Sanchez,352
+Santa Barbara,12-0020,U.S. Senate,,DEM,Kamala D. Harris,10
+Santa Barbara,12-0020,U.S. Senate,,DEM,Loretta L. Sanchez,6
+Santa Barbara,12-1110,U.S. Senate,,DEM,Kamala D. Harris,222
+Santa Barbara,12-1110,U.S. Senate,,DEM,Loretta L. Sanchez,155
+Santa Barbara,12-1120,U.S. Senate,,DEM,Kamala D. Harris,236
+Santa Barbara,12-1120,U.S. Senate,,DEM,Loretta L. Sanchez,151
+Santa Barbara,12-1130,U.S. Senate,,DEM,Kamala D. Harris,586
+Santa Barbara,12-1130,U.S. Senate,,DEM,Loretta L. Sanchez,527
+Santa Barbara,12-1170,U.S. Senate,,DEM,Kamala D. Harris,683
+Santa Barbara,12-1170,U.S. Senate,,DEM,Loretta L. Sanchez,460
+Santa Barbara,12-1180,U.S. Senate,,DEM,Kamala D. Harris,582
+Santa Barbara,12-1180,U.S. Senate,,DEM,Loretta L. Sanchez,299
+Santa Barbara,12-1190,U.S. Senate,,DEM,Kamala D. Harris,449
+Santa Barbara,12-1190,U.S. Senate,,DEM,Loretta L. Sanchez,165
+Santa Barbara,12-1210,U.S. Senate,,DEM,Kamala D. Harris,873
+Santa Barbara,12-1210,U.S. Senate,,DEM,Loretta L. Sanchez,412
+Santa Barbara,12-1216,U.S. Senate,,DEM,Kamala D. Harris,47
+Santa Barbara,12-1216,U.S. Senate,,DEM,Loretta L. Sanchez,19
+Santa Barbara,12-1218,U.S. Senate,,DEM,Kamala D. Harris,103
+Santa Barbara,12-1218,U.S. Senate,,DEM,Loretta L. Sanchez,51
+Santa Barbara,12-1219,U.S. Senate,,DEM,Kamala D. Harris,9
+Santa Barbara,12-1219,U.S. Senate,,DEM,Loretta L. Sanchez,7
+Santa Barbara,12-1220,U.S. Senate,,DEM,Kamala D. Harris,798
+Santa Barbara,12-1220,U.S. Senate,,DEM,Loretta L. Sanchez,330
+Santa Barbara,12-1230,U.S. Senate,,DEM,Kamala D. Harris,739
+Santa Barbara,12-1230,U.S. Senate,,DEM,Loretta L. Sanchez,320
+Santa Barbara,12-1240,U.S. Senate,,DEM,Kamala D. Harris,293
+Santa Barbara,12-1240,U.S. Senate,,DEM,Loretta L. Sanchez,183
+Santa Barbara,12-1260,U.S. Senate,,DEM,Kamala D. Harris,563
+Santa Barbara,12-1260,U.S. Senate,,DEM,Loretta L. Sanchez,418
+Santa Barbara,12-1280,U.S. Senate,,DEM,Kamala D. Harris,770
+Santa Barbara,12-1280,U.S. Senate,,DEM,Loretta L. Sanchez,260
+Santa Barbara,12-1290,U.S. Senate,,DEM,Kamala D. Harris,635
+Santa Barbara,12-1290,U.S. Senate,,DEM,Loretta L. Sanchez,214
+Santa Barbara,12-1310,U.S. Senate,,DEM,Kamala D. Harris,622
+Santa Barbara,12-1310,U.S. Senate,,DEM,Loretta L. Sanchez,429
+Santa Barbara,12-1320,U.S. Senate,,DEM,Kamala D. Harris,575
+Santa Barbara,12-1320,U.S. Senate,,DEM,Loretta L. Sanchez,490
+Santa Barbara,12-1340,U.S. Senate,,DEM,Kamala D. Harris,544
+Santa Barbara,12-1340,U.S. Senate,,DEM,Loretta L. Sanchez,544
+Santa Barbara,12-1370,U.S. Senate,,DEM,Kamala D. Harris,893
+Santa Barbara,12-1370,U.S. Senate,,DEM,Loretta L. Sanchez,401
+Santa Barbara,12-1380,U.S. Senate,,DEM,Kamala D. Harris,624
+Santa Barbara,12-1380,U.S. Senate,,DEM,Loretta L. Sanchez,303
+Santa Barbara,12-1390,U.S. Senate,,DEM,Kamala D. Harris,443
+Santa Barbara,12-1390,U.S. Senate,,DEM,Loretta L. Sanchez,151
+Santa Barbara,12-1430,U.S. Senate,,DEM,Kamala D. Harris,812
+Santa Barbara,12-1430,U.S. Senate,,DEM,Loretta L. Sanchez,290
+Santa Barbara,12-1440,U.S. Senate,,DEM,Kamala D. Harris,336
+Santa Barbara,12-1440,U.S. Senate,,DEM,Loretta L. Sanchez,154
+Santa Barbara,12-1460,U.S. Senate,,DEM,Kamala D. Harris,577
+Santa Barbara,12-1460,U.S. Senate,,DEM,Loretta L. Sanchez,219
+Santa Barbara,12-1470,U.S. Senate,,DEM,Kamala D. Harris,737
+Santa Barbara,12-1470,U.S. Senate,,DEM,Loretta L. Sanchez,333
+Santa Barbara,20-2005,U.S. Senate,,DEM,Kamala D. Harris,348
+Santa Barbara,20-2005,U.S. Senate,,DEM,Loretta L. Sanchez,114
+Santa Barbara,20-2009,U.S. Senate,,DEM,Kamala D. Harris,272
+Santa Barbara,20-2009,U.S. Senate,,DEM,Loretta L. Sanchez,182
+Santa Barbara,20-2010,U.S. Senate,,DEM,Kamala D. Harris,28
+Santa Barbara,20-2010,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Santa Barbara,20-2011,U.S. Senate,,DEM,Kamala D. Harris,49
+Santa Barbara,20-2011,U.S. Senate,,DEM,Loretta L. Sanchez,29
+Santa Barbara,20-2021,U.S. Senate,,DEM,Kamala D. Harris,189
+Santa Barbara,20-2021,U.S. Senate,,DEM,Loretta L. Sanchez,93
+Santa Barbara,20-2022,U.S. Senate,,DEM,Kamala D. Harris,5
+Santa Barbara,20-2022,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Santa Barbara,20-2530,U.S. Senate,,DEM,Kamala D. Harris,375
+Santa Barbara,20-2530,U.S. Senate,,DEM,Loretta L. Sanchez,140
+Santa Barbara,20-2540,U.S. Senate,,DEM,Kamala D. Harris,241
+Santa Barbara,20-2540,U.S. Senate,,DEM,Loretta L. Sanchez,124
+Santa Barbara,20-2560,U.S. Senate,,DEM,Kamala D. Harris,546
+Santa Barbara,20-2560,U.S. Senate,,DEM,Loretta L. Sanchez,374
+Santa Barbara,20-2570,U.S. Senate,,DEM,Kamala D. Harris,767
+Santa Barbara,20-2570,U.S. Senate,,DEM,Loretta L. Sanchez,333
+Santa Barbara,20-2580,U.S. Senate,,DEM,Kamala D. Harris,634
+Santa Barbara,20-2580,U.S. Senate,,DEM,Loretta L. Sanchez,334
+Santa Barbara,20-2610,U.S. Senate,,DEM,Kamala D. Harris,520
+Santa Barbara,20-2610,U.S. Senate,,DEM,Loretta L. Sanchez,301
+Santa Barbara,20-2620,U.S. Senate,,DEM,Kamala D. Harris,531
+Santa Barbara,20-2620,U.S. Senate,,DEM,Loretta L. Sanchez,300
+Santa Barbara,20-2630,U.S. Senate,,DEM,Kamala D. Harris,423
+Santa Barbara,20-2630,U.S. Senate,,DEM,Loretta L. Sanchez,251
+Santa Barbara,20-2640,U.S. Senate,,DEM,Kamala D. Harris,397
+Santa Barbara,20-2640,U.S. Senate,,DEM,Loretta L. Sanchez,263
+Santa Barbara,20-2660,U.S. Senate,,DEM,Kamala D. Harris,513
+Santa Barbara,20-2660,U.S. Senate,,DEM,Loretta L. Sanchez,324
+Santa Barbara,20-2710,U.S. Senate,,DEM,Kamala D. Harris,539
+Santa Barbara,20-2710,U.S. Senate,,DEM,Loretta L. Sanchez,294
+Santa Barbara,20-2720,U.S. Senate,,DEM,Kamala D. Harris,665
+Santa Barbara,20-2720,U.S. Senate,,DEM,Loretta L. Sanchez,391
+Santa Barbara,20-2730,U.S. Senate,,DEM,Kamala D. Harris,548
+Santa Barbara,20-2730,U.S. Senate,,DEM,Loretta L. Sanchez,287
+Santa Barbara,20-2740,U.S. Senate,,DEM,Kamala D. Harris,544
+Santa Barbara,20-2740,U.S. Senate,,DEM,Loretta L. Sanchez,282
+Santa Barbara,20-2760,U.S. Senate,,DEM,Kamala D. Harris,512
+Santa Barbara,20-2760,U.S. Senate,,DEM,Loretta L. Sanchez,266
+Santa Barbara,20-2770,U.S. Senate,,DEM,Kamala D. Harris,759
+Santa Barbara,20-2770,U.S. Senate,,DEM,Loretta L. Sanchez,393
+Santa Barbara,22-2010,U.S. Senate,,DEM,Kamala D. Harris,292
+Santa Barbara,22-2010,U.S. Senate,,DEM,Loretta L. Sanchez,135
+Santa Barbara,22-2020,U.S. Senate,,DEM,Kamala D. Harris,653
+Santa Barbara,22-2020,U.S. Senate,,DEM,Loretta L. Sanchez,300
+Santa Barbara,22-2030,U.S. Senate,,DEM,Kamala D. Harris,531
+Santa Barbara,22-2030,U.S. Senate,,DEM,Loretta L. Sanchez,279
+Santa Barbara,22-2040,U.S. Senate,,DEM,Kamala D. Harris,648
+Santa Barbara,22-2040,U.S. Senate,,DEM,Loretta L. Sanchez,257
+Santa Barbara,22-2070,U.S. Senate,,DEM,Kamala D. Harris,844
+Santa Barbara,22-2070,U.S. Senate,,DEM,Loretta L. Sanchez,379
+Santa Barbara,22-2080,U.S. Senate,,DEM,Kamala D. Harris,300
+Santa Barbara,22-2080,U.S. Senate,,DEM,Loretta L. Sanchez,177
+Santa Barbara,22-2090,U.S. Senate,,DEM,Kamala D. Harris,623
+Santa Barbara,22-2090,U.S. Senate,,DEM,Loretta L. Sanchez,255
+Santa Barbara,22-2110,U.S. Senate,,DEM,Kamala D. Harris,579
+Santa Barbara,22-2110,U.S. Senate,,DEM,Loretta L. Sanchez,257
+Santa Barbara,22-2120,U.S. Senate,,DEM,Kamala D. Harris,568
+Santa Barbara,22-2120,U.S. Senate,,DEM,Loretta L. Sanchez,233
+Santa Barbara,22-2130,U.S. Senate,,DEM,Kamala D. Harris,814
+Santa Barbara,22-2130,U.S. Senate,,DEM,Loretta L. Sanchez,331
+Santa Barbara,22-2160,U.S. Senate,,DEM,Kamala D. Harris,807
+Santa Barbara,22-2160,U.S. Senate,,DEM,Loretta L. Sanchez,339
+Santa Barbara,22-2180,U.S. Senate,,DEM,Kamala D. Harris,562
+Santa Barbara,22-2180,U.S. Senate,,DEM,Loretta L. Sanchez,316
+Santa Barbara,22-2190,U.S. Senate,,DEM,Kamala D. Harris,597
+Santa Barbara,22-2190,U.S. Senate,,DEM,Loretta L. Sanchez,241
+Santa Barbara,22-2210,U.S. Senate,,DEM,Kamala D. Harris,470
+Santa Barbara,22-2210,U.S. Senate,,DEM,Loretta L. Sanchez,274
+Santa Barbara,22-2217,U.S. Senate,,DEM,Kamala D. Harris,212
+Santa Barbara,22-2217,U.S. Senate,,DEM,Loretta L. Sanchez,167
+Santa Barbara,22-2220,U.S. Senate,,DEM,Kamala D. Harris,659
+Santa Barbara,22-2220,U.S. Senate,,DEM,Loretta L. Sanchez,279
+Santa Barbara,22-2224,U.S. Senate,,DEM,Kamala D. Harris,0
+Santa Barbara,22-2224,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Santa Barbara,22-2225,U.S. Senate,,DEM,Kamala D. Harris,0
+Santa Barbara,22-2225,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Santa Barbara,22-2230,U.S. Senate,,DEM,Kamala D. Harris,423
+Santa Barbara,22-2230,U.S. Senate,,DEM,Loretta L. Sanchez,194
+Santa Barbara,22-2240,U.S. Senate,,DEM,Kamala D. Harris,416
+Santa Barbara,22-2240,U.S. Senate,,DEM,Loretta L. Sanchez,180
+Santa Barbara,22-2260,U.S. Senate,,DEM,Kamala D. Harris,436
+Santa Barbara,22-2260,U.S. Senate,,DEM,Loretta L. Sanchez,182
+Santa Barbara,22-2280,U.S. Senate,,DEM,Kamala D. Harris,575
+Santa Barbara,22-2280,U.S. Senate,,DEM,Loretta L. Sanchez,330
+Santa Barbara,23-2310,U.S. Senate,,DEM,Kamala D. Harris,562
+Santa Barbara,23-2310,U.S. Senate,,DEM,Loretta L. Sanchez,304
+Santa Barbara,23-2320,U.S. Senate,,DEM,Kamala D. Harris,358
+Santa Barbara,23-2320,U.S. Senate,,DEM,Loretta L. Sanchez,390
+Santa Barbara,23-2326,U.S. Senate,,DEM,Kamala D. Harris,146
+Santa Barbara,23-2326,U.S. Senate,,DEM,Loretta L. Sanchez,63
+Santa Barbara,23-2327,U.S. Senate,,DEM,Kamala D. Harris,6
+Santa Barbara,23-2327,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Santa Barbara,23-2330,U.S. Senate,,DEM,Kamala D. Harris,698
+Santa Barbara,23-2330,U.S. Senate,,DEM,Loretta L. Sanchez,362
+Santa Barbara,23-2360,U.S. Senate,,DEM,Kamala D. Harris,663
+Santa Barbara,23-2360,U.S. Senate,,DEM,Loretta L. Sanchez,384
+Santa Barbara,23-2370,U.S. Senate,,DEM,Kamala D. Harris,768
+Santa Barbara,23-2370,U.S. Senate,,DEM,Loretta L. Sanchez,356
+Santa Barbara,23-2380,U.S. Senate,,DEM,Kamala D. Harris,645
+Santa Barbara,23-2380,U.S. Senate,,DEM,Loretta L. Sanchez,403
+Santa Barbara,23-2420,U.S. Senate,,DEM,Kamala D. Harris,448
+Santa Barbara,23-2420,U.S. Senate,,DEM,Loretta L. Sanchez,272
+Santa Barbara,23-2430,U.S. Senate,,DEM,Kamala D. Harris,407
+Santa Barbara,23-2430,U.S. Senate,,DEM,Loretta L. Sanchez,297
+Santa Barbara,23-2440,U.S. Senate,,DEM,Kamala D. Harris,422
+Santa Barbara,23-2440,U.S. Senate,,DEM,Loretta L. Sanchez,294
+Santa Barbara,30-3028,U.S. Senate,,DEM,Kamala D. Harris,124
+Santa Barbara,30-3028,U.S. Senate,,DEM,Loretta L. Sanchez,45
+Santa Barbara,30-3031,U.S. Senate,,DEM,Kamala D. Harris,175
+Santa Barbara,30-3031,U.S. Senate,,DEM,Loretta L. Sanchez,79
+Santa Barbara,30-3032,U.S. Senate,,DEM,Kamala D. Harris,2
+Santa Barbara,30-3032,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Santa Barbara,30-3033,U.S. Senate,,DEM,Kamala D. Harris,45
+Santa Barbara,30-3033,U.S. Senate,,DEM,Loretta L. Sanchez,24
+Santa Barbara,30-3034,U.S. Senate,,DEM,Kamala D. Harris,531
+Santa Barbara,30-3034,U.S. Senate,,DEM,Loretta L. Sanchez,380
+Santa Barbara,30-3035,U.S. Senate,,DEM,Kamala D. Harris,19
+Santa Barbara,30-3035,U.S. Senate,,DEM,Loretta L. Sanchez,8
+Santa Barbara,30-3036,U.S. Senate,,DEM,Kamala D. Harris,16
+Santa Barbara,30-3036,U.S. Senate,,DEM,Loretta L. Sanchez,12
+Santa Barbara,30-3037,U.S. Senate,,DEM,Kamala D. Harris,240
+Santa Barbara,30-3037,U.S. Senate,,DEM,Loretta L. Sanchez,172
+Santa Barbara,30-3038,U.S. Senate,,DEM,Kamala D. Harris,4
+Santa Barbara,30-3038,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Santa Barbara,30-3039,U.S. Senate,,DEM,Kamala D. Harris,42
+Santa Barbara,30-3039,U.S. Senate,,DEM,Loretta L. Sanchez,48
+Santa Barbara,30-3040,U.S. Senate,,DEM,Kamala D. Harris,33
+Santa Barbara,30-3040,U.S. Senate,,DEM,Loretta L. Sanchez,36
+Santa Barbara,30-3044,U.S. Senate,,DEM,Kamala D. Harris,109
+Santa Barbara,30-3044,U.S. Senate,,DEM,Loretta L. Sanchez,81
+Santa Barbara,30-3045,U.S. Senate,,DEM,Kamala D. Harris,15
+Santa Barbara,30-3045,U.S. Senate,,DEM,Loretta L. Sanchez,19
+Santa Barbara,30-3046,U.S. Senate,,DEM,Kamala D. Harris,2
+Santa Barbara,30-3046,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Santa Barbara,30-3047,U.S. Senate,,DEM,Kamala D. Harris,20
+Santa Barbara,30-3047,U.S. Senate,,DEM,Loretta L. Sanchez,35
+Santa Barbara,30-3048,U.S. Senate,,DEM,Kamala D. Harris,5
+Santa Barbara,30-3048,U.S. Senate,,DEM,Loretta L. Sanchez,7
+Santa Barbara,30-3110,U.S. Senate,,DEM,Kamala D. Harris,331
+Santa Barbara,30-3110,U.S. Senate,,DEM,Loretta L. Sanchez,265
+Santa Barbara,30-3120,U.S. Senate,,DEM,Kamala D. Harris,156
+Santa Barbara,30-3120,U.S. Senate,,DEM,Loretta L. Sanchez,148
+Santa Barbara,30-3130,U.S. Senate,,DEM,Kamala D. Harris,333
+Santa Barbara,30-3130,U.S. Senate,,DEM,Loretta L. Sanchez,311
+Santa Barbara,30-3140,U.S. Senate,,DEM,Kamala D. Harris,251
+Santa Barbara,30-3140,U.S. Senate,,DEM,Loretta L. Sanchez,278
+Santa Barbara,30-3160,U.S. Senate,,DEM,Kamala D. Harris,580
+Santa Barbara,30-3160,U.S. Senate,,DEM,Loretta L. Sanchez,366
+Santa Barbara,30-3170,U.S. Senate,,DEM,Kamala D. Harris,224
+Santa Barbara,30-3170,U.S. Senate,,DEM,Loretta L. Sanchez,213
+Santa Barbara,30-3180,U.S. Senate,,DEM,Kamala D. Harris,227
+Santa Barbara,30-3180,U.S. Senate,,DEM,Loretta L. Sanchez,248
+Santa Barbara,30-3190,U.S. Senate,,DEM,Kamala D. Harris,341
+Santa Barbara,30-3190,U.S. Senate,,DEM,Loretta L. Sanchez,154
+Santa Barbara,30-3260,U.S. Senate,,DEM,Kamala D. Harris,433
+Santa Barbara,30-3260,U.S. Senate,,DEM,Loretta L. Sanchez,230
+Santa Barbara,30-3270,U.S. Senate,,DEM,Kamala D. Harris,377
+Santa Barbara,30-3270,U.S. Senate,,DEM,Loretta L. Sanchez,265
+Santa Barbara,30-3280,U.S. Senate,,DEM,Kamala D. Harris,383
+Santa Barbara,30-3280,U.S. Senate,,DEM,Loretta L. Sanchez,248
+Santa Barbara,30-3290,U.S. Senate,,DEM,Kamala D. Harris,374
+Santa Barbara,30-3290,U.S. Senate,,DEM,Loretta L. Sanchez,251
+Santa Barbara,30-3310,U.S. Senate,,DEM,Kamala D. Harris,495
+Santa Barbara,30-3310,U.S. Senate,,DEM,Loretta L. Sanchez,284
+Santa Barbara,30-3320,U.S. Senate,,DEM,Kamala D. Harris,429
+Santa Barbara,30-3320,U.S. Senate,,DEM,Loretta L. Sanchez,306
+Santa Barbara,30-3330,U.S. Senate,,DEM,Kamala D. Harris,418
+Santa Barbara,30-3330,U.S. Senate,,DEM,Loretta L. Sanchez,309
+Santa Barbara,30-3340,U.S. Senate,,DEM,Kamala D. Harris,408
+Santa Barbara,30-3340,U.S. Senate,,DEM,Loretta L. Sanchez,219
+Santa Barbara,30-3360,U.S. Senate,,DEM,Kamala D. Harris,405
+Santa Barbara,30-3360,U.S. Senate,,DEM,Loretta L. Sanchez,224
+Santa Barbara,30-3370,U.S. Senate,,DEM,Kamala D. Harris,234
+Santa Barbara,30-3370,U.S. Senate,,DEM,Loretta L. Sanchez,172
+Santa Barbara,30-3530,U.S. Senate,,DEM,Kamala D. Harris,364
+Santa Barbara,30-3530,U.S. Senate,,DEM,Loretta L. Sanchez,237
+Santa Barbara,30-3610,U.S. Senate,,DEM,Kamala D. Harris,463
+Santa Barbara,30-3610,U.S. Senate,,DEM,Loretta L. Sanchez,278
+Santa Barbara,30-3620,U.S. Senate,,DEM,Kamala D. Harris,370
+Santa Barbara,30-3620,U.S. Senate,,DEM,Loretta L. Sanchez,265
+Santa Barbara,30-3630,U.S. Senate,,DEM,Kamala D. Harris,338
+Santa Barbara,30-3630,U.S. Senate,,DEM,Loretta L. Sanchez,275
+Santa Barbara,30-3640,U.S. Senate,,DEM,Kamala D. Harris,99
+Santa Barbara,30-3640,U.S. Senate,,DEM,Loretta L. Sanchez,42
+Santa Barbara,30-3670,U.S. Senate,,DEM,Kamala D. Harris,331
+Santa Barbara,30-3670,U.S. Senate,,DEM,Loretta L. Sanchez,196
+Santa Barbara,30-3810,U.S. Senate,,DEM,Kamala D. Harris,571
+Santa Barbara,30-3810,U.S. Senate,,DEM,Loretta L. Sanchez,463
+Santa Barbara,30-3820,U.S. Senate,,DEM,Kamala D. Harris,513
+Santa Barbara,30-3820,U.S. Senate,,DEM,Loretta L. Sanchez,386
+Santa Barbara,30-3830,U.S. Senate,,DEM,Kamala D. Harris,608
+Santa Barbara,30-3830,U.S. Senate,,DEM,Loretta L. Sanchez,388
+Santa Barbara,30-3840,U.S. Senate,,DEM,Kamala D. Harris,389
+Santa Barbara,30-3840,U.S. Senate,,DEM,Loretta L. Sanchez,252
+Santa Barbara,30-3860,U.S. Senate,,DEM,Kamala D. Harris,407
+Santa Barbara,30-3860,U.S. Senate,,DEM,Loretta L. Sanchez,326
+Santa Barbara,30-3880,U.S. Senate,,DEM,Kamala D. Harris,330
+Santa Barbara,30-3880,U.S. Senate,,DEM,Loretta L. Sanchez,294
+Santa Barbara,30-3910,U.S. Senate,,DEM,Kamala D. Harris,149
+Santa Barbara,30-3910,U.S. Senate,,DEM,Loretta L. Sanchez,264
+Santa Barbara,33-3010,U.S. Senate,,DEM,Kamala D. Harris,663
+Santa Barbara,33-3010,U.S. Senate,,DEM,Loretta L. Sanchez,343
+Santa Barbara,33-3020,U.S. Senate,,DEM,Kamala D. Harris,520
+Santa Barbara,33-3020,U.S. Senate,,DEM,Loretta L. Sanchez,296
+Santa Barbara,33-3030,U.S. Senate,,DEM,Kamala D. Harris,562
+Santa Barbara,33-3030,U.S. Senate,,DEM,Loretta L. Sanchez,297
+Santa Barbara,33-3040,U.S. Senate,,DEM,Kamala D. Harris,618
+Santa Barbara,33-3040,U.S. Senate,,DEM,Loretta L. Sanchez,276
+Santa Barbara,33-3060,U.S. Senate,,DEM,Kamala D. Harris,588
+Santa Barbara,33-3060,U.S. Senate,,DEM,Loretta L. Sanchez,361
+Santa Barbara,33-3349,U.S. Senate,,DEM,Kamala D. Harris,0
+Santa Barbara,33-3349,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Santa Barbara,33-3350,U.S. Senate,,DEM,Kamala D. Harris,0
+Santa Barbara,33-3350,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Santa Barbara,34-3080,U.S. Senate,,DEM,Kamala D. Harris,478
+Santa Barbara,34-3080,U.S. Senate,,DEM,Loretta L. Sanchez,361
+Santa Barbara,34-3090,U.S. Senate,,DEM,Kamala D. Harris,369
+Santa Barbara,34-3090,U.S. Senate,,DEM,Loretta L. Sanchez,201
+Santa Barbara,34-3110,U.S. Senate,,DEM,Kamala D. Harris,398
+Santa Barbara,34-3110,U.S. Senate,,DEM,Loretta L. Sanchez,289
+Santa Barbara,34-3451,U.S. Senate,,DEM,Kamala D. Harris,152
+Santa Barbara,34-3451,U.S. Senate,,DEM,Loretta L. Sanchez,78
+Santa Barbara,35-3120,U.S. Senate,,DEM,Kamala D. Harris,500
+Santa Barbara,35-3120,U.S. Senate,,DEM,Loretta L. Sanchez,406
+Santa Barbara,35-3130,U.S. Senate,,DEM,Kamala D. Harris,632
+Santa Barbara,35-3130,U.S. Senate,,DEM,Loretta L. Sanchez,418
+Santa Barbara,35-3552,U.S. Senate,,DEM,Kamala D. Harris,0
+Santa Barbara,35-3552,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Santa Barbara,36-3653,U.S. Senate,,DEM,Kamala D. Harris,99
+Santa Barbara,36-3653,U.S. Senate,,DEM,Loretta L. Sanchez,87
+Santa Barbara,36-3654,U.S. Senate,,DEM,Kamala D. Harris,0
+Santa Barbara,36-3654,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Santa Barbara,36-3655,U.S. Senate,,DEM,Kamala D. Harris,25
+Santa Barbara,36-3655,U.S. Senate,,DEM,Loretta L. Sanchez,13
+Santa Barbara,38-3170,U.S. Senate,,DEM,Kamala D. Harris,241
+Santa Barbara,38-3170,U.S. Senate,,DEM,Loretta L. Sanchez,469
+Santa Barbara,38-3180,U.S. Senate,,DEM,Kamala D. Harris,317
+Santa Barbara,38-3180,U.S. Senate,,DEM,Loretta L. Sanchez,518
+Santa Barbara,40-4057,U.S. Senate,,DEM,Kamala D. Harris,103
+Santa Barbara,40-4057,U.S. Senate,,DEM,Loretta L. Sanchez,84
+Santa Barbara,40-4058,U.S. Senate,,DEM,Kamala D. Harris,56
+Santa Barbara,40-4058,U.S. Senate,,DEM,Loretta L. Sanchez,37
+Santa Barbara,40-4059,U.S. Senate,,DEM,Kamala D. Harris,6
+Santa Barbara,40-4059,U.S. Senate,,DEM,Loretta L. Sanchez,9
+Santa Barbara,40-4060,U.S. Senate,,DEM,Kamala D. Harris,16
+Santa Barbara,40-4060,U.S. Senate,,DEM,Loretta L. Sanchez,8
+Santa Barbara,40-4061,U.S. Senate,,DEM,Kamala D. Harris,0
+Santa Barbara,40-4061,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Santa Barbara,40-4062,U.S. Senate,,DEM,Kamala D. Harris,0
+Santa Barbara,40-4062,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Santa Barbara,40-4063,U.S. Senate,,DEM,Kamala D. Harris,19
+Santa Barbara,40-4063,U.S. Senate,,DEM,Loretta L. Sanchez,5
+Santa Barbara,40-4064,U.S. Senate,,DEM,Kamala D. Harris,8
+Santa Barbara,40-4064,U.S. Senate,,DEM,Loretta L. Sanchez,12
+Santa Barbara,40-4065,U.S. Senate,,DEM,Kamala D. Harris,244
+Santa Barbara,40-4065,U.S. Senate,,DEM,Loretta L. Sanchez,177
+Santa Barbara,40-4066,U.S. Senate,,DEM,Kamala D. Harris,0
+Santa Barbara,40-4066,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Santa Barbara,40-4067,U.S. Senate,,DEM,Kamala D. Harris,2
+Santa Barbara,40-4067,U.S. Senate,,DEM,Loretta L. Sanchez,7
+Santa Barbara,40-4068,U.S. Senate,,DEM,Kamala D. Harris,2
+Santa Barbara,40-4068,U.S. Senate,,DEM,Loretta L. Sanchez,5
+Santa Barbara,40-4069,U.S. Senate,,DEM,Kamala D. Harris,0
+Santa Barbara,40-4069,U.S. Senate,,DEM,Loretta L. Sanchez,9
+Santa Barbara,40-4610,U.S. Senate,,DEM,Kamala D. Harris,463
+Santa Barbara,40-4610,U.S. Senate,,DEM,Loretta L. Sanchez,321
+Santa Barbara,40-4620,U.S. Senate,,DEM,Kamala D. Harris,502
+Santa Barbara,40-4620,U.S. Senate,,DEM,Loretta L. Sanchez,399
+Santa Barbara,40-4630,U.S. Senate,,DEM,Kamala D. Harris,376
+Santa Barbara,40-4630,U.S. Senate,,DEM,Loretta L. Sanchez,320
+Santa Barbara,40-4640,U.S. Senate,,DEM,Kamala D. Harris,466
+Santa Barbara,40-4640,U.S. Senate,,DEM,Loretta L. Sanchez,333
+Santa Barbara,40-4660,U.S. Senate,,DEM,Kamala D. Harris,433
+Santa Barbara,40-4660,U.S. Senate,,DEM,Loretta L. Sanchez,318
+Santa Barbara,40-4670,U.S. Senate,,DEM,Kamala D. Harris,458
+Santa Barbara,40-4670,U.S. Senate,,DEM,Loretta L. Sanchez,366
+Santa Barbara,40-4710,U.S. Senate,,DEM,Kamala D. Harris,367
+Santa Barbara,40-4710,U.S. Senate,,DEM,Loretta L. Sanchez,344
+Santa Barbara,40-4720,U.S. Senate,,DEM,Kamala D. Harris,395
+Santa Barbara,40-4720,U.S. Senate,,DEM,Loretta L. Sanchez,288
+Santa Barbara,40-4730,U.S. Senate,,DEM,Kamala D. Harris,461
+Santa Barbara,40-4730,U.S. Senate,,DEM,Loretta L. Sanchez,356
+Santa Barbara,40-4740,U.S. Senate,,DEM,Kamala D. Harris,415
+Santa Barbara,40-4740,U.S. Senate,,DEM,Loretta L. Sanchez,296
+Santa Barbara,40-4760,U.S. Senate,,DEM,Kamala D. Harris,464
+Santa Barbara,40-4760,U.S. Senate,,DEM,Loretta L. Sanchez,329
+Santa Barbara,40-4770,U.S. Senate,,DEM,Kamala D. Harris,311
+Santa Barbara,40-4770,U.S. Senate,,DEM,Loretta L. Sanchez,286
+Santa Barbara,40-4780,U.S. Senate,,DEM,Kamala D. Harris,406
+Santa Barbara,40-4780,U.S. Senate,,DEM,Loretta L. Sanchez,328
+Santa Barbara,40-4810,U.S. Senate,,DEM,Kamala D. Harris,451
+Santa Barbara,40-4810,U.S. Senate,,DEM,Loretta L. Sanchez,323
+Santa Barbara,40-4820,U.S. Senate,,DEM,Kamala D. Harris,437
+Santa Barbara,40-4820,U.S. Senate,,DEM,Loretta L. Sanchez,350
+Santa Barbara,46-4010,U.S. Senate,,DEM,Kamala D. Harris,345
+Santa Barbara,46-4010,U.S. Senate,,DEM,Loretta L. Sanchez,331
+Santa Barbara,46-4020,U.S. Senate,,DEM,Kamala D. Harris,396
+Santa Barbara,46-4020,U.S. Senate,,DEM,Loretta L. Sanchez,356
+Santa Barbara,46-4030,U.S. Senate,,DEM,Kamala D. Harris,408
+Santa Barbara,46-4030,U.S. Senate,,DEM,Loretta L. Sanchez,370
+Santa Barbara,46-4040,U.S. Senate,,DEM,Kamala D. Harris,417
+Santa Barbara,46-4040,U.S. Senate,,DEM,Loretta L. Sanchez,351
+Santa Barbara,46-4060,U.S. Senate,,DEM,Kamala D. Harris,369
+Santa Barbara,46-4060,U.S. Senate,,DEM,Loretta L. Sanchez,338
+Santa Barbara,46-4080,U.S. Senate,,DEM,Kamala D. Harris,352
+Santa Barbara,46-4080,U.S. Senate,,DEM,Loretta L. Sanchez,493
+Santa Barbara,46-4090,U.S. Senate,,DEM,Kamala D. Harris,355
+Santa Barbara,46-4090,U.S. Senate,,DEM,Loretta L. Sanchez,453
+Santa Barbara,46-4110,U.S. Senate,,DEM,Kamala D. Harris,383
+Santa Barbara,46-4110,U.S. Senate,,DEM,Loretta L. Sanchez,421
+Santa Barbara,46-4120,U.S. Senate,,DEM,Kamala D. Harris,386
+Santa Barbara,46-4120,U.S. Senate,,DEM,Loretta L. Sanchez,356
+Santa Barbara,46-4130,U.S. Senate,,DEM,Kamala D. Harris,376
+Santa Barbara,46-4130,U.S. Senate,,DEM,Loretta L. Sanchez,365
+Santa Barbara,46-4140,U.S. Senate,,DEM,Kamala D. Harris,391
+Santa Barbara,46-4140,U.S. Senate,,DEM,Loretta L. Sanchez,467
+Santa Barbara,46-4160,U.S. Senate,,DEM,Kamala D. Harris,391
+Santa Barbara,46-4160,U.S. Senate,,DEM,Loretta L. Sanchez,366
+Santa Barbara,46-4170,U.S. Senate,,DEM,Kamala D. Harris,438
+Santa Barbara,46-4170,U.S. Senate,,DEM,Loretta L. Sanchez,317
+Santa Barbara,46-4180,U.S. Senate,,DEM,Kamala D. Harris,431
+Santa Barbara,46-4180,U.S. Senate,,DEM,Loretta L. Sanchez,393
+Santa Barbara,46-4670,U.S. Senate,,DEM,Kamala D. Harris,0
+Santa Barbara,46-4670,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Santa Barbara,47-4220,U.S. Senate,,DEM,Kamala D. Harris,372
+Santa Barbara,47-4220,U.S. Senate,,DEM,Loretta L. Sanchez,292
+Santa Barbara,47-4230,U.S. Senate,,DEM,Kamala D. Harris,570
+Santa Barbara,47-4230,U.S. Senate,,DEM,Loretta L. Sanchez,483
+Santa Barbara,47-4270,U.S. Senate,,DEM,Kamala D. Harris,287
+Santa Barbara,47-4270,U.S. Senate,,DEM,Loretta L. Sanchez,391
+Santa Barbara,47-4280,U.S. Senate,,DEM,Kamala D. Harris,169
+Santa Barbara,47-4280,U.S. Senate,,DEM,Loretta L. Sanchez,398
+Santa Barbara,47-4771,U.S. Senate,,DEM,Kamala D. Harris,112
+Santa Barbara,47-4771,U.S. Senate,,DEM,Loretta L. Sanchez,117
+Santa Barbara,47-4773,U.S. Senate,,DEM,Kamala D. Harris,0
+Santa Barbara,47-4773,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Santa Barbara,50-5012,U.S. Senate,,DEM,Kamala D. Harris,0
+Santa Barbara,50-5012,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Santa Barbara,50-5014,U.S. Senate,,DEM,Kamala D. Harris,9
+Santa Barbara,50-5014,U.S. Senate,,DEM,Loretta L. Sanchez,7
+Santa Barbara,50-5064,U.S. Senate,,DEM,Kamala D. Harris,0
+Santa Barbara,50-5064,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Santa Barbara,50-5066,U.S. Senate,,DEM,Kamala D. Harris,64
+Santa Barbara,50-5066,U.S. Senate,,DEM,Loretta L. Sanchez,58
+Santa Barbara,50-5067,U.S. Senate,,DEM,Kamala D. Harris,26
+Santa Barbara,50-5067,U.S. Senate,,DEM,Loretta L. Sanchez,19
+Santa Barbara,50-5068,U.S. Senate,,DEM,Kamala D. Harris,135
+Santa Barbara,50-5068,U.S. Senate,,DEM,Loretta L. Sanchez,124
+Santa Barbara,50-5069,U.S. Senate,,DEM,Kamala D. Harris,15
+Santa Barbara,50-5069,U.S. Senate,,DEM,Loretta L. Sanchez,31
+Santa Barbara,50-5075,U.S. Senate,,DEM,Kamala D. Harris,0
+Santa Barbara,50-5075,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Santa Barbara,50-5076,U.S. Senate,,DEM,Kamala D. Harris,0
+Santa Barbara,50-5076,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Santa Barbara,57-5010,U.S. Senate,,DEM,Kamala D. Harris,334
+Santa Barbara,57-5010,U.S. Senate,,DEM,Loretta L. Sanchez,248
+Santa Barbara,57-5020,U.S. Senate,,DEM,Kamala D. Harris,279
+Santa Barbara,57-5020,U.S. Senate,,DEM,Loretta L. Sanchez,255
+Santa Barbara,57-5030,U.S. Senate,,DEM,Kamala D. Harris,302
+Santa Barbara,57-5030,U.S. Senate,,DEM,Loretta L. Sanchez,293
+Santa Barbara,57-5040,U.S. Senate,,DEM,Kamala D. Harris,339
+Santa Barbara,57-5040,U.S. Senate,,DEM,Loretta L. Sanchez,548
+Santa Barbara,57-5060,U.S. Senate,,DEM,Kamala D. Harris,340
+Santa Barbara,57-5060,U.S. Senate,,DEM,Loretta L. Sanchez,313
+Santa Barbara,57-5070,U.S. Senate,,DEM,Kamala D. Harris,282
+Santa Barbara,57-5070,U.S. Senate,,DEM,Loretta L. Sanchez,227
+Santa Barbara,57-5080,U.S. Senate,,DEM,Kamala D. Harris,330
+Santa Barbara,57-5080,U.S. Senate,,DEM,Loretta L. Sanchez,391
+Santa Barbara,57-5110,U.S. Senate,,DEM,Kamala D. Harris,458
+Santa Barbara,57-5110,U.S. Senate,,DEM,Loretta L. Sanchez,538
+Santa Barbara,57-5210,U.S. Senate,,DEM,Kamala D. Harris,401
+Santa Barbara,57-5210,U.S. Senate,,DEM,Loretta L. Sanchez,341
+Santa Barbara,57-5220,U.S. Senate,,DEM,Kamala D. Harris,402
+Santa Barbara,57-5220,U.S. Senate,,DEM,Loretta L. Sanchez,345
+Santa Barbara,57-5230,U.S. Senate,,DEM,Kamala D. Harris,387
+Santa Barbara,57-5230,U.S. Senate,,DEM,Loretta L. Sanchez,398
+Santa Barbara,57-5240,U.S. Senate,,DEM,Kamala D. Harris,361
+Santa Barbara,57-5240,U.S. Senate,,DEM,Loretta L. Sanchez,352
+Santa Barbara,57-5260,U.S. Senate,,DEM,Kamala D. Harris,307
+Santa Barbara,57-5260,U.S. Senate,,DEM,Loretta L. Sanchez,345
+Santa Barbara,57-5310,U.S. Senate,,DEM,Kamala D. Harris,326
+Santa Barbara,57-5310,U.S. Senate,,DEM,Loretta L. Sanchez,362
+Santa Barbara,57-5320,U.S. Senate,,DEM,Kamala D. Harris,342
+Santa Barbara,57-5320,U.S. Senate,,DEM,Loretta L. Sanchez,387
+Santa Barbara,57-5330,U.S. Senate,,DEM,Kamala D. Harris,319
+Santa Barbara,57-5330,U.S. Senate,,DEM,Loretta L. Sanchez,461
+Santa Barbara,57-5340,U.S. Senate,,DEM,Kamala D. Harris,271
+Santa Barbara,57-5340,U.S. Senate,,DEM,Loretta L. Sanchez,559
+Santa Barbara,57-5360,U.S. Senate,,DEM,Kamala D. Harris,314
+Santa Barbara,57-5360,U.S. Senate,,DEM,Loretta L. Sanchez,651
+Santa Barbara,57-5370,U.S. Senate,,DEM,Kamala D. Harris,331
+Santa Barbara,57-5370,U.S. Senate,,DEM,Loretta L. Sanchez,507
+Santa Barbara,57-5380,U.S. Senate,,DEM,Kamala D. Harris,243
+Santa Barbara,57-5380,U.S. Senate,,DEM,Loretta L. Sanchez,489
+Santa Barbara,57-5390,U.S. Senate,,DEM,Kamala D. Harris,299
+Santa Barbara,57-5390,U.S. Senate,,DEM,Loretta L. Sanchez,389
+Santa Barbara,57-5410,U.S. Senate,,DEM,Kamala D. Harris,324
+Santa Barbara,57-5410,U.S. Senate,,DEM,Loretta L. Sanchez,431
+Santa Barbara,57-5420,U.S. Senate,,DEM,Kamala D. Harris,367
+Santa Barbara,57-5420,U.S. Senate,,DEM,Loretta L. Sanchez,447
+Santa Barbara,57-5774,U.S. Senate,,DEM,Kamala D. Harris,63
+Santa Barbara,57-5774,U.S. Senate,,DEM,Loretta L. Sanchez,108

--- a/2016/20161108__ca__general__santa_clara__precinct.csv
+++ b/2016/20161108__ca__general__santa_clara__precinct.csv
@@ -42519,2129 +42519,2129 @@ Santa Clara,6674,Proposition 67,,N/A,Yes,52
 Santa Clara,6674,Proposition 67,,N/A,No,51
 Santa Clara,6678,Proposition 67,,N/A,Yes,26
 Santa Clara,6678,Proposition 67,,N/A,No,14
-Santa Clara,1001,U.S. Senate,,DEM,Kamala Harris,680
-Santa Clara,1001,U.S. Senate,,DEM,Loretta Sanchez,299
-Santa Clara,1003,U.S. Senate,,DEM,Kamala Harris,541
-Santa Clara,1003,U.S. Senate,,DEM,Loretta Sanchez,262
-Santa Clara,1006,U.S. Senate,,DEM,Kamala Harris,610
-Santa Clara,1006,U.S. Senate,,DEM,Loretta Sanchez,242
-Santa Clara,1008,U.S. Senate,,DEM,Kamala Harris,710
-Santa Clara,1008,U.S. Senate,,DEM,Loretta Sanchez,344
-Santa Clara,1009,U.S. Senate,,DEM,Kamala Harris,460
-Santa Clara,1009,U.S. Senate,,DEM,Loretta Sanchez,212
-Santa Clara,1011,U.S. Senate,,DEM,Kamala Harris,583
-Santa Clara,1011,U.S. Senate,,DEM,Loretta Sanchez,243
-Santa Clara,1013,U.S. Senate,,DEM,Kamala Harris,578
-Santa Clara,1013,U.S. Senate,,DEM,Loretta Sanchez,196
-Santa Clara,1015,U.S. Senate,,DEM,Kamala Harris,392
-Santa Clara,1015,U.S. Senate,,DEM,Loretta Sanchez,149
-Santa Clara,1017,U.S. Senate,,DEM,Kamala Harris,450
-Santa Clara,1017,U.S. Senate,,DEM,Loretta Sanchez,278
-Santa Clara,1020,U.S. Senate,,DEM,Kamala Harris,558
-Santa Clara,1020,U.S. Senate,,DEM,Loretta Sanchez,199
-Santa Clara,1021,U.S. Senate,,DEM,Kamala Harris,640
-Santa Clara,1021,U.S. Senate,,DEM,Loretta Sanchez,219
-Santa Clara,1023,U.S. Senate,,DEM,Kamala Harris,338
-Santa Clara,1023,U.S. Senate,,DEM,Loretta Sanchez,121
-Santa Clara,1024,U.S. Senate,,DEM,Kamala Harris,641
-Santa Clara,1024,U.S. Senate,,DEM,Loretta Sanchez,254
-Santa Clara,1026,U.S. Senate,,DEM,Kamala Harris,616
-Santa Clara,1026,U.S. Senate,,DEM,Loretta Sanchez,236
-Santa Clara,1029,U.S. Senate,,DEM,Kamala Harris,617
-Santa Clara,1029,U.S. Senate,,DEM,Loretta Sanchez,235
-Santa Clara,1031,U.S. Senate,,DEM,Kamala Harris,158
-Santa Clara,1031,U.S. Senate,,DEM,Loretta Sanchez,78
-Santa Clara,1032,U.S. Senate,,DEM,Kamala Harris,589
-Santa Clara,1032,U.S. Senate,,DEM,Loretta Sanchez,225
-Santa Clara,1034,U.S. Senate,,DEM,Kamala Harris,461
-Santa Clara,1034,U.S. Senate,,DEM,Loretta Sanchez,189
-Santa Clara,1035,U.S. Senate,,DEM,Kamala Harris,567
-Santa Clara,1035,U.S. Senate,,DEM,Loretta Sanchez,203
-Santa Clara,1037,U.S. Senate,,DEM,Kamala Harris,660
-Santa Clara,1037,U.S. Senate,,DEM,Loretta Sanchez,175
-Santa Clara,1038,U.S. Senate,,DEM,Kamala Harris,455
-Santa Clara,1038,U.S. Senate,,DEM,Loretta Sanchez,156
-Santa Clara,1040,U.S. Senate,,DEM,Kamala Harris,746
-Santa Clara,1040,U.S. Senate,,DEM,Loretta Sanchez,212
-Santa Clara,1041,U.S. Senate,,DEM,Kamala Harris,9
-Santa Clara,1041,U.S. Senate,,DEM,Loretta Sanchez,4
-Santa Clara,1042,U.S. Senate,,DEM,Kamala Harris,4
-Santa Clara,1042,U.S. Senate,,DEM,Loretta Sanchez,1
-Santa Clara,1045,U.S. Senate,,DEM,Kamala Harris,525
-Santa Clara,1045,U.S. Senate,,DEM,Loretta Sanchez,179
-Santa Clara,1047,U.S. Senate,,DEM,Kamala Harris,467
-Santa Clara,1047,U.S. Senate,,DEM,Loretta Sanchez,163
-Santa Clara,1050,U.S. Senate,,DEM,Kamala Harris,538
-Santa Clara,1050,U.S. Senate,,DEM,Loretta Sanchez,196
-Santa Clara,1051,U.S. Senate,,DEM,Kamala Harris,476
-Santa Clara,1051,U.S. Senate,,DEM,Loretta Sanchez,134
-Santa Clara,1053,U.S. Senate,,DEM,Kamala Harris,649
-Santa Clara,1053,U.S. Senate,,DEM,Loretta Sanchez,266
-Santa Clara,1055,U.S. Senate,,DEM,Kamala Harris,509
-Santa Clara,1055,U.S. Senate,,DEM,Loretta Sanchez,218
-Santa Clara,1056,U.S. Senate,,DEM,Kamala Harris,567
-Santa Clara,1056,U.S. Senate,,DEM,Loretta Sanchez,210
-Santa Clara,1057,U.S. Senate,,DEM,Kamala Harris,431
-Santa Clara,1057,U.S. Senate,,DEM,Loretta Sanchez,236
-Santa Clara,1060,U.S. Senate,,DEM,Kamala Harris,512
-Santa Clara,1060,U.S. Senate,,DEM,Loretta Sanchez,315
-Santa Clara,1062,U.S. Senate,,DEM,Kamala Harris,560
-Santa Clara,1062,U.S. Senate,,DEM,Loretta Sanchez,275
-Santa Clara,1063,U.S. Senate,,DEM,Kamala Harris,535
-Santa Clara,1063,U.S. Senate,,DEM,Loretta Sanchez,335
-Santa Clara,1066,U.S. Senate,,DEM,Kamala Harris,607
-Santa Clara,1066,U.S. Senate,,DEM,Loretta Sanchez,353
-Santa Clara,1069,U.S. Senate,,DEM,Kamala Harris,476
-Santa Clara,1069,U.S. Senate,,DEM,Loretta Sanchez,263
-Santa Clara,1070,U.S. Senate,,DEM,Kamala Harris,522
-Santa Clara,1070,U.S. Senate,,DEM,Loretta Sanchez,235
-Santa Clara,1071,U.S. Senate,,DEM,Kamala Harris,1
-Santa Clara,1071,U.S. Senate,,DEM,Loretta Sanchez,0
-Santa Clara,1072,U.S. Senate,,DEM,Kamala Harris,441
-Santa Clara,1072,U.S. Senate,,DEM,Loretta Sanchez,113
-Santa Clara,1075,U.S. Senate,,DEM,Kamala Harris,309
-Santa Clara,1075,U.S. Senate,,DEM,Loretta Sanchez,91
-Santa Clara,1077,U.S. Senate,,DEM,Kamala Harris,153
-Santa Clara,1077,U.S. Senate,,DEM,Loretta Sanchez,35
-Santa Clara,1078,U.S. Senate,,DEM,Kamala Harris,421
-Santa Clara,1078,U.S. Senate,,DEM,Loretta Sanchez,299
-Santa Clara,1080,U.S. Senate,,DEM,Kamala Harris,366
-Santa Clara,1080,U.S. Senate,,DEM,Loretta Sanchez,116
-Santa Clara,1081,U.S. Senate,,DEM,Kamala Harris,576
-Santa Clara,1081,U.S. Senate,,DEM,Loretta Sanchez,294
-Santa Clara,1082,U.S. Senate,,DEM,Kamala Harris,584
-Santa Clara,1082,U.S. Senate,,DEM,Loretta Sanchez,275
-Santa Clara,1087,U.S. Senate,,DEM,Kamala Harris,0
-Santa Clara,1087,U.S. Senate,,DEM,Loretta Sanchez,0
-Santa Clara,1092,U.S. Senate,,DEM,Kamala Harris,483
-Santa Clara,1092,U.S. Senate,,DEM,Loretta Sanchez,154
-Santa Clara,1094,U.S. Senate,,DEM,Kamala Harris,564
-Santa Clara,1094,U.S. Senate,,DEM,Loretta Sanchez,307
-Santa Clara,1101,U.S. Senate,,DEM,Kamala Harris,544
-Santa Clara,1101,U.S. Senate,,DEM,Loretta Sanchez,233
-Santa Clara,1104,U.S. Senate,,DEM,Kamala Harris,520
-Santa Clara,1104,U.S. Senate,,DEM,Loretta Sanchez,176
-Santa Clara,1106,U.S. Senate,,DEM,Kamala Harris,553
-Santa Clara,1106,U.S. Senate,,DEM,Loretta Sanchez,187
-Santa Clara,1107,U.S. Senate,,DEM,Kamala Harris,624
-Santa Clara,1107,U.S. Senate,,DEM,Loretta Sanchez,186
-Santa Clara,1108,U.S. Senate,,DEM,Kamala Harris,521
-Santa Clara,1108,U.S. Senate,,DEM,Loretta Sanchez,123
-Santa Clara,1111,U.S. Senate,,DEM,Kamala Harris,98
-Santa Clara,1111,U.S. Senate,,DEM,Loretta Sanchez,43
-Santa Clara,1113,U.S. Senate,,DEM,Kamala Harris,671
-Santa Clara,1113,U.S. Senate,,DEM,Loretta Sanchez,184
-Santa Clara,1115,U.S. Senate,,DEM,Kamala Harris,616
-Santa Clara,1115,U.S. Senate,,DEM,Loretta Sanchez,165
-Santa Clara,1117,U.S. Senate,,DEM,Kamala Harris,569
-Santa Clara,1117,U.S. Senate,,DEM,Loretta Sanchez,139
-Santa Clara,1118,U.S. Senate,,DEM,Kamala Harris,147
-Santa Clara,1118,U.S. Senate,,DEM,Loretta Sanchez,38
-Santa Clara,1119,U.S. Senate,,DEM,Kamala Harris,318
-Santa Clara,1119,U.S. Senate,,DEM,Loretta Sanchez,111
-Santa Clara,1121,U.S. Senate,,DEM,Kamala Harris,228
-Santa Clara,1121,U.S. Senate,,DEM,Loretta Sanchez,96
-Santa Clara,1123,U.S. Senate,,DEM,Kamala Harris,541
-Santa Clara,1123,U.S. Senate,,DEM,Loretta Sanchez,216
-Santa Clara,1125,U.S. Senate,,DEM,Kamala Harris,604
-Santa Clara,1125,U.S. Senate,,DEM,Loretta Sanchez,174
-Santa Clara,1127,U.S. Senate,,DEM,Kamala Harris,601
-Santa Clara,1127,U.S. Senate,,DEM,Loretta Sanchez,195
-Santa Clara,1129,U.S. Senate,,DEM,Kamala Harris,503
-Santa Clara,1129,U.S. Senate,,DEM,Loretta Sanchez,200
-Santa Clara,1131,U.S. Senate,,DEM,Kamala Harris,525
-Santa Clara,1131,U.S. Senate,,DEM,Loretta Sanchez,184
-Santa Clara,1133,U.S. Senate,,DEM,Kamala Harris,0
-Santa Clara,1133,U.S. Senate,,DEM,Loretta Sanchez,0
-Santa Clara,1134,U.S. Senate,,DEM,Kamala Harris,364
-Santa Clara,1134,U.S. Senate,,DEM,Loretta Sanchez,179
-Santa Clara,1135,U.S. Senate,,DEM,Kamala Harris,666
-Santa Clara,1135,U.S. Senate,,DEM,Loretta Sanchez,274
-Santa Clara,1137,U.S. Senate,,DEM,Kamala Harris,119
-Santa Clara,1137,U.S. Senate,,DEM,Loretta Sanchez,59
-Santa Clara,1138,U.S. Senate,,DEM,Kamala Harris,464
-Santa Clara,1138,U.S. Senate,,DEM,Loretta Sanchez,224
-Santa Clara,1141,U.S. Senate,,DEM,Kamala Harris,636
-Santa Clara,1141,U.S. Senate,,DEM,Loretta Sanchez,271
-Santa Clara,1142,U.S. Senate,,DEM,Kamala Harris,560
-Santa Clara,1142,U.S. Senate,,DEM,Loretta Sanchez,269
-Santa Clara,1144,U.S. Senate,,DEM,Kamala Harris,529
-Santa Clara,1144,U.S. Senate,,DEM,Loretta Sanchez,270
-Santa Clara,1145,U.S. Senate,,DEM,Kamala Harris,569
-Santa Clara,1145,U.S. Senate,,DEM,Loretta Sanchez,275
-Santa Clara,1146,U.S. Senate,,DEM,Kamala Harris,495
-Santa Clara,1146,U.S. Senate,,DEM,Loretta Sanchez,285
-Santa Clara,1149,U.S. Senate,,DEM,Kamala Harris,515
-Santa Clara,1149,U.S. Senate,,DEM,Loretta Sanchez,213
-Santa Clara,1152,U.S. Senate,,DEM,Kamala Harris,641
-Santa Clara,1152,U.S. Senate,,DEM,Loretta Sanchez,294
-Santa Clara,1153,U.S. Senate,,DEM,Kamala Harris,418
-Santa Clara,1153,U.S. Senate,,DEM,Loretta Sanchez,193
-Santa Clara,1154,U.S. Senate,,DEM,Kamala Harris,511
-Santa Clara,1154,U.S. Senate,,DEM,Loretta Sanchez,213
-Santa Clara,1156,U.S. Senate,,DEM,Kamala Harris,721
-Santa Clara,1156,U.S. Senate,,DEM,Loretta Sanchez,298
-Santa Clara,1158,U.S. Senate,,DEM,Kamala Harris,430
-Santa Clara,1158,U.S. Senate,,DEM,Loretta Sanchez,147
-Santa Clara,1159,U.S. Senate,,DEM,Kamala Harris,290
-Santa Clara,1159,U.S. Senate,,DEM,Loretta Sanchez,84
-Santa Clara,1160,U.S. Senate,,DEM,Kamala Harris,618
-Santa Clara,1160,U.S. Senate,,DEM,Loretta Sanchez,243
-Santa Clara,1161,U.S. Senate,,DEM,Kamala Harris,644
-Santa Clara,1161,U.S. Senate,,DEM,Loretta Sanchez,201
-Santa Clara,1163,U.S. Senate,,DEM,Kamala Harris,297
-Santa Clara,1163,U.S. Senate,,DEM,Loretta Sanchez,148
-Santa Clara,1169,U.S. Senate,,DEM,Kamala Harris,42
-Santa Clara,1169,U.S. Senate,,DEM,Loretta Sanchez,14
-Santa Clara,1198,U.S. Senate,,DEM,Kamala Harris,462
-Santa Clara,1198,U.S. Senate,,DEM,Loretta Sanchez,155
-Santa Clara,1199,U.S. Senate,,DEM,Kamala Harris,625
-Santa Clara,1199,U.S. Senate,,DEM,Loretta Sanchez,259
-Santa Clara,1201,U.S. Senate,,DEM,Kamala Harris,410
-Santa Clara,1201,U.S. Senate,,DEM,Loretta Sanchez,205
-Santa Clara,1204,U.S. Senate,,DEM,Kamala Harris,334
-Santa Clara,1204,U.S. Senate,,DEM,Loretta Sanchez,182
-Santa Clara,1205,U.S. Senate,,DEM,Kamala Harris,482
-Santa Clara,1205,U.S. Senate,,DEM,Loretta Sanchez,372
-Santa Clara,1206,U.S. Senate,,DEM,Kamala Harris,311
-Santa Clara,1206,U.S. Senate,,DEM,Loretta Sanchez,190
-Santa Clara,1207,U.S. Senate,,DEM,Kamala Harris,356
-Santa Clara,1207,U.S. Senate,,DEM,Loretta Sanchez,267
-Santa Clara,1208,U.S. Senate,,DEM,Kamala Harris,435
-Santa Clara,1208,U.S. Senate,,DEM,Loretta Sanchez,266
-Santa Clara,1209,U.S. Senate,,DEM,Kamala Harris,309
-Santa Clara,1209,U.S. Senate,,DEM,Loretta Sanchez,147
-Santa Clara,1210,U.S. Senate,,DEM,Kamala Harris,168
-Santa Clara,1210,U.S. Senate,,DEM,Loretta Sanchez,120
-Santa Clara,1211,U.S. Senate,,DEM,Kamala Harris,275
-Santa Clara,1211,U.S. Senate,,DEM,Loretta Sanchez,190
-Santa Clara,1212,U.S. Senate,,DEM,Kamala Harris,360
-Santa Clara,1212,U.S. Senate,,DEM,Loretta Sanchez,313
-Santa Clara,1213,U.S. Senate,,DEM,Kamala Harris,338
-Santa Clara,1213,U.S. Senate,,DEM,Loretta Sanchez,263
-Santa Clara,1214,U.S. Senate,,DEM,Kamala Harris,334
-Santa Clara,1214,U.S. Senate,,DEM,Loretta Sanchez,232
-Santa Clara,1215,U.S. Senate,,DEM,Kamala Harris,499
-Santa Clara,1215,U.S. Senate,,DEM,Loretta Sanchez,456
-Santa Clara,1217,U.S. Senate,,DEM,Kamala Harris,626
-Santa Clara,1217,U.S. Senate,,DEM,Loretta Sanchez,381
-Santa Clara,1218,U.S. Senate,,DEM,Kamala Harris,597
-Santa Clara,1218,U.S. Senate,,DEM,Loretta Sanchez,352
-Santa Clara,1220,U.S. Senate,,DEM,Kamala Harris,414
-Santa Clara,1220,U.S. Senate,,DEM,Loretta Sanchez,346
-Santa Clara,1221,U.S. Senate,,DEM,Kamala Harris,388
-Santa Clara,1221,U.S. Senate,,DEM,Loretta Sanchez,210
-Santa Clara,1222,U.S. Senate,,DEM,Kamala Harris,273
-Santa Clara,1222,U.S. Senate,,DEM,Loretta Sanchez,198
-Santa Clara,1223,U.S. Senate,,DEM,Kamala Harris,550
-Santa Clara,1223,U.S. Senate,,DEM,Loretta Sanchez,309
-Santa Clara,1224,U.S. Senate,,DEM,Kamala Harris,559
-Santa Clara,1224,U.S. Senate,,DEM,Loretta Sanchez,276
-Santa Clara,1226,U.S. Senate,,DEM,Kamala Harris,613
-Santa Clara,1226,U.S. Senate,,DEM,Loretta Sanchez,360
-Santa Clara,1228,U.S. Senate,,DEM,Kamala Harris,296
-Santa Clara,1228,U.S. Senate,,DEM,Loretta Sanchez,201
-Santa Clara,1229,U.S. Senate,,DEM,Kamala Harris,588
-Santa Clara,1229,U.S. Senate,,DEM,Loretta Sanchez,344
-Santa Clara,1231,U.S. Senate,,DEM,Kamala Harris,616
-Santa Clara,1231,U.S. Senate,,DEM,Loretta Sanchez,302
-Santa Clara,1232,U.S. Senate,,DEM,Kamala Harris,400
-Santa Clara,1232,U.S. Senate,,DEM,Loretta Sanchez,176
-Santa Clara,1233,U.S. Senate,,DEM,Kamala Harris,324
-Santa Clara,1233,U.S. Senate,,DEM,Loretta Sanchez,176
-Santa Clara,1236,U.S. Senate,,DEM,Kamala Harris,588
-Santa Clara,1236,U.S. Senate,,DEM,Loretta Sanchez,287
-Santa Clara,1238,U.S. Senate,,DEM,Kamala Harris,624
-Santa Clara,1238,U.S. Senate,,DEM,Loretta Sanchez,353
-Santa Clara,1239,U.S. Senate,,DEM,Kamala Harris,618
-Santa Clara,1239,U.S. Senate,,DEM,Loretta Sanchez,337
-Santa Clara,1240,U.S. Senate,,DEM,Kamala Harris,374
-Santa Clara,1240,U.S. Senate,,DEM,Loretta Sanchez,232
-Santa Clara,1242,U.S. Senate,,DEM,Kamala Harris,314
-Santa Clara,1242,U.S. Senate,,DEM,Loretta Sanchez,232
-Santa Clara,1243,U.S. Senate,,DEM,Kamala Harris,302
-Santa Clara,1243,U.S. Senate,,DEM,Loretta Sanchez,244
-Santa Clara,1244,U.S. Senate,,DEM,Kamala Harris,520
-Santa Clara,1244,U.S. Senate,,DEM,Loretta Sanchez,335
-Santa Clara,1246,U.S. Senate,,DEM,Kamala Harris,493
-Santa Clara,1246,U.S. Senate,,DEM,Loretta Sanchez,299
-Santa Clara,1247,U.S. Senate,,DEM,Kamala Harris,600
-Santa Clara,1247,U.S. Senate,,DEM,Loretta Sanchez,308
-Santa Clara,1250,U.S. Senate,,DEM,Kamala Harris,584
-Santa Clara,1250,U.S. Senate,,DEM,Loretta Sanchez,268
-Santa Clara,1252,U.S. Senate,,DEM,Kamala Harris,9
-Santa Clara,1252,U.S. Senate,,DEM,Loretta Sanchez,8
-Santa Clara,1253,U.S. Senate,,DEM,Kamala Harris,0
-Santa Clara,1253,U.S. Senate,,DEM,Loretta Sanchez,0
-Santa Clara,1254,U.S. Senate,,DEM,Kamala Harris,267
-Santa Clara,1254,U.S. Senate,,DEM,Loretta Sanchez,124
-Santa Clara,1263,U.S. Senate,,DEM,Kamala Harris,99
-Santa Clara,1263,U.S. Senate,,DEM,Loretta Sanchez,60
-Santa Clara,1266,U.S. Senate,,DEM,Kamala Harris,37
-Santa Clara,1266,U.S. Senate,,DEM,Loretta Sanchez,44
-Santa Clara,1271,U.S. Senate,,DEM,Kamala Harris,165
-Santa Clara,1271,U.S. Senate,,DEM,Loretta Sanchez,92
-Santa Clara,1274,U.S. Senate,,DEM,Kamala Harris,362
-Santa Clara,1274,U.S. Senate,,DEM,Loretta Sanchez,176
-Santa Clara,1276,U.S. Senate,,DEM,Kamala Harris,405
-Santa Clara,1276,U.S. Senate,,DEM,Loretta Sanchez,261
-Santa Clara,1281,U.S. Senate,,DEM,Kamala Harris,0
-Santa Clara,1281,U.S. Senate,,DEM,Loretta Sanchez,0
-Santa Clara,1289,U.S. Senate,,DEM,Kamala Harris,11
-Santa Clara,1289,U.S. Senate,,DEM,Loretta Sanchez,15
-Santa Clara,1290,U.S. Senate,,DEM,Kamala Harris,5
-Santa Clara,1290,U.S. Senate,,DEM,Loretta Sanchez,6
-Santa Clara,1301,U.S. Senate,,DEM,Kamala Harris,21
-Santa Clara,1301,U.S. Senate,,DEM,Loretta Sanchez,11
-Santa Clara,1302,U.S. Senate,,DEM,Kamala Harris,185
-Santa Clara,1302,U.S. Senate,,DEM,Loretta Sanchez,86
-Santa Clara,1303,U.S. Senate,,DEM,Kamala Harris,399
-Santa Clara,1303,U.S. Senate,,DEM,Loretta Sanchez,218
-Santa Clara,1304,U.S. Senate,,DEM,Kamala Harris,211
-Santa Clara,1304,U.S. Senate,,DEM,Loretta Sanchez,97
-Santa Clara,1305,U.S. Senate,,DEM,Kamala Harris,695
-Santa Clara,1305,U.S. Senate,,DEM,Loretta Sanchez,275
-Santa Clara,1306,U.S. Senate,,DEM,Kamala Harris,327
-Santa Clara,1306,U.S. Senate,,DEM,Loretta Sanchez,134
-Santa Clara,1307,U.S. Senate,,DEM,Kamala Harris,299
-Santa Clara,1307,U.S. Senate,,DEM,Loretta Sanchez,139
-Santa Clara,1308,U.S. Senate,,DEM,Kamala Harris,62
-Santa Clara,1308,U.S. Senate,,DEM,Loretta Sanchez,51
-Santa Clara,1310,U.S. Senate,,DEM,Kamala Harris,654
-Santa Clara,1310,U.S. Senate,,DEM,Loretta Sanchez,312
-Santa Clara,1311,U.S. Senate,,DEM,Kamala Harris,650
-Santa Clara,1311,U.S. Senate,,DEM,Loretta Sanchez,328
-Santa Clara,1312,U.S. Senate,,DEM,Kamala Harris,564
-Santa Clara,1312,U.S. Senate,,DEM,Loretta Sanchez,311
-Santa Clara,1313,U.S. Senate,,DEM,Kamala Harris,335
-Santa Clara,1313,U.S. Senate,,DEM,Loretta Sanchez,325
-Santa Clara,1314,U.S. Senate,,DEM,Kamala Harris,233
-Santa Clara,1314,U.S. Senate,,DEM,Loretta Sanchez,217
-Santa Clara,1315,U.S. Senate,,DEM,Kamala Harris,439
-Santa Clara,1315,U.S. Senate,,DEM,Loretta Sanchez,279
-Santa Clara,1316,U.S. Senate,,DEM,Kamala Harris,374
-Santa Clara,1316,U.S. Senate,,DEM,Loretta Sanchez,326
-Santa Clara,1317,U.S. Senate,,DEM,Kamala Harris,569
-Santa Clara,1317,U.S. Senate,,DEM,Loretta Sanchez,329
-Santa Clara,1319,U.S. Senate,,DEM,Kamala Harris,437
-Santa Clara,1319,U.S. Senate,,DEM,Loretta Sanchez,283
-Santa Clara,1321,U.S. Senate,,DEM,Kamala Harris,438
-Santa Clara,1321,U.S. Senate,,DEM,Loretta Sanchez,320
-Santa Clara,1322,U.S. Senate,,DEM,Kamala Harris,495
-Santa Clara,1322,U.S. Senate,,DEM,Loretta Sanchez,299
-Santa Clara,1323,U.S. Senate,,DEM,Kamala Harris,398
-Santa Clara,1323,U.S. Senate,,DEM,Loretta Sanchez,235
-Santa Clara,1324,U.S. Senate,,DEM,Kamala Harris,276
-Santa Clara,1324,U.S. Senate,,DEM,Loretta Sanchez,300
-Santa Clara,1325,U.S. Senate,,DEM,Kamala Harris,355
-Santa Clara,1325,U.S. Senate,,DEM,Loretta Sanchez,327
-Santa Clara,1326,U.S. Senate,,DEM,Kamala Harris,459
-Santa Clara,1326,U.S. Senate,,DEM,Loretta Sanchez,398
-Santa Clara,1327,U.S. Senate,,DEM,Kamala Harris,395
-Santa Clara,1327,U.S. Senate,,DEM,Loretta Sanchez,542
-Santa Clara,1329,U.S. Senate,,DEM,Kamala Harris,737
-Santa Clara,1329,U.S. Senate,,DEM,Loretta Sanchez,284
-Santa Clara,1330,U.S. Senate,,DEM,Kamala Harris,294
-Santa Clara,1330,U.S. Senate,,DEM,Loretta Sanchez,139
-Santa Clara,1333,U.S. Senate,,DEM,Kamala Harris,575
-Santa Clara,1333,U.S. Senate,,DEM,Loretta Sanchez,344
-Santa Clara,1334,U.S. Senate,,DEM,Kamala Harris,259
-Santa Clara,1334,U.S. Senate,,DEM,Loretta Sanchez,232
-Santa Clara,1336,U.S. Senate,,DEM,Kamala Harris,276
-Santa Clara,1336,U.S. Senate,,DEM,Loretta Sanchez,252
-Santa Clara,1338,U.S. Senate,,DEM,Kamala Harris,545
-Santa Clara,1338,U.S. Senate,,DEM,Loretta Sanchez,233
-Santa Clara,1339,U.S. Senate,,DEM,Kamala Harris,208
-Santa Clara,1339,U.S. Senate,,DEM,Loretta Sanchez,154
-Santa Clara,1340,U.S. Senate,,DEM,Kamala Harris,517
-Santa Clara,1340,U.S. Senate,,DEM,Loretta Sanchez,336
-Santa Clara,1343,U.S. Senate,,DEM,Kamala Harris,262
-Santa Clara,1343,U.S. Senate,,DEM,Loretta Sanchez,400
-Santa Clara,1344,U.S. Senate,,DEM,Kamala Harris,329
-Santa Clara,1344,U.S. Senate,,DEM,Loretta Sanchez,358
-Santa Clara,1345,U.S. Senate,,DEM,Kamala Harris,305
-Santa Clara,1345,U.S. Senate,,DEM,Loretta Sanchez,308
-Santa Clara,1346,U.S. Senate,,DEM,Kamala Harris,178
-Santa Clara,1346,U.S. Senate,,DEM,Loretta Sanchez,154
-Santa Clara,1347,U.S. Senate,,DEM,Kamala Harris,310
-Santa Clara,1347,U.S. Senate,,DEM,Loretta Sanchez,134
-Santa Clara,1348,U.S. Senate,,DEM,Kamala Harris,415
-Santa Clara,1348,U.S. Senate,,DEM,Loretta Sanchez,132
-Santa Clara,1356,U.S. Senate,,DEM,Kamala Harris,240
-Santa Clara,1356,U.S. Senate,,DEM,Loretta Sanchez,188
-Santa Clara,1357,U.S. Senate,,DEM,Kamala Harris,39
-Santa Clara,1357,U.S. Senate,,DEM,Loretta Sanchez,52
-Santa Clara,1358,U.S. Senate,,DEM,Kamala Harris,146
-Santa Clara,1358,U.S. Senate,,DEM,Loretta Sanchez,45
-Santa Clara,1359,U.S. Senate,,DEM,Kamala Harris,470
-Santa Clara,1359,U.S. Senate,,DEM,Loretta Sanchez,190
-Santa Clara,1360,U.S. Senate,,DEM,Kamala Harris,206
-Santa Clara,1360,U.S. Senate,,DEM,Loretta Sanchez,67
-Santa Clara,1361,U.S. Senate,,DEM,Kamala Harris,483
-Santa Clara,1361,U.S. Senate,,DEM,Loretta Sanchez,141
-Santa Clara,1364,U.S. Senate,,DEM,Kamala Harris,3
-Santa Clara,1364,U.S. Senate,,DEM,Loretta Sanchez,0
-Santa Clara,1365,U.S. Senate,,DEM,Kamala Harris,133
-Santa Clara,1365,U.S. Senate,,DEM,Loretta Sanchez,67
-Santa Clara,1366,U.S. Senate,,DEM,Kamala Harris,106
-Santa Clara,1366,U.S. Senate,,DEM,Loretta Sanchez,112
-Santa Clara,1367,U.S. Senate,,DEM,Kamala Harris,0
-Santa Clara,1367,U.S. Senate,,DEM,Loretta Sanchez,0
-Santa Clara,1368,U.S. Senate,,DEM,Kamala Harris,676
-Santa Clara,1368,U.S. Senate,,DEM,Loretta Sanchez,212
-Santa Clara,1369,U.S. Senate,,DEM,Kamala Harris,0
-Santa Clara,1369,U.S. Senate,,DEM,Loretta Sanchez,0
-Santa Clara,1370,U.S. Senate,,DEM,Kamala Harris,0
-Santa Clara,1370,U.S. Senate,,DEM,Loretta Sanchez,3
-Santa Clara,1380,U.S. Senate,,DEM,Kamala Harris,25
-Santa Clara,1380,U.S. Senate,,DEM,Loretta Sanchez,9
-Santa Clara,1398,U.S. Senate,,DEM,Kamala Harris,313
-Santa Clara,1398,U.S. Senate,,DEM,Loretta Sanchez,457
-Santa Clara,1399,U.S. Senate,,DEM,Kamala Harris,429
-Santa Clara,1399,U.S. Senate,,DEM,Loretta Sanchez,442
-Santa Clara,1401,U.S. Senate,,DEM,Kamala Harris,284
-Santa Clara,1401,U.S. Senate,,DEM,Loretta Sanchez,335
-Santa Clara,1402,U.S. Senate,,DEM,Kamala Harris,215
-Santa Clara,1402,U.S. Senate,,DEM,Loretta Sanchez,170
-Santa Clara,1403,U.S. Senate,,DEM,Kamala Harris,516
-Santa Clara,1403,U.S. Senate,,DEM,Loretta Sanchez,418
-Santa Clara,1405,U.S. Senate,,DEM,Kamala Harris,3
-Santa Clara,1405,U.S. Senate,,DEM,Loretta Sanchez,2
-Santa Clara,1406,U.S. Senate,,DEM,Kamala Harris,11
-Santa Clara,1406,U.S. Senate,,DEM,Loretta Sanchez,5
-Santa Clara,1407,U.S. Senate,,DEM,Kamala Harris,255
-Santa Clara,1407,U.S. Senate,,DEM,Loretta Sanchez,248
-Santa Clara,1408,U.S. Senate,,DEM,Kamala Harris,594
-Santa Clara,1408,U.S. Senate,,DEM,Loretta Sanchez,427
-Santa Clara,1409,U.S. Senate,,DEM,Kamala Harris,371
-Santa Clara,1409,U.S. Senate,,DEM,Loretta Sanchez,329
-Santa Clara,1410,U.S. Senate,,DEM,Kamala Harris,369
-Santa Clara,1410,U.S. Senate,,DEM,Loretta Sanchez,339
-Santa Clara,1411,U.S. Senate,,DEM,Kamala Harris,360
-Santa Clara,1411,U.S. Senate,,DEM,Loretta Sanchez,274
-Santa Clara,1413,U.S. Senate,,DEM,Kamala Harris,371
-Santa Clara,1413,U.S. Senate,,DEM,Loretta Sanchez,267
-Santa Clara,1414,U.S. Senate,,DEM,Kamala Harris,319
-Santa Clara,1414,U.S. Senate,,DEM,Loretta Sanchez,233
-Santa Clara,1415,U.S. Senate,,DEM,Kamala Harris,348
-Santa Clara,1415,U.S. Senate,,DEM,Loretta Sanchez,263
-Santa Clara,1416,U.S. Senate,,DEM,Kamala Harris,322
-Santa Clara,1416,U.S. Senate,,DEM,Loretta Sanchez,218
-Santa Clara,1417,U.S. Senate,,DEM,Kamala Harris,653
-Santa Clara,1417,U.S. Senate,,DEM,Loretta Sanchez,386
-Santa Clara,1419,U.S. Senate,,DEM,Kamala Harris,536
-Santa Clara,1419,U.S. Senate,,DEM,Loretta Sanchez,376
-Santa Clara,1420,U.S. Senate,,DEM,Kamala Harris,596
-Santa Clara,1420,U.S. Senate,,DEM,Loretta Sanchez,335
-Santa Clara,1422,U.S. Senate,,DEM,Kamala Harris,590
-Santa Clara,1422,U.S. Senate,,DEM,Loretta Sanchez,451
-Santa Clara,1423,U.S. Senate,,DEM,Kamala Harris,367
-Santa Clara,1423,U.S. Senate,,DEM,Loretta Sanchez,318
-Santa Clara,1424,U.S. Senate,,DEM,Kamala Harris,428
-Santa Clara,1424,U.S. Senate,,DEM,Loretta Sanchez,439
-Santa Clara,1425,U.S. Senate,,DEM,Kamala Harris,321
-Santa Clara,1425,U.S. Senate,,DEM,Loretta Sanchez,321
-Santa Clara,1426,U.S. Senate,,DEM,Kamala Harris,162
-Santa Clara,1426,U.S. Senate,,DEM,Loretta Sanchez,120
-Santa Clara,1427,U.S. Senate,,DEM,Kamala Harris,325
-Santa Clara,1427,U.S. Senate,,DEM,Loretta Sanchez,194
-Santa Clara,1428,U.S. Senate,,DEM,Kamala Harris,478
-Santa Clara,1428,U.S. Senate,,DEM,Loretta Sanchez,286
-Santa Clara,1429,U.S. Senate,,DEM,Kamala Harris,284
-Santa Clara,1429,U.S. Senate,,DEM,Loretta Sanchez,193
-Santa Clara,1431,U.S. Senate,,DEM,Kamala Harris,405
-Santa Clara,1431,U.S. Senate,,DEM,Loretta Sanchez,240
-Santa Clara,1432,U.S. Senate,,DEM,Kamala Harris,578
-Santa Clara,1432,U.S. Senate,,DEM,Loretta Sanchez,400
-Santa Clara,1433,U.S. Senate,,DEM,Kamala Harris,416
-Santa Clara,1433,U.S. Senate,,DEM,Loretta Sanchez,223
-Santa Clara,1434,U.S. Senate,,DEM,Kamala Harris,421
-Santa Clara,1434,U.S. Senate,,DEM,Loretta Sanchez,359
-Santa Clara,1435,U.S. Senate,,DEM,Kamala Harris,313
-Santa Clara,1435,U.S. Senate,,DEM,Loretta Sanchez,180
-Santa Clara,1436,U.S. Senate,,DEM,Kamala Harris,452
-Santa Clara,1436,U.S. Senate,,DEM,Loretta Sanchez,311
-Santa Clara,1439,U.S. Senate,,DEM,Kamala Harris,763
-Santa Clara,1439,U.S. Senate,,DEM,Loretta Sanchez,376
-Santa Clara,1440,U.S. Senate,,DEM,Kamala Harris,42
-Santa Clara,1440,U.S. Senate,,DEM,Loretta Sanchez,69
-Santa Clara,1443,U.S. Senate,,DEM,Kamala Harris,62
-Santa Clara,1443,U.S. Senate,,DEM,Loretta Sanchez,39
-Santa Clara,1444,U.S. Senate,,DEM,Kamala Harris,460
-Santa Clara,1444,U.S. Senate,,DEM,Loretta Sanchez,341
-Santa Clara,1446,U.S. Senate,,DEM,Kamala Harris,597
-Santa Clara,1446,U.S. Senate,,DEM,Loretta Sanchez,448
-Santa Clara,1447,U.S. Senate,,DEM,Kamala Harris,314
-Santa Clara,1447,U.S. Senate,,DEM,Loretta Sanchez,220
-Santa Clara,1448,U.S. Senate,,DEM,Kamala Harris,277
-Santa Clara,1448,U.S. Senate,,DEM,Loretta Sanchez,220
-Santa Clara,1449,U.S. Senate,,DEM,Kamala Harris,387
-Santa Clara,1449,U.S. Senate,,DEM,Loretta Sanchez,219
-Santa Clara,1450,U.S. Senate,,DEM,Kamala Harris,383
-Santa Clara,1450,U.S. Senate,,DEM,Loretta Sanchez,270
-Santa Clara,1451,U.S. Senate,,DEM,Kamala Harris,458
-Santa Clara,1451,U.S. Senate,,DEM,Loretta Sanchez,341
-Santa Clara,1453,U.S. Senate,,DEM,Kamala Harris,386
-Santa Clara,1453,U.S. Senate,,DEM,Loretta Sanchez,264
-Santa Clara,1455,U.S. Senate,,DEM,Kamala Harris,496
-Santa Clara,1455,U.S. Senate,,DEM,Loretta Sanchez,340
-Santa Clara,1459,U.S. Senate,,DEM,Kamala Harris,664
-Santa Clara,1459,U.S. Senate,,DEM,Loretta Sanchez,300
-Santa Clara,1461,U.S. Senate,,DEM,Kamala Harris,497
-Santa Clara,1461,U.S. Senate,,DEM,Loretta Sanchez,233
-Santa Clara,1465,U.S. Senate,,DEM,Kamala Harris,675
-Santa Clara,1465,U.S. Senate,,DEM,Loretta Sanchez,306
-Santa Clara,1467,U.S. Senate,,DEM,Kamala Harris,442
-Santa Clara,1467,U.S. Senate,,DEM,Loretta Sanchez,236
-Santa Clara,1469,U.S. Senate,,DEM,Kamala Harris,371
-Santa Clara,1469,U.S. Senate,,DEM,Loretta Sanchez,255
-Santa Clara,1470,U.S. Senate,,DEM,Kamala Harris,386
-Santa Clara,1470,U.S. Senate,,DEM,Loretta Sanchez,454
-Santa Clara,1472,U.S. Senate,,DEM,Kamala Harris,541
-Santa Clara,1472,U.S. Senate,,DEM,Loretta Sanchez,293
-Santa Clara,1481,U.S. Senate,,DEM,Kamala Harris,0
-Santa Clara,1481,U.S. Senate,,DEM,Loretta Sanchez,0
-Santa Clara,1482,U.S. Senate,,DEM,Kamala Harris,447
-Santa Clara,1482,U.S. Senate,,DEM,Loretta Sanchez,231
-Santa Clara,1483,U.S. Senate,,DEM,Kamala Harris,0
-Santa Clara,1483,U.S. Senate,,DEM,Loretta Sanchez,0
-Santa Clara,1497,U.S. Senate,,DEM,Kamala Harris,441
-Santa Clara,1497,U.S. Senate,,DEM,Loretta Sanchez,216
-Santa Clara,1501,U.S. Senate,,DEM,Kamala Harris,127
-Santa Clara,1501,U.S. Senate,,DEM,Loretta Sanchez,104
-Santa Clara,1502,U.S. Senate,,DEM,Kamala Harris,8
-Santa Clara,1502,U.S. Senate,,DEM,Loretta Sanchez,15
-Santa Clara,1504,U.S. Senate,,DEM,Kamala Harris,408
-Santa Clara,1504,U.S. Senate,,DEM,Loretta Sanchez,498
-Santa Clara,1505,U.S. Senate,,DEM,Kamala Harris,268
-Santa Clara,1505,U.S. Senate,,DEM,Loretta Sanchez,295
-Santa Clara,1506,U.S. Senate,,DEM,Kamala Harris,370
-Santa Clara,1506,U.S. Senate,,DEM,Loretta Sanchez,436
-Santa Clara,1508,U.S. Senate,,DEM,Kamala Harris,297
-Santa Clara,1508,U.S. Senate,,DEM,Loretta Sanchez,290
-Santa Clara,1509,U.S. Senate,,DEM,Kamala Harris,227
-Santa Clara,1509,U.S. Senate,,DEM,Loretta Sanchez,250
-Santa Clara,1510,U.S. Senate,,DEM,Kamala Harris,242
-Santa Clara,1510,U.S. Senate,,DEM,Loretta Sanchez,343
-Santa Clara,1512,U.S. Senate,,DEM,Kamala Harris,312
-Santa Clara,1512,U.S. Senate,,DEM,Loretta Sanchez,578
-Santa Clara,1513,U.S. Senate,,DEM,Kamala Harris,338
-Santa Clara,1513,U.S. Senate,,DEM,Loretta Sanchez,361
-Santa Clara,1515,U.S. Senate,,DEM,Kamala Harris,425
-Santa Clara,1515,U.S. Senate,,DEM,Loretta Sanchez,289
-Santa Clara,1516,U.S. Senate,,DEM,Kamala Harris,323
-Santa Clara,1516,U.S. Senate,,DEM,Loretta Sanchez,522
-Santa Clara,1517,U.S. Senate,,DEM,Kamala Harris,204
-Santa Clara,1517,U.S. Senate,,DEM,Loretta Sanchez,279
-Santa Clara,1518,U.S. Senate,,DEM,Kamala Harris,308
-Santa Clara,1518,U.S. Senate,,DEM,Loretta Sanchez,430
-Santa Clara,1519,U.S. Senate,,DEM,Kamala Harris,463
-Santa Clara,1519,U.S. Senate,,DEM,Loretta Sanchez,483
-Santa Clara,1521,U.S. Senate,,DEM,Kamala Harris,347
-Santa Clara,1521,U.S. Senate,,DEM,Loretta Sanchez,434
-Santa Clara,1523,U.S. Senate,,DEM,Kamala Harris,334
-Santa Clara,1523,U.S. Senate,,DEM,Loretta Sanchez,455
-Santa Clara,1525,U.S. Senate,,DEM,Kamala Harris,375
-Santa Clara,1525,U.S. Senate,,DEM,Loretta Sanchez,342
-Santa Clara,1526,U.S. Senate,,DEM,Kamala Harris,230
-Santa Clara,1526,U.S. Senate,,DEM,Loretta Sanchez,236
-Santa Clara,1527,U.S. Senate,,DEM,Kamala Harris,430
-Santa Clara,1527,U.S. Senate,,DEM,Loretta Sanchez,589
-Santa Clara,1528,U.S. Senate,,DEM,Kamala Harris,335
-Santa Clara,1528,U.S. Senate,,DEM,Loretta Sanchez,489
-Santa Clara,1530,U.S. Senate,,DEM,Kamala Harris,283
-Santa Clara,1530,U.S. Senate,,DEM,Loretta Sanchez,459
-Santa Clara,1531,U.S. Senate,,DEM,Kamala Harris,195
-Santa Clara,1531,U.S. Senate,,DEM,Loretta Sanchez,281
-Santa Clara,1534,U.S. Senate,,DEM,Kamala Harris,311
-Santa Clara,1534,U.S. Senate,,DEM,Loretta Sanchez,562
-Santa Clara,1535,U.S. Senate,,DEM,Kamala Harris,181
-Santa Clara,1535,U.S. Senate,,DEM,Loretta Sanchez,248
-Santa Clara,1536,U.S. Senate,,DEM,Kamala Harris,272
-Santa Clara,1536,U.S. Senate,,DEM,Loretta Sanchez,467
-Santa Clara,1537,U.S. Senate,,DEM,Kamala Harris,346
-Santa Clara,1537,U.S. Senate,,DEM,Loretta Sanchez,607
-Santa Clara,1539,U.S. Senate,,DEM,Kamala Harris,194
-Santa Clara,1539,U.S. Senate,,DEM,Loretta Sanchez,286
-Santa Clara,1543,U.S. Senate,,DEM,Kamala Harris,56
-Santa Clara,1543,U.S. Senate,,DEM,Loretta Sanchez,96
-Santa Clara,1544,U.S. Senate,,DEM,Kamala Harris,367
-Santa Clara,1544,U.S. Senate,,DEM,Loretta Sanchez,513
-Santa Clara,1546,U.S. Senate,,DEM,Kamala Harris,585
-Santa Clara,1546,U.S. Senate,,DEM,Loretta Sanchez,419
-Santa Clara,1548,U.S. Senate,,DEM,Kamala Harris,71
-Santa Clara,1548,U.S. Senate,,DEM,Loretta Sanchez,86
-Santa Clara,1550,U.S. Senate,,DEM,Kamala Harris,83
-Santa Clara,1550,U.S. Senate,,DEM,Loretta Sanchez,43
-Santa Clara,1551,U.S. Senate,,DEM,Kamala Harris,325
-Santa Clara,1551,U.S. Senate,,DEM,Loretta Sanchez,442
-Santa Clara,1553,U.S. Senate,,DEM,Kamala Harris,253
-Santa Clara,1553,U.S. Senate,,DEM,Loretta Sanchez,203
-Santa Clara,1555,U.S. Senate,,DEM,Kamala Harris,160
-Santa Clara,1555,U.S. Senate,,DEM,Loretta Sanchez,113
-Santa Clara,1556,U.S. Senate,,DEM,Kamala Harris,164
-Santa Clara,1556,U.S. Senate,,DEM,Loretta Sanchez,108
-Santa Clara,1558,U.S. Senate,,DEM,Kamala Harris,336
-Santa Clara,1558,U.S. Senate,,DEM,Loretta Sanchez,521
-Santa Clara,1560,U.S. Senate,,DEM,Kamala Harris,14
-Santa Clara,1560,U.S. Senate,,DEM,Loretta Sanchez,6
-Santa Clara,1562,U.S. Senate,,DEM,Kamala Harris,0
-Santa Clara,1562,U.S. Senate,,DEM,Loretta Sanchez,0
-Santa Clara,1570,U.S. Senate,,DEM,Kamala Harris,1
-Santa Clara,1570,U.S. Senate,,DEM,Loretta Sanchez,0
-Santa Clara,1571,U.S. Senate,,DEM,Kamala Harris,110
-Santa Clara,1571,U.S. Senate,,DEM,Loretta Sanchez,52
-Santa Clara,1574,U.S. Senate,,DEM,Kamala Harris,1
-Santa Clara,1574,U.S. Senate,,DEM,Loretta Sanchez,2
-Santa Clara,1578,U.S. Senate,,DEM,Kamala Harris,197
-Santa Clara,1578,U.S. Senate,,DEM,Loretta Sanchez,180
-Santa Clara,1586,U.S. Senate,,DEM,Kamala Harris,6
-Santa Clara,1586,U.S. Senate,,DEM,Loretta Sanchez,5
-Santa Clara,1587,U.S. Senate,,DEM,Kamala Harris,641
-Santa Clara,1587,U.S. Senate,,DEM,Loretta Sanchez,261
-Santa Clara,1588,U.S. Senate,,DEM,Kamala Harris,218
-Santa Clara,1588,U.S. Senate,,DEM,Loretta Sanchez,94
-Santa Clara,1590,U.S. Senate,,DEM,Kamala Harris,378
-Santa Clara,1590,U.S. Senate,,DEM,Loretta Sanchez,411
-Santa Clara,1591,U.S. Senate,,DEM,Kamala Harris,5
-Santa Clara,1591,U.S. Senate,,DEM,Loretta Sanchez,2
-Santa Clara,1592,U.S. Senate,,DEM,Kamala Harris,226
-Santa Clara,1592,U.S. Senate,,DEM,Loretta Sanchez,149
-Santa Clara,1593,U.S. Senate,,DEM,Kamala Harris,105
-Santa Clara,1593,U.S. Senate,,DEM,Loretta Sanchez,39
-Santa Clara,1595,U.S. Senate,,DEM,Kamala Harris,1
-Santa Clara,1595,U.S. Senate,,DEM,Loretta Sanchez,1
-Santa Clara,1597,U.S. Senate,,DEM,Kamala Harris,217
-Santa Clara,1597,U.S. Senate,,DEM,Loretta Sanchez,366
-Santa Clara,1599,U.S. Senate,,DEM,Kamala Harris,688
-Santa Clara,1599,U.S. Senate,,DEM,Loretta Sanchez,336
-Santa Clara,1600,U.S. Senate,,DEM,Kamala Harris,102
-Santa Clara,1600,U.S. Senate,,DEM,Loretta Sanchez,92
-Santa Clara,1601,U.S. Senate,,DEM,Kamala Harris,345
-Santa Clara,1601,U.S. Senate,,DEM,Loretta Sanchez,182
-Santa Clara,1602,U.S. Senate,,DEM,Kamala Harris,392
-Santa Clara,1602,U.S. Senate,,DEM,Loretta Sanchez,164
-Santa Clara,1603,U.S. Senate,,DEM,Kamala Harris,669
-Santa Clara,1603,U.S. Senate,,DEM,Loretta Sanchez,257
-Santa Clara,1605,U.S. Senate,,DEM,Kamala Harris,593
-Santa Clara,1605,U.S. Senate,,DEM,Loretta Sanchez,360
-Santa Clara,1607,U.S. Senate,,DEM,Kamala Harris,311
-Santa Clara,1607,U.S. Senate,,DEM,Loretta Sanchez,169
-Santa Clara,1608,U.S. Senate,,DEM,Kamala Harris,468
-Santa Clara,1608,U.S. Senate,,DEM,Loretta Sanchez,227
-Santa Clara,1610,U.S. Senate,,DEM,Kamala Harris,607
-Santa Clara,1610,U.S. Senate,,DEM,Loretta Sanchez,321
-Santa Clara,1612,U.S. Senate,,DEM,Kamala Harris,569
-Santa Clara,1612,U.S. Senate,,DEM,Loretta Sanchez,233
-Santa Clara,1613,U.S. Senate,,DEM,Kamala Harris,705
-Santa Clara,1613,U.S. Senate,,DEM,Loretta Sanchez,286
-Santa Clara,1616,U.S. Senate,,DEM,Kamala Harris,663
-Santa Clara,1616,U.S. Senate,,DEM,Loretta Sanchez,307
-Santa Clara,1618,U.S. Senate,,DEM,Kamala Harris,237
-Santa Clara,1618,U.S. Senate,,DEM,Loretta Sanchez,116
-Santa Clara,1619,U.S. Senate,,DEM,Kamala Harris,45
-Santa Clara,1619,U.S. Senate,,DEM,Loretta Sanchez,22
-Santa Clara,1621,U.S. Senate,,DEM,Kamala Harris,826
-Santa Clara,1621,U.S. Senate,,DEM,Loretta Sanchez,291
-Santa Clara,1622,U.S. Senate,,DEM,Kamala Harris,492
-Santa Clara,1622,U.S. Senate,,DEM,Loretta Sanchez,202
-Santa Clara,1623,U.S. Senate,,DEM,Kamala Harris,787
-Santa Clara,1623,U.S. Senate,,DEM,Loretta Sanchez,257
-Santa Clara,1625,U.S. Senate,,DEM,Kamala Harris,344
-Santa Clara,1625,U.S. Senate,,DEM,Loretta Sanchez,217
-Santa Clara,1629,U.S. Senate,,DEM,Kamala Harris,383
-Santa Clara,1629,U.S. Senate,,DEM,Loretta Sanchez,241
-Santa Clara,1631,U.S. Senate,,DEM,Kamala Harris,613
-Santa Clara,1631,U.S. Senate,,DEM,Loretta Sanchez,253
-Santa Clara,1632,U.S. Senate,,DEM,Kamala Harris,15
-Santa Clara,1632,U.S. Senate,,DEM,Loretta Sanchez,12
-Santa Clara,1634,U.S. Senate,,DEM,Kamala Harris,495
-Santa Clara,1634,U.S. Senate,,DEM,Loretta Sanchez,318
-Santa Clara,1635,U.S. Senate,,DEM,Kamala Harris,733
-Santa Clara,1635,U.S. Senate,,DEM,Loretta Sanchez,305
-Santa Clara,1636,U.S. Senate,,DEM,Kamala Harris,121
-Santa Clara,1636,U.S. Senate,,DEM,Loretta Sanchez,73
-Santa Clara,1638,U.S. Senate,,DEM,Kamala Harris,583
-Santa Clara,1638,U.S. Senate,,DEM,Loretta Sanchez,194
-Santa Clara,1639,U.S. Senate,,DEM,Kamala Harris,611
-Santa Clara,1639,U.S. Senate,,DEM,Loretta Sanchez,306
-Santa Clara,1640,U.S. Senate,,DEM,Kamala Harris,729
-Santa Clara,1640,U.S. Senate,,DEM,Loretta Sanchez,270
-Santa Clara,1645,U.S. Senate,,DEM,Kamala Harris,370
-Santa Clara,1645,U.S. Senate,,DEM,Loretta Sanchez,140
-Santa Clara,1646,U.S. Senate,,DEM,Kamala Harris,420
-Santa Clara,1646,U.S. Senate,,DEM,Loretta Sanchez,174
-Santa Clara,1648,U.S. Senate,,DEM,Kamala Harris,767
-Santa Clara,1648,U.S. Senate,,DEM,Loretta Sanchez,305
-Santa Clara,1649,U.S. Senate,,DEM,Kamala Harris,655
-Santa Clara,1649,U.S. Senate,,DEM,Loretta Sanchez,242
-Santa Clara,1650,U.S. Senate,,DEM,Kamala Harris,220
-Santa Clara,1650,U.S. Senate,,DEM,Loretta Sanchez,97
-Santa Clara,1654,U.S. Senate,,DEM,Kamala Harris,540
-Santa Clara,1654,U.S. Senate,,DEM,Loretta Sanchez,209
-Santa Clara,1656,U.S. Senate,,DEM,Kamala Harris,639
-Santa Clara,1656,U.S. Senate,,DEM,Loretta Sanchez,269
-Santa Clara,1658,U.S. Senate,,DEM,Kamala Harris,712
-Santa Clara,1658,U.S. Senate,,DEM,Loretta Sanchez,206
-Santa Clara,1661,U.S. Senate,,DEM,Kamala Harris,69
-Santa Clara,1661,U.S. Senate,,DEM,Loretta Sanchez,43
-Santa Clara,1662,U.S. Senate,,DEM,Kamala Harris,464
-Santa Clara,1662,U.S. Senate,,DEM,Loretta Sanchez,144
-Santa Clara,1663,U.S. Senate,,DEM,Kamala Harris,432
-Santa Clara,1663,U.S. Senate,,DEM,Loretta Sanchez,147
-Santa Clara,1664,U.S. Senate,,DEM,Kamala Harris,552
-Santa Clara,1664,U.S. Senate,,DEM,Loretta Sanchez,177
-Santa Clara,1666,U.S. Senate,,DEM,Kamala Harris,649
-Santa Clara,1666,U.S. Senate,,DEM,Loretta Sanchez,285
-Santa Clara,1667,U.S. Senate,,DEM,Kamala Harris,397
-Santa Clara,1667,U.S. Senate,,DEM,Loretta Sanchez,303
-Santa Clara,1668,U.S. Senate,,DEM,Kamala Harris,488
-Santa Clara,1668,U.S. Senate,,DEM,Loretta Sanchez,315
-Santa Clara,1669,U.S. Senate,,DEM,Kamala Harris,47
-Santa Clara,1669,U.S. Senate,,DEM,Loretta Sanchez,15
-Santa Clara,1671,U.S. Senate,,DEM,Kamala Harris,630
-Santa Clara,1671,U.S. Senate,,DEM,Loretta Sanchez,207
-Santa Clara,1672,U.S. Senate,,DEM,Kamala Harris,353
-Santa Clara,1672,U.S. Senate,,DEM,Loretta Sanchez,134
-Santa Clara,1673,U.S. Senate,,DEM,Kamala Harris,399
-Santa Clara,1673,U.S. Senate,,DEM,Loretta Sanchez,162
-Santa Clara,1675,U.S. Senate,,DEM,Kamala Harris,521
-Santa Clara,1675,U.S. Senate,,DEM,Loretta Sanchez,227
-Santa Clara,1677,U.S. Senate,,DEM,Kamala Harris,397
-Santa Clara,1677,U.S. Senate,,DEM,Loretta Sanchez,200
-Santa Clara,1679,U.S. Senate,,DEM,Kamala Harris,15
-Santa Clara,1679,U.S. Senate,,DEM,Loretta Sanchez,10
-Santa Clara,1683,U.S. Senate,,DEM,Kamala Harris,460
-Santa Clara,1683,U.S. Senate,,DEM,Loretta Sanchez,170
-Santa Clara,1685,U.S. Senate,,DEM,Kamala Harris,217
-Santa Clara,1685,U.S. Senate,,DEM,Loretta Sanchez,138
-Santa Clara,1687,U.S. Senate,,DEM,Kamala Harris,814
-Santa Clara,1687,U.S. Senate,,DEM,Loretta Sanchez,297
-Santa Clara,1693,U.S. Senate,,DEM,Kamala Harris,10
-Santa Clara,1693,U.S. Senate,,DEM,Loretta Sanchez,5
-Santa Clara,1700,U.S. Senate,,DEM,Kamala Harris,579
-Santa Clara,1700,U.S. Senate,,DEM,Loretta Sanchez,195
-Santa Clara,1701,U.S. Senate,,DEM,Kamala Harris,470
-Santa Clara,1701,U.S. Senate,,DEM,Loretta Sanchez,408
-Santa Clara,1702,U.S. Senate,,DEM,Kamala Harris,297
-Santa Clara,1702,U.S. Senate,,DEM,Loretta Sanchez,263
-Santa Clara,1704,U.S. Senate,,DEM,Kamala Harris,151
-Santa Clara,1704,U.S. Senate,,DEM,Loretta Sanchez,205
-Santa Clara,1706,U.S. Senate,,DEM,Kamala Harris,583
-Santa Clara,1706,U.S. Senate,,DEM,Loretta Sanchez,274
-Santa Clara,1707,U.S. Senate,,DEM,Kamala Harris,219
-Santa Clara,1707,U.S. Senate,,DEM,Loretta Sanchez,379
-Santa Clara,1708,U.S. Senate,,DEM,Kamala Harris,250
-Santa Clara,1708,U.S. Senate,,DEM,Loretta Sanchez,441
-Santa Clara,1709,U.S. Senate,,DEM,Kamala Harris,224
-Santa Clara,1709,U.S. Senate,,DEM,Loretta Sanchez,404
-Santa Clara,1710,U.S. Senate,,DEM,Kamala Harris,141
-Santa Clara,1710,U.S. Senate,,DEM,Loretta Sanchez,327
-Santa Clara,1711,U.S. Senate,,DEM,Kamala Harris,273
-Santa Clara,1711,U.S. Senate,,DEM,Loretta Sanchez,383
-Santa Clara,1712,U.S. Senate,,DEM,Kamala Harris,210
-Santa Clara,1712,U.S. Senate,,DEM,Loretta Sanchez,272
-Santa Clara,1713,U.S. Senate,,DEM,Kamala Harris,250
-Santa Clara,1713,U.S. Senate,,DEM,Loretta Sanchez,343
-Santa Clara,1715,U.S. Senate,,DEM,Kamala Harris,291
-Santa Clara,1715,U.S. Senate,,DEM,Loretta Sanchez,370
-Santa Clara,1716,U.S. Senate,,DEM,Kamala Harris,256
-Santa Clara,1716,U.S. Senate,,DEM,Loretta Sanchez,285
-Santa Clara,1717,U.S. Senate,,DEM,Kamala Harris,262
-Santa Clara,1717,U.S. Senate,,DEM,Loretta Sanchez,267
-Santa Clara,1718,U.S. Senate,,DEM,Kamala Harris,294
-Santa Clara,1718,U.S. Senate,,DEM,Loretta Sanchez,385
-Santa Clara,1719,U.S. Senate,,DEM,Kamala Harris,254
-Santa Clara,1719,U.S. Senate,,DEM,Loretta Sanchez,316
-Santa Clara,1720,U.S. Senate,,DEM,Kamala Harris,265
-Santa Clara,1720,U.S. Senate,,DEM,Loretta Sanchez,361
-Santa Clara,1721,U.S. Senate,,DEM,Kamala Harris,215
-Santa Clara,1721,U.S. Senate,,DEM,Loretta Sanchez,352
-Santa Clara,1723,U.S. Senate,,DEM,Kamala Harris,215
-Santa Clara,1723,U.S. Senate,,DEM,Loretta Sanchez,292
-Santa Clara,1724,U.S. Senate,,DEM,Kamala Harris,295
-Santa Clara,1724,U.S. Senate,,DEM,Loretta Sanchez,418
-Santa Clara,1726,U.S. Senate,,DEM,Kamala Harris,227
-Santa Clara,1726,U.S. Senate,,DEM,Loretta Sanchez,285
-Santa Clara,1727,U.S. Senate,,DEM,Kamala Harris,303
-Santa Clara,1727,U.S. Senate,,DEM,Loretta Sanchez,316
-Santa Clara,1728,U.S. Senate,,DEM,Kamala Harris,256
-Santa Clara,1728,U.S. Senate,,DEM,Loretta Sanchez,413
-Santa Clara,1729,U.S. Senate,,DEM,Kamala Harris,222
-Santa Clara,1729,U.S. Senate,,DEM,Loretta Sanchez,311
-Santa Clara,1730,U.S. Senate,,DEM,Kamala Harris,133
-Santa Clara,1730,U.S. Senate,,DEM,Loretta Sanchez,186
-Santa Clara,1732,U.S. Senate,,DEM,Kamala Harris,388
-Santa Clara,1732,U.S. Senate,,DEM,Loretta Sanchez,580
-Santa Clara,1735,U.S. Senate,,DEM,Kamala Harris,359
-Santa Clara,1735,U.S. Senate,,DEM,Loretta Sanchez,572
-Santa Clara,1737,U.S. Senate,,DEM,Kamala Harris,319
-Santa Clara,1737,U.S. Senate,,DEM,Loretta Sanchez,577
-Santa Clara,1740,U.S. Senate,,DEM,Kamala Harris,225
-Santa Clara,1740,U.S. Senate,,DEM,Loretta Sanchez,207
-Santa Clara,1743,U.S. Senate,,DEM,Kamala Harris,601
-Santa Clara,1743,U.S. Senate,,DEM,Loretta Sanchez,256
-Santa Clara,1744,U.S. Senate,,DEM,Kamala Harris,668
-Santa Clara,1744,U.S. Senate,,DEM,Loretta Sanchez,406
-Santa Clara,1746,U.S. Senate,,DEM,Kamala Harris,300
-Santa Clara,1746,U.S. Senate,,DEM,Loretta Sanchez,335
-Santa Clara,1747,U.S. Senate,,DEM,Kamala Harris,407
-Santa Clara,1747,U.S. Senate,,DEM,Loretta Sanchez,263
-Santa Clara,1751,U.S. Senate,,DEM,Kamala Harris,562
-Santa Clara,1751,U.S. Senate,,DEM,Loretta Sanchez,311
-Santa Clara,1753,U.S. Senate,,DEM,Kamala Harris,376
-Santa Clara,1753,U.S. Senate,,DEM,Loretta Sanchez,170
-Santa Clara,1755,U.S. Senate,,DEM,Kamala Harris,598
-Santa Clara,1755,U.S. Senate,,DEM,Loretta Sanchez,282
-Santa Clara,1760,U.S. Senate,,DEM,Kamala Harris,320
-Santa Clara,1760,U.S. Senate,,DEM,Loretta Sanchez,331
-Santa Clara,1767,U.S. Senate,,DEM,Kamala Harris,187
-Santa Clara,1767,U.S. Senate,,DEM,Loretta Sanchez,306
-Santa Clara,1773,U.S. Senate,,DEM,Kamala Harris,353
-Santa Clara,1773,U.S. Senate,,DEM,Loretta Sanchez,298
-Santa Clara,1775,U.S. Senate,,DEM,Kamala Harris,85
-Santa Clara,1775,U.S. Senate,,DEM,Loretta Sanchez,96
-Santa Clara,1780,U.S. Senate,,DEM,Kamala Harris,468
-Santa Clara,1780,U.S. Senate,,DEM,Loretta Sanchez,325
-Santa Clara,1781,U.S. Senate,,DEM,Kamala Harris,668
-Santa Clara,1781,U.S. Senate,,DEM,Loretta Sanchez,328
-Santa Clara,1784,U.S. Senate,,DEM,Kamala Harris,523
-Santa Clara,1784,U.S. Senate,,DEM,Loretta Sanchez,181
-Santa Clara,1785,U.S. Senate,,DEM,Kamala Harris,336
-Santa Clara,1785,U.S. Senate,,DEM,Loretta Sanchez,295
-Santa Clara,1786,U.S. Senate,,DEM,Kamala Harris,1181
-Santa Clara,1786,U.S. Senate,,DEM,Loretta Sanchez,436
-Santa Clara,1787,U.S. Senate,,DEM,Kamala Harris,526
-Santa Clara,1787,U.S. Senate,,DEM,Loretta Sanchez,235
-Santa Clara,1788,U.S. Senate,,DEM,Kamala Harris,667
-Santa Clara,1788,U.S. Senate,,DEM,Loretta Sanchez,150
-Santa Clara,1789,U.S. Senate,,DEM,Kamala Harris,645
-Santa Clara,1789,U.S. Senate,,DEM,Loretta Sanchez,407
-Santa Clara,1790,U.S. Senate,,DEM,Kamala Harris,566
-Santa Clara,1790,U.S. Senate,,DEM,Loretta Sanchez,252
-Santa Clara,1792,U.S. Senate,,DEM,Kamala Harris,566
-Santa Clara,1792,U.S. Senate,,DEM,Loretta Sanchez,198
-Santa Clara,1793,U.S. Senate,,DEM,Kamala Harris,722
-Santa Clara,1793,U.S. Senate,,DEM,Loretta Sanchez,282
-Santa Clara,1794,U.S. Senate,,DEM,Kamala Harris,493
-Santa Clara,1794,U.S. Senate,,DEM,Loretta Sanchez,245
-Santa Clara,1795,U.S. Senate,,DEM,Kamala Harris,498
-Santa Clara,1795,U.S. Senate,,DEM,Loretta Sanchez,377
-Santa Clara,1796,U.S. Senate,,DEM,Kamala Harris,488
-Santa Clara,1796,U.S. Senate,,DEM,Loretta Sanchez,194
-Santa Clara,1797,U.S. Senate,,DEM,Kamala Harris,731
-Santa Clara,1797,U.S. Senate,,DEM,Loretta Sanchez,326
-Santa Clara,1798,U.S. Senate,,DEM,Kamala Harris,113
-Santa Clara,1798,U.S. Senate,,DEM,Loretta Sanchez,56
-Santa Clara,1799,U.S. Senate,,DEM,Kamala Harris,254
-Santa Clara,1799,U.S. Senate,,DEM,Loretta Sanchez,184
-Santa Clara,1801,U.S. Senate,,DEM,Kamala Harris,31
-Santa Clara,1801,U.S. Senate,,DEM,Loretta Sanchez,11
-Santa Clara,1804,U.S. Senate,,DEM,Kamala Harris,398
-Santa Clara,1804,U.S. Senate,,DEM,Loretta Sanchez,518
-Santa Clara,1808,U.S. Senate,,DEM,Kamala Harris,0
-Santa Clara,1808,U.S. Senate,,DEM,Loretta Sanchez,0
-Santa Clara,1811,U.S. Senate,,DEM,Kamala Harris,246
-Santa Clara,1811,U.S. Senate,,DEM,Loretta Sanchez,218
-Santa Clara,1813,U.S. Senate,,DEM,Kamala Harris,158
-Santa Clara,1813,U.S. Senate,,DEM,Loretta Sanchez,87
-Santa Clara,1817,U.S. Senate,,DEM,Kamala Harris,367
-Santa Clara,1817,U.S. Senate,,DEM,Loretta Sanchez,292
-Santa Clara,1820,U.S. Senate,,DEM,Kamala Harris,306
-Santa Clara,1820,U.S. Senate,,DEM,Loretta Sanchez,243
-Santa Clara,1821,U.S. Senate,,DEM,Kamala Harris,277
-Santa Clara,1821,U.S. Senate,,DEM,Loretta Sanchez,278
-Santa Clara,1822,U.S. Senate,,DEM,Kamala Harris,522
-Santa Clara,1822,U.S. Senate,,DEM,Loretta Sanchez,379
-Santa Clara,1823,U.S. Senate,,DEM,Kamala Harris,293
-Santa Clara,1823,U.S. Senate,,DEM,Loretta Sanchez,259
-Santa Clara,1824,U.S. Senate,,DEM,Kamala Harris,367
-Santa Clara,1824,U.S. Senate,,DEM,Loretta Sanchez,308
-Santa Clara,1826,U.S. Senate,,DEM,Kamala Harris,298
-Santa Clara,1826,U.S. Senate,,DEM,Loretta Sanchez,328
-Santa Clara,1827,U.S. Senate,,DEM,Kamala Harris,527
-Santa Clara,1827,U.S. Senate,,DEM,Loretta Sanchez,479
-Santa Clara,1828,U.S. Senate,,DEM,Kamala Harris,336
-Santa Clara,1828,U.S. Senate,,DEM,Loretta Sanchez,153
-Santa Clara,1829,U.S. Senate,,DEM,Kamala Harris,319
-Santa Clara,1829,U.S. Senate,,DEM,Loretta Sanchez,267
-Santa Clara,1830,U.S. Senate,,DEM,Kamala Harris,215
-Santa Clara,1830,U.S. Senate,,DEM,Loretta Sanchez,254
-Santa Clara,1831,U.S. Senate,,DEM,Kamala Harris,366
-Santa Clara,1831,U.S. Senate,,DEM,Loretta Sanchez,321
-Santa Clara,1832,U.S. Senate,,DEM,Kamala Harris,626
-Santa Clara,1832,U.S. Senate,,DEM,Loretta Sanchez,272
-Santa Clara,1835,U.S. Senate,,DEM,Kamala Harris,475
-Santa Clara,1835,U.S. Senate,,DEM,Loretta Sanchez,166
-Santa Clara,1839,U.S. Senate,,DEM,Kamala Harris,793
-Santa Clara,1839,U.S. Senate,,DEM,Loretta Sanchez,286
-Santa Clara,1840,U.S. Senate,,DEM,Kamala Harris,423
-Santa Clara,1840,U.S. Senate,,DEM,Loretta Sanchez,244
-Santa Clara,1841,U.S. Senate,,DEM,Kamala Harris,548
-Santa Clara,1841,U.S. Senate,,DEM,Loretta Sanchez,351
-Santa Clara,1842,U.S. Senate,,DEM,Kamala Harris,400
-Santa Clara,1842,U.S. Senate,,DEM,Loretta Sanchez,312
-Santa Clara,1843,U.S. Senate,,DEM,Kamala Harris,274
-Santa Clara,1843,U.S. Senate,,DEM,Loretta Sanchez,296
-Santa Clara,1844,U.S. Senate,,DEM,Kamala Harris,594
-Santa Clara,1844,U.S. Senate,,DEM,Loretta Sanchez,411
-Santa Clara,1845,U.S. Senate,,DEM,Kamala Harris,278
-Santa Clara,1845,U.S. Senate,,DEM,Loretta Sanchez,240
-Santa Clara,1846,U.S. Senate,,DEM,Kamala Harris,286
-Santa Clara,1846,U.S. Senate,,DEM,Loretta Sanchez,332
-Santa Clara,1847,U.S. Senate,,DEM,Kamala Harris,204
-Santa Clara,1847,U.S. Senate,,DEM,Loretta Sanchez,306
-Santa Clara,1848,U.S. Senate,,DEM,Kamala Harris,244
-Santa Clara,1848,U.S. Senate,,DEM,Loretta Sanchez,380
-Santa Clara,1849,U.S. Senate,,DEM,Kamala Harris,248
-Santa Clara,1849,U.S. Senate,,DEM,Loretta Sanchez,355
-Santa Clara,1850,U.S. Senate,,DEM,Kamala Harris,309
-Santa Clara,1850,U.S. Senate,,DEM,Loretta Sanchez,507
-Santa Clara,1852,U.S. Senate,,DEM,Kamala Harris,287
-Santa Clara,1852,U.S. Senate,,DEM,Loretta Sanchez,327
-Santa Clara,1853,U.S. Senate,,DEM,Kamala Harris,27
-Santa Clara,1853,U.S. Senate,,DEM,Loretta Sanchez,26
-Santa Clara,1855,U.S. Senate,,DEM,Kamala Harris,296
-Santa Clara,1855,U.S. Senate,,DEM,Loretta Sanchez,244
-Santa Clara,1856,U.S. Senate,,DEM,Kamala Harris,298
-Santa Clara,1856,U.S. Senate,,DEM,Loretta Sanchez,282
-Santa Clara,1857,U.S. Senate,,DEM,Kamala Harris,301
-Santa Clara,1857,U.S. Senate,,DEM,Loretta Sanchez,355
-Santa Clara,1859,U.S. Senate,,DEM,Kamala Harris,386
-Santa Clara,1859,U.S. Senate,,DEM,Loretta Sanchez,485
-Santa Clara,1861,U.S. Senate,,DEM,Kamala Harris,214
-Santa Clara,1861,U.S. Senate,,DEM,Loretta Sanchez,313
-Santa Clara,1863,U.S. Senate,,DEM,Kamala Harris,320
-Santa Clara,1863,U.S. Senate,,DEM,Loretta Sanchez,208
-Santa Clara,1865,U.S. Senate,,DEM,Kamala Harris,345
-Santa Clara,1865,U.S. Senate,,DEM,Loretta Sanchez,402
-Santa Clara,1866,U.S. Senate,,DEM,Kamala Harris,404
-Santa Clara,1866,U.S. Senate,,DEM,Loretta Sanchez,265
-Santa Clara,1869,U.S. Senate,,DEM,Kamala Harris,340
-Santa Clara,1869,U.S. Senate,,DEM,Loretta Sanchez,264
-Santa Clara,1871,U.S. Senate,,DEM,Kamala Harris,594
-Santa Clara,1871,U.S. Senate,,DEM,Loretta Sanchez,314
-Santa Clara,1872,U.S. Senate,,DEM,Kamala Harris,207
-Santa Clara,1872,U.S. Senate,,DEM,Loretta Sanchez,193
-Santa Clara,1877,U.S. Senate,,DEM,Kamala Harris,269
-Santa Clara,1877,U.S. Senate,,DEM,Loretta Sanchez,187
-Santa Clara,1881,U.S. Senate,,DEM,Kamala Harris,380
-Santa Clara,1881,U.S. Senate,,DEM,Loretta Sanchez,243
-Santa Clara,1886,U.S. Senate,,DEM,Kamala Harris,302
-Santa Clara,1886,U.S. Senate,,DEM,Loretta Sanchez,163
-Santa Clara,1887,U.S. Senate,,DEM,Kamala Harris,386
-Santa Clara,1887,U.S. Senate,,DEM,Loretta Sanchez,291
-Santa Clara,1897,U.S. Senate,,DEM,Kamala Harris,447
-Santa Clara,1897,U.S. Senate,,DEM,Loretta Sanchez,237
-Santa Clara,1901,U.S. Senate,,DEM,Kamala Harris,571
-Santa Clara,1901,U.S. Senate,,DEM,Loretta Sanchez,283
-Santa Clara,1902,U.S. Senate,,DEM,Kamala Harris,326
-Santa Clara,1902,U.S. Senate,,DEM,Loretta Sanchez,119
-Santa Clara,1903,U.S. Senate,,DEM,Kamala Harris,651
-Santa Clara,1903,U.S. Senate,,DEM,Loretta Sanchez,278
-Santa Clara,1904,U.S. Senate,,DEM,Kamala Harris,514
-Santa Clara,1904,U.S. Senate,,DEM,Loretta Sanchez,232
-Santa Clara,1907,U.S. Senate,,DEM,Kamala Harris,547
-Santa Clara,1907,U.S. Senate,,DEM,Loretta Sanchez,210
-Santa Clara,1909,U.S. Senate,,DEM,Kamala Harris,690
-Santa Clara,1909,U.S. Senate,,DEM,Loretta Sanchez,317
-Santa Clara,1911,U.S. Senate,,DEM,Kamala Harris,557
-Santa Clara,1911,U.S. Senate,,DEM,Loretta Sanchez,211
-Santa Clara,1913,U.S. Senate,,DEM,Kamala Harris,513
-Santa Clara,1913,U.S. Senate,,DEM,Loretta Sanchez,177
-Santa Clara,1914,U.S. Senate,,DEM,Kamala Harris,402
-Santa Clara,1914,U.S. Senate,,DEM,Loretta Sanchez,181
-Santa Clara,1916,U.S. Senate,,DEM,Kamala Harris,646
-Santa Clara,1916,U.S. Senate,,DEM,Loretta Sanchez,226
-Santa Clara,1918,U.S. Senate,,DEM,Kamala Harris,504
-Santa Clara,1918,U.S. Senate,,DEM,Loretta Sanchez,195
-Santa Clara,1919,U.S. Senate,,DEM,Kamala Harris,301
-Santa Clara,1919,U.S. Senate,,DEM,Loretta Sanchez,147
-Santa Clara,1920,U.S. Senate,,DEM,Kamala Harris,571
-Santa Clara,1920,U.S. Senate,,DEM,Loretta Sanchez,228
-Santa Clara,1922,U.S. Senate,,DEM,Kamala Harris,450
-Santa Clara,1922,U.S. Senate,,DEM,Loretta Sanchez,172
-Santa Clara,1924,U.S. Senate,,DEM,Kamala Harris,405
-Santa Clara,1924,U.S. Senate,,DEM,Loretta Sanchez,172
-Santa Clara,1925,U.S. Senate,,DEM,Kamala Harris,494
-Santa Clara,1925,U.S. Senate,,DEM,Loretta Sanchez,206
-Santa Clara,1927,U.S. Senate,,DEM,Kamala Harris,620
-Santa Clara,1927,U.S. Senate,,DEM,Loretta Sanchez,283
-Santa Clara,1928,U.S. Senate,,DEM,Kamala Harris,479
-Santa Clara,1928,U.S. Senate,,DEM,Loretta Sanchez,224
-Santa Clara,1930,U.S. Senate,,DEM,Kamala Harris,470
-Santa Clara,1930,U.S. Senate,,DEM,Loretta Sanchez,266
-Santa Clara,1932,U.S. Senate,,DEM,Kamala Harris,458
-Santa Clara,1932,U.S. Senate,,DEM,Loretta Sanchez,214
-Santa Clara,1935,U.S. Senate,,DEM,Kamala Harris,339
-Santa Clara,1935,U.S. Senate,,DEM,Loretta Sanchez,146
-Santa Clara,1936,U.S. Senate,,DEM,Kamala Harris,665
-Santa Clara,1936,U.S. Senate,,DEM,Loretta Sanchez,307
-Santa Clara,1937,U.S. Senate,,DEM,Kamala Harris,643
-Santa Clara,1937,U.S. Senate,,DEM,Loretta Sanchez,224
-Santa Clara,1939,U.S. Senate,,DEM,Kamala Harris,421
-Santa Clara,1939,U.S. Senate,,DEM,Loretta Sanchez,213
-Santa Clara,1941,U.S. Senate,,DEM,Kamala Harris,294
-Santa Clara,1941,U.S. Senate,,DEM,Loretta Sanchez,149
-Santa Clara,1944,U.S. Senate,,DEM,Kamala Harris,540
-Santa Clara,1944,U.S. Senate,,DEM,Loretta Sanchez,238
-Santa Clara,1945,U.S. Senate,,DEM,Kamala Harris,382
-Santa Clara,1945,U.S. Senate,,DEM,Loretta Sanchez,205
-Santa Clara,1947,U.S. Senate,,DEM,Kamala Harris,550
-Santa Clara,1947,U.S. Senate,,DEM,Loretta Sanchez,267
-Santa Clara,1949,U.S. Senate,,DEM,Kamala Harris,707
-Santa Clara,1949,U.S. Senate,,DEM,Loretta Sanchez,296
-Santa Clara,1952,U.S. Senate,,DEM,Kamala Harris,491
-Santa Clara,1952,U.S. Senate,,DEM,Loretta Sanchez,231
-Santa Clara,1953,U.S. Senate,,DEM,Kamala Harris,417
-Santa Clara,1953,U.S. Senate,,DEM,Loretta Sanchez,229
-Santa Clara,1954,U.S. Senate,,DEM,Kamala Harris,508
-Santa Clara,1954,U.S. Senate,,DEM,Loretta Sanchez,253
-Santa Clara,1957,U.S. Senate,,DEM,Kamala Harris,481
-Santa Clara,1957,U.S. Senate,,DEM,Loretta Sanchez,215
-Santa Clara,1960,U.S. Senate,,DEM,Kamala Harris,448
-Santa Clara,1960,U.S. Senate,,DEM,Loretta Sanchez,189
-Santa Clara,1962,U.S. Senate,,DEM,Kamala Harris,283
-Santa Clara,1962,U.S. Senate,,DEM,Loretta Sanchez,123
-Santa Clara,1963,U.S. Senate,,DEM,Kamala Harris,489
-Santa Clara,1963,U.S. Senate,,DEM,Loretta Sanchez,161
-Santa Clara,1964,U.S. Senate,,DEM,Kamala Harris,375
-Santa Clara,1964,U.S. Senate,,DEM,Loretta Sanchez,94
-Santa Clara,1968,U.S. Senate,,DEM,Kamala Harris,43
-Santa Clara,1968,U.S. Senate,,DEM,Loretta Sanchez,26
-Santa Clara,1977,U.S. Senate,,DEM,Kamala Harris,195
-Santa Clara,1977,U.S. Senate,,DEM,Loretta Sanchez,130
-Santa Clara,1978,U.S. Senate,,DEM,Kamala Harris,220
-Santa Clara,1978,U.S. Senate,,DEM,Loretta Sanchez,167
-Santa Clara,1986,U.S. Senate,,DEM,Kamala Harris,323
-Santa Clara,1986,U.S. Senate,,DEM,Loretta Sanchez,207
-Santa Clara,1990,U.S. Senate,,DEM,Kamala Harris,38
-Santa Clara,1990,U.S. Senate,,DEM,Loretta Sanchez,25
-Santa Clara,1991,U.S. Senate,,DEM,Kamala Harris,108
-Santa Clara,1991,U.S. Senate,,DEM,Loretta Sanchez,170
-Santa Clara,1994,U.S. Senate,,DEM,Kamala Harris,176
-Santa Clara,1994,U.S. Senate,,DEM,Loretta Sanchez,69
-Santa Clara,1995,U.S. Senate,,DEM,Kamala Harris,0
-Santa Clara,1995,U.S. Senate,,DEM,Loretta Sanchez,0
-Santa Clara,1996,U.S. Senate,,DEM,Kamala Harris,86
-Santa Clara,1996,U.S. Senate,,DEM,Loretta Sanchez,25
-Santa Clara,1999,U.S. Senate,,DEM,Kamala Harris,1
-Santa Clara,1999,U.S. Senate,,DEM,Loretta Sanchez,3
-Santa Clara,2001,U.S. Senate,,DEM,Kamala Harris,3
-Santa Clara,2001,U.S. Senate,,DEM,Loretta Sanchez,0
-Santa Clara,2002,U.S. Senate,,DEM,Kamala Harris,833
-Santa Clara,2002,U.S. Senate,,DEM,Loretta Sanchez,225
-Santa Clara,2003,U.S. Senate,,DEM,Kamala Harris,574
-Santa Clara,2003,U.S. Senate,,DEM,Loretta Sanchez,135
-Santa Clara,2004,U.S. Senate,,DEM,Kamala Harris,854
-Santa Clara,2004,U.S. Senate,,DEM,Loretta Sanchez,226
-Santa Clara,2005,U.S. Senate,,DEM,Kamala Harris,769
-Santa Clara,2005,U.S. Senate,,DEM,Loretta Sanchez,184
-Santa Clara,2006,U.S. Senate,,DEM,Kamala Harris,175
-Santa Clara,2006,U.S. Senate,,DEM,Loretta Sanchez,64
-Santa Clara,2009,U.S. Senate,,DEM,Kamala Harris,821
-Santa Clara,2009,U.S. Senate,,DEM,Loretta Sanchez,251
-Santa Clara,2010,U.S. Senate,,DEM,Kamala Harris,452
-Santa Clara,2010,U.S. Senate,,DEM,Loretta Sanchez,141
-Santa Clara,2013,U.S. Senate,,DEM,Kamala Harris,851
-Santa Clara,2013,U.S. Senate,,DEM,Loretta Sanchez,178
-Santa Clara,2014,U.S. Senate,,DEM,Kamala Harris,420
-Santa Clara,2014,U.S. Senate,,DEM,Loretta Sanchez,137
-Santa Clara,2015,U.S. Senate,,DEM,Kamala Harris,556
-Santa Clara,2015,U.S. Senate,,DEM,Loretta Sanchez,175
-Santa Clara,2018,U.S. Senate,,DEM,Kamala Harris,69
-Santa Clara,2018,U.S. Senate,,DEM,Loretta Sanchez,26
-Santa Clara,2019,U.S. Senate,,DEM,Kamala Harris,505
-Santa Clara,2019,U.S. Senate,,DEM,Loretta Sanchez,147
-Santa Clara,2022,U.S. Senate,,DEM,Kamala Harris,0
-Santa Clara,2022,U.S. Senate,,DEM,Loretta Sanchez,0
-Santa Clara,2025,U.S. Senate,,DEM,Kamala Harris,862
-Santa Clara,2025,U.S. Senate,,DEM,Loretta Sanchez,210
-Santa Clara,2028,U.S. Senate,,DEM,Kamala Harris,440
-Santa Clara,2028,U.S. Senate,,DEM,Loretta Sanchez,127
-Santa Clara,2034,U.S. Senate,,DEM,Kamala Harris,552
-Santa Clara,2034,U.S. Senate,,DEM,Loretta Sanchez,147
-Santa Clara,2038,U.S. Senate,,DEM,Kamala Harris,480
-Santa Clara,2038,U.S. Senate,,DEM,Loretta Sanchez,120
-Santa Clara,2046,U.S. Senate,,DEM,Kamala Harris,751
-Santa Clara,2046,U.S. Senate,,DEM,Loretta Sanchez,207
-Santa Clara,2048,U.S. Senate,,DEM,Kamala Harris,878
-Santa Clara,2048,U.S. Senate,,DEM,Loretta Sanchez,193
-Santa Clara,2056,U.S. Senate,,DEM,Kamala Harris,471
-Santa Clara,2056,U.S. Senate,,DEM,Loretta Sanchez,118
-Santa Clara,2057,U.S. Senate,,DEM,Kamala Harris,849
-Santa Clara,2057,U.S. Senate,,DEM,Loretta Sanchez,180
-Santa Clara,2061,U.S. Senate,,DEM,Kamala Harris,849
-Santa Clara,2061,U.S. Senate,,DEM,Loretta Sanchez,185
-Santa Clara,2068,U.S. Senate,,DEM,Kamala Harris,854
-Santa Clara,2068,U.S. Senate,,DEM,Loretta Sanchez,187
-Santa Clara,2075,U.S. Senate,,DEM,Kamala Harris,820
-Santa Clara,2075,U.S. Senate,,DEM,Loretta Sanchez,154
-Santa Clara,2078,U.S. Senate,,DEM,Kamala Harris,857
-Santa Clara,2078,U.S. Senate,,DEM,Loretta Sanchez,181
-Santa Clara,2081,U.S. Senate,,DEM,Kamala Harris,448
-Santa Clara,2081,U.S. Senate,,DEM,Loretta Sanchez,113
-Santa Clara,2090,U.S. Senate,,DEM,Kamala Harris,537
-Santa Clara,2090,U.S. Senate,,DEM,Loretta Sanchez,135
-Santa Clara,2096,U.S. Senate,,DEM,Kamala Harris,531
-Santa Clara,2096,U.S. Senate,,DEM,Loretta Sanchez,107
-Santa Clara,2098,U.S. Senate,,DEM,Kamala Harris,505
-Santa Clara,2098,U.S. Senate,,DEM,Loretta Sanchez,81
-Santa Clara,2101,U.S. Senate,,DEM,Kamala Harris,829
-Santa Clara,2101,U.S. Senate,,DEM,Loretta Sanchez,227
-Santa Clara,2103,U.S. Senate,,DEM,Kamala Harris,422
-Santa Clara,2103,U.S. Senate,,DEM,Loretta Sanchez,100
-Santa Clara,2107,U.S. Senate,,DEM,Kamala Harris,508
-Santa Clara,2107,U.S. Senate,,DEM,Loretta Sanchez,141
-Santa Clara,2110,U.S. Senate,,DEM,Kamala Harris,544
-Santa Clara,2110,U.S. Senate,,DEM,Loretta Sanchez,124
-Santa Clara,2112,U.S. Senate,,DEM,Kamala Harris,582
-Santa Clara,2112,U.S. Senate,,DEM,Loretta Sanchez,156
-Santa Clara,2113,U.S. Senate,,DEM,Kamala Harris,769
-Santa Clara,2113,U.S. Senate,,DEM,Loretta Sanchez,200
-Santa Clara,2115,U.S. Senate,,DEM,Kamala Harris,410
-Santa Clara,2115,U.S. Senate,,DEM,Loretta Sanchez,119
-Santa Clara,2117,U.S. Senate,,DEM,Kamala Harris,553
-Santa Clara,2117,U.S. Senate,,DEM,Loretta Sanchez,119
-Santa Clara,2118,U.S. Senate,,DEM,Kamala Harris,555
-Santa Clara,2118,U.S. Senate,,DEM,Loretta Sanchez,178
-Santa Clara,2120,U.S. Senate,,DEM,Kamala Harris,524
-Santa Clara,2120,U.S. Senate,,DEM,Loretta Sanchez,159
-Santa Clara,2122,U.S. Senate,,DEM,Kamala Harris,516
-Santa Clara,2122,U.S. Senate,,DEM,Loretta Sanchez,143
-Santa Clara,2124,U.S. Senate,,DEM,Kamala Harris,110
-Santa Clara,2124,U.S. Senate,,DEM,Loretta Sanchez,43
-Santa Clara,2126,U.S. Senate,,DEM,Kamala Harris,34
-Santa Clara,2126,U.S. Senate,,DEM,Loretta Sanchez,12
-Santa Clara,2129,U.S. Senate,,DEM,Kamala Harris,433
-Santa Clara,2129,U.S. Senate,,DEM,Loretta Sanchez,118
-Santa Clara,2301,U.S. Senate,,DEM,Kamala Harris,721
-Santa Clara,2301,U.S. Senate,,DEM,Loretta Sanchez,189
-Santa Clara,2305,U.S. Senate,,DEM,Kamala Harris,512
-Santa Clara,2305,U.S. Senate,,DEM,Loretta Sanchez,151
-Santa Clara,2306,U.S. Senate,,DEM,Kamala Harris,758
-Santa Clara,2306,U.S. Senate,,DEM,Loretta Sanchez,230
-Santa Clara,2309,U.S. Senate,,DEM,Kamala Harris,514
-Santa Clara,2309,U.S. Senate,,DEM,Loretta Sanchez,154
-Santa Clara,2311,U.S. Senate,,DEM,Kamala Harris,746
-Santa Clara,2311,U.S. Senate,,DEM,Loretta Sanchez,183
-Santa Clara,2314,U.S. Senate,,DEM,Kamala Harris,481
-Santa Clara,2314,U.S. Senate,,DEM,Loretta Sanchez,177
-Santa Clara,2321,U.S. Senate,,DEM,Kamala Harris,795
-Santa Clara,2321,U.S. Senate,,DEM,Loretta Sanchez,197
-Santa Clara,2323,U.S. Senate,,DEM,Kamala Harris,501
-Santa Clara,2323,U.S. Senate,,DEM,Loretta Sanchez,153
-Santa Clara,2326,U.S. Senate,,DEM,Kamala Harris,462
-Santa Clara,2326,U.S. Senate,,DEM,Loretta Sanchez,160
-Santa Clara,2330,U.S. Senate,,DEM,Kamala Harris,690
-Santa Clara,2330,U.S. Senate,,DEM,Loretta Sanchez,201
-Santa Clara,2333,U.S. Senate,,DEM,Kamala Harris,659
-Santa Clara,2333,U.S. Senate,,DEM,Loretta Sanchez,203
-Santa Clara,2336,U.S. Senate,,DEM,Kamala Harris,453
-Santa Clara,2336,U.S. Senate,,DEM,Loretta Sanchez,151
-Santa Clara,2338,U.S. Senate,,DEM,Kamala Harris,509
-Santa Clara,2338,U.S. Senate,,DEM,Loretta Sanchez,174
-Santa Clara,2339,U.S. Senate,,DEM,Kamala Harris,508
-Santa Clara,2339,U.S. Senate,,DEM,Loretta Sanchez,152
-Santa Clara,2342,U.S. Senate,,DEM,Kamala Harris,553
-Santa Clara,2342,U.S. Senate,,DEM,Loretta Sanchez,124
-Santa Clara,2343,U.S. Senate,,DEM,Kamala Harris,453
-Santa Clara,2343,U.S. Senate,,DEM,Loretta Sanchez,145
-Santa Clara,2345,U.S. Senate,,DEM,Kamala Harris,500
-Santa Clara,2345,U.S. Senate,,DEM,Loretta Sanchez,133
-Santa Clara,2346,U.S. Senate,,DEM,Kamala Harris,618
-Santa Clara,2346,U.S. Senate,,DEM,Loretta Sanchez,188
-Santa Clara,2351,U.S. Senate,,DEM,Kamala Harris,733
-Santa Clara,2351,U.S. Senate,,DEM,Loretta Sanchez,188
-Santa Clara,2352,U.S. Senate,,DEM,Kamala Harris,567
-Santa Clara,2352,U.S. Senate,,DEM,Loretta Sanchez,150
-Santa Clara,2353,U.S. Senate,,DEM,Kamala Harris,17
-Santa Clara,2353,U.S. Senate,,DEM,Loretta Sanchez,5
-Santa Clara,2376,U.S. Senate,,DEM,Kamala Harris,699
-Santa Clara,2376,U.S. Senate,,DEM,Loretta Sanchez,281
-Santa Clara,2378,U.S. Senate,,DEM,Kamala Harris,525
-Santa Clara,2378,U.S. Senate,,DEM,Loretta Sanchez,174
-Santa Clara,2379,U.S. Senate,,DEM,Kamala Harris,27
-Santa Clara,2379,U.S. Senate,,DEM,Loretta Sanchez,8
-Santa Clara,2381,U.S. Senate,,DEM,Kamala Harris,740
-Santa Clara,2381,U.S. Senate,,DEM,Loretta Sanchez,214
-Santa Clara,2386,U.S. Senate,,DEM,Kamala Harris,552
-Santa Clara,2386,U.S. Senate,,DEM,Loretta Sanchez,207
-Santa Clara,2389,U.S. Senate,,DEM,Kamala Harris,638
-Santa Clara,2389,U.S. Senate,,DEM,Loretta Sanchez,188
-Santa Clara,2402,U.S. Senate,,DEM,Kamala Harris,474
-Santa Clara,2402,U.S. Senate,,DEM,Loretta Sanchez,135
-Santa Clara,2403,U.S. Senate,,DEM,Kamala Harris,905
-Santa Clara,2403,U.S. Senate,,DEM,Loretta Sanchez,279
-Santa Clara,2406,U.S. Senate,,DEM,Kamala Harris,750
-Santa Clara,2406,U.S. Senate,,DEM,Loretta Sanchez,291
-Santa Clara,2407,U.S. Senate,,DEM,Kamala Harris,564
-Santa Clara,2407,U.S. Senate,,DEM,Loretta Sanchez,168
-Santa Clara,2408,U.S. Senate,,DEM,Kamala Harris,828
-Santa Clara,2408,U.S. Senate,,DEM,Loretta Sanchez,389
-Santa Clara,2409,U.S. Senate,,DEM,Kamala Harris,432
-Santa Clara,2409,U.S. Senate,,DEM,Loretta Sanchez,188
-Santa Clara,2410,U.S. Senate,,DEM,Kamala Harris,801
-Santa Clara,2410,U.S. Senate,,DEM,Loretta Sanchez,282
-Santa Clara,2412,U.S. Senate,,DEM,Kamala Harris,733
-Santa Clara,2412,U.S. Senate,,DEM,Loretta Sanchez,229
-Santa Clara,2414,U.S. Senate,,DEM,Kamala Harris,743
-Santa Clara,2414,U.S. Senate,,DEM,Loretta Sanchez,248
-Santa Clara,2417,U.S. Senate,,DEM,Kamala Harris,820
-Santa Clara,2417,U.S. Senate,,DEM,Loretta Sanchez,255
-Santa Clara,2418,U.S. Senate,,DEM,Kamala Harris,755
-Santa Clara,2418,U.S. Senate,,DEM,Loretta Sanchez,310
-Santa Clara,2419,U.S. Senate,,DEM,Kamala Harris,638
-Santa Clara,2419,U.S. Senate,,DEM,Loretta Sanchez,191
-Santa Clara,2427,U.S. Senate,,DEM,Kamala Harris,518
-Santa Clara,2427,U.S. Senate,,DEM,Loretta Sanchez,200
-Santa Clara,2428,U.S. Senate,,DEM,Kamala Harris,503
-Santa Clara,2428,U.S. Senate,,DEM,Loretta Sanchez,145
-Santa Clara,2431,U.S. Senate,,DEM,Kamala Harris,318
-Santa Clara,2431,U.S. Senate,,DEM,Loretta Sanchez,82
-Santa Clara,2432,U.S. Senate,,DEM,Kamala Harris,8
-Santa Clara,2432,U.S. Senate,,DEM,Loretta Sanchez,2
-Santa Clara,2434,U.S. Senate,,DEM,Kamala Harris,533
-Santa Clara,2434,U.S. Senate,,DEM,Loretta Sanchez,136
-Santa Clara,2436,U.S. Senate,,DEM,Kamala Harris,616
-Santa Clara,2436,U.S. Senate,,DEM,Loretta Sanchez,129
-Santa Clara,2438,U.S. Senate,,DEM,Kamala Harris,548
-Santa Clara,2438,U.S. Senate,,DEM,Loretta Sanchez,155
-Santa Clara,2439,U.S. Senate,,DEM,Kamala Harris,543
-Santa Clara,2439,U.S. Senate,,DEM,Loretta Sanchez,123
-Santa Clara,2440,U.S. Senate,,DEM,Kamala Harris,449
-Santa Clara,2440,U.S. Senate,,DEM,Loretta Sanchez,130
-Santa Clara,2441,U.S. Senate,,DEM,Kamala Harris,488
-Santa Clara,2441,U.S. Senate,,DEM,Loretta Sanchez,144
-Santa Clara,2442,U.S. Senate,,DEM,Kamala Harris,495
-Santa Clara,2442,U.S. Senate,,DEM,Loretta Sanchez,182
-Santa Clara,2445,U.S. Senate,,DEM,Kamala Harris,779
-Santa Clara,2445,U.S. Senate,,DEM,Loretta Sanchez,255
-Santa Clara,2457,U.S. Senate,,DEM,Kamala Harris,735
-Santa Clara,2457,U.S. Senate,,DEM,Loretta Sanchez,216
-Santa Clara,2459,U.S. Senate,,DEM,Kamala Harris,449
-Santa Clara,2459,U.S. Senate,,DEM,Loretta Sanchez,189
-Santa Clara,2460,U.S. Senate,,DEM,Kamala Harris,406
-Santa Clara,2460,U.S. Senate,,DEM,Loretta Sanchez,151
-Santa Clara,2464,U.S. Senate,,DEM,Kamala Harris,264
-Santa Clara,2464,U.S. Senate,,DEM,Loretta Sanchez,63
-Santa Clara,2467,U.S. Senate,,DEM,Kamala Harris,431
-Santa Clara,2467,U.S. Senate,,DEM,Loretta Sanchez,133
-Santa Clara,2469,U.S. Senate,,DEM,Kamala Harris,193
-Santa Clara,2469,U.S. Senate,,DEM,Loretta Sanchez,130
-Santa Clara,2470,U.S. Senate,,DEM,Kamala Harris,552
-Santa Clara,2470,U.S. Senate,,DEM,Loretta Sanchez,176
-Santa Clara,2475,U.S. Senate,,DEM,Kamala Harris,821
-Santa Clara,2475,U.S. Senate,,DEM,Loretta Sanchez,274
-Santa Clara,2477,U.S. Senate,,DEM,Kamala Harris,579
-Santa Clara,2477,U.S. Senate,,DEM,Loretta Sanchez,206
-Santa Clara,2479,U.S. Senate,,DEM,Kamala Harris,697
-Santa Clara,2479,U.S. Senate,,DEM,Loretta Sanchez,194
-Santa Clara,2489,U.S. Senate,,DEM,Kamala Harris,675
-Santa Clara,2489,U.S. Senate,,DEM,Loretta Sanchez,215
-Santa Clara,2492,U.S. Senate,,DEM,Kamala Harris,779
-Santa Clara,2492,U.S. Senate,,DEM,Loretta Sanchez,298
-Santa Clara,2539,U.S. Senate,,DEM,Kamala Harris,42
-Santa Clara,2539,U.S. Senate,,DEM,Loretta Sanchez,18
-Santa Clara,2542,U.S. Senate,,DEM,Kamala Harris,539
-Santa Clara,2542,U.S. Senate,,DEM,Loretta Sanchez,175
-Santa Clara,2544,U.S. Senate,,DEM,Kamala Harris,843
-Santa Clara,2544,U.S. Senate,,DEM,Loretta Sanchez,227
-Santa Clara,2545,U.S. Senate,,DEM,Kamala Harris,543
-Santa Clara,2545,U.S. Senate,,DEM,Loretta Sanchez,98
-Santa Clara,2546,U.S. Senate,,DEM,Kamala Harris,818
-Santa Clara,2546,U.S. Senate,,DEM,Loretta Sanchez,131
-Santa Clara,2802,U.S. Senate,,DEM,Kamala Harris,653
-Santa Clara,2802,U.S. Senate,,DEM,Loretta Sanchez,216
-Santa Clara,2808,U.S. Senate,,DEM,Kamala Harris,6
-Santa Clara,2808,U.S. Senate,,DEM,Loretta Sanchez,5
-Santa Clara,2811,U.S. Senate,,DEM,Kamala Harris,17
-Santa Clara,2811,U.S. Senate,,DEM,Loretta Sanchez,5
-Santa Clara,2812,U.S. Senate,,DEM,Kamala Harris,153
-Santa Clara,2812,U.S. Senate,,DEM,Loretta Sanchez,37
-Santa Clara,2813,U.S. Senate,,DEM,Kamala Harris,101
-Santa Clara,2813,U.S. Senate,,DEM,Loretta Sanchez,50
-Santa Clara,2815,U.S. Senate,,DEM,Kamala Harris,0
-Santa Clara,2815,U.S. Senate,,DEM,Loretta Sanchez,0
-Santa Clara,2816,U.S. Senate,,DEM,Kamala Harris,15
-Santa Clara,2816,U.S. Senate,,DEM,Loretta Sanchez,2
-Santa Clara,2825,U.S. Senate,,DEM,Kamala Harris,0
-Santa Clara,2825,U.S. Senate,,DEM,Loretta Sanchez,0
-Santa Clara,2826,U.S. Senate,,DEM,Kamala Harris,6
-Santa Clara,2826,U.S. Senate,,DEM,Loretta Sanchez,6
-Santa Clara,2833,U.S. Senate,,DEM,Kamala Harris,643
-Santa Clara,2833,U.S. Senate,,DEM,Loretta Sanchez,207
-Santa Clara,2871,U.S. Senate,,DEM,Kamala Harris,55
-Santa Clara,2871,U.S. Senate,,DEM,Loretta Sanchez,22
-Santa Clara,2873,U.S. Senate,,DEM,Kamala Harris,2
-Santa Clara,2873,U.S. Senate,,DEM,Loretta Sanchez,1
-Santa Clara,2951,U.S. Senate,,DEM,Kamala Harris,39
-Santa Clara,2951,U.S. Senate,,DEM,Loretta Sanchez,31
-Santa Clara,2953,U.S. Senate,,DEM,Kamala Harris,40
-Santa Clara,2953,U.S. Senate,,DEM,Loretta Sanchez,24
-Santa Clara,3601,U.S. Senate,,DEM,Kamala Harris,796
-Santa Clara,3601,U.S. Senate,,DEM,Loretta Sanchez,208
-Santa Clara,3602,U.S. Senate,,DEM,Kamala Harris,638
-Santa Clara,3602,U.S. Senate,,DEM,Loretta Sanchez,162
-Santa Clara,3603,U.S. Senate,,DEM,Kamala Harris,215
-Santa Clara,3603,U.S. Senate,,DEM,Loretta Sanchez,85
-Santa Clara,3604,U.S. Senate,,DEM,Kamala Harris,524
-Santa Clara,3604,U.S. Senate,,DEM,Loretta Sanchez,173
-Santa Clara,3605,U.S. Senate,,DEM,Kamala Harris,502
-Santa Clara,3605,U.S. Senate,,DEM,Loretta Sanchez,119
-Santa Clara,3606,U.S. Senate,,DEM,Kamala Harris,675
-Santa Clara,3606,U.S. Senate,,DEM,Loretta Sanchez,170
-Santa Clara,3607,U.S. Senate,,DEM,Kamala Harris,498
-Santa Clara,3607,U.S. Senate,,DEM,Loretta Sanchez,154
-Santa Clara,3608,U.S. Senate,,DEM,Kamala Harris,619
-Santa Clara,3608,U.S. Senate,,DEM,Loretta Sanchez,188
-Santa Clara,3609,U.S. Senate,,DEM,Kamala Harris,699
-Santa Clara,3609,U.S. Senate,,DEM,Loretta Sanchez,175
-Santa Clara,3610,U.S. Senate,,DEM,Kamala Harris,698
-Santa Clara,3610,U.S. Senate,,DEM,Loretta Sanchez,156
-Santa Clara,3611,U.S. Senate,,DEM,Kamala Harris,618
-Santa Clara,3611,U.S. Senate,,DEM,Loretta Sanchez,155
-Santa Clara,3612,U.S. Senate,,DEM,Kamala Harris,492
-Santa Clara,3612,U.S. Senate,,DEM,Loretta Sanchez,159
-Santa Clara,3614,U.S. Senate,,DEM,Kamala Harris,725
-Santa Clara,3614,U.S. Senate,,DEM,Loretta Sanchez,268
-Santa Clara,3616,U.S. Senate,,DEM,Kamala Harris,665
-Santa Clara,3616,U.S. Senate,,DEM,Loretta Sanchez,188
-Santa Clara,3617,U.S. Senate,,DEM,Kamala Harris,396
-Santa Clara,3617,U.S. Senate,,DEM,Loretta Sanchez,117
-Santa Clara,3620,U.S. Senate,,DEM,Kamala Harris,428
-Santa Clara,3620,U.S. Senate,,DEM,Loretta Sanchez,114
-Santa Clara,3621,U.S. Senate,,DEM,Kamala Harris,746
-Santa Clara,3621,U.S. Senate,,DEM,Loretta Sanchez,195
-Santa Clara,3623,U.S. Senate,,DEM,Kamala Harris,652
-Santa Clara,3623,U.S. Senate,,DEM,Loretta Sanchez,147
-Santa Clara,3624,U.S. Senate,,DEM,Kamala Harris,858
-Santa Clara,3624,U.S. Senate,,DEM,Loretta Sanchez,223
-Santa Clara,3629,U.S. Senate,,DEM,Kamala Harris,628
-Santa Clara,3629,U.S. Senate,,DEM,Loretta Sanchez,180
-Santa Clara,3635,U.S. Senate,,DEM,Kamala Harris,55
-Santa Clara,3635,U.S. Senate,,DEM,Loretta Sanchez,21
-Santa Clara,3636,U.S. Senate,,DEM,Kamala Harris,387
-Santa Clara,3636,U.S. Senate,,DEM,Loretta Sanchez,100
-Santa Clara,3639,U.S. Senate,,DEM,Kamala Harris,797
-Santa Clara,3639,U.S. Senate,,DEM,Loretta Sanchez,193
-Santa Clara,3640,U.S. Senate,,DEM,Kamala Harris,684
-Santa Clara,3640,U.S. Senate,,DEM,Loretta Sanchez,160
-Santa Clara,3643,U.S. Senate,,DEM,Kamala Harris,634
-Santa Clara,3643,U.S. Senate,,DEM,Loretta Sanchez,190
-Santa Clara,3646,U.S. Senate,,DEM,Kamala Harris,516
-Santa Clara,3646,U.S. Senate,,DEM,Loretta Sanchez,142
-Santa Clara,3648,U.S. Senate,,DEM,Kamala Harris,57
-Santa Clara,3648,U.S. Senate,,DEM,Loretta Sanchez,13
-Santa Clara,3651,U.S. Senate,,DEM,Kamala Harris,529
-Santa Clara,3651,U.S. Senate,,DEM,Loretta Sanchez,138
-Santa Clara,3654,U.S. Senate,,DEM,Kamala Harris,470
-Santa Clara,3654,U.S. Senate,,DEM,Loretta Sanchez,183
-Santa Clara,3655,U.S. Senate,,DEM,Kamala Harris,0
-Santa Clara,3655,U.S. Senate,,DEM,Loretta Sanchez,0
-Santa Clara,3722,U.S. Senate,,DEM,Kamala Harris,6
-Santa Clara,3722,U.S. Senate,,DEM,Loretta Sanchez,4
-Santa Clara,3723,U.S. Senate,,DEM,Kamala Harris,25
-Santa Clara,3723,U.S. Senate,,DEM,Loretta Sanchez,7
-Santa Clara,3724,U.S. Senate,,DEM,Kamala Harris,710
-Santa Clara,3724,U.S. Senate,,DEM,Loretta Sanchez,288
-Santa Clara,3725,U.S. Senate,,DEM,Kamala Harris,712
-Santa Clara,3725,U.S. Senate,,DEM,Loretta Sanchez,280
-Santa Clara,3726,U.S. Senate,,DEM,Kamala Harris,551
-Santa Clara,3726,U.S. Senate,,DEM,Loretta Sanchez,227
-Santa Clara,3727,U.S. Senate,,DEM,Kamala Harris,3
-Santa Clara,3727,U.S. Senate,,DEM,Loretta Sanchez,2
-Santa Clara,3728,U.S. Senate,,DEM,Kamala Harris,2
-Santa Clara,3728,U.S. Senate,,DEM,Loretta Sanchez,0
-Santa Clara,3729,U.S. Senate,,DEM,Kamala Harris,729
-Santa Clara,3729,U.S. Senate,,DEM,Loretta Sanchez,228
-Santa Clara,3730,U.S. Senate,,DEM,Kamala Harris,5
-Santa Clara,3730,U.S. Senate,,DEM,Loretta Sanchez,1
-Santa Clara,3731,U.S. Senate,,DEM,Kamala Harris,427
-Santa Clara,3731,U.S. Senate,,DEM,Loretta Sanchez,152
-Santa Clara,3733,U.S. Senate,,DEM,Kamala Harris,660
-Santa Clara,3733,U.S. Senate,,DEM,Loretta Sanchez,245
-Santa Clara,3734,U.S. Senate,,DEM,Kamala Harris,336
-Santa Clara,3734,U.S. Senate,,DEM,Loretta Sanchez,77
-Santa Clara,3737,U.S. Senate,,DEM,Kamala Harris,694
-Santa Clara,3737,U.S. Senate,,DEM,Loretta Sanchez,232
-Santa Clara,3738,U.S. Senate,,DEM,Kamala Harris,15
-Santa Clara,3738,U.S. Senate,,DEM,Loretta Sanchez,8
-Santa Clara,3739,U.S. Senate,,DEM,Kamala Harris,16
-Santa Clara,3739,U.S. Senate,,DEM,Loretta Sanchez,3
-Santa Clara,3740,U.S. Senate,,DEM,Kamala Harris,566
-Santa Clara,3740,U.S. Senate,,DEM,Loretta Sanchez,223
-Santa Clara,3741,U.S. Senate,,DEM,Kamala Harris,798
-Santa Clara,3741,U.S. Senate,,DEM,Loretta Sanchez,257
-Santa Clara,3744,U.S. Senate,,DEM,Kamala Harris,522
-Santa Clara,3744,U.S. Senate,,DEM,Loretta Sanchez,158
-Santa Clara,3745,U.S. Senate,,DEM,Kamala Harris,633
-Santa Clara,3745,U.S. Senate,,DEM,Loretta Sanchez,223
-Santa Clara,3746,U.S. Senate,,DEM,Kamala Harris,660
-Santa Clara,3746,U.S. Senate,,DEM,Loretta Sanchez,219
-Santa Clara,3751,U.S. Senate,,DEM,Kamala Harris,7
-Santa Clara,3751,U.S. Senate,,DEM,Loretta Sanchez,7
-Santa Clara,3757,U.S. Senate,,DEM,Kamala Harris,411
-Santa Clara,3757,U.S. Senate,,DEM,Loretta Sanchez,144
-Santa Clara,3761,U.S. Senate,,DEM,Kamala Harris,4
-Santa Clara,3761,U.S. Senate,,DEM,Loretta Sanchez,0
-Santa Clara,3763,U.S. Senate,,DEM,Kamala Harris,505
-Santa Clara,3763,U.S. Senate,,DEM,Loretta Sanchez,142
-Santa Clara,3767,U.S. Senate,,DEM,Kamala Harris,406
-Santa Clara,3767,U.S. Senate,,DEM,Loretta Sanchez,151
-Santa Clara,3771,U.S. Senate,,DEM,Kamala Harris,414
-Santa Clara,3771,U.S. Senate,,DEM,Loretta Sanchez,136
-Santa Clara,3774,U.S. Senate,,DEM,Kamala Harris,794
-Santa Clara,3774,U.S. Senate,,DEM,Loretta Sanchez,229
-Santa Clara,3781,U.S. Senate,,DEM,Kamala Harris,556
-Santa Clara,3781,U.S. Senate,,DEM,Loretta Sanchez,208
-Santa Clara,3782,U.S. Senate,,DEM,Kamala Harris,106
-Santa Clara,3782,U.S. Senate,,DEM,Loretta Sanchez,41
-Santa Clara,3784,U.S. Senate,,DEM,Kamala Harris,62
-Santa Clara,3784,U.S. Senate,,DEM,Loretta Sanchez,18
-Santa Clara,3785,U.S. Senate,,DEM,Kamala Harris,504
-Santa Clara,3785,U.S. Senate,,DEM,Loretta Sanchez,172
-Santa Clara,3786,U.S. Senate,,DEM,Kamala Harris,74
-Santa Clara,3786,U.S. Senate,,DEM,Loretta Sanchez,20
-Santa Clara,3787,U.S. Senate,,DEM,Kamala Harris,17
-Santa Clara,3787,U.S. Senate,,DEM,Loretta Sanchez,4
-Santa Clara,3801,U.S. Senate,,DEM,Kamala Harris,483
-Santa Clara,3801,U.S. Senate,,DEM,Loretta Sanchez,186
-Santa Clara,3802,U.S. Senate,,DEM,Kamala Harris,507
-Santa Clara,3802,U.S. Senate,,DEM,Loretta Sanchez,178
-Santa Clara,3803,U.S. Senate,,DEM,Kamala Harris,0
-Santa Clara,3803,U.S. Senate,,DEM,Loretta Sanchez,1
-Santa Clara,3804,U.S. Senate,,DEM,Kamala Harris,789
-Santa Clara,3804,U.S. Senate,,DEM,Loretta Sanchez,327
-Santa Clara,3805,U.S. Senate,,DEM,Kamala Harris,758
-Santa Clara,3805,U.S. Senate,,DEM,Loretta Sanchez,282
-Santa Clara,3806,U.S. Senate,,DEM,Kamala Harris,568
-Santa Clara,3806,U.S. Senate,,DEM,Loretta Sanchez,239
-Santa Clara,3809,U.S. Senate,,DEM,Kamala Harris,493
-Santa Clara,3809,U.S. Senate,,DEM,Loretta Sanchez,195
-Santa Clara,3810,U.S. Senate,,DEM,Kamala Harris,552
-Santa Clara,3810,U.S. Senate,,DEM,Loretta Sanchez,304
-Santa Clara,3812,U.S. Senate,,DEM,Kamala Harris,772
-Santa Clara,3812,U.S. Senate,,DEM,Loretta Sanchez,301
-Santa Clara,3813,U.S. Senate,,DEM,Kamala Harris,659
-Santa Clara,3813,U.S. Senate,,DEM,Loretta Sanchez,237
-Santa Clara,3814,U.S. Senate,,DEM,Kamala Harris,578
-Santa Clara,3814,U.S. Senate,,DEM,Loretta Sanchez,232
-Santa Clara,3818,U.S. Senate,,DEM,Kamala Harris,378
-Santa Clara,3818,U.S. Senate,,DEM,Loretta Sanchez,141
-Santa Clara,3820,U.S. Senate,,DEM,Kamala Harris,654
-Santa Clara,3820,U.S. Senate,,DEM,Loretta Sanchez,262
-Santa Clara,3821,U.S. Senate,,DEM,Kamala Harris,453
-Santa Clara,3821,U.S. Senate,,DEM,Loretta Sanchez,194
-Santa Clara,3823,U.S. Senate,,DEM,Kamala Harris,422
-Santa Clara,3823,U.S. Senate,,DEM,Loretta Sanchez,172
-Santa Clara,3826,U.S. Senate,,DEM,Kamala Harris,411
-Santa Clara,3826,U.S. Senate,,DEM,Loretta Sanchez,176
-Santa Clara,3827,U.S. Senate,,DEM,Kamala Harris,443
-Santa Clara,3827,U.S. Senate,,DEM,Loretta Sanchez,222
-Santa Clara,3828,U.S. Senate,,DEM,Kamala Harris,694
-Santa Clara,3828,U.S. Senate,,DEM,Loretta Sanchez,242
-Santa Clara,3834,U.S. Senate,,DEM,Kamala Harris,559
-Santa Clara,3834,U.S. Senate,,DEM,Loretta Sanchez,221
-Santa Clara,3835,U.S. Senate,,DEM,Kamala Harris,531
-Santa Clara,3835,U.S. Senate,,DEM,Loretta Sanchez,207
-Santa Clara,3840,U.S. Senate,,DEM,Kamala Harris,602
-Santa Clara,3840,U.S. Senate,,DEM,Loretta Sanchez,265
-Santa Clara,3845,U.S. Senate,,DEM,Kamala Harris,450
-Santa Clara,3845,U.S. Senate,,DEM,Loretta Sanchez,188
-Santa Clara,3846,U.S. Senate,,DEM,Kamala Harris,60
-Santa Clara,3846,U.S. Senate,,DEM,Loretta Sanchez,25
-Santa Clara,3901,U.S. Senate,,DEM,Kamala Harris,628
-Santa Clara,3901,U.S. Senate,,DEM,Loretta Sanchez,325
-Santa Clara,3902,U.S. Senate,,DEM,Kamala Harris,544
-Santa Clara,3902,U.S. Senate,,DEM,Loretta Sanchez,438
-Santa Clara,3903,U.S. Senate,,DEM,Kamala Harris,607
-Santa Clara,3903,U.S. Senate,,DEM,Loretta Sanchez,332
-Santa Clara,3905,U.S. Senate,,DEM,Kamala Harris,453
-Santa Clara,3905,U.S. Senate,,DEM,Loretta Sanchez,275
-Santa Clara,3906,U.S. Senate,,DEM,Kamala Harris,507
-Santa Clara,3906,U.S. Senate,,DEM,Loretta Sanchez,310
-Santa Clara,3907,U.S. Senate,,DEM,Kamala Harris,8
-Santa Clara,3907,U.S. Senate,,DEM,Loretta Sanchez,2
-Santa Clara,3908,U.S. Senate,,DEM,Kamala Harris,31
-Santa Clara,3908,U.S. Senate,,DEM,Loretta Sanchez,29
-Santa Clara,3909,U.S. Senate,,DEM,Kamala Harris,620
-Santa Clara,3909,U.S. Senate,,DEM,Loretta Sanchez,339
-Santa Clara,3910,U.S. Senate,,DEM,Kamala Harris,403
-Santa Clara,3910,U.S. Senate,,DEM,Loretta Sanchez,285
-Santa Clara,3912,U.S. Senate,,DEM,Kamala Harris,264
-Santa Clara,3912,U.S. Senate,,DEM,Loretta Sanchez,160
-Santa Clara,3914,U.S. Senate,,DEM,Kamala Harris,445
-Santa Clara,3914,U.S. Senate,,DEM,Loretta Sanchez,221
-Santa Clara,3915,U.S. Senate,,DEM,Kamala Harris,508
-Santa Clara,3915,U.S. Senate,,DEM,Loretta Sanchez,272
-Santa Clara,3916,U.S. Senate,,DEM,Kamala Harris,395
-Santa Clara,3916,U.S. Senate,,DEM,Loretta Sanchez,238
-Santa Clara,3917,U.S. Senate,,DEM,Kamala Harris,408
-Santa Clara,3917,U.S. Senate,,DEM,Loretta Sanchez,188
-Santa Clara,3918,U.S. Senate,,DEM,Kamala Harris,560
-Santa Clara,3918,U.S. Senate,,DEM,Loretta Sanchez,249
-Santa Clara,3923,U.S. Senate,,DEM,Kamala Harris,496
-Santa Clara,3923,U.S. Senate,,DEM,Loretta Sanchez,254
-Santa Clara,3924,U.S. Senate,,DEM,Kamala Harris,519
-Santa Clara,3924,U.S. Senate,,DEM,Loretta Sanchez,227
-Santa Clara,3928,U.S. Senate,,DEM,Kamala Harris,478
-Santa Clara,3928,U.S. Senate,,DEM,Loretta Sanchez,295
-Santa Clara,3932,U.S. Senate,,DEM,Kamala Harris,499
-Santa Clara,3932,U.S. Senate,,DEM,Loretta Sanchez,226
-Santa Clara,3937,U.S. Senate,,DEM,Kamala Harris,467
-Santa Clara,3937,U.S. Senate,,DEM,Loretta Sanchez,271
-Santa Clara,3938,U.S. Senate,,DEM,Kamala Harris,224
-Santa Clara,3938,U.S. Senate,,DEM,Loretta Sanchez,124
-Santa Clara,3939,U.S. Senate,,DEM,Kamala Harris,671
-Santa Clara,3939,U.S. Senate,,DEM,Loretta Sanchez,343
-Santa Clara,3943,U.S. Senate,,DEM,Kamala Harris,249
-Santa Clara,3943,U.S. Senate,,DEM,Loretta Sanchez,177
-Santa Clara,3951,U.S. Senate,,DEM,Kamala Harris,507
-Santa Clara,3951,U.S. Senate,,DEM,Loretta Sanchez,421
-Santa Clara,3952,U.S. Senate,,DEM,Kamala Harris,617
-Santa Clara,3952,U.S. Senate,,DEM,Loretta Sanchez,277
-Santa Clara,3953,U.S. Senate,,DEM,Kamala Harris,511
-Santa Clara,3953,U.S. Senate,,DEM,Loretta Sanchez,415
-Santa Clara,3954,U.S. Senate,,DEM,Kamala Harris,397
-Santa Clara,3954,U.S. Senate,,DEM,Loretta Sanchez,276
-Santa Clara,3955,U.S. Senate,,DEM,Kamala Harris,417
-Santa Clara,3955,U.S. Senate,,DEM,Loretta Sanchez,243
-Santa Clara,3958,U.S. Senate,,DEM,Kamala Harris,258
-Santa Clara,3958,U.S. Senate,,DEM,Loretta Sanchez,301
-Santa Clara,3959,U.S. Senate,,DEM,Kamala Harris,483
-Santa Clara,3959,U.S. Senate,,DEM,Loretta Sanchez,288
-Santa Clara,3960,U.S. Senate,,DEM,Kamala Harris,267
-Santa Clara,3960,U.S. Senate,,DEM,Loretta Sanchez,212
-Santa Clara,3962,U.S. Senate,,DEM,Kamala Harris,337
-Santa Clara,3962,U.S. Senate,,DEM,Loretta Sanchez,395
-Santa Clara,3964,U.S. Senate,,DEM,Kamala Harris,595
-Santa Clara,3964,U.S. Senate,,DEM,Loretta Sanchez,361
-Santa Clara,3965,U.S. Senate,,DEM,Kamala Harris,504
-Santa Clara,3965,U.S. Senate,,DEM,Loretta Sanchez,262
-Santa Clara,3969,U.S. Senate,,DEM,Kamala Harris,578
-Santa Clara,3969,U.S. Senate,,DEM,Loretta Sanchez,506
-Santa Clara,3970,U.S. Senate,,DEM,Kamala Harris,409
-Santa Clara,3970,U.S. Senate,,DEM,Loretta Sanchez,258
-Santa Clara,3971,U.S. Senate,,DEM,Kamala Harris,0
-Santa Clara,3971,U.S. Senate,,DEM,Loretta Sanchez,0
-Santa Clara,3972,U.S. Senate,,DEM,Kamala Harris,193
-Santa Clara,3972,U.S. Senate,,DEM,Loretta Sanchez,75
-Santa Clara,3976,U.S. Senate,,DEM,Kamala Harris,578
-Santa Clara,3976,U.S. Senate,,DEM,Loretta Sanchez,276
-Santa Clara,3981,U.S. Senate,,DEM,Kamala Harris,511
-Santa Clara,3981,U.S. Senate,,DEM,Loretta Sanchez,230
-Santa Clara,3982,U.S. Senate,,DEM,Kamala Harris,439
-Santa Clara,3982,U.S. Senate,,DEM,Loretta Sanchez,303
-Santa Clara,3983,U.S. Senate,,DEM,Kamala Harris,443
-Santa Clara,3983,U.S. Senate,,DEM,Loretta Sanchez,243
-Santa Clara,3984,U.S. Senate,,DEM,Kamala Harris,358
-Santa Clara,3984,U.S. Senate,,DEM,Loretta Sanchez,187
-Santa Clara,3985,U.S. Senate,,DEM,Kamala Harris,420
-Santa Clara,3985,U.S. Senate,,DEM,Loretta Sanchez,351
-Santa Clara,3986,U.S. Senate,,DEM,Kamala Harris,432
-Santa Clara,3986,U.S. Senate,,DEM,Loretta Sanchez,220
-Santa Clara,3989,U.S. Senate,,DEM,Kamala Harris,367
-Santa Clara,3989,U.S. Senate,,DEM,Loretta Sanchez,181
-Santa Clara,3992,U.S. Senate,,DEM,Kamala Harris,0
-Santa Clara,3992,U.S. Senate,,DEM,Loretta Sanchez,0
-Santa Clara,3993,U.S. Senate,,DEM,Kamala Harris,304
-Santa Clara,3993,U.S. Senate,,DEM,Loretta Sanchez,240
-Santa Clara,4001,U.S. Senate,,DEM,Kamala Harris,617
-Santa Clara,4001,U.S. Senate,,DEM,Loretta Sanchez,346
-Santa Clara,4002,U.S. Senate,,DEM,Kamala Harris,668
-Santa Clara,4002,U.S. Senate,,DEM,Loretta Sanchez,390
-Santa Clara,4005,U.S. Senate,,DEM,Kamala Harris,19
-Santa Clara,4005,U.S. Senate,,DEM,Loretta Sanchez,10
-Santa Clara,4006,U.S. Senate,,DEM,Kamala Harris,630
-Santa Clara,4006,U.S. Senate,,DEM,Loretta Sanchez,317
-Santa Clara,4007,U.S. Senate,,DEM,Kamala Harris,603
-Santa Clara,4007,U.S. Senate,,DEM,Loretta Sanchez,380
-Santa Clara,4008,U.S. Senate,,DEM,Kamala Harris,17
-Santa Clara,4008,U.S. Senate,,DEM,Loretta Sanchez,7
-Santa Clara,4010,U.S. Senate,,DEM,Kamala Harris,814
-Santa Clara,4010,U.S. Senate,,DEM,Loretta Sanchez,264
-Santa Clara,4011,U.S. Senate,,DEM,Kamala Harris,536
-Santa Clara,4011,U.S. Senate,,DEM,Loretta Sanchez,304
-Santa Clara,4012,U.S. Senate,,DEM,Kamala Harris,58
-Santa Clara,4012,U.S. Senate,,DEM,Loretta Sanchez,16
-Santa Clara,4013,U.S. Senate,,DEM,Kamala Harris,495
-Santa Clara,4013,U.S. Senate,,DEM,Loretta Sanchez,247
-Santa Clara,4015,U.S. Senate,,DEM,Kamala Harris,250
-Santa Clara,4015,U.S. Senate,,DEM,Loretta Sanchez,97
-Santa Clara,4016,U.S. Senate,,DEM,Kamala Harris,684
-Santa Clara,4016,U.S. Senate,,DEM,Loretta Sanchez,267
-Santa Clara,4017,U.S. Senate,,DEM,Kamala Harris,457
-Santa Clara,4017,U.S. Senate,,DEM,Loretta Sanchez,209
-Santa Clara,4019,U.S. Senate,,DEM,Kamala Harris,591
-Santa Clara,4019,U.S. Senate,,DEM,Loretta Sanchez,260
-Santa Clara,4020,U.S. Senate,,DEM,Kamala Harris,746
-Santa Clara,4020,U.S. Senate,,DEM,Loretta Sanchez,302
-Santa Clara,4023,U.S. Senate,,DEM,Kamala Harris,641
-Santa Clara,4023,U.S. Senate,,DEM,Loretta Sanchez,231
-Santa Clara,4026,U.S. Senate,,DEM,Kamala Harris,559
-Santa Clara,4026,U.S. Senate,,DEM,Loretta Sanchez,329
-Santa Clara,4029,U.S. Senate,,DEM,Kamala Harris,0
-Santa Clara,4029,U.S. Senate,,DEM,Loretta Sanchez,0
-Santa Clara,4034,U.S. Senate,,DEM,Kamala Harris,661
-Santa Clara,4034,U.S. Senate,,DEM,Loretta Sanchez,236
-Santa Clara,4035,U.S. Senate,,DEM,Kamala Harris,548
-Santa Clara,4035,U.S. Senate,,DEM,Loretta Sanchez,291
-Santa Clara,4036,U.S. Senate,,DEM,Kamala Harris,609
-Santa Clara,4036,U.S. Senate,,DEM,Loretta Sanchez,255
-Santa Clara,4038,U.S. Senate,,DEM,Kamala Harris,627
-Santa Clara,4038,U.S. Senate,,DEM,Loretta Sanchez,241
-Santa Clara,4039,U.S. Senate,,DEM,Kamala Harris,437
-Santa Clara,4039,U.S. Senate,,DEM,Loretta Sanchez,135
-Santa Clara,4041,U.S. Senate,,DEM,Kamala Harris,797
-Santa Clara,4041,U.S. Senate,,DEM,Loretta Sanchez,297
-Santa Clara,4043,U.S. Senate,,DEM,Kamala Harris,484
-Santa Clara,4043,U.S. Senate,,DEM,Loretta Sanchez,138
-Santa Clara,4045,U.S. Senate,,DEM,Kamala Harris,685
-Santa Clara,4045,U.S. Senate,,DEM,Loretta Sanchez,216
-Santa Clara,4047,U.S. Senate,,DEM,Kamala Harris,76
-Santa Clara,4047,U.S. Senate,,DEM,Loretta Sanchez,26
-Santa Clara,4048,U.S. Senate,,DEM,Kamala Harris,365
-Santa Clara,4048,U.S. Senate,,DEM,Loretta Sanchez,234
-Santa Clara,4050,U.S. Senate,,DEM,Kamala Harris,616
-Santa Clara,4050,U.S. Senate,,DEM,Loretta Sanchez,377
-Santa Clara,4051,U.S. Senate,,DEM,Kamala Harris,793
-Santa Clara,4051,U.S. Senate,,DEM,Loretta Sanchez,254
-Santa Clara,4052,U.S. Senate,,DEM,Kamala Harris,834
-Santa Clara,4052,U.S. Senate,,DEM,Loretta Sanchez,174
-Santa Clara,4053,U.S. Senate,,DEM,Kamala Harris,811
-Santa Clara,4053,U.S. Senate,,DEM,Loretta Sanchez,253
-Santa Clara,4059,U.S. Senate,,DEM,Kamala Harris,256
-Santa Clara,4059,U.S. Senate,,DEM,Loretta Sanchez,161
-Santa Clara,4060,U.S. Senate,,DEM,Kamala Harris,284
-Santa Clara,4060,U.S. Senate,,DEM,Loretta Sanchez,171
-Santa Clara,4061,U.S. Senate,,DEM,Kamala Harris,147
-Santa Clara,4061,U.S. Senate,,DEM,Loretta Sanchez,43
-Santa Clara,4062,U.S. Senate,,DEM,Kamala Harris,669
-Santa Clara,4062,U.S. Senate,,DEM,Loretta Sanchez,272
-Santa Clara,4066,U.S. Senate,,DEM,Kamala Harris,398
-Santa Clara,4066,U.S. Senate,,DEM,Loretta Sanchez,205
-Santa Clara,4071,U.S. Senate,,DEM,Kamala Harris,690
-Santa Clara,4071,U.S. Senate,,DEM,Loretta Sanchez,296
-Santa Clara,4074,U.S. Senate,,DEM,Kamala Harris,654
-Santa Clara,4074,U.S. Senate,,DEM,Loretta Sanchez,207
-Santa Clara,4075,U.S. Senate,,DEM,Kamala Harris,627
-Santa Clara,4075,U.S. Senate,,DEM,Loretta Sanchez,356
-Santa Clara,4076,U.S. Senate,,DEM,Kamala Harris,705
-Santa Clara,4076,U.S. Senate,,DEM,Loretta Sanchez,257
-Santa Clara,4078,U.S. Senate,,DEM,Kamala Harris,604
-Santa Clara,4078,U.S. Senate,,DEM,Loretta Sanchez,182
-Santa Clara,4083,U.S. Senate,,DEM,Kamala Harris,488
-Santa Clara,4083,U.S. Senate,,DEM,Loretta Sanchez,140
-Santa Clara,4085,U.S. Senate,,DEM,Kamala Harris,556
-Santa Clara,4085,U.S. Senate,,DEM,Loretta Sanchez,184
-Santa Clara,4086,U.S. Senate,,DEM,Kamala Harris,697
-Santa Clara,4086,U.S. Senate,,DEM,Loretta Sanchez,229
-Santa Clara,4087,U.S. Senate,,DEM,Kamala Harris,431
-Santa Clara,4087,U.S. Senate,,DEM,Loretta Sanchez,235
-Santa Clara,4089,U.S. Senate,,DEM,Kamala Harris,0
-Santa Clara,4089,U.S. Senate,,DEM,Loretta Sanchez,0
-Santa Clara,4090,U.S. Senate,,DEM,Kamala Harris,65
-Santa Clara,4090,U.S. Senate,,DEM,Loretta Sanchez,29
-Santa Clara,4095,U.S. Senate,,DEM,Kamala Harris,1
-Santa Clara,4095,U.S. Senate,,DEM,Loretta Sanchez,1
-Santa Clara,4103,U.S. Senate,,DEM,Kamala Harris,648
-Santa Clara,4103,U.S. Senate,,DEM,Loretta Sanchez,220
-Santa Clara,4113,U.S. Senate,,DEM,Kamala Harris,582
-Santa Clara,4113,U.S. Senate,,DEM,Loretta Sanchez,171
-Santa Clara,4117,U.S. Senate,,DEM,Kamala Harris,428
-Santa Clara,4117,U.S. Senate,,DEM,Loretta Sanchez,194
-Santa Clara,4118,U.S. Senate,,DEM,Kamala Harris,609
-Santa Clara,4118,U.S. Senate,,DEM,Loretta Sanchez,159
-Santa Clara,4120,U.S. Senate,,DEM,Kamala Harris,604
-Santa Clara,4120,U.S. Senate,,DEM,Loretta Sanchez,236
-Santa Clara,4122,U.S. Senate,,DEM,Kamala Harris,667
-Santa Clara,4122,U.S. Senate,,DEM,Loretta Sanchez,192
-Santa Clara,4126,U.S. Senate,,DEM,Kamala Harris,727
-Santa Clara,4126,U.S. Senate,,DEM,Loretta Sanchez,182
-Santa Clara,4128,U.S. Senate,,DEM,Kamala Harris,862
-Santa Clara,4128,U.S. Senate,,DEM,Loretta Sanchez,246
-Santa Clara,4129,U.S. Senate,,DEM,Kamala Harris,803
-Santa Clara,4129,U.S. Senate,,DEM,Loretta Sanchez,257
-Santa Clara,4131,U.S. Senate,,DEM,Kamala Harris,517
-Santa Clara,4131,U.S. Senate,,DEM,Loretta Sanchez,245
-Santa Clara,4139,U.S. Senate,,DEM,Kamala Harris,481
-Santa Clara,4139,U.S. Senate,,DEM,Loretta Sanchez,145
-Santa Clara,4155,U.S. Senate,,DEM,Kamala Harris,342
-Santa Clara,4155,U.S. Senate,,DEM,Loretta Sanchez,128
-Santa Clara,4201,U.S. Senate,,DEM,Kamala Harris,674
-Santa Clara,4201,U.S. Senate,,DEM,Loretta Sanchez,267
-Santa Clara,4202,U.S. Senate,,DEM,Kamala Harris,45
-Santa Clara,4202,U.S. Senate,,DEM,Loretta Sanchez,41
-Santa Clara,4205,U.S. Senate,,DEM,Kamala Harris,51
-Santa Clara,4205,U.S. Senate,,DEM,Loretta Sanchez,28
-Santa Clara,4208,U.S. Senate,,DEM,Kamala Harris,508
-Santa Clara,4208,U.S. Senate,,DEM,Loretta Sanchez,327
-Santa Clara,4211,U.S. Senate,,DEM,Kamala Harris,599
-Santa Clara,4211,U.S. Senate,,DEM,Loretta Sanchez,309
-Santa Clara,4213,U.S. Senate,,DEM,Kamala Harris,0
-Santa Clara,4213,U.S. Senate,,DEM,Loretta Sanchez,0
-Santa Clara,4217,U.S. Senate,,DEM,Kamala Harris,672
-Santa Clara,4217,U.S. Senate,,DEM,Loretta Sanchez,328
-Santa Clara,4218,U.S. Senate,,DEM,Kamala Harris,426
-Santa Clara,4218,U.S. Senate,,DEM,Loretta Sanchez,233
-Santa Clara,4225,U.S. Senate,,DEM,Kamala Harris,635
-Santa Clara,4225,U.S. Senate,,DEM,Loretta Sanchez,363
-Santa Clara,4226,U.S. Senate,,DEM,Kamala Harris,683
-Santa Clara,4226,U.S. Senate,,DEM,Loretta Sanchez,317
-Santa Clara,4231,U.S. Senate,,DEM,Kamala Harris,587
-Santa Clara,4231,U.S. Senate,,DEM,Loretta Sanchez,290
-Santa Clara,4233,U.S. Senate,,DEM,Kamala Harris,539
-Santa Clara,4233,U.S. Senate,,DEM,Loretta Sanchez,278
-Santa Clara,4238,U.S. Senate,,DEM,Kamala Harris,644
-Santa Clara,4238,U.S. Senate,,DEM,Loretta Sanchez,330
-Santa Clara,4241,U.S. Senate,,DEM,Kamala Harris,664
-Santa Clara,4241,U.S. Senate,,DEM,Loretta Sanchez,322
-Santa Clara,4242,U.S. Senate,,DEM,Kamala Harris,674
-Santa Clara,4242,U.S. Senate,,DEM,Loretta Sanchez,361
-Santa Clara,4249,U.S. Senate,,DEM,Kamala Harris,621
-Santa Clara,4249,U.S. Senate,,DEM,Loretta Sanchez,397
-Santa Clara,4251,U.S. Senate,,DEM,Kamala Harris,751
-Santa Clara,4251,U.S. Senate,,DEM,Loretta Sanchez,363
-Santa Clara,4255,U.S. Senate,,DEM,Kamala Harris,229
-Santa Clara,4255,U.S. Senate,,DEM,Loretta Sanchez,85
-Santa Clara,4256,U.S. Senate,,DEM,Kamala Harris,716
-Santa Clara,4256,U.S. Senate,,DEM,Loretta Sanchez,278
-Santa Clara,4257,U.S. Senate,,DEM,Kamala Harris,666
-Santa Clara,4257,U.S. Senate,,DEM,Loretta Sanchez,357
-Santa Clara,4258,U.S. Senate,,DEM,Kamala Harris,362
-Santa Clara,4258,U.S. Senate,,DEM,Loretta Sanchez,225
-Santa Clara,4259,U.S. Senate,,DEM,Kamala Harris,679
-Santa Clara,4259,U.S. Senate,,DEM,Loretta Sanchez,366
-Santa Clara,4261,U.S. Senate,,DEM,Kamala Harris,417
-Santa Clara,4261,U.S. Senate,,DEM,Loretta Sanchez,254
-Santa Clara,4262,U.S. Senate,,DEM,Kamala Harris,517
-Santa Clara,4262,U.S. Senate,,DEM,Loretta Sanchez,294
-Santa Clara,4265,U.S. Senate,,DEM,Kamala Harris,637
-Santa Clara,4265,U.S. Senate,,DEM,Loretta Sanchez,284
-Santa Clara,4268,U.S. Senate,,DEM,Kamala Harris,517
-Santa Clara,4268,U.S. Senate,,DEM,Loretta Sanchez,356
-Santa Clara,4269,U.S. Senate,,DEM,Kamala Harris,511
-Santa Clara,4269,U.S. Senate,,DEM,Loretta Sanchez,185
-Santa Clara,4270,U.S. Senate,,DEM,Kamala Harris,629
-Santa Clara,4270,U.S. Senate,,DEM,Loretta Sanchez,333
-Santa Clara,4272,U.S. Senate,,DEM,Kamala Harris,533
-Santa Clara,4272,U.S. Senate,,DEM,Loretta Sanchez,284
-Santa Clara,4285,U.S. Senate,,DEM,Kamala Harris,376
-Santa Clara,4285,U.S. Senate,,DEM,Loretta Sanchez,273
-Santa Clara,4288,U.S. Senate,,DEM,Kamala Harris,444
-Santa Clara,4288,U.S. Senate,,DEM,Loretta Sanchez,159
-Santa Clara,4289,U.S. Senate,,DEM,Kamala Harris,355
-Santa Clara,4289,U.S. Senate,,DEM,Loretta Sanchez,197
-Santa Clara,4290,U.S. Senate,,DEM,Kamala Harris,348
-Santa Clara,4290,U.S. Senate,,DEM,Loretta Sanchez,184
-Santa Clara,4292,U.S. Senate,,DEM,Kamala Harris,393
-Santa Clara,4292,U.S. Senate,,DEM,Loretta Sanchez,126
-Santa Clara,4297,U.S. Senate,,DEM,Kamala Harris,647
-Santa Clara,4297,U.S. Senate,,DEM,Loretta Sanchez,286
-Santa Clara,4298,U.S. Senate,,DEM,Kamala Harris,735
-Santa Clara,4298,U.S. Senate,,DEM,Loretta Sanchez,325
-Santa Clara,4299,U.S. Senate,,DEM,Kamala Harris,61
-Santa Clara,4299,U.S. Senate,,DEM,Loretta Sanchez,28
-Santa Clara,4301,U.S. Senate,,DEM,Kamala Harris,682
-Santa Clara,4301,U.S. Senate,,DEM,Loretta Sanchez,237
-Santa Clara,4305,U.S. Senate,,DEM,Kamala Harris,706
-Santa Clara,4305,U.S. Senate,,DEM,Loretta Sanchez,251
-Santa Clara,4309,U.S. Senate,,DEM,Kamala Harris,18
-Santa Clara,4309,U.S. Senate,,DEM,Loretta Sanchez,13
-Santa Clara,4312,U.S. Senate,,DEM,Kamala Harris,487
-Santa Clara,4312,U.S. Senate,,DEM,Loretta Sanchez,147
-Santa Clara,4315,U.S. Senate,,DEM,Kamala Harris,467
-Santa Clara,4315,U.S. Senate,,DEM,Loretta Sanchez,209
-Santa Clara,4319,U.S. Senate,,DEM,Kamala Harris,685
-Santa Clara,4319,U.S. Senate,,DEM,Loretta Sanchez,350
-Santa Clara,4321,U.S. Senate,,DEM,Kamala Harris,541
-Santa Clara,4321,U.S. Senate,,DEM,Loretta Sanchez,284
-Santa Clara,4327,U.S. Senate,,DEM,Kamala Harris,693
-Santa Clara,4327,U.S. Senate,,DEM,Loretta Sanchez,298
-Santa Clara,4332,U.S. Senate,,DEM,Kamala Harris,298
-Santa Clara,4332,U.S. Senate,,DEM,Loretta Sanchez,193
-Santa Clara,4334,U.S. Senate,,DEM,Kamala Harris,498
-Santa Clara,4334,U.S. Senate,,DEM,Loretta Sanchez,175
-Santa Clara,4344,U.S. Senate,,DEM,Kamala Harris,385
-Santa Clara,4344,U.S. Senate,,DEM,Loretta Sanchez,172
-Santa Clara,4353,U.S. Senate,,DEM,Kamala Harris,230
-Santa Clara,4353,U.S. Senate,,DEM,Loretta Sanchez,95
-Santa Clara,4401,U.S. Senate,,DEM,Kamala Harris,302
-Santa Clara,4401,U.S. Senate,,DEM,Loretta Sanchez,295
-Santa Clara,4402,U.S. Senate,,DEM,Kamala Harris,602
-Santa Clara,4402,U.S. Senate,,DEM,Loretta Sanchez,323
-Santa Clara,4403,U.S. Senate,,DEM,Kamala Harris,43
-Santa Clara,4403,U.S. Senate,,DEM,Loretta Sanchez,27
-Santa Clara,4404,U.S. Senate,,DEM,Kamala Harris,470
-Santa Clara,4404,U.S. Senate,,DEM,Loretta Sanchez,357
-Santa Clara,4405,U.S. Senate,,DEM,Kamala Harris,680
-Santa Clara,4405,U.S. Senate,,DEM,Loretta Sanchez,328
-Santa Clara,4406,U.S. Senate,,DEM,Kamala Harris,362
-Santa Clara,4406,U.S. Senate,,DEM,Loretta Sanchez,220
-Santa Clara,4407,U.S. Senate,,DEM,Kamala Harris,610
-Santa Clara,4407,U.S. Senate,,DEM,Loretta Sanchez,374
-Santa Clara,4408,U.S. Senate,,DEM,Kamala Harris,578
-Santa Clara,4408,U.S. Senate,,DEM,Loretta Sanchez,368
-Santa Clara,4409,U.S. Senate,,DEM,Kamala Harris,577
-Santa Clara,4409,U.S. Senate,,DEM,Loretta Sanchez,394
-Santa Clara,4410,U.S. Senate,,DEM,Kamala Harris,609
-Santa Clara,4410,U.S. Senate,,DEM,Loretta Sanchez,386
-Santa Clara,4411,U.S. Senate,,DEM,Kamala Harris,668
-Santa Clara,4411,U.S. Senate,,DEM,Loretta Sanchez,367
-Santa Clara,4413,U.S. Senate,,DEM,Kamala Harris,357
-Santa Clara,4413,U.S. Senate,,DEM,Loretta Sanchez,204
-Santa Clara,4414,U.S. Senate,,DEM,Kamala Harris,730
-Santa Clara,4414,U.S. Senate,,DEM,Loretta Sanchez,342
-Santa Clara,4415,U.S. Senate,,DEM,Kamala Harris,502
-Santa Clara,4415,U.S. Senate,,DEM,Loretta Sanchez,329
-Santa Clara,4416,U.S. Senate,,DEM,Kamala Harris,570
-Santa Clara,4416,U.S. Senate,,DEM,Loretta Sanchez,432
-Santa Clara,4417,U.S. Senate,,DEM,Kamala Harris,402
-Santa Clara,4417,U.S. Senate,,DEM,Loretta Sanchez,256
-Santa Clara,4418,U.S. Senate,,DEM,Kamala Harris,533
-Santa Clara,4418,U.S. Senate,,DEM,Loretta Sanchez,438
-Santa Clara,4419,U.S. Senate,,DEM,Kamala Harris,513
-Santa Clara,4419,U.S. Senate,,DEM,Loretta Sanchez,270
-Santa Clara,4420,U.S. Senate,,DEM,Kamala Harris,444
-Santa Clara,4420,U.S. Senate,,DEM,Loretta Sanchez,234
-Santa Clara,4422,U.S. Senate,,DEM,Kamala Harris,406
-Santa Clara,4422,U.S. Senate,,DEM,Loretta Sanchez,255
-Santa Clara,4423,U.S. Senate,,DEM,Kamala Harris,258
-Santa Clara,4423,U.S. Senate,,DEM,Loretta Sanchez,148
-Santa Clara,4424,U.S. Senate,,DEM,Kamala Harris,500
-Santa Clara,4424,U.S. Senate,,DEM,Loretta Sanchez,207
-Santa Clara,4425,U.S. Senate,,DEM,Kamala Harris,649
-Santa Clara,4425,U.S. Senate,,DEM,Loretta Sanchez,375
-Santa Clara,4426,U.S. Senate,,DEM,Kamala Harris,533
-Santa Clara,4426,U.S. Senate,,DEM,Loretta Sanchez,421
-Santa Clara,4430,U.S. Senate,,DEM,Kamala Harris,151
-Santa Clara,4430,U.S. Senate,,DEM,Loretta Sanchez,55
-Santa Clara,4431,U.S. Senate,,DEM,Kamala Harris,24
-Santa Clara,4431,U.S. Senate,,DEM,Loretta Sanchez,1
-Santa Clara,4440,U.S. Senate,,DEM,Kamala Harris,546
-Santa Clara,4440,U.S. Senate,,DEM,Loretta Sanchez,251
-Santa Clara,4674,U.S. Senate,,DEM,Kamala Harris,538
-Santa Clara,4674,U.S. Senate,,DEM,Loretta Sanchez,162
-Santa Clara,4675,U.S. Senate,,DEM,Kamala Harris,559
-Santa Clara,4675,U.S. Senate,,DEM,Loretta Sanchez,169
-Santa Clara,4676,U.S. Senate,,DEM,Kamala Harris,704
-Santa Clara,4676,U.S. Senate,,DEM,Loretta Sanchez,230
-Santa Clara,4678,U.S. Senate,,DEM,Kamala Harris,573
-Santa Clara,4678,U.S. Senate,,DEM,Loretta Sanchez,136
-Santa Clara,4679,U.S. Senate,,DEM,Kamala Harris,374
-Santa Clara,4679,U.S. Senate,,DEM,Loretta Sanchez,128
-Santa Clara,4685,U.S. Senate,,DEM,Kamala Harris,748
-Santa Clara,4685,U.S. Senate,,DEM,Loretta Sanchez,243
-Santa Clara,4687,U.S. Senate,,DEM,Kamala Harris,462
-Santa Clara,4687,U.S. Senate,,DEM,Loretta Sanchez,105
-Santa Clara,4688,U.S. Senate,,DEM,Kamala Harris,642
-Santa Clara,4688,U.S. Senate,,DEM,Loretta Sanchez,150
-Santa Clara,4689,U.S. Senate,,DEM,Kamala Harris,740
-Santa Clara,4689,U.S. Senate,,DEM,Loretta Sanchez,221
-Santa Clara,4690,U.S. Senate,,DEM,Kamala Harris,566
-Santa Clara,4690,U.S. Senate,,DEM,Loretta Sanchez,162
-Santa Clara,4691,U.S. Senate,,DEM,Kamala Harris,588
-Santa Clara,4691,U.S. Senate,,DEM,Loretta Sanchez,161
-Santa Clara,4692,U.S. Senate,,DEM,Kamala Harris,459
-Santa Clara,4692,U.S. Senate,,DEM,Loretta Sanchez,138
-Santa Clara,4696,U.S. Senate,,DEM,Kamala Harris,648
-Santa Clara,4696,U.S. Senate,,DEM,Loretta Sanchez,169
-Santa Clara,4697,U.S. Senate,,DEM,Kamala Harris,767
-Santa Clara,4697,U.S. Senate,,DEM,Loretta Sanchez,241
-Santa Clara,4698,U.S. Senate,,DEM,Kamala Harris,611
-Santa Clara,4698,U.S. Senate,,DEM,Loretta Sanchez,150
-Santa Clara,4699,U.S. Senate,,DEM,Kamala Harris,705
-Santa Clara,4699,U.S. Senate,,DEM,Loretta Sanchez,203
-Santa Clara,4702,U.S. Senate,,DEM,Kamala Harris,399
-Santa Clara,4702,U.S. Senate,,DEM,Loretta Sanchez,91
-Santa Clara,4705,U.S. Senate,,DEM,Kamala Harris,764
-Santa Clara,4705,U.S. Senate,,DEM,Loretta Sanchez,204
-Santa Clara,4707,U.S. Senate,,DEM,Kamala Harris,79
-Santa Clara,4707,U.S. Senate,,DEM,Loretta Sanchez,27
-Santa Clara,4721,U.S. Senate,,DEM,Kamala Harris,152
-Santa Clara,4721,U.S. Senate,,DEM,Loretta Sanchez,45
-Santa Clara,4729,U.S. Senate,,DEM,Kamala Harris,1
-Santa Clara,4729,U.S. Senate,,DEM,Loretta Sanchez,1
-Santa Clara,4733,U.S. Senate,,DEM,Kamala Harris,16
-Santa Clara,4733,U.S. Senate,,DEM,Loretta Sanchez,9
-Santa Clara,4740,U.S. Senate,,DEM,Kamala Harris,26
-Santa Clara,4740,U.S. Senate,,DEM,Loretta Sanchez,12
-Santa Clara,5449,U.S. Senate,,DEM,Kamala Harris,51
-Santa Clara,5449,U.S. Senate,,DEM,Loretta Sanchez,33
-Santa Clara,5451,U.S. Senate,,DEM,Kamala Harris,0
-Santa Clara,5451,U.S. Senate,,DEM,Loretta Sanchez,0
-Santa Clara,5453,U.S. Senate,,DEM,Kamala Harris,8
-Santa Clara,5453,U.S. Senate,,DEM,Loretta Sanchez,2
-Santa Clara,5456,U.S. Senate,,DEM,Kamala Harris,92
-Santa Clara,5456,U.S. Senate,,DEM,Loretta Sanchez,44
-Santa Clara,5458,U.S. Senate,,DEM,Kamala Harris,0
-Santa Clara,5458,U.S. Senate,,DEM,Loretta Sanchez,2
-Santa Clara,5461,U.S. Senate,,DEM,Kamala Harris,0
-Santa Clara,5461,U.S. Senate,,DEM,Loretta Sanchez,0
-Santa Clara,5502,U.S. Senate,,DEM,Kamala Harris,181
-Santa Clara,5502,U.S. Senate,,DEM,Loretta Sanchez,116
-Santa Clara,5503,U.S. Senate,,DEM,Kamala Harris,99
-Santa Clara,5503,U.S. Senate,,DEM,Loretta Sanchez,134
-Santa Clara,5507,U.S. Senate,,DEM,Kamala Harris,0
-Santa Clara,5507,U.S. Senate,,DEM,Loretta Sanchez,0
-Santa Clara,5556,U.S. Senate,,DEM,Kamala Harris,622
-Santa Clara,5556,U.S. Senate,,DEM,Loretta Sanchez,391
-Santa Clara,5557,U.S. Senate,,DEM,Kamala Harris,468
-Santa Clara,5557,U.S. Senate,,DEM,Loretta Sanchez,223
-Santa Clara,5567,U.S. Senate,,DEM,Kamala Harris,298
-Santa Clara,5567,U.S. Senate,,DEM,Loretta Sanchez,124
-Santa Clara,5648,U.S. Senate,,DEM,Kamala Harris,0
-Santa Clara,5648,U.S. Senate,,DEM,Loretta Sanchez,0
-Santa Clara,5742,U.S. Senate,,DEM,Kamala Harris,0
-Santa Clara,5742,U.S. Senate,,DEM,Loretta Sanchez,0
-Santa Clara,5743,U.S. Senate,,DEM,Kamala Harris,8
-Santa Clara,5743,U.S. Senate,,DEM,Loretta Sanchez,1
-Santa Clara,5744,U.S. Senate,,DEM,Kamala Harris,7
-Santa Clara,5744,U.S. Senate,,DEM,Loretta Sanchez,2
-Santa Clara,5745,U.S. Senate,,DEM,Kamala Harris,84
-Santa Clara,5745,U.S. Senate,,DEM,Loretta Sanchez,45
-Santa Clara,5746,U.S. Senate,,DEM,Kamala Harris,10
-Santa Clara,5746,U.S. Senate,,DEM,Loretta Sanchez,5
-Santa Clara,5747,U.S. Senate,,DEM,Kamala Harris,6
-Santa Clara,5747,U.S. Senate,,DEM,Loretta Sanchez,1
-Santa Clara,5748,U.S. Senate,,DEM,Kamala Harris,98
-Santa Clara,5748,U.S. Senate,,DEM,Loretta Sanchez,38
-Santa Clara,5750,U.S. Senate,,DEM,Kamala Harris,124
-Santa Clara,5750,U.S. Senate,,DEM,Loretta Sanchez,44
-Santa Clara,5752,U.S. Senate,,DEM,Kamala Harris,526
-Santa Clara,5752,U.S. Senate,,DEM,Loretta Sanchez,207
-Santa Clara,5754,U.S. Senate,,DEM,Kamala Harris,377
-Santa Clara,5754,U.S. Senate,,DEM,Loretta Sanchez,122
-Santa Clara,5755,U.S. Senate,,DEM,Kamala Harris,291
-Santa Clara,5755,U.S. Senate,,DEM,Loretta Sanchez,114
-Santa Clara,5756,U.S. Senate,,DEM,Kamala Harris,46
-Santa Clara,5756,U.S. Senate,,DEM,Loretta Sanchez,30
-Santa Clara,5758,U.S. Senate,,DEM,Kamala Harris,65
-Santa Clara,5758,U.S. Senate,,DEM,Loretta Sanchez,29
-Santa Clara,5759,U.S. Senate,,DEM,Kamala Harris,201
-Santa Clara,5759,U.S. Senate,,DEM,Loretta Sanchez,69
-Santa Clara,5760,U.S. Senate,,DEM,Kamala Harris,5
-Santa Clara,5760,U.S. Senate,,DEM,Loretta Sanchez,0
-Santa Clara,5762,U.S. Senate,,DEM,Kamala Harris,33
-Santa Clara,5762,U.S. Senate,,DEM,Loretta Sanchez,21
-Santa Clara,5764,U.S. Senate,,DEM,Kamala Harris,59
-Santa Clara,5764,U.S. Senate,,DEM,Loretta Sanchez,15
-Santa Clara,5770,U.S. Senate,,DEM,Kamala Harris,92
-Santa Clara,5770,U.S. Senate,,DEM,Loretta Sanchez,36
-Santa Clara,5772,U.S. Senate,,DEM,Kamala Harris,0
-Santa Clara,5772,U.S. Senate,,DEM,Loretta Sanchez,1
-Santa Clara,5773,U.S. Senate,,DEM,Kamala Harris,233
-Santa Clara,5773,U.S. Senate,,DEM,Loretta Sanchez,78
-Santa Clara,5774,U.S. Senate,,DEM,Kamala Harris,19
-Santa Clara,5774,U.S. Senate,,DEM,Loretta Sanchez,0
-Santa Clara,5775,U.S. Senate,,DEM,Kamala Harris,177
-Santa Clara,5775,U.S. Senate,,DEM,Loretta Sanchez,63
-Santa Clara,5777,U.S. Senate,,DEM,Kamala Harris,483
-Santa Clara,5777,U.S. Senate,,DEM,Loretta Sanchez,127
-Santa Clara,5781,U.S. Senate,,DEM,Kamala Harris,0
-Santa Clara,5781,U.S. Senate,,DEM,Loretta Sanchez,1
-Santa Clara,5782,U.S. Senate,,DEM,Kamala Harris,64
-Santa Clara,5782,U.S. Senate,,DEM,Loretta Sanchez,33
-Santa Clara,5784,U.S. Senate,,DEM,Kamala Harris,3
-Santa Clara,5784,U.S. Senate,,DEM,Loretta Sanchez,2
-Santa Clara,5788,U.S. Senate,,DEM,Kamala Harris,9
-Santa Clara,5788,U.S. Senate,,DEM,Loretta Sanchez,3
-Santa Clara,5789,U.S. Senate,,DEM,Kamala Harris,5
-Santa Clara,5789,U.S. Senate,,DEM,Loretta Sanchez,4
-Santa Clara,5793,U.S. Senate,,DEM,Kamala Harris,0
-Santa Clara,5793,U.S. Senate,,DEM,Loretta Sanchez,0
-Santa Clara,5804,U.S. Senate,,DEM,Kamala Harris,676
-Santa Clara,5804,U.S. Senate,,DEM,Loretta Sanchez,311
-Santa Clara,5810,U.S. Senate,,DEM,Kamala Harris,312
-Santa Clara,5810,U.S. Senate,,DEM,Loretta Sanchez,153
-Santa Clara,5813,U.S. Senate,,DEM,Kamala Harris,29
-Santa Clara,5813,U.S. Senate,,DEM,Loretta Sanchez,11
-Santa Clara,5858,U.S. Senate,,DEM,Kamala Harris,86
-Santa Clara,5858,U.S. Senate,,DEM,Loretta Sanchez,22
-Santa Clara,5879,U.S. Senate,,DEM,Kamala Harris,0
-Santa Clara,5879,U.S. Senate,,DEM,Loretta Sanchez,0
-Santa Clara,5881,U.S. Senate,,DEM,Kamala Harris,4
-Santa Clara,5881,U.S. Senate,,DEM,Loretta Sanchez,3
-Santa Clara,5884,U.S. Senate,,DEM,Kamala Harris,0
-Santa Clara,5884,U.S. Senate,,DEM,Loretta Sanchez,0
-Santa Clara,5886,U.S. Senate,,DEM,Kamala Harris,5
-Santa Clara,5886,U.S. Senate,,DEM,Loretta Sanchez,4
-Santa Clara,5888,U.S. Senate,,DEM,Kamala Harris,0
-Santa Clara,5888,U.S. Senate,,DEM,Loretta Sanchez,0
-Santa Clara,5894,U.S. Senate,,DEM,Kamala Harris,1
-Santa Clara,5894,U.S. Senate,,DEM,Loretta Sanchez,3
-Santa Clara,5895,U.S. Senate,,DEM,Kamala Harris,5
-Santa Clara,5895,U.S. Senate,,DEM,Loretta Sanchez,4
-Santa Clara,5897,U.S. Senate,,DEM,Kamala Harris,0
-Santa Clara,5897,U.S. Senate,,DEM,Loretta Sanchez,0
-Santa Clara,5901,U.S. Senate,,DEM,Kamala Harris,0
-Santa Clara,5901,U.S. Senate,,DEM,Loretta Sanchez,0
-Santa Clara,5902,U.S. Senate,,DEM,Kamala Harris,111
-Santa Clara,5902,U.S. Senate,,DEM,Loretta Sanchez,51
-Santa Clara,5903,U.S. Senate,,DEM,Kamala Harris,184
-Santa Clara,5903,U.S. Senate,,DEM,Loretta Sanchez,76
-Santa Clara,5904,U.S. Senate,,DEM,Kamala Harris,134
-Santa Clara,5904,U.S. Senate,,DEM,Loretta Sanchez,51
-Santa Clara,5905,U.S. Senate,,DEM,Kamala Harris,106
-Santa Clara,5905,U.S. Senate,,DEM,Loretta Sanchez,39
-Santa Clara,5906,U.S. Senate,,DEM,Kamala Harris,105
-Santa Clara,5906,U.S. Senate,,DEM,Loretta Sanchez,131
-Santa Clara,5908,U.S. Senate,,DEM,Kamala Harris,40
-Santa Clara,5908,U.S. Senate,,DEM,Loretta Sanchez,30
-Santa Clara,5911,U.S. Senate,,DEM,Kamala Harris,103
-Santa Clara,5911,U.S. Senate,,DEM,Loretta Sanchez,85
-Santa Clara,5912,U.S. Senate,,DEM,Kamala Harris,28
-Santa Clara,5912,U.S. Senate,,DEM,Loretta Sanchez,23
-Santa Clara,5913,U.S. Senate,,DEM,Kamala Harris,2
-Santa Clara,5913,U.S. Senate,,DEM,Loretta Sanchez,1
-Santa Clara,5914,U.S. Senate,,DEM,Kamala Harris,410
-Santa Clara,5914,U.S. Senate,,DEM,Loretta Sanchez,247
-Santa Clara,5915,U.S. Senate,,DEM,Kamala Harris,361
-Santa Clara,5915,U.S. Senate,,DEM,Loretta Sanchez,248
-Santa Clara,5916,U.S. Senate,,DEM,Kamala Harris,32
-Santa Clara,5916,U.S. Senate,,DEM,Loretta Sanchez,20
-Santa Clara,5917,U.S. Senate,,DEM,Kamala Harris,21
-Santa Clara,5917,U.S. Senate,,DEM,Loretta Sanchez,11
-Santa Clara,5919,U.S. Senate,,DEM,Kamala Harris,145
-Santa Clara,5919,U.S. Senate,,DEM,Loretta Sanchez,89
-Santa Clara,5920,U.S. Senate,,DEM,Kamala Harris,6
-Santa Clara,5920,U.S. Senate,,DEM,Loretta Sanchez,0
-Santa Clara,5921,U.S. Senate,,DEM,Kamala Harris,2
-Santa Clara,5921,U.S. Senate,,DEM,Loretta Sanchez,0
-Santa Clara,5922,U.S. Senate,,DEM,Kamala Harris,3
-Santa Clara,5922,U.S. Senate,,DEM,Loretta Sanchez,2
-Santa Clara,5925,U.S. Senate,,DEM,Kamala Harris,33
-Santa Clara,5925,U.S. Senate,,DEM,Loretta Sanchez,17
-Santa Clara,5926,U.S. Senate,,DEM,Kamala Harris,203
-Santa Clara,5926,U.S. Senate,,DEM,Loretta Sanchez,165
-Santa Clara,5927,U.S. Senate,,DEM,Kamala Harris,0
-Santa Clara,5927,U.S. Senate,,DEM,Loretta Sanchez,0
-Santa Clara,5929,U.S. Senate,,DEM,Kamala Harris,26
-Santa Clara,5929,U.S. Senate,,DEM,Loretta Sanchez,13
-Santa Clara,5936,U.S. Senate,,DEM,Kamala Harris,136
-Santa Clara,5936,U.S. Senate,,DEM,Loretta Sanchez,87
-Santa Clara,5937,U.S. Senate,,DEM,Kamala Harris,41
-Santa Clara,5937,U.S. Senate,,DEM,Loretta Sanchez,47
-Santa Clara,5940,U.S. Senate,,DEM,Kamala Harris,10
-Santa Clara,5940,U.S. Senate,,DEM,Loretta Sanchez,10
-Santa Clara,5943,U.S. Senate,,DEM,Kamala Harris,145
-Santa Clara,5943,U.S. Senate,,DEM,Loretta Sanchez,93
-Santa Clara,5947,U.S. Senate,,DEM,Kamala Harris,205
-Santa Clara,5947,U.S. Senate,,DEM,Loretta Sanchez,145
-Santa Clara,5949,U.S. Senate,,DEM,Kamala Harris,55
-Santa Clara,5949,U.S. Senate,,DEM,Loretta Sanchez,59
-Santa Clara,5950,U.S. Senate,,DEM,Kamala Harris,77
-Santa Clara,5950,U.S. Senate,,DEM,Loretta Sanchez,32
-Santa Clara,5951,U.S. Senate,,DEM,Kamala Harris,16
-Santa Clara,5951,U.S. Senate,,DEM,Loretta Sanchez,18
-Santa Clara,5952,U.S. Senate,,DEM,Kamala Harris,40
-Santa Clara,5952,U.S. Senate,,DEM,Loretta Sanchez,29
-Santa Clara,5953,U.S. Senate,,DEM,Kamala Harris,137
-Santa Clara,5953,U.S. Senate,,DEM,Loretta Sanchez,97
-Santa Clara,5955,U.S. Senate,,DEM,Kamala Harris,457
-Santa Clara,5955,U.S. Senate,,DEM,Loretta Sanchez,326
-Santa Clara,5956,U.S. Senate,,DEM,Kamala Harris,458
-Santa Clara,5956,U.S. Senate,,DEM,Loretta Sanchez,278
-Santa Clara,5957,U.S. Senate,,DEM,Kamala Harris,39
-Santa Clara,5957,U.S. Senate,,DEM,Loretta Sanchez,29
-Santa Clara,5959,U.S. Senate,,DEM,Kamala Harris,27
-Santa Clara,5959,U.S. Senate,,DEM,Loretta Sanchez,18
-Santa Clara,5961,U.S. Senate,,DEM,Kamala Harris,280
-Santa Clara,5961,U.S. Senate,,DEM,Loretta Sanchez,218
-Santa Clara,5962,U.S. Senate,,DEM,Kamala Harris,384
-Santa Clara,5962,U.S. Senate,,DEM,Loretta Sanchez,231
-Santa Clara,5965,U.S. Senate,,DEM,Kamala Harris,417
-Santa Clara,5965,U.S. Senate,,DEM,Loretta Sanchez,267
-Santa Clara,5966,U.S. Senate,,DEM,Kamala Harris,39
-Santa Clara,5966,U.S. Senate,,DEM,Loretta Sanchez,35
-Santa Clara,5977,U.S. Senate,,DEM,Kamala Harris,33
-Santa Clara,5977,U.S. Senate,,DEM,Loretta Sanchez,26
-Santa Clara,5988,U.S. Senate,,DEM,Kamala Harris,2
-Santa Clara,5988,U.S. Senate,,DEM,Loretta Sanchez,1
-Santa Clara,5996,U.S. Senate,,DEM,Kamala Harris,21
-Santa Clara,5996,U.S. Senate,,DEM,Loretta Sanchez,17
-Santa Clara,6002,U.S. Senate,,DEM,Kamala Harris,10
-Santa Clara,6002,U.S. Senate,,DEM,Loretta Sanchez,7
-Santa Clara,6006,U.S. Senate,,DEM,Kamala Harris,126
-Santa Clara,6006,U.S. Senate,,DEM,Loretta Sanchez,84
-Santa Clara,6021,U.S. Senate,,DEM,Kamala Harris,15
-Santa Clara,6021,U.S. Senate,,DEM,Loretta Sanchez,7
-Santa Clara,6022,U.S. Senate,,DEM,Kamala Harris,9
-Santa Clara,6022,U.S. Senate,,DEM,Loretta Sanchez,4
-Santa Clara,6023,U.S. Senate,,DEM,Kamala Harris,9
-Santa Clara,6023,U.S. Senate,,DEM,Loretta Sanchez,1
-Santa Clara,6028,U.S. Senate,,DEM,Kamala Harris,1
-Santa Clara,6028,U.S. Senate,,DEM,Loretta Sanchez,0
-Santa Clara,6031,U.S. Senate,,DEM,Kamala Harris,17
-Santa Clara,6031,U.S. Senate,,DEM,Loretta Sanchez,7
-Santa Clara,6034,U.S. Senate,,DEM,Kamala Harris,8
-Santa Clara,6034,U.S. Senate,,DEM,Loretta Sanchez,3
-Santa Clara,6036,U.S. Senate,,DEM,Kamala Harris,0
-Santa Clara,6036,U.S. Senate,,DEM,Loretta Sanchez,0
-Santa Clara,6038,U.S. Senate,,DEM,Kamala Harris,73
-Santa Clara,6038,U.S. Senate,,DEM,Loretta Sanchez,73
-Santa Clara,6040,U.S. Senate,,DEM,Kamala Harris,17
-Santa Clara,6040,U.S. Senate,,DEM,Loretta Sanchez,16
-Santa Clara,6401,U.S. Senate,,DEM,Kamala Harris,0
-Santa Clara,6401,U.S. Senate,,DEM,Loretta Sanchez,0
-Santa Clara,6402,U.S. Senate,,DEM,Kamala Harris,33
-Santa Clara,6402,U.S. Senate,,DEM,Loretta Sanchez,25
-Santa Clara,6404,U.S. Senate,,DEM,Kamala Harris,573
-Santa Clara,6404,U.S. Senate,,DEM,Loretta Sanchez,280
-Santa Clara,6405,U.S. Senate,,DEM,Kamala Harris,2
-Santa Clara,6405,U.S. Senate,,DEM,Loretta Sanchez,3
-Santa Clara,6411,U.S. Senate,,DEM,Kamala Harris,59
-Santa Clara,6411,U.S. Senate,,DEM,Loretta Sanchez,39
-Santa Clara,6413,U.S. Senate,,DEM,Kamala Harris,18
-Santa Clara,6413,U.S. Senate,,DEM,Loretta Sanchez,5
-Santa Clara,6416,U.S. Senate,,DEM,Kamala Harris,35
-Santa Clara,6416,U.S. Senate,,DEM,Loretta Sanchez,20
-Santa Clara,6418,U.S. Senate,,DEM,Kamala Harris,356
-Santa Clara,6418,U.S. Senate,,DEM,Loretta Sanchez,197
-Santa Clara,6419,U.S. Senate,,DEM,Kamala Harris,25
-Santa Clara,6419,U.S. Senate,,DEM,Loretta Sanchez,28
-Santa Clara,6423,U.S. Senate,,DEM,Kamala Harris,24
-Santa Clara,6423,U.S. Senate,,DEM,Loretta Sanchez,16
-Santa Clara,6452,U.S. Senate,,DEM,Kamala Harris,262
-Santa Clara,6452,U.S. Senate,,DEM,Loretta Sanchez,379
-Santa Clara,6454,U.S. Senate,,DEM,Kamala Harris,18
-Santa Clara,6454,U.S. Senate,,DEM,Loretta Sanchez,5
-Santa Clara,6455,U.S. Senate,,DEM,Kamala Harris,532
-Santa Clara,6455,U.S. Senate,,DEM,Loretta Sanchez,474
-Santa Clara,6458,U.S. Senate,,DEM,Kamala Harris,432
-Santa Clara,6458,U.S. Senate,,DEM,Loretta Sanchez,479
-Santa Clara,6462,U.S. Senate,,DEM,Kamala Harris,380
-Santa Clara,6462,U.S. Senate,,DEM,Loretta Sanchez,184
-Santa Clara,6463,U.S. Senate,,DEM,Kamala Harris,4
-Santa Clara,6463,U.S. Senate,,DEM,Loretta Sanchez,0
-Santa Clara,6464,U.S. Senate,,DEM,Kamala Harris,2
-Santa Clara,6464,U.S. Senate,,DEM,Loretta Sanchez,0
-Santa Clara,6465,U.S. Senate,,DEM,Kamala Harris,94
-Santa Clara,6465,U.S. Senate,,DEM,Loretta Sanchez,66
-Santa Clara,6466,U.S. Senate,,DEM,Kamala Harris,71
-Santa Clara,6466,U.S. Senate,,DEM,Loretta Sanchez,56
-Santa Clara,6470,U.S. Senate,,DEM,Kamala Harris,321
-Santa Clara,6470,U.S. Senate,,DEM,Loretta Sanchez,188
-Santa Clara,6492,U.S. Senate,,DEM,Kamala Harris,18
-Santa Clara,6492,U.S. Senate,,DEM,Loretta Sanchez,23
-Santa Clara,6502,U.S. Senate,,DEM,Kamala Harris,111
-Santa Clara,6502,U.S. Senate,,DEM,Loretta Sanchez,100
-Santa Clara,6509,U.S. Senate,,DEM,Kamala Harris,16
-Santa Clara,6509,U.S. Senate,,DEM,Loretta Sanchez,16
-Santa Clara,6515,U.S. Senate,,DEM,Kamala Harris,46
-Santa Clara,6515,U.S. Senate,,DEM,Loretta Sanchez,22
-Santa Clara,6624,U.S. Senate,,DEM,Kamala Harris,3
-Santa Clara,6624,U.S. Senate,,DEM,Loretta Sanchez,0
-Santa Clara,6664,U.S. Senate,,DEM,Kamala Harris,0
-Santa Clara,6664,U.S. Senate,,DEM,Loretta Sanchez,0
-Santa Clara,6665,U.S. Senate,,DEM,Kamala Harris,1
-Santa Clara,6665,U.S. Senate,,DEM,Loretta Sanchez,0
-Santa Clara,6666,U.S. Senate,,DEM,Kamala Harris,47
-Santa Clara,6666,U.S. Senate,,DEM,Loretta Sanchez,22
-Santa Clara,6673,U.S. Senate,,DEM,Kamala Harris,1
-Santa Clara,6673,U.S. Senate,,DEM,Loretta Sanchez,1
-Santa Clara,6674,U.S. Senate,,DEM,Kamala Harris,52
-Santa Clara,6674,U.S. Senate,,DEM,Loretta Sanchez,25
-Santa Clara,6678,U.S. Senate,,DEM,Kamala Harris,30
-Santa Clara,6678,U.S. Senate,,DEM,Loretta Sanchez,10
+Santa Clara,1001,U.S. Senate,,DEM,Kamala D. Harris,680
+Santa Clara,1001,U.S. Senate,,DEM,Loretta L. Sanchez,299
+Santa Clara,1003,U.S. Senate,,DEM,Kamala D. Harris,541
+Santa Clara,1003,U.S. Senate,,DEM,Loretta L. Sanchez,262
+Santa Clara,1006,U.S. Senate,,DEM,Kamala D. Harris,610
+Santa Clara,1006,U.S. Senate,,DEM,Loretta L. Sanchez,242
+Santa Clara,1008,U.S. Senate,,DEM,Kamala D. Harris,710
+Santa Clara,1008,U.S. Senate,,DEM,Loretta L. Sanchez,344
+Santa Clara,1009,U.S. Senate,,DEM,Kamala D. Harris,460
+Santa Clara,1009,U.S. Senate,,DEM,Loretta L. Sanchez,212
+Santa Clara,1011,U.S. Senate,,DEM,Kamala D. Harris,583
+Santa Clara,1011,U.S. Senate,,DEM,Loretta L. Sanchez,243
+Santa Clara,1013,U.S. Senate,,DEM,Kamala D. Harris,578
+Santa Clara,1013,U.S. Senate,,DEM,Loretta L. Sanchez,196
+Santa Clara,1015,U.S. Senate,,DEM,Kamala D. Harris,392
+Santa Clara,1015,U.S. Senate,,DEM,Loretta L. Sanchez,149
+Santa Clara,1017,U.S. Senate,,DEM,Kamala D. Harris,450
+Santa Clara,1017,U.S. Senate,,DEM,Loretta L. Sanchez,278
+Santa Clara,1020,U.S. Senate,,DEM,Kamala D. Harris,558
+Santa Clara,1020,U.S. Senate,,DEM,Loretta L. Sanchez,199
+Santa Clara,1021,U.S. Senate,,DEM,Kamala D. Harris,640
+Santa Clara,1021,U.S. Senate,,DEM,Loretta L. Sanchez,219
+Santa Clara,1023,U.S. Senate,,DEM,Kamala D. Harris,338
+Santa Clara,1023,U.S. Senate,,DEM,Loretta L. Sanchez,121
+Santa Clara,1024,U.S. Senate,,DEM,Kamala D. Harris,641
+Santa Clara,1024,U.S. Senate,,DEM,Loretta L. Sanchez,254
+Santa Clara,1026,U.S. Senate,,DEM,Kamala D. Harris,616
+Santa Clara,1026,U.S. Senate,,DEM,Loretta L. Sanchez,236
+Santa Clara,1029,U.S. Senate,,DEM,Kamala D. Harris,617
+Santa Clara,1029,U.S. Senate,,DEM,Loretta L. Sanchez,235
+Santa Clara,1031,U.S. Senate,,DEM,Kamala D. Harris,158
+Santa Clara,1031,U.S. Senate,,DEM,Loretta L. Sanchez,78
+Santa Clara,1032,U.S. Senate,,DEM,Kamala D. Harris,589
+Santa Clara,1032,U.S. Senate,,DEM,Loretta L. Sanchez,225
+Santa Clara,1034,U.S. Senate,,DEM,Kamala D. Harris,461
+Santa Clara,1034,U.S. Senate,,DEM,Loretta L. Sanchez,189
+Santa Clara,1035,U.S. Senate,,DEM,Kamala D. Harris,567
+Santa Clara,1035,U.S. Senate,,DEM,Loretta L. Sanchez,203
+Santa Clara,1037,U.S. Senate,,DEM,Kamala D. Harris,660
+Santa Clara,1037,U.S. Senate,,DEM,Loretta L. Sanchez,175
+Santa Clara,1038,U.S. Senate,,DEM,Kamala D. Harris,455
+Santa Clara,1038,U.S. Senate,,DEM,Loretta L. Sanchez,156
+Santa Clara,1040,U.S. Senate,,DEM,Kamala D. Harris,746
+Santa Clara,1040,U.S. Senate,,DEM,Loretta L. Sanchez,212
+Santa Clara,1041,U.S. Senate,,DEM,Kamala D. Harris,9
+Santa Clara,1041,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Santa Clara,1042,U.S. Senate,,DEM,Kamala D. Harris,4
+Santa Clara,1042,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Santa Clara,1045,U.S. Senate,,DEM,Kamala D. Harris,525
+Santa Clara,1045,U.S. Senate,,DEM,Loretta L. Sanchez,179
+Santa Clara,1047,U.S. Senate,,DEM,Kamala D. Harris,467
+Santa Clara,1047,U.S. Senate,,DEM,Loretta L. Sanchez,163
+Santa Clara,1050,U.S. Senate,,DEM,Kamala D. Harris,538
+Santa Clara,1050,U.S. Senate,,DEM,Loretta L. Sanchez,196
+Santa Clara,1051,U.S. Senate,,DEM,Kamala D. Harris,476
+Santa Clara,1051,U.S. Senate,,DEM,Loretta L. Sanchez,134
+Santa Clara,1053,U.S. Senate,,DEM,Kamala D. Harris,649
+Santa Clara,1053,U.S. Senate,,DEM,Loretta L. Sanchez,266
+Santa Clara,1055,U.S. Senate,,DEM,Kamala D. Harris,509
+Santa Clara,1055,U.S. Senate,,DEM,Loretta L. Sanchez,218
+Santa Clara,1056,U.S. Senate,,DEM,Kamala D. Harris,567
+Santa Clara,1056,U.S. Senate,,DEM,Loretta L. Sanchez,210
+Santa Clara,1057,U.S. Senate,,DEM,Kamala D. Harris,431
+Santa Clara,1057,U.S. Senate,,DEM,Loretta L. Sanchez,236
+Santa Clara,1060,U.S. Senate,,DEM,Kamala D. Harris,512
+Santa Clara,1060,U.S. Senate,,DEM,Loretta L. Sanchez,315
+Santa Clara,1062,U.S. Senate,,DEM,Kamala D. Harris,560
+Santa Clara,1062,U.S. Senate,,DEM,Loretta L. Sanchez,275
+Santa Clara,1063,U.S. Senate,,DEM,Kamala D. Harris,535
+Santa Clara,1063,U.S. Senate,,DEM,Loretta L. Sanchez,335
+Santa Clara,1066,U.S. Senate,,DEM,Kamala D. Harris,607
+Santa Clara,1066,U.S. Senate,,DEM,Loretta L. Sanchez,353
+Santa Clara,1069,U.S. Senate,,DEM,Kamala D. Harris,476
+Santa Clara,1069,U.S. Senate,,DEM,Loretta L. Sanchez,263
+Santa Clara,1070,U.S. Senate,,DEM,Kamala D. Harris,522
+Santa Clara,1070,U.S. Senate,,DEM,Loretta L. Sanchez,235
+Santa Clara,1071,U.S. Senate,,DEM,Kamala D. Harris,1
+Santa Clara,1071,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Santa Clara,1072,U.S. Senate,,DEM,Kamala D. Harris,441
+Santa Clara,1072,U.S. Senate,,DEM,Loretta L. Sanchez,113
+Santa Clara,1075,U.S. Senate,,DEM,Kamala D. Harris,309
+Santa Clara,1075,U.S. Senate,,DEM,Loretta L. Sanchez,91
+Santa Clara,1077,U.S. Senate,,DEM,Kamala D. Harris,153
+Santa Clara,1077,U.S. Senate,,DEM,Loretta L. Sanchez,35
+Santa Clara,1078,U.S. Senate,,DEM,Kamala D. Harris,421
+Santa Clara,1078,U.S. Senate,,DEM,Loretta L. Sanchez,299
+Santa Clara,1080,U.S. Senate,,DEM,Kamala D. Harris,366
+Santa Clara,1080,U.S. Senate,,DEM,Loretta L. Sanchez,116
+Santa Clara,1081,U.S. Senate,,DEM,Kamala D. Harris,576
+Santa Clara,1081,U.S. Senate,,DEM,Loretta L. Sanchez,294
+Santa Clara,1082,U.S. Senate,,DEM,Kamala D. Harris,584
+Santa Clara,1082,U.S. Senate,,DEM,Loretta L. Sanchez,275
+Santa Clara,1087,U.S. Senate,,DEM,Kamala D. Harris,0
+Santa Clara,1087,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Santa Clara,1092,U.S. Senate,,DEM,Kamala D. Harris,483
+Santa Clara,1092,U.S. Senate,,DEM,Loretta L. Sanchez,154
+Santa Clara,1094,U.S. Senate,,DEM,Kamala D. Harris,564
+Santa Clara,1094,U.S. Senate,,DEM,Loretta L. Sanchez,307
+Santa Clara,1101,U.S. Senate,,DEM,Kamala D. Harris,544
+Santa Clara,1101,U.S. Senate,,DEM,Loretta L. Sanchez,233
+Santa Clara,1104,U.S. Senate,,DEM,Kamala D. Harris,520
+Santa Clara,1104,U.S. Senate,,DEM,Loretta L. Sanchez,176
+Santa Clara,1106,U.S. Senate,,DEM,Kamala D. Harris,553
+Santa Clara,1106,U.S. Senate,,DEM,Loretta L. Sanchez,187
+Santa Clara,1107,U.S. Senate,,DEM,Kamala D. Harris,624
+Santa Clara,1107,U.S. Senate,,DEM,Loretta L. Sanchez,186
+Santa Clara,1108,U.S. Senate,,DEM,Kamala D. Harris,521
+Santa Clara,1108,U.S. Senate,,DEM,Loretta L. Sanchez,123
+Santa Clara,1111,U.S. Senate,,DEM,Kamala D. Harris,98
+Santa Clara,1111,U.S. Senate,,DEM,Loretta L. Sanchez,43
+Santa Clara,1113,U.S. Senate,,DEM,Kamala D. Harris,671
+Santa Clara,1113,U.S. Senate,,DEM,Loretta L. Sanchez,184
+Santa Clara,1115,U.S. Senate,,DEM,Kamala D. Harris,616
+Santa Clara,1115,U.S. Senate,,DEM,Loretta L. Sanchez,165
+Santa Clara,1117,U.S. Senate,,DEM,Kamala D. Harris,569
+Santa Clara,1117,U.S. Senate,,DEM,Loretta L. Sanchez,139
+Santa Clara,1118,U.S. Senate,,DEM,Kamala D. Harris,147
+Santa Clara,1118,U.S. Senate,,DEM,Loretta L. Sanchez,38
+Santa Clara,1119,U.S. Senate,,DEM,Kamala D. Harris,318
+Santa Clara,1119,U.S. Senate,,DEM,Loretta L. Sanchez,111
+Santa Clara,1121,U.S. Senate,,DEM,Kamala D. Harris,228
+Santa Clara,1121,U.S. Senate,,DEM,Loretta L. Sanchez,96
+Santa Clara,1123,U.S. Senate,,DEM,Kamala D. Harris,541
+Santa Clara,1123,U.S. Senate,,DEM,Loretta L. Sanchez,216
+Santa Clara,1125,U.S. Senate,,DEM,Kamala D. Harris,604
+Santa Clara,1125,U.S. Senate,,DEM,Loretta L. Sanchez,174
+Santa Clara,1127,U.S. Senate,,DEM,Kamala D. Harris,601
+Santa Clara,1127,U.S. Senate,,DEM,Loretta L. Sanchez,195
+Santa Clara,1129,U.S. Senate,,DEM,Kamala D. Harris,503
+Santa Clara,1129,U.S. Senate,,DEM,Loretta L. Sanchez,200
+Santa Clara,1131,U.S. Senate,,DEM,Kamala D. Harris,525
+Santa Clara,1131,U.S. Senate,,DEM,Loretta L. Sanchez,184
+Santa Clara,1133,U.S. Senate,,DEM,Kamala D. Harris,0
+Santa Clara,1133,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Santa Clara,1134,U.S. Senate,,DEM,Kamala D. Harris,364
+Santa Clara,1134,U.S. Senate,,DEM,Loretta L. Sanchez,179
+Santa Clara,1135,U.S. Senate,,DEM,Kamala D. Harris,666
+Santa Clara,1135,U.S. Senate,,DEM,Loretta L. Sanchez,274
+Santa Clara,1137,U.S. Senate,,DEM,Kamala D. Harris,119
+Santa Clara,1137,U.S. Senate,,DEM,Loretta L. Sanchez,59
+Santa Clara,1138,U.S. Senate,,DEM,Kamala D. Harris,464
+Santa Clara,1138,U.S. Senate,,DEM,Loretta L. Sanchez,224
+Santa Clara,1141,U.S. Senate,,DEM,Kamala D. Harris,636
+Santa Clara,1141,U.S. Senate,,DEM,Loretta L. Sanchez,271
+Santa Clara,1142,U.S. Senate,,DEM,Kamala D. Harris,560
+Santa Clara,1142,U.S. Senate,,DEM,Loretta L. Sanchez,269
+Santa Clara,1144,U.S. Senate,,DEM,Kamala D. Harris,529
+Santa Clara,1144,U.S. Senate,,DEM,Loretta L. Sanchez,270
+Santa Clara,1145,U.S. Senate,,DEM,Kamala D. Harris,569
+Santa Clara,1145,U.S. Senate,,DEM,Loretta L. Sanchez,275
+Santa Clara,1146,U.S. Senate,,DEM,Kamala D. Harris,495
+Santa Clara,1146,U.S. Senate,,DEM,Loretta L. Sanchez,285
+Santa Clara,1149,U.S. Senate,,DEM,Kamala D. Harris,515
+Santa Clara,1149,U.S. Senate,,DEM,Loretta L. Sanchez,213
+Santa Clara,1152,U.S. Senate,,DEM,Kamala D. Harris,641
+Santa Clara,1152,U.S. Senate,,DEM,Loretta L. Sanchez,294
+Santa Clara,1153,U.S. Senate,,DEM,Kamala D. Harris,418
+Santa Clara,1153,U.S. Senate,,DEM,Loretta L. Sanchez,193
+Santa Clara,1154,U.S. Senate,,DEM,Kamala D. Harris,511
+Santa Clara,1154,U.S. Senate,,DEM,Loretta L. Sanchez,213
+Santa Clara,1156,U.S. Senate,,DEM,Kamala D. Harris,721
+Santa Clara,1156,U.S. Senate,,DEM,Loretta L. Sanchez,298
+Santa Clara,1158,U.S. Senate,,DEM,Kamala D. Harris,430
+Santa Clara,1158,U.S. Senate,,DEM,Loretta L. Sanchez,147
+Santa Clara,1159,U.S. Senate,,DEM,Kamala D. Harris,290
+Santa Clara,1159,U.S. Senate,,DEM,Loretta L. Sanchez,84
+Santa Clara,1160,U.S. Senate,,DEM,Kamala D. Harris,618
+Santa Clara,1160,U.S. Senate,,DEM,Loretta L. Sanchez,243
+Santa Clara,1161,U.S. Senate,,DEM,Kamala D. Harris,644
+Santa Clara,1161,U.S. Senate,,DEM,Loretta L. Sanchez,201
+Santa Clara,1163,U.S. Senate,,DEM,Kamala D. Harris,297
+Santa Clara,1163,U.S. Senate,,DEM,Loretta L. Sanchez,148
+Santa Clara,1169,U.S. Senate,,DEM,Kamala D. Harris,42
+Santa Clara,1169,U.S. Senate,,DEM,Loretta L. Sanchez,14
+Santa Clara,1198,U.S. Senate,,DEM,Kamala D. Harris,462
+Santa Clara,1198,U.S. Senate,,DEM,Loretta L. Sanchez,155
+Santa Clara,1199,U.S. Senate,,DEM,Kamala D. Harris,625
+Santa Clara,1199,U.S. Senate,,DEM,Loretta L. Sanchez,259
+Santa Clara,1201,U.S. Senate,,DEM,Kamala D. Harris,410
+Santa Clara,1201,U.S. Senate,,DEM,Loretta L. Sanchez,205
+Santa Clara,1204,U.S. Senate,,DEM,Kamala D. Harris,334
+Santa Clara,1204,U.S. Senate,,DEM,Loretta L. Sanchez,182
+Santa Clara,1205,U.S. Senate,,DEM,Kamala D. Harris,482
+Santa Clara,1205,U.S. Senate,,DEM,Loretta L. Sanchez,372
+Santa Clara,1206,U.S. Senate,,DEM,Kamala D. Harris,311
+Santa Clara,1206,U.S. Senate,,DEM,Loretta L. Sanchez,190
+Santa Clara,1207,U.S. Senate,,DEM,Kamala D. Harris,356
+Santa Clara,1207,U.S. Senate,,DEM,Loretta L. Sanchez,267
+Santa Clara,1208,U.S. Senate,,DEM,Kamala D. Harris,435
+Santa Clara,1208,U.S. Senate,,DEM,Loretta L. Sanchez,266
+Santa Clara,1209,U.S. Senate,,DEM,Kamala D. Harris,309
+Santa Clara,1209,U.S. Senate,,DEM,Loretta L. Sanchez,147
+Santa Clara,1210,U.S. Senate,,DEM,Kamala D. Harris,168
+Santa Clara,1210,U.S. Senate,,DEM,Loretta L. Sanchez,120
+Santa Clara,1211,U.S. Senate,,DEM,Kamala D. Harris,275
+Santa Clara,1211,U.S. Senate,,DEM,Loretta L. Sanchez,190
+Santa Clara,1212,U.S. Senate,,DEM,Kamala D. Harris,360
+Santa Clara,1212,U.S. Senate,,DEM,Loretta L. Sanchez,313
+Santa Clara,1213,U.S. Senate,,DEM,Kamala D. Harris,338
+Santa Clara,1213,U.S. Senate,,DEM,Loretta L. Sanchez,263
+Santa Clara,1214,U.S. Senate,,DEM,Kamala D. Harris,334
+Santa Clara,1214,U.S. Senate,,DEM,Loretta L. Sanchez,232
+Santa Clara,1215,U.S. Senate,,DEM,Kamala D. Harris,499
+Santa Clara,1215,U.S. Senate,,DEM,Loretta L. Sanchez,456
+Santa Clara,1217,U.S. Senate,,DEM,Kamala D. Harris,626
+Santa Clara,1217,U.S. Senate,,DEM,Loretta L. Sanchez,381
+Santa Clara,1218,U.S. Senate,,DEM,Kamala D. Harris,597
+Santa Clara,1218,U.S. Senate,,DEM,Loretta L. Sanchez,352
+Santa Clara,1220,U.S. Senate,,DEM,Kamala D. Harris,414
+Santa Clara,1220,U.S. Senate,,DEM,Loretta L. Sanchez,346
+Santa Clara,1221,U.S. Senate,,DEM,Kamala D. Harris,388
+Santa Clara,1221,U.S. Senate,,DEM,Loretta L. Sanchez,210
+Santa Clara,1222,U.S. Senate,,DEM,Kamala D. Harris,273
+Santa Clara,1222,U.S. Senate,,DEM,Loretta L. Sanchez,198
+Santa Clara,1223,U.S. Senate,,DEM,Kamala D. Harris,550
+Santa Clara,1223,U.S. Senate,,DEM,Loretta L. Sanchez,309
+Santa Clara,1224,U.S. Senate,,DEM,Kamala D. Harris,559
+Santa Clara,1224,U.S. Senate,,DEM,Loretta L. Sanchez,276
+Santa Clara,1226,U.S. Senate,,DEM,Kamala D. Harris,613
+Santa Clara,1226,U.S. Senate,,DEM,Loretta L. Sanchez,360
+Santa Clara,1228,U.S. Senate,,DEM,Kamala D. Harris,296
+Santa Clara,1228,U.S. Senate,,DEM,Loretta L. Sanchez,201
+Santa Clara,1229,U.S. Senate,,DEM,Kamala D. Harris,588
+Santa Clara,1229,U.S. Senate,,DEM,Loretta L. Sanchez,344
+Santa Clara,1231,U.S. Senate,,DEM,Kamala D. Harris,616
+Santa Clara,1231,U.S. Senate,,DEM,Loretta L. Sanchez,302
+Santa Clara,1232,U.S. Senate,,DEM,Kamala D. Harris,400
+Santa Clara,1232,U.S. Senate,,DEM,Loretta L. Sanchez,176
+Santa Clara,1233,U.S. Senate,,DEM,Kamala D. Harris,324
+Santa Clara,1233,U.S. Senate,,DEM,Loretta L. Sanchez,176
+Santa Clara,1236,U.S. Senate,,DEM,Kamala D. Harris,588
+Santa Clara,1236,U.S. Senate,,DEM,Loretta L. Sanchez,287
+Santa Clara,1238,U.S. Senate,,DEM,Kamala D. Harris,624
+Santa Clara,1238,U.S. Senate,,DEM,Loretta L. Sanchez,353
+Santa Clara,1239,U.S. Senate,,DEM,Kamala D. Harris,618
+Santa Clara,1239,U.S. Senate,,DEM,Loretta L. Sanchez,337
+Santa Clara,1240,U.S. Senate,,DEM,Kamala D. Harris,374
+Santa Clara,1240,U.S. Senate,,DEM,Loretta L. Sanchez,232
+Santa Clara,1242,U.S. Senate,,DEM,Kamala D. Harris,314
+Santa Clara,1242,U.S. Senate,,DEM,Loretta L. Sanchez,232
+Santa Clara,1243,U.S. Senate,,DEM,Kamala D. Harris,302
+Santa Clara,1243,U.S. Senate,,DEM,Loretta L. Sanchez,244
+Santa Clara,1244,U.S. Senate,,DEM,Kamala D. Harris,520
+Santa Clara,1244,U.S. Senate,,DEM,Loretta L. Sanchez,335
+Santa Clara,1246,U.S. Senate,,DEM,Kamala D. Harris,493
+Santa Clara,1246,U.S. Senate,,DEM,Loretta L. Sanchez,299
+Santa Clara,1247,U.S. Senate,,DEM,Kamala D. Harris,600
+Santa Clara,1247,U.S. Senate,,DEM,Loretta L. Sanchez,308
+Santa Clara,1250,U.S. Senate,,DEM,Kamala D. Harris,584
+Santa Clara,1250,U.S. Senate,,DEM,Loretta L. Sanchez,268
+Santa Clara,1252,U.S. Senate,,DEM,Kamala D. Harris,9
+Santa Clara,1252,U.S. Senate,,DEM,Loretta L. Sanchez,8
+Santa Clara,1253,U.S. Senate,,DEM,Kamala D. Harris,0
+Santa Clara,1253,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Santa Clara,1254,U.S. Senate,,DEM,Kamala D. Harris,267
+Santa Clara,1254,U.S. Senate,,DEM,Loretta L. Sanchez,124
+Santa Clara,1263,U.S. Senate,,DEM,Kamala D. Harris,99
+Santa Clara,1263,U.S. Senate,,DEM,Loretta L. Sanchez,60
+Santa Clara,1266,U.S. Senate,,DEM,Kamala D. Harris,37
+Santa Clara,1266,U.S. Senate,,DEM,Loretta L. Sanchez,44
+Santa Clara,1271,U.S. Senate,,DEM,Kamala D. Harris,165
+Santa Clara,1271,U.S. Senate,,DEM,Loretta L. Sanchez,92
+Santa Clara,1274,U.S. Senate,,DEM,Kamala D. Harris,362
+Santa Clara,1274,U.S. Senate,,DEM,Loretta L. Sanchez,176
+Santa Clara,1276,U.S. Senate,,DEM,Kamala D. Harris,405
+Santa Clara,1276,U.S. Senate,,DEM,Loretta L. Sanchez,261
+Santa Clara,1281,U.S. Senate,,DEM,Kamala D. Harris,0
+Santa Clara,1281,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Santa Clara,1289,U.S. Senate,,DEM,Kamala D. Harris,11
+Santa Clara,1289,U.S. Senate,,DEM,Loretta L. Sanchez,15
+Santa Clara,1290,U.S. Senate,,DEM,Kamala D. Harris,5
+Santa Clara,1290,U.S. Senate,,DEM,Loretta L. Sanchez,6
+Santa Clara,1301,U.S. Senate,,DEM,Kamala D. Harris,21
+Santa Clara,1301,U.S. Senate,,DEM,Loretta L. Sanchez,11
+Santa Clara,1302,U.S. Senate,,DEM,Kamala D. Harris,185
+Santa Clara,1302,U.S. Senate,,DEM,Loretta L. Sanchez,86
+Santa Clara,1303,U.S. Senate,,DEM,Kamala D. Harris,399
+Santa Clara,1303,U.S. Senate,,DEM,Loretta L. Sanchez,218
+Santa Clara,1304,U.S. Senate,,DEM,Kamala D. Harris,211
+Santa Clara,1304,U.S. Senate,,DEM,Loretta L. Sanchez,97
+Santa Clara,1305,U.S. Senate,,DEM,Kamala D. Harris,695
+Santa Clara,1305,U.S. Senate,,DEM,Loretta L. Sanchez,275
+Santa Clara,1306,U.S. Senate,,DEM,Kamala D. Harris,327
+Santa Clara,1306,U.S. Senate,,DEM,Loretta L. Sanchez,134
+Santa Clara,1307,U.S. Senate,,DEM,Kamala D. Harris,299
+Santa Clara,1307,U.S. Senate,,DEM,Loretta L. Sanchez,139
+Santa Clara,1308,U.S. Senate,,DEM,Kamala D. Harris,62
+Santa Clara,1308,U.S. Senate,,DEM,Loretta L. Sanchez,51
+Santa Clara,1310,U.S. Senate,,DEM,Kamala D. Harris,654
+Santa Clara,1310,U.S. Senate,,DEM,Loretta L. Sanchez,312
+Santa Clara,1311,U.S. Senate,,DEM,Kamala D. Harris,650
+Santa Clara,1311,U.S. Senate,,DEM,Loretta L. Sanchez,328
+Santa Clara,1312,U.S. Senate,,DEM,Kamala D. Harris,564
+Santa Clara,1312,U.S. Senate,,DEM,Loretta L. Sanchez,311
+Santa Clara,1313,U.S. Senate,,DEM,Kamala D. Harris,335
+Santa Clara,1313,U.S. Senate,,DEM,Loretta L. Sanchez,325
+Santa Clara,1314,U.S. Senate,,DEM,Kamala D. Harris,233
+Santa Clara,1314,U.S. Senate,,DEM,Loretta L. Sanchez,217
+Santa Clara,1315,U.S. Senate,,DEM,Kamala D. Harris,439
+Santa Clara,1315,U.S. Senate,,DEM,Loretta L. Sanchez,279
+Santa Clara,1316,U.S. Senate,,DEM,Kamala D. Harris,374
+Santa Clara,1316,U.S. Senate,,DEM,Loretta L. Sanchez,326
+Santa Clara,1317,U.S. Senate,,DEM,Kamala D. Harris,569
+Santa Clara,1317,U.S. Senate,,DEM,Loretta L. Sanchez,329
+Santa Clara,1319,U.S. Senate,,DEM,Kamala D. Harris,437
+Santa Clara,1319,U.S. Senate,,DEM,Loretta L. Sanchez,283
+Santa Clara,1321,U.S. Senate,,DEM,Kamala D. Harris,438
+Santa Clara,1321,U.S. Senate,,DEM,Loretta L. Sanchez,320
+Santa Clara,1322,U.S. Senate,,DEM,Kamala D. Harris,495
+Santa Clara,1322,U.S. Senate,,DEM,Loretta L. Sanchez,299
+Santa Clara,1323,U.S. Senate,,DEM,Kamala D. Harris,398
+Santa Clara,1323,U.S. Senate,,DEM,Loretta L. Sanchez,235
+Santa Clara,1324,U.S. Senate,,DEM,Kamala D. Harris,276
+Santa Clara,1324,U.S. Senate,,DEM,Loretta L. Sanchez,300
+Santa Clara,1325,U.S. Senate,,DEM,Kamala D. Harris,355
+Santa Clara,1325,U.S. Senate,,DEM,Loretta L. Sanchez,327
+Santa Clara,1326,U.S. Senate,,DEM,Kamala D. Harris,459
+Santa Clara,1326,U.S. Senate,,DEM,Loretta L. Sanchez,398
+Santa Clara,1327,U.S. Senate,,DEM,Kamala D. Harris,395
+Santa Clara,1327,U.S. Senate,,DEM,Loretta L. Sanchez,542
+Santa Clara,1329,U.S. Senate,,DEM,Kamala D. Harris,737
+Santa Clara,1329,U.S. Senate,,DEM,Loretta L. Sanchez,284
+Santa Clara,1330,U.S. Senate,,DEM,Kamala D. Harris,294
+Santa Clara,1330,U.S. Senate,,DEM,Loretta L. Sanchez,139
+Santa Clara,1333,U.S. Senate,,DEM,Kamala D. Harris,575
+Santa Clara,1333,U.S. Senate,,DEM,Loretta L. Sanchez,344
+Santa Clara,1334,U.S. Senate,,DEM,Kamala D. Harris,259
+Santa Clara,1334,U.S. Senate,,DEM,Loretta L. Sanchez,232
+Santa Clara,1336,U.S. Senate,,DEM,Kamala D. Harris,276
+Santa Clara,1336,U.S. Senate,,DEM,Loretta L. Sanchez,252
+Santa Clara,1338,U.S. Senate,,DEM,Kamala D. Harris,545
+Santa Clara,1338,U.S. Senate,,DEM,Loretta L. Sanchez,233
+Santa Clara,1339,U.S. Senate,,DEM,Kamala D. Harris,208
+Santa Clara,1339,U.S. Senate,,DEM,Loretta L. Sanchez,154
+Santa Clara,1340,U.S. Senate,,DEM,Kamala D. Harris,517
+Santa Clara,1340,U.S. Senate,,DEM,Loretta L. Sanchez,336
+Santa Clara,1343,U.S. Senate,,DEM,Kamala D. Harris,262
+Santa Clara,1343,U.S. Senate,,DEM,Loretta L. Sanchez,400
+Santa Clara,1344,U.S. Senate,,DEM,Kamala D. Harris,329
+Santa Clara,1344,U.S. Senate,,DEM,Loretta L. Sanchez,358
+Santa Clara,1345,U.S. Senate,,DEM,Kamala D. Harris,305
+Santa Clara,1345,U.S. Senate,,DEM,Loretta L. Sanchez,308
+Santa Clara,1346,U.S. Senate,,DEM,Kamala D. Harris,178
+Santa Clara,1346,U.S. Senate,,DEM,Loretta L. Sanchez,154
+Santa Clara,1347,U.S. Senate,,DEM,Kamala D. Harris,310
+Santa Clara,1347,U.S. Senate,,DEM,Loretta L. Sanchez,134
+Santa Clara,1348,U.S. Senate,,DEM,Kamala D. Harris,415
+Santa Clara,1348,U.S. Senate,,DEM,Loretta L. Sanchez,132
+Santa Clara,1356,U.S. Senate,,DEM,Kamala D. Harris,240
+Santa Clara,1356,U.S. Senate,,DEM,Loretta L. Sanchez,188
+Santa Clara,1357,U.S. Senate,,DEM,Kamala D. Harris,39
+Santa Clara,1357,U.S. Senate,,DEM,Loretta L. Sanchez,52
+Santa Clara,1358,U.S. Senate,,DEM,Kamala D. Harris,146
+Santa Clara,1358,U.S. Senate,,DEM,Loretta L. Sanchez,45
+Santa Clara,1359,U.S. Senate,,DEM,Kamala D. Harris,470
+Santa Clara,1359,U.S. Senate,,DEM,Loretta L. Sanchez,190
+Santa Clara,1360,U.S. Senate,,DEM,Kamala D. Harris,206
+Santa Clara,1360,U.S. Senate,,DEM,Loretta L. Sanchez,67
+Santa Clara,1361,U.S. Senate,,DEM,Kamala D. Harris,483
+Santa Clara,1361,U.S. Senate,,DEM,Loretta L. Sanchez,141
+Santa Clara,1364,U.S. Senate,,DEM,Kamala D. Harris,3
+Santa Clara,1364,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Santa Clara,1365,U.S. Senate,,DEM,Kamala D. Harris,133
+Santa Clara,1365,U.S. Senate,,DEM,Loretta L. Sanchez,67
+Santa Clara,1366,U.S. Senate,,DEM,Kamala D. Harris,106
+Santa Clara,1366,U.S. Senate,,DEM,Loretta L. Sanchez,112
+Santa Clara,1367,U.S. Senate,,DEM,Kamala D. Harris,0
+Santa Clara,1367,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Santa Clara,1368,U.S. Senate,,DEM,Kamala D. Harris,676
+Santa Clara,1368,U.S. Senate,,DEM,Loretta L. Sanchez,212
+Santa Clara,1369,U.S. Senate,,DEM,Kamala D. Harris,0
+Santa Clara,1369,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Santa Clara,1370,U.S. Senate,,DEM,Kamala D. Harris,0
+Santa Clara,1370,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Santa Clara,1380,U.S. Senate,,DEM,Kamala D. Harris,25
+Santa Clara,1380,U.S. Senate,,DEM,Loretta L. Sanchez,9
+Santa Clara,1398,U.S. Senate,,DEM,Kamala D. Harris,313
+Santa Clara,1398,U.S. Senate,,DEM,Loretta L. Sanchez,457
+Santa Clara,1399,U.S. Senate,,DEM,Kamala D. Harris,429
+Santa Clara,1399,U.S. Senate,,DEM,Loretta L. Sanchez,442
+Santa Clara,1401,U.S. Senate,,DEM,Kamala D. Harris,284
+Santa Clara,1401,U.S. Senate,,DEM,Loretta L. Sanchez,335
+Santa Clara,1402,U.S. Senate,,DEM,Kamala D. Harris,215
+Santa Clara,1402,U.S. Senate,,DEM,Loretta L. Sanchez,170
+Santa Clara,1403,U.S. Senate,,DEM,Kamala D. Harris,516
+Santa Clara,1403,U.S. Senate,,DEM,Loretta L. Sanchez,418
+Santa Clara,1405,U.S. Senate,,DEM,Kamala D. Harris,3
+Santa Clara,1405,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Santa Clara,1406,U.S. Senate,,DEM,Kamala D. Harris,11
+Santa Clara,1406,U.S. Senate,,DEM,Loretta L. Sanchez,5
+Santa Clara,1407,U.S. Senate,,DEM,Kamala D. Harris,255
+Santa Clara,1407,U.S. Senate,,DEM,Loretta L. Sanchez,248
+Santa Clara,1408,U.S. Senate,,DEM,Kamala D. Harris,594
+Santa Clara,1408,U.S. Senate,,DEM,Loretta L. Sanchez,427
+Santa Clara,1409,U.S. Senate,,DEM,Kamala D. Harris,371
+Santa Clara,1409,U.S. Senate,,DEM,Loretta L. Sanchez,329
+Santa Clara,1410,U.S. Senate,,DEM,Kamala D. Harris,369
+Santa Clara,1410,U.S. Senate,,DEM,Loretta L. Sanchez,339
+Santa Clara,1411,U.S. Senate,,DEM,Kamala D. Harris,360
+Santa Clara,1411,U.S. Senate,,DEM,Loretta L. Sanchez,274
+Santa Clara,1413,U.S. Senate,,DEM,Kamala D. Harris,371
+Santa Clara,1413,U.S. Senate,,DEM,Loretta L. Sanchez,267
+Santa Clara,1414,U.S. Senate,,DEM,Kamala D. Harris,319
+Santa Clara,1414,U.S. Senate,,DEM,Loretta L. Sanchez,233
+Santa Clara,1415,U.S. Senate,,DEM,Kamala D. Harris,348
+Santa Clara,1415,U.S. Senate,,DEM,Loretta L. Sanchez,263
+Santa Clara,1416,U.S. Senate,,DEM,Kamala D. Harris,322
+Santa Clara,1416,U.S. Senate,,DEM,Loretta L. Sanchez,218
+Santa Clara,1417,U.S. Senate,,DEM,Kamala D. Harris,653
+Santa Clara,1417,U.S. Senate,,DEM,Loretta L. Sanchez,386
+Santa Clara,1419,U.S. Senate,,DEM,Kamala D. Harris,536
+Santa Clara,1419,U.S. Senate,,DEM,Loretta L. Sanchez,376
+Santa Clara,1420,U.S. Senate,,DEM,Kamala D. Harris,596
+Santa Clara,1420,U.S. Senate,,DEM,Loretta L. Sanchez,335
+Santa Clara,1422,U.S. Senate,,DEM,Kamala D. Harris,590
+Santa Clara,1422,U.S. Senate,,DEM,Loretta L. Sanchez,451
+Santa Clara,1423,U.S. Senate,,DEM,Kamala D. Harris,367
+Santa Clara,1423,U.S. Senate,,DEM,Loretta L. Sanchez,318
+Santa Clara,1424,U.S. Senate,,DEM,Kamala D. Harris,428
+Santa Clara,1424,U.S. Senate,,DEM,Loretta L. Sanchez,439
+Santa Clara,1425,U.S. Senate,,DEM,Kamala D. Harris,321
+Santa Clara,1425,U.S. Senate,,DEM,Loretta L. Sanchez,321
+Santa Clara,1426,U.S. Senate,,DEM,Kamala D. Harris,162
+Santa Clara,1426,U.S. Senate,,DEM,Loretta L. Sanchez,120
+Santa Clara,1427,U.S. Senate,,DEM,Kamala D. Harris,325
+Santa Clara,1427,U.S. Senate,,DEM,Loretta L. Sanchez,194
+Santa Clara,1428,U.S. Senate,,DEM,Kamala D. Harris,478
+Santa Clara,1428,U.S. Senate,,DEM,Loretta L. Sanchez,286
+Santa Clara,1429,U.S. Senate,,DEM,Kamala D. Harris,284
+Santa Clara,1429,U.S. Senate,,DEM,Loretta L. Sanchez,193
+Santa Clara,1431,U.S. Senate,,DEM,Kamala D. Harris,405
+Santa Clara,1431,U.S. Senate,,DEM,Loretta L. Sanchez,240
+Santa Clara,1432,U.S. Senate,,DEM,Kamala D. Harris,578
+Santa Clara,1432,U.S. Senate,,DEM,Loretta L. Sanchez,400
+Santa Clara,1433,U.S. Senate,,DEM,Kamala D. Harris,416
+Santa Clara,1433,U.S. Senate,,DEM,Loretta L. Sanchez,223
+Santa Clara,1434,U.S. Senate,,DEM,Kamala D. Harris,421
+Santa Clara,1434,U.S. Senate,,DEM,Loretta L. Sanchez,359
+Santa Clara,1435,U.S. Senate,,DEM,Kamala D. Harris,313
+Santa Clara,1435,U.S. Senate,,DEM,Loretta L. Sanchez,180
+Santa Clara,1436,U.S. Senate,,DEM,Kamala D. Harris,452
+Santa Clara,1436,U.S. Senate,,DEM,Loretta L. Sanchez,311
+Santa Clara,1439,U.S. Senate,,DEM,Kamala D. Harris,763
+Santa Clara,1439,U.S. Senate,,DEM,Loretta L. Sanchez,376
+Santa Clara,1440,U.S. Senate,,DEM,Kamala D. Harris,42
+Santa Clara,1440,U.S. Senate,,DEM,Loretta L. Sanchez,69
+Santa Clara,1443,U.S. Senate,,DEM,Kamala D. Harris,62
+Santa Clara,1443,U.S. Senate,,DEM,Loretta L. Sanchez,39
+Santa Clara,1444,U.S. Senate,,DEM,Kamala D. Harris,460
+Santa Clara,1444,U.S. Senate,,DEM,Loretta L. Sanchez,341
+Santa Clara,1446,U.S. Senate,,DEM,Kamala D. Harris,597
+Santa Clara,1446,U.S. Senate,,DEM,Loretta L. Sanchez,448
+Santa Clara,1447,U.S. Senate,,DEM,Kamala D. Harris,314
+Santa Clara,1447,U.S. Senate,,DEM,Loretta L. Sanchez,220
+Santa Clara,1448,U.S. Senate,,DEM,Kamala D. Harris,277
+Santa Clara,1448,U.S. Senate,,DEM,Loretta L. Sanchez,220
+Santa Clara,1449,U.S. Senate,,DEM,Kamala D. Harris,387
+Santa Clara,1449,U.S. Senate,,DEM,Loretta L. Sanchez,219
+Santa Clara,1450,U.S. Senate,,DEM,Kamala D. Harris,383
+Santa Clara,1450,U.S. Senate,,DEM,Loretta L. Sanchez,270
+Santa Clara,1451,U.S. Senate,,DEM,Kamala D. Harris,458
+Santa Clara,1451,U.S. Senate,,DEM,Loretta L. Sanchez,341
+Santa Clara,1453,U.S. Senate,,DEM,Kamala D. Harris,386
+Santa Clara,1453,U.S. Senate,,DEM,Loretta L. Sanchez,264
+Santa Clara,1455,U.S. Senate,,DEM,Kamala D. Harris,496
+Santa Clara,1455,U.S. Senate,,DEM,Loretta L. Sanchez,340
+Santa Clara,1459,U.S. Senate,,DEM,Kamala D. Harris,664
+Santa Clara,1459,U.S. Senate,,DEM,Loretta L. Sanchez,300
+Santa Clara,1461,U.S. Senate,,DEM,Kamala D. Harris,497
+Santa Clara,1461,U.S. Senate,,DEM,Loretta L. Sanchez,233
+Santa Clara,1465,U.S. Senate,,DEM,Kamala D. Harris,675
+Santa Clara,1465,U.S. Senate,,DEM,Loretta L. Sanchez,306
+Santa Clara,1467,U.S. Senate,,DEM,Kamala D. Harris,442
+Santa Clara,1467,U.S. Senate,,DEM,Loretta L. Sanchez,236
+Santa Clara,1469,U.S. Senate,,DEM,Kamala D. Harris,371
+Santa Clara,1469,U.S. Senate,,DEM,Loretta L. Sanchez,255
+Santa Clara,1470,U.S. Senate,,DEM,Kamala D. Harris,386
+Santa Clara,1470,U.S. Senate,,DEM,Loretta L. Sanchez,454
+Santa Clara,1472,U.S. Senate,,DEM,Kamala D. Harris,541
+Santa Clara,1472,U.S. Senate,,DEM,Loretta L. Sanchez,293
+Santa Clara,1481,U.S. Senate,,DEM,Kamala D. Harris,0
+Santa Clara,1481,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Santa Clara,1482,U.S. Senate,,DEM,Kamala D. Harris,447
+Santa Clara,1482,U.S. Senate,,DEM,Loretta L. Sanchez,231
+Santa Clara,1483,U.S. Senate,,DEM,Kamala D. Harris,0
+Santa Clara,1483,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Santa Clara,1497,U.S. Senate,,DEM,Kamala D. Harris,441
+Santa Clara,1497,U.S. Senate,,DEM,Loretta L. Sanchez,216
+Santa Clara,1501,U.S. Senate,,DEM,Kamala D. Harris,127
+Santa Clara,1501,U.S. Senate,,DEM,Loretta L. Sanchez,104
+Santa Clara,1502,U.S. Senate,,DEM,Kamala D. Harris,8
+Santa Clara,1502,U.S. Senate,,DEM,Loretta L. Sanchez,15
+Santa Clara,1504,U.S. Senate,,DEM,Kamala D. Harris,408
+Santa Clara,1504,U.S. Senate,,DEM,Loretta L. Sanchez,498
+Santa Clara,1505,U.S. Senate,,DEM,Kamala D. Harris,268
+Santa Clara,1505,U.S. Senate,,DEM,Loretta L. Sanchez,295
+Santa Clara,1506,U.S. Senate,,DEM,Kamala D. Harris,370
+Santa Clara,1506,U.S. Senate,,DEM,Loretta L. Sanchez,436
+Santa Clara,1508,U.S. Senate,,DEM,Kamala D. Harris,297
+Santa Clara,1508,U.S. Senate,,DEM,Loretta L. Sanchez,290
+Santa Clara,1509,U.S. Senate,,DEM,Kamala D. Harris,227
+Santa Clara,1509,U.S. Senate,,DEM,Loretta L. Sanchez,250
+Santa Clara,1510,U.S. Senate,,DEM,Kamala D. Harris,242
+Santa Clara,1510,U.S. Senate,,DEM,Loretta L. Sanchez,343
+Santa Clara,1512,U.S. Senate,,DEM,Kamala D. Harris,312
+Santa Clara,1512,U.S. Senate,,DEM,Loretta L. Sanchez,578
+Santa Clara,1513,U.S. Senate,,DEM,Kamala D. Harris,338
+Santa Clara,1513,U.S. Senate,,DEM,Loretta L. Sanchez,361
+Santa Clara,1515,U.S. Senate,,DEM,Kamala D. Harris,425
+Santa Clara,1515,U.S. Senate,,DEM,Loretta L. Sanchez,289
+Santa Clara,1516,U.S. Senate,,DEM,Kamala D. Harris,323
+Santa Clara,1516,U.S. Senate,,DEM,Loretta L. Sanchez,522
+Santa Clara,1517,U.S. Senate,,DEM,Kamala D. Harris,204
+Santa Clara,1517,U.S. Senate,,DEM,Loretta L. Sanchez,279
+Santa Clara,1518,U.S. Senate,,DEM,Kamala D. Harris,308
+Santa Clara,1518,U.S. Senate,,DEM,Loretta L. Sanchez,430
+Santa Clara,1519,U.S. Senate,,DEM,Kamala D. Harris,463
+Santa Clara,1519,U.S. Senate,,DEM,Loretta L. Sanchez,483
+Santa Clara,1521,U.S. Senate,,DEM,Kamala D. Harris,347
+Santa Clara,1521,U.S. Senate,,DEM,Loretta L. Sanchez,434
+Santa Clara,1523,U.S. Senate,,DEM,Kamala D. Harris,334
+Santa Clara,1523,U.S. Senate,,DEM,Loretta L. Sanchez,455
+Santa Clara,1525,U.S. Senate,,DEM,Kamala D. Harris,375
+Santa Clara,1525,U.S. Senate,,DEM,Loretta L. Sanchez,342
+Santa Clara,1526,U.S. Senate,,DEM,Kamala D. Harris,230
+Santa Clara,1526,U.S. Senate,,DEM,Loretta L. Sanchez,236
+Santa Clara,1527,U.S. Senate,,DEM,Kamala D. Harris,430
+Santa Clara,1527,U.S. Senate,,DEM,Loretta L. Sanchez,589
+Santa Clara,1528,U.S. Senate,,DEM,Kamala D. Harris,335
+Santa Clara,1528,U.S. Senate,,DEM,Loretta L. Sanchez,489
+Santa Clara,1530,U.S. Senate,,DEM,Kamala D. Harris,283
+Santa Clara,1530,U.S. Senate,,DEM,Loretta L. Sanchez,459
+Santa Clara,1531,U.S. Senate,,DEM,Kamala D. Harris,195
+Santa Clara,1531,U.S. Senate,,DEM,Loretta L. Sanchez,281
+Santa Clara,1534,U.S. Senate,,DEM,Kamala D. Harris,311
+Santa Clara,1534,U.S. Senate,,DEM,Loretta L. Sanchez,562
+Santa Clara,1535,U.S. Senate,,DEM,Kamala D. Harris,181
+Santa Clara,1535,U.S. Senate,,DEM,Loretta L. Sanchez,248
+Santa Clara,1536,U.S. Senate,,DEM,Kamala D. Harris,272
+Santa Clara,1536,U.S. Senate,,DEM,Loretta L. Sanchez,467
+Santa Clara,1537,U.S. Senate,,DEM,Kamala D. Harris,346
+Santa Clara,1537,U.S. Senate,,DEM,Loretta L. Sanchez,607
+Santa Clara,1539,U.S. Senate,,DEM,Kamala D. Harris,194
+Santa Clara,1539,U.S. Senate,,DEM,Loretta L. Sanchez,286
+Santa Clara,1543,U.S. Senate,,DEM,Kamala D. Harris,56
+Santa Clara,1543,U.S. Senate,,DEM,Loretta L. Sanchez,96
+Santa Clara,1544,U.S. Senate,,DEM,Kamala D. Harris,367
+Santa Clara,1544,U.S. Senate,,DEM,Loretta L. Sanchez,513
+Santa Clara,1546,U.S. Senate,,DEM,Kamala D. Harris,585
+Santa Clara,1546,U.S. Senate,,DEM,Loretta L. Sanchez,419
+Santa Clara,1548,U.S. Senate,,DEM,Kamala D. Harris,71
+Santa Clara,1548,U.S. Senate,,DEM,Loretta L. Sanchez,86
+Santa Clara,1550,U.S. Senate,,DEM,Kamala D. Harris,83
+Santa Clara,1550,U.S. Senate,,DEM,Loretta L. Sanchez,43
+Santa Clara,1551,U.S. Senate,,DEM,Kamala D. Harris,325
+Santa Clara,1551,U.S. Senate,,DEM,Loretta L. Sanchez,442
+Santa Clara,1553,U.S. Senate,,DEM,Kamala D. Harris,253
+Santa Clara,1553,U.S. Senate,,DEM,Loretta L. Sanchez,203
+Santa Clara,1555,U.S. Senate,,DEM,Kamala D. Harris,160
+Santa Clara,1555,U.S. Senate,,DEM,Loretta L. Sanchez,113
+Santa Clara,1556,U.S. Senate,,DEM,Kamala D. Harris,164
+Santa Clara,1556,U.S. Senate,,DEM,Loretta L. Sanchez,108
+Santa Clara,1558,U.S. Senate,,DEM,Kamala D. Harris,336
+Santa Clara,1558,U.S. Senate,,DEM,Loretta L. Sanchez,521
+Santa Clara,1560,U.S. Senate,,DEM,Kamala D. Harris,14
+Santa Clara,1560,U.S. Senate,,DEM,Loretta L. Sanchez,6
+Santa Clara,1562,U.S. Senate,,DEM,Kamala D. Harris,0
+Santa Clara,1562,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Santa Clara,1570,U.S. Senate,,DEM,Kamala D. Harris,1
+Santa Clara,1570,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Santa Clara,1571,U.S. Senate,,DEM,Kamala D. Harris,110
+Santa Clara,1571,U.S. Senate,,DEM,Loretta L. Sanchez,52
+Santa Clara,1574,U.S. Senate,,DEM,Kamala D. Harris,1
+Santa Clara,1574,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Santa Clara,1578,U.S. Senate,,DEM,Kamala D. Harris,197
+Santa Clara,1578,U.S. Senate,,DEM,Loretta L. Sanchez,180
+Santa Clara,1586,U.S. Senate,,DEM,Kamala D. Harris,6
+Santa Clara,1586,U.S. Senate,,DEM,Loretta L. Sanchez,5
+Santa Clara,1587,U.S. Senate,,DEM,Kamala D. Harris,641
+Santa Clara,1587,U.S. Senate,,DEM,Loretta L. Sanchez,261
+Santa Clara,1588,U.S. Senate,,DEM,Kamala D. Harris,218
+Santa Clara,1588,U.S. Senate,,DEM,Loretta L. Sanchez,94
+Santa Clara,1590,U.S. Senate,,DEM,Kamala D. Harris,378
+Santa Clara,1590,U.S. Senate,,DEM,Loretta L. Sanchez,411
+Santa Clara,1591,U.S. Senate,,DEM,Kamala D. Harris,5
+Santa Clara,1591,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Santa Clara,1592,U.S. Senate,,DEM,Kamala D. Harris,226
+Santa Clara,1592,U.S. Senate,,DEM,Loretta L. Sanchez,149
+Santa Clara,1593,U.S. Senate,,DEM,Kamala D. Harris,105
+Santa Clara,1593,U.S. Senate,,DEM,Loretta L. Sanchez,39
+Santa Clara,1595,U.S. Senate,,DEM,Kamala D. Harris,1
+Santa Clara,1595,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Santa Clara,1597,U.S. Senate,,DEM,Kamala D. Harris,217
+Santa Clara,1597,U.S. Senate,,DEM,Loretta L. Sanchez,366
+Santa Clara,1599,U.S. Senate,,DEM,Kamala D. Harris,688
+Santa Clara,1599,U.S. Senate,,DEM,Loretta L. Sanchez,336
+Santa Clara,1600,U.S. Senate,,DEM,Kamala D. Harris,102
+Santa Clara,1600,U.S. Senate,,DEM,Loretta L. Sanchez,92
+Santa Clara,1601,U.S. Senate,,DEM,Kamala D. Harris,345
+Santa Clara,1601,U.S. Senate,,DEM,Loretta L. Sanchez,182
+Santa Clara,1602,U.S. Senate,,DEM,Kamala D. Harris,392
+Santa Clara,1602,U.S. Senate,,DEM,Loretta L. Sanchez,164
+Santa Clara,1603,U.S. Senate,,DEM,Kamala D. Harris,669
+Santa Clara,1603,U.S. Senate,,DEM,Loretta L. Sanchez,257
+Santa Clara,1605,U.S. Senate,,DEM,Kamala D. Harris,593
+Santa Clara,1605,U.S. Senate,,DEM,Loretta L. Sanchez,360
+Santa Clara,1607,U.S. Senate,,DEM,Kamala D. Harris,311
+Santa Clara,1607,U.S. Senate,,DEM,Loretta L. Sanchez,169
+Santa Clara,1608,U.S. Senate,,DEM,Kamala D. Harris,468
+Santa Clara,1608,U.S. Senate,,DEM,Loretta L. Sanchez,227
+Santa Clara,1610,U.S. Senate,,DEM,Kamala D. Harris,607
+Santa Clara,1610,U.S. Senate,,DEM,Loretta L. Sanchez,321
+Santa Clara,1612,U.S. Senate,,DEM,Kamala D. Harris,569
+Santa Clara,1612,U.S. Senate,,DEM,Loretta L. Sanchez,233
+Santa Clara,1613,U.S. Senate,,DEM,Kamala D. Harris,705
+Santa Clara,1613,U.S. Senate,,DEM,Loretta L. Sanchez,286
+Santa Clara,1616,U.S. Senate,,DEM,Kamala D. Harris,663
+Santa Clara,1616,U.S. Senate,,DEM,Loretta L. Sanchez,307
+Santa Clara,1618,U.S. Senate,,DEM,Kamala D. Harris,237
+Santa Clara,1618,U.S. Senate,,DEM,Loretta L. Sanchez,116
+Santa Clara,1619,U.S. Senate,,DEM,Kamala D. Harris,45
+Santa Clara,1619,U.S. Senate,,DEM,Loretta L. Sanchez,22
+Santa Clara,1621,U.S. Senate,,DEM,Kamala D. Harris,826
+Santa Clara,1621,U.S. Senate,,DEM,Loretta L. Sanchez,291
+Santa Clara,1622,U.S. Senate,,DEM,Kamala D. Harris,492
+Santa Clara,1622,U.S. Senate,,DEM,Loretta L. Sanchez,202
+Santa Clara,1623,U.S. Senate,,DEM,Kamala D. Harris,787
+Santa Clara,1623,U.S. Senate,,DEM,Loretta L. Sanchez,257
+Santa Clara,1625,U.S. Senate,,DEM,Kamala D. Harris,344
+Santa Clara,1625,U.S. Senate,,DEM,Loretta L. Sanchez,217
+Santa Clara,1629,U.S. Senate,,DEM,Kamala D. Harris,383
+Santa Clara,1629,U.S. Senate,,DEM,Loretta L. Sanchez,241
+Santa Clara,1631,U.S. Senate,,DEM,Kamala D. Harris,613
+Santa Clara,1631,U.S. Senate,,DEM,Loretta L. Sanchez,253
+Santa Clara,1632,U.S. Senate,,DEM,Kamala D. Harris,15
+Santa Clara,1632,U.S. Senate,,DEM,Loretta L. Sanchez,12
+Santa Clara,1634,U.S. Senate,,DEM,Kamala D. Harris,495
+Santa Clara,1634,U.S. Senate,,DEM,Loretta L. Sanchez,318
+Santa Clara,1635,U.S. Senate,,DEM,Kamala D. Harris,733
+Santa Clara,1635,U.S. Senate,,DEM,Loretta L. Sanchez,305
+Santa Clara,1636,U.S. Senate,,DEM,Kamala D. Harris,121
+Santa Clara,1636,U.S. Senate,,DEM,Loretta L. Sanchez,73
+Santa Clara,1638,U.S. Senate,,DEM,Kamala D. Harris,583
+Santa Clara,1638,U.S. Senate,,DEM,Loretta L. Sanchez,194
+Santa Clara,1639,U.S. Senate,,DEM,Kamala D. Harris,611
+Santa Clara,1639,U.S. Senate,,DEM,Loretta L. Sanchez,306
+Santa Clara,1640,U.S. Senate,,DEM,Kamala D. Harris,729
+Santa Clara,1640,U.S. Senate,,DEM,Loretta L. Sanchez,270
+Santa Clara,1645,U.S. Senate,,DEM,Kamala D. Harris,370
+Santa Clara,1645,U.S. Senate,,DEM,Loretta L. Sanchez,140
+Santa Clara,1646,U.S. Senate,,DEM,Kamala D. Harris,420
+Santa Clara,1646,U.S. Senate,,DEM,Loretta L. Sanchez,174
+Santa Clara,1648,U.S. Senate,,DEM,Kamala D. Harris,767
+Santa Clara,1648,U.S. Senate,,DEM,Loretta L. Sanchez,305
+Santa Clara,1649,U.S. Senate,,DEM,Kamala D. Harris,655
+Santa Clara,1649,U.S. Senate,,DEM,Loretta L. Sanchez,242
+Santa Clara,1650,U.S. Senate,,DEM,Kamala D. Harris,220
+Santa Clara,1650,U.S. Senate,,DEM,Loretta L. Sanchez,97
+Santa Clara,1654,U.S. Senate,,DEM,Kamala D. Harris,540
+Santa Clara,1654,U.S. Senate,,DEM,Loretta L. Sanchez,209
+Santa Clara,1656,U.S. Senate,,DEM,Kamala D. Harris,639
+Santa Clara,1656,U.S. Senate,,DEM,Loretta L. Sanchez,269
+Santa Clara,1658,U.S. Senate,,DEM,Kamala D. Harris,712
+Santa Clara,1658,U.S. Senate,,DEM,Loretta L. Sanchez,206
+Santa Clara,1661,U.S. Senate,,DEM,Kamala D. Harris,69
+Santa Clara,1661,U.S. Senate,,DEM,Loretta L. Sanchez,43
+Santa Clara,1662,U.S. Senate,,DEM,Kamala D. Harris,464
+Santa Clara,1662,U.S. Senate,,DEM,Loretta L. Sanchez,144
+Santa Clara,1663,U.S. Senate,,DEM,Kamala D. Harris,432
+Santa Clara,1663,U.S. Senate,,DEM,Loretta L. Sanchez,147
+Santa Clara,1664,U.S. Senate,,DEM,Kamala D. Harris,552
+Santa Clara,1664,U.S. Senate,,DEM,Loretta L. Sanchez,177
+Santa Clara,1666,U.S. Senate,,DEM,Kamala D. Harris,649
+Santa Clara,1666,U.S. Senate,,DEM,Loretta L. Sanchez,285
+Santa Clara,1667,U.S. Senate,,DEM,Kamala D. Harris,397
+Santa Clara,1667,U.S. Senate,,DEM,Loretta L. Sanchez,303
+Santa Clara,1668,U.S. Senate,,DEM,Kamala D. Harris,488
+Santa Clara,1668,U.S. Senate,,DEM,Loretta L. Sanchez,315
+Santa Clara,1669,U.S. Senate,,DEM,Kamala D. Harris,47
+Santa Clara,1669,U.S. Senate,,DEM,Loretta L. Sanchez,15
+Santa Clara,1671,U.S. Senate,,DEM,Kamala D. Harris,630
+Santa Clara,1671,U.S. Senate,,DEM,Loretta L. Sanchez,207
+Santa Clara,1672,U.S. Senate,,DEM,Kamala D. Harris,353
+Santa Clara,1672,U.S. Senate,,DEM,Loretta L. Sanchez,134
+Santa Clara,1673,U.S. Senate,,DEM,Kamala D. Harris,399
+Santa Clara,1673,U.S. Senate,,DEM,Loretta L. Sanchez,162
+Santa Clara,1675,U.S. Senate,,DEM,Kamala D. Harris,521
+Santa Clara,1675,U.S. Senate,,DEM,Loretta L. Sanchez,227
+Santa Clara,1677,U.S. Senate,,DEM,Kamala D. Harris,397
+Santa Clara,1677,U.S. Senate,,DEM,Loretta L. Sanchez,200
+Santa Clara,1679,U.S. Senate,,DEM,Kamala D. Harris,15
+Santa Clara,1679,U.S. Senate,,DEM,Loretta L. Sanchez,10
+Santa Clara,1683,U.S. Senate,,DEM,Kamala D. Harris,460
+Santa Clara,1683,U.S. Senate,,DEM,Loretta L. Sanchez,170
+Santa Clara,1685,U.S. Senate,,DEM,Kamala D. Harris,217
+Santa Clara,1685,U.S. Senate,,DEM,Loretta L. Sanchez,138
+Santa Clara,1687,U.S. Senate,,DEM,Kamala D. Harris,814
+Santa Clara,1687,U.S. Senate,,DEM,Loretta L. Sanchez,297
+Santa Clara,1693,U.S. Senate,,DEM,Kamala D. Harris,10
+Santa Clara,1693,U.S. Senate,,DEM,Loretta L. Sanchez,5
+Santa Clara,1700,U.S. Senate,,DEM,Kamala D. Harris,579
+Santa Clara,1700,U.S. Senate,,DEM,Loretta L. Sanchez,195
+Santa Clara,1701,U.S. Senate,,DEM,Kamala D. Harris,470
+Santa Clara,1701,U.S. Senate,,DEM,Loretta L. Sanchez,408
+Santa Clara,1702,U.S. Senate,,DEM,Kamala D. Harris,297
+Santa Clara,1702,U.S. Senate,,DEM,Loretta L. Sanchez,263
+Santa Clara,1704,U.S. Senate,,DEM,Kamala D. Harris,151
+Santa Clara,1704,U.S. Senate,,DEM,Loretta L. Sanchez,205
+Santa Clara,1706,U.S. Senate,,DEM,Kamala D. Harris,583
+Santa Clara,1706,U.S. Senate,,DEM,Loretta L. Sanchez,274
+Santa Clara,1707,U.S. Senate,,DEM,Kamala D. Harris,219
+Santa Clara,1707,U.S. Senate,,DEM,Loretta L. Sanchez,379
+Santa Clara,1708,U.S. Senate,,DEM,Kamala D. Harris,250
+Santa Clara,1708,U.S. Senate,,DEM,Loretta L. Sanchez,441
+Santa Clara,1709,U.S. Senate,,DEM,Kamala D. Harris,224
+Santa Clara,1709,U.S. Senate,,DEM,Loretta L. Sanchez,404
+Santa Clara,1710,U.S. Senate,,DEM,Kamala D. Harris,141
+Santa Clara,1710,U.S. Senate,,DEM,Loretta L. Sanchez,327
+Santa Clara,1711,U.S. Senate,,DEM,Kamala D. Harris,273
+Santa Clara,1711,U.S. Senate,,DEM,Loretta L. Sanchez,383
+Santa Clara,1712,U.S. Senate,,DEM,Kamala D. Harris,210
+Santa Clara,1712,U.S. Senate,,DEM,Loretta L. Sanchez,272
+Santa Clara,1713,U.S. Senate,,DEM,Kamala D. Harris,250
+Santa Clara,1713,U.S. Senate,,DEM,Loretta L. Sanchez,343
+Santa Clara,1715,U.S. Senate,,DEM,Kamala D. Harris,291
+Santa Clara,1715,U.S. Senate,,DEM,Loretta L. Sanchez,370
+Santa Clara,1716,U.S. Senate,,DEM,Kamala D. Harris,256
+Santa Clara,1716,U.S. Senate,,DEM,Loretta L. Sanchez,285
+Santa Clara,1717,U.S. Senate,,DEM,Kamala D. Harris,262
+Santa Clara,1717,U.S. Senate,,DEM,Loretta L. Sanchez,267
+Santa Clara,1718,U.S. Senate,,DEM,Kamala D. Harris,294
+Santa Clara,1718,U.S. Senate,,DEM,Loretta L. Sanchez,385
+Santa Clara,1719,U.S. Senate,,DEM,Kamala D. Harris,254
+Santa Clara,1719,U.S. Senate,,DEM,Loretta L. Sanchez,316
+Santa Clara,1720,U.S. Senate,,DEM,Kamala D. Harris,265
+Santa Clara,1720,U.S. Senate,,DEM,Loretta L. Sanchez,361
+Santa Clara,1721,U.S. Senate,,DEM,Kamala D. Harris,215
+Santa Clara,1721,U.S. Senate,,DEM,Loretta L. Sanchez,352
+Santa Clara,1723,U.S. Senate,,DEM,Kamala D. Harris,215
+Santa Clara,1723,U.S. Senate,,DEM,Loretta L. Sanchez,292
+Santa Clara,1724,U.S. Senate,,DEM,Kamala D. Harris,295
+Santa Clara,1724,U.S. Senate,,DEM,Loretta L. Sanchez,418
+Santa Clara,1726,U.S. Senate,,DEM,Kamala D. Harris,227
+Santa Clara,1726,U.S. Senate,,DEM,Loretta L. Sanchez,285
+Santa Clara,1727,U.S. Senate,,DEM,Kamala D. Harris,303
+Santa Clara,1727,U.S. Senate,,DEM,Loretta L. Sanchez,316
+Santa Clara,1728,U.S. Senate,,DEM,Kamala D. Harris,256
+Santa Clara,1728,U.S. Senate,,DEM,Loretta L. Sanchez,413
+Santa Clara,1729,U.S. Senate,,DEM,Kamala D. Harris,222
+Santa Clara,1729,U.S. Senate,,DEM,Loretta L. Sanchez,311
+Santa Clara,1730,U.S. Senate,,DEM,Kamala D. Harris,133
+Santa Clara,1730,U.S. Senate,,DEM,Loretta L. Sanchez,186
+Santa Clara,1732,U.S. Senate,,DEM,Kamala D. Harris,388
+Santa Clara,1732,U.S. Senate,,DEM,Loretta L. Sanchez,580
+Santa Clara,1735,U.S. Senate,,DEM,Kamala D. Harris,359
+Santa Clara,1735,U.S. Senate,,DEM,Loretta L. Sanchez,572
+Santa Clara,1737,U.S. Senate,,DEM,Kamala D. Harris,319
+Santa Clara,1737,U.S. Senate,,DEM,Loretta L. Sanchez,577
+Santa Clara,1740,U.S. Senate,,DEM,Kamala D. Harris,225
+Santa Clara,1740,U.S. Senate,,DEM,Loretta L. Sanchez,207
+Santa Clara,1743,U.S. Senate,,DEM,Kamala D. Harris,601
+Santa Clara,1743,U.S. Senate,,DEM,Loretta L. Sanchez,256
+Santa Clara,1744,U.S. Senate,,DEM,Kamala D. Harris,668
+Santa Clara,1744,U.S. Senate,,DEM,Loretta L. Sanchez,406
+Santa Clara,1746,U.S. Senate,,DEM,Kamala D. Harris,300
+Santa Clara,1746,U.S. Senate,,DEM,Loretta L. Sanchez,335
+Santa Clara,1747,U.S. Senate,,DEM,Kamala D. Harris,407
+Santa Clara,1747,U.S. Senate,,DEM,Loretta L. Sanchez,263
+Santa Clara,1751,U.S. Senate,,DEM,Kamala D. Harris,562
+Santa Clara,1751,U.S. Senate,,DEM,Loretta L. Sanchez,311
+Santa Clara,1753,U.S. Senate,,DEM,Kamala D. Harris,376
+Santa Clara,1753,U.S. Senate,,DEM,Loretta L. Sanchez,170
+Santa Clara,1755,U.S. Senate,,DEM,Kamala D. Harris,598
+Santa Clara,1755,U.S. Senate,,DEM,Loretta L. Sanchez,282
+Santa Clara,1760,U.S. Senate,,DEM,Kamala D. Harris,320
+Santa Clara,1760,U.S. Senate,,DEM,Loretta L. Sanchez,331
+Santa Clara,1767,U.S. Senate,,DEM,Kamala D. Harris,187
+Santa Clara,1767,U.S. Senate,,DEM,Loretta L. Sanchez,306
+Santa Clara,1773,U.S. Senate,,DEM,Kamala D. Harris,353
+Santa Clara,1773,U.S. Senate,,DEM,Loretta L. Sanchez,298
+Santa Clara,1775,U.S. Senate,,DEM,Kamala D. Harris,85
+Santa Clara,1775,U.S. Senate,,DEM,Loretta L. Sanchez,96
+Santa Clara,1780,U.S. Senate,,DEM,Kamala D. Harris,468
+Santa Clara,1780,U.S. Senate,,DEM,Loretta L. Sanchez,325
+Santa Clara,1781,U.S. Senate,,DEM,Kamala D. Harris,668
+Santa Clara,1781,U.S. Senate,,DEM,Loretta L. Sanchez,328
+Santa Clara,1784,U.S. Senate,,DEM,Kamala D. Harris,523
+Santa Clara,1784,U.S. Senate,,DEM,Loretta L. Sanchez,181
+Santa Clara,1785,U.S. Senate,,DEM,Kamala D. Harris,336
+Santa Clara,1785,U.S. Senate,,DEM,Loretta L. Sanchez,295
+Santa Clara,1786,U.S. Senate,,DEM,Kamala D. Harris,1181
+Santa Clara,1786,U.S. Senate,,DEM,Loretta L. Sanchez,436
+Santa Clara,1787,U.S. Senate,,DEM,Kamala D. Harris,526
+Santa Clara,1787,U.S. Senate,,DEM,Loretta L. Sanchez,235
+Santa Clara,1788,U.S. Senate,,DEM,Kamala D. Harris,667
+Santa Clara,1788,U.S. Senate,,DEM,Loretta L. Sanchez,150
+Santa Clara,1789,U.S. Senate,,DEM,Kamala D. Harris,645
+Santa Clara,1789,U.S. Senate,,DEM,Loretta L. Sanchez,407
+Santa Clara,1790,U.S. Senate,,DEM,Kamala D. Harris,566
+Santa Clara,1790,U.S. Senate,,DEM,Loretta L. Sanchez,252
+Santa Clara,1792,U.S. Senate,,DEM,Kamala D. Harris,566
+Santa Clara,1792,U.S. Senate,,DEM,Loretta L. Sanchez,198
+Santa Clara,1793,U.S. Senate,,DEM,Kamala D. Harris,722
+Santa Clara,1793,U.S. Senate,,DEM,Loretta L. Sanchez,282
+Santa Clara,1794,U.S. Senate,,DEM,Kamala D. Harris,493
+Santa Clara,1794,U.S. Senate,,DEM,Loretta L. Sanchez,245
+Santa Clara,1795,U.S. Senate,,DEM,Kamala D. Harris,498
+Santa Clara,1795,U.S. Senate,,DEM,Loretta L. Sanchez,377
+Santa Clara,1796,U.S. Senate,,DEM,Kamala D. Harris,488
+Santa Clara,1796,U.S. Senate,,DEM,Loretta L. Sanchez,194
+Santa Clara,1797,U.S. Senate,,DEM,Kamala D. Harris,731
+Santa Clara,1797,U.S. Senate,,DEM,Loretta L. Sanchez,326
+Santa Clara,1798,U.S. Senate,,DEM,Kamala D. Harris,113
+Santa Clara,1798,U.S. Senate,,DEM,Loretta L. Sanchez,56
+Santa Clara,1799,U.S. Senate,,DEM,Kamala D. Harris,254
+Santa Clara,1799,U.S. Senate,,DEM,Loretta L. Sanchez,184
+Santa Clara,1801,U.S. Senate,,DEM,Kamala D. Harris,31
+Santa Clara,1801,U.S. Senate,,DEM,Loretta L. Sanchez,11
+Santa Clara,1804,U.S. Senate,,DEM,Kamala D. Harris,398
+Santa Clara,1804,U.S. Senate,,DEM,Loretta L. Sanchez,518
+Santa Clara,1808,U.S. Senate,,DEM,Kamala D. Harris,0
+Santa Clara,1808,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Santa Clara,1811,U.S. Senate,,DEM,Kamala D. Harris,246
+Santa Clara,1811,U.S. Senate,,DEM,Loretta L. Sanchez,218
+Santa Clara,1813,U.S. Senate,,DEM,Kamala D. Harris,158
+Santa Clara,1813,U.S. Senate,,DEM,Loretta L. Sanchez,87
+Santa Clara,1817,U.S. Senate,,DEM,Kamala D. Harris,367
+Santa Clara,1817,U.S. Senate,,DEM,Loretta L. Sanchez,292
+Santa Clara,1820,U.S. Senate,,DEM,Kamala D. Harris,306
+Santa Clara,1820,U.S. Senate,,DEM,Loretta L. Sanchez,243
+Santa Clara,1821,U.S. Senate,,DEM,Kamala D. Harris,277
+Santa Clara,1821,U.S. Senate,,DEM,Loretta L. Sanchez,278
+Santa Clara,1822,U.S. Senate,,DEM,Kamala D. Harris,522
+Santa Clara,1822,U.S. Senate,,DEM,Loretta L. Sanchez,379
+Santa Clara,1823,U.S. Senate,,DEM,Kamala D. Harris,293
+Santa Clara,1823,U.S. Senate,,DEM,Loretta L. Sanchez,259
+Santa Clara,1824,U.S. Senate,,DEM,Kamala D. Harris,367
+Santa Clara,1824,U.S. Senate,,DEM,Loretta L. Sanchez,308
+Santa Clara,1826,U.S. Senate,,DEM,Kamala D. Harris,298
+Santa Clara,1826,U.S. Senate,,DEM,Loretta L. Sanchez,328
+Santa Clara,1827,U.S. Senate,,DEM,Kamala D. Harris,527
+Santa Clara,1827,U.S. Senate,,DEM,Loretta L. Sanchez,479
+Santa Clara,1828,U.S. Senate,,DEM,Kamala D. Harris,336
+Santa Clara,1828,U.S. Senate,,DEM,Loretta L. Sanchez,153
+Santa Clara,1829,U.S. Senate,,DEM,Kamala D. Harris,319
+Santa Clara,1829,U.S. Senate,,DEM,Loretta L. Sanchez,267
+Santa Clara,1830,U.S. Senate,,DEM,Kamala D. Harris,215
+Santa Clara,1830,U.S. Senate,,DEM,Loretta L. Sanchez,254
+Santa Clara,1831,U.S. Senate,,DEM,Kamala D. Harris,366
+Santa Clara,1831,U.S. Senate,,DEM,Loretta L. Sanchez,321
+Santa Clara,1832,U.S. Senate,,DEM,Kamala D. Harris,626
+Santa Clara,1832,U.S. Senate,,DEM,Loretta L. Sanchez,272
+Santa Clara,1835,U.S. Senate,,DEM,Kamala D. Harris,475
+Santa Clara,1835,U.S. Senate,,DEM,Loretta L. Sanchez,166
+Santa Clara,1839,U.S. Senate,,DEM,Kamala D. Harris,793
+Santa Clara,1839,U.S. Senate,,DEM,Loretta L. Sanchez,286
+Santa Clara,1840,U.S. Senate,,DEM,Kamala D. Harris,423
+Santa Clara,1840,U.S. Senate,,DEM,Loretta L. Sanchez,244
+Santa Clara,1841,U.S. Senate,,DEM,Kamala D. Harris,548
+Santa Clara,1841,U.S. Senate,,DEM,Loretta L. Sanchez,351
+Santa Clara,1842,U.S. Senate,,DEM,Kamala D. Harris,400
+Santa Clara,1842,U.S. Senate,,DEM,Loretta L. Sanchez,312
+Santa Clara,1843,U.S. Senate,,DEM,Kamala D. Harris,274
+Santa Clara,1843,U.S. Senate,,DEM,Loretta L. Sanchez,296
+Santa Clara,1844,U.S. Senate,,DEM,Kamala D. Harris,594
+Santa Clara,1844,U.S. Senate,,DEM,Loretta L. Sanchez,411
+Santa Clara,1845,U.S. Senate,,DEM,Kamala D. Harris,278
+Santa Clara,1845,U.S. Senate,,DEM,Loretta L. Sanchez,240
+Santa Clara,1846,U.S. Senate,,DEM,Kamala D. Harris,286
+Santa Clara,1846,U.S. Senate,,DEM,Loretta L. Sanchez,332
+Santa Clara,1847,U.S. Senate,,DEM,Kamala D. Harris,204
+Santa Clara,1847,U.S. Senate,,DEM,Loretta L. Sanchez,306
+Santa Clara,1848,U.S. Senate,,DEM,Kamala D. Harris,244
+Santa Clara,1848,U.S. Senate,,DEM,Loretta L. Sanchez,380
+Santa Clara,1849,U.S. Senate,,DEM,Kamala D. Harris,248
+Santa Clara,1849,U.S. Senate,,DEM,Loretta L. Sanchez,355
+Santa Clara,1850,U.S. Senate,,DEM,Kamala D. Harris,309
+Santa Clara,1850,U.S. Senate,,DEM,Loretta L. Sanchez,507
+Santa Clara,1852,U.S. Senate,,DEM,Kamala D. Harris,287
+Santa Clara,1852,U.S. Senate,,DEM,Loretta L. Sanchez,327
+Santa Clara,1853,U.S. Senate,,DEM,Kamala D. Harris,27
+Santa Clara,1853,U.S. Senate,,DEM,Loretta L. Sanchez,26
+Santa Clara,1855,U.S. Senate,,DEM,Kamala D. Harris,296
+Santa Clara,1855,U.S. Senate,,DEM,Loretta L. Sanchez,244
+Santa Clara,1856,U.S. Senate,,DEM,Kamala D. Harris,298
+Santa Clara,1856,U.S. Senate,,DEM,Loretta L. Sanchez,282
+Santa Clara,1857,U.S. Senate,,DEM,Kamala D. Harris,301
+Santa Clara,1857,U.S. Senate,,DEM,Loretta L. Sanchez,355
+Santa Clara,1859,U.S. Senate,,DEM,Kamala D. Harris,386
+Santa Clara,1859,U.S. Senate,,DEM,Loretta L. Sanchez,485
+Santa Clara,1861,U.S. Senate,,DEM,Kamala D. Harris,214
+Santa Clara,1861,U.S. Senate,,DEM,Loretta L. Sanchez,313
+Santa Clara,1863,U.S. Senate,,DEM,Kamala D. Harris,320
+Santa Clara,1863,U.S. Senate,,DEM,Loretta L. Sanchez,208
+Santa Clara,1865,U.S. Senate,,DEM,Kamala D. Harris,345
+Santa Clara,1865,U.S. Senate,,DEM,Loretta L. Sanchez,402
+Santa Clara,1866,U.S. Senate,,DEM,Kamala D. Harris,404
+Santa Clara,1866,U.S. Senate,,DEM,Loretta L. Sanchez,265
+Santa Clara,1869,U.S. Senate,,DEM,Kamala D. Harris,340
+Santa Clara,1869,U.S. Senate,,DEM,Loretta L. Sanchez,264
+Santa Clara,1871,U.S. Senate,,DEM,Kamala D. Harris,594
+Santa Clara,1871,U.S. Senate,,DEM,Loretta L. Sanchez,314
+Santa Clara,1872,U.S. Senate,,DEM,Kamala D. Harris,207
+Santa Clara,1872,U.S. Senate,,DEM,Loretta L. Sanchez,193
+Santa Clara,1877,U.S. Senate,,DEM,Kamala D. Harris,269
+Santa Clara,1877,U.S. Senate,,DEM,Loretta L. Sanchez,187
+Santa Clara,1881,U.S. Senate,,DEM,Kamala D. Harris,380
+Santa Clara,1881,U.S. Senate,,DEM,Loretta L. Sanchez,243
+Santa Clara,1886,U.S. Senate,,DEM,Kamala D. Harris,302
+Santa Clara,1886,U.S. Senate,,DEM,Loretta L. Sanchez,163
+Santa Clara,1887,U.S. Senate,,DEM,Kamala D. Harris,386
+Santa Clara,1887,U.S. Senate,,DEM,Loretta L. Sanchez,291
+Santa Clara,1897,U.S. Senate,,DEM,Kamala D. Harris,447
+Santa Clara,1897,U.S. Senate,,DEM,Loretta L. Sanchez,237
+Santa Clara,1901,U.S. Senate,,DEM,Kamala D. Harris,571
+Santa Clara,1901,U.S. Senate,,DEM,Loretta L. Sanchez,283
+Santa Clara,1902,U.S. Senate,,DEM,Kamala D. Harris,326
+Santa Clara,1902,U.S. Senate,,DEM,Loretta L. Sanchez,119
+Santa Clara,1903,U.S. Senate,,DEM,Kamala D. Harris,651
+Santa Clara,1903,U.S. Senate,,DEM,Loretta L. Sanchez,278
+Santa Clara,1904,U.S. Senate,,DEM,Kamala D. Harris,514
+Santa Clara,1904,U.S. Senate,,DEM,Loretta L. Sanchez,232
+Santa Clara,1907,U.S. Senate,,DEM,Kamala D. Harris,547
+Santa Clara,1907,U.S. Senate,,DEM,Loretta L. Sanchez,210
+Santa Clara,1909,U.S. Senate,,DEM,Kamala D. Harris,690
+Santa Clara,1909,U.S. Senate,,DEM,Loretta L. Sanchez,317
+Santa Clara,1911,U.S. Senate,,DEM,Kamala D. Harris,557
+Santa Clara,1911,U.S. Senate,,DEM,Loretta L. Sanchez,211
+Santa Clara,1913,U.S. Senate,,DEM,Kamala D. Harris,513
+Santa Clara,1913,U.S. Senate,,DEM,Loretta L. Sanchez,177
+Santa Clara,1914,U.S. Senate,,DEM,Kamala D. Harris,402
+Santa Clara,1914,U.S. Senate,,DEM,Loretta L. Sanchez,181
+Santa Clara,1916,U.S. Senate,,DEM,Kamala D. Harris,646
+Santa Clara,1916,U.S. Senate,,DEM,Loretta L. Sanchez,226
+Santa Clara,1918,U.S. Senate,,DEM,Kamala D. Harris,504
+Santa Clara,1918,U.S. Senate,,DEM,Loretta L. Sanchez,195
+Santa Clara,1919,U.S. Senate,,DEM,Kamala D. Harris,301
+Santa Clara,1919,U.S. Senate,,DEM,Loretta L. Sanchez,147
+Santa Clara,1920,U.S. Senate,,DEM,Kamala D. Harris,571
+Santa Clara,1920,U.S. Senate,,DEM,Loretta L. Sanchez,228
+Santa Clara,1922,U.S. Senate,,DEM,Kamala D. Harris,450
+Santa Clara,1922,U.S. Senate,,DEM,Loretta L. Sanchez,172
+Santa Clara,1924,U.S. Senate,,DEM,Kamala D. Harris,405
+Santa Clara,1924,U.S. Senate,,DEM,Loretta L. Sanchez,172
+Santa Clara,1925,U.S. Senate,,DEM,Kamala D. Harris,494
+Santa Clara,1925,U.S. Senate,,DEM,Loretta L. Sanchez,206
+Santa Clara,1927,U.S. Senate,,DEM,Kamala D. Harris,620
+Santa Clara,1927,U.S. Senate,,DEM,Loretta L. Sanchez,283
+Santa Clara,1928,U.S. Senate,,DEM,Kamala D. Harris,479
+Santa Clara,1928,U.S. Senate,,DEM,Loretta L. Sanchez,224
+Santa Clara,1930,U.S. Senate,,DEM,Kamala D. Harris,470
+Santa Clara,1930,U.S. Senate,,DEM,Loretta L. Sanchez,266
+Santa Clara,1932,U.S. Senate,,DEM,Kamala D. Harris,458
+Santa Clara,1932,U.S. Senate,,DEM,Loretta L. Sanchez,214
+Santa Clara,1935,U.S. Senate,,DEM,Kamala D. Harris,339
+Santa Clara,1935,U.S. Senate,,DEM,Loretta L. Sanchez,146
+Santa Clara,1936,U.S. Senate,,DEM,Kamala D. Harris,665
+Santa Clara,1936,U.S. Senate,,DEM,Loretta L. Sanchez,307
+Santa Clara,1937,U.S. Senate,,DEM,Kamala D. Harris,643
+Santa Clara,1937,U.S. Senate,,DEM,Loretta L. Sanchez,224
+Santa Clara,1939,U.S. Senate,,DEM,Kamala D. Harris,421
+Santa Clara,1939,U.S. Senate,,DEM,Loretta L. Sanchez,213
+Santa Clara,1941,U.S. Senate,,DEM,Kamala D. Harris,294
+Santa Clara,1941,U.S. Senate,,DEM,Loretta L. Sanchez,149
+Santa Clara,1944,U.S. Senate,,DEM,Kamala D. Harris,540
+Santa Clara,1944,U.S. Senate,,DEM,Loretta L. Sanchez,238
+Santa Clara,1945,U.S. Senate,,DEM,Kamala D. Harris,382
+Santa Clara,1945,U.S. Senate,,DEM,Loretta L. Sanchez,205
+Santa Clara,1947,U.S. Senate,,DEM,Kamala D. Harris,550
+Santa Clara,1947,U.S. Senate,,DEM,Loretta L. Sanchez,267
+Santa Clara,1949,U.S. Senate,,DEM,Kamala D. Harris,707
+Santa Clara,1949,U.S. Senate,,DEM,Loretta L. Sanchez,296
+Santa Clara,1952,U.S. Senate,,DEM,Kamala D. Harris,491
+Santa Clara,1952,U.S. Senate,,DEM,Loretta L. Sanchez,231
+Santa Clara,1953,U.S. Senate,,DEM,Kamala D. Harris,417
+Santa Clara,1953,U.S. Senate,,DEM,Loretta L. Sanchez,229
+Santa Clara,1954,U.S. Senate,,DEM,Kamala D. Harris,508
+Santa Clara,1954,U.S. Senate,,DEM,Loretta L. Sanchez,253
+Santa Clara,1957,U.S. Senate,,DEM,Kamala D. Harris,481
+Santa Clara,1957,U.S. Senate,,DEM,Loretta L. Sanchez,215
+Santa Clara,1960,U.S. Senate,,DEM,Kamala D. Harris,448
+Santa Clara,1960,U.S. Senate,,DEM,Loretta L. Sanchez,189
+Santa Clara,1962,U.S. Senate,,DEM,Kamala D. Harris,283
+Santa Clara,1962,U.S. Senate,,DEM,Loretta L. Sanchez,123
+Santa Clara,1963,U.S. Senate,,DEM,Kamala D. Harris,489
+Santa Clara,1963,U.S. Senate,,DEM,Loretta L. Sanchez,161
+Santa Clara,1964,U.S. Senate,,DEM,Kamala D. Harris,375
+Santa Clara,1964,U.S. Senate,,DEM,Loretta L. Sanchez,94
+Santa Clara,1968,U.S. Senate,,DEM,Kamala D. Harris,43
+Santa Clara,1968,U.S. Senate,,DEM,Loretta L. Sanchez,26
+Santa Clara,1977,U.S. Senate,,DEM,Kamala D. Harris,195
+Santa Clara,1977,U.S. Senate,,DEM,Loretta L. Sanchez,130
+Santa Clara,1978,U.S. Senate,,DEM,Kamala D. Harris,220
+Santa Clara,1978,U.S. Senate,,DEM,Loretta L. Sanchez,167
+Santa Clara,1986,U.S. Senate,,DEM,Kamala D. Harris,323
+Santa Clara,1986,U.S. Senate,,DEM,Loretta L. Sanchez,207
+Santa Clara,1990,U.S. Senate,,DEM,Kamala D. Harris,38
+Santa Clara,1990,U.S. Senate,,DEM,Loretta L. Sanchez,25
+Santa Clara,1991,U.S. Senate,,DEM,Kamala D. Harris,108
+Santa Clara,1991,U.S. Senate,,DEM,Loretta L. Sanchez,170
+Santa Clara,1994,U.S. Senate,,DEM,Kamala D. Harris,176
+Santa Clara,1994,U.S. Senate,,DEM,Loretta L. Sanchez,69
+Santa Clara,1995,U.S. Senate,,DEM,Kamala D. Harris,0
+Santa Clara,1995,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Santa Clara,1996,U.S. Senate,,DEM,Kamala D. Harris,86
+Santa Clara,1996,U.S. Senate,,DEM,Loretta L. Sanchez,25
+Santa Clara,1999,U.S. Senate,,DEM,Kamala D. Harris,1
+Santa Clara,1999,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Santa Clara,2001,U.S. Senate,,DEM,Kamala D. Harris,3
+Santa Clara,2001,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Santa Clara,2002,U.S. Senate,,DEM,Kamala D. Harris,833
+Santa Clara,2002,U.S. Senate,,DEM,Loretta L. Sanchez,225
+Santa Clara,2003,U.S. Senate,,DEM,Kamala D. Harris,574
+Santa Clara,2003,U.S. Senate,,DEM,Loretta L. Sanchez,135
+Santa Clara,2004,U.S. Senate,,DEM,Kamala D. Harris,854
+Santa Clara,2004,U.S. Senate,,DEM,Loretta L. Sanchez,226
+Santa Clara,2005,U.S. Senate,,DEM,Kamala D. Harris,769
+Santa Clara,2005,U.S. Senate,,DEM,Loretta L. Sanchez,184
+Santa Clara,2006,U.S. Senate,,DEM,Kamala D. Harris,175
+Santa Clara,2006,U.S. Senate,,DEM,Loretta L. Sanchez,64
+Santa Clara,2009,U.S. Senate,,DEM,Kamala D. Harris,821
+Santa Clara,2009,U.S. Senate,,DEM,Loretta L. Sanchez,251
+Santa Clara,2010,U.S. Senate,,DEM,Kamala D. Harris,452
+Santa Clara,2010,U.S. Senate,,DEM,Loretta L. Sanchez,141
+Santa Clara,2013,U.S. Senate,,DEM,Kamala D. Harris,851
+Santa Clara,2013,U.S. Senate,,DEM,Loretta L. Sanchez,178
+Santa Clara,2014,U.S. Senate,,DEM,Kamala D. Harris,420
+Santa Clara,2014,U.S. Senate,,DEM,Loretta L. Sanchez,137
+Santa Clara,2015,U.S. Senate,,DEM,Kamala D. Harris,556
+Santa Clara,2015,U.S. Senate,,DEM,Loretta L. Sanchez,175
+Santa Clara,2018,U.S. Senate,,DEM,Kamala D. Harris,69
+Santa Clara,2018,U.S. Senate,,DEM,Loretta L. Sanchez,26
+Santa Clara,2019,U.S. Senate,,DEM,Kamala D. Harris,505
+Santa Clara,2019,U.S. Senate,,DEM,Loretta L. Sanchez,147
+Santa Clara,2022,U.S. Senate,,DEM,Kamala D. Harris,0
+Santa Clara,2022,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Santa Clara,2025,U.S. Senate,,DEM,Kamala D. Harris,862
+Santa Clara,2025,U.S. Senate,,DEM,Loretta L. Sanchez,210
+Santa Clara,2028,U.S. Senate,,DEM,Kamala D. Harris,440
+Santa Clara,2028,U.S. Senate,,DEM,Loretta L. Sanchez,127
+Santa Clara,2034,U.S. Senate,,DEM,Kamala D. Harris,552
+Santa Clara,2034,U.S. Senate,,DEM,Loretta L. Sanchez,147
+Santa Clara,2038,U.S. Senate,,DEM,Kamala D. Harris,480
+Santa Clara,2038,U.S. Senate,,DEM,Loretta L. Sanchez,120
+Santa Clara,2046,U.S. Senate,,DEM,Kamala D. Harris,751
+Santa Clara,2046,U.S. Senate,,DEM,Loretta L. Sanchez,207
+Santa Clara,2048,U.S. Senate,,DEM,Kamala D. Harris,878
+Santa Clara,2048,U.S. Senate,,DEM,Loretta L. Sanchez,193
+Santa Clara,2056,U.S. Senate,,DEM,Kamala D. Harris,471
+Santa Clara,2056,U.S. Senate,,DEM,Loretta L. Sanchez,118
+Santa Clara,2057,U.S. Senate,,DEM,Kamala D. Harris,849
+Santa Clara,2057,U.S. Senate,,DEM,Loretta L. Sanchez,180
+Santa Clara,2061,U.S. Senate,,DEM,Kamala D. Harris,849
+Santa Clara,2061,U.S. Senate,,DEM,Loretta L. Sanchez,185
+Santa Clara,2068,U.S. Senate,,DEM,Kamala D. Harris,854
+Santa Clara,2068,U.S. Senate,,DEM,Loretta L. Sanchez,187
+Santa Clara,2075,U.S. Senate,,DEM,Kamala D. Harris,820
+Santa Clara,2075,U.S. Senate,,DEM,Loretta L. Sanchez,154
+Santa Clara,2078,U.S. Senate,,DEM,Kamala D. Harris,857
+Santa Clara,2078,U.S. Senate,,DEM,Loretta L. Sanchez,181
+Santa Clara,2081,U.S. Senate,,DEM,Kamala D. Harris,448
+Santa Clara,2081,U.S. Senate,,DEM,Loretta L. Sanchez,113
+Santa Clara,2090,U.S. Senate,,DEM,Kamala D. Harris,537
+Santa Clara,2090,U.S. Senate,,DEM,Loretta L. Sanchez,135
+Santa Clara,2096,U.S. Senate,,DEM,Kamala D. Harris,531
+Santa Clara,2096,U.S. Senate,,DEM,Loretta L. Sanchez,107
+Santa Clara,2098,U.S. Senate,,DEM,Kamala D. Harris,505
+Santa Clara,2098,U.S. Senate,,DEM,Loretta L. Sanchez,81
+Santa Clara,2101,U.S. Senate,,DEM,Kamala D. Harris,829
+Santa Clara,2101,U.S. Senate,,DEM,Loretta L. Sanchez,227
+Santa Clara,2103,U.S. Senate,,DEM,Kamala D. Harris,422
+Santa Clara,2103,U.S. Senate,,DEM,Loretta L. Sanchez,100
+Santa Clara,2107,U.S. Senate,,DEM,Kamala D. Harris,508
+Santa Clara,2107,U.S. Senate,,DEM,Loretta L. Sanchez,141
+Santa Clara,2110,U.S. Senate,,DEM,Kamala D. Harris,544
+Santa Clara,2110,U.S. Senate,,DEM,Loretta L. Sanchez,124
+Santa Clara,2112,U.S. Senate,,DEM,Kamala D. Harris,582
+Santa Clara,2112,U.S. Senate,,DEM,Loretta L. Sanchez,156
+Santa Clara,2113,U.S. Senate,,DEM,Kamala D. Harris,769
+Santa Clara,2113,U.S. Senate,,DEM,Loretta L. Sanchez,200
+Santa Clara,2115,U.S. Senate,,DEM,Kamala D. Harris,410
+Santa Clara,2115,U.S. Senate,,DEM,Loretta L. Sanchez,119
+Santa Clara,2117,U.S. Senate,,DEM,Kamala D. Harris,553
+Santa Clara,2117,U.S. Senate,,DEM,Loretta L. Sanchez,119
+Santa Clara,2118,U.S. Senate,,DEM,Kamala D. Harris,555
+Santa Clara,2118,U.S. Senate,,DEM,Loretta L. Sanchez,178
+Santa Clara,2120,U.S. Senate,,DEM,Kamala D. Harris,524
+Santa Clara,2120,U.S. Senate,,DEM,Loretta L. Sanchez,159
+Santa Clara,2122,U.S. Senate,,DEM,Kamala D. Harris,516
+Santa Clara,2122,U.S. Senate,,DEM,Loretta L. Sanchez,143
+Santa Clara,2124,U.S. Senate,,DEM,Kamala D. Harris,110
+Santa Clara,2124,U.S. Senate,,DEM,Loretta L. Sanchez,43
+Santa Clara,2126,U.S. Senate,,DEM,Kamala D. Harris,34
+Santa Clara,2126,U.S. Senate,,DEM,Loretta L. Sanchez,12
+Santa Clara,2129,U.S. Senate,,DEM,Kamala D. Harris,433
+Santa Clara,2129,U.S. Senate,,DEM,Loretta L. Sanchez,118
+Santa Clara,2301,U.S. Senate,,DEM,Kamala D. Harris,721
+Santa Clara,2301,U.S. Senate,,DEM,Loretta L. Sanchez,189
+Santa Clara,2305,U.S. Senate,,DEM,Kamala D. Harris,512
+Santa Clara,2305,U.S. Senate,,DEM,Loretta L. Sanchez,151
+Santa Clara,2306,U.S. Senate,,DEM,Kamala D. Harris,758
+Santa Clara,2306,U.S. Senate,,DEM,Loretta L. Sanchez,230
+Santa Clara,2309,U.S. Senate,,DEM,Kamala D. Harris,514
+Santa Clara,2309,U.S. Senate,,DEM,Loretta L. Sanchez,154
+Santa Clara,2311,U.S. Senate,,DEM,Kamala D. Harris,746
+Santa Clara,2311,U.S. Senate,,DEM,Loretta L. Sanchez,183
+Santa Clara,2314,U.S. Senate,,DEM,Kamala D. Harris,481
+Santa Clara,2314,U.S. Senate,,DEM,Loretta L. Sanchez,177
+Santa Clara,2321,U.S. Senate,,DEM,Kamala D. Harris,795
+Santa Clara,2321,U.S. Senate,,DEM,Loretta L. Sanchez,197
+Santa Clara,2323,U.S. Senate,,DEM,Kamala D. Harris,501
+Santa Clara,2323,U.S. Senate,,DEM,Loretta L. Sanchez,153
+Santa Clara,2326,U.S. Senate,,DEM,Kamala D. Harris,462
+Santa Clara,2326,U.S. Senate,,DEM,Loretta L. Sanchez,160
+Santa Clara,2330,U.S. Senate,,DEM,Kamala D. Harris,690
+Santa Clara,2330,U.S. Senate,,DEM,Loretta L. Sanchez,201
+Santa Clara,2333,U.S. Senate,,DEM,Kamala D. Harris,659
+Santa Clara,2333,U.S. Senate,,DEM,Loretta L. Sanchez,203
+Santa Clara,2336,U.S. Senate,,DEM,Kamala D. Harris,453
+Santa Clara,2336,U.S. Senate,,DEM,Loretta L. Sanchez,151
+Santa Clara,2338,U.S. Senate,,DEM,Kamala D. Harris,509
+Santa Clara,2338,U.S. Senate,,DEM,Loretta L. Sanchez,174
+Santa Clara,2339,U.S. Senate,,DEM,Kamala D. Harris,508
+Santa Clara,2339,U.S. Senate,,DEM,Loretta L. Sanchez,152
+Santa Clara,2342,U.S. Senate,,DEM,Kamala D. Harris,553
+Santa Clara,2342,U.S. Senate,,DEM,Loretta L. Sanchez,124
+Santa Clara,2343,U.S. Senate,,DEM,Kamala D. Harris,453
+Santa Clara,2343,U.S. Senate,,DEM,Loretta L. Sanchez,145
+Santa Clara,2345,U.S. Senate,,DEM,Kamala D. Harris,500
+Santa Clara,2345,U.S. Senate,,DEM,Loretta L. Sanchez,133
+Santa Clara,2346,U.S. Senate,,DEM,Kamala D. Harris,618
+Santa Clara,2346,U.S. Senate,,DEM,Loretta L. Sanchez,188
+Santa Clara,2351,U.S. Senate,,DEM,Kamala D. Harris,733
+Santa Clara,2351,U.S. Senate,,DEM,Loretta L. Sanchez,188
+Santa Clara,2352,U.S. Senate,,DEM,Kamala D. Harris,567
+Santa Clara,2352,U.S. Senate,,DEM,Loretta L. Sanchez,150
+Santa Clara,2353,U.S. Senate,,DEM,Kamala D. Harris,17
+Santa Clara,2353,U.S. Senate,,DEM,Loretta L. Sanchez,5
+Santa Clara,2376,U.S. Senate,,DEM,Kamala D. Harris,699
+Santa Clara,2376,U.S. Senate,,DEM,Loretta L. Sanchez,281
+Santa Clara,2378,U.S. Senate,,DEM,Kamala D. Harris,525
+Santa Clara,2378,U.S. Senate,,DEM,Loretta L. Sanchez,174
+Santa Clara,2379,U.S. Senate,,DEM,Kamala D. Harris,27
+Santa Clara,2379,U.S. Senate,,DEM,Loretta L. Sanchez,8
+Santa Clara,2381,U.S. Senate,,DEM,Kamala D. Harris,740
+Santa Clara,2381,U.S. Senate,,DEM,Loretta L. Sanchez,214
+Santa Clara,2386,U.S. Senate,,DEM,Kamala D. Harris,552
+Santa Clara,2386,U.S. Senate,,DEM,Loretta L. Sanchez,207
+Santa Clara,2389,U.S. Senate,,DEM,Kamala D. Harris,638
+Santa Clara,2389,U.S. Senate,,DEM,Loretta L. Sanchez,188
+Santa Clara,2402,U.S. Senate,,DEM,Kamala D. Harris,474
+Santa Clara,2402,U.S. Senate,,DEM,Loretta L. Sanchez,135
+Santa Clara,2403,U.S. Senate,,DEM,Kamala D. Harris,905
+Santa Clara,2403,U.S. Senate,,DEM,Loretta L. Sanchez,279
+Santa Clara,2406,U.S. Senate,,DEM,Kamala D. Harris,750
+Santa Clara,2406,U.S. Senate,,DEM,Loretta L. Sanchez,291
+Santa Clara,2407,U.S. Senate,,DEM,Kamala D. Harris,564
+Santa Clara,2407,U.S. Senate,,DEM,Loretta L. Sanchez,168
+Santa Clara,2408,U.S. Senate,,DEM,Kamala D. Harris,828
+Santa Clara,2408,U.S. Senate,,DEM,Loretta L. Sanchez,389
+Santa Clara,2409,U.S. Senate,,DEM,Kamala D. Harris,432
+Santa Clara,2409,U.S. Senate,,DEM,Loretta L. Sanchez,188
+Santa Clara,2410,U.S. Senate,,DEM,Kamala D. Harris,801
+Santa Clara,2410,U.S. Senate,,DEM,Loretta L. Sanchez,282
+Santa Clara,2412,U.S. Senate,,DEM,Kamala D. Harris,733
+Santa Clara,2412,U.S. Senate,,DEM,Loretta L. Sanchez,229
+Santa Clara,2414,U.S. Senate,,DEM,Kamala D. Harris,743
+Santa Clara,2414,U.S. Senate,,DEM,Loretta L. Sanchez,248
+Santa Clara,2417,U.S. Senate,,DEM,Kamala D. Harris,820
+Santa Clara,2417,U.S. Senate,,DEM,Loretta L. Sanchez,255
+Santa Clara,2418,U.S. Senate,,DEM,Kamala D. Harris,755
+Santa Clara,2418,U.S. Senate,,DEM,Loretta L. Sanchez,310
+Santa Clara,2419,U.S. Senate,,DEM,Kamala D. Harris,638
+Santa Clara,2419,U.S. Senate,,DEM,Loretta L. Sanchez,191
+Santa Clara,2427,U.S. Senate,,DEM,Kamala D. Harris,518
+Santa Clara,2427,U.S. Senate,,DEM,Loretta L. Sanchez,200
+Santa Clara,2428,U.S. Senate,,DEM,Kamala D. Harris,503
+Santa Clara,2428,U.S. Senate,,DEM,Loretta L. Sanchez,145
+Santa Clara,2431,U.S. Senate,,DEM,Kamala D. Harris,318
+Santa Clara,2431,U.S. Senate,,DEM,Loretta L. Sanchez,82
+Santa Clara,2432,U.S. Senate,,DEM,Kamala D. Harris,8
+Santa Clara,2432,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Santa Clara,2434,U.S. Senate,,DEM,Kamala D. Harris,533
+Santa Clara,2434,U.S. Senate,,DEM,Loretta L. Sanchez,136
+Santa Clara,2436,U.S. Senate,,DEM,Kamala D. Harris,616
+Santa Clara,2436,U.S. Senate,,DEM,Loretta L. Sanchez,129
+Santa Clara,2438,U.S. Senate,,DEM,Kamala D. Harris,548
+Santa Clara,2438,U.S. Senate,,DEM,Loretta L. Sanchez,155
+Santa Clara,2439,U.S. Senate,,DEM,Kamala D. Harris,543
+Santa Clara,2439,U.S. Senate,,DEM,Loretta L. Sanchez,123
+Santa Clara,2440,U.S. Senate,,DEM,Kamala D. Harris,449
+Santa Clara,2440,U.S. Senate,,DEM,Loretta L. Sanchez,130
+Santa Clara,2441,U.S. Senate,,DEM,Kamala D. Harris,488
+Santa Clara,2441,U.S. Senate,,DEM,Loretta L. Sanchez,144
+Santa Clara,2442,U.S. Senate,,DEM,Kamala D. Harris,495
+Santa Clara,2442,U.S. Senate,,DEM,Loretta L. Sanchez,182
+Santa Clara,2445,U.S. Senate,,DEM,Kamala D. Harris,779
+Santa Clara,2445,U.S. Senate,,DEM,Loretta L. Sanchez,255
+Santa Clara,2457,U.S. Senate,,DEM,Kamala D. Harris,735
+Santa Clara,2457,U.S. Senate,,DEM,Loretta L. Sanchez,216
+Santa Clara,2459,U.S. Senate,,DEM,Kamala D. Harris,449
+Santa Clara,2459,U.S. Senate,,DEM,Loretta L. Sanchez,189
+Santa Clara,2460,U.S. Senate,,DEM,Kamala D. Harris,406
+Santa Clara,2460,U.S. Senate,,DEM,Loretta L. Sanchez,151
+Santa Clara,2464,U.S. Senate,,DEM,Kamala D. Harris,264
+Santa Clara,2464,U.S. Senate,,DEM,Loretta L. Sanchez,63
+Santa Clara,2467,U.S. Senate,,DEM,Kamala D. Harris,431
+Santa Clara,2467,U.S. Senate,,DEM,Loretta L. Sanchez,133
+Santa Clara,2469,U.S. Senate,,DEM,Kamala D. Harris,193
+Santa Clara,2469,U.S. Senate,,DEM,Loretta L. Sanchez,130
+Santa Clara,2470,U.S. Senate,,DEM,Kamala D. Harris,552
+Santa Clara,2470,U.S. Senate,,DEM,Loretta L. Sanchez,176
+Santa Clara,2475,U.S. Senate,,DEM,Kamala D. Harris,821
+Santa Clara,2475,U.S. Senate,,DEM,Loretta L. Sanchez,274
+Santa Clara,2477,U.S. Senate,,DEM,Kamala D. Harris,579
+Santa Clara,2477,U.S. Senate,,DEM,Loretta L. Sanchez,206
+Santa Clara,2479,U.S. Senate,,DEM,Kamala D. Harris,697
+Santa Clara,2479,U.S. Senate,,DEM,Loretta L. Sanchez,194
+Santa Clara,2489,U.S. Senate,,DEM,Kamala D. Harris,675
+Santa Clara,2489,U.S. Senate,,DEM,Loretta L. Sanchez,215
+Santa Clara,2492,U.S. Senate,,DEM,Kamala D. Harris,779
+Santa Clara,2492,U.S. Senate,,DEM,Loretta L. Sanchez,298
+Santa Clara,2539,U.S. Senate,,DEM,Kamala D. Harris,42
+Santa Clara,2539,U.S. Senate,,DEM,Loretta L. Sanchez,18
+Santa Clara,2542,U.S. Senate,,DEM,Kamala D. Harris,539
+Santa Clara,2542,U.S. Senate,,DEM,Loretta L. Sanchez,175
+Santa Clara,2544,U.S. Senate,,DEM,Kamala D. Harris,843
+Santa Clara,2544,U.S. Senate,,DEM,Loretta L. Sanchez,227
+Santa Clara,2545,U.S. Senate,,DEM,Kamala D. Harris,543
+Santa Clara,2545,U.S. Senate,,DEM,Loretta L. Sanchez,98
+Santa Clara,2546,U.S. Senate,,DEM,Kamala D. Harris,818
+Santa Clara,2546,U.S. Senate,,DEM,Loretta L. Sanchez,131
+Santa Clara,2802,U.S. Senate,,DEM,Kamala D. Harris,653
+Santa Clara,2802,U.S. Senate,,DEM,Loretta L. Sanchez,216
+Santa Clara,2808,U.S. Senate,,DEM,Kamala D. Harris,6
+Santa Clara,2808,U.S. Senate,,DEM,Loretta L. Sanchez,5
+Santa Clara,2811,U.S. Senate,,DEM,Kamala D. Harris,17
+Santa Clara,2811,U.S. Senate,,DEM,Loretta L. Sanchez,5
+Santa Clara,2812,U.S. Senate,,DEM,Kamala D. Harris,153
+Santa Clara,2812,U.S. Senate,,DEM,Loretta L. Sanchez,37
+Santa Clara,2813,U.S. Senate,,DEM,Kamala D. Harris,101
+Santa Clara,2813,U.S. Senate,,DEM,Loretta L. Sanchez,50
+Santa Clara,2815,U.S. Senate,,DEM,Kamala D. Harris,0
+Santa Clara,2815,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Santa Clara,2816,U.S. Senate,,DEM,Kamala D. Harris,15
+Santa Clara,2816,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Santa Clara,2825,U.S. Senate,,DEM,Kamala D. Harris,0
+Santa Clara,2825,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Santa Clara,2826,U.S. Senate,,DEM,Kamala D. Harris,6
+Santa Clara,2826,U.S. Senate,,DEM,Loretta L. Sanchez,6
+Santa Clara,2833,U.S. Senate,,DEM,Kamala D. Harris,643
+Santa Clara,2833,U.S. Senate,,DEM,Loretta L. Sanchez,207
+Santa Clara,2871,U.S. Senate,,DEM,Kamala D. Harris,55
+Santa Clara,2871,U.S. Senate,,DEM,Loretta L. Sanchez,22
+Santa Clara,2873,U.S. Senate,,DEM,Kamala D. Harris,2
+Santa Clara,2873,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Santa Clara,2951,U.S. Senate,,DEM,Kamala D. Harris,39
+Santa Clara,2951,U.S. Senate,,DEM,Loretta L. Sanchez,31
+Santa Clara,2953,U.S. Senate,,DEM,Kamala D. Harris,40
+Santa Clara,2953,U.S. Senate,,DEM,Loretta L. Sanchez,24
+Santa Clara,3601,U.S. Senate,,DEM,Kamala D. Harris,796
+Santa Clara,3601,U.S. Senate,,DEM,Loretta L. Sanchez,208
+Santa Clara,3602,U.S. Senate,,DEM,Kamala D. Harris,638
+Santa Clara,3602,U.S. Senate,,DEM,Loretta L. Sanchez,162
+Santa Clara,3603,U.S. Senate,,DEM,Kamala D. Harris,215
+Santa Clara,3603,U.S. Senate,,DEM,Loretta L. Sanchez,85
+Santa Clara,3604,U.S. Senate,,DEM,Kamala D. Harris,524
+Santa Clara,3604,U.S. Senate,,DEM,Loretta L. Sanchez,173
+Santa Clara,3605,U.S. Senate,,DEM,Kamala D. Harris,502
+Santa Clara,3605,U.S. Senate,,DEM,Loretta L. Sanchez,119
+Santa Clara,3606,U.S. Senate,,DEM,Kamala D. Harris,675
+Santa Clara,3606,U.S. Senate,,DEM,Loretta L. Sanchez,170
+Santa Clara,3607,U.S. Senate,,DEM,Kamala D. Harris,498
+Santa Clara,3607,U.S. Senate,,DEM,Loretta L. Sanchez,154
+Santa Clara,3608,U.S. Senate,,DEM,Kamala D. Harris,619
+Santa Clara,3608,U.S. Senate,,DEM,Loretta L. Sanchez,188
+Santa Clara,3609,U.S. Senate,,DEM,Kamala D. Harris,699
+Santa Clara,3609,U.S. Senate,,DEM,Loretta L. Sanchez,175
+Santa Clara,3610,U.S. Senate,,DEM,Kamala D. Harris,698
+Santa Clara,3610,U.S. Senate,,DEM,Loretta L. Sanchez,156
+Santa Clara,3611,U.S. Senate,,DEM,Kamala D. Harris,618
+Santa Clara,3611,U.S. Senate,,DEM,Loretta L. Sanchez,155
+Santa Clara,3612,U.S. Senate,,DEM,Kamala D. Harris,492
+Santa Clara,3612,U.S. Senate,,DEM,Loretta L. Sanchez,159
+Santa Clara,3614,U.S. Senate,,DEM,Kamala D. Harris,725
+Santa Clara,3614,U.S. Senate,,DEM,Loretta L. Sanchez,268
+Santa Clara,3616,U.S. Senate,,DEM,Kamala D. Harris,665
+Santa Clara,3616,U.S. Senate,,DEM,Loretta L. Sanchez,188
+Santa Clara,3617,U.S. Senate,,DEM,Kamala D. Harris,396
+Santa Clara,3617,U.S. Senate,,DEM,Loretta L. Sanchez,117
+Santa Clara,3620,U.S. Senate,,DEM,Kamala D. Harris,428
+Santa Clara,3620,U.S. Senate,,DEM,Loretta L. Sanchez,114
+Santa Clara,3621,U.S. Senate,,DEM,Kamala D. Harris,746
+Santa Clara,3621,U.S. Senate,,DEM,Loretta L. Sanchez,195
+Santa Clara,3623,U.S. Senate,,DEM,Kamala D. Harris,652
+Santa Clara,3623,U.S. Senate,,DEM,Loretta L. Sanchez,147
+Santa Clara,3624,U.S. Senate,,DEM,Kamala D. Harris,858
+Santa Clara,3624,U.S. Senate,,DEM,Loretta L. Sanchez,223
+Santa Clara,3629,U.S. Senate,,DEM,Kamala D. Harris,628
+Santa Clara,3629,U.S. Senate,,DEM,Loretta L. Sanchez,180
+Santa Clara,3635,U.S. Senate,,DEM,Kamala D. Harris,55
+Santa Clara,3635,U.S. Senate,,DEM,Loretta L. Sanchez,21
+Santa Clara,3636,U.S. Senate,,DEM,Kamala D. Harris,387
+Santa Clara,3636,U.S. Senate,,DEM,Loretta L. Sanchez,100
+Santa Clara,3639,U.S. Senate,,DEM,Kamala D. Harris,797
+Santa Clara,3639,U.S. Senate,,DEM,Loretta L. Sanchez,193
+Santa Clara,3640,U.S. Senate,,DEM,Kamala D. Harris,684
+Santa Clara,3640,U.S. Senate,,DEM,Loretta L. Sanchez,160
+Santa Clara,3643,U.S. Senate,,DEM,Kamala D. Harris,634
+Santa Clara,3643,U.S. Senate,,DEM,Loretta L. Sanchez,190
+Santa Clara,3646,U.S. Senate,,DEM,Kamala D. Harris,516
+Santa Clara,3646,U.S. Senate,,DEM,Loretta L. Sanchez,142
+Santa Clara,3648,U.S. Senate,,DEM,Kamala D. Harris,57
+Santa Clara,3648,U.S. Senate,,DEM,Loretta L. Sanchez,13
+Santa Clara,3651,U.S. Senate,,DEM,Kamala D. Harris,529
+Santa Clara,3651,U.S. Senate,,DEM,Loretta L. Sanchez,138
+Santa Clara,3654,U.S. Senate,,DEM,Kamala D. Harris,470
+Santa Clara,3654,U.S. Senate,,DEM,Loretta L. Sanchez,183
+Santa Clara,3655,U.S. Senate,,DEM,Kamala D. Harris,0
+Santa Clara,3655,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Santa Clara,3722,U.S. Senate,,DEM,Kamala D. Harris,6
+Santa Clara,3722,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Santa Clara,3723,U.S. Senate,,DEM,Kamala D. Harris,25
+Santa Clara,3723,U.S. Senate,,DEM,Loretta L. Sanchez,7
+Santa Clara,3724,U.S. Senate,,DEM,Kamala D. Harris,710
+Santa Clara,3724,U.S. Senate,,DEM,Loretta L. Sanchez,288
+Santa Clara,3725,U.S. Senate,,DEM,Kamala D. Harris,712
+Santa Clara,3725,U.S. Senate,,DEM,Loretta L. Sanchez,280
+Santa Clara,3726,U.S. Senate,,DEM,Kamala D. Harris,551
+Santa Clara,3726,U.S. Senate,,DEM,Loretta L. Sanchez,227
+Santa Clara,3727,U.S. Senate,,DEM,Kamala D. Harris,3
+Santa Clara,3727,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Santa Clara,3728,U.S. Senate,,DEM,Kamala D. Harris,2
+Santa Clara,3728,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Santa Clara,3729,U.S. Senate,,DEM,Kamala D. Harris,729
+Santa Clara,3729,U.S. Senate,,DEM,Loretta L. Sanchez,228
+Santa Clara,3730,U.S. Senate,,DEM,Kamala D. Harris,5
+Santa Clara,3730,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Santa Clara,3731,U.S. Senate,,DEM,Kamala D. Harris,427
+Santa Clara,3731,U.S. Senate,,DEM,Loretta L. Sanchez,152
+Santa Clara,3733,U.S. Senate,,DEM,Kamala D. Harris,660
+Santa Clara,3733,U.S. Senate,,DEM,Loretta L. Sanchez,245
+Santa Clara,3734,U.S. Senate,,DEM,Kamala D. Harris,336
+Santa Clara,3734,U.S. Senate,,DEM,Loretta L. Sanchez,77
+Santa Clara,3737,U.S. Senate,,DEM,Kamala D. Harris,694
+Santa Clara,3737,U.S. Senate,,DEM,Loretta L. Sanchez,232
+Santa Clara,3738,U.S. Senate,,DEM,Kamala D. Harris,15
+Santa Clara,3738,U.S. Senate,,DEM,Loretta L. Sanchez,8
+Santa Clara,3739,U.S. Senate,,DEM,Kamala D. Harris,16
+Santa Clara,3739,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Santa Clara,3740,U.S. Senate,,DEM,Kamala D. Harris,566
+Santa Clara,3740,U.S. Senate,,DEM,Loretta L. Sanchez,223
+Santa Clara,3741,U.S. Senate,,DEM,Kamala D. Harris,798
+Santa Clara,3741,U.S. Senate,,DEM,Loretta L. Sanchez,257
+Santa Clara,3744,U.S. Senate,,DEM,Kamala D. Harris,522
+Santa Clara,3744,U.S. Senate,,DEM,Loretta L. Sanchez,158
+Santa Clara,3745,U.S. Senate,,DEM,Kamala D. Harris,633
+Santa Clara,3745,U.S. Senate,,DEM,Loretta L. Sanchez,223
+Santa Clara,3746,U.S. Senate,,DEM,Kamala D. Harris,660
+Santa Clara,3746,U.S. Senate,,DEM,Loretta L. Sanchez,219
+Santa Clara,3751,U.S. Senate,,DEM,Kamala D. Harris,7
+Santa Clara,3751,U.S. Senate,,DEM,Loretta L. Sanchez,7
+Santa Clara,3757,U.S. Senate,,DEM,Kamala D. Harris,411
+Santa Clara,3757,U.S. Senate,,DEM,Loretta L. Sanchez,144
+Santa Clara,3761,U.S. Senate,,DEM,Kamala D. Harris,4
+Santa Clara,3761,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Santa Clara,3763,U.S. Senate,,DEM,Kamala D. Harris,505
+Santa Clara,3763,U.S. Senate,,DEM,Loretta L. Sanchez,142
+Santa Clara,3767,U.S. Senate,,DEM,Kamala D. Harris,406
+Santa Clara,3767,U.S. Senate,,DEM,Loretta L. Sanchez,151
+Santa Clara,3771,U.S. Senate,,DEM,Kamala D. Harris,414
+Santa Clara,3771,U.S. Senate,,DEM,Loretta L. Sanchez,136
+Santa Clara,3774,U.S. Senate,,DEM,Kamala D. Harris,794
+Santa Clara,3774,U.S. Senate,,DEM,Loretta L. Sanchez,229
+Santa Clara,3781,U.S. Senate,,DEM,Kamala D. Harris,556
+Santa Clara,3781,U.S. Senate,,DEM,Loretta L. Sanchez,208
+Santa Clara,3782,U.S. Senate,,DEM,Kamala D. Harris,106
+Santa Clara,3782,U.S. Senate,,DEM,Loretta L. Sanchez,41
+Santa Clara,3784,U.S. Senate,,DEM,Kamala D. Harris,62
+Santa Clara,3784,U.S. Senate,,DEM,Loretta L. Sanchez,18
+Santa Clara,3785,U.S. Senate,,DEM,Kamala D. Harris,504
+Santa Clara,3785,U.S. Senate,,DEM,Loretta L. Sanchez,172
+Santa Clara,3786,U.S. Senate,,DEM,Kamala D. Harris,74
+Santa Clara,3786,U.S. Senate,,DEM,Loretta L. Sanchez,20
+Santa Clara,3787,U.S. Senate,,DEM,Kamala D. Harris,17
+Santa Clara,3787,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Santa Clara,3801,U.S. Senate,,DEM,Kamala D. Harris,483
+Santa Clara,3801,U.S. Senate,,DEM,Loretta L. Sanchez,186
+Santa Clara,3802,U.S. Senate,,DEM,Kamala D. Harris,507
+Santa Clara,3802,U.S. Senate,,DEM,Loretta L. Sanchez,178
+Santa Clara,3803,U.S. Senate,,DEM,Kamala D. Harris,0
+Santa Clara,3803,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Santa Clara,3804,U.S. Senate,,DEM,Kamala D. Harris,789
+Santa Clara,3804,U.S. Senate,,DEM,Loretta L. Sanchez,327
+Santa Clara,3805,U.S. Senate,,DEM,Kamala D. Harris,758
+Santa Clara,3805,U.S. Senate,,DEM,Loretta L. Sanchez,282
+Santa Clara,3806,U.S. Senate,,DEM,Kamala D. Harris,568
+Santa Clara,3806,U.S. Senate,,DEM,Loretta L. Sanchez,239
+Santa Clara,3809,U.S. Senate,,DEM,Kamala D. Harris,493
+Santa Clara,3809,U.S. Senate,,DEM,Loretta L. Sanchez,195
+Santa Clara,3810,U.S. Senate,,DEM,Kamala D. Harris,552
+Santa Clara,3810,U.S. Senate,,DEM,Loretta L. Sanchez,304
+Santa Clara,3812,U.S. Senate,,DEM,Kamala D. Harris,772
+Santa Clara,3812,U.S. Senate,,DEM,Loretta L. Sanchez,301
+Santa Clara,3813,U.S. Senate,,DEM,Kamala D. Harris,659
+Santa Clara,3813,U.S. Senate,,DEM,Loretta L. Sanchez,237
+Santa Clara,3814,U.S. Senate,,DEM,Kamala D. Harris,578
+Santa Clara,3814,U.S. Senate,,DEM,Loretta L. Sanchez,232
+Santa Clara,3818,U.S. Senate,,DEM,Kamala D. Harris,378
+Santa Clara,3818,U.S. Senate,,DEM,Loretta L. Sanchez,141
+Santa Clara,3820,U.S. Senate,,DEM,Kamala D. Harris,654
+Santa Clara,3820,U.S. Senate,,DEM,Loretta L. Sanchez,262
+Santa Clara,3821,U.S. Senate,,DEM,Kamala D. Harris,453
+Santa Clara,3821,U.S. Senate,,DEM,Loretta L. Sanchez,194
+Santa Clara,3823,U.S. Senate,,DEM,Kamala D. Harris,422
+Santa Clara,3823,U.S. Senate,,DEM,Loretta L. Sanchez,172
+Santa Clara,3826,U.S. Senate,,DEM,Kamala D. Harris,411
+Santa Clara,3826,U.S. Senate,,DEM,Loretta L. Sanchez,176
+Santa Clara,3827,U.S. Senate,,DEM,Kamala D. Harris,443
+Santa Clara,3827,U.S. Senate,,DEM,Loretta L. Sanchez,222
+Santa Clara,3828,U.S. Senate,,DEM,Kamala D. Harris,694
+Santa Clara,3828,U.S. Senate,,DEM,Loretta L. Sanchez,242
+Santa Clara,3834,U.S. Senate,,DEM,Kamala D. Harris,559
+Santa Clara,3834,U.S. Senate,,DEM,Loretta L. Sanchez,221
+Santa Clara,3835,U.S. Senate,,DEM,Kamala D. Harris,531
+Santa Clara,3835,U.S. Senate,,DEM,Loretta L. Sanchez,207
+Santa Clara,3840,U.S. Senate,,DEM,Kamala D. Harris,602
+Santa Clara,3840,U.S. Senate,,DEM,Loretta L. Sanchez,265
+Santa Clara,3845,U.S. Senate,,DEM,Kamala D. Harris,450
+Santa Clara,3845,U.S. Senate,,DEM,Loretta L. Sanchez,188
+Santa Clara,3846,U.S. Senate,,DEM,Kamala D. Harris,60
+Santa Clara,3846,U.S. Senate,,DEM,Loretta L. Sanchez,25
+Santa Clara,3901,U.S. Senate,,DEM,Kamala D. Harris,628
+Santa Clara,3901,U.S. Senate,,DEM,Loretta L. Sanchez,325
+Santa Clara,3902,U.S. Senate,,DEM,Kamala D. Harris,544
+Santa Clara,3902,U.S. Senate,,DEM,Loretta L. Sanchez,438
+Santa Clara,3903,U.S. Senate,,DEM,Kamala D. Harris,607
+Santa Clara,3903,U.S. Senate,,DEM,Loretta L. Sanchez,332
+Santa Clara,3905,U.S. Senate,,DEM,Kamala D. Harris,453
+Santa Clara,3905,U.S. Senate,,DEM,Loretta L. Sanchez,275
+Santa Clara,3906,U.S. Senate,,DEM,Kamala D. Harris,507
+Santa Clara,3906,U.S. Senate,,DEM,Loretta L. Sanchez,310
+Santa Clara,3907,U.S. Senate,,DEM,Kamala D. Harris,8
+Santa Clara,3907,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Santa Clara,3908,U.S. Senate,,DEM,Kamala D. Harris,31
+Santa Clara,3908,U.S. Senate,,DEM,Loretta L. Sanchez,29
+Santa Clara,3909,U.S. Senate,,DEM,Kamala D. Harris,620
+Santa Clara,3909,U.S. Senate,,DEM,Loretta L. Sanchez,339
+Santa Clara,3910,U.S. Senate,,DEM,Kamala D. Harris,403
+Santa Clara,3910,U.S. Senate,,DEM,Loretta L. Sanchez,285
+Santa Clara,3912,U.S. Senate,,DEM,Kamala D. Harris,264
+Santa Clara,3912,U.S. Senate,,DEM,Loretta L. Sanchez,160
+Santa Clara,3914,U.S. Senate,,DEM,Kamala D. Harris,445
+Santa Clara,3914,U.S. Senate,,DEM,Loretta L. Sanchez,221
+Santa Clara,3915,U.S. Senate,,DEM,Kamala D. Harris,508
+Santa Clara,3915,U.S. Senate,,DEM,Loretta L. Sanchez,272
+Santa Clara,3916,U.S. Senate,,DEM,Kamala D. Harris,395
+Santa Clara,3916,U.S. Senate,,DEM,Loretta L. Sanchez,238
+Santa Clara,3917,U.S. Senate,,DEM,Kamala D. Harris,408
+Santa Clara,3917,U.S. Senate,,DEM,Loretta L. Sanchez,188
+Santa Clara,3918,U.S. Senate,,DEM,Kamala D. Harris,560
+Santa Clara,3918,U.S. Senate,,DEM,Loretta L. Sanchez,249
+Santa Clara,3923,U.S. Senate,,DEM,Kamala D. Harris,496
+Santa Clara,3923,U.S. Senate,,DEM,Loretta L. Sanchez,254
+Santa Clara,3924,U.S. Senate,,DEM,Kamala D. Harris,519
+Santa Clara,3924,U.S. Senate,,DEM,Loretta L. Sanchez,227
+Santa Clara,3928,U.S. Senate,,DEM,Kamala D. Harris,478
+Santa Clara,3928,U.S. Senate,,DEM,Loretta L. Sanchez,295
+Santa Clara,3932,U.S. Senate,,DEM,Kamala D. Harris,499
+Santa Clara,3932,U.S. Senate,,DEM,Loretta L. Sanchez,226
+Santa Clara,3937,U.S. Senate,,DEM,Kamala D. Harris,467
+Santa Clara,3937,U.S. Senate,,DEM,Loretta L. Sanchez,271
+Santa Clara,3938,U.S. Senate,,DEM,Kamala D. Harris,224
+Santa Clara,3938,U.S. Senate,,DEM,Loretta L. Sanchez,124
+Santa Clara,3939,U.S. Senate,,DEM,Kamala D. Harris,671
+Santa Clara,3939,U.S. Senate,,DEM,Loretta L. Sanchez,343
+Santa Clara,3943,U.S. Senate,,DEM,Kamala D. Harris,249
+Santa Clara,3943,U.S. Senate,,DEM,Loretta L. Sanchez,177
+Santa Clara,3951,U.S. Senate,,DEM,Kamala D. Harris,507
+Santa Clara,3951,U.S. Senate,,DEM,Loretta L. Sanchez,421
+Santa Clara,3952,U.S. Senate,,DEM,Kamala D. Harris,617
+Santa Clara,3952,U.S. Senate,,DEM,Loretta L. Sanchez,277
+Santa Clara,3953,U.S. Senate,,DEM,Kamala D. Harris,511
+Santa Clara,3953,U.S. Senate,,DEM,Loretta L. Sanchez,415
+Santa Clara,3954,U.S. Senate,,DEM,Kamala D. Harris,397
+Santa Clara,3954,U.S. Senate,,DEM,Loretta L. Sanchez,276
+Santa Clara,3955,U.S. Senate,,DEM,Kamala D. Harris,417
+Santa Clara,3955,U.S. Senate,,DEM,Loretta L. Sanchez,243
+Santa Clara,3958,U.S. Senate,,DEM,Kamala D. Harris,258
+Santa Clara,3958,U.S. Senate,,DEM,Loretta L. Sanchez,301
+Santa Clara,3959,U.S. Senate,,DEM,Kamala D. Harris,483
+Santa Clara,3959,U.S. Senate,,DEM,Loretta L. Sanchez,288
+Santa Clara,3960,U.S. Senate,,DEM,Kamala D. Harris,267
+Santa Clara,3960,U.S. Senate,,DEM,Loretta L. Sanchez,212
+Santa Clara,3962,U.S. Senate,,DEM,Kamala D. Harris,337
+Santa Clara,3962,U.S. Senate,,DEM,Loretta L. Sanchez,395
+Santa Clara,3964,U.S. Senate,,DEM,Kamala D. Harris,595
+Santa Clara,3964,U.S. Senate,,DEM,Loretta L. Sanchez,361
+Santa Clara,3965,U.S. Senate,,DEM,Kamala D. Harris,504
+Santa Clara,3965,U.S. Senate,,DEM,Loretta L. Sanchez,262
+Santa Clara,3969,U.S. Senate,,DEM,Kamala D. Harris,578
+Santa Clara,3969,U.S. Senate,,DEM,Loretta L. Sanchez,506
+Santa Clara,3970,U.S. Senate,,DEM,Kamala D. Harris,409
+Santa Clara,3970,U.S. Senate,,DEM,Loretta L. Sanchez,258
+Santa Clara,3971,U.S. Senate,,DEM,Kamala D. Harris,0
+Santa Clara,3971,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Santa Clara,3972,U.S. Senate,,DEM,Kamala D. Harris,193
+Santa Clara,3972,U.S. Senate,,DEM,Loretta L. Sanchez,75
+Santa Clara,3976,U.S. Senate,,DEM,Kamala D. Harris,578
+Santa Clara,3976,U.S. Senate,,DEM,Loretta L. Sanchez,276
+Santa Clara,3981,U.S. Senate,,DEM,Kamala D. Harris,511
+Santa Clara,3981,U.S. Senate,,DEM,Loretta L. Sanchez,230
+Santa Clara,3982,U.S. Senate,,DEM,Kamala D. Harris,439
+Santa Clara,3982,U.S. Senate,,DEM,Loretta L. Sanchez,303
+Santa Clara,3983,U.S. Senate,,DEM,Kamala D. Harris,443
+Santa Clara,3983,U.S. Senate,,DEM,Loretta L. Sanchez,243
+Santa Clara,3984,U.S. Senate,,DEM,Kamala D. Harris,358
+Santa Clara,3984,U.S. Senate,,DEM,Loretta L. Sanchez,187
+Santa Clara,3985,U.S. Senate,,DEM,Kamala D. Harris,420
+Santa Clara,3985,U.S. Senate,,DEM,Loretta L. Sanchez,351
+Santa Clara,3986,U.S. Senate,,DEM,Kamala D. Harris,432
+Santa Clara,3986,U.S. Senate,,DEM,Loretta L. Sanchez,220
+Santa Clara,3989,U.S. Senate,,DEM,Kamala D. Harris,367
+Santa Clara,3989,U.S. Senate,,DEM,Loretta L. Sanchez,181
+Santa Clara,3992,U.S. Senate,,DEM,Kamala D. Harris,0
+Santa Clara,3992,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Santa Clara,3993,U.S. Senate,,DEM,Kamala D. Harris,304
+Santa Clara,3993,U.S. Senate,,DEM,Loretta L. Sanchez,240
+Santa Clara,4001,U.S. Senate,,DEM,Kamala D. Harris,617
+Santa Clara,4001,U.S. Senate,,DEM,Loretta L. Sanchez,346
+Santa Clara,4002,U.S. Senate,,DEM,Kamala D. Harris,668
+Santa Clara,4002,U.S. Senate,,DEM,Loretta L. Sanchez,390
+Santa Clara,4005,U.S. Senate,,DEM,Kamala D. Harris,19
+Santa Clara,4005,U.S. Senate,,DEM,Loretta L. Sanchez,10
+Santa Clara,4006,U.S. Senate,,DEM,Kamala D. Harris,630
+Santa Clara,4006,U.S. Senate,,DEM,Loretta L. Sanchez,317
+Santa Clara,4007,U.S. Senate,,DEM,Kamala D. Harris,603
+Santa Clara,4007,U.S. Senate,,DEM,Loretta L. Sanchez,380
+Santa Clara,4008,U.S. Senate,,DEM,Kamala D. Harris,17
+Santa Clara,4008,U.S. Senate,,DEM,Loretta L. Sanchez,7
+Santa Clara,4010,U.S. Senate,,DEM,Kamala D. Harris,814
+Santa Clara,4010,U.S. Senate,,DEM,Loretta L. Sanchez,264
+Santa Clara,4011,U.S. Senate,,DEM,Kamala D. Harris,536
+Santa Clara,4011,U.S. Senate,,DEM,Loretta L. Sanchez,304
+Santa Clara,4012,U.S. Senate,,DEM,Kamala D. Harris,58
+Santa Clara,4012,U.S. Senate,,DEM,Loretta L. Sanchez,16
+Santa Clara,4013,U.S. Senate,,DEM,Kamala D. Harris,495
+Santa Clara,4013,U.S. Senate,,DEM,Loretta L. Sanchez,247
+Santa Clara,4015,U.S. Senate,,DEM,Kamala D. Harris,250
+Santa Clara,4015,U.S. Senate,,DEM,Loretta L. Sanchez,97
+Santa Clara,4016,U.S. Senate,,DEM,Kamala D. Harris,684
+Santa Clara,4016,U.S. Senate,,DEM,Loretta L. Sanchez,267
+Santa Clara,4017,U.S. Senate,,DEM,Kamala D. Harris,457
+Santa Clara,4017,U.S. Senate,,DEM,Loretta L. Sanchez,209
+Santa Clara,4019,U.S. Senate,,DEM,Kamala D. Harris,591
+Santa Clara,4019,U.S. Senate,,DEM,Loretta L. Sanchez,260
+Santa Clara,4020,U.S. Senate,,DEM,Kamala D. Harris,746
+Santa Clara,4020,U.S. Senate,,DEM,Loretta L. Sanchez,302
+Santa Clara,4023,U.S. Senate,,DEM,Kamala D. Harris,641
+Santa Clara,4023,U.S. Senate,,DEM,Loretta L. Sanchez,231
+Santa Clara,4026,U.S. Senate,,DEM,Kamala D. Harris,559
+Santa Clara,4026,U.S. Senate,,DEM,Loretta L. Sanchez,329
+Santa Clara,4029,U.S. Senate,,DEM,Kamala D. Harris,0
+Santa Clara,4029,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Santa Clara,4034,U.S. Senate,,DEM,Kamala D. Harris,661
+Santa Clara,4034,U.S. Senate,,DEM,Loretta L. Sanchez,236
+Santa Clara,4035,U.S. Senate,,DEM,Kamala D. Harris,548
+Santa Clara,4035,U.S. Senate,,DEM,Loretta L. Sanchez,291
+Santa Clara,4036,U.S. Senate,,DEM,Kamala D. Harris,609
+Santa Clara,4036,U.S. Senate,,DEM,Loretta L. Sanchez,255
+Santa Clara,4038,U.S. Senate,,DEM,Kamala D. Harris,627
+Santa Clara,4038,U.S. Senate,,DEM,Loretta L. Sanchez,241
+Santa Clara,4039,U.S. Senate,,DEM,Kamala D. Harris,437
+Santa Clara,4039,U.S. Senate,,DEM,Loretta L. Sanchez,135
+Santa Clara,4041,U.S. Senate,,DEM,Kamala D. Harris,797
+Santa Clara,4041,U.S. Senate,,DEM,Loretta L. Sanchez,297
+Santa Clara,4043,U.S. Senate,,DEM,Kamala D. Harris,484
+Santa Clara,4043,U.S. Senate,,DEM,Loretta L. Sanchez,138
+Santa Clara,4045,U.S. Senate,,DEM,Kamala D. Harris,685
+Santa Clara,4045,U.S. Senate,,DEM,Loretta L. Sanchez,216
+Santa Clara,4047,U.S. Senate,,DEM,Kamala D. Harris,76
+Santa Clara,4047,U.S. Senate,,DEM,Loretta L. Sanchez,26
+Santa Clara,4048,U.S. Senate,,DEM,Kamala D. Harris,365
+Santa Clara,4048,U.S. Senate,,DEM,Loretta L. Sanchez,234
+Santa Clara,4050,U.S. Senate,,DEM,Kamala D. Harris,616
+Santa Clara,4050,U.S. Senate,,DEM,Loretta L. Sanchez,377
+Santa Clara,4051,U.S. Senate,,DEM,Kamala D. Harris,793
+Santa Clara,4051,U.S. Senate,,DEM,Loretta L. Sanchez,254
+Santa Clara,4052,U.S. Senate,,DEM,Kamala D. Harris,834
+Santa Clara,4052,U.S. Senate,,DEM,Loretta L. Sanchez,174
+Santa Clara,4053,U.S. Senate,,DEM,Kamala D. Harris,811
+Santa Clara,4053,U.S. Senate,,DEM,Loretta L. Sanchez,253
+Santa Clara,4059,U.S. Senate,,DEM,Kamala D. Harris,256
+Santa Clara,4059,U.S. Senate,,DEM,Loretta L. Sanchez,161
+Santa Clara,4060,U.S. Senate,,DEM,Kamala D. Harris,284
+Santa Clara,4060,U.S. Senate,,DEM,Loretta L. Sanchez,171
+Santa Clara,4061,U.S. Senate,,DEM,Kamala D. Harris,147
+Santa Clara,4061,U.S. Senate,,DEM,Loretta L. Sanchez,43
+Santa Clara,4062,U.S. Senate,,DEM,Kamala D. Harris,669
+Santa Clara,4062,U.S. Senate,,DEM,Loretta L. Sanchez,272
+Santa Clara,4066,U.S. Senate,,DEM,Kamala D. Harris,398
+Santa Clara,4066,U.S. Senate,,DEM,Loretta L. Sanchez,205
+Santa Clara,4071,U.S. Senate,,DEM,Kamala D. Harris,690
+Santa Clara,4071,U.S. Senate,,DEM,Loretta L. Sanchez,296
+Santa Clara,4074,U.S. Senate,,DEM,Kamala D. Harris,654
+Santa Clara,4074,U.S. Senate,,DEM,Loretta L. Sanchez,207
+Santa Clara,4075,U.S. Senate,,DEM,Kamala D. Harris,627
+Santa Clara,4075,U.S. Senate,,DEM,Loretta L. Sanchez,356
+Santa Clara,4076,U.S. Senate,,DEM,Kamala D. Harris,705
+Santa Clara,4076,U.S. Senate,,DEM,Loretta L. Sanchez,257
+Santa Clara,4078,U.S. Senate,,DEM,Kamala D. Harris,604
+Santa Clara,4078,U.S. Senate,,DEM,Loretta L. Sanchez,182
+Santa Clara,4083,U.S. Senate,,DEM,Kamala D. Harris,488
+Santa Clara,4083,U.S. Senate,,DEM,Loretta L. Sanchez,140
+Santa Clara,4085,U.S. Senate,,DEM,Kamala D. Harris,556
+Santa Clara,4085,U.S. Senate,,DEM,Loretta L. Sanchez,184
+Santa Clara,4086,U.S. Senate,,DEM,Kamala D. Harris,697
+Santa Clara,4086,U.S. Senate,,DEM,Loretta L. Sanchez,229
+Santa Clara,4087,U.S. Senate,,DEM,Kamala D. Harris,431
+Santa Clara,4087,U.S. Senate,,DEM,Loretta L. Sanchez,235
+Santa Clara,4089,U.S. Senate,,DEM,Kamala D. Harris,0
+Santa Clara,4089,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Santa Clara,4090,U.S. Senate,,DEM,Kamala D. Harris,65
+Santa Clara,4090,U.S. Senate,,DEM,Loretta L. Sanchez,29
+Santa Clara,4095,U.S. Senate,,DEM,Kamala D. Harris,1
+Santa Clara,4095,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Santa Clara,4103,U.S. Senate,,DEM,Kamala D. Harris,648
+Santa Clara,4103,U.S. Senate,,DEM,Loretta L. Sanchez,220
+Santa Clara,4113,U.S. Senate,,DEM,Kamala D. Harris,582
+Santa Clara,4113,U.S. Senate,,DEM,Loretta L. Sanchez,171
+Santa Clara,4117,U.S. Senate,,DEM,Kamala D. Harris,428
+Santa Clara,4117,U.S. Senate,,DEM,Loretta L. Sanchez,194
+Santa Clara,4118,U.S. Senate,,DEM,Kamala D. Harris,609
+Santa Clara,4118,U.S. Senate,,DEM,Loretta L. Sanchez,159
+Santa Clara,4120,U.S. Senate,,DEM,Kamala D. Harris,604
+Santa Clara,4120,U.S. Senate,,DEM,Loretta L. Sanchez,236
+Santa Clara,4122,U.S. Senate,,DEM,Kamala D. Harris,667
+Santa Clara,4122,U.S. Senate,,DEM,Loretta L. Sanchez,192
+Santa Clara,4126,U.S. Senate,,DEM,Kamala D. Harris,727
+Santa Clara,4126,U.S. Senate,,DEM,Loretta L. Sanchez,182
+Santa Clara,4128,U.S. Senate,,DEM,Kamala D. Harris,862
+Santa Clara,4128,U.S. Senate,,DEM,Loretta L. Sanchez,246
+Santa Clara,4129,U.S. Senate,,DEM,Kamala D. Harris,803
+Santa Clara,4129,U.S. Senate,,DEM,Loretta L. Sanchez,257
+Santa Clara,4131,U.S. Senate,,DEM,Kamala D. Harris,517
+Santa Clara,4131,U.S. Senate,,DEM,Loretta L. Sanchez,245
+Santa Clara,4139,U.S. Senate,,DEM,Kamala D. Harris,481
+Santa Clara,4139,U.S. Senate,,DEM,Loretta L. Sanchez,145
+Santa Clara,4155,U.S. Senate,,DEM,Kamala D. Harris,342
+Santa Clara,4155,U.S. Senate,,DEM,Loretta L. Sanchez,128
+Santa Clara,4201,U.S. Senate,,DEM,Kamala D. Harris,674
+Santa Clara,4201,U.S. Senate,,DEM,Loretta L. Sanchez,267
+Santa Clara,4202,U.S. Senate,,DEM,Kamala D. Harris,45
+Santa Clara,4202,U.S. Senate,,DEM,Loretta L. Sanchez,41
+Santa Clara,4205,U.S. Senate,,DEM,Kamala D. Harris,51
+Santa Clara,4205,U.S. Senate,,DEM,Loretta L. Sanchez,28
+Santa Clara,4208,U.S. Senate,,DEM,Kamala D. Harris,508
+Santa Clara,4208,U.S. Senate,,DEM,Loretta L. Sanchez,327
+Santa Clara,4211,U.S. Senate,,DEM,Kamala D. Harris,599
+Santa Clara,4211,U.S. Senate,,DEM,Loretta L. Sanchez,309
+Santa Clara,4213,U.S. Senate,,DEM,Kamala D. Harris,0
+Santa Clara,4213,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Santa Clara,4217,U.S. Senate,,DEM,Kamala D. Harris,672
+Santa Clara,4217,U.S. Senate,,DEM,Loretta L. Sanchez,328
+Santa Clara,4218,U.S. Senate,,DEM,Kamala D. Harris,426
+Santa Clara,4218,U.S. Senate,,DEM,Loretta L. Sanchez,233
+Santa Clara,4225,U.S. Senate,,DEM,Kamala D. Harris,635
+Santa Clara,4225,U.S. Senate,,DEM,Loretta L. Sanchez,363
+Santa Clara,4226,U.S. Senate,,DEM,Kamala D. Harris,683
+Santa Clara,4226,U.S. Senate,,DEM,Loretta L. Sanchez,317
+Santa Clara,4231,U.S. Senate,,DEM,Kamala D. Harris,587
+Santa Clara,4231,U.S. Senate,,DEM,Loretta L. Sanchez,290
+Santa Clara,4233,U.S. Senate,,DEM,Kamala D. Harris,539
+Santa Clara,4233,U.S. Senate,,DEM,Loretta L. Sanchez,278
+Santa Clara,4238,U.S. Senate,,DEM,Kamala D. Harris,644
+Santa Clara,4238,U.S. Senate,,DEM,Loretta L. Sanchez,330
+Santa Clara,4241,U.S. Senate,,DEM,Kamala D. Harris,664
+Santa Clara,4241,U.S. Senate,,DEM,Loretta L. Sanchez,322
+Santa Clara,4242,U.S. Senate,,DEM,Kamala D. Harris,674
+Santa Clara,4242,U.S. Senate,,DEM,Loretta L. Sanchez,361
+Santa Clara,4249,U.S. Senate,,DEM,Kamala D. Harris,621
+Santa Clara,4249,U.S. Senate,,DEM,Loretta L. Sanchez,397
+Santa Clara,4251,U.S. Senate,,DEM,Kamala D. Harris,751
+Santa Clara,4251,U.S. Senate,,DEM,Loretta L. Sanchez,363
+Santa Clara,4255,U.S. Senate,,DEM,Kamala D. Harris,229
+Santa Clara,4255,U.S. Senate,,DEM,Loretta L. Sanchez,85
+Santa Clara,4256,U.S. Senate,,DEM,Kamala D. Harris,716
+Santa Clara,4256,U.S. Senate,,DEM,Loretta L. Sanchez,278
+Santa Clara,4257,U.S. Senate,,DEM,Kamala D. Harris,666
+Santa Clara,4257,U.S. Senate,,DEM,Loretta L. Sanchez,357
+Santa Clara,4258,U.S. Senate,,DEM,Kamala D. Harris,362
+Santa Clara,4258,U.S. Senate,,DEM,Loretta L. Sanchez,225
+Santa Clara,4259,U.S. Senate,,DEM,Kamala D. Harris,679
+Santa Clara,4259,U.S. Senate,,DEM,Loretta L. Sanchez,366
+Santa Clara,4261,U.S. Senate,,DEM,Kamala D. Harris,417
+Santa Clara,4261,U.S. Senate,,DEM,Loretta L. Sanchez,254
+Santa Clara,4262,U.S. Senate,,DEM,Kamala D. Harris,517
+Santa Clara,4262,U.S. Senate,,DEM,Loretta L. Sanchez,294
+Santa Clara,4265,U.S. Senate,,DEM,Kamala D. Harris,637
+Santa Clara,4265,U.S. Senate,,DEM,Loretta L. Sanchez,284
+Santa Clara,4268,U.S. Senate,,DEM,Kamala D. Harris,517
+Santa Clara,4268,U.S. Senate,,DEM,Loretta L. Sanchez,356
+Santa Clara,4269,U.S. Senate,,DEM,Kamala D. Harris,511
+Santa Clara,4269,U.S. Senate,,DEM,Loretta L. Sanchez,185
+Santa Clara,4270,U.S. Senate,,DEM,Kamala D. Harris,629
+Santa Clara,4270,U.S. Senate,,DEM,Loretta L. Sanchez,333
+Santa Clara,4272,U.S. Senate,,DEM,Kamala D. Harris,533
+Santa Clara,4272,U.S. Senate,,DEM,Loretta L. Sanchez,284
+Santa Clara,4285,U.S. Senate,,DEM,Kamala D. Harris,376
+Santa Clara,4285,U.S. Senate,,DEM,Loretta L. Sanchez,273
+Santa Clara,4288,U.S. Senate,,DEM,Kamala D. Harris,444
+Santa Clara,4288,U.S. Senate,,DEM,Loretta L. Sanchez,159
+Santa Clara,4289,U.S. Senate,,DEM,Kamala D. Harris,355
+Santa Clara,4289,U.S. Senate,,DEM,Loretta L. Sanchez,197
+Santa Clara,4290,U.S. Senate,,DEM,Kamala D. Harris,348
+Santa Clara,4290,U.S. Senate,,DEM,Loretta L. Sanchez,184
+Santa Clara,4292,U.S. Senate,,DEM,Kamala D. Harris,393
+Santa Clara,4292,U.S. Senate,,DEM,Loretta L. Sanchez,126
+Santa Clara,4297,U.S. Senate,,DEM,Kamala D. Harris,647
+Santa Clara,4297,U.S. Senate,,DEM,Loretta L. Sanchez,286
+Santa Clara,4298,U.S. Senate,,DEM,Kamala D. Harris,735
+Santa Clara,4298,U.S. Senate,,DEM,Loretta L. Sanchez,325
+Santa Clara,4299,U.S. Senate,,DEM,Kamala D. Harris,61
+Santa Clara,4299,U.S. Senate,,DEM,Loretta L. Sanchez,28
+Santa Clara,4301,U.S. Senate,,DEM,Kamala D. Harris,682
+Santa Clara,4301,U.S. Senate,,DEM,Loretta L. Sanchez,237
+Santa Clara,4305,U.S. Senate,,DEM,Kamala D. Harris,706
+Santa Clara,4305,U.S. Senate,,DEM,Loretta L. Sanchez,251
+Santa Clara,4309,U.S. Senate,,DEM,Kamala D. Harris,18
+Santa Clara,4309,U.S. Senate,,DEM,Loretta L. Sanchez,13
+Santa Clara,4312,U.S. Senate,,DEM,Kamala D. Harris,487
+Santa Clara,4312,U.S. Senate,,DEM,Loretta L. Sanchez,147
+Santa Clara,4315,U.S. Senate,,DEM,Kamala D. Harris,467
+Santa Clara,4315,U.S. Senate,,DEM,Loretta L. Sanchez,209
+Santa Clara,4319,U.S. Senate,,DEM,Kamala D. Harris,685
+Santa Clara,4319,U.S. Senate,,DEM,Loretta L. Sanchez,350
+Santa Clara,4321,U.S. Senate,,DEM,Kamala D. Harris,541
+Santa Clara,4321,U.S. Senate,,DEM,Loretta L. Sanchez,284
+Santa Clara,4327,U.S. Senate,,DEM,Kamala D. Harris,693
+Santa Clara,4327,U.S. Senate,,DEM,Loretta L. Sanchez,298
+Santa Clara,4332,U.S. Senate,,DEM,Kamala D. Harris,298
+Santa Clara,4332,U.S. Senate,,DEM,Loretta L. Sanchez,193
+Santa Clara,4334,U.S. Senate,,DEM,Kamala D. Harris,498
+Santa Clara,4334,U.S. Senate,,DEM,Loretta L. Sanchez,175
+Santa Clara,4344,U.S. Senate,,DEM,Kamala D. Harris,385
+Santa Clara,4344,U.S. Senate,,DEM,Loretta L. Sanchez,172
+Santa Clara,4353,U.S. Senate,,DEM,Kamala D. Harris,230
+Santa Clara,4353,U.S. Senate,,DEM,Loretta L. Sanchez,95
+Santa Clara,4401,U.S. Senate,,DEM,Kamala D. Harris,302
+Santa Clara,4401,U.S. Senate,,DEM,Loretta L. Sanchez,295
+Santa Clara,4402,U.S. Senate,,DEM,Kamala D. Harris,602
+Santa Clara,4402,U.S. Senate,,DEM,Loretta L. Sanchez,323
+Santa Clara,4403,U.S. Senate,,DEM,Kamala D. Harris,43
+Santa Clara,4403,U.S. Senate,,DEM,Loretta L. Sanchez,27
+Santa Clara,4404,U.S. Senate,,DEM,Kamala D. Harris,470
+Santa Clara,4404,U.S. Senate,,DEM,Loretta L. Sanchez,357
+Santa Clara,4405,U.S. Senate,,DEM,Kamala D. Harris,680
+Santa Clara,4405,U.S. Senate,,DEM,Loretta L. Sanchez,328
+Santa Clara,4406,U.S. Senate,,DEM,Kamala D. Harris,362
+Santa Clara,4406,U.S. Senate,,DEM,Loretta L. Sanchez,220
+Santa Clara,4407,U.S. Senate,,DEM,Kamala D. Harris,610
+Santa Clara,4407,U.S. Senate,,DEM,Loretta L. Sanchez,374
+Santa Clara,4408,U.S. Senate,,DEM,Kamala D. Harris,578
+Santa Clara,4408,U.S. Senate,,DEM,Loretta L. Sanchez,368
+Santa Clara,4409,U.S. Senate,,DEM,Kamala D. Harris,577
+Santa Clara,4409,U.S. Senate,,DEM,Loretta L. Sanchez,394
+Santa Clara,4410,U.S. Senate,,DEM,Kamala D. Harris,609
+Santa Clara,4410,U.S. Senate,,DEM,Loretta L. Sanchez,386
+Santa Clara,4411,U.S. Senate,,DEM,Kamala D. Harris,668
+Santa Clara,4411,U.S. Senate,,DEM,Loretta L. Sanchez,367
+Santa Clara,4413,U.S. Senate,,DEM,Kamala D. Harris,357
+Santa Clara,4413,U.S. Senate,,DEM,Loretta L. Sanchez,204
+Santa Clara,4414,U.S. Senate,,DEM,Kamala D. Harris,730
+Santa Clara,4414,U.S. Senate,,DEM,Loretta L. Sanchez,342
+Santa Clara,4415,U.S. Senate,,DEM,Kamala D. Harris,502
+Santa Clara,4415,U.S. Senate,,DEM,Loretta L. Sanchez,329
+Santa Clara,4416,U.S. Senate,,DEM,Kamala D. Harris,570
+Santa Clara,4416,U.S. Senate,,DEM,Loretta L. Sanchez,432
+Santa Clara,4417,U.S. Senate,,DEM,Kamala D. Harris,402
+Santa Clara,4417,U.S. Senate,,DEM,Loretta L. Sanchez,256
+Santa Clara,4418,U.S. Senate,,DEM,Kamala D. Harris,533
+Santa Clara,4418,U.S. Senate,,DEM,Loretta L. Sanchez,438
+Santa Clara,4419,U.S. Senate,,DEM,Kamala D. Harris,513
+Santa Clara,4419,U.S. Senate,,DEM,Loretta L. Sanchez,270
+Santa Clara,4420,U.S. Senate,,DEM,Kamala D. Harris,444
+Santa Clara,4420,U.S. Senate,,DEM,Loretta L. Sanchez,234
+Santa Clara,4422,U.S. Senate,,DEM,Kamala D. Harris,406
+Santa Clara,4422,U.S. Senate,,DEM,Loretta L. Sanchez,255
+Santa Clara,4423,U.S. Senate,,DEM,Kamala D. Harris,258
+Santa Clara,4423,U.S. Senate,,DEM,Loretta L. Sanchez,148
+Santa Clara,4424,U.S. Senate,,DEM,Kamala D. Harris,500
+Santa Clara,4424,U.S. Senate,,DEM,Loretta L. Sanchez,207
+Santa Clara,4425,U.S. Senate,,DEM,Kamala D. Harris,649
+Santa Clara,4425,U.S. Senate,,DEM,Loretta L. Sanchez,375
+Santa Clara,4426,U.S. Senate,,DEM,Kamala D. Harris,533
+Santa Clara,4426,U.S. Senate,,DEM,Loretta L. Sanchez,421
+Santa Clara,4430,U.S. Senate,,DEM,Kamala D. Harris,151
+Santa Clara,4430,U.S. Senate,,DEM,Loretta L. Sanchez,55
+Santa Clara,4431,U.S. Senate,,DEM,Kamala D. Harris,24
+Santa Clara,4431,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Santa Clara,4440,U.S. Senate,,DEM,Kamala D. Harris,546
+Santa Clara,4440,U.S. Senate,,DEM,Loretta L. Sanchez,251
+Santa Clara,4674,U.S. Senate,,DEM,Kamala D. Harris,538
+Santa Clara,4674,U.S. Senate,,DEM,Loretta L. Sanchez,162
+Santa Clara,4675,U.S. Senate,,DEM,Kamala D. Harris,559
+Santa Clara,4675,U.S. Senate,,DEM,Loretta L. Sanchez,169
+Santa Clara,4676,U.S. Senate,,DEM,Kamala D. Harris,704
+Santa Clara,4676,U.S. Senate,,DEM,Loretta L. Sanchez,230
+Santa Clara,4678,U.S. Senate,,DEM,Kamala D. Harris,573
+Santa Clara,4678,U.S. Senate,,DEM,Loretta L. Sanchez,136
+Santa Clara,4679,U.S. Senate,,DEM,Kamala D. Harris,374
+Santa Clara,4679,U.S. Senate,,DEM,Loretta L. Sanchez,128
+Santa Clara,4685,U.S. Senate,,DEM,Kamala D. Harris,748
+Santa Clara,4685,U.S. Senate,,DEM,Loretta L. Sanchez,243
+Santa Clara,4687,U.S. Senate,,DEM,Kamala D. Harris,462
+Santa Clara,4687,U.S. Senate,,DEM,Loretta L. Sanchez,105
+Santa Clara,4688,U.S. Senate,,DEM,Kamala D. Harris,642
+Santa Clara,4688,U.S. Senate,,DEM,Loretta L. Sanchez,150
+Santa Clara,4689,U.S. Senate,,DEM,Kamala D. Harris,740
+Santa Clara,4689,U.S. Senate,,DEM,Loretta L. Sanchez,221
+Santa Clara,4690,U.S. Senate,,DEM,Kamala D. Harris,566
+Santa Clara,4690,U.S. Senate,,DEM,Loretta L. Sanchez,162
+Santa Clara,4691,U.S. Senate,,DEM,Kamala D. Harris,588
+Santa Clara,4691,U.S. Senate,,DEM,Loretta L. Sanchez,161
+Santa Clara,4692,U.S. Senate,,DEM,Kamala D. Harris,459
+Santa Clara,4692,U.S. Senate,,DEM,Loretta L. Sanchez,138
+Santa Clara,4696,U.S. Senate,,DEM,Kamala D. Harris,648
+Santa Clara,4696,U.S. Senate,,DEM,Loretta L. Sanchez,169
+Santa Clara,4697,U.S. Senate,,DEM,Kamala D. Harris,767
+Santa Clara,4697,U.S. Senate,,DEM,Loretta L. Sanchez,241
+Santa Clara,4698,U.S. Senate,,DEM,Kamala D. Harris,611
+Santa Clara,4698,U.S. Senate,,DEM,Loretta L. Sanchez,150
+Santa Clara,4699,U.S. Senate,,DEM,Kamala D. Harris,705
+Santa Clara,4699,U.S. Senate,,DEM,Loretta L. Sanchez,203
+Santa Clara,4702,U.S. Senate,,DEM,Kamala D. Harris,399
+Santa Clara,4702,U.S. Senate,,DEM,Loretta L. Sanchez,91
+Santa Clara,4705,U.S. Senate,,DEM,Kamala D. Harris,764
+Santa Clara,4705,U.S. Senate,,DEM,Loretta L. Sanchez,204
+Santa Clara,4707,U.S. Senate,,DEM,Kamala D. Harris,79
+Santa Clara,4707,U.S. Senate,,DEM,Loretta L. Sanchez,27
+Santa Clara,4721,U.S. Senate,,DEM,Kamala D. Harris,152
+Santa Clara,4721,U.S. Senate,,DEM,Loretta L. Sanchez,45
+Santa Clara,4729,U.S. Senate,,DEM,Kamala D. Harris,1
+Santa Clara,4729,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Santa Clara,4733,U.S. Senate,,DEM,Kamala D. Harris,16
+Santa Clara,4733,U.S. Senate,,DEM,Loretta L. Sanchez,9
+Santa Clara,4740,U.S. Senate,,DEM,Kamala D. Harris,26
+Santa Clara,4740,U.S. Senate,,DEM,Loretta L. Sanchez,12
+Santa Clara,5449,U.S. Senate,,DEM,Kamala D. Harris,51
+Santa Clara,5449,U.S. Senate,,DEM,Loretta L. Sanchez,33
+Santa Clara,5451,U.S. Senate,,DEM,Kamala D. Harris,0
+Santa Clara,5451,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Santa Clara,5453,U.S. Senate,,DEM,Kamala D. Harris,8
+Santa Clara,5453,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Santa Clara,5456,U.S. Senate,,DEM,Kamala D. Harris,92
+Santa Clara,5456,U.S. Senate,,DEM,Loretta L. Sanchez,44
+Santa Clara,5458,U.S. Senate,,DEM,Kamala D. Harris,0
+Santa Clara,5458,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Santa Clara,5461,U.S. Senate,,DEM,Kamala D. Harris,0
+Santa Clara,5461,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Santa Clara,5502,U.S. Senate,,DEM,Kamala D. Harris,181
+Santa Clara,5502,U.S. Senate,,DEM,Loretta L. Sanchez,116
+Santa Clara,5503,U.S. Senate,,DEM,Kamala D. Harris,99
+Santa Clara,5503,U.S. Senate,,DEM,Loretta L. Sanchez,134
+Santa Clara,5507,U.S. Senate,,DEM,Kamala D. Harris,0
+Santa Clara,5507,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Santa Clara,5556,U.S. Senate,,DEM,Kamala D. Harris,622
+Santa Clara,5556,U.S. Senate,,DEM,Loretta L. Sanchez,391
+Santa Clara,5557,U.S. Senate,,DEM,Kamala D. Harris,468
+Santa Clara,5557,U.S. Senate,,DEM,Loretta L. Sanchez,223
+Santa Clara,5567,U.S. Senate,,DEM,Kamala D. Harris,298
+Santa Clara,5567,U.S. Senate,,DEM,Loretta L. Sanchez,124
+Santa Clara,5648,U.S. Senate,,DEM,Kamala D. Harris,0
+Santa Clara,5648,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Santa Clara,5742,U.S. Senate,,DEM,Kamala D. Harris,0
+Santa Clara,5742,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Santa Clara,5743,U.S. Senate,,DEM,Kamala D. Harris,8
+Santa Clara,5743,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Santa Clara,5744,U.S. Senate,,DEM,Kamala D. Harris,7
+Santa Clara,5744,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Santa Clara,5745,U.S. Senate,,DEM,Kamala D. Harris,84
+Santa Clara,5745,U.S. Senate,,DEM,Loretta L. Sanchez,45
+Santa Clara,5746,U.S. Senate,,DEM,Kamala D. Harris,10
+Santa Clara,5746,U.S. Senate,,DEM,Loretta L. Sanchez,5
+Santa Clara,5747,U.S. Senate,,DEM,Kamala D. Harris,6
+Santa Clara,5747,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Santa Clara,5748,U.S. Senate,,DEM,Kamala D. Harris,98
+Santa Clara,5748,U.S. Senate,,DEM,Loretta L. Sanchez,38
+Santa Clara,5750,U.S. Senate,,DEM,Kamala D. Harris,124
+Santa Clara,5750,U.S. Senate,,DEM,Loretta L. Sanchez,44
+Santa Clara,5752,U.S. Senate,,DEM,Kamala D. Harris,526
+Santa Clara,5752,U.S. Senate,,DEM,Loretta L. Sanchez,207
+Santa Clara,5754,U.S. Senate,,DEM,Kamala D. Harris,377
+Santa Clara,5754,U.S. Senate,,DEM,Loretta L. Sanchez,122
+Santa Clara,5755,U.S. Senate,,DEM,Kamala D. Harris,291
+Santa Clara,5755,U.S. Senate,,DEM,Loretta L. Sanchez,114
+Santa Clara,5756,U.S. Senate,,DEM,Kamala D. Harris,46
+Santa Clara,5756,U.S. Senate,,DEM,Loretta L. Sanchez,30
+Santa Clara,5758,U.S. Senate,,DEM,Kamala D. Harris,65
+Santa Clara,5758,U.S. Senate,,DEM,Loretta L. Sanchez,29
+Santa Clara,5759,U.S. Senate,,DEM,Kamala D. Harris,201
+Santa Clara,5759,U.S. Senate,,DEM,Loretta L. Sanchez,69
+Santa Clara,5760,U.S. Senate,,DEM,Kamala D. Harris,5
+Santa Clara,5760,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Santa Clara,5762,U.S. Senate,,DEM,Kamala D. Harris,33
+Santa Clara,5762,U.S. Senate,,DEM,Loretta L. Sanchez,21
+Santa Clara,5764,U.S. Senate,,DEM,Kamala D. Harris,59
+Santa Clara,5764,U.S. Senate,,DEM,Loretta L. Sanchez,15
+Santa Clara,5770,U.S. Senate,,DEM,Kamala D. Harris,92
+Santa Clara,5770,U.S. Senate,,DEM,Loretta L. Sanchez,36
+Santa Clara,5772,U.S. Senate,,DEM,Kamala D. Harris,0
+Santa Clara,5772,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Santa Clara,5773,U.S. Senate,,DEM,Kamala D. Harris,233
+Santa Clara,5773,U.S. Senate,,DEM,Loretta L. Sanchez,78
+Santa Clara,5774,U.S. Senate,,DEM,Kamala D. Harris,19
+Santa Clara,5774,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Santa Clara,5775,U.S. Senate,,DEM,Kamala D. Harris,177
+Santa Clara,5775,U.S. Senate,,DEM,Loretta L. Sanchez,63
+Santa Clara,5777,U.S. Senate,,DEM,Kamala D. Harris,483
+Santa Clara,5777,U.S. Senate,,DEM,Loretta L. Sanchez,127
+Santa Clara,5781,U.S. Senate,,DEM,Kamala D. Harris,0
+Santa Clara,5781,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Santa Clara,5782,U.S. Senate,,DEM,Kamala D. Harris,64
+Santa Clara,5782,U.S. Senate,,DEM,Loretta L. Sanchez,33
+Santa Clara,5784,U.S. Senate,,DEM,Kamala D. Harris,3
+Santa Clara,5784,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Santa Clara,5788,U.S. Senate,,DEM,Kamala D. Harris,9
+Santa Clara,5788,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Santa Clara,5789,U.S. Senate,,DEM,Kamala D. Harris,5
+Santa Clara,5789,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Santa Clara,5793,U.S. Senate,,DEM,Kamala D. Harris,0
+Santa Clara,5793,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Santa Clara,5804,U.S. Senate,,DEM,Kamala D. Harris,676
+Santa Clara,5804,U.S. Senate,,DEM,Loretta L. Sanchez,311
+Santa Clara,5810,U.S. Senate,,DEM,Kamala D. Harris,312
+Santa Clara,5810,U.S. Senate,,DEM,Loretta L. Sanchez,153
+Santa Clara,5813,U.S. Senate,,DEM,Kamala D. Harris,29
+Santa Clara,5813,U.S. Senate,,DEM,Loretta L. Sanchez,11
+Santa Clara,5858,U.S. Senate,,DEM,Kamala D. Harris,86
+Santa Clara,5858,U.S. Senate,,DEM,Loretta L. Sanchez,22
+Santa Clara,5879,U.S. Senate,,DEM,Kamala D. Harris,0
+Santa Clara,5879,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Santa Clara,5881,U.S. Senate,,DEM,Kamala D. Harris,4
+Santa Clara,5881,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Santa Clara,5884,U.S. Senate,,DEM,Kamala D. Harris,0
+Santa Clara,5884,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Santa Clara,5886,U.S. Senate,,DEM,Kamala D. Harris,5
+Santa Clara,5886,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Santa Clara,5888,U.S. Senate,,DEM,Kamala D. Harris,0
+Santa Clara,5888,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Santa Clara,5894,U.S. Senate,,DEM,Kamala D. Harris,1
+Santa Clara,5894,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Santa Clara,5895,U.S. Senate,,DEM,Kamala D. Harris,5
+Santa Clara,5895,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Santa Clara,5897,U.S. Senate,,DEM,Kamala D. Harris,0
+Santa Clara,5897,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Santa Clara,5901,U.S. Senate,,DEM,Kamala D. Harris,0
+Santa Clara,5901,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Santa Clara,5902,U.S. Senate,,DEM,Kamala D. Harris,111
+Santa Clara,5902,U.S. Senate,,DEM,Loretta L. Sanchez,51
+Santa Clara,5903,U.S. Senate,,DEM,Kamala D. Harris,184
+Santa Clara,5903,U.S. Senate,,DEM,Loretta L. Sanchez,76
+Santa Clara,5904,U.S. Senate,,DEM,Kamala D. Harris,134
+Santa Clara,5904,U.S. Senate,,DEM,Loretta L. Sanchez,51
+Santa Clara,5905,U.S. Senate,,DEM,Kamala D. Harris,106
+Santa Clara,5905,U.S. Senate,,DEM,Loretta L. Sanchez,39
+Santa Clara,5906,U.S. Senate,,DEM,Kamala D. Harris,105
+Santa Clara,5906,U.S. Senate,,DEM,Loretta L. Sanchez,131
+Santa Clara,5908,U.S. Senate,,DEM,Kamala D. Harris,40
+Santa Clara,5908,U.S. Senate,,DEM,Loretta L. Sanchez,30
+Santa Clara,5911,U.S. Senate,,DEM,Kamala D. Harris,103
+Santa Clara,5911,U.S. Senate,,DEM,Loretta L. Sanchez,85
+Santa Clara,5912,U.S. Senate,,DEM,Kamala D. Harris,28
+Santa Clara,5912,U.S. Senate,,DEM,Loretta L. Sanchez,23
+Santa Clara,5913,U.S. Senate,,DEM,Kamala D. Harris,2
+Santa Clara,5913,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Santa Clara,5914,U.S. Senate,,DEM,Kamala D. Harris,410
+Santa Clara,5914,U.S. Senate,,DEM,Loretta L. Sanchez,247
+Santa Clara,5915,U.S. Senate,,DEM,Kamala D. Harris,361
+Santa Clara,5915,U.S. Senate,,DEM,Loretta L. Sanchez,248
+Santa Clara,5916,U.S. Senate,,DEM,Kamala D. Harris,32
+Santa Clara,5916,U.S. Senate,,DEM,Loretta L. Sanchez,20
+Santa Clara,5917,U.S. Senate,,DEM,Kamala D. Harris,21
+Santa Clara,5917,U.S. Senate,,DEM,Loretta L. Sanchez,11
+Santa Clara,5919,U.S. Senate,,DEM,Kamala D. Harris,145
+Santa Clara,5919,U.S. Senate,,DEM,Loretta L. Sanchez,89
+Santa Clara,5920,U.S. Senate,,DEM,Kamala D. Harris,6
+Santa Clara,5920,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Santa Clara,5921,U.S. Senate,,DEM,Kamala D. Harris,2
+Santa Clara,5921,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Santa Clara,5922,U.S. Senate,,DEM,Kamala D. Harris,3
+Santa Clara,5922,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Santa Clara,5925,U.S. Senate,,DEM,Kamala D. Harris,33
+Santa Clara,5925,U.S. Senate,,DEM,Loretta L. Sanchez,17
+Santa Clara,5926,U.S. Senate,,DEM,Kamala D. Harris,203
+Santa Clara,5926,U.S. Senate,,DEM,Loretta L. Sanchez,165
+Santa Clara,5927,U.S. Senate,,DEM,Kamala D. Harris,0
+Santa Clara,5927,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Santa Clara,5929,U.S. Senate,,DEM,Kamala D. Harris,26
+Santa Clara,5929,U.S. Senate,,DEM,Loretta L. Sanchez,13
+Santa Clara,5936,U.S. Senate,,DEM,Kamala D. Harris,136
+Santa Clara,5936,U.S. Senate,,DEM,Loretta L. Sanchez,87
+Santa Clara,5937,U.S. Senate,,DEM,Kamala D. Harris,41
+Santa Clara,5937,U.S. Senate,,DEM,Loretta L. Sanchez,47
+Santa Clara,5940,U.S. Senate,,DEM,Kamala D. Harris,10
+Santa Clara,5940,U.S. Senate,,DEM,Loretta L. Sanchez,10
+Santa Clara,5943,U.S. Senate,,DEM,Kamala D. Harris,145
+Santa Clara,5943,U.S. Senate,,DEM,Loretta L. Sanchez,93
+Santa Clara,5947,U.S. Senate,,DEM,Kamala D. Harris,205
+Santa Clara,5947,U.S. Senate,,DEM,Loretta L. Sanchez,145
+Santa Clara,5949,U.S. Senate,,DEM,Kamala D. Harris,55
+Santa Clara,5949,U.S. Senate,,DEM,Loretta L. Sanchez,59
+Santa Clara,5950,U.S. Senate,,DEM,Kamala D. Harris,77
+Santa Clara,5950,U.S. Senate,,DEM,Loretta L. Sanchez,32
+Santa Clara,5951,U.S. Senate,,DEM,Kamala D. Harris,16
+Santa Clara,5951,U.S. Senate,,DEM,Loretta L. Sanchez,18
+Santa Clara,5952,U.S. Senate,,DEM,Kamala D. Harris,40
+Santa Clara,5952,U.S. Senate,,DEM,Loretta L. Sanchez,29
+Santa Clara,5953,U.S. Senate,,DEM,Kamala D. Harris,137
+Santa Clara,5953,U.S. Senate,,DEM,Loretta L. Sanchez,97
+Santa Clara,5955,U.S. Senate,,DEM,Kamala D. Harris,457
+Santa Clara,5955,U.S. Senate,,DEM,Loretta L. Sanchez,326
+Santa Clara,5956,U.S. Senate,,DEM,Kamala D. Harris,458
+Santa Clara,5956,U.S. Senate,,DEM,Loretta L. Sanchez,278
+Santa Clara,5957,U.S. Senate,,DEM,Kamala D. Harris,39
+Santa Clara,5957,U.S. Senate,,DEM,Loretta L. Sanchez,29
+Santa Clara,5959,U.S. Senate,,DEM,Kamala D. Harris,27
+Santa Clara,5959,U.S. Senate,,DEM,Loretta L. Sanchez,18
+Santa Clara,5961,U.S. Senate,,DEM,Kamala D. Harris,280
+Santa Clara,5961,U.S. Senate,,DEM,Loretta L. Sanchez,218
+Santa Clara,5962,U.S. Senate,,DEM,Kamala D. Harris,384
+Santa Clara,5962,U.S. Senate,,DEM,Loretta L. Sanchez,231
+Santa Clara,5965,U.S. Senate,,DEM,Kamala D. Harris,417
+Santa Clara,5965,U.S. Senate,,DEM,Loretta L. Sanchez,267
+Santa Clara,5966,U.S. Senate,,DEM,Kamala D. Harris,39
+Santa Clara,5966,U.S. Senate,,DEM,Loretta L. Sanchez,35
+Santa Clara,5977,U.S. Senate,,DEM,Kamala D. Harris,33
+Santa Clara,5977,U.S. Senate,,DEM,Loretta L. Sanchez,26
+Santa Clara,5988,U.S. Senate,,DEM,Kamala D. Harris,2
+Santa Clara,5988,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Santa Clara,5996,U.S. Senate,,DEM,Kamala D. Harris,21
+Santa Clara,5996,U.S. Senate,,DEM,Loretta L. Sanchez,17
+Santa Clara,6002,U.S. Senate,,DEM,Kamala D. Harris,10
+Santa Clara,6002,U.S. Senate,,DEM,Loretta L. Sanchez,7
+Santa Clara,6006,U.S. Senate,,DEM,Kamala D. Harris,126
+Santa Clara,6006,U.S. Senate,,DEM,Loretta L. Sanchez,84
+Santa Clara,6021,U.S. Senate,,DEM,Kamala D. Harris,15
+Santa Clara,6021,U.S. Senate,,DEM,Loretta L. Sanchez,7
+Santa Clara,6022,U.S. Senate,,DEM,Kamala D. Harris,9
+Santa Clara,6022,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Santa Clara,6023,U.S. Senate,,DEM,Kamala D. Harris,9
+Santa Clara,6023,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Santa Clara,6028,U.S. Senate,,DEM,Kamala D. Harris,1
+Santa Clara,6028,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Santa Clara,6031,U.S. Senate,,DEM,Kamala D. Harris,17
+Santa Clara,6031,U.S. Senate,,DEM,Loretta L. Sanchez,7
+Santa Clara,6034,U.S. Senate,,DEM,Kamala D. Harris,8
+Santa Clara,6034,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Santa Clara,6036,U.S. Senate,,DEM,Kamala D. Harris,0
+Santa Clara,6036,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Santa Clara,6038,U.S. Senate,,DEM,Kamala D. Harris,73
+Santa Clara,6038,U.S. Senate,,DEM,Loretta L. Sanchez,73
+Santa Clara,6040,U.S. Senate,,DEM,Kamala D. Harris,17
+Santa Clara,6040,U.S. Senate,,DEM,Loretta L. Sanchez,16
+Santa Clara,6401,U.S. Senate,,DEM,Kamala D. Harris,0
+Santa Clara,6401,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Santa Clara,6402,U.S. Senate,,DEM,Kamala D. Harris,33
+Santa Clara,6402,U.S. Senate,,DEM,Loretta L. Sanchez,25
+Santa Clara,6404,U.S. Senate,,DEM,Kamala D. Harris,573
+Santa Clara,6404,U.S. Senate,,DEM,Loretta L. Sanchez,280
+Santa Clara,6405,U.S. Senate,,DEM,Kamala D. Harris,2
+Santa Clara,6405,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Santa Clara,6411,U.S. Senate,,DEM,Kamala D. Harris,59
+Santa Clara,6411,U.S. Senate,,DEM,Loretta L. Sanchez,39
+Santa Clara,6413,U.S. Senate,,DEM,Kamala D. Harris,18
+Santa Clara,6413,U.S. Senate,,DEM,Loretta L. Sanchez,5
+Santa Clara,6416,U.S. Senate,,DEM,Kamala D. Harris,35
+Santa Clara,6416,U.S. Senate,,DEM,Loretta L. Sanchez,20
+Santa Clara,6418,U.S. Senate,,DEM,Kamala D. Harris,356
+Santa Clara,6418,U.S. Senate,,DEM,Loretta L. Sanchez,197
+Santa Clara,6419,U.S. Senate,,DEM,Kamala D. Harris,25
+Santa Clara,6419,U.S. Senate,,DEM,Loretta L. Sanchez,28
+Santa Clara,6423,U.S. Senate,,DEM,Kamala D. Harris,24
+Santa Clara,6423,U.S. Senate,,DEM,Loretta L. Sanchez,16
+Santa Clara,6452,U.S. Senate,,DEM,Kamala D. Harris,262
+Santa Clara,6452,U.S. Senate,,DEM,Loretta L. Sanchez,379
+Santa Clara,6454,U.S. Senate,,DEM,Kamala D. Harris,18
+Santa Clara,6454,U.S. Senate,,DEM,Loretta L. Sanchez,5
+Santa Clara,6455,U.S. Senate,,DEM,Kamala D. Harris,532
+Santa Clara,6455,U.S. Senate,,DEM,Loretta L. Sanchez,474
+Santa Clara,6458,U.S. Senate,,DEM,Kamala D. Harris,432
+Santa Clara,6458,U.S. Senate,,DEM,Loretta L. Sanchez,479
+Santa Clara,6462,U.S. Senate,,DEM,Kamala D. Harris,380
+Santa Clara,6462,U.S. Senate,,DEM,Loretta L. Sanchez,184
+Santa Clara,6463,U.S. Senate,,DEM,Kamala D. Harris,4
+Santa Clara,6463,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Santa Clara,6464,U.S. Senate,,DEM,Kamala D. Harris,2
+Santa Clara,6464,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Santa Clara,6465,U.S. Senate,,DEM,Kamala D. Harris,94
+Santa Clara,6465,U.S. Senate,,DEM,Loretta L. Sanchez,66
+Santa Clara,6466,U.S. Senate,,DEM,Kamala D. Harris,71
+Santa Clara,6466,U.S. Senate,,DEM,Loretta L. Sanchez,56
+Santa Clara,6470,U.S. Senate,,DEM,Kamala D. Harris,321
+Santa Clara,6470,U.S. Senate,,DEM,Loretta L. Sanchez,188
+Santa Clara,6492,U.S. Senate,,DEM,Kamala D. Harris,18
+Santa Clara,6492,U.S. Senate,,DEM,Loretta L. Sanchez,23
+Santa Clara,6502,U.S. Senate,,DEM,Kamala D. Harris,111
+Santa Clara,6502,U.S. Senate,,DEM,Loretta L. Sanchez,100
+Santa Clara,6509,U.S. Senate,,DEM,Kamala D. Harris,16
+Santa Clara,6509,U.S. Senate,,DEM,Loretta L. Sanchez,16
+Santa Clara,6515,U.S. Senate,,DEM,Kamala D. Harris,46
+Santa Clara,6515,U.S. Senate,,DEM,Loretta L. Sanchez,22
+Santa Clara,6624,U.S. Senate,,DEM,Kamala D. Harris,3
+Santa Clara,6624,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Santa Clara,6664,U.S. Senate,,DEM,Kamala D. Harris,0
+Santa Clara,6664,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Santa Clara,6665,U.S. Senate,,DEM,Kamala D. Harris,1
+Santa Clara,6665,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Santa Clara,6666,U.S. Senate,,DEM,Kamala D. Harris,47
+Santa Clara,6666,U.S. Senate,,DEM,Loretta L. Sanchez,22
+Santa Clara,6673,U.S. Senate,,DEM,Kamala D. Harris,1
+Santa Clara,6673,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Santa Clara,6674,U.S. Senate,,DEM,Kamala D. Harris,52
+Santa Clara,6674,U.S. Senate,,DEM,Loretta L. Sanchez,25
+Santa Clara,6678,U.S. Senate,,DEM,Kamala D. Harris,30
+Santa Clara,6678,U.S. Senate,,DEM,Loretta L. Sanchez,10

--- a/2016/20161108__ca__general__santa_cruz__precinct.csv
+++ b/2016/20161108__ca__general__santa_cruz__precinct.csv
@@ -10639,535 +10639,535 @@ Santa Cruz,54070,Proposition 67,,N/A,Yes,626
 Santa Cruz,54070,Proposition 67,,N/A,No,370
 Santa Cruz,54071,Proposition 67,,N/A,Yes,3
 Santa Cruz,54071,Proposition 67,,N/A,No,3
-Santa Cruz,10020,U.S. Senate,,DEM,Kamala Harris,681
-Santa Cruz,10020,U.S. Senate,,DEM,Loretta Sanchez,221
-Santa Cruz,10060,U.S. Senate,,DEM,Kamala Harris,659
-Santa Cruz,10060,U.S. Senate,,DEM,Loretta Sanchez,190
-Santa Cruz,10080,U.S. Senate,,DEM,Kamala Harris,579
-Santa Cruz,10080,U.S. Senate,,DEM,Loretta Sanchez,235
-Santa Cruz,10090,U.S. Senate,,DEM,Kamala Harris,595
-Santa Cruz,10090,U.S. Senate,,DEM,Loretta Sanchez,240
-Santa Cruz,10100,U.S. Senate,,DEM,Kamala Harris,679
-Santa Cruz,10100,U.S. Senate,,DEM,Loretta Sanchez,236
-Santa Cruz,10110,U.S. Senate,,DEM,Kamala Harris,602
-Santa Cruz,10110,U.S. Senate,,DEM,Loretta Sanchez,267
-Santa Cruz,10130,U.S. Senate,,DEM,Kamala Harris,740
-Santa Cruz,10130,U.S. Senate,,DEM,Loretta Sanchez,305
-Santa Cruz,10141,U.S. Senate,,DEM,Kamala Harris,59
-Santa Cruz,10141,U.S. Senate,,DEM,Loretta Sanchez,13
-Santa Cruz,10142,U.S. Senate,,DEM,Kamala Harris,75
-Santa Cruz,10142,U.S. Senate,,DEM,Loretta Sanchez,15
-Santa Cruz,10144,U.S. Senate,,DEM,Kamala Harris,624
-Santa Cruz,10144,U.S. Senate,,DEM,Loretta Sanchez,186
-Santa Cruz,10145,U.S. Senate,,DEM,Kamala Harris,13
-Santa Cruz,10145,U.S. Senate,,DEM,Loretta Sanchez,3
-Santa Cruz,10146,U.S. Senate,,DEM,Kamala Harris,3
-Santa Cruz,10146,U.S. Senate,,DEM,Loretta Sanchez,2
-Santa Cruz,10151,U.S. Senate,,DEM,Kamala Harris,26
-Santa Cruz,10151,U.S. Senate,,DEM,Loretta Sanchez,5
-Santa Cruz,10152,U.S. Senate,,DEM,Kamala Harris,0
-Santa Cruz,10152,U.S. Senate,,DEM,Loretta Sanchez,1
-Santa Cruz,10161,U.S. Senate,,DEM,Kamala Harris,264
-Santa Cruz,10161,U.S. Senate,,DEM,Loretta Sanchez,98
-Santa Cruz,10162,U.S. Senate,,DEM,Kamala Harris,54
-Santa Cruz,10162,U.S. Senate,,DEM,Loretta Sanchez,27
-Santa Cruz,10163,U.S. Senate,,DEM,Kamala Harris,4
-Santa Cruz,10163,U.S. Senate,,DEM,Loretta Sanchez,1
-Santa Cruz,10164,U.S. Senate,,DEM,Kamala Harris,107
-Santa Cruz,10164,U.S. Senate,,DEM,Loretta Sanchez,35
-Santa Cruz,10165,U.S. Senate,,DEM,Kamala Harris,0
-Santa Cruz,10165,U.S. Senate,,DEM,Loretta Sanchez,0
-Santa Cruz,10170,U.S. Senate,,DEM,Kamala Harris,493
-Santa Cruz,10170,U.S. Senate,,DEM,Loretta Sanchez,142
-Santa Cruz,10190,U.S. Senate,,DEM,Kamala Harris,786
-Santa Cruz,10190,U.S. Senate,,DEM,Loretta Sanchez,249
-Santa Cruz,10201,U.S. Senate,,DEM,Kamala Harris,260
-Santa Cruz,10201,U.S. Senate,,DEM,Loretta Sanchez,96
-Santa Cruz,10220,U.S. Senate,,DEM,Kamala Harris,551
-Santa Cruz,10220,U.S. Senate,,DEM,Loretta Sanchez,209
-Santa Cruz,10231,U.S. Senate,,DEM,Kamala Harris,46
-Santa Cruz,10231,U.S. Senate,,DEM,Loretta Sanchez,7
-Santa Cruz,10232,U.S. Senate,,DEM,Kamala Harris,4
-Santa Cruz,10232,U.S. Senate,,DEM,Loretta Sanchez,3
-Santa Cruz,10234,U.S. Senate,,DEM,Kamala Harris,55
-Santa Cruz,10234,U.S. Senate,,DEM,Loretta Sanchez,19
-Santa Cruz,10236,U.S. Senate,,DEM,Kamala Harris,13
-Santa Cruz,10236,U.S. Senate,,DEM,Loretta Sanchez,8
-Santa Cruz,10237,U.S. Senate,,DEM,Kamala Harris,2
-Santa Cruz,10237,U.S. Senate,,DEM,Loretta Sanchez,1
-Santa Cruz,10240,U.S. Senate,,DEM,Kamala Harris,388
-Santa Cruz,10240,U.S. Senate,,DEM,Loretta Sanchez,165
-Santa Cruz,10260,U.S. Senate,,DEM,Kamala Harris,236
-Santa Cruz,10260,U.S. Senate,,DEM,Loretta Sanchez,83
-Santa Cruz,10270,U.S. Senate,,DEM,Kamala Harris,490
-Santa Cruz,10270,U.S. Senate,,DEM,Loretta Sanchez,191
-Santa Cruz,10281,U.S. Senate,,DEM,Kamala Harris,421
-Santa Cruz,10281,U.S. Senate,,DEM,Loretta Sanchez,130
-Santa Cruz,10283,U.S. Senate,,DEM,Kamala Harris,84
-Santa Cruz,10283,U.S. Senate,,DEM,Loretta Sanchez,44
-Santa Cruz,10284,U.S. Senate,,DEM,Kamala Harris,3
-Santa Cruz,10284,U.S. Senate,,DEM,Loretta Sanchez,2
-Santa Cruz,10286,U.S. Senate,,DEM,Kamala Harris,57
-Santa Cruz,10286,U.S. Senate,,DEM,Loretta Sanchez,17
-Santa Cruz,10287,U.S. Senate,,DEM,Kamala Harris,0
-Santa Cruz,10287,U.S. Senate,,DEM,Loretta Sanchez,2
-Santa Cruz,10291,U.S. Senate,,DEM,Kamala Harris,83
-Santa Cruz,10291,U.S. Senate,,DEM,Loretta Sanchez,30
-Santa Cruz,10292,U.S. Senate,,DEM,Kamala Harris,99
-Santa Cruz,10292,U.S. Senate,,DEM,Loretta Sanchez,30
-Santa Cruz,10294,U.S. Senate,,DEM,Kamala Harris,906
-Santa Cruz,10294,U.S. Senate,,DEM,Loretta Sanchez,323
-Santa Cruz,10295,U.S. Senate,,DEM,Kamala Harris,50
-Santa Cruz,10295,U.S. Senate,,DEM,Loretta Sanchez,22
-Santa Cruz,10310,U.S. Senate,,DEM,Kamala Harris,737
-Santa Cruz,10310,U.S. Senate,,DEM,Loretta Sanchez,240
-Santa Cruz,10351,U.S. Senate,,DEM,Kamala Harris,433
-Santa Cruz,10351,U.S. Senate,,DEM,Loretta Sanchez,149
-Santa Cruz,10352,U.S. Senate,,DEM,Kamala Harris,157
-Santa Cruz,10352,U.S. Senate,,DEM,Loretta Sanchez,47
-Santa Cruz,10381,U.S. Senate,,DEM,Kamala Harris,727
-Santa Cruz,10381,U.S. Senate,,DEM,Loretta Sanchez,288
-Santa Cruz,10382,U.S. Senate,,DEM,Kamala Harris,41
-Santa Cruz,10382,U.S. Senate,,DEM,Loretta Sanchez,11
-Santa Cruz,10410,U.S. Senate,,DEM,Kamala Harris,418
-Santa Cruz,10410,U.S. Senate,,DEM,Loretta Sanchez,123
-Santa Cruz,10490,U.S. Senate,,DEM,Kamala Harris,317
-Santa Cruz,10490,U.S. Senate,,DEM,Loretta Sanchez,86
-Santa Cruz,10521,U.S. Senate,,DEM,Kamala Harris,57
-Santa Cruz,10521,U.S. Senate,,DEM,Loretta Sanchez,19
-Santa Cruz,10523,U.S. Senate,,DEM,Kamala Harris,4
-Santa Cruz,10523,U.S. Senate,,DEM,Loretta Sanchez,0
-Santa Cruz,10533,U.S. Senate,,DEM,Kamala Harris,7
-Santa Cruz,10533,U.S. Senate,,DEM,Loretta Sanchez,0
-Santa Cruz,10551,U.S. Senate,,DEM,Kamala Harris,3
-Santa Cruz,10551,U.S. Senate,,DEM,Loretta Sanchez,7
-Santa Cruz,10552,U.S. Senate,,DEM,Kamala Harris,0
-Santa Cruz,10552,U.S. Senate,,DEM,Loretta Sanchez,0
-Santa Cruz,10572,U.S. Senate,,DEM,Kamala Harris,26
-Santa Cruz,10572,U.S. Senate,,DEM,Loretta Sanchez,11
-Santa Cruz,10581,U.S. Senate,,DEM,Kamala Harris,59
-Santa Cruz,10581,U.S. Senate,,DEM,Loretta Sanchez,17
-Santa Cruz,10603,U.S. Senate,,DEM,Kamala Harris,634
-Santa Cruz,10603,U.S. Senate,,DEM,Loretta Sanchez,201
-Santa Cruz,10620,U.S. Senate,,DEM,Kamala Harris,707
-Santa Cruz,10620,U.S. Senate,,DEM,Loretta Sanchez,264
-Santa Cruz,10653,U.S. Senate,,DEM,Kamala Harris,3
-Santa Cruz,10653,U.S. Senate,,DEM,Loretta Sanchez,0
-Santa Cruz,10682,U.S. Senate,,DEM,Kamala Harris,151
-Santa Cruz,10682,U.S. Senate,,DEM,Loretta Sanchez,43
-Santa Cruz,10690,U.S. Senate,,DEM,Kamala Harris,4
-Santa Cruz,10690,U.S. Senate,,DEM,Loretta Sanchez,3
-Santa Cruz,10700,U.S. Senate,,DEM,Kamala Harris,64
-Santa Cruz,10700,U.S. Senate,,DEM,Loretta Sanchez,16
-Santa Cruz,10763,U.S. Senate,,DEM,Kamala Harris,177
-Santa Cruz,10763,U.S. Senate,,DEM,Loretta Sanchez,46
-Santa Cruz,11010,U.S. Senate,,DEM,Kamala Harris,872
-Santa Cruz,11010,U.S. Senate,,DEM,Loretta Sanchez,257
-Santa Cruz,11120,U.S. Senate,,DEM,Kamala Harris,545
-Santa Cruz,11120,U.S. Senate,,DEM,Loretta Sanchez,179
-Santa Cruz,12010,U.S. Senate,,DEM,Kamala Harris,161
-Santa Cruz,12010,U.S. Senate,,DEM,Loretta Sanchez,92
-Santa Cruz,12023,U.S. Senate,,DEM,Kamala Harris,221
-Santa Cruz,12023,U.S. Senate,,DEM,Loretta Sanchez,95
-Santa Cruz,12024,U.S. Senate,,DEM,Kamala Harris,868
-Santa Cruz,12024,U.S. Senate,,DEM,Loretta Sanchez,363
-Santa Cruz,14110,U.S. Senate,,DEM,Kamala Harris,0
-Santa Cruz,14110,U.S. Senate,,DEM,Loretta Sanchez,0
-Santa Cruz,14121,U.S. Senate,,DEM,Kamala Harris,690
-Santa Cruz,14121,U.S. Senate,,DEM,Loretta Sanchez,231
-Santa Cruz,14123,U.S. Senate,,DEM,Kamala Harris,0
-Santa Cruz,14123,U.S. Senate,,DEM,Loretta Sanchez,0
-Santa Cruz,14141,U.S. Senate,,DEM,Kamala Harris,76
-Santa Cruz,14141,U.S. Senate,,DEM,Loretta Sanchez,24
-Santa Cruz,20011,U.S. Senate,,DEM,Kamala Harris,499
-Santa Cruz,20011,U.S. Senate,,DEM,Loretta Sanchez,360
-Santa Cruz,20013,U.S. Senate,,DEM,Kamala Harris,195
-Santa Cruz,20013,U.S. Senate,,DEM,Loretta Sanchez,139
-Santa Cruz,20020,U.S. Senate,,DEM,Kamala Harris,689
-Santa Cruz,20020,U.S. Senate,,DEM,Loretta Sanchez,356
-Santa Cruz,20041,U.S. Senate,,DEM,Kamala Harris,516
-Santa Cruz,20041,U.S. Senate,,DEM,Loretta Sanchez,257
-Santa Cruz,20044,U.S. Senate,,DEM,Kamala Harris,517
-Santa Cruz,20044,U.S. Senate,,DEM,Loretta Sanchez,215
-Santa Cruz,20061,U.S. Senate,,DEM,Kamala Harris,423
-Santa Cruz,20061,U.S. Senate,,DEM,Loretta Sanchez,153
-Santa Cruz,20093,U.S. Senate,,DEM,Kamala Harris,1
-Santa Cruz,20093,U.S. Senate,,DEM,Loretta Sanchez,1
-Santa Cruz,20101,U.S. Senate,,DEM,Kamala Harris,535
-Santa Cruz,20101,U.S. Senate,,DEM,Loretta Sanchez,217
-Santa Cruz,20150,U.S. Senate,,DEM,Kamala Harris,332
-Santa Cruz,20150,U.S. Senate,,DEM,Loretta Sanchez,139
-Santa Cruz,20221,U.S. Senate,,DEM,Kamala Harris,703
-Santa Cruz,20221,U.S. Senate,,DEM,Loretta Sanchez,230
-Santa Cruz,20222,U.S. Senate,,DEM,Kamala Harris,2
-Santa Cruz,20222,U.S. Senate,,DEM,Loretta Sanchez,0
-Santa Cruz,20231,U.S. Senate,,DEM,Kamala Harris,44
-Santa Cruz,20231,U.S. Senate,,DEM,Loretta Sanchez,10
-Santa Cruz,20232,U.S. Senate,,DEM,Kamala Harris,670
-Santa Cruz,20232,U.S. Senate,,DEM,Loretta Sanchez,230
-Santa Cruz,20241,U.S. Senate,,DEM,Kamala Harris,7
-Santa Cruz,20241,U.S. Senate,,DEM,Loretta Sanchez,6
-Santa Cruz,20242,U.S. Senate,,DEM,Kamala Harris,428
-Santa Cruz,20242,U.S. Senate,,DEM,Loretta Sanchez,118
-Santa Cruz,20243,U.S. Senate,,DEM,Kamala Harris,320
-Santa Cruz,20243,U.S. Senate,,DEM,Loretta Sanchez,133
-Santa Cruz,20244,U.S. Senate,,DEM,Kamala Harris,26
-Santa Cruz,20244,U.S. Senate,,DEM,Loretta Sanchez,9
-Santa Cruz,20260,U.S. Senate,,DEM,Kamala Harris,734
-Santa Cruz,20260,U.S. Senate,,DEM,Loretta Sanchez,252
-Santa Cruz,20280,U.S. Senate,,DEM,Kamala Harris,830
-Santa Cruz,20280,U.S. Senate,,DEM,Loretta Sanchez,323
-Santa Cruz,20300,U.S. Senate,,DEM,Kamala Harris,775
-Santa Cruz,20300,U.S. Senate,,DEM,Loretta Sanchez,244
-Santa Cruz,20320,U.S. Senate,,DEM,Kamala Harris,886
-Santa Cruz,20320,U.S. Senate,,DEM,Loretta Sanchez,264
-Santa Cruz,20330,U.S. Senate,,DEM,Kamala Harris,752
-Santa Cruz,20330,U.S. Senate,,DEM,Loretta Sanchez,264
-Santa Cruz,20341,U.S. Senate,,DEM,Kamala Harris,217
-Santa Cruz,20341,U.S. Senate,,DEM,Loretta Sanchez,104
-Santa Cruz,20351,U.S. Senate,,DEM,Kamala Harris,741
-Santa Cruz,20351,U.S. Senate,,DEM,Loretta Sanchez,229
-Santa Cruz,20352,U.S. Senate,,DEM,Kamala Harris,0
-Santa Cruz,20352,U.S. Senate,,DEM,Loretta Sanchez,1
-Santa Cruz,20354,U.S. Senate,,DEM,Kamala Harris,632
-Santa Cruz,20354,U.S. Senate,,DEM,Loretta Sanchez,233
-Santa Cruz,20381,U.S. Senate,,DEM,Kamala Harris,89
-Santa Cruz,20381,U.S. Senate,,DEM,Loretta Sanchez,60
-Santa Cruz,20392,U.S. Senate,,DEM,Kamala Harris,35
-Santa Cruz,20392,U.S. Senate,,DEM,Loretta Sanchez,8
-Santa Cruz,20402,U.S. Senate,,DEM,Kamala Harris,522
-Santa Cruz,20402,U.S. Senate,,DEM,Loretta Sanchez,227
-Santa Cruz,20421,U.S. Senate,,DEM,Kamala Harris,20
-Santa Cruz,20421,U.S. Senate,,DEM,Loretta Sanchez,5
-Santa Cruz,20520,U.S. Senate,,DEM,Kamala Harris,736
-Santa Cruz,20520,U.S. Senate,,DEM,Loretta Sanchez,226
-Santa Cruz,20541,U.S. Senate,,DEM,Kamala Harris,570
-Santa Cruz,20541,U.S. Senate,,DEM,Loretta Sanchez,227
-Santa Cruz,20551,U.S. Senate,,DEM,Kamala Harris,649
-Santa Cruz,20551,U.S. Senate,,DEM,Loretta Sanchez,208
-Santa Cruz,20591,U.S. Senate,,DEM,Kamala Harris,0
-Santa Cruz,20591,U.S. Senate,,DEM,Loretta Sanchez,0
-Santa Cruz,20592,U.S. Senate,,DEM,Kamala Harris,0
-Santa Cruz,20592,U.S. Senate,,DEM,Loretta Sanchez,0
-Santa Cruz,20611,U.S. Senate,,DEM,Kamala Harris,0
-Santa Cruz,20611,U.S. Senate,,DEM,Loretta Sanchez,0
-Santa Cruz,20622,U.S. Senate,,DEM,Kamala Harris,0
-Santa Cruz,20622,U.S. Senate,,DEM,Loretta Sanchez,0
-Santa Cruz,22010,U.S. Senate,,DEM,Kamala Harris,676
-Santa Cruz,22010,U.S. Senate,,DEM,Loretta Sanchez,236
-Santa Cruz,22040,U.S. Senate,,DEM,Kamala Harris,537
-Santa Cruz,22040,U.S. Senate,,DEM,Loretta Sanchez,157
-Santa Cruz,22050,U.S. Senate,,DEM,Kamala Harris,910
-Santa Cruz,22050,U.S. Senate,,DEM,Loretta Sanchez,303
-Santa Cruz,23190,U.S. Senate,,DEM,Kamala Harris,0
-Santa Cruz,23190,U.S. Senate,,DEM,Loretta Sanchez,0
-Santa Cruz,23311,U.S. Senate,,DEM,Kamala Harris,689
-Santa Cruz,23311,U.S. Senate,,DEM,Loretta Sanchez,582
-Santa Cruz,23312,U.S. Senate,,DEM,Kamala Harris,196
-Santa Cruz,23312,U.S. Senate,,DEM,Loretta Sanchez,205
-Santa Cruz,23360,U.S. Senate,,DEM,Kamala Harris,266
-Santa Cruz,23360,U.S. Senate,,DEM,Loretta Sanchez,207
-Santa Cruz,23492,U.S. Senate,,DEM,Kamala Harris,0
-Santa Cruz,23492,U.S. Senate,,DEM,Loretta Sanchez,0
-Santa Cruz,23660,U.S. Senate,,DEM,Kamala Harris,0
-Santa Cruz,23660,U.S. Senate,,DEM,Loretta Sanchez,0
-Santa Cruz,30010,U.S. Senate,,DEM,Kamala Harris,121
-Santa Cruz,30010,U.S. Senate,,DEM,Loretta Sanchez,38
-Santa Cruz,30020,U.S. Senate,,DEM,Kamala Harris,273
-Santa Cruz,30020,U.S. Senate,,DEM,Loretta Sanchez,88
-Santa Cruz,30030,U.S. Senate,,DEM,Kamala Harris,546
-Santa Cruz,30030,U.S. Senate,,DEM,Loretta Sanchez,192
-Santa Cruz,30041,U.S. Senate,,DEM,Kamala Harris,761
-Santa Cruz,30041,U.S. Senate,,DEM,Loretta Sanchez,221
-Santa Cruz,30042,U.S. Senate,,DEM,Kamala Harris,0
-Santa Cruz,30042,U.S. Senate,,DEM,Loretta Sanchez,0
-Santa Cruz,30044,U.S. Senate,,DEM,Kamala Harris,0
-Santa Cruz,30044,U.S. Senate,,DEM,Loretta Sanchez,0
-Santa Cruz,30046,U.S. Senate,,DEM,Kamala Harris,24
-Santa Cruz,30046,U.S. Senate,,DEM,Loretta Sanchez,8
-Santa Cruz,30047,U.S. Senate,,DEM,Kamala Harris,0
-Santa Cruz,30047,U.S. Senate,,DEM,Loretta Sanchez,0
-Santa Cruz,30052,U.S. Senate,,DEM,Kamala Harris,0
-Santa Cruz,30052,U.S. Senate,,DEM,Loretta Sanchez,0
-Santa Cruz,30072,U.S. Senate,,DEM,Kamala Harris,0
-Santa Cruz,30072,U.S. Senate,,DEM,Loretta Sanchez,0
-Santa Cruz,30080,U.S. Senate,,DEM,Kamala Harris,185
-Santa Cruz,30080,U.S. Senate,,DEM,Loretta Sanchez,58
-Santa Cruz,30100,U.S. Senate,,DEM,Kamala Harris,57
-Santa Cruz,30100,U.S. Senate,,DEM,Loretta Sanchez,16
-Santa Cruz,30121,U.S. Senate,,DEM,Kamala Harris,11
-Santa Cruz,30121,U.S. Senate,,DEM,Loretta Sanchez,4
-Santa Cruz,31011,U.S. Senate,,DEM,Kamala Harris,269
-Santa Cruz,31011,U.S. Senate,,DEM,Loretta Sanchez,80
-Santa Cruz,31012,U.S. Senate,,DEM,Kamala Harris,0
-Santa Cruz,31012,U.S. Senate,,DEM,Loretta Sanchez,0
-Santa Cruz,31013,U.S. Senate,,DEM,Kamala Harris,770
-Santa Cruz,31013,U.S. Senate,,DEM,Loretta Sanchez,234
-Santa Cruz,31020,U.S. Senate,,DEM,Kamala Harris,828
-Santa Cruz,31020,U.S. Senate,,DEM,Loretta Sanchez,238
-Santa Cruz,31030,U.S. Senate,,DEM,Kamala Harris,880
-Santa Cruz,31030,U.S. Senate,,DEM,Loretta Sanchez,278
-Santa Cruz,31050,U.S. Senate,,DEM,Kamala Harris,715
-Santa Cruz,31050,U.S. Senate,,DEM,Loretta Sanchez,189
-Santa Cruz,31070,U.S. Senate,,DEM,Kamala Harris,804
-Santa Cruz,31070,U.S. Senate,,DEM,Loretta Sanchez,209
-Santa Cruz,31140,U.S. Senate,,DEM,Kamala Harris,955
-Santa Cruz,31140,U.S. Senate,,DEM,Loretta Sanchez,285
-Santa Cruz,31150,U.S. Senate,,DEM,Kamala Harris,870
-Santa Cruz,31150,U.S. Senate,,DEM,Loretta Sanchez,236
-Santa Cruz,31160,U.S. Senate,,DEM,Kamala Harris,622
-Santa Cruz,31160,U.S. Senate,,DEM,Loretta Sanchez,199
-Santa Cruz,31190,U.S. Senate,,DEM,Kamala Harris,755
-Santa Cruz,31190,U.S. Senate,,DEM,Loretta Sanchez,281
-Santa Cruz,31210,U.S. Senate,,DEM,Kamala Harris,545
-Santa Cruz,31210,U.S. Senate,,DEM,Loretta Sanchez,233
-Santa Cruz,31240,U.S. Senate,,DEM,Kamala Harris,800
-Santa Cruz,31240,U.S. Senate,,DEM,Loretta Sanchez,386
-Santa Cruz,31250,U.S. Senate,,DEM,Kamala Harris,917
-Santa Cruz,31250,U.S. Senate,,DEM,Loretta Sanchez,268
-Santa Cruz,31300,U.S. Senate,,DEM,Kamala Harris,381
-Santa Cruz,31300,U.S. Senate,,DEM,Loretta Sanchez,121
-Santa Cruz,31301,U.S. Senate,,DEM,Kamala Harris,371
-Santa Cruz,31301,U.S. Senate,,DEM,Loretta Sanchez,147
-Santa Cruz,31342,U.S. Senate,,DEM,Kamala Harris,290
-Santa Cruz,31342,U.S. Senate,,DEM,Loretta Sanchez,76
-Santa Cruz,31400,U.S. Senate,,DEM,Kamala Harris,899
-Santa Cruz,31400,U.S. Senate,,DEM,Loretta Sanchez,254
-Santa Cruz,31450,U.S. Senate,,DEM,Kamala Harris,808
-Santa Cruz,31450,U.S. Senate,,DEM,Loretta Sanchez,171
-Santa Cruz,31480,U.S. Senate,,DEM,Kamala Harris,597
-Santa Cruz,31480,U.S. Senate,,DEM,Loretta Sanchez,186
-Santa Cruz,31490,U.S. Senate,,DEM,Kamala Harris,590
-Santa Cruz,31490,U.S. Senate,,DEM,Loretta Sanchez,151
-Santa Cruz,31511,U.S. Senate,,DEM,Kamala Harris,0
-Santa Cruz,31511,U.S. Senate,,DEM,Loretta Sanchez,0
-Santa Cruz,31530,U.S. Senate,,DEM,Kamala Harris,719
-Santa Cruz,31530,U.S. Senate,,DEM,Loretta Sanchez,205
-Santa Cruz,31560,U.S. Senate,,DEM,Kamala Harris,531
-Santa Cruz,31560,U.S. Senate,,DEM,Loretta Sanchez,140
-Santa Cruz,31580,U.S. Senate,,DEM,Kamala Harris,440
-Santa Cruz,31580,U.S. Senate,,DEM,Loretta Sanchez,136
-Santa Cruz,31600,U.S. Senate,,DEM,Kamala Harris,344
-Santa Cruz,31600,U.S. Senate,,DEM,Loretta Sanchez,287
-Santa Cruz,31610,U.S. Senate,,DEM,Kamala Harris,204
-Santa Cruz,31610,U.S. Senate,,DEM,Loretta Sanchez,188
-Santa Cruz,31630,U.S. Senate,,DEM,Kamala Harris,176
-Santa Cruz,31630,U.S. Senate,,DEM,Loretta Sanchez,160
-Santa Cruz,31650,U.S. Senate,,DEM,Kamala Harris,284
-Santa Cruz,31650,U.S. Senate,,DEM,Loretta Sanchez,220
-Santa Cruz,31690,U.S. Senate,,DEM,Kamala Harris,190
-Santa Cruz,31690,U.S. Senate,,DEM,Loretta Sanchez,168
-Santa Cruz,31710,U.S. Senate,,DEM,Kamala Harris,721
-Santa Cruz,31710,U.S. Senate,,DEM,Loretta Sanchez,215
-Santa Cruz,40010,U.S. Senate,,DEM,Kamala Harris,22
-Santa Cruz,40010,U.S. Senate,,DEM,Loretta Sanchez,24
-Santa Cruz,40071,U.S. Senate,,DEM,Kamala Harris,448
-Santa Cruz,40071,U.S. Senate,,DEM,Loretta Sanchez,270
-Santa Cruz,40161,U.S. Senate,,DEM,Kamala Harris,615
-Santa Cruz,40161,U.S. Senate,,DEM,Loretta Sanchez,534
-Santa Cruz,40162,U.S. Senate,,DEM,Kamala Harris,269
-Santa Cruz,40162,U.S. Senate,,DEM,Loretta Sanchez,165
-Santa Cruz,40221,U.S. Senate,,DEM,Kamala Harris,0
-Santa Cruz,40221,U.S. Senate,,DEM,Loretta Sanchez,0
-Santa Cruz,40230,U.S. Senate,,DEM,Kamala Harris,21
-Santa Cruz,40230,U.S. Senate,,DEM,Loretta Sanchez,16
-Santa Cruz,40270,U.S. Senate,,DEM,Kamala Harris,287
-Santa Cruz,40270,U.S. Senate,,DEM,Loretta Sanchez,171
-Santa Cruz,40310,U.S. Senate,,DEM,Kamala Harris,0
-Santa Cruz,40310,U.S. Senate,,DEM,Loretta Sanchez,0
-Santa Cruz,43100,U.S. Senate,,DEM,Kamala Harris,219
-Santa Cruz,43100,U.S. Senate,,DEM,Loretta Sanchez,347
-Santa Cruz,43110,U.S. Senate,,DEM,Kamala Harris,329
-Santa Cruz,43110,U.S. Senate,,DEM,Loretta Sanchez,283
-Santa Cruz,43200,U.S. Senate,,DEM,Kamala Harris,370
-Santa Cruz,43200,U.S. Senate,,DEM,Loretta Sanchez,299
-Santa Cruz,43220,U.S. Senate,,DEM,Kamala Harris,242
-Santa Cruz,43220,U.S. Senate,,DEM,Loretta Sanchez,348
-Santa Cruz,43260,U.S. Senate,,DEM,Kamala Harris,33
-Santa Cruz,43260,U.S. Senate,,DEM,Loretta Sanchez,45
-Santa Cruz,43410,U.S. Senate,,DEM,Kamala Harris,592
-Santa Cruz,43410,U.S. Senate,,DEM,Loretta Sanchez,448
-Santa Cruz,43441,U.S. Senate,,DEM,Kamala Harris,392
-Santa Cruz,43441,U.S. Senate,,DEM,Loretta Sanchez,268
-Santa Cruz,43501,U.S. Senate,,DEM,Kamala Harris,467
-Santa Cruz,43501,U.S. Senate,,DEM,Loretta Sanchez,316
-Santa Cruz,43540,U.S. Senate,,DEM,Kamala Harris,359
-Santa Cruz,43540,U.S. Senate,,DEM,Loretta Sanchez,368
-Santa Cruz,43610,U.S. Senate,,DEM,Kamala Harris,504
-Santa Cruz,43610,U.S. Senate,,DEM,Loretta Sanchez,417
-Santa Cruz,43621,U.S. Senate,,DEM,Kamala Harris,261
-Santa Cruz,43621,U.S. Senate,,DEM,Loretta Sanchez,162
-Santa Cruz,43631,U.S. Senate,,DEM,Kamala Harris,413
-Santa Cruz,43631,U.S. Senate,,DEM,Loretta Sanchez,284
-Santa Cruz,43710,U.S. Senate,,DEM,Kamala Harris,283
-Santa Cruz,43710,U.S. Senate,,DEM,Loretta Sanchez,167
-Santa Cruz,43711,U.S. Senate,,DEM,Kamala Harris,62
-Santa Cruz,43711,U.S. Senate,,DEM,Loretta Sanchez,42
-Santa Cruz,43731,U.S. Senate,,DEM,Kamala Harris,597
-Santa Cruz,43731,U.S. Senate,,DEM,Loretta Sanchez,373
-Santa Cruz,43732,U.S. Senate,,DEM,Kamala Harris,155
-Santa Cruz,43732,U.S. Senate,,DEM,Loretta Sanchez,104
-Santa Cruz,43741,U.S. Senate,,DEM,Kamala Harris,514
-Santa Cruz,43741,U.S. Senate,,DEM,Loretta Sanchez,146
-Santa Cruz,50011,U.S. Senate,,DEM,Kamala Harris,1
-Santa Cruz,50011,U.S. Senate,,DEM,Loretta Sanchez,0
-Santa Cruz,50013,U.S. Senate,,DEM,Kamala Harris,0
-Santa Cruz,50013,U.S. Senate,,DEM,Loretta Sanchez,0
-Santa Cruz,50014,U.S. Senate,,DEM,Kamala Harris,0
-Santa Cruz,50014,U.S. Senate,,DEM,Loretta Sanchez,0
-Santa Cruz,50015,U.S. Senate,,DEM,Kamala Harris,1
-Santa Cruz,50015,U.S. Senate,,DEM,Loretta Sanchez,0
-Santa Cruz,50017,U.S. Senate,,DEM,Kamala Harris,0
-Santa Cruz,50017,U.S. Senate,,DEM,Loretta Sanchez,0
-Santa Cruz,50021,U.S. Senate,,DEM,Kamala Harris,384
-Santa Cruz,50021,U.S. Senate,,DEM,Loretta Sanchez,130
-Santa Cruz,50023,U.S. Senate,,DEM,Kamala Harris,507
-Santa Cruz,50023,U.S. Senate,,DEM,Loretta Sanchez,169
-Santa Cruz,50040,U.S. Senate,,DEM,Kamala Harris,445
-Santa Cruz,50040,U.S. Senate,,DEM,Loretta Sanchez,155
-Santa Cruz,50061,U.S. Senate,,DEM,Kamala Harris,352
-Santa Cruz,50061,U.S. Senate,,DEM,Loretta Sanchez,173
-Santa Cruz,50082,U.S. Senate,,DEM,Kamala Harris,16
-Santa Cruz,50082,U.S. Senate,,DEM,Loretta Sanchez,8
-Santa Cruz,50083,U.S. Senate,,DEM,Kamala Harris,7
-Santa Cruz,50083,U.S. Senate,,DEM,Loretta Sanchez,8
-Santa Cruz,50090,U.S. Senate,,DEM,Kamala Harris,0
-Santa Cruz,50090,U.S. Senate,,DEM,Loretta Sanchez,2
-Santa Cruz,50091,U.S. Senate,,DEM,Kamala Harris,457
-Santa Cruz,50091,U.S. Senate,,DEM,Loretta Sanchez,149
-Santa Cruz,50092,U.S. Senate,,DEM,Kamala Harris,492
-Santa Cruz,50092,U.S. Senate,,DEM,Loretta Sanchez,188
-Santa Cruz,50093,U.S. Senate,,DEM,Kamala Harris,0
-Santa Cruz,50093,U.S. Senate,,DEM,Loretta Sanchez,1
-Santa Cruz,50096,U.S. Senate,,DEM,Kamala Harris,3
-Santa Cruz,50096,U.S. Senate,,DEM,Loretta Sanchez,2
-Santa Cruz,50102,U.S. Senate,,DEM,Kamala Harris,750
-Santa Cruz,50102,U.S. Senate,,DEM,Loretta Sanchez,270
-Santa Cruz,50111,U.S. Senate,,DEM,Kamala Harris,528
-Santa Cruz,50111,U.S. Senate,,DEM,Loretta Sanchez,234
-Santa Cruz,50112,U.S. Senate,,DEM,Kamala Harris,350
-Santa Cruz,50112,U.S. Senate,,DEM,Loretta Sanchez,116
-Santa Cruz,50115,U.S. Senate,,DEM,Kamala Harris,0
-Santa Cruz,50115,U.S. Senate,,DEM,Loretta Sanchez,0
-Santa Cruz,50121,U.S. Senate,,DEM,Kamala Harris,646
-Santa Cruz,50121,U.S. Senate,,DEM,Loretta Sanchez,223
-Santa Cruz,50141,U.S. Senate,,DEM,Kamala Harris,630
-Santa Cruz,50141,U.S. Senate,,DEM,Loretta Sanchez,235
-Santa Cruz,50142,U.S. Senate,,DEM,Kamala Harris,0
-Santa Cruz,50142,U.S. Senate,,DEM,Loretta Sanchez,0
-Santa Cruz,50144,U.S. Senate,,DEM,Kamala Harris,39
-Santa Cruz,50144,U.S. Senate,,DEM,Loretta Sanchez,11
-Santa Cruz,50146,U.S. Senate,,DEM,Kamala Harris,58
-Santa Cruz,50146,U.S. Senate,,DEM,Loretta Sanchez,19
-Santa Cruz,50148,U.S. Senate,,DEM,Kamala Harris,2
-Santa Cruz,50148,U.S. Senate,,DEM,Loretta Sanchez,1
-Santa Cruz,50151,U.S. Senate,,DEM,Kamala Harris,0
-Santa Cruz,50151,U.S. Senate,,DEM,Loretta Sanchez,0
-Santa Cruz,50154,U.S. Senate,,DEM,Kamala Harris,1
-Santa Cruz,50154,U.S. Senate,,DEM,Loretta Sanchez,0
-Santa Cruz,50157,U.S. Senate,,DEM,Kamala Harris,472
-Santa Cruz,50157,U.S. Senate,,DEM,Loretta Sanchez,164
-Santa Cruz,50161,U.S. Senate,,DEM,Kamala Harris,805
-Santa Cruz,50161,U.S. Senate,,DEM,Loretta Sanchez,299
-Santa Cruz,50163,U.S. Senate,,DEM,Kamala Harris,17
-Santa Cruz,50163,U.S. Senate,,DEM,Loretta Sanchez,9
-Santa Cruz,50174,U.S. Senate,,DEM,Kamala Harris,1
-Santa Cruz,50174,U.S. Senate,,DEM,Loretta Sanchez,2
-Santa Cruz,50181,U.S. Senate,,DEM,Kamala Harris,30
-Santa Cruz,50181,U.S. Senate,,DEM,Loretta Sanchez,12
-Santa Cruz,50183,U.S. Senate,,DEM,Kamala Harris,490
-Santa Cruz,50183,U.S. Senate,,DEM,Loretta Sanchez,163
-Santa Cruz,50191,U.S. Senate,,DEM,Kamala Harris,698
-Santa Cruz,50191,U.S. Senate,,DEM,Loretta Sanchez,250
-Santa Cruz,50202,U.S. Senate,,DEM,Kamala Harris,115
-Santa Cruz,50202,U.S. Senate,,DEM,Loretta Sanchez,49
-Santa Cruz,50203,U.S. Senate,,DEM,Kamala Harris,552
-Santa Cruz,50203,U.S. Senate,,DEM,Loretta Sanchez,188
-Santa Cruz,50204,U.S. Senate,,DEM,Kamala Harris,375
-Santa Cruz,50204,U.S. Senate,,DEM,Loretta Sanchez,153
-Santa Cruz,50211,U.S. Senate,,DEM,Kamala Harris,377
-Santa Cruz,50211,U.S. Senate,,DEM,Loretta Sanchez,164
-Santa Cruz,50221,U.S. Senate,,DEM,Kamala Harris,367
-Santa Cruz,50221,U.S. Senate,,DEM,Loretta Sanchez,122
-Santa Cruz,50222,U.S. Senate,,DEM,Kamala Harris,19
-Santa Cruz,50222,U.S. Senate,,DEM,Loretta Sanchez,7
-Santa Cruz,50224,U.S. Senate,,DEM,Kamala Harris,0
-Santa Cruz,50224,U.S. Senate,,DEM,Loretta Sanchez,0
-Santa Cruz,50232,U.S. Senate,,DEM,Kamala Harris,311
-Santa Cruz,50232,U.S. Senate,,DEM,Loretta Sanchez,113
-Santa Cruz,50233,U.S. Senate,,DEM,Kamala Harris,54
-Santa Cruz,50233,U.S. Senate,,DEM,Loretta Sanchez,31
-Santa Cruz,50243,U.S. Senate,,DEM,Kamala Harris,3
-Santa Cruz,50243,U.S. Senate,,DEM,Loretta Sanchez,0
-Santa Cruz,50250,U.S. Senate,,DEM,Kamala Harris,76
-Santa Cruz,50250,U.S. Senate,,DEM,Loretta Sanchez,42
-Santa Cruz,50263,U.S. Senate,,DEM,Kamala Harris,25
-Santa Cruz,50263,U.S. Senate,,DEM,Loretta Sanchez,9
-Santa Cruz,50265,U.S. Senate,,DEM,Kamala Harris,10
-Santa Cruz,50265,U.S. Senate,,DEM,Loretta Sanchez,5
-Santa Cruz,50273,U.S. Senate,,DEM,Kamala Harris,0
-Santa Cruz,50273,U.S. Senate,,DEM,Loretta Sanchez,0
-Santa Cruz,50284,U.S. Senate,,DEM,Kamala Harris,3
-Santa Cruz,50284,U.S. Senate,,DEM,Loretta Sanchez,0
-Santa Cruz,50302,U.S. Senate,,DEM,Kamala Harris,0
-Santa Cruz,50302,U.S. Senate,,DEM,Loretta Sanchez,0
-Santa Cruz,50341,U.S. Senate,,DEM,Kamala Harris,295
-Santa Cruz,50341,U.S. Senate,,DEM,Loretta Sanchez,131
-Santa Cruz,50342,U.S. Senate,,DEM,Kamala Harris,8
-Santa Cruz,50342,U.S. Senate,,DEM,Loretta Sanchez,1
-Santa Cruz,50344,U.S. Senate,,DEM,Kamala Harris,0
-Santa Cruz,50344,U.S. Senate,,DEM,Loretta Sanchez,0
-Santa Cruz,50381,U.S. Senate,,DEM,Kamala Harris,200
-Santa Cruz,50381,U.S. Senate,,DEM,Loretta Sanchez,51
-Santa Cruz,50382,U.S. Senate,,DEM,Kamala Harris,208
-Santa Cruz,50382,U.S. Senate,,DEM,Loretta Sanchez,101
-Santa Cruz,50401,U.S. Senate,,DEM,Kamala Harris,420
-Santa Cruz,50401,U.S. Senate,,DEM,Loretta Sanchez,151
-Santa Cruz,50403,U.S. Senate,,DEM,Kamala Harris,0
-Santa Cruz,50403,U.S. Senate,,DEM,Loretta Sanchez,0
-Santa Cruz,50415,U.S. Senate,,DEM,Kamala Harris,2
-Santa Cruz,50415,U.S. Senate,,DEM,Loretta Sanchez,4
-Santa Cruz,50416,U.S. Senate,,DEM,Kamala Harris,0
-Santa Cruz,50416,U.S. Senate,,DEM,Loretta Sanchez,0
-Santa Cruz,50453,U.S. Senate,,DEM,Kamala Harris,0
-Santa Cruz,50453,U.S. Senate,,DEM,Loretta Sanchez,1
-Santa Cruz,50480,U.S. Senate,,DEM,Kamala Harris,304
-Santa Cruz,50480,U.S. Senate,,DEM,Loretta Sanchez,103
-Santa Cruz,50492,U.S. Senate,,DEM,Kamala Harris,48
-Santa Cruz,50492,U.S. Senate,,DEM,Loretta Sanchez,19
-Santa Cruz,50502,U.S. Senate,,DEM,Kamala Harris,0
-Santa Cruz,50502,U.S. Senate,,DEM,Loretta Sanchez,0
-Santa Cruz,50503,U.S. Senate,,DEM,Kamala Harris,12
-Santa Cruz,50503,U.S. Senate,,DEM,Loretta Sanchez,7
-Santa Cruz,50507,U.S. Senate,,DEM,Kamala Harris,0
-Santa Cruz,50507,U.S. Senate,,DEM,Loretta Sanchez,0
-Santa Cruz,50521,U.S. Senate,,DEM,Kamala Harris,258
-Santa Cruz,50521,U.S. Senate,,DEM,Loretta Sanchez,89
-Santa Cruz,50522,U.S. Senate,,DEM,Kamala Harris,123
-Santa Cruz,50522,U.S. Senate,,DEM,Loretta Sanchez,34
-Santa Cruz,50541,U.S. Senate,,DEM,Kamala Harris,129
-Santa Cruz,50541,U.S. Senate,,DEM,Loretta Sanchez,50
-Santa Cruz,51010,U.S. Senate,,DEM,Kamala Harris,342
-Santa Cruz,51010,U.S. Senate,,DEM,Loretta Sanchez,152
-Santa Cruz,51080,U.S. Senate,,DEM,Kamala Harris,854
-Santa Cruz,51080,U.S. Senate,,DEM,Loretta Sanchez,317
-Santa Cruz,51090,U.S. Senate,,DEM,Kamala Harris,915
-Santa Cruz,51090,U.S. Senate,,DEM,Loretta Sanchez,323
-Santa Cruz,51620,U.S. Senate,,DEM,Kamala Harris,163
-Santa Cruz,51620,U.S. Senate,,DEM,Loretta Sanchez,25
-Santa Cruz,51770,U.S. Senate,,DEM,Kamala Harris,288
-Santa Cruz,51770,U.S. Senate,,DEM,Loretta Sanchez,92
-Santa Cruz,54010,U.S. Senate,,DEM,Kamala Harris,544
-Santa Cruz,54010,U.S. Senate,,DEM,Loretta Sanchez,173
-Santa Cruz,54020,U.S. Senate,,DEM,Kamala Harris,294
-Santa Cruz,54020,U.S. Senate,,DEM,Loretta Sanchez,106
-Santa Cruz,54031,U.S. Senate,,DEM,Kamala Harris,588
-Santa Cruz,54031,U.S. Senate,,DEM,Loretta Sanchez,247
-Santa Cruz,54051,U.S. Senate,,DEM,Kamala Harris,822
-Santa Cruz,54051,U.S. Senate,,DEM,Loretta Sanchez,289
-Santa Cruz,54061,U.S. Senate,,DEM,Kamala Harris,469
-Santa Cruz,54061,U.S. Senate,,DEM,Loretta Sanchez,200
-Santa Cruz,54070,U.S. Senate,,DEM,Kamala Harris,658
-Santa Cruz,54070,U.S. Senate,,DEM,Loretta Sanchez,211
-Santa Cruz,54071,U.S. Senate,,DEM,Kamala Harris,4
-Santa Cruz,54071,U.S. Senate,,DEM,Loretta Sanchez,1
+Santa Cruz,10020,U.S. Senate,,DEM,Kamala D. Harris,681
+Santa Cruz,10020,U.S. Senate,,DEM,Loretta L. Sanchez,221
+Santa Cruz,10060,U.S. Senate,,DEM,Kamala D. Harris,659
+Santa Cruz,10060,U.S. Senate,,DEM,Loretta L. Sanchez,190
+Santa Cruz,10080,U.S. Senate,,DEM,Kamala D. Harris,579
+Santa Cruz,10080,U.S. Senate,,DEM,Loretta L. Sanchez,235
+Santa Cruz,10090,U.S. Senate,,DEM,Kamala D. Harris,595
+Santa Cruz,10090,U.S. Senate,,DEM,Loretta L. Sanchez,240
+Santa Cruz,10100,U.S. Senate,,DEM,Kamala D. Harris,679
+Santa Cruz,10100,U.S. Senate,,DEM,Loretta L. Sanchez,236
+Santa Cruz,10110,U.S. Senate,,DEM,Kamala D. Harris,602
+Santa Cruz,10110,U.S. Senate,,DEM,Loretta L. Sanchez,267
+Santa Cruz,10130,U.S. Senate,,DEM,Kamala D. Harris,740
+Santa Cruz,10130,U.S. Senate,,DEM,Loretta L. Sanchez,305
+Santa Cruz,10141,U.S. Senate,,DEM,Kamala D. Harris,59
+Santa Cruz,10141,U.S. Senate,,DEM,Loretta L. Sanchez,13
+Santa Cruz,10142,U.S. Senate,,DEM,Kamala D. Harris,75
+Santa Cruz,10142,U.S. Senate,,DEM,Loretta L. Sanchez,15
+Santa Cruz,10144,U.S. Senate,,DEM,Kamala D. Harris,624
+Santa Cruz,10144,U.S. Senate,,DEM,Loretta L. Sanchez,186
+Santa Cruz,10145,U.S. Senate,,DEM,Kamala D. Harris,13
+Santa Cruz,10145,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Santa Cruz,10146,U.S. Senate,,DEM,Kamala D. Harris,3
+Santa Cruz,10146,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Santa Cruz,10151,U.S. Senate,,DEM,Kamala D. Harris,26
+Santa Cruz,10151,U.S. Senate,,DEM,Loretta L. Sanchez,5
+Santa Cruz,10152,U.S. Senate,,DEM,Kamala D. Harris,0
+Santa Cruz,10152,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Santa Cruz,10161,U.S. Senate,,DEM,Kamala D. Harris,264
+Santa Cruz,10161,U.S. Senate,,DEM,Loretta L. Sanchez,98
+Santa Cruz,10162,U.S. Senate,,DEM,Kamala D. Harris,54
+Santa Cruz,10162,U.S. Senate,,DEM,Loretta L. Sanchez,27
+Santa Cruz,10163,U.S. Senate,,DEM,Kamala D. Harris,4
+Santa Cruz,10163,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Santa Cruz,10164,U.S. Senate,,DEM,Kamala D. Harris,107
+Santa Cruz,10164,U.S. Senate,,DEM,Loretta L. Sanchez,35
+Santa Cruz,10165,U.S. Senate,,DEM,Kamala D. Harris,0
+Santa Cruz,10165,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Santa Cruz,10170,U.S. Senate,,DEM,Kamala D. Harris,493
+Santa Cruz,10170,U.S. Senate,,DEM,Loretta L. Sanchez,142
+Santa Cruz,10190,U.S. Senate,,DEM,Kamala D. Harris,786
+Santa Cruz,10190,U.S. Senate,,DEM,Loretta L. Sanchez,249
+Santa Cruz,10201,U.S. Senate,,DEM,Kamala D. Harris,260
+Santa Cruz,10201,U.S. Senate,,DEM,Loretta L. Sanchez,96
+Santa Cruz,10220,U.S. Senate,,DEM,Kamala D. Harris,551
+Santa Cruz,10220,U.S. Senate,,DEM,Loretta L. Sanchez,209
+Santa Cruz,10231,U.S. Senate,,DEM,Kamala D. Harris,46
+Santa Cruz,10231,U.S. Senate,,DEM,Loretta L. Sanchez,7
+Santa Cruz,10232,U.S. Senate,,DEM,Kamala D. Harris,4
+Santa Cruz,10232,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Santa Cruz,10234,U.S. Senate,,DEM,Kamala D. Harris,55
+Santa Cruz,10234,U.S. Senate,,DEM,Loretta L. Sanchez,19
+Santa Cruz,10236,U.S. Senate,,DEM,Kamala D. Harris,13
+Santa Cruz,10236,U.S. Senate,,DEM,Loretta L. Sanchez,8
+Santa Cruz,10237,U.S. Senate,,DEM,Kamala D. Harris,2
+Santa Cruz,10237,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Santa Cruz,10240,U.S. Senate,,DEM,Kamala D. Harris,388
+Santa Cruz,10240,U.S. Senate,,DEM,Loretta L. Sanchez,165
+Santa Cruz,10260,U.S. Senate,,DEM,Kamala D. Harris,236
+Santa Cruz,10260,U.S. Senate,,DEM,Loretta L. Sanchez,83
+Santa Cruz,10270,U.S. Senate,,DEM,Kamala D. Harris,490
+Santa Cruz,10270,U.S. Senate,,DEM,Loretta L. Sanchez,191
+Santa Cruz,10281,U.S. Senate,,DEM,Kamala D. Harris,421
+Santa Cruz,10281,U.S. Senate,,DEM,Loretta L. Sanchez,130
+Santa Cruz,10283,U.S. Senate,,DEM,Kamala D. Harris,84
+Santa Cruz,10283,U.S. Senate,,DEM,Loretta L. Sanchez,44
+Santa Cruz,10284,U.S. Senate,,DEM,Kamala D. Harris,3
+Santa Cruz,10284,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Santa Cruz,10286,U.S. Senate,,DEM,Kamala D. Harris,57
+Santa Cruz,10286,U.S. Senate,,DEM,Loretta L. Sanchez,17
+Santa Cruz,10287,U.S. Senate,,DEM,Kamala D. Harris,0
+Santa Cruz,10287,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Santa Cruz,10291,U.S. Senate,,DEM,Kamala D. Harris,83
+Santa Cruz,10291,U.S. Senate,,DEM,Loretta L. Sanchez,30
+Santa Cruz,10292,U.S. Senate,,DEM,Kamala D. Harris,99
+Santa Cruz,10292,U.S. Senate,,DEM,Loretta L. Sanchez,30
+Santa Cruz,10294,U.S. Senate,,DEM,Kamala D. Harris,906
+Santa Cruz,10294,U.S. Senate,,DEM,Loretta L. Sanchez,323
+Santa Cruz,10295,U.S. Senate,,DEM,Kamala D. Harris,50
+Santa Cruz,10295,U.S. Senate,,DEM,Loretta L. Sanchez,22
+Santa Cruz,10310,U.S. Senate,,DEM,Kamala D. Harris,737
+Santa Cruz,10310,U.S. Senate,,DEM,Loretta L. Sanchez,240
+Santa Cruz,10351,U.S. Senate,,DEM,Kamala D. Harris,433
+Santa Cruz,10351,U.S. Senate,,DEM,Loretta L. Sanchez,149
+Santa Cruz,10352,U.S. Senate,,DEM,Kamala D. Harris,157
+Santa Cruz,10352,U.S. Senate,,DEM,Loretta L. Sanchez,47
+Santa Cruz,10381,U.S. Senate,,DEM,Kamala D. Harris,727
+Santa Cruz,10381,U.S. Senate,,DEM,Loretta L. Sanchez,288
+Santa Cruz,10382,U.S. Senate,,DEM,Kamala D. Harris,41
+Santa Cruz,10382,U.S. Senate,,DEM,Loretta L. Sanchez,11
+Santa Cruz,10410,U.S. Senate,,DEM,Kamala D. Harris,418
+Santa Cruz,10410,U.S. Senate,,DEM,Loretta L. Sanchez,123
+Santa Cruz,10490,U.S. Senate,,DEM,Kamala D. Harris,317
+Santa Cruz,10490,U.S. Senate,,DEM,Loretta L. Sanchez,86
+Santa Cruz,10521,U.S. Senate,,DEM,Kamala D. Harris,57
+Santa Cruz,10521,U.S. Senate,,DEM,Loretta L. Sanchez,19
+Santa Cruz,10523,U.S. Senate,,DEM,Kamala D. Harris,4
+Santa Cruz,10523,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Santa Cruz,10533,U.S. Senate,,DEM,Kamala D. Harris,7
+Santa Cruz,10533,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Santa Cruz,10551,U.S. Senate,,DEM,Kamala D. Harris,3
+Santa Cruz,10551,U.S. Senate,,DEM,Loretta L. Sanchez,7
+Santa Cruz,10552,U.S. Senate,,DEM,Kamala D. Harris,0
+Santa Cruz,10552,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Santa Cruz,10572,U.S. Senate,,DEM,Kamala D. Harris,26
+Santa Cruz,10572,U.S. Senate,,DEM,Loretta L. Sanchez,11
+Santa Cruz,10581,U.S. Senate,,DEM,Kamala D. Harris,59
+Santa Cruz,10581,U.S. Senate,,DEM,Loretta L. Sanchez,17
+Santa Cruz,10603,U.S. Senate,,DEM,Kamala D. Harris,634
+Santa Cruz,10603,U.S. Senate,,DEM,Loretta L. Sanchez,201
+Santa Cruz,10620,U.S. Senate,,DEM,Kamala D. Harris,707
+Santa Cruz,10620,U.S. Senate,,DEM,Loretta L. Sanchez,264
+Santa Cruz,10653,U.S. Senate,,DEM,Kamala D. Harris,3
+Santa Cruz,10653,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Santa Cruz,10682,U.S. Senate,,DEM,Kamala D. Harris,151
+Santa Cruz,10682,U.S. Senate,,DEM,Loretta L. Sanchez,43
+Santa Cruz,10690,U.S. Senate,,DEM,Kamala D. Harris,4
+Santa Cruz,10690,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Santa Cruz,10700,U.S. Senate,,DEM,Kamala D. Harris,64
+Santa Cruz,10700,U.S. Senate,,DEM,Loretta L. Sanchez,16
+Santa Cruz,10763,U.S. Senate,,DEM,Kamala D. Harris,177
+Santa Cruz,10763,U.S. Senate,,DEM,Loretta L. Sanchez,46
+Santa Cruz,11010,U.S. Senate,,DEM,Kamala D. Harris,872
+Santa Cruz,11010,U.S. Senate,,DEM,Loretta L. Sanchez,257
+Santa Cruz,11120,U.S. Senate,,DEM,Kamala D. Harris,545
+Santa Cruz,11120,U.S. Senate,,DEM,Loretta L. Sanchez,179
+Santa Cruz,12010,U.S. Senate,,DEM,Kamala D. Harris,161
+Santa Cruz,12010,U.S. Senate,,DEM,Loretta L. Sanchez,92
+Santa Cruz,12023,U.S. Senate,,DEM,Kamala D. Harris,221
+Santa Cruz,12023,U.S. Senate,,DEM,Loretta L. Sanchez,95
+Santa Cruz,12024,U.S. Senate,,DEM,Kamala D. Harris,868
+Santa Cruz,12024,U.S. Senate,,DEM,Loretta L. Sanchez,363
+Santa Cruz,14110,U.S. Senate,,DEM,Kamala D. Harris,0
+Santa Cruz,14110,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Santa Cruz,14121,U.S. Senate,,DEM,Kamala D. Harris,690
+Santa Cruz,14121,U.S. Senate,,DEM,Loretta L. Sanchez,231
+Santa Cruz,14123,U.S. Senate,,DEM,Kamala D. Harris,0
+Santa Cruz,14123,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Santa Cruz,14141,U.S. Senate,,DEM,Kamala D. Harris,76
+Santa Cruz,14141,U.S. Senate,,DEM,Loretta L. Sanchez,24
+Santa Cruz,20011,U.S. Senate,,DEM,Kamala D. Harris,499
+Santa Cruz,20011,U.S. Senate,,DEM,Loretta L. Sanchez,360
+Santa Cruz,20013,U.S. Senate,,DEM,Kamala D. Harris,195
+Santa Cruz,20013,U.S. Senate,,DEM,Loretta L. Sanchez,139
+Santa Cruz,20020,U.S. Senate,,DEM,Kamala D. Harris,689
+Santa Cruz,20020,U.S. Senate,,DEM,Loretta L. Sanchez,356
+Santa Cruz,20041,U.S. Senate,,DEM,Kamala D. Harris,516
+Santa Cruz,20041,U.S. Senate,,DEM,Loretta L. Sanchez,257
+Santa Cruz,20044,U.S. Senate,,DEM,Kamala D. Harris,517
+Santa Cruz,20044,U.S. Senate,,DEM,Loretta L. Sanchez,215
+Santa Cruz,20061,U.S. Senate,,DEM,Kamala D. Harris,423
+Santa Cruz,20061,U.S. Senate,,DEM,Loretta L. Sanchez,153
+Santa Cruz,20093,U.S. Senate,,DEM,Kamala D. Harris,1
+Santa Cruz,20093,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Santa Cruz,20101,U.S. Senate,,DEM,Kamala D. Harris,535
+Santa Cruz,20101,U.S. Senate,,DEM,Loretta L. Sanchez,217
+Santa Cruz,20150,U.S. Senate,,DEM,Kamala D. Harris,332
+Santa Cruz,20150,U.S. Senate,,DEM,Loretta L. Sanchez,139
+Santa Cruz,20221,U.S. Senate,,DEM,Kamala D. Harris,703
+Santa Cruz,20221,U.S. Senate,,DEM,Loretta L. Sanchez,230
+Santa Cruz,20222,U.S. Senate,,DEM,Kamala D. Harris,2
+Santa Cruz,20222,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Santa Cruz,20231,U.S. Senate,,DEM,Kamala D. Harris,44
+Santa Cruz,20231,U.S. Senate,,DEM,Loretta L. Sanchez,10
+Santa Cruz,20232,U.S. Senate,,DEM,Kamala D. Harris,670
+Santa Cruz,20232,U.S. Senate,,DEM,Loretta L. Sanchez,230
+Santa Cruz,20241,U.S. Senate,,DEM,Kamala D. Harris,7
+Santa Cruz,20241,U.S. Senate,,DEM,Loretta L. Sanchez,6
+Santa Cruz,20242,U.S. Senate,,DEM,Kamala D. Harris,428
+Santa Cruz,20242,U.S. Senate,,DEM,Loretta L. Sanchez,118
+Santa Cruz,20243,U.S. Senate,,DEM,Kamala D. Harris,320
+Santa Cruz,20243,U.S. Senate,,DEM,Loretta L. Sanchez,133
+Santa Cruz,20244,U.S. Senate,,DEM,Kamala D. Harris,26
+Santa Cruz,20244,U.S. Senate,,DEM,Loretta L. Sanchez,9
+Santa Cruz,20260,U.S. Senate,,DEM,Kamala D. Harris,734
+Santa Cruz,20260,U.S. Senate,,DEM,Loretta L. Sanchez,252
+Santa Cruz,20280,U.S. Senate,,DEM,Kamala D. Harris,830
+Santa Cruz,20280,U.S. Senate,,DEM,Loretta L. Sanchez,323
+Santa Cruz,20300,U.S. Senate,,DEM,Kamala D. Harris,775
+Santa Cruz,20300,U.S. Senate,,DEM,Loretta L. Sanchez,244
+Santa Cruz,20320,U.S. Senate,,DEM,Kamala D. Harris,886
+Santa Cruz,20320,U.S. Senate,,DEM,Loretta L. Sanchez,264
+Santa Cruz,20330,U.S. Senate,,DEM,Kamala D. Harris,752
+Santa Cruz,20330,U.S. Senate,,DEM,Loretta L. Sanchez,264
+Santa Cruz,20341,U.S. Senate,,DEM,Kamala D. Harris,217
+Santa Cruz,20341,U.S. Senate,,DEM,Loretta L. Sanchez,104
+Santa Cruz,20351,U.S. Senate,,DEM,Kamala D. Harris,741
+Santa Cruz,20351,U.S. Senate,,DEM,Loretta L. Sanchez,229
+Santa Cruz,20352,U.S. Senate,,DEM,Kamala D. Harris,0
+Santa Cruz,20352,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Santa Cruz,20354,U.S. Senate,,DEM,Kamala D. Harris,632
+Santa Cruz,20354,U.S. Senate,,DEM,Loretta L. Sanchez,233
+Santa Cruz,20381,U.S. Senate,,DEM,Kamala D. Harris,89
+Santa Cruz,20381,U.S. Senate,,DEM,Loretta L. Sanchez,60
+Santa Cruz,20392,U.S. Senate,,DEM,Kamala D. Harris,35
+Santa Cruz,20392,U.S. Senate,,DEM,Loretta L. Sanchez,8
+Santa Cruz,20402,U.S. Senate,,DEM,Kamala D. Harris,522
+Santa Cruz,20402,U.S. Senate,,DEM,Loretta L. Sanchez,227
+Santa Cruz,20421,U.S. Senate,,DEM,Kamala D. Harris,20
+Santa Cruz,20421,U.S. Senate,,DEM,Loretta L. Sanchez,5
+Santa Cruz,20520,U.S. Senate,,DEM,Kamala D. Harris,736
+Santa Cruz,20520,U.S. Senate,,DEM,Loretta L. Sanchez,226
+Santa Cruz,20541,U.S. Senate,,DEM,Kamala D. Harris,570
+Santa Cruz,20541,U.S. Senate,,DEM,Loretta L. Sanchez,227
+Santa Cruz,20551,U.S. Senate,,DEM,Kamala D. Harris,649
+Santa Cruz,20551,U.S. Senate,,DEM,Loretta L. Sanchez,208
+Santa Cruz,20591,U.S. Senate,,DEM,Kamala D. Harris,0
+Santa Cruz,20591,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Santa Cruz,20592,U.S. Senate,,DEM,Kamala D. Harris,0
+Santa Cruz,20592,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Santa Cruz,20611,U.S. Senate,,DEM,Kamala D. Harris,0
+Santa Cruz,20611,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Santa Cruz,20622,U.S. Senate,,DEM,Kamala D. Harris,0
+Santa Cruz,20622,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Santa Cruz,22010,U.S. Senate,,DEM,Kamala D. Harris,676
+Santa Cruz,22010,U.S. Senate,,DEM,Loretta L. Sanchez,236
+Santa Cruz,22040,U.S. Senate,,DEM,Kamala D. Harris,537
+Santa Cruz,22040,U.S. Senate,,DEM,Loretta L. Sanchez,157
+Santa Cruz,22050,U.S. Senate,,DEM,Kamala D. Harris,910
+Santa Cruz,22050,U.S. Senate,,DEM,Loretta L. Sanchez,303
+Santa Cruz,23190,U.S. Senate,,DEM,Kamala D. Harris,0
+Santa Cruz,23190,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Santa Cruz,23311,U.S. Senate,,DEM,Kamala D. Harris,689
+Santa Cruz,23311,U.S. Senate,,DEM,Loretta L. Sanchez,582
+Santa Cruz,23312,U.S. Senate,,DEM,Kamala D. Harris,196
+Santa Cruz,23312,U.S. Senate,,DEM,Loretta L. Sanchez,205
+Santa Cruz,23360,U.S. Senate,,DEM,Kamala D. Harris,266
+Santa Cruz,23360,U.S. Senate,,DEM,Loretta L. Sanchez,207
+Santa Cruz,23492,U.S. Senate,,DEM,Kamala D. Harris,0
+Santa Cruz,23492,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Santa Cruz,23660,U.S. Senate,,DEM,Kamala D. Harris,0
+Santa Cruz,23660,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Santa Cruz,30010,U.S. Senate,,DEM,Kamala D. Harris,121
+Santa Cruz,30010,U.S. Senate,,DEM,Loretta L. Sanchez,38
+Santa Cruz,30020,U.S. Senate,,DEM,Kamala D. Harris,273
+Santa Cruz,30020,U.S. Senate,,DEM,Loretta L. Sanchez,88
+Santa Cruz,30030,U.S. Senate,,DEM,Kamala D. Harris,546
+Santa Cruz,30030,U.S. Senate,,DEM,Loretta L. Sanchez,192
+Santa Cruz,30041,U.S. Senate,,DEM,Kamala D. Harris,761
+Santa Cruz,30041,U.S. Senate,,DEM,Loretta L. Sanchez,221
+Santa Cruz,30042,U.S. Senate,,DEM,Kamala D. Harris,0
+Santa Cruz,30042,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Santa Cruz,30044,U.S. Senate,,DEM,Kamala D. Harris,0
+Santa Cruz,30044,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Santa Cruz,30046,U.S. Senate,,DEM,Kamala D. Harris,24
+Santa Cruz,30046,U.S. Senate,,DEM,Loretta L. Sanchez,8
+Santa Cruz,30047,U.S. Senate,,DEM,Kamala D. Harris,0
+Santa Cruz,30047,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Santa Cruz,30052,U.S. Senate,,DEM,Kamala D. Harris,0
+Santa Cruz,30052,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Santa Cruz,30072,U.S. Senate,,DEM,Kamala D. Harris,0
+Santa Cruz,30072,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Santa Cruz,30080,U.S. Senate,,DEM,Kamala D. Harris,185
+Santa Cruz,30080,U.S. Senate,,DEM,Loretta L. Sanchez,58
+Santa Cruz,30100,U.S. Senate,,DEM,Kamala D. Harris,57
+Santa Cruz,30100,U.S. Senate,,DEM,Loretta L. Sanchez,16
+Santa Cruz,30121,U.S. Senate,,DEM,Kamala D. Harris,11
+Santa Cruz,30121,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Santa Cruz,31011,U.S. Senate,,DEM,Kamala D. Harris,269
+Santa Cruz,31011,U.S. Senate,,DEM,Loretta L. Sanchez,80
+Santa Cruz,31012,U.S. Senate,,DEM,Kamala D. Harris,0
+Santa Cruz,31012,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Santa Cruz,31013,U.S. Senate,,DEM,Kamala D. Harris,770
+Santa Cruz,31013,U.S. Senate,,DEM,Loretta L. Sanchez,234
+Santa Cruz,31020,U.S. Senate,,DEM,Kamala D. Harris,828
+Santa Cruz,31020,U.S. Senate,,DEM,Loretta L. Sanchez,238
+Santa Cruz,31030,U.S. Senate,,DEM,Kamala D. Harris,880
+Santa Cruz,31030,U.S. Senate,,DEM,Loretta L. Sanchez,278
+Santa Cruz,31050,U.S. Senate,,DEM,Kamala D. Harris,715
+Santa Cruz,31050,U.S. Senate,,DEM,Loretta L. Sanchez,189
+Santa Cruz,31070,U.S. Senate,,DEM,Kamala D. Harris,804
+Santa Cruz,31070,U.S. Senate,,DEM,Loretta L. Sanchez,209
+Santa Cruz,31140,U.S. Senate,,DEM,Kamala D. Harris,955
+Santa Cruz,31140,U.S. Senate,,DEM,Loretta L. Sanchez,285
+Santa Cruz,31150,U.S. Senate,,DEM,Kamala D. Harris,870
+Santa Cruz,31150,U.S. Senate,,DEM,Loretta L. Sanchez,236
+Santa Cruz,31160,U.S. Senate,,DEM,Kamala D. Harris,622
+Santa Cruz,31160,U.S. Senate,,DEM,Loretta L. Sanchez,199
+Santa Cruz,31190,U.S. Senate,,DEM,Kamala D. Harris,755
+Santa Cruz,31190,U.S. Senate,,DEM,Loretta L. Sanchez,281
+Santa Cruz,31210,U.S. Senate,,DEM,Kamala D. Harris,545
+Santa Cruz,31210,U.S. Senate,,DEM,Loretta L. Sanchez,233
+Santa Cruz,31240,U.S. Senate,,DEM,Kamala D. Harris,800
+Santa Cruz,31240,U.S. Senate,,DEM,Loretta L. Sanchez,386
+Santa Cruz,31250,U.S. Senate,,DEM,Kamala D. Harris,917
+Santa Cruz,31250,U.S. Senate,,DEM,Loretta L. Sanchez,268
+Santa Cruz,31300,U.S. Senate,,DEM,Kamala D. Harris,381
+Santa Cruz,31300,U.S. Senate,,DEM,Loretta L. Sanchez,121
+Santa Cruz,31301,U.S. Senate,,DEM,Kamala D. Harris,371
+Santa Cruz,31301,U.S. Senate,,DEM,Loretta L. Sanchez,147
+Santa Cruz,31342,U.S. Senate,,DEM,Kamala D. Harris,290
+Santa Cruz,31342,U.S. Senate,,DEM,Loretta L. Sanchez,76
+Santa Cruz,31400,U.S. Senate,,DEM,Kamala D. Harris,899
+Santa Cruz,31400,U.S. Senate,,DEM,Loretta L. Sanchez,254
+Santa Cruz,31450,U.S. Senate,,DEM,Kamala D. Harris,808
+Santa Cruz,31450,U.S. Senate,,DEM,Loretta L. Sanchez,171
+Santa Cruz,31480,U.S. Senate,,DEM,Kamala D. Harris,597
+Santa Cruz,31480,U.S. Senate,,DEM,Loretta L. Sanchez,186
+Santa Cruz,31490,U.S. Senate,,DEM,Kamala D. Harris,590
+Santa Cruz,31490,U.S. Senate,,DEM,Loretta L. Sanchez,151
+Santa Cruz,31511,U.S. Senate,,DEM,Kamala D. Harris,0
+Santa Cruz,31511,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Santa Cruz,31530,U.S. Senate,,DEM,Kamala D. Harris,719
+Santa Cruz,31530,U.S. Senate,,DEM,Loretta L. Sanchez,205
+Santa Cruz,31560,U.S. Senate,,DEM,Kamala D. Harris,531
+Santa Cruz,31560,U.S. Senate,,DEM,Loretta L. Sanchez,140
+Santa Cruz,31580,U.S. Senate,,DEM,Kamala D. Harris,440
+Santa Cruz,31580,U.S. Senate,,DEM,Loretta L. Sanchez,136
+Santa Cruz,31600,U.S. Senate,,DEM,Kamala D. Harris,344
+Santa Cruz,31600,U.S. Senate,,DEM,Loretta L. Sanchez,287
+Santa Cruz,31610,U.S. Senate,,DEM,Kamala D. Harris,204
+Santa Cruz,31610,U.S. Senate,,DEM,Loretta L. Sanchez,188
+Santa Cruz,31630,U.S. Senate,,DEM,Kamala D. Harris,176
+Santa Cruz,31630,U.S. Senate,,DEM,Loretta L. Sanchez,160
+Santa Cruz,31650,U.S. Senate,,DEM,Kamala D. Harris,284
+Santa Cruz,31650,U.S. Senate,,DEM,Loretta L. Sanchez,220
+Santa Cruz,31690,U.S. Senate,,DEM,Kamala D. Harris,190
+Santa Cruz,31690,U.S. Senate,,DEM,Loretta L. Sanchez,168
+Santa Cruz,31710,U.S. Senate,,DEM,Kamala D. Harris,721
+Santa Cruz,31710,U.S. Senate,,DEM,Loretta L. Sanchez,215
+Santa Cruz,40010,U.S. Senate,,DEM,Kamala D. Harris,22
+Santa Cruz,40010,U.S. Senate,,DEM,Loretta L. Sanchez,24
+Santa Cruz,40071,U.S. Senate,,DEM,Kamala D. Harris,448
+Santa Cruz,40071,U.S. Senate,,DEM,Loretta L. Sanchez,270
+Santa Cruz,40161,U.S. Senate,,DEM,Kamala D. Harris,615
+Santa Cruz,40161,U.S. Senate,,DEM,Loretta L. Sanchez,534
+Santa Cruz,40162,U.S. Senate,,DEM,Kamala D. Harris,269
+Santa Cruz,40162,U.S. Senate,,DEM,Loretta L. Sanchez,165
+Santa Cruz,40221,U.S. Senate,,DEM,Kamala D. Harris,0
+Santa Cruz,40221,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Santa Cruz,40230,U.S. Senate,,DEM,Kamala D. Harris,21
+Santa Cruz,40230,U.S. Senate,,DEM,Loretta L. Sanchez,16
+Santa Cruz,40270,U.S. Senate,,DEM,Kamala D. Harris,287
+Santa Cruz,40270,U.S. Senate,,DEM,Loretta L. Sanchez,171
+Santa Cruz,40310,U.S. Senate,,DEM,Kamala D. Harris,0
+Santa Cruz,40310,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Santa Cruz,43100,U.S. Senate,,DEM,Kamala D. Harris,219
+Santa Cruz,43100,U.S. Senate,,DEM,Loretta L. Sanchez,347
+Santa Cruz,43110,U.S. Senate,,DEM,Kamala D. Harris,329
+Santa Cruz,43110,U.S. Senate,,DEM,Loretta L. Sanchez,283
+Santa Cruz,43200,U.S. Senate,,DEM,Kamala D. Harris,370
+Santa Cruz,43200,U.S. Senate,,DEM,Loretta L. Sanchez,299
+Santa Cruz,43220,U.S. Senate,,DEM,Kamala D. Harris,242
+Santa Cruz,43220,U.S. Senate,,DEM,Loretta L. Sanchez,348
+Santa Cruz,43260,U.S. Senate,,DEM,Kamala D. Harris,33
+Santa Cruz,43260,U.S. Senate,,DEM,Loretta L. Sanchez,45
+Santa Cruz,43410,U.S. Senate,,DEM,Kamala D. Harris,592
+Santa Cruz,43410,U.S. Senate,,DEM,Loretta L. Sanchez,448
+Santa Cruz,43441,U.S. Senate,,DEM,Kamala D. Harris,392
+Santa Cruz,43441,U.S. Senate,,DEM,Loretta L. Sanchez,268
+Santa Cruz,43501,U.S. Senate,,DEM,Kamala D. Harris,467
+Santa Cruz,43501,U.S. Senate,,DEM,Loretta L. Sanchez,316
+Santa Cruz,43540,U.S. Senate,,DEM,Kamala D. Harris,359
+Santa Cruz,43540,U.S. Senate,,DEM,Loretta L. Sanchez,368
+Santa Cruz,43610,U.S. Senate,,DEM,Kamala D. Harris,504
+Santa Cruz,43610,U.S. Senate,,DEM,Loretta L. Sanchez,417
+Santa Cruz,43621,U.S. Senate,,DEM,Kamala D. Harris,261
+Santa Cruz,43621,U.S. Senate,,DEM,Loretta L. Sanchez,162
+Santa Cruz,43631,U.S. Senate,,DEM,Kamala D. Harris,413
+Santa Cruz,43631,U.S. Senate,,DEM,Loretta L. Sanchez,284
+Santa Cruz,43710,U.S. Senate,,DEM,Kamala D. Harris,283
+Santa Cruz,43710,U.S. Senate,,DEM,Loretta L. Sanchez,167
+Santa Cruz,43711,U.S. Senate,,DEM,Kamala D. Harris,62
+Santa Cruz,43711,U.S. Senate,,DEM,Loretta L. Sanchez,42
+Santa Cruz,43731,U.S. Senate,,DEM,Kamala D. Harris,597
+Santa Cruz,43731,U.S. Senate,,DEM,Loretta L. Sanchez,373
+Santa Cruz,43732,U.S. Senate,,DEM,Kamala D. Harris,155
+Santa Cruz,43732,U.S. Senate,,DEM,Loretta L. Sanchez,104
+Santa Cruz,43741,U.S. Senate,,DEM,Kamala D. Harris,514
+Santa Cruz,43741,U.S. Senate,,DEM,Loretta L. Sanchez,146
+Santa Cruz,50011,U.S. Senate,,DEM,Kamala D. Harris,1
+Santa Cruz,50011,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Santa Cruz,50013,U.S. Senate,,DEM,Kamala D. Harris,0
+Santa Cruz,50013,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Santa Cruz,50014,U.S. Senate,,DEM,Kamala D. Harris,0
+Santa Cruz,50014,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Santa Cruz,50015,U.S. Senate,,DEM,Kamala D. Harris,1
+Santa Cruz,50015,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Santa Cruz,50017,U.S. Senate,,DEM,Kamala D. Harris,0
+Santa Cruz,50017,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Santa Cruz,50021,U.S. Senate,,DEM,Kamala D. Harris,384
+Santa Cruz,50021,U.S. Senate,,DEM,Loretta L. Sanchez,130
+Santa Cruz,50023,U.S. Senate,,DEM,Kamala D. Harris,507
+Santa Cruz,50023,U.S. Senate,,DEM,Loretta L. Sanchez,169
+Santa Cruz,50040,U.S. Senate,,DEM,Kamala D. Harris,445
+Santa Cruz,50040,U.S. Senate,,DEM,Loretta L. Sanchez,155
+Santa Cruz,50061,U.S. Senate,,DEM,Kamala D. Harris,352
+Santa Cruz,50061,U.S. Senate,,DEM,Loretta L. Sanchez,173
+Santa Cruz,50082,U.S. Senate,,DEM,Kamala D. Harris,16
+Santa Cruz,50082,U.S. Senate,,DEM,Loretta L. Sanchez,8
+Santa Cruz,50083,U.S. Senate,,DEM,Kamala D. Harris,7
+Santa Cruz,50083,U.S. Senate,,DEM,Loretta L. Sanchez,8
+Santa Cruz,50090,U.S. Senate,,DEM,Kamala D. Harris,0
+Santa Cruz,50090,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Santa Cruz,50091,U.S. Senate,,DEM,Kamala D. Harris,457
+Santa Cruz,50091,U.S. Senate,,DEM,Loretta L. Sanchez,149
+Santa Cruz,50092,U.S. Senate,,DEM,Kamala D. Harris,492
+Santa Cruz,50092,U.S. Senate,,DEM,Loretta L. Sanchez,188
+Santa Cruz,50093,U.S. Senate,,DEM,Kamala D. Harris,0
+Santa Cruz,50093,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Santa Cruz,50096,U.S. Senate,,DEM,Kamala D. Harris,3
+Santa Cruz,50096,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Santa Cruz,50102,U.S. Senate,,DEM,Kamala D. Harris,750
+Santa Cruz,50102,U.S. Senate,,DEM,Loretta L. Sanchez,270
+Santa Cruz,50111,U.S. Senate,,DEM,Kamala D. Harris,528
+Santa Cruz,50111,U.S. Senate,,DEM,Loretta L. Sanchez,234
+Santa Cruz,50112,U.S. Senate,,DEM,Kamala D. Harris,350
+Santa Cruz,50112,U.S. Senate,,DEM,Loretta L. Sanchez,116
+Santa Cruz,50115,U.S. Senate,,DEM,Kamala D. Harris,0
+Santa Cruz,50115,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Santa Cruz,50121,U.S. Senate,,DEM,Kamala D. Harris,646
+Santa Cruz,50121,U.S. Senate,,DEM,Loretta L. Sanchez,223
+Santa Cruz,50141,U.S. Senate,,DEM,Kamala D. Harris,630
+Santa Cruz,50141,U.S. Senate,,DEM,Loretta L. Sanchez,235
+Santa Cruz,50142,U.S. Senate,,DEM,Kamala D. Harris,0
+Santa Cruz,50142,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Santa Cruz,50144,U.S. Senate,,DEM,Kamala D. Harris,39
+Santa Cruz,50144,U.S. Senate,,DEM,Loretta L. Sanchez,11
+Santa Cruz,50146,U.S. Senate,,DEM,Kamala D. Harris,58
+Santa Cruz,50146,U.S. Senate,,DEM,Loretta L. Sanchez,19
+Santa Cruz,50148,U.S. Senate,,DEM,Kamala D. Harris,2
+Santa Cruz,50148,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Santa Cruz,50151,U.S. Senate,,DEM,Kamala D. Harris,0
+Santa Cruz,50151,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Santa Cruz,50154,U.S. Senate,,DEM,Kamala D. Harris,1
+Santa Cruz,50154,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Santa Cruz,50157,U.S. Senate,,DEM,Kamala D. Harris,472
+Santa Cruz,50157,U.S. Senate,,DEM,Loretta L. Sanchez,164
+Santa Cruz,50161,U.S. Senate,,DEM,Kamala D. Harris,805
+Santa Cruz,50161,U.S. Senate,,DEM,Loretta L. Sanchez,299
+Santa Cruz,50163,U.S. Senate,,DEM,Kamala D. Harris,17
+Santa Cruz,50163,U.S. Senate,,DEM,Loretta L. Sanchez,9
+Santa Cruz,50174,U.S. Senate,,DEM,Kamala D. Harris,1
+Santa Cruz,50174,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Santa Cruz,50181,U.S. Senate,,DEM,Kamala D. Harris,30
+Santa Cruz,50181,U.S. Senate,,DEM,Loretta L. Sanchez,12
+Santa Cruz,50183,U.S. Senate,,DEM,Kamala D. Harris,490
+Santa Cruz,50183,U.S. Senate,,DEM,Loretta L. Sanchez,163
+Santa Cruz,50191,U.S. Senate,,DEM,Kamala D. Harris,698
+Santa Cruz,50191,U.S. Senate,,DEM,Loretta L. Sanchez,250
+Santa Cruz,50202,U.S. Senate,,DEM,Kamala D. Harris,115
+Santa Cruz,50202,U.S. Senate,,DEM,Loretta L. Sanchez,49
+Santa Cruz,50203,U.S. Senate,,DEM,Kamala D. Harris,552
+Santa Cruz,50203,U.S. Senate,,DEM,Loretta L. Sanchez,188
+Santa Cruz,50204,U.S. Senate,,DEM,Kamala D. Harris,375
+Santa Cruz,50204,U.S. Senate,,DEM,Loretta L. Sanchez,153
+Santa Cruz,50211,U.S. Senate,,DEM,Kamala D. Harris,377
+Santa Cruz,50211,U.S. Senate,,DEM,Loretta L. Sanchez,164
+Santa Cruz,50221,U.S. Senate,,DEM,Kamala D. Harris,367
+Santa Cruz,50221,U.S. Senate,,DEM,Loretta L. Sanchez,122
+Santa Cruz,50222,U.S. Senate,,DEM,Kamala D. Harris,19
+Santa Cruz,50222,U.S. Senate,,DEM,Loretta L. Sanchez,7
+Santa Cruz,50224,U.S. Senate,,DEM,Kamala D. Harris,0
+Santa Cruz,50224,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Santa Cruz,50232,U.S. Senate,,DEM,Kamala D. Harris,311
+Santa Cruz,50232,U.S. Senate,,DEM,Loretta L. Sanchez,113
+Santa Cruz,50233,U.S. Senate,,DEM,Kamala D. Harris,54
+Santa Cruz,50233,U.S. Senate,,DEM,Loretta L. Sanchez,31
+Santa Cruz,50243,U.S. Senate,,DEM,Kamala D. Harris,3
+Santa Cruz,50243,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Santa Cruz,50250,U.S. Senate,,DEM,Kamala D. Harris,76
+Santa Cruz,50250,U.S. Senate,,DEM,Loretta L. Sanchez,42
+Santa Cruz,50263,U.S. Senate,,DEM,Kamala D. Harris,25
+Santa Cruz,50263,U.S. Senate,,DEM,Loretta L. Sanchez,9
+Santa Cruz,50265,U.S. Senate,,DEM,Kamala D. Harris,10
+Santa Cruz,50265,U.S. Senate,,DEM,Loretta L. Sanchez,5
+Santa Cruz,50273,U.S. Senate,,DEM,Kamala D. Harris,0
+Santa Cruz,50273,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Santa Cruz,50284,U.S. Senate,,DEM,Kamala D. Harris,3
+Santa Cruz,50284,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Santa Cruz,50302,U.S. Senate,,DEM,Kamala D. Harris,0
+Santa Cruz,50302,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Santa Cruz,50341,U.S. Senate,,DEM,Kamala D. Harris,295
+Santa Cruz,50341,U.S. Senate,,DEM,Loretta L. Sanchez,131
+Santa Cruz,50342,U.S. Senate,,DEM,Kamala D. Harris,8
+Santa Cruz,50342,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Santa Cruz,50344,U.S. Senate,,DEM,Kamala D. Harris,0
+Santa Cruz,50344,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Santa Cruz,50381,U.S. Senate,,DEM,Kamala D. Harris,200
+Santa Cruz,50381,U.S. Senate,,DEM,Loretta L. Sanchez,51
+Santa Cruz,50382,U.S. Senate,,DEM,Kamala D. Harris,208
+Santa Cruz,50382,U.S. Senate,,DEM,Loretta L. Sanchez,101
+Santa Cruz,50401,U.S. Senate,,DEM,Kamala D. Harris,420
+Santa Cruz,50401,U.S. Senate,,DEM,Loretta L. Sanchez,151
+Santa Cruz,50403,U.S. Senate,,DEM,Kamala D. Harris,0
+Santa Cruz,50403,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Santa Cruz,50415,U.S. Senate,,DEM,Kamala D. Harris,2
+Santa Cruz,50415,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Santa Cruz,50416,U.S. Senate,,DEM,Kamala D. Harris,0
+Santa Cruz,50416,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Santa Cruz,50453,U.S. Senate,,DEM,Kamala D. Harris,0
+Santa Cruz,50453,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Santa Cruz,50480,U.S. Senate,,DEM,Kamala D. Harris,304
+Santa Cruz,50480,U.S. Senate,,DEM,Loretta L. Sanchez,103
+Santa Cruz,50492,U.S. Senate,,DEM,Kamala D. Harris,48
+Santa Cruz,50492,U.S. Senate,,DEM,Loretta L. Sanchez,19
+Santa Cruz,50502,U.S. Senate,,DEM,Kamala D. Harris,0
+Santa Cruz,50502,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Santa Cruz,50503,U.S. Senate,,DEM,Kamala D. Harris,12
+Santa Cruz,50503,U.S. Senate,,DEM,Loretta L. Sanchez,7
+Santa Cruz,50507,U.S. Senate,,DEM,Kamala D. Harris,0
+Santa Cruz,50507,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Santa Cruz,50521,U.S. Senate,,DEM,Kamala D. Harris,258
+Santa Cruz,50521,U.S. Senate,,DEM,Loretta L. Sanchez,89
+Santa Cruz,50522,U.S. Senate,,DEM,Kamala D. Harris,123
+Santa Cruz,50522,U.S. Senate,,DEM,Loretta L. Sanchez,34
+Santa Cruz,50541,U.S. Senate,,DEM,Kamala D. Harris,129
+Santa Cruz,50541,U.S. Senate,,DEM,Loretta L. Sanchez,50
+Santa Cruz,51010,U.S. Senate,,DEM,Kamala D. Harris,342
+Santa Cruz,51010,U.S. Senate,,DEM,Loretta L. Sanchez,152
+Santa Cruz,51080,U.S. Senate,,DEM,Kamala D. Harris,854
+Santa Cruz,51080,U.S. Senate,,DEM,Loretta L. Sanchez,317
+Santa Cruz,51090,U.S. Senate,,DEM,Kamala D. Harris,915
+Santa Cruz,51090,U.S. Senate,,DEM,Loretta L. Sanchez,323
+Santa Cruz,51620,U.S. Senate,,DEM,Kamala D. Harris,163
+Santa Cruz,51620,U.S. Senate,,DEM,Loretta L. Sanchez,25
+Santa Cruz,51770,U.S. Senate,,DEM,Kamala D. Harris,288
+Santa Cruz,51770,U.S. Senate,,DEM,Loretta L. Sanchez,92
+Santa Cruz,54010,U.S. Senate,,DEM,Kamala D. Harris,544
+Santa Cruz,54010,U.S. Senate,,DEM,Loretta L. Sanchez,173
+Santa Cruz,54020,U.S. Senate,,DEM,Kamala D. Harris,294
+Santa Cruz,54020,U.S. Senate,,DEM,Loretta L. Sanchez,106
+Santa Cruz,54031,U.S. Senate,,DEM,Kamala D. Harris,588
+Santa Cruz,54031,U.S. Senate,,DEM,Loretta L. Sanchez,247
+Santa Cruz,54051,U.S. Senate,,DEM,Kamala D. Harris,822
+Santa Cruz,54051,U.S. Senate,,DEM,Loretta L. Sanchez,289
+Santa Cruz,54061,U.S. Senate,,DEM,Kamala D. Harris,469
+Santa Cruz,54061,U.S. Senate,,DEM,Loretta L. Sanchez,200
+Santa Cruz,54070,U.S. Senate,,DEM,Kamala D. Harris,658
+Santa Cruz,54070,U.S. Senate,,DEM,Loretta L. Sanchez,211
+Santa Cruz,54071,U.S. Senate,,DEM,Kamala D. Harris,4
+Santa Cruz,54071,U.S. Senate,,DEM,Loretta L. Sanchez,1

--- a/2016/20161108__ca__general__shasta__precinct.csv
+++ b/2016/20161108__ca__general__shasta__precinct.csv
@@ -4839,245 +4839,245 @@ Shasta,Westwood,Proposition 67,,N/A,Yes,166
 Shasta,Westwood,Proposition 67,,N/A,No,318
 Shasta,Whiskeytown,Proposition 67,,N/A,Yes,4
 Shasta,Whiskeytown,Proposition 67,,N/A,No,6
-Shasta,Airport1,U.S. Senate,,DEM,Kamala Harris,83
-Shasta,Airport1,U.S. Senate,,DEM,Loretta Sanchez,43
-Shasta,Airport2,U.S. Senate,,DEM,Kamala Harris,70
-Shasta,Airport2,U.S. Senate,,DEM,Loretta Sanchez,38
-Shasta,Anderson1,U.S. Senate,,DEM,Kamala Harris,281
-Shasta,Anderson1,U.S. Senate,,DEM,Loretta Sanchez,212
-Shasta,Anderson2,U.S. Senate,,DEM,Kamala Harris,330
-Shasta,Anderson2,U.S. Senate,,DEM,Loretta Sanchez,275
-Shasta,Anderson34,U.S. Senate,,DEM,Kamala Harris,363
-Shasta,Anderson34,U.S. Senate,,DEM,Loretta Sanchez,275
-Shasta,Anderson57,U.S. Senate,,DEM,Kamala Harris,173
-Shasta,Anderson57,U.S. Senate,,DEM,Loretta Sanchez,150
-Shasta,Anderson6,U.S. Senate,,DEM,Kamala Harris,280
-Shasta,Anderson6,U.S. Senate,,DEM,Loretta Sanchez,242
-Shasta,ArgyleEnt11Ent4,U.S. Senate,,DEM,Kamala Harris,467
-Shasta,ArgyleEnt11Ent4,U.S. Senate,,DEM,Loretta Sanchez,385
-Shasta,Atkins,U.S. Senate,,DEM,Kamala Harris,168
-Shasta,Atkins,U.S. Senate,,DEM,Loretta Sanchez,147
-Shasta,BallsFerry1,U.S. Senate,,DEM,Kamala Harris,313
-Shasta,BallsFerry1,U.S. Senate,,DEM,Loretta Sanchez,204
-Shasta,BallsFerry2BelleVue4,U.S. Senate,,DEM,Kamala Harris,76
-Shasta,BallsFerry2BelleVue4,U.S. Senate,,DEM,Loretta Sanchez,53
-Shasta,BellaVista1,U.S. Senate,,DEM,Kamala Harris,261
-Shasta,BellaVista1,U.S. Senate,,DEM,Loretta Sanchez,211
-Shasta,BellaVista23,U.S. Senate,,DEM,Kamala Harris,274
-Shasta,BellaVista23,U.S. Senate,,DEM,Loretta Sanchez,249
-Shasta,BelleVue1,U.S. Senate,,DEM,Kamala Harris,51
-Shasta,BelleVue1,U.S. Senate,,DEM,Loretta Sanchez,43
-Shasta,BelleVue2Prairie,U.S. Senate,,DEM,Kamala Harris,442
-Shasta,BelleVue2Prairie,U.S. Senate,,DEM,Loretta Sanchez,320
-Shasta,BelleVue3Redding8D,U.S. Senate,,DEM,Kamala Harris,50
-Shasta,BelleVue3Redding8D,U.S. Senate,,DEM,Loretta Sanchez,56
-Shasta,Bells2Redding6,U.S. Senate,,DEM,Kamala Harris,443
-Shasta,Bells2Redding6,U.S. Senate,,DEM,Loretta Sanchez,290
-Shasta,Bells4TexasSpringsRdng12,U.S. Senate,,DEM,Kamala Harris,12
-Shasta,Bells4TexasSpringsRdng12,U.S. Senate,,DEM,Loretta Sanchez,9
-Shasta,BendCdrCrkMontgomery,U.S. Senate,,DEM,Kamala Harris,238
-Shasta,BendCdrCrkMontgomery,U.S. Senate,,DEM,Loretta Sanchez,195
-Shasta,Benton,U.S. Senate,,DEM,Kamala Harris,50
-Shasta,Benton,U.S. Senate,,DEM,Loretta Sanchez,45
-Shasta,Bonnyview12,U.S. Senate,,DEM,Kamala Harris,361
-Shasta,Bonnyview12,U.S. Senate,,DEM,Loretta Sanchez,282
-Shasta,Bonnyview35,U.S. Senate,,DEM,Kamala Harris,346
-Shasta,Bonnyview35,U.S. Senate,,DEM,Loretta Sanchez,253
-Shasta,Bonnyview467,U.S. Senate,,DEM,Kamala Harris,352
-Shasta,Bonnyview467,U.S. Senate,,DEM,Loretta Sanchez,226
-Shasta,Buckeye123,U.S. Senate,,DEM,Kamala Harris,443
-Shasta,Buckeye123,U.S. Senate,,DEM,Loretta Sanchez,358
-Shasta,Burney12,U.S. Senate,,DEM,Kamala Harris,518
-Shasta,Burney12,U.S. Senate,,DEM,Loretta Sanchez,374
-Shasta,Castle,U.S. Senate,,DEM,Kamala Harris,75
-Shasta,Castle,U.S. Senate,,DEM,Loretta Sanchez,39
-Shasta,Centerville1,U.S. Senate,,DEM,Kamala Harris,294
-Shasta,Centerville1,U.S. Senate,,DEM,Loretta Sanchez,220
-Shasta,Centerville23,U.S. Senate,,DEM,Kamala Harris,327
-Shasta,Centerville23,U.S. Senate,,DEM,Loretta Sanchez,252
-Shasta,Centerville4Shasta2,U.S. Senate,,DEM,Kamala Harris,7
-Shasta,Centerville4Shasta2,U.S. Senate,,DEM,Loretta Sanchez,10
-Shasta,Cloverdale1,U.S. Senate,,DEM,Kamala Harris,197
-Shasta,Cloverdale1,U.S. Senate,,DEM,Loretta Sanchez,125
-Shasta,Cloverdale2,U.S. Senate,,DEM,Kamala Harris,510
-Shasta,Cloverdale2,U.S. Senate,,DEM,Loretta Sanchez,410
-Shasta,Columbia134,U.S. Senate,,DEM,Kamala Harris,462
-Shasta,Columbia134,U.S. Senate,,DEM,Loretta Sanchez,373
-Shasta,Columbia2,U.S. Senate,,DEM,Kamala Harris,4
-Shasta,Columbia2,U.S. Senate,,DEM,Loretta Sanchez,8
-Shasta,CottEast12,U.S. Senate,,DEM,Kamala Harris,383
-Shasta,CottEast12,U.S. Senate,,DEM,Loretta Sanchez,339
-Shasta,CottWest12,U.S. Senate,,DEM,Kamala Harris,453
-Shasta,CottWest12,U.S. Senate,,DEM,Loretta Sanchez,382
-Shasta,CountryHTS12Redding8C,U.S. Senate,,DEM,Kamala Harris,535
-Shasta,CountryHTS12Redding8C,U.S. Senate,,DEM,Loretta Sanchez,378
-Shasta,CrookFallsMcArthur,U.S. Senate,,DEM,Kamala Harris,377
-Shasta,CrookFallsMcArthur,U.S. Senate,,DEM,Loretta Sanchez,320
-Shasta,Delta,U.S. Senate,,DEM,Kamala Harris,266
-Shasta,Delta,U.S. Senate,,DEM,Loretta Sanchez,167
-Shasta,DiggerBaySummit,U.S. Senate,,DEM,Kamala Harris,2
-Shasta,DiggerBaySummit,U.S. Senate,,DEM,Loretta Sanchez,4
-Shasta,Dryden1,U.S. Senate,,DEM,Kamala Harris,256
-Shasta,Dryden1,U.S. Senate,,DEM,Loretta Sanchez,228
-Shasta,Dryden24,U.S. Senate,,DEM,Kamala Harris,476
-Shasta,Dryden24,U.S. Senate,,DEM,Loretta Sanchez,388
-Shasta,Dryden35,U.S. Senate,,DEM,Kamala Harris,370
-Shasta,Dryden35,U.S. Senate,,DEM,Loretta Sanchez,294
-Shasta,Elena,U.S. Senate,,DEM,Kamala Harris,46
-Shasta,Elena,U.S. Senate,,DEM,Loretta Sanchez,28
-Shasta,Ent1A,U.S. Senate,,DEM,Kamala Harris,190
-Shasta,Ent1A,U.S. Senate,,DEM,Loretta Sanchez,154
-Shasta,Ent1B9,U.S. Senate,,DEM,Kamala Harris,283
-Shasta,Ent1B9,U.S. Senate,,DEM,Loretta Sanchez,212
-Shasta,Ent1CMistletoe,U.S. Senate,,DEM,Kamala Harris,174
-Shasta,Ent1CMistletoe,U.S. Senate,,DEM,Loretta Sanchez,122
-Shasta,Ent1D10,U.S. Senate,,DEM,Kamala Harris,243
-Shasta,Ent1D10,U.S. Senate,,DEM,Loretta Sanchez,263
-Shasta,Ent1E2E,U.S. Senate,,DEM,Kamala Harris,404
-Shasta,Ent1E2E,U.S. Senate,,DEM,Loretta Sanchez,312
-Shasta,Ent2A2B2C,U.S. Senate,,DEM,Kamala Harris,413
-Shasta,Ent2A2B2C,U.S. Senate,,DEM,Loretta Sanchez,301
-Shasta,Ent3A,U.S. Senate,,DEM,Kamala Harris,37
-Shasta,Ent3A,U.S. Senate,,DEM,Loretta Sanchez,20
-Shasta,Ent3B,U.S. Senate,,DEM,Kamala Harris,1
-Shasta,Ent3B,U.S. Senate,,DEM,Loretta Sanchez,1
-Shasta,Ent3C3D,U.S. Senate,,DEM,Kamala Harris,13
-Shasta,Ent3C3D,U.S. Senate,,DEM,Loretta Sanchez,10
-Shasta,Ent56,U.S. Senate,,DEM,Kamala Harris,453
-Shasta,Ent56,U.S. Senate,,DEM,Loretta Sanchez,318
-Shasta,Ent78,U.S. Senate,,DEM,Kamala Harris,327
-Shasta,Ent78,U.S. Senate,,DEM,Loretta Sanchez,271
-Shasta,FairwayStillwater,U.S. Senate,,DEM,Kamala Harris,65
-Shasta,FairwayStillwater,U.S. Senate,,DEM,Loretta Sanchez,57
-Shasta,French,U.S. Senate,,DEM,Kamala Harris,102
-Shasta,French,U.S. Senate,,DEM,Loretta Sanchez,60
-Shasta,HammansPineGrove12,U.S. Senate,,DEM,Kamala Harris,400
-Shasta,HammansPineGrove12,U.S. Senate,,DEM,Loretta Sanchez,346
-Shasta,HarrisonOno2,U.S. Senate,,DEM,Kamala Harris,59
-Shasta,HarrisonOno2,U.S. Senate,,DEM,Loretta Sanchez,44
-Shasta,HatCreek,U.S. Senate,,DEM,Kamala Harris,136
-Shasta,HatCreek,U.S. Senate,,DEM,Loretta Sanchez,125
-Shasta,Hilltop,U.S. Senate,,DEM,Kamala Harris,291
-Shasta,Hilltop,U.S. Senate,,DEM,Loretta Sanchez,269
-Shasta,Igo1,U.S. Senate,,DEM,Kamala Harris,50
-Shasta,Igo1,U.S. Senate,,DEM,Loretta Sanchez,42
-Shasta,Igo23,U.S. Senate,,DEM,Kamala Harris,87
-Shasta,Igo23,U.S. Senate,,DEM,Loretta Sanchez,46
-Shasta,IronShasta1,U.S. Senate,,DEM,Kamala Harris,517
-Shasta,IronShasta1,U.S. Senate,,DEM,Loretta Sanchez,324
-Shasta,JohnsonPark,U.S. Senate,,DEM,Kamala Harris,154
-Shasta,JohnsonPark,U.S. Senate,,DEM,Loretta Sanchez,117
-Shasta,JonesValley,U.S. Senate,,DEM,Kamala Harris,149
-Shasta,JonesValley,U.S. Senate,,DEM,Loretta Sanchez,127
-Shasta,Junction1,U.S. Senate,,DEM,Kamala Harris,263
-Shasta,Junction1,U.S. Senate,,DEM,Loretta Sanchez,248
-Shasta,Junction23,U.S. Senate,,DEM,Kamala Harris,329
-Shasta,Junction23,U.S. Senate,,DEM,Loretta Sanchez,266
-Shasta,LakeReddingRedding17,U.S. Senate,,DEM,Kamala Harris,581
-Shasta,LakeReddingRedding17,U.S. Senate,,DEM,Loretta Sanchez,395
-Shasta,MaryLake12Redding43,U.S. Senate,,DEM,Kamala Harris,478
-Shasta,MaryLake12Redding43,U.S. Senate,,DEM,Loretta Sanchez,344
-Shasta,Millville123,U.S. Senate,,DEM,Kamala Harris,347
-Shasta,Millville123,U.S. Senate,,DEM,Loretta Sanchez,245
-Shasta,Mistletoe12,U.S. Senate,,DEM,Kamala Harris,351
-Shasta,Mistletoe12,U.S. Senate,,DEM,Loretta Sanchez,251
-Shasta,Mistletoe35,U.S. Senate,,DEM,Kamala Harris,298
-Shasta,Mistletoe35,U.S. Senate,,DEM,Loretta Sanchez,215
-Shasta,Morley,U.S. Senate,,DEM,Kamala Harris,127
-Shasta,Morley,U.S. Senate,,DEM,Loretta Sanchez,103
-Shasta,MountainGate123Bass12,U.S. Senate,,DEM,Kamala Harris,340
-Shasta,MountainGate123Bass12,U.S. Senate,,DEM,Loretta Sanchez,266
-Shasta,NorthCowCreek12,U.S. Senate,,DEM,Kamala Harris,382
-Shasta,NorthCowCreek12,U.S. Senate,,DEM,Loretta Sanchez,246
-Shasta,Olinda12,U.S. Senate,,DEM,Kamala Harris,379
-Shasta,Olinda12,U.S. Senate,,DEM,Loretta Sanchez,301
-Shasta,Ono1,U.S. Senate,,DEM,Kamala Harris,33
-Shasta,Ono1,U.S. Senate,,DEM,Loretta Sanchez,35
-Shasta,Pacheco128,U.S. Senate,,DEM,Kamala Harris,411
-Shasta,Pacheco128,U.S. Senate,,DEM,Loretta Sanchez,346
-Shasta,Pacheco3,U.S. Senate,,DEM,Kamala Harris,176
-Shasta,Pacheco3,U.S. Senate,,DEM,Loretta Sanchez,153
-Shasta,Pacheco4,U.S. Senate,,DEM,Kamala Harris,78
-Shasta,Pacheco4,U.S. Senate,,DEM,Loretta Sanchez,55
-Shasta,Pacheco56Rancho1,U.S. Senate,,DEM,Kamala Harris,10
-Shasta,Pacheco56Rancho1,U.S. Senate,,DEM,Loretta Sanchez,10
-Shasta,Pacheco7,U.S. Senate,,DEM,Kamala Harris,37
-Shasta,Pacheco7,U.S. Senate,,DEM,Loretta Sanchez,31
-Shasta,Redding113739,U.S. Senate,,DEM,Kamala Harris,87
-Shasta,Redding113739,U.S. Senate,,DEM,Loretta Sanchez,46
-Shasta,Redding123,U.S. Senate,,DEM,Kamala Harris,621
-Shasta,Redding123,U.S. Senate,,DEM,Loretta Sanchez,391
-Shasta,Redding1415,U.S. Senate,,DEM,Kamala Harris,542
-Shasta,Redding1415,U.S. Senate,,DEM,Loretta Sanchez,331
-Shasta,Redding16,U.S. Senate,,DEM,Kamala Harris,267
-Shasta,Redding16,U.S. Senate,,DEM,Loretta Sanchez,196
-Shasta,Redding18A18B42,U.S. Senate,,DEM,Kamala Harris,680
-Shasta,Redding18A18B42,U.S. Senate,,DEM,Loretta Sanchez,532
-Shasta,Redding19,U.S. Senate,,DEM,Kamala Harris,376
-Shasta,Redding19,U.S. Senate,,DEM,Loretta Sanchez,203
-Shasta,Redding2040,U.S. Senate,,DEM,Kamala Harris,319
-Shasta,Redding2040,U.S. Senate,,DEM,Loretta Sanchez,279
-Shasta,Redding21,U.S. Senate,,DEM,Kamala Harris,39
-Shasta,Redding21,U.S. Senate,,DEM,Loretta Sanchez,36
-Shasta,Redding2426,U.S. Senate,,DEM,Kamala Harris,532
-Shasta,Redding2426,U.S. Senate,,DEM,Loretta Sanchez,332
-Shasta,Redding25,U.S. Senate,,DEM,Kamala Harris,327
-Shasta,Redding25,U.S. Senate,,DEM,Loretta Sanchez,221
-Shasta,Redding272829,U.S. Senate,,DEM,Kamala Harris,526
-Shasta,Redding272829,U.S. Senate,,DEM,Loretta Sanchez,409
-Shasta,Redding30,U.S. Senate,,DEM,Kamala Harris,54
-Shasta,Redding30,U.S. Senate,,DEM,Loretta Sanchez,34
-Shasta,Redding31,U.S. Senate,,DEM,Kamala Harris,172
-Shasta,Redding31,U.S. Senate,,DEM,Loretta Sanchez,153
-Shasta,Redding32343638,U.S. Senate,,DEM,Kamala Harris,499
-Shasta,Redding32343638,U.S. Senate,,DEM,Loretta Sanchez,385
-Shasta,Redding3339,U.S. Senate,,DEM,Kamala Harris,39
-Shasta,Redding3339,U.S. Senate,,DEM,Loretta Sanchez,30
-Shasta,Redding744,U.S. Senate,,DEM,Kamala Harris,7
-Shasta,Redding744,U.S. Senate,,DEM,Loretta Sanchez,5
-Shasta,Redding8A,U.S. Senate,,DEM,Kamala Harris,300
-Shasta,Redding8A,U.S. Senate,,DEM,Loretta Sanchez,223
-Shasta,Redding8B35,U.S. Senate,,DEM,Kamala Harris,437
-Shasta,Redding8B35,U.S. Senate,,DEM,Loretta Sanchez,287
-Shasta,Redding8E41,U.S. Senate,,DEM,Kamala Harris,15
-Shasta,Redding8E41,U.S. Senate,,DEM,Loretta Sanchez,12
-Shasta,Redding91013,U.S. Senate,,DEM,Kamala Harris,528
-Shasta,Redding91013,U.S. Senate,,DEM,Loretta Sanchez,413
-Shasta,ShastaLake1,U.S. Senate,,DEM,Kamala Harris,0
-Shasta,ShastaLake1,U.S. Senate,,DEM,Loretta Sanchez,0
-Shasta,ShastaLake2,U.S. Senate,,DEM,Kamala Harris,23
-Shasta,ShastaLake2,U.S. Senate,,DEM,Loretta Sanchez,21
-Shasta,ShastaLake37,U.S. Senate,,DEM,Kamala Harris,269
-Shasta,ShastaLake37,U.S. Senate,,DEM,Loretta Sanchez,240
-Shasta,ShastaLake4,U.S. Senate,,DEM,Kamala Harris,263
-Shasta,ShastaLake4,U.S. Senate,,DEM,Loretta Sanchez,182
-Shasta,ShastaLake5,U.S. Senate,,DEM,Kamala Harris,396
-Shasta,ShastaLake5,U.S. Senate,,DEM,Loretta Sanchez,304
-Shasta,ShastaLake68,U.S. Senate,,DEM,Kamala Harris,439
-Shasta,ShastaLake68,U.S. Senate,,DEM,Loretta Sanchez,362
-Shasta,ShastaLake9,U.S. Senate,,DEM,Kamala Harris,302
-Shasta,ShastaLake9,U.S. Senate,,DEM,Loretta Sanchez,222
-Shasta,ShastaView12,U.S. Senate,,DEM,Kamala Harris,357
-Shasta,ShastaView12,U.S. Senate,,DEM,Loretta Sanchez,269
-Shasta,Sheldon,U.S. Senate,,DEM,Kamala Harris,205
-Shasta,Sheldon,U.S. Senate,,DEM,Loretta Sanchez,198
-Shasta,Shingletown12,U.S. Senate,,DEM,Kamala Harris,511
-Shasta,Shingletown12,U.S. Senate,,DEM,Loretta Sanchez,461
-Shasta,Shingletown3,U.S. Senate,,DEM,Kamala Harris,392
-Shasta,Shingletown3,U.S. Senate,,DEM,Loretta Sanchez,263
-Shasta,TierraOaks,U.S. Senate,,DEM,Kamala Harris,55
-Shasta,TierraOaks,U.S. Senate,,DEM,Loretta Sanchez,46
-Shasta,VerdeVale,U.S. Senate,,DEM,Kamala Harris,332
-Shasta,VerdeVale,U.S. Senate,,DEM,Loretta Sanchez,260
-Shasta,Vineyard,U.S. Senate,,DEM,Kamala Harris,97
-Shasta,Vineyard,U.S. Senate,,DEM,Loretta Sanchez,67
-Shasta,WRanches1,U.S. Senate,,DEM,Kamala Harris,195
-Shasta,WRanches1,U.S. Senate,,DEM,Loretta Sanchez,145
-Shasta,WRanches23,U.S. Senate,,DEM,Kamala Harris,445
-Shasta,WRanches23,U.S. Senate,,DEM,Loretta Sanchez,414
-Shasta,WestValley12,U.S. Senate,,DEM,Kamala Harris,361
-Shasta,WestValley12,U.S. Senate,,DEM,Loretta Sanchez,293
-Shasta,Westwood,U.S. Senate,,DEM,Kamala Harris,210
-Shasta,Westwood,U.S. Senate,,DEM,Loretta Sanchez,148
-Shasta,Whiskeytown,U.S. Senate,,DEM,Kamala Harris,5
-Shasta,Whiskeytown,U.S. Senate,,DEM,Loretta Sanchez,5
+Shasta,Airport1,U.S. Senate,,DEM,Kamala D. Harris,83
+Shasta,Airport1,U.S. Senate,,DEM,Loretta L. Sanchez,43
+Shasta,Airport2,U.S. Senate,,DEM,Kamala D. Harris,70
+Shasta,Airport2,U.S. Senate,,DEM,Loretta L. Sanchez,38
+Shasta,Anderson1,U.S. Senate,,DEM,Kamala D. Harris,281
+Shasta,Anderson1,U.S. Senate,,DEM,Loretta L. Sanchez,212
+Shasta,Anderson2,U.S. Senate,,DEM,Kamala D. Harris,330
+Shasta,Anderson2,U.S. Senate,,DEM,Loretta L. Sanchez,275
+Shasta,Anderson34,U.S. Senate,,DEM,Kamala D. Harris,363
+Shasta,Anderson34,U.S. Senate,,DEM,Loretta L. Sanchez,275
+Shasta,Anderson57,U.S. Senate,,DEM,Kamala D. Harris,173
+Shasta,Anderson57,U.S. Senate,,DEM,Loretta L. Sanchez,150
+Shasta,Anderson6,U.S. Senate,,DEM,Kamala D. Harris,280
+Shasta,Anderson6,U.S. Senate,,DEM,Loretta L. Sanchez,242
+Shasta,ArgyleEnt11Ent4,U.S. Senate,,DEM,Kamala D. Harris,467
+Shasta,ArgyleEnt11Ent4,U.S. Senate,,DEM,Loretta L. Sanchez,385
+Shasta,Atkins,U.S. Senate,,DEM,Kamala D. Harris,168
+Shasta,Atkins,U.S. Senate,,DEM,Loretta L. Sanchez,147
+Shasta,BallsFerry1,U.S. Senate,,DEM,Kamala D. Harris,313
+Shasta,BallsFerry1,U.S. Senate,,DEM,Loretta L. Sanchez,204
+Shasta,BallsFerry2BelleVue4,U.S. Senate,,DEM,Kamala D. Harris,76
+Shasta,BallsFerry2BelleVue4,U.S. Senate,,DEM,Loretta L. Sanchez,53
+Shasta,BellaVista1,U.S. Senate,,DEM,Kamala D. Harris,261
+Shasta,BellaVista1,U.S. Senate,,DEM,Loretta L. Sanchez,211
+Shasta,BellaVista23,U.S. Senate,,DEM,Kamala D. Harris,274
+Shasta,BellaVista23,U.S. Senate,,DEM,Loretta L. Sanchez,249
+Shasta,BelleVue1,U.S. Senate,,DEM,Kamala D. Harris,51
+Shasta,BelleVue1,U.S. Senate,,DEM,Loretta L. Sanchez,43
+Shasta,BelleVue2Prairie,U.S. Senate,,DEM,Kamala D. Harris,442
+Shasta,BelleVue2Prairie,U.S. Senate,,DEM,Loretta L. Sanchez,320
+Shasta,BelleVue3Redding8D,U.S. Senate,,DEM,Kamala D. Harris,50
+Shasta,BelleVue3Redding8D,U.S. Senate,,DEM,Loretta L. Sanchez,56
+Shasta,Bells2Redding6,U.S. Senate,,DEM,Kamala D. Harris,443
+Shasta,Bells2Redding6,U.S. Senate,,DEM,Loretta L. Sanchez,290
+Shasta,Bells4TexasSpringsRdng12,U.S. Senate,,DEM,Kamala D. Harris,12
+Shasta,Bells4TexasSpringsRdng12,U.S. Senate,,DEM,Loretta L. Sanchez,9
+Shasta,BendCdrCrkMontgomery,U.S. Senate,,DEM,Kamala D. Harris,238
+Shasta,BendCdrCrkMontgomery,U.S. Senate,,DEM,Loretta L. Sanchez,195
+Shasta,Benton,U.S. Senate,,DEM,Kamala D. Harris,50
+Shasta,Benton,U.S. Senate,,DEM,Loretta L. Sanchez,45
+Shasta,Bonnyview12,U.S. Senate,,DEM,Kamala D. Harris,361
+Shasta,Bonnyview12,U.S. Senate,,DEM,Loretta L. Sanchez,282
+Shasta,Bonnyview35,U.S. Senate,,DEM,Kamala D. Harris,346
+Shasta,Bonnyview35,U.S. Senate,,DEM,Loretta L. Sanchez,253
+Shasta,Bonnyview467,U.S. Senate,,DEM,Kamala D. Harris,352
+Shasta,Bonnyview467,U.S. Senate,,DEM,Loretta L. Sanchez,226
+Shasta,Buckeye123,U.S. Senate,,DEM,Kamala D. Harris,443
+Shasta,Buckeye123,U.S. Senate,,DEM,Loretta L. Sanchez,358
+Shasta,Burney12,U.S. Senate,,DEM,Kamala D. Harris,518
+Shasta,Burney12,U.S. Senate,,DEM,Loretta L. Sanchez,374
+Shasta,Castle,U.S. Senate,,DEM,Kamala D. Harris,75
+Shasta,Castle,U.S. Senate,,DEM,Loretta L. Sanchez,39
+Shasta,Centerville1,U.S. Senate,,DEM,Kamala D. Harris,294
+Shasta,Centerville1,U.S. Senate,,DEM,Loretta L. Sanchez,220
+Shasta,Centerville23,U.S. Senate,,DEM,Kamala D. Harris,327
+Shasta,Centerville23,U.S. Senate,,DEM,Loretta L. Sanchez,252
+Shasta,Centerville4Shasta2,U.S. Senate,,DEM,Kamala D. Harris,7
+Shasta,Centerville4Shasta2,U.S. Senate,,DEM,Loretta L. Sanchez,10
+Shasta,Cloverdale1,U.S. Senate,,DEM,Kamala D. Harris,197
+Shasta,Cloverdale1,U.S. Senate,,DEM,Loretta L. Sanchez,125
+Shasta,Cloverdale2,U.S. Senate,,DEM,Kamala D. Harris,510
+Shasta,Cloverdale2,U.S. Senate,,DEM,Loretta L. Sanchez,410
+Shasta,Columbia134,U.S. Senate,,DEM,Kamala D. Harris,462
+Shasta,Columbia134,U.S. Senate,,DEM,Loretta L. Sanchez,373
+Shasta,Columbia2,U.S. Senate,,DEM,Kamala D. Harris,4
+Shasta,Columbia2,U.S. Senate,,DEM,Loretta L. Sanchez,8
+Shasta,CottEast12,U.S. Senate,,DEM,Kamala D. Harris,383
+Shasta,CottEast12,U.S. Senate,,DEM,Loretta L. Sanchez,339
+Shasta,CottWest12,U.S. Senate,,DEM,Kamala D. Harris,453
+Shasta,CottWest12,U.S. Senate,,DEM,Loretta L. Sanchez,382
+Shasta,CountryHTS12Redding8C,U.S. Senate,,DEM,Kamala D. Harris,535
+Shasta,CountryHTS12Redding8C,U.S. Senate,,DEM,Loretta L. Sanchez,378
+Shasta,CrookFallsMcArthur,U.S. Senate,,DEM,Kamala D. Harris,377
+Shasta,CrookFallsMcArthur,U.S. Senate,,DEM,Loretta L. Sanchez,320
+Shasta,Delta,U.S. Senate,,DEM,Kamala D. Harris,266
+Shasta,Delta,U.S. Senate,,DEM,Loretta L. Sanchez,167
+Shasta,DiggerBaySummit,U.S. Senate,,DEM,Kamala D. Harris,2
+Shasta,DiggerBaySummit,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Shasta,Dryden1,U.S. Senate,,DEM,Kamala D. Harris,256
+Shasta,Dryden1,U.S. Senate,,DEM,Loretta L. Sanchez,228
+Shasta,Dryden24,U.S. Senate,,DEM,Kamala D. Harris,476
+Shasta,Dryden24,U.S. Senate,,DEM,Loretta L. Sanchez,388
+Shasta,Dryden35,U.S. Senate,,DEM,Kamala D. Harris,370
+Shasta,Dryden35,U.S. Senate,,DEM,Loretta L. Sanchez,294
+Shasta,Elena,U.S. Senate,,DEM,Kamala D. Harris,46
+Shasta,Elena,U.S. Senate,,DEM,Loretta L. Sanchez,28
+Shasta,Ent1A,U.S. Senate,,DEM,Kamala D. Harris,190
+Shasta,Ent1A,U.S. Senate,,DEM,Loretta L. Sanchez,154
+Shasta,Ent1B9,U.S. Senate,,DEM,Kamala D. Harris,283
+Shasta,Ent1B9,U.S. Senate,,DEM,Loretta L. Sanchez,212
+Shasta,Ent1CMistletoe,U.S. Senate,,DEM,Kamala D. Harris,174
+Shasta,Ent1CMistletoe,U.S. Senate,,DEM,Loretta L. Sanchez,122
+Shasta,Ent1D10,U.S. Senate,,DEM,Kamala D. Harris,243
+Shasta,Ent1D10,U.S. Senate,,DEM,Loretta L. Sanchez,263
+Shasta,Ent1E2E,U.S. Senate,,DEM,Kamala D. Harris,404
+Shasta,Ent1E2E,U.S. Senate,,DEM,Loretta L. Sanchez,312
+Shasta,Ent2A2B2C,U.S. Senate,,DEM,Kamala D. Harris,413
+Shasta,Ent2A2B2C,U.S. Senate,,DEM,Loretta L. Sanchez,301
+Shasta,Ent3A,U.S. Senate,,DEM,Kamala D. Harris,37
+Shasta,Ent3A,U.S. Senate,,DEM,Loretta L. Sanchez,20
+Shasta,Ent3B,U.S. Senate,,DEM,Kamala D. Harris,1
+Shasta,Ent3B,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Shasta,Ent3C3D,U.S. Senate,,DEM,Kamala D. Harris,13
+Shasta,Ent3C3D,U.S. Senate,,DEM,Loretta L. Sanchez,10
+Shasta,Ent56,U.S. Senate,,DEM,Kamala D. Harris,453
+Shasta,Ent56,U.S. Senate,,DEM,Loretta L. Sanchez,318
+Shasta,Ent78,U.S. Senate,,DEM,Kamala D. Harris,327
+Shasta,Ent78,U.S. Senate,,DEM,Loretta L. Sanchez,271
+Shasta,FairwayStillwater,U.S. Senate,,DEM,Kamala D. Harris,65
+Shasta,FairwayStillwater,U.S. Senate,,DEM,Loretta L. Sanchez,57
+Shasta,French,U.S. Senate,,DEM,Kamala D. Harris,102
+Shasta,French,U.S. Senate,,DEM,Loretta L. Sanchez,60
+Shasta,HammansPineGrove12,U.S. Senate,,DEM,Kamala D. Harris,400
+Shasta,HammansPineGrove12,U.S. Senate,,DEM,Loretta L. Sanchez,346
+Shasta,HarrisonOno2,U.S. Senate,,DEM,Kamala D. Harris,59
+Shasta,HarrisonOno2,U.S. Senate,,DEM,Loretta L. Sanchez,44
+Shasta,HatCreek,U.S. Senate,,DEM,Kamala D. Harris,136
+Shasta,HatCreek,U.S. Senate,,DEM,Loretta L. Sanchez,125
+Shasta,Hilltop,U.S. Senate,,DEM,Kamala D. Harris,291
+Shasta,Hilltop,U.S. Senate,,DEM,Loretta L. Sanchez,269
+Shasta,Igo1,U.S. Senate,,DEM,Kamala D. Harris,50
+Shasta,Igo1,U.S. Senate,,DEM,Loretta L. Sanchez,42
+Shasta,Igo23,U.S. Senate,,DEM,Kamala D. Harris,87
+Shasta,Igo23,U.S. Senate,,DEM,Loretta L. Sanchez,46
+Shasta,IronShasta1,U.S. Senate,,DEM,Kamala D. Harris,517
+Shasta,IronShasta1,U.S. Senate,,DEM,Loretta L. Sanchez,324
+Shasta,JohnsonPark,U.S. Senate,,DEM,Kamala D. Harris,154
+Shasta,JohnsonPark,U.S. Senate,,DEM,Loretta L. Sanchez,117
+Shasta,JonesValley,U.S. Senate,,DEM,Kamala D. Harris,149
+Shasta,JonesValley,U.S. Senate,,DEM,Loretta L. Sanchez,127
+Shasta,Junction1,U.S. Senate,,DEM,Kamala D. Harris,263
+Shasta,Junction1,U.S. Senate,,DEM,Loretta L. Sanchez,248
+Shasta,Junction23,U.S. Senate,,DEM,Kamala D. Harris,329
+Shasta,Junction23,U.S. Senate,,DEM,Loretta L. Sanchez,266
+Shasta,LakeReddingRedding17,U.S. Senate,,DEM,Kamala D. Harris,581
+Shasta,LakeReddingRedding17,U.S. Senate,,DEM,Loretta L. Sanchez,395
+Shasta,MaryLake12Redding43,U.S. Senate,,DEM,Kamala D. Harris,478
+Shasta,MaryLake12Redding43,U.S. Senate,,DEM,Loretta L. Sanchez,344
+Shasta,Millville123,U.S. Senate,,DEM,Kamala D. Harris,347
+Shasta,Millville123,U.S. Senate,,DEM,Loretta L. Sanchez,245
+Shasta,Mistletoe12,U.S. Senate,,DEM,Kamala D. Harris,351
+Shasta,Mistletoe12,U.S. Senate,,DEM,Loretta L. Sanchez,251
+Shasta,Mistletoe35,U.S. Senate,,DEM,Kamala D. Harris,298
+Shasta,Mistletoe35,U.S. Senate,,DEM,Loretta L. Sanchez,215
+Shasta,Morley,U.S. Senate,,DEM,Kamala D. Harris,127
+Shasta,Morley,U.S. Senate,,DEM,Loretta L. Sanchez,103
+Shasta,MountainGate123Bass12,U.S. Senate,,DEM,Kamala D. Harris,340
+Shasta,MountainGate123Bass12,U.S. Senate,,DEM,Loretta L. Sanchez,266
+Shasta,NorthCowCreek12,U.S. Senate,,DEM,Kamala D. Harris,382
+Shasta,NorthCowCreek12,U.S. Senate,,DEM,Loretta L. Sanchez,246
+Shasta,Olinda12,U.S. Senate,,DEM,Kamala D. Harris,379
+Shasta,Olinda12,U.S. Senate,,DEM,Loretta L. Sanchez,301
+Shasta,Ono1,U.S. Senate,,DEM,Kamala D. Harris,33
+Shasta,Ono1,U.S. Senate,,DEM,Loretta L. Sanchez,35
+Shasta,Pacheco128,U.S. Senate,,DEM,Kamala D. Harris,411
+Shasta,Pacheco128,U.S. Senate,,DEM,Loretta L. Sanchez,346
+Shasta,Pacheco3,U.S. Senate,,DEM,Kamala D. Harris,176
+Shasta,Pacheco3,U.S. Senate,,DEM,Loretta L. Sanchez,153
+Shasta,Pacheco4,U.S. Senate,,DEM,Kamala D. Harris,78
+Shasta,Pacheco4,U.S. Senate,,DEM,Loretta L. Sanchez,55
+Shasta,Pacheco56Rancho1,U.S. Senate,,DEM,Kamala D. Harris,10
+Shasta,Pacheco56Rancho1,U.S. Senate,,DEM,Loretta L. Sanchez,10
+Shasta,Pacheco7,U.S. Senate,,DEM,Kamala D. Harris,37
+Shasta,Pacheco7,U.S. Senate,,DEM,Loretta L. Sanchez,31
+Shasta,Redding113739,U.S. Senate,,DEM,Kamala D. Harris,87
+Shasta,Redding113739,U.S. Senate,,DEM,Loretta L. Sanchez,46
+Shasta,Redding123,U.S. Senate,,DEM,Kamala D. Harris,621
+Shasta,Redding123,U.S. Senate,,DEM,Loretta L. Sanchez,391
+Shasta,Redding1415,U.S. Senate,,DEM,Kamala D. Harris,542
+Shasta,Redding1415,U.S. Senate,,DEM,Loretta L. Sanchez,331
+Shasta,Redding16,U.S. Senate,,DEM,Kamala D. Harris,267
+Shasta,Redding16,U.S. Senate,,DEM,Loretta L. Sanchez,196
+Shasta,Redding18A18B42,U.S. Senate,,DEM,Kamala D. Harris,680
+Shasta,Redding18A18B42,U.S. Senate,,DEM,Loretta L. Sanchez,532
+Shasta,Redding19,U.S. Senate,,DEM,Kamala D. Harris,376
+Shasta,Redding19,U.S. Senate,,DEM,Loretta L. Sanchez,203
+Shasta,Redding2040,U.S. Senate,,DEM,Kamala D. Harris,319
+Shasta,Redding2040,U.S. Senate,,DEM,Loretta L. Sanchez,279
+Shasta,Redding21,U.S. Senate,,DEM,Kamala D. Harris,39
+Shasta,Redding21,U.S. Senate,,DEM,Loretta L. Sanchez,36
+Shasta,Redding2426,U.S. Senate,,DEM,Kamala D. Harris,532
+Shasta,Redding2426,U.S. Senate,,DEM,Loretta L. Sanchez,332
+Shasta,Redding25,U.S. Senate,,DEM,Kamala D. Harris,327
+Shasta,Redding25,U.S. Senate,,DEM,Loretta L. Sanchez,221
+Shasta,Redding272829,U.S. Senate,,DEM,Kamala D. Harris,526
+Shasta,Redding272829,U.S. Senate,,DEM,Loretta L. Sanchez,409
+Shasta,Redding30,U.S. Senate,,DEM,Kamala D. Harris,54
+Shasta,Redding30,U.S. Senate,,DEM,Loretta L. Sanchez,34
+Shasta,Redding31,U.S. Senate,,DEM,Kamala D. Harris,172
+Shasta,Redding31,U.S. Senate,,DEM,Loretta L. Sanchez,153
+Shasta,Redding32343638,U.S. Senate,,DEM,Kamala D. Harris,499
+Shasta,Redding32343638,U.S. Senate,,DEM,Loretta L. Sanchez,385
+Shasta,Redding3339,U.S. Senate,,DEM,Kamala D. Harris,39
+Shasta,Redding3339,U.S. Senate,,DEM,Loretta L. Sanchez,30
+Shasta,Redding744,U.S. Senate,,DEM,Kamala D. Harris,7
+Shasta,Redding744,U.S. Senate,,DEM,Loretta L. Sanchez,5
+Shasta,Redding8A,U.S. Senate,,DEM,Kamala D. Harris,300
+Shasta,Redding8A,U.S. Senate,,DEM,Loretta L. Sanchez,223
+Shasta,Redding8B35,U.S. Senate,,DEM,Kamala D. Harris,437
+Shasta,Redding8B35,U.S. Senate,,DEM,Loretta L. Sanchez,287
+Shasta,Redding8E41,U.S. Senate,,DEM,Kamala D. Harris,15
+Shasta,Redding8E41,U.S. Senate,,DEM,Loretta L. Sanchez,12
+Shasta,Redding91013,U.S. Senate,,DEM,Kamala D. Harris,528
+Shasta,Redding91013,U.S. Senate,,DEM,Loretta L. Sanchez,413
+Shasta,ShastaLake1,U.S. Senate,,DEM,Kamala D. Harris,0
+Shasta,ShastaLake1,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Shasta,ShastaLake2,U.S. Senate,,DEM,Kamala D. Harris,23
+Shasta,ShastaLake2,U.S. Senate,,DEM,Loretta L. Sanchez,21
+Shasta,ShastaLake37,U.S. Senate,,DEM,Kamala D. Harris,269
+Shasta,ShastaLake37,U.S. Senate,,DEM,Loretta L. Sanchez,240
+Shasta,ShastaLake4,U.S. Senate,,DEM,Kamala D. Harris,263
+Shasta,ShastaLake4,U.S. Senate,,DEM,Loretta L. Sanchez,182
+Shasta,ShastaLake5,U.S. Senate,,DEM,Kamala D. Harris,396
+Shasta,ShastaLake5,U.S. Senate,,DEM,Loretta L. Sanchez,304
+Shasta,ShastaLake68,U.S. Senate,,DEM,Kamala D. Harris,439
+Shasta,ShastaLake68,U.S. Senate,,DEM,Loretta L. Sanchez,362
+Shasta,ShastaLake9,U.S. Senate,,DEM,Kamala D. Harris,302
+Shasta,ShastaLake9,U.S. Senate,,DEM,Loretta L. Sanchez,222
+Shasta,ShastaView12,U.S. Senate,,DEM,Kamala D. Harris,357
+Shasta,ShastaView12,U.S. Senate,,DEM,Loretta L. Sanchez,269
+Shasta,Sheldon,U.S. Senate,,DEM,Kamala D. Harris,205
+Shasta,Sheldon,U.S. Senate,,DEM,Loretta L. Sanchez,198
+Shasta,Shingletown12,U.S. Senate,,DEM,Kamala D. Harris,511
+Shasta,Shingletown12,U.S. Senate,,DEM,Loretta L. Sanchez,461
+Shasta,Shingletown3,U.S. Senate,,DEM,Kamala D. Harris,392
+Shasta,Shingletown3,U.S. Senate,,DEM,Loretta L. Sanchez,263
+Shasta,TierraOaks,U.S. Senate,,DEM,Kamala D. Harris,55
+Shasta,TierraOaks,U.S. Senate,,DEM,Loretta L. Sanchez,46
+Shasta,VerdeVale,U.S. Senate,,DEM,Kamala D. Harris,332
+Shasta,VerdeVale,U.S. Senate,,DEM,Loretta L. Sanchez,260
+Shasta,Vineyard,U.S. Senate,,DEM,Kamala D. Harris,97
+Shasta,Vineyard,U.S. Senate,,DEM,Loretta L. Sanchez,67
+Shasta,WRanches1,U.S. Senate,,DEM,Kamala D. Harris,195
+Shasta,WRanches1,U.S. Senate,,DEM,Loretta L. Sanchez,145
+Shasta,WRanches23,U.S. Senate,,DEM,Kamala D. Harris,445
+Shasta,WRanches23,U.S. Senate,,DEM,Loretta L. Sanchez,414
+Shasta,WestValley12,U.S. Senate,,DEM,Kamala D. Harris,361
+Shasta,WestValley12,U.S. Senate,,DEM,Loretta L. Sanchez,293
+Shasta,Westwood,U.S. Senate,,DEM,Kamala D. Harris,210
+Shasta,Westwood,U.S. Senate,,DEM,Loretta L. Sanchez,148
+Shasta,Whiskeytown,U.S. Senate,,DEM,Kamala D. Harris,5
+Shasta,Whiskeytown,U.S. Senate,,DEM,Loretta L. Sanchez,5

--- a/2016/20161108__ca__general__sierra__precinct.csv
+++ b/2016/20161108__ca__general__sierra__precinct.csv
@@ -879,47 +879,47 @@ Sierra,8,Proposition 67,,N/A,Yes,4
 Sierra,8,Proposition 67,,N/A,No,5
 Sierra,9,Proposition 67,,N/A,Yes,38
 Sierra,9,Proposition 67,,N/A,No,23
-Sierra,1,U.S. Senate,,DEM,Kamala Harris,56
-Sierra,1,U.S. Senate,,DEM,Loretta Sanchez,47
-Sierra,10,U.S. Senate,,DEM,Kamala Harris,4
-Sierra,10,U.S. Senate,,DEM,Loretta Sanchez,0
-Sierra,11,U.S. Senate,,DEM,Kamala Harris,27
-Sierra,11,U.S. Senate,,DEM,Loretta Sanchez,22
-Sierra,12,U.S. Senate,,DEM,Kamala Harris,75
-Sierra,12,U.S. Senate,,DEM,Loretta Sanchez,40
-Sierra,13,U.S. Senate,,DEM,Kamala Harris,17
-Sierra,13,U.S. Senate,,DEM,Loretta Sanchez,8
-Sierra,14,U.S. Senate,,DEM,Kamala Harris,82
-Sierra,14,U.S. Senate,,DEM,Loretta Sanchez,28
-Sierra,15,U.S. Senate,,DEM,Kamala Harris,26
-Sierra,15,U.S. Senate,,DEM,Loretta Sanchez,15
-Sierra,16,U.S. Senate,,DEM,Kamala Harris,47
-Sierra,16,U.S. Senate,,DEM,Loretta Sanchez,41
-Sierra,17,U.S. Senate,,DEM,Kamala Harris,68
-Sierra,17,U.S. Senate,,DEM,Loretta Sanchez,35
-Sierra,18,U.S. Senate,,DEM,Kamala Harris,29
-Sierra,18,U.S. Senate,,DEM,Loretta Sanchez,7
-Sierra,19,U.S. Senate,,DEM,Kamala Harris,4
-Sierra,19,U.S. Senate,,DEM,Loretta Sanchez,1
-Sierra,2,U.S. Senate,,DEM,Kamala Harris,31
-Sierra,2,U.S. Senate,,DEM,Loretta Sanchez,10
-Sierra,20,U.S. Senate,,DEM,Kamala Harris,7
-Sierra,20,U.S. Senate,,DEM,Loretta Sanchez,7
-Sierra,21,U.S. Senate,,DEM,Kamala Harris,43
-Sierra,21,U.S. Senate,,DEM,Loretta Sanchez,24
-Sierra,22,U.S. Senate,,DEM,Kamala Harris,60
-Sierra,22,U.S. Senate,,DEM,Loretta Sanchez,27
-Sierra,3,U.S. Senate,,DEM,Kamala Harris,34
-Sierra,3,U.S. Senate,,DEM,Loretta Sanchez,12
-Sierra,4,U.S. Senate,,DEM,Kamala Harris,20
-Sierra,4,U.S. Senate,,DEM,Loretta Sanchez,16
-Sierra,5,U.S. Senate,,DEM,Kamala Harris,55
-Sierra,5,U.S. Senate,,DEM,Loretta Sanchez,37
-Sierra,6,U.S. Senate,,DEM,Kamala Harris,54
-Sierra,6,U.S. Senate,,DEM,Loretta Sanchez,22
-Sierra,7,U.S. Senate,,DEM,Kamala Harris,52
-Sierra,7,U.S. Senate,,DEM,Loretta Sanchez,24
-Sierra,8,U.S. Senate,,DEM,Kamala Harris,3
-Sierra,8,U.S. Senate,,DEM,Loretta Sanchez,5
-Sierra,9,U.S. Senate,,DEM,Kamala Harris,32
-Sierra,9,U.S. Senate,,DEM,Loretta Sanchez,14
+Sierra,1,U.S. Senate,,DEM,Kamala D. Harris,56
+Sierra,1,U.S. Senate,,DEM,Loretta L. Sanchez,47
+Sierra,10,U.S. Senate,,DEM,Kamala D. Harris,4
+Sierra,10,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sierra,11,U.S. Senate,,DEM,Kamala D. Harris,27
+Sierra,11,U.S. Senate,,DEM,Loretta L. Sanchez,22
+Sierra,12,U.S. Senate,,DEM,Kamala D. Harris,75
+Sierra,12,U.S. Senate,,DEM,Loretta L. Sanchez,40
+Sierra,13,U.S. Senate,,DEM,Kamala D. Harris,17
+Sierra,13,U.S. Senate,,DEM,Loretta L. Sanchez,8
+Sierra,14,U.S. Senate,,DEM,Kamala D. Harris,82
+Sierra,14,U.S. Senate,,DEM,Loretta L. Sanchez,28
+Sierra,15,U.S. Senate,,DEM,Kamala D. Harris,26
+Sierra,15,U.S. Senate,,DEM,Loretta L. Sanchez,15
+Sierra,16,U.S. Senate,,DEM,Kamala D. Harris,47
+Sierra,16,U.S. Senate,,DEM,Loretta L. Sanchez,41
+Sierra,17,U.S. Senate,,DEM,Kamala D. Harris,68
+Sierra,17,U.S. Senate,,DEM,Loretta L. Sanchez,35
+Sierra,18,U.S. Senate,,DEM,Kamala D. Harris,29
+Sierra,18,U.S. Senate,,DEM,Loretta L. Sanchez,7
+Sierra,19,U.S. Senate,,DEM,Kamala D. Harris,4
+Sierra,19,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Sierra,2,U.S. Senate,,DEM,Kamala D. Harris,31
+Sierra,2,U.S. Senate,,DEM,Loretta L. Sanchez,10
+Sierra,20,U.S. Senate,,DEM,Kamala D. Harris,7
+Sierra,20,U.S. Senate,,DEM,Loretta L. Sanchez,7
+Sierra,21,U.S. Senate,,DEM,Kamala D. Harris,43
+Sierra,21,U.S. Senate,,DEM,Loretta L. Sanchez,24
+Sierra,22,U.S. Senate,,DEM,Kamala D. Harris,60
+Sierra,22,U.S. Senate,,DEM,Loretta L. Sanchez,27
+Sierra,3,U.S. Senate,,DEM,Kamala D. Harris,34
+Sierra,3,U.S. Senate,,DEM,Loretta L. Sanchez,12
+Sierra,4,U.S. Senate,,DEM,Kamala D. Harris,20
+Sierra,4,U.S. Senate,,DEM,Loretta L. Sanchez,16
+Sierra,5,U.S. Senate,,DEM,Kamala D. Harris,55
+Sierra,5,U.S. Senate,,DEM,Loretta L. Sanchez,37
+Sierra,6,U.S. Senate,,DEM,Kamala D. Harris,54
+Sierra,6,U.S. Senate,,DEM,Loretta L. Sanchez,22
+Sierra,7,U.S. Senate,,DEM,Kamala D. Harris,52
+Sierra,7,U.S. Senate,,DEM,Loretta L. Sanchez,24
+Sierra,8,U.S. Senate,,DEM,Kamala D. Harris,3
+Sierra,8,U.S. Senate,,DEM,Loretta L. Sanchez,5
+Sierra,9,U.S. Senate,,DEM,Kamala D. Harris,32
+Sierra,9,U.S. Senate,,DEM,Loretta L. Sanchez,14

--- a/2016/20161108__ca__general__siskiyou__precinct.csv
+++ b/2016/20161108__ca__general__siskiyou__precinct.csv
@@ -2159,111 +2159,111 @@ Siskiyou,P5107,Proposition 67,,N/A,Yes,105
 Siskiyou,P5107,Proposition 67,,N/A,No,176
 Siskiyou,WEED,Proposition 67,,N/A,Yes,328
 Siskiyou,WEED,Proposition 67,,N/A,No,449
-Siskiyou,CON1,U.S. Senate,,DEM,Kamala Harris,377
-Siskiyou,CON1,U.S. Senate,,DEM,Loretta Sanchez,343
-Siskiyou,M1001,U.S. Senate,,DEM,Kamala Harris,73
-Siskiyou,M1001,U.S. Senate,,DEM,Loretta Sanchez,63
-Siskiyou,M1009,U.S. Senate,,DEM,Kamala Harris,74
-Siskiyou,M1009,U.S. Senate,,DEM,Loretta Sanchez,33
-Siskiyou,M1020,U.S. Senate,,DEM,Kamala Harris,42
-Siskiyou,M1020,U.S. Senate,,DEM,Loretta Sanchez,21
-Siskiyou,M1023,U.S. Senate,,DEM,Kamala Harris,59
-Siskiyou,M1023,U.S. Senate,,DEM,Loretta Sanchez,58
-Siskiyou,M1060,U.S. Senate,,DEM,Kamala Harris,95
-Siskiyou,M1060,U.S. Senate,,DEM,Loretta Sanchez,37
-Siskiyou,M1065,U.S. Senate,,DEM,Kamala Harris,30
-Siskiyou,M1065,U.S. Senate,,DEM,Loretta Sanchez,24
-Siskiyou,M1070,U.S. Senate,,DEM,Kamala Harris,66
-Siskiyou,M1070,U.S. Senate,,DEM,Loretta Sanchez,65
-Siskiyou,M1117,U.S. Senate,,DEM,Kamala Harris,83
-Siskiyou,M1117,U.S. Senate,,DEM,Loretta Sanchez,58
-Siskiyou,M2009,U.S. Senate,,DEM,Kamala Harris,92
-Siskiyou,M2009,U.S. Senate,,DEM,Loretta Sanchez,83
-Siskiyou,M3013,U.S. Senate,,DEM,Kamala Harris,78
-Siskiyou,M3013,U.S. Senate,,DEM,Loretta Sanchez,65
-Siskiyou,M3065,U.S. Senate,,DEM,Kamala Harris,55
-Siskiyou,M3065,U.S. Senate,,DEM,Loretta Sanchez,50
-Siskiyou,M4060,U.S. Senate,,DEM,Kamala Harris,51
-Siskiyou,M4060,U.S. Senate,,DEM,Loretta Sanchez,59
-Siskiyou,M4065,U.S. Senate,,DEM,Kamala Harris,68
-Siskiyou,M4065,U.S. Senate,,DEM,Loretta Sanchez,58
-Siskiyou,M5018,U.S. Senate,,DEM,Kamala Harris,64
-Siskiyou,M5018,U.S. Senate,,DEM,Loretta Sanchez,51
-Siskiyou,M5019,U.S. Senate,,DEM,Kamala Harris,39
-Siskiyou,M5019,U.S. Senate,,DEM,Loretta Sanchez,7
-Siskiyou,M5038,U.S. Senate,,DEM,Kamala Harris,56
-Siskiyou,M5038,U.S. Senate,,DEM,Loretta Sanchez,45
-Siskiyou,M5070,U.S. Senate,,DEM,Kamala Harris,62
-Siskiyou,M5070,U.S. Senate,,DEM,Loretta Sanchez,51
-Siskiyou,M5075,U.S. Senate,,DEM,Kamala Harris,59
-Siskiyou,M5075,U.S. Senate,,DEM,Loretta Sanchez,47
-Siskiyou,M5080,U.S. Senate,,DEM,Kamala Harris,66
-Siskiyou,M5080,U.S. Senate,,DEM,Loretta Sanchez,52
-Siskiyou,M5090,U.S. Senate,,DEM,Kamala Harris,88
-Siskiyou,M5090,U.S. Senate,,DEM,Loretta Sanchez,53
-Siskiyou,P1000,U.S. Senate,,DEM,Kamala Harris,205
-Siskiyou,P1000,U.S. Senate,,DEM,Loretta Sanchez,164
-Siskiyou,P1002,U.S. Senate,,DEM,Kamala Harris,92
-Siskiyou,P1002,U.S. Senate,,DEM,Loretta Sanchez,68
-Siskiyou,P1003,U.S. Senate,,DEM,Kamala Harris,152
-Siskiyou,P1003,U.S. Senate,,DEM,Loretta Sanchez,126
-Siskiyou,P1026,U.S. Senate,,DEM,Kamala Harris,105
-Siskiyou,P1026,U.S. Senate,,DEM,Loretta Sanchez,77
-Siskiyou,P1105,U.S. Senate,,DEM,Kamala Harris,111
-Siskiyou,P1105,U.S. Senate,,DEM,Loretta Sanchez,89
-Siskiyou,P1110,U.S. Senate,,DEM,Kamala Harris,219
-Siskiyou,P1110,U.S. Senate,,DEM,Loretta Sanchez,172
-Siskiyou,P2014,U.S. Senate,,DEM,Kamala Harris,324
-Siskiyou,P2014,U.S. Senate,,DEM,Loretta Sanchez,220
-Siskiyou,P2015,U.S. Senate,,DEM,Kamala Harris,223
-Siskiyou,P2015,U.S. Senate,,DEM,Loretta Sanchez,109
-Siskiyou,P2019,U.S. Senate,,DEM,Kamala Harris,348
-Siskiyou,P2019,U.S. Senate,,DEM,Loretta Sanchez,236
-Siskiyou,P2100,U.S. Senate,,DEM,Kamala Harris,350
-Siskiyou,P2100,U.S. Senate,,DEM,Loretta Sanchez,236
-Siskiyou,P2110,U.S. Senate,,DEM,Kamala Harris,259
-Siskiyou,P2110,U.S. Senate,,DEM,Loretta Sanchez,158
-Siskiyou,P2111,U.S. Senate,,DEM,Kamala Harris,325
-Siskiyou,P2111,U.S. Senate,,DEM,Loretta Sanchez,192
-Siskiyou,P2115,U.S. Senate,,DEM,Kamala Harris,265
-Siskiyou,P2115,U.S. Senate,,DEM,Loretta Sanchez,143
-Siskiyou,P3001,U.S. Senate,,DEM,Kamala Harris,122
-Siskiyou,P3001,U.S. Senate,,DEM,Loretta Sanchez,79
-Siskiyou,P3006,U.S. Senate,,DEM,Kamala Harris,212
-Siskiyou,P3006,U.S. Senate,,DEM,Loretta Sanchez,158
-Siskiyou,P3007,U.S. Senate,,DEM,Kamala Harris,301
-Siskiyou,P3007,U.S. Senate,,DEM,Loretta Sanchez,277
-Siskiyou,P3009,U.S. Senate,,DEM,Kamala Harris,144
-Siskiyou,P3009,U.S. Senate,,DEM,Loretta Sanchez,126
-Siskiyou,P3014,U.S. Senate,,DEM,Kamala Harris,241
-Siskiyou,P3014,U.S. Senate,,DEM,Loretta Sanchez,123
-Siskiyou,P3021,U.S. Senate,,DEM,Kamala Harris,237
-Siskiyou,P3021,U.S. Senate,,DEM,Loretta Sanchez,94
-Siskiyou,P4110,U.S. Senate,,DEM,Kamala Harris,244
-Siskiyou,P4110,U.S. Senate,,DEM,Loretta Sanchez,192
-Siskiyou,P4112,U.S. Senate,,DEM,Kamala Harris,227
-Siskiyou,P4112,U.S. Senate,,DEM,Loretta Sanchez,170
-Siskiyou,P4115,U.S. Senate,,DEM,Kamala Harris,201
-Siskiyou,P4115,U.S. Senate,,DEM,Loretta Sanchez,210
-Siskiyou,P4116,U.S. Senate,,DEM,Kamala Harris,157
-Siskiyou,P4116,U.S. Senate,,DEM,Loretta Sanchez,134
-Siskiyou,P4118,U.S. Senate,,DEM,Kamala Harris,229
-Siskiyou,P4118,U.S. Senate,,DEM,Loretta Sanchez,160
-Siskiyou,P4121,U.S. Senate,,DEM,Kamala Harris,210
-Siskiyou,P4121,U.S. Senate,,DEM,Loretta Sanchez,149
-Siskiyou,P5005,U.S. Senate,,DEM,Kamala Harris,280
-Siskiyou,P5005,U.S. Senate,,DEM,Loretta Sanchez,247
-Siskiyou,P5008,U.S. Senate,,DEM,Kamala Harris,175
-Siskiyou,P5008,U.S. Senate,,DEM,Loretta Sanchez,125
-Siskiyou,P5011,U.S. Senate,,DEM,Kamala Harris,205
-Siskiyou,P5011,U.S. Senate,,DEM,Loretta Sanchez,130
-Siskiyou,P5012,U.S. Senate,,DEM,Kamala Harris,84
-Siskiyou,P5012,U.S. Senate,,DEM,Loretta Sanchez,79
-Siskiyou,P5095,U.S. Senate,,DEM,Kamala Harris,230
-Siskiyou,P5095,U.S. Senate,,DEM,Loretta Sanchez,186
-Siskiyou,P5103,U.S. Senate,,DEM,Kamala Harris,141
-Siskiyou,P5103,U.S. Senate,,DEM,Loretta Sanchez,100
-Siskiyou,P5107,U.S. Senate,,DEM,Kamala Harris,121
-Siskiyou,P5107,U.S. Senate,,DEM,Loretta Sanchez,96
-Siskiyou,WEED,U.S. Senate,,DEM,Kamala Harris,328
-Siskiyou,WEED,U.S. Senate,,DEM,Loretta Sanchez,309
+Siskiyou,CON1,U.S. Senate,,DEM,Kamala D. Harris,377
+Siskiyou,CON1,U.S. Senate,,DEM,Loretta L. Sanchez,343
+Siskiyou,M1001,U.S. Senate,,DEM,Kamala D. Harris,73
+Siskiyou,M1001,U.S. Senate,,DEM,Loretta L. Sanchez,63
+Siskiyou,M1009,U.S. Senate,,DEM,Kamala D. Harris,74
+Siskiyou,M1009,U.S. Senate,,DEM,Loretta L. Sanchez,33
+Siskiyou,M1020,U.S. Senate,,DEM,Kamala D. Harris,42
+Siskiyou,M1020,U.S. Senate,,DEM,Loretta L. Sanchez,21
+Siskiyou,M1023,U.S. Senate,,DEM,Kamala D. Harris,59
+Siskiyou,M1023,U.S. Senate,,DEM,Loretta L. Sanchez,58
+Siskiyou,M1060,U.S. Senate,,DEM,Kamala D. Harris,95
+Siskiyou,M1060,U.S. Senate,,DEM,Loretta L. Sanchez,37
+Siskiyou,M1065,U.S. Senate,,DEM,Kamala D. Harris,30
+Siskiyou,M1065,U.S. Senate,,DEM,Loretta L. Sanchez,24
+Siskiyou,M1070,U.S. Senate,,DEM,Kamala D. Harris,66
+Siskiyou,M1070,U.S. Senate,,DEM,Loretta L. Sanchez,65
+Siskiyou,M1117,U.S. Senate,,DEM,Kamala D. Harris,83
+Siskiyou,M1117,U.S. Senate,,DEM,Loretta L. Sanchez,58
+Siskiyou,M2009,U.S. Senate,,DEM,Kamala D. Harris,92
+Siskiyou,M2009,U.S. Senate,,DEM,Loretta L. Sanchez,83
+Siskiyou,M3013,U.S. Senate,,DEM,Kamala D. Harris,78
+Siskiyou,M3013,U.S. Senate,,DEM,Loretta L. Sanchez,65
+Siskiyou,M3065,U.S. Senate,,DEM,Kamala D. Harris,55
+Siskiyou,M3065,U.S. Senate,,DEM,Loretta L. Sanchez,50
+Siskiyou,M4060,U.S. Senate,,DEM,Kamala D. Harris,51
+Siskiyou,M4060,U.S. Senate,,DEM,Loretta L. Sanchez,59
+Siskiyou,M4065,U.S. Senate,,DEM,Kamala D. Harris,68
+Siskiyou,M4065,U.S. Senate,,DEM,Loretta L. Sanchez,58
+Siskiyou,M5018,U.S. Senate,,DEM,Kamala D. Harris,64
+Siskiyou,M5018,U.S. Senate,,DEM,Loretta L. Sanchez,51
+Siskiyou,M5019,U.S. Senate,,DEM,Kamala D. Harris,39
+Siskiyou,M5019,U.S. Senate,,DEM,Loretta L. Sanchez,7
+Siskiyou,M5038,U.S. Senate,,DEM,Kamala D. Harris,56
+Siskiyou,M5038,U.S. Senate,,DEM,Loretta L. Sanchez,45
+Siskiyou,M5070,U.S. Senate,,DEM,Kamala D. Harris,62
+Siskiyou,M5070,U.S. Senate,,DEM,Loretta L. Sanchez,51
+Siskiyou,M5075,U.S. Senate,,DEM,Kamala D. Harris,59
+Siskiyou,M5075,U.S. Senate,,DEM,Loretta L. Sanchez,47
+Siskiyou,M5080,U.S. Senate,,DEM,Kamala D. Harris,66
+Siskiyou,M5080,U.S. Senate,,DEM,Loretta L. Sanchez,52
+Siskiyou,M5090,U.S. Senate,,DEM,Kamala D. Harris,88
+Siskiyou,M5090,U.S. Senate,,DEM,Loretta L. Sanchez,53
+Siskiyou,P1000,U.S. Senate,,DEM,Kamala D. Harris,205
+Siskiyou,P1000,U.S. Senate,,DEM,Loretta L. Sanchez,164
+Siskiyou,P1002,U.S. Senate,,DEM,Kamala D. Harris,92
+Siskiyou,P1002,U.S. Senate,,DEM,Loretta L. Sanchez,68
+Siskiyou,P1003,U.S. Senate,,DEM,Kamala D. Harris,152
+Siskiyou,P1003,U.S. Senate,,DEM,Loretta L. Sanchez,126
+Siskiyou,P1026,U.S. Senate,,DEM,Kamala D. Harris,105
+Siskiyou,P1026,U.S. Senate,,DEM,Loretta L. Sanchez,77
+Siskiyou,P1105,U.S. Senate,,DEM,Kamala D. Harris,111
+Siskiyou,P1105,U.S. Senate,,DEM,Loretta L. Sanchez,89
+Siskiyou,P1110,U.S. Senate,,DEM,Kamala D. Harris,219
+Siskiyou,P1110,U.S. Senate,,DEM,Loretta L. Sanchez,172
+Siskiyou,P2014,U.S. Senate,,DEM,Kamala D. Harris,324
+Siskiyou,P2014,U.S. Senate,,DEM,Loretta L. Sanchez,220
+Siskiyou,P2015,U.S. Senate,,DEM,Kamala D. Harris,223
+Siskiyou,P2015,U.S. Senate,,DEM,Loretta L. Sanchez,109
+Siskiyou,P2019,U.S. Senate,,DEM,Kamala D. Harris,348
+Siskiyou,P2019,U.S. Senate,,DEM,Loretta L. Sanchez,236
+Siskiyou,P2100,U.S. Senate,,DEM,Kamala D. Harris,350
+Siskiyou,P2100,U.S. Senate,,DEM,Loretta L. Sanchez,236
+Siskiyou,P2110,U.S. Senate,,DEM,Kamala D. Harris,259
+Siskiyou,P2110,U.S. Senate,,DEM,Loretta L. Sanchez,158
+Siskiyou,P2111,U.S. Senate,,DEM,Kamala D. Harris,325
+Siskiyou,P2111,U.S. Senate,,DEM,Loretta L. Sanchez,192
+Siskiyou,P2115,U.S. Senate,,DEM,Kamala D. Harris,265
+Siskiyou,P2115,U.S. Senate,,DEM,Loretta L. Sanchez,143
+Siskiyou,P3001,U.S. Senate,,DEM,Kamala D. Harris,122
+Siskiyou,P3001,U.S. Senate,,DEM,Loretta L. Sanchez,79
+Siskiyou,P3006,U.S. Senate,,DEM,Kamala D. Harris,212
+Siskiyou,P3006,U.S. Senate,,DEM,Loretta L. Sanchez,158
+Siskiyou,P3007,U.S. Senate,,DEM,Kamala D. Harris,301
+Siskiyou,P3007,U.S. Senate,,DEM,Loretta L. Sanchez,277
+Siskiyou,P3009,U.S. Senate,,DEM,Kamala D. Harris,144
+Siskiyou,P3009,U.S. Senate,,DEM,Loretta L. Sanchez,126
+Siskiyou,P3014,U.S. Senate,,DEM,Kamala D. Harris,241
+Siskiyou,P3014,U.S. Senate,,DEM,Loretta L. Sanchez,123
+Siskiyou,P3021,U.S. Senate,,DEM,Kamala D. Harris,237
+Siskiyou,P3021,U.S. Senate,,DEM,Loretta L. Sanchez,94
+Siskiyou,P4110,U.S. Senate,,DEM,Kamala D. Harris,244
+Siskiyou,P4110,U.S. Senate,,DEM,Loretta L. Sanchez,192
+Siskiyou,P4112,U.S. Senate,,DEM,Kamala D. Harris,227
+Siskiyou,P4112,U.S. Senate,,DEM,Loretta L. Sanchez,170
+Siskiyou,P4115,U.S. Senate,,DEM,Kamala D. Harris,201
+Siskiyou,P4115,U.S. Senate,,DEM,Loretta L. Sanchez,210
+Siskiyou,P4116,U.S. Senate,,DEM,Kamala D. Harris,157
+Siskiyou,P4116,U.S. Senate,,DEM,Loretta L. Sanchez,134
+Siskiyou,P4118,U.S. Senate,,DEM,Kamala D. Harris,229
+Siskiyou,P4118,U.S. Senate,,DEM,Loretta L. Sanchez,160
+Siskiyou,P4121,U.S. Senate,,DEM,Kamala D. Harris,210
+Siskiyou,P4121,U.S. Senate,,DEM,Loretta L. Sanchez,149
+Siskiyou,P5005,U.S. Senate,,DEM,Kamala D. Harris,280
+Siskiyou,P5005,U.S. Senate,,DEM,Loretta L. Sanchez,247
+Siskiyou,P5008,U.S. Senate,,DEM,Kamala D. Harris,175
+Siskiyou,P5008,U.S. Senate,,DEM,Loretta L. Sanchez,125
+Siskiyou,P5011,U.S. Senate,,DEM,Kamala D. Harris,205
+Siskiyou,P5011,U.S. Senate,,DEM,Loretta L. Sanchez,130
+Siskiyou,P5012,U.S. Senate,,DEM,Kamala D. Harris,84
+Siskiyou,P5012,U.S. Senate,,DEM,Loretta L. Sanchez,79
+Siskiyou,P5095,U.S. Senate,,DEM,Kamala D. Harris,230
+Siskiyou,P5095,U.S. Senate,,DEM,Loretta L. Sanchez,186
+Siskiyou,P5103,U.S. Senate,,DEM,Kamala D. Harris,141
+Siskiyou,P5103,U.S. Senate,,DEM,Loretta L. Sanchez,100
+Siskiyou,P5107,U.S. Senate,,DEM,Kamala D. Harris,121
+Siskiyou,P5107,U.S. Senate,,DEM,Loretta L. Sanchez,96
+Siskiyou,WEED,U.S. Senate,,DEM,Kamala D. Harris,328
+Siskiyou,WEED,U.S. Senate,,DEM,Loretta L. Sanchez,309

--- a/2016/20161108__ca__general__solano__precinct.csv
+++ b/2016/20161108__ca__general__solano__precinct.csv
@@ -10599,533 +10599,533 @@ Solano,99969,Proposition 67,,N/A,Yes,0
 Solano,99969,Proposition 67,,N/A,No,0
 Solano,99977,Proposition 67,,N/A,Yes,0
 Solano,99977,Proposition 67,,N/A,No,0
-Solano,17005,U.S. Senate,,DEM,Kamala Harris,1004
-Solano,17005,U.S. Senate,,DEM,Loretta Sanchez,555
-Solano,17045,U.S. Senate,,DEM,Kamala Harris,1521
-Solano,17045,U.S. Senate,,DEM,Loretta Sanchez,748
-Solano,17070,U.S. Senate,,DEM,Kamala Harris,1761
-Solano,17070,U.S. Senate,,DEM,Loretta Sanchez,571
-Solano,17100,U.S. Senate,,DEM,Kamala Harris,1326
-Solano,17100,U.S. Senate,,DEM,Loretta Sanchez,500
-Solano,17110,U.S. Senate,,DEM,Kamala Harris,709
-Solano,17110,U.S. Senate,,DEM,Loretta Sanchez,253
-Solano,17115,U.S. Senate,,DEM,Kamala Harris,921
-Solano,17115,U.S. Senate,,DEM,Loretta Sanchez,405
-Solano,17140,U.S. Senate,,DEM,Kamala Harris,944
-Solano,17140,U.S. Senate,,DEM,Loretta Sanchez,329
-Solano,17152,U.S. Senate,,DEM,Kamala Harris,626
-Solano,17152,U.S. Senate,,DEM,Loretta Sanchez,238
-Solano,17180,U.S. Senate,,DEM,Kamala Harris,304
-Solano,17180,U.S. Senate,,DEM,Loretta Sanchez,152
-Solano,17185,U.S. Senate,,DEM,Kamala Harris,1071
-Solano,17185,U.S. Senate,,DEM,Loretta Sanchez,392
-Solano,17205,U.S. Senate,,DEM,Kamala Harris,817
-Solano,17205,U.S. Senate,,DEM,Loretta Sanchez,325
-Solano,17220,U.S. Senate,,DEM,Kamala Harris,647
-Solano,17220,U.S. Senate,,DEM,Loretta Sanchez,285
-Solano,17245,U.S. Senate,,DEM,Kamala Harris,1516
-Solano,17245,U.S. Senate,,DEM,Loretta Sanchez,570
-Solano,17265,U.S. Senate,,DEM,Kamala Harris,632
-Solano,17265,U.S. Senate,,DEM,Loretta Sanchez,209
-Solano,17285,U.S. Senate,,DEM,Kamala Harris,1080
-Solano,17285,U.S. Senate,,DEM,Loretta Sanchez,390
-Solano,17289,U.S. Senate,,DEM,Kamala Harris,868
-Solano,17289,U.S. Senate,,DEM,Loretta Sanchez,299
-Solano,17290,U.S. Senate,,DEM,Kamala Harris,818
-Solano,17290,U.S. Senate,,DEM,Loretta Sanchez,270
-Solano,17310,U.S. Senate,,DEM,Kamala Harris,831
-Solano,17310,U.S. Senate,,DEM,Loretta Sanchez,274
-Solano,17335,U.S. Senate,,DEM,Kamala Harris,667
-Solano,17335,U.S. Senate,,DEM,Loretta Sanchez,252
-Solano,17380,U.S. Senate,,DEM,Kamala Harris,978
-Solano,17380,U.S. Senate,,DEM,Loretta Sanchez,349
-Solano,17395,U.S. Senate,,DEM,Kamala Harris,1546
-Solano,17395,U.S. Senate,,DEM,Loretta Sanchez,615
-Solano,17400,U.S. Senate,,DEM,Kamala Harris,12
-Solano,17400,U.S. Senate,,DEM,Loretta Sanchez,8
-Solano,19805,U.S. Senate,,DEM,Kamala Harris,3
-Solano,19805,U.S. Senate,,DEM,Loretta Sanchez,1
-Solano,19820,U.S. Senate,,DEM,Kamala Harris,5
-Solano,19820,U.S. Senate,,DEM,Loretta Sanchez,0
-Solano,21005,U.S. Senate,,DEM,Kamala Harris,1224
-Solano,21005,U.S. Senate,,DEM,Loretta Sanchez,509
-Solano,21007,U.S. Senate,,DEM,Kamala Harris,1259
-Solano,21007,U.S. Senate,,DEM,Loretta Sanchez,481
-Solano,21020,U.S. Senate,,DEM,Kamala Harris,867
-Solano,21020,U.S. Senate,,DEM,Loretta Sanchez,393
-Solano,21035,U.S. Senate,,DEM,Kamala Harris,975
-Solano,21035,U.S. Senate,,DEM,Loretta Sanchez,406
-Solano,21090,U.S. Senate,,DEM,Kamala Harris,656
-Solano,21090,U.S. Senate,,DEM,Loretta Sanchez,265
-Solano,21095,U.S. Senate,,DEM,Kamala Harris,1620
-Solano,21095,U.S. Senate,,DEM,Loretta Sanchez,709
-Solano,21125,U.S. Senate,,DEM,Kamala Harris,1771
-Solano,21125,U.S. Senate,,DEM,Loretta Sanchez,776
-Solano,21130,U.S. Senate,,DEM,Kamala Harris,1155
-Solano,21130,U.S. Senate,,DEM,Loretta Sanchez,528
-Solano,23005,U.S. Senate,,DEM,Kamala Harris,847
-Solano,23005,U.S. Senate,,DEM,Loretta Sanchez,469
-Solano,23016,U.S. Senate,,DEM,Kamala Harris,1203
-Solano,23016,U.S. Senate,,DEM,Loretta Sanchez,620
-Solano,23018,U.S. Senate,,DEM,Kamala Harris,2
-Solano,23018,U.S. Senate,,DEM,Loretta Sanchez,1
-Solano,23020,U.S. Senate,,DEM,Kamala Harris,1077
-Solano,23020,U.S. Senate,,DEM,Loretta Sanchez,629
-Solano,23050,U.S. Senate,,DEM,Kamala Harris,5
-Solano,23050,U.S. Senate,,DEM,Loretta Sanchez,1
-Solano,23055,U.S. Senate,,DEM,Kamala Harris,391
-Solano,23055,U.S. Senate,,DEM,Loretta Sanchez,158
-Solano,23090,U.S. Senate,,DEM,Kamala Harris,321
-Solano,23090,U.S. Senate,,DEM,Loretta Sanchez,191
-Solano,23095,U.S. Senate,,DEM,Kamala Harris,414
-Solano,23095,U.S. Senate,,DEM,Loretta Sanchez,259
-Solano,27020,U.S. Senate,,DEM,Kamala Harris,261
-Solano,27020,U.S. Senate,,DEM,Loretta Sanchez,82
-Solano,27050,U.S. Senate,,DEM,Kamala Harris,871
-Solano,27050,U.S. Senate,,DEM,Loretta Sanchez,364
-Solano,27055,U.S. Senate,,DEM,Kamala Harris,403
-Solano,27055,U.S. Senate,,DEM,Loretta Sanchez,125
-Solano,27070,U.S. Senate,,DEM,Kamala Harris,855
-Solano,27070,U.S. Senate,,DEM,Loretta Sanchez,335
-Solano,27080,U.S. Senate,,DEM,Kamala Harris,559
-Solano,27080,U.S. Senate,,DEM,Loretta Sanchez,257
-Solano,27090,U.S. Senate,,DEM,Kamala Harris,934
-Solano,27090,U.S. Senate,,DEM,Loretta Sanchez,371
-Solano,27110,U.S. Senate,,DEM,Kamala Harris,963
-Solano,27110,U.S. Senate,,DEM,Loretta Sanchez,340
-Solano,27115,U.S. Senate,,DEM,Kamala Harris,995
-Solano,27115,U.S. Senate,,DEM,Loretta Sanchez,310
-Solano,27130,U.S. Senate,,DEM,Kamala Harris,843
-Solano,27130,U.S. Senate,,DEM,Loretta Sanchez,310
-Solano,27165,U.S. Senate,,DEM,Kamala Harris,989
-Solano,27165,U.S. Senate,,DEM,Loretta Sanchez,434
-Solano,27175,U.S. Senate,,DEM,Kamala Harris,585
-Solano,27175,U.S. Senate,,DEM,Loretta Sanchez,256
-Solano,27185,U.S. Senate,,DEM,Kamala Harris,383
-Solano,27185,U.S. Senate,,DEM,Loretta Sanchez,226
-Solano,27187,U.S. Senate,,DEM,Kamala Harris,161
-Solano,27187,U.S. Senate,,DEM,Loretta Sanchez,93
-Solano,29405,U.S. Senate,,DEM,Kamala Harris,250
-Solano,29405,U.S. Senate,,DEM,Loretta Sanchez,164
-Solano,29406,U.S. Senate,,DEM,Kamala Harris,239
-Solano,29406,U.S. Senate,,DEM,Loretta Sanchez,126
-Solano,29407,U.S. Senate,,DEM,Kamala Harris,60
-Solano,29407,U.S. Senate,,DEM,Loretta Sanchez,36
-Solano,29408,U.S. Senate,,DEM,Kamala Harris,36
-Solano,29408,U.S. Senate,,DEM,Loretta Sanchez,30
-Solano,29820,U.S. Senate,,DEM,Kamala Harris,230
-Solano,29820,U.S. Senate,,DEM,Loretta Sanchez,96
-Solano,29830,U.S. Senate,,DEM,Kamala Harris,11
-Solano,29830,U.S. Senate,,DEM,Loretta Sanchez,9
-Solano,29835,U.S. Senate,,DEM,Kamala Harris,23
-Solano,29835,U.S. Senate,,DEM,Loretta Sanchez,9
-Solano,29840,U.S. Senate,,DEM,Kamala Harris,145
-Solano,29840,U.S. Senate,,DEM,Loretta Sanchez,94
-Solano,33010,U.S. Senate,,DEM,Kamala Harris,449
-Solano,33010,U.S. Senate,,DEM,Loretta Sanchez,213
-Solano,33015,U.S. Senate,,DEM,Kamala Harris,724
-Solano,33015,U.S. Senate,,DEM,Loretta Sanchez,472
-Solano,33025,U.S. Senate,,DEM,Kamala Harris,485
-Solano,33025,U.S. Senate,,DEM,Loretta Sanchez,246
-Solano,33040,U.S. Senate,,DEM,Kamala Harris,507
-Solano,33040,U.S. Senate,,DEM,Loretta Sanchez,296
-Solano,33041,U.S. Senate,,DEM,Kamala Harris,330
-Solano,33041,U.S. Senate,,DEM,Loretta Sanchez,139
-Solano,33042,U.S. Senate,,DEM,Kamala Harris,184
-Solano,33042,U.S. Senate,,DEM,Loretta Sanchez,112
-Solano,33043,U.S. Senate,,DEM,Kamala Harris,156
-Solano,33043,U.S. Senate,,DEM,Loretta Sanchez,79
-Solano,33045,U.S. Senate,,DEM,Kamala Harris,412
-Solano,33045,U.S. Senate,,DEM,Loretta Sanchez,219
-Solano,33050,U.S. Senate,,DEM,Kamala Harris,756
-Solano,33050,U.S. Senate,,DEM,Loretta Sanchez,411
-Solano,33065,U.S. Senate,,DEM,Kamala Harris,839
-Solano,33065,U.S. Senate,,DEM,Loretta Sanchez,296
-Solano,33070,U.S. Senate,,DEM,Kamala Harris,785
-Solano,33070,U.S. Senate,,DEM,Loretta Sanchez,525
-Solano,33075,U.S. Senate,,DEM,Kamala Harris,554
-Solano,33075,U.S. Senate,,DEM,Loretta Sanchez,320
-Solano,33080,U.S. Senate,,DEM,Kamala Harris,160
-Solano,33080,U.S. Senate,,DEM,Loretta Sanchez,101
-Solano,33115,U.S. Senate,,DEM,Kamala Harris,846
-Solano,33115,U.S. Senate,,DEM,Loretta Sanchez,388
-Solano,33117,U.S. Senate,,DEM,Kamala Harris,0
-Solano,33117,U.S. Senate,,DEM,Loretta Sanchez,0
-Solano,33119,U.S. Senate,,DEM,Kamala Harris,75
-Solano,33119,U.S. Senate,,DEM,Loretta Sanchez,54
-Solano,33190,U.S. Senate,,DEM,Kamala Harris,841
-Solano,33190,U.S. Senate,,DEM,Loretta Sanchez,560
-Solano,33195,U.S. Senate,,DEM,Kamala Harris,377
-Solano,33195,U.S. Senate,,DEM,Loretta Sanchez,272
-Solano,33215,U.S. Senate,,DEM,Kamala Harris,199
-Solano,33215,U.S. Senate,,DEM,Loretta Sanchez,124
-Solano,33216,U.S. Senate,,DEM,Kamala Harris,80
-Solano,33216,U.S. Senate,,DEM,Loretta Sanchez,51
-Solano,33217,U.S. Senate,,DEM,Kamala Harris,269
-Solano,33217,U.S. Senate,,DEM,Loretta Sanchez,153
-Solano,33218,U.S. Senate,,DEM,Kamala Harris,141
-Solano,33218,U.S. Senate,,DEM,Loretta Sanchez,118
-Solano,33230,U.S. Senate,,DEM,Kamala Harris,515
-Solano,33230,U.S. Senate,,DEM,Loretta Sanchez,265
-Solano,33240,U.S. Senate,,DEM,Kamala Harris,308
-Solano,33240,U.S. Senate,,DEM,Loretta Sanchez,180
-Solano,33245,U.S. Senate,,DEM,Kamala Harris,556
-Solano,33245,U.S. Senate,,DEM,Loretta Sanchez,312
-Solano,33250,U.S. Senate,,DEM,Kamala Harris,366
-Solano,33250,U.S. Senate,,DEM,Loretta Sanchez,220
-Solano,33252,U.S. Senate,,DEM,Kamala Harris,3
-Solano,33252,U.S. Senate,,DEM,Loretta Sanchez,1
-Solano,33254,U.S. Senate,,DEM,Kamala Harris,18
-Solano,33254,U.S. Senate,,DEM,Loretta Sanchez,16
-Solano,33255,U.S. Senate,,DEM,Kamala Harris,7
-Solano,33255,U.S. Senate,,DEM,Loretta Sanchez,6
-Solano,33256,U.S. Senate,,DEM,Kamala Harris,108
-Solano,33256,U.S. Senate,,DEM,Loretta Sanchez,96
-Solano,33265,U.S. Senate,,DEM,Kamala Harris,237
-Solano,33265,U.S. Senate,,DEM,Loretta Sanchez,154
-Solano,33267,U.S. Senate,,DEM,Kamala Harris,243
-Solano,33267,U.S. Senate,,DEM,Loretta Sanchez,142
-Solano,35005,U.S. Senate,,DEM,Kamala Harris,578
-Solano,35005,U.S. Senate,,DEM,Loretta Sanchez,289
-Solano,35020,U.S. Senate,,DEM,Kamala Harris,634
-Solano,35020,U.S. Senate,,DEM,Loretta Sanchez,287
-Solano,35025,U.S. Senate,,DEM,Kamala Harris,355
-Solano,35025,U.S. Senate,,DEM,Loretta Sanchez,252
-Solano,35040,U.S. Senate,,DEM,Kamala Harris,996
-Solano,35040,U.S. Senate,,DEM,Loretta Sanchez,568
-Solano,35045,U.S. Senate,,DEM,Kamala Harris,932
-Solano,35045,U.S. Senate,,DEM,Loretta Sanchez,440
-Solano,35055,U.S. Senate,,DEM,Kamala Harris,644
-Solano,35055,U.S. Senate,,DEM,Loretta Sanchez,325
-Solano,35057,U.S. Senate,,DEM,Kamala Harris,153
-Solano,35057,U.S. Senate,,DEM,Loretta Sanchez,99
-Solano,39452,U.S. Senate,,DEM,Kamala Harris,84
-Solano,39452,U.S. Senate,,DEM,Loretta Sanchez,69
-Solano,39454,U.S. Senate,,DEM,Kamala Harris,74
-Solano,39454,U.S. Senate,,DEM,Loretta Sanchez,56
-Solano,42010,U.S. Senate,,DEM,Kamala Harris,674
-Solano,42010,U.S. Senate,,DEM,Loretta Sanchez,472
-Solano,42012,U.S. Senate,,DEM,Kamala Harris,96
-Solano,42012,U.S. Senate,,DEM,Loretta Sanchez,74
-Solano,42020,U.S. Senate,,DEM,Kamala Harris,432
-Solano,42020,U.S. Senate,,DEM,Loretta Sanchez,360
-Solano,42022,U.S. Senate,,DEM,Kamala Harris,332
-Solano,42022,U.S. Senate,,DEM,Loretta Sanchez,223
-Solano,42025,U.S. Senate,,DEM,Kamala Harris,229
-Solano,42025,U.S. Senate,,DEM,Loretta Sanchez,183
-Solano,42045,U.S. Senate,,DEM,Kamala Harris,205
-Solano,42045,U.S. Senate,,DEM,Loretta Sanchez,135
-Solano,42047,U.S. Senate,,DEM,Kamala Harris,85
-Solano,42047,U.S. Senate,,DEM,Loretta Sanchez,52
-Solano,42048,U.S. Senate,,DEM,Kamala Harris,41
-Solano,42048,U.S. Senate,,DEM,Loretta Sanchez,24
-Solano,42049,U.S. Senate,,DEM,Kamala Harris,52
-Solano,42049,U.S. Senate,,DEM,Loretta Sanchez,23
-Solano,42050,U.S. Senate,,DEM,Kamala Harris,607
-Solano,42050,U.S. Senate,,DEM,Loretta Sanchez,400
-Solano,42055,U.S. Senate,,DEM,Kamala Harris,249
-Solano,42055,U.S. Senate,,DEM,Loretta Sanchez,123
-Solano,42060,U.S. Senate,,DEM,Kamala Harris,67
-Solano,42060,U.S. Senate,,DEM,Loretta Sanchez,33
-Solano,42065,U.S. Senate,,DEM,Kamala Harris,706
-Solano,42065,U.S. Senate,,DEM,Loretta Sanchez,535
-Solano,42070,U.S. Senate,,DEM,Kamala Harris,268
-Solano,42070,U.S. Senate,,DEM,Loretta Sanchez,264
-Solano,46015,U.S. Senate,,DEM,Kamala Harris,489
-Solano,46015,U.S. Senate,,DEM,Loretta Sanchez,240
-Solano,46020,U.S. Senate,,DEM,Kamala Harris,858
-Solano,46020,U.S. Senate,,DEM,Loretta Sanchez,444
-Solano,46030,U.S. Senate,,DEM,Kamala Harris,64
-Solano,46030,U.S. Senate,,DEM,Loretta Sanchez,32
-Solano,46050,U.S. Senate,,DEM,Kamala Harris,851
-Solano,46050,U.S. Senate,,DEM,Loretta Sanchez,461
-Solano,46065,U.S. Senate,,DEM,Kamala Harris,657
-Solano,46065,U.S. Senate,,DEM,Loretta Sanchez,397
-Solano,46070,U.S. Senate,,DEM,Kamala Harris,586
-Solano,46070,U.S. Senate,,DEM,Loretta Sanchez,332
-Solano,46120,U.S. Senate,,DEM,Kamala Harris,891
-Solano,46120,U.S. Senate,,DEM,Loretta Sanchez,600
-Solano,46123,U.S. Senate,,DEM,Kamala Harris,91
-Solano,46123,U.S. Senate,,DEM,Loretta Sanchez,54
-Solano,46124,U.S. Senate,,DEM,Kamala Harris,32
-Solano,46124,U.S. Senate,,DEM,Loretta Sanchez,10
-Solano,46125,U.S. Senate,,DEM,Kamala Harris,18
-Solano,46125,U.S. Senate,,DEM,Loretta Sanchez,15
-Solano,46127,U.S. Senate,,DEM,Kamala Harris,253
-Solano,46127,U.S. Senate,,DEM,Loretta Sanchez,151
-Solano,46129,U.S. Senate,,DEM,Kamala Harris,162
-Solano,46129,U.S. Senate,,DEM,Loretta Sanchez,89
-Solano,46130,U.S. Senate,,DEM,Kamala Harris,880
-Solano,46130,U.S. Senate,,DEM,Loretta Sanchez,403
-Solano,46150,U.S. Senate,,DEM,Kamala Harris,870
-Solano,46150,U.S. Senate,,DEM,Loretta Sanchez,561
-Solano,46155,U.S. Senate,,DEM,Kamala Harris,0
-Solano,46155,U.S. Senate,,DEM,Loretta Sanchez,0
-Solano,46157,U.S. Senate,,DEM,Kamala Harris,234
-Solano,46157,U.S. Senate,,DEM,Loretta Sanchez,147
-Solano,46158,U.S. Senate,,DEM,Kamala Harris,26
-Solano,46158,U.S. Senate,,DEM,Loretta Sanchez,17
-Solano,46159,U.S. Senate,,DEM,Kamala Harris,56
-Solano,46159,U.S. Senate,,DEM,Loretta Sanchez,31
-Solano,46180,U.S. Senate,,DEM,Kamala Harris,212
-Solano,46180,U.S. Senate,,DEM,Loretta Sanchez,101
-Solano,46185,U.S. Senate,,DEM,Kamala Harris,427
-Solano,46185,U.S. Senate,,DEM,Loretta Sanchez,199
-Solano,46190,U.S. Senate,,DEM,Kamala Harris,632
-Solano,46190,U.S. Senate,,DEM,Loretta Sanchez,400
-Solano,46210,U.S. Senate,,DEM,Kamala Harris,538
-Solano,46210,U.S. Senate,,DEM,Loretta Sanchez,335
-Solano,46270,U.S. Senate,,DEM,Kamala Harris,804
-Solano,46270,U.S. Senate,,DEM,Loretta Sanchez,487
-Solano,46380,U.S. Senate,,DEM,Kamala Harris,664
-Solano,46380,U.S. Senate,,DEM,Loretta Sanchez,509
-Solano,46400,U.S. Senate,,DEM,Kamala Harris,1042
-Solano,46400,U.S. Senate,,DEM,Loretta Sanchez,598
-Solano,46405,U.S. Senate,,DEM,Kamala Harris,60
-Solano,46405,U.S. Senate,,DEM,Loretta Sanchez,35
-Solano,49730,U.S. Senate,,DEM,Kamala Harris,219
-Solano,49730,U.S. Senate,,DEM,Loretta Sanchez,161
-Solano,49733,U.S. Senate,,DEM,Kamala Harris,462
-Solano,49733,U.S. Senate,,DEM,Loretta Sanchez,297
-Solano,49740,U.S. Senate,,DEM,Kamala Harris,52
-Solano,49740,U.S. Senate,,DEM,Loretta Sanchez,29
-Solano,49742,U.S. Senate,,DEM,Kamala Harris,8
-Solano,49742,U.S. Senate,,DEM,Loretta Sanchez,9
-Solano,49744,U.S. Senate,,DEM,Kamala Harris,181
-Solano,49744,U.S. Senate,,DEM,Loretta Sanchez,78
-Solano,53005,U.S. Senate,,DEM,Kamala Harris,1355
-Solano,53005,U.S. Senate,,DEM,Loretta Sanchez,709
-Solano,53007,U.S. Senate,,DEM,Kamala Harris,4
-Solano,53007,U.S. Senate,,DEM,Loretta Sanchez,0
-Solano,53070,U.S. Senate,,DEM,Kamala Harris,1287
-Solano,53070,U.S. Senate,,DEM,Loretta Sanchez,705
-Solano,53075,U.S. Senate,,DEM,Kamala Harris,2
-Solano,53075,U.S. Senate,,DEM,Loretta Sanchez,0
-Solano,53100,U.S. Senate,,DEM,Kamala Harris,1352
-Solano,53100,U.S. Senate,,DEM,Loretta Sanchez,828
-Solano,53125,U.S. Senate,,DEM,Kamala Harris,1415
-Solano,53125,U.S. Senate,,DEM,Loretta Sanchez,763
-Solano,53140,U.S. Senate,,DEM,Kamala Harris,995
-Solano,53140,U.S. Senate,,DEM,Loretta Sanchez,530
-Solano,54005,U.S. Senate,,DEM,Kamala Harris,879
-Solano,54005,U.S. Senate,,DEM,Loretta Sanchez,539
-Solano,54020,U.S. Senate,,DEM,Kamala Harris,1993
-Solano,54020,U.S. Senate,,DEM,Loretta Sanchez,757
-Solano,55005,U.S. Senate,,DEM,Kamala Harris,1394
-Solano,55005,U.S. Senate,,DEM,Loretta Sanchez,796
-Solano,55010,U.S. Senate,,DEM,Kamala Harris,103
-Solano,55010,U.S. Senate,,DEM,Loretta Sanchez,46
-Solano,56010,U.S. Senate,,DEM,Kamala Harris,1143
-Solano,56010,U.S. Senate,,DEM,Loretta Sanchez,512
-Solano,56012,U.S. Senate,,DEM,Kamala Harris,68
-Solano,56012,U.S. Senate,,DEM,Loretta Sanchez,49
-Solano,56020,U.S. Senate,,DEM,Kamala Harris,659
-Solano,56020,U.S. Senate,,DEM,Loretta Sanchez,429
-Solano,56050,U.S. Senate,,DEM,Kamala Harris,600
-Solano,56050,U.S. Senate,,DEM,Loretta Sanchez,338
-Solano,56055,U.S. Senate,,DEM,Kamala Harris,0
-Solano,56055,U.S. Senate,,DEM,Loretta Sanchez,0
-Solano,56100,U.S. Senate,,DEM,Kamala Harris,561
-Solano,56100,U.S. Senate,,DEM,Loretta Sanchez,393
-Solano,56105,U.S. Senate,,DEM,Kamala Harris,807
-Solano,56105,U.S. Senate,,DEM,Loretta Sanchez,454
-Solano,56107,U.S. Senate,,DEM,Kamala Harris,876
-Solano,56107,U.S. Senate,,DEM,Loretta Sanchez,640
-Solano,56109,U.S. Senate,,DEM,Kamala Harris,71
-Solano,56109,U.S. Senate,,DEM,Loretta Sanchez,33
-Solano,56110,U.S. Senate,,DEM,Kamala Harris,844
-Solano,56110,U.S. Senate,,DEM,Loretta Sanchez,474
-Solano,56125,U.S. Senate,,DEM,Kamala Harris,916
-Solano,56125,U.S. Senate,,DEM,Loretta Sanchez,498
-Solano,56155,U.S. Senate,,DEM,Kamala Harris,75
-Solano,56155,U.S. Senate,,DEM,Loretta Sanchez,34
-Solano,56165,U.S. Senate,,DEM,Kamala Harris,394
-Solano,56165,U.S. Senate,,DEM,Loretta Sanchez,228
-Solano,56175,U.S. Senate,,DEM,Kamala Harris,467
-Solano,56175,U.S. Senate,,DEM,Loretta Sanchez,263
-Solano,56190,U.S. Senate,,DEM,Kamala Harris,769
-Solano,56190,U.S. Senate,,DEM,Loretta Sanchez,491
-Solano,56210,U.S. Senate,,DEM,Kamala Harris,721
-Solano,56210,U.S. Senate,,DEM,Loretta Sanchez,400
-Solano,56215,U.S. Senate,,DEM,Kamala Harris,6
-Solano,56215,U.S. Senate,,DEM,Loretta Sanchez,3
-Solano,59530,U.S. Senate,,DEM,Kamala Harris,73
-Solano,59530,U.S. Senate,,DEM,Loretta Sanchez,58
-Solano,59700,U.S. Senate,,DEM,Kamala Harris,72
-Solano,59700,U.S. Senate,,DEM,Loretta Sanchez,61
-Solano,59705,U.S. Senate,,DEM,Kamala Harris,59
-Solano,59705,U.S. Senate,,DEM,Loretta Sanchez,58
-Solano,99001,U.S. Senate,,DEM,Kamala Harris,22
-Solano,99001,U.S. Senate,,DEM,Loretta Sanchez,21
-Solano,99002,U.S. Senate,,DEM,Kamala Harris,2
-Solano,99002,U.S. Senate,,DEM,Loretta Sanchez,4
-Solano,99003,U.S. Senate,,DEM,Kamala Harris,12
-Solano,99003,U.S. Senate,,DEM,Loretta Sanchez,19
-Solano,99004,U.S. Senate,,DEM,Kamala Harris,55
-Solano,99004,U.S. Senate,,DEM,Loretta Sanchez,24
-Solano,99005,U.S. Senate,,DEM,Kamala Harris,15
-Solano,99005,U.S. Senate,,DEM,Loretta Sanchez,11
-Solano,99006,U.S. Senate,,DEM,Kamala Harris,58
-Solano,99006,U.S. Senate,,DEM,Loretta Sanchez,39
-Solano,99008,U.S. Senate,,DEM,Kamala Harris,0
-Solano,99008,U.S. Senate,,DEM,Loretta Sanchez,1
-Solano,99009,U.S. Senate,,DEM,Kamala Harris,13
-Solano,99009,U.S. Senate,,DEM,Loretta Sanchez,11
-Solano,99010,U.S. Senate,,DEM,Kamala Harris,73
-Solano,99010,U.S. Senate,,DEM,Loretta Sanchez,74
-Solano,99011,U.S. Senate,,DEM,Kamala Harris,38
-Solano,99011,U.S. Senate,,DEM,Loretta Sanchez,26
-Solano,99015,U.S. Senate,,DEM,Kamala Harris,0
-Solano,99015,U.S. Senate,,DEM,Loretta Sanchez,2
-Solano,99016,U.S. Senate,,DEM,Kamala Harris,32
-Solano,99016,U.S. Senate,,DEM,Loretta Sanchez,22
-Solano,99018,U.S. Senate,,DEM,Kamala Harris,7
-Solano,99018,U.S. Senate,,DEM,Loretta Sanchez,8
-Solano,99020,U.S. Senate,,DEM,Kamala Harris,27
-Solano,99020,U.S. Senate,,DEM,Loretta Sanchez,24
-Solano,99024,U.S. Senate,,DEM,Kamala Harris,41
-Solano,99024,U.S. Senate,,DEM,Loretta Sanchez,18
-Solano,99025,U.S. Senate,,DEM,Kamala Harris,0
-Solano,99025,U.S. Senate,,DEM,Loretta Sanchez,1
-Solano,99027,U.S. Senate,,DEM,Kamala Harris,7
-Solano,99027,U.S. Senate,,DEM,Loretta Sanchez,8
-Solano,99028,U.S. Senate,,DEM,Kamala Harris,2
-Solano,99028,U.S. Senate,,DEM,Loretta Sanchez,0
-Solano,99029,U.S. Senate,,DEM,Kamala Harris,38
-Solano,99029,U.S. Senate,,DEM,Loretta Sanchez,35
-Solano,99031,U.S. Senate,,DEM,Kamala Harris,8
-Solano,99031,U.S. Senate,,DEM,Loretta Sanchez,5
-Solano,99032,U.S. Senate,,DEM,Kamala Harris,61
-Solano,99032,U.S. Senate,,DEM,Loretta Sanchez,21
-Solano,99033,U.S. Senate,,DEM,Kamala Harris,4
-Solano,99033,U.S. Senate,,DEM,Loretta Sanchez,1
-Solano,99034,U.S. Senate,,DEM,Kamala Harris,5
-Solano,99034,U.S. Senate,,DEM,Loretta Sanchez,2
-Solano,99035,U.S. Senate,,DEM,Kamala Harris,7
-Solano,99035,U.S. Senate,,DEM,Loretta Sanchez,15
-Solano,99038,U.S. Senate,,DEM,Kamala Harris,9
-Solano,99038,U.S. Senate,,DEM,Loretta Sanchez,3
-Solano,99039,U.S. Senate,,DEM,Kamala Harris,7
-Solano,99039,U.S. Senate,,DEM,Loretta Sanchez,7
-Solano,99043,U.S. Senate,,DEM,Kamala Harris,2
-Solano,99043,U.S. Senate,,DEM,Loretta Sanchez,7
-Solano,99045,U.S. Senate,,DEM,Kamala Harris,16
-Solano,99045,U.S. Senate,,DEM,Loretta Sanchez,5
-Solano,99046,U.S. Senate,,DEM,Kamala Harris,11
-Solano,99046,U.S. Senate,,DEM,Loretta Sanchez,9
-Solano,99047,U.S. Senate,,DEM,Kamala Harris,3
-Solano,99047,U.S. Senate,,DEM,Loretta Sanchez,1
-Solano,99049,U.S. Senate,,DEM,Kamala Harris,24
-Solano,99049,U.S. Senate,,DEM,Loretta Sanchez,10
-Solano,99051,U.S. Senate,,DEM,Kamala Harris,16
-Solano,99051,U.S. Senate,,DEM,Loretta Sanchez,8
-Solano,99055,U.S. Senate,,DEM,Kamala Harris,1
-Solano,99055,U.S. Senate,,DEM,Loretta Sanchez,1
-Solano,99057,U.S. Senate,,DEM,Kamala Harris,54
-Solano,99057,U.S. Senate,,DEM,Loretta Sanchez,48
-Solano,99059,U.S. Senate,,DEM,Kamala Harris,19
-Solano,99059,U.S. Senate,,DEM,Loretta Sanchez,6
-Solano,99061,U.S. Senate,,DEM,Kamala Harris,34
-Solano,99061,U.S. Senate,,DEM,Loretta Sanchez,21
-Solano,99063,U.S. Senate,,DEM,Kamala Harris,60
-Solano,99063,U.S. Senate,,DEM,Loretta Sanchez,16
-Solano,99067,U.S. Senate,,DEM,Kamala Harris,4
-Solano,99067,U.S. Senate,,DEM,Loretta Sanchez,5
-Solano,99071,U.S. Senate,,DEM,Kamala Harris,6
-Solano,99071,U.S. Senate,,DEM,Loretta Sanchez,1
-Solano,99073,U.S. Senate,,DEM,Kamala Harris,9
-Solano,99073,U.S. Senate,,DEM,Loretta Sanchez,3
-Solano,99075,U.S. Senate,,DEM,Kamala Harris,4
-Solano,99075,U.S. Senate,,DEM,Loretta Sanchez,3
-Solano,99079,U.S. Senate,,DEM,Kamala Harris,5
-Solano,99079,U.S. Senate,,DEM,Loretta Sanchez,15
-Solano,99081,U.S. Senate,,DEM,Kamala Harris,0
-Solano,99081,U.S. Senate,,DEM,Loretta Sanchez,0
-Solano,99083,U.S. Senate,,DEM,Kamala Harris,48
-Solano,99083,U.S. Senate,,DEM,Loretta Sanchez,34
-Solano,99085,U.S. Senate,,DEM,Kamala Harris,15
-Solano,99085,U.S. Senate,,DEM,Loretta Sanchez,13
-Solano,99087,U.S. Senate,,DEM,Kamala Harris,6
-Solano,99087,U.S. Senate,,DEM,Loretta Sanchez,20
-Solano,99089,U.S. Senate,,DEM,Kamala Harris,2
-Solano,99089,U.S. Senate,,DEM,Loretta Sanchez,0
-Solano,99091,U.S. Senate,,DEM,Kamala Harris,12
-Solano,99091,U.S. Senate,,DEM,Loretta Sanchez,4
-Solano,99093,U.S. Senate,,DEM,Kamala Harris,4
-Solano,99093,U.S. Senate,,DEM,Loretta Sanchez,0
-Solano,99095,U.S. Senate,,DEM,Kamala Harris,2
-Solano,99095,U.S. Senate,,DEM,Loretta Sanchez,0
-Solano,99904,U.S. Senate,,DEM,Kamala Harris,0
-Solano,99904,U.S. Senate,,DEM,Loretta Sanchez,0
-Solano,99905,U.S. Senate,,DEM,Kamala Harris,0
-Solano,99905,U.S. Senate,,DEM,Loretta Sanchez,0
-Solano,99907,U.S. Senate,,DEM,Kamala Harris,0
-Solano,99907,U.S. Senate,,DEM,Loretta Sanchez,0
-Solano,99909,U.S. Senate,,DEM,Kamala Harris,0
-Solano,99909,U.S. Senate,,DEM,Loretta Sanchez,0
-Solano,99913,U.S. Senate,,DEM,Kamala Harris,0
-Solano,99913,U.S. Senate,,DEM,Loretta Sanchez,0
-Solano,99915,U.S. Senate,,DEM,Kamala Harris,0
-Solano,99915,U.S. Senate,,DEM,Loretta Sanchez,0
-Solano,99917,U.S. Senate,,DEM,Kamala Harris,0
-Solano,99917,U.S. Senate,,DEM,Loretta Sanchez,0
-Solano,99918,U.S. Senate,,DEM,Kamala Harris,0
-Solano,99918,U.S. Senate,,DEM,Loretta Sanchez,0
-Solano,99919,U.S. Senate,,DEM,Kamala Harris,0
-Solano,99919,U.S. Senate,,DEM,Loretta Sanchez,0
-Solano,99921,U.S. Senate,,DEM,Kamala Harris,0
-Solano,99921,U.S. Senate,,DEM,Loretta Sanchez,0
-Solano,99925,U.S. Senate,,DEM,Kamala Harris,0
-Solano,99925,U.S. Senate,,DEM,Loretta Sanchez,0
-Solano,99926,U.S. Senate,,DEM,Kamala Harris,0
-Solano,99926,U.S. Senate,,DEM,Loretta Sanchez,0
-Solano,99927,U.S. Senate,,DEM,Kamala Harris,0
-Solano,99927,U.S. Senate,,DEM,Loretta Sanchez,0
-Solano,99929,U.S. Senate,,DEM,Kamala Harris,0
-Solano,99929,U.S. Senate,,DEM,Loretta Sanchez,0
-Solano,99930,U.S. Senate,,DEM,Kamala Harris,0
-Solano,99930,U.S. Senate,,DEM,Loretta Sanchez,0
-Solano,99932,U.S. Senate,,DEM,Kamala Harris,0
-Solano,99932,U.S. Senate,,DEM,Loretta Sanchez,0
-Solano,99933,U.S. Senate,,DEM,Kamala Harris,0
-Solano,99933,U.S. Senate,,DEM,Loretta Sanchez,0
-Solano,99941,U.S. Senate,,DEM,Kamala Harris,0
-Solano,99941,U.S. Senate,,DEM,Loretta Sanchez,0
-Solano,99944,U.S. Senate,,DEM,Kamala Harris,0
-Solano,99944,U.S. Senate,,DEM,Loretta Sanchez,0
-Solano,99945,U.S. Senate,,DEM,Kamala Harris,0
-Solano,99945,U.S. Senate,,DEM,Loretta Sanchez,0
-Solano,99947,U.S. Senate,,DEM,Kamala Harris,0
-Solano,99947,U.S. Senate,,DEM,Loretta Sanchez,0
-Solano,99948,U.S. Senate,,DEM,Kamala Harris,18
-Solano,99948,U.S. Senate,,DEM,Loretta Sanchez,7
-Solano,99949,U.S. Senate,,DEM,Kamala Harris,0
-Solano,99949,U.S. Senate,,DEM,Loretta Sanchez,0
-Solano,99952,U.S. Senate,,DEM,Kamala Harris,0
-Solano,99952,U.S. Senate,,DEM,Loretta Sanchez,0
-Solano,99953,U.S. Senate,,DEM,Kamala Harris,0
-Solano,99953,U.S. Senate,,DEM,Loretta Sanchez,0
-Solano,99954,U.S. Senate,,DEM,Kamala Harris,0
-Solano,99954,U.S. Senate,,DEM,Loretta Sanchez,0
-Solano,99955,U.S. Senate,,DEM,Kamala Harris,0
-Solano,99955,U.S. Senate,,DEM,Loretta Sanchez,0
-Solano,99956,U.S. Senate,,DEM,Kamala Harris,0
-Solano,99956,U.S. Senate,,DEM,Loretta Sanchez,0
-Solano,99957,U.S. Senate,,DEM,Kamala Harris,0
-Solano,99957,U.S. Senate,,DEM,Loretta Sanchez,0
-Solano,99958,U.S. Senate,,DEM,Kamala Harris,0
-Solano,99958,U.S. Senate,,DEM,Loretta Sanchez,0
-Solano,99959,U.S. Senate,,DEM,Kamala Harris,0
-Solano,99959,U.S. Senate,,DEM,Loretta Sanchez,0
-Solano,99960,U.S. Senate,,DEM,Kamala Harris,0
-Solano,99960,U.S. Senate,,DEM,Loretta Sanchez,0
-Solano,99961,U.S. Senate,,DEM,Kamala Harris,0
-Solano,99961,U.S. Senate,,DEM,Loretta Sanchez,0
-Solano,99962,U.S. Senate,,DEM,Kamala Harris,0
-Solano,99962,U.S. Senate,,DEM,Loretta Sanchez,0
-Solano,99965,U.S. Senate,,DEM,Kamala Harris,0
-Solano,99965,U.S. Senate,,DEM,Loretta Sanchez,0
-Solano,99969,U.S. Senate,,DEM,Kamala Harris,0
-Solano,99969,U.S. Senate,,DEM,Loretta Sanchez,0
-Solano,99977,U.S. Senate,,DEM,Kamala Harris,0
-Solano,99977,U.S. Senate,,DEM,Loretta Sanchez,0
+Solano,17005,U.S. Senate,,DEM,Kamala D. Harris,1004
+Solano,17005,U.S. Senate,,DEM,Loretta L. Sanchez,555
+Solano,17045,U.S. Senate,,DEM,Kamala D. Harris,1521
+Solano,17045,U.S. Senate,,DEM,Loretta L. Sanchez,748
+Solano,17070,U.S. Senate,,DEM,Kamala D. Harris,1761
+Solano,17070,U.S. Senate,,DEM,Loretta L. Sanchez,571
+Solano,17100,U.S. Senate,,DEM,Kamala D. Harris,1326
+Solano,17100,U.S. Senate,,DEM,Loretta L. Sanchez,500
+Solano,17110,U.S. Senate,,DEM,Kamala D. Harris,709
+Solano,17110,U.S. Senate,,DEM,Loretta L. Sanchez,253
+Solano,17115,U.S. Senate,,DEM,Kamala D. Harris,921
+Solano,17115,U.S. Senate,,DEM,Loretta L. Sanchez,405
+Solano,17140,U.S. Senate,,DEM,Kamala D. Harris,944
+Solano,17140,U.S. Senate,,DEM,Loretta L. Sanchez,329
+Solano,17152,U.S. Senate,,DEM,Kamala D. Harris,626
+Solano,17152,U.S. Senate,,DEM,Loretta L. Sanchez,238
+Solano,17180,U.S. Senate,,DEM,Kamala D. Harris,304
+Solano,17180,U.S. Senate,,DEM,Loretta L. Sanchez,152
+Solano,17185,U.S. Senate,,DEM,Kamala D. Harris,1071
+Solano,17185,U.S. Senate,,DEM,Loretta L. Sanchez,392
+Solano,17205,U.S. Senate,,DEM,Kamala D. Harris,817
+Solano,17205,U.S. Senate,,DEM,Loretta L. Sanchez,325
+Solano,17220,U.S. Senate,,DEM,Kamala D. Harris,647
+Solano,17220,U.S. Senate,,DEM,Loretta L. Sanchez,285
+Solano,17245,U.S. Senate,,DEM,Kamala D. Harris,1516
+Solano,17245,U.S. Senate,,DEM,Loretta L. Sanchez,570
+Solano,17265,U.S. Senate,,DEM,Kamala D. Harris,632
+Solano,17265,U.S. Senate,,DEM,Loretta L. Sanchez,209
+Solano,17285,U.S. Senate,,DEM,Kamala D. Harris,1080
+Solano,17285,U.S. Senate,,DEM,Loretta L. Sanchez,390
+Solano,17289,U.S. Senate,,DEM,Kamala D. Harris,868
+Solano,17289,U.S. Senate,,DEM,Loretta L. Sanchez,299
+Solano,17290,U.S. Senate,,DEM,Kamala D. Harris,818
+Solano,17290,U.S. Senate,,DEM,Loretta L. Sanchez,270
+Solano,17310,U.S. Senate,,DEM,Kamala D. Harris,831
+Solano,17310,U.S. Senate,,DEM,Loretta L. Sanchez,274
+Solano,17335,U.S. Senate,,DEM,Kamala D. Harris,667
+Solano,17335,U.S. Senate,,DEM,Loretta L. Sanchez,252
+Solano,17380,U.S. Senate,,DEM,Kamala D. Harris,978
+Solano,17380,U.S. Senate,,DEM,Loretta L. Sanchez,349
+Solano,17395,U.S. Senate,,DEM,Kamala D. Harris,1546
+Solano,17395,U.S. Senate,,DEM,Loretta L. Sanchez,615
+Solano,17400,U.S. Senate,,DEM,Kamala D. Harris,12
+Solano,17400,U.S. Senate,,DEM,Loretta L. Sanchez,8
+Solano,19805,U.S. Senate,,DEM,Kamala D. Harris,3
+Solano,19805,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Solano,19820,U.S. Senate,,DEM,Kamala D. Harris,5
+Solano,19820,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Solano,21005,U.S. Senate,,DEM,Kamala D. Harris,1224
+Solano,21005,U.S. Senate,,DEM,Loretta L. Sanchez,509
+Solano,21007,U.S. Senate,,DEM,Kamala D. Harris,1259
+Solano,21007,U.S. Senate,,DEM,Loretta L. Sanchez,481
+Solano,21020,U.S. Senate,,DEM,Kamala D. Harris,867
+Solano,21020,U.S. Senate,,DEM,Loretta L. Sanchez,393
+Solano,21035,U.S. Senate,,DEM,Kamala D. Harris,975
+Solano,21035,U.S. Senate,,DEM,Loretta L. Sanchez,406
+Solano,21090,U.S. Senate,,DEM,Kamala D. Harris,656
+Solano,21090,U.S. Senate,,DEM,Loretta L. Sanchez,265
+Solano,21095,U.S. Senate,,DEM,Kamala D. Harris,1620
+Solano,21095,U.S. Senate,,DEM,Loretta L. Sanchez,709
+Solano,21125,U.S. Senate,,DEM,Kamala D. Harris,1771
+Solano,21125,U.S. Senate,,DEM,Loretta L. Sanchez,776
+Solano,21130,U.S. Senate,,DEM,Kamala D. Harris,1155
+Solano,21130,U.S. Senate,,DEM,Loretta L. Sanchez,528
+Solano,23005,U.S. Senate,,DEM,Kamala D. Harris,847
+Solano,23005,U.S. Senate,,DEM,Loretta L. Sanchez,469
+Solano,23016,U.S. Senate,,DEM,Kamala D. Harris,1203
+Solano,23016,U.S. Senate,,DEM,Loretta L. Sanchez,620
+Solano,23018,U.S. Senate,,DEM,Kamala D. Harris,2
+Solano,23018,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Solano,23020,U.S. Senate,,DEM,Kamala D. Harris,1077
+Solano,23020,U.S. Senate,,DEM,Loretta L. Sanchez,629
+Solano,23050,U.S. Senate,,DEM,Kamala D. Harris,5
+Solano,23050,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Solano,23055,U.S. Senate,,DEM,Kamala D. Harris,391
+Solano,23055,U.S. Senate,,DEM,Loretta L. Sanchez,158
+Solano,23090,U.S. Senate,,DEM,Kamala D. Harris,321
+Solano,23090,U.S. Senate,,DEM,Loretta L. Sanchez,191
+Solano,23095,U.S. Senate,,DEM,Kamala D. Harris,414
+Solano,23095,U.S. Senate,,DEM,Loretta L. Sanchez,259
+Solano,27020,U.S. Senate,,DEM,Kamala D. Harris,261
+Solano,27020,U.S. Senate,,DEM,Loretta L. Sanchez,82
+Solano,27050,U.S. Senate,,DEM,Kamala D. Harris,871
+Solano,27050,U.S. Senate,,DEM,Loretta L. Sanchez,364
+Solano,27055,U.S. Senate,,DEM,Kamala D. Harris,403
+Solano,27055,U.S. Senate,,DEM,Loretta L. Sanchez,125
+Solano,27070,U.S. Senate,,DEM,Kamala D. Harris,855
+Solano,27070,U.S. Senate,,DEM,Loretta L. Sanchez,335
+Solano,27080,U.S. Senate,,DEM,Kamala D. Harris,559
+Solano,27080,U.S. Senate,,DEM,Loretta L. Sanchez,257
+Solano,27090,U.S. Senate,,DEM,Kamala D. Harris,934
+Solano,27090,U.S. Senate,,DEM,Loretta L. Sanchez,371
+Solano,27110,U.S. Senate,,DEM,Kamala D. Harris,963
+Solano,27110,U.S. Senate,,DEM,Loretta L. Sanchez,340
+Solano,27115,U.S. Senate,,DEM,Kamala D. Harris,995
+Solano,27115,U.S. Senate,,DEM,Loretta L. Sanchez,310
+Solano,27130,U.S. Senate,,DEM,Kamala D. Harris,843
+Solano,27130,U.S. Senate,,DEM,Loretta L. Sanchez,310
+Solano,27165,U.S. Senate,,DEM,Kamala D. Harris,989
+Solano,27165,U.S. Senate,,DEM,Loretta L. Sanchez,434
+Solano,27175,U.S. Senate,,DEM,Kamala D. Harris,585
+Solano,27175,U.S. Senate,,DEM,Loretta L. Sanchez,256
+Solano,27185,U.S. Senate,,DEM,Kamala D. Harris,383
+Solano,27185,U.S. Senate,,DEM,Loretta L. Sanchez,226
+Solano,27187,U.S. Senate,,DEM,Kamala D. Harris,161
+Solano,27187,U.S. Senate,,DEM,Loretta L. Sanchez,93
+Solano,29405,U.S. Senate,,DEM,Kamala D. Harris,250
+Solano,29405,U.S. Senate,,DEM,Loretta L. Sanchez,164
+Solano,29406,U.S. Senate,,DEM,Kamala D. Harris,239
+Solano,29406,U.S. Senate,,DEM,Loretta L. Sanchez,126
+Solano,29407,U.S. Senate,,DEM,Kamala D. Harris,60
+Solano,29407,U.S. Senate,,DEM,Loretta L. Sanchez,36
+Solano,29408,U.S. Senate,,DEM,Kamala D. Harris,36
+Solano,29408,U.S. Senate,,DEM,Loretta L. Sanchez,30
+Solano,29820,U.S. Senate,,DEM,Kamala D. Harris,230
+Solano,29820,U.S. Senate,,DEM,Loretta L. Sanchez,96
+Solano,29830,U.S. Senate,,DEM,Kamala D. Harris,11
+Solano,29830,U.S. Senate,,DEM,Loretta L. Sanchez,9
+Solano,29835,U.S. Senate,,DEM,Kamala D. Harris,23
+Solano,29835,U.S. Senate,,DEM,Loretta L. Sanchez,9
+Solano,29840,U.S. Senate,,DEM,Kamala D. Harris,145
+Solano,29840,U.S. Senate,,DEM,Loretta L. Sanchez,94
+Solano,33010,U.S. Senate,,DEM,Kamala D. Harris,449
+Solano,33010,U.S. Senate,,DEM,Loretta L. Sanchez,213
+Solano,33015,U.S. Senate,,DEM,Kamala D. Harris,724
+Solano,33015,U.S. Senate,,DEM,Loretta L. Sanchez,472
+Solano,33025,U.S. Senate,,DEM,Kamala D. Harris,485
+Solano,33025,U.S. Senate,,DEM,Loretta L. Sanchez,246
+Solano,33040,U.S. Senate,,DEM,Kamala D. Harris,507
+Solano,33040,U.S. Senate,,DEM,Loretta L. Sanchez,296
+Solano,33041,U.S. Senate,,DEM,Kamala D. Harris,330
+Solano,33041,U.S. Senate,,DEM,Loretta L. Sanchez,139
+Solano,33042,U.S. Senate,,DEM,Kamala D. Harris,184
+Solano,33042,U.S. Senate,,DEM,Loretta L. Sanchez,112
+Solano,33043,U.S. Senate,,DEM,Kamala D. Harris,156
+Solano,33043,U.S. Senate,,DEM,Loretta L. Sanchez,79
+Solano,33045,U.S. Senate,,DEM,Kamala D. Harris,412
+Solano,33045,U.S. Senate,,DEM,Loretta L. Sanchez,219
+Solano,33050,U.S. Senate,,DEM,Kamala D. Harris,756
+Solano,33050,U.S. Senate,,DEM,Loretta L. Sanchez,411
+Solano,33065,U.S. Senate,,DEM,Kamala D. Harris,839
+Solano,33065,U.S. Senate,,DEM,Loretta L. Sanchez,296
+Solano,33070,U.S. Senate,,DEM,Kamala D. Harris,785
+Solano,33070,U.S. Senate,,DEM,Loretta L. Sanchez,525
+Solano,33075,U.S. Senate,,DEM,Kamala D. Harris,554
+Solano,33075,U.S. Senate,,DEM,Loretta L. Sanchez,320
+Solano,33080,U.S. Senate,,DEM,Kamala D. Harris,160
+Solano,33080,U.S. Senate,,DEM,Loretta L. Sanchez,101
+Solano,33115,U.S. Senate,,DEM,Kamala D. Harris,846
+Solano,33115,U.S. Senate,,DEM,Loretta L. Sanchez,388
+Solano,33117,U.S. Senate,,DEM,Kamala D. Harris,0
+Solano,33117,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Solano,33119,U.S. Senate,,DEM,Kamala D. Harris,75
+Solano,33119,U.S. Senate,,DEM,Loretta L. Sanchez,54
+Solano,33190,U.S. Senate,,DEM,Kamala D. Harris,841
+Solano,33190,U.S. Senate,,DEM,Loretta L. Sanchez,560
+Solano,33195,U.S. Senate,,DEM,Kamala D. Harris,377
+Solano,33195,U.S. Senate,,DEM,Loretta L. Sanchez,272
+Solano,33215,U.S. Senate,,DEM,Kamala D. Harris,199
+Solano,33215,U.S. Senate,,DEM,Loretta L. Sanchez,124
+Solano,33216,U.S. Senate,,DEM,Kamala D. Harris,80
+Solano,33216,U.S. Senate,,DEM,Loretta L. Sanchez,51
+Solano,33217,U.S. Senate,,DEM,Kamala D. Harris,269
+Solano,33217,U.S. Senate,,DEM,Loretta L. Sanchez,153
+Solano,33218,U.S. Senate,,DEM,Kamala D. Harris,141
+Solano,33218,U.S. Senate,,DEM,Loretta L. Sanchez,118
+Solano,33230,U.S. Senate,,DEM,Kamala D. Harris,515
+Solano,33230,U.S. Senate,,DEM,Loretta L. Sanchez,265
+Solano,33240,U.S. Senate,,DEM,Kamala D. Harris,308
+Solano,33240,U.S. Senate,,DEM,Loretta L. Sanchez,180
+Solano,33245,U.S. Senate,,DEM,Kamala D. Harris,556
+Solano,33245,U.S. Senate,,DEM,Loretta L. Sanchez,312
+Solano,33250,U.S. Senate,,DEM,Kamala D. Harris,366
+Solano,33250,U.S. Senate,,DEM,Loretta L. Sanchez,220
+Solano,33252,U.S. Senate,,DEM,Kamala D. Harris,3
+Solano,33252,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Solano,33254,U.S. Senate,,DEM,Kamala D. Harris,18
+Solano,33254,U.S. Senate,,DEM,Loretta L. Sanchez,16
+Solano,33255,U.S. Senate,,DEM,Kamala D. Harris,7
+Solano,33255,U.S. Senate,,DEM,Loretta L. Sanchez,6
+Solano,33256,U.S. Senate,,DEM,Kamala D. Harris,108
+Solano,33256,U.S. Senate,,DEM,Loretta L. Sanchez,96
+Solano,33265,U.S. Senate,,DEM,Kamala D. Harris,237
+Solano,33265,U.S. Senate,,DEM,Loretta L. Sanchez,154
+Solano,33267,U.S. Senate,,DEM,Kamala D. Harris,243
+Solano,33267,U.S. Senate,,DEM,Loretta L. Sanchez,142
+Solano,35005,U.S. Senate,,DEM,Kamala D. Harris,578
+Solano,35005,U.S. Senate,,DEM,Loretta L. Sanchez,289
+Solano,35020,U.S. Senate,,DEM,Kamala D. Harris,634
+Solano,35020,U.S. Senate,,DEM,Loretta L. Sanchez,287
+Solano,35025,U.S. Senate,,DEM,Kamala D. Harris,355
+Solano,35025,U.S. Senate,,DEM,Loretta L. Sanchez,252
+Solano,35040,U.S. Senate,,DEM,Kamala D. Harris,996
+Solano,35040,U.S. Senate,,DEM,Loretta L. Sanchez,568
+Solano,35045,U.S. Senate,,DEM,Kamala D. Harris,932
+Solano,35045,U.S. Senate,,DEM,Loretta L. Sanchez,440
+Solano,35055,U.S. Senate,,DEM,Kamala D. Harris,644
+Solano,35055,U.S. Senate,,DEM,Loretta L. Sanchez,325
+Solano,35057,U.S. Senate,,DEM,Kamala D. Harris,153
+Solano,35057,U.S. Senate,,DEM,Loretta L. Sanchez,99
+Solano,39452,U.S. Senate,,DEM,Kamala D. Harris,84
+Solano,39452,U.S. Senate,,DEM,Loretta L. Sanchez,69
+Solano,39454,U.S. Senate,,DEM,Kamala D. Harris,74
+Solano,39454,U.S. Senate,,DEM,Loretta L. Sanchez,56
+Solano,42010,U.S. Senate,,DEM,Kamala D. Harris,674
+Solano,42010,U.S. Senate,,DEM,Loretta L. Sanchez,472
+Solano,42012,U.S. Senate,,DEM,Kamala D. Harris,96
+Solano,42012,U.S. Senate,,DEM,Loretta L. Sanchez,74
+Solano,42020,U.S. Senate,,DEM,Kamala D. Harris,432
+Solano,42020,U.S. Senate,,DEM,Loretta L. Sanchez,360
+Solano,42022,U.S. Senate,,DEM,Kamala D. Harris,332
+Solano,42022,U.S. Senate,,DEM,Loretta L. Sanchez,223
+Solano,42025,U.S. Senate,,DEM,Kamala D. Harris,229
+Solano,42025,U.S. Senate,,DEM,Loretta L. Sanchez,183
+Solano,42045,U.S. Senate,,DEM,Kamala D. Harris,205
+Solano,42045,U.S. Senate,,DEM,Loretta L. Sanchez,135
+Solano,42047,U.S. Senate,,DEM,Kamala D. Harris,85
+Solano,42047,U.S. Senate,,DEM,Loretta L. Sanchez,52
+Solano,42048,U.S. Senate,,DEM,Kamala D. Harris,41
+Solano,42048,U.S. Senate,,DEM,Loretta L. Sanchez,24
+Solano,42049,U.S. Senate,,DEM,Kamala D. Harris,52
+Solano,42049,U.S. Senate,,DEM,Loretta L. Sanchez,23
+Solano,42050,U.S. Senate,,DEM,Kamala D. Harris,607
+Solano,42050,U.S. Senate,,DEM,Loretta L. Sanchez,400
+Solano,42055,U.S. Senate,,DEM,Kamala D. Harris,249
+Solano,42055,U.S. Senate,,DEM,Loretta L. Sanchez,123
+Solano,42060,U.S. Senate,,DEM,Kamala D. Harris,67
+Solano,42060,U.S. Senate,,DEM,Loretta L. Sanchez,33
+Solano,42065,U.S. Senate,,DEM,Kamala D. Harris,706
+Solano,42065,U.S. Senate,,DEM,Loretta L. Sanchez,535
+Solano,42070,U.S. Senate,,DEM,Kamala D. Harris,268
+Solano,42070,U.S. Senate,,DEM,Loretta L. Sanchez,264
+Solano,46015,U.S. Senate,,DEM,Kamala D. Harris,489
+Solano,46015,U.S. Senate,,DEM,Loretta L. Sanchez,240
+Solano,46020,U.S. Senate,,DEM,Kamala D. Harris,858
+Solano,46020,U.S. Senate,,DEM,Loretta L. Sanchez,444
+Solano,46030,U.S. Senate,,DEM,Kamala D. Harris,64
+Solano,46030,U.S. Senate,,DEM,Loretta L. Sanchez,32
+Solano,46050,U.S. Senate,,DEM,Kamala D. Harris,851
+Solano,46050,U.S. Senate,,DEM,Loretta L. Sanchez,461
+Solano,46065,U.S. Senate,,DEM,Kamala D. Harris,657
+Solano,46065,U.S. Senate,,DEM,Loretta L. Sanchez,397
+Solano,46070,U.S. Senate,,DEM,Kamala D. Harris,586
+Solano,46070,U.S. Senate,,DEM,Loretta L. Sanchez,332
+Solano,46120,U.S. Senate,,DEM,Kamala D. Harris,891
+Solano,46120,U.S. Senate,,DEM,Loretta L. Sanchez,600
+Solano,46123,U.S. Senate,,DEM,Kamala D. Harris,91
+Solano,46123,U.S. Senate,,DEM,Loretta L. Sanchez,54
+Solano,46124,U.S. Senate,,DEM,Kamala D. Harris,32
+Solano,46124,U.S. Senate,,DEM,Loretta L. Sanchez,10
+Solano,46125,U.S. Senate,,DEM,Kamala D. Harris,18
+Solano,46125,U.S. Senate,,DEM,Loretta L. Sanchez,15
+Solano,46127,U.S. Senate,,DEM,Kamala D. Harris,253
+Solano,46127,U.S. Senate,,DEM,Loretta L. Sanchez,151
+Solano,46129,U.S. Senate,,DEM,Kamala D. Harris,162
+Solano,46129,U.S. Senate,,DEM,Loretta L. Sanchez,89
+Solano,46130,U.S. Senate,,DEM,Kamala D. Harris,880
+Solano,46130,U.S. Senate,,DEM,Loretta L. Sanchez,403
+Solano,46150,U.S. Senate,,DEM,Kamala D. Harris,870
+Solano,46150,U.S. Senate,,DEM,Loretta L. Sanchez,561
+Solano,46155,U.S. Senate,,DEM,Kamala D. Harris,0
+Solano,46155,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Solano,46157,U.S. Senate,,DEM,Kamala D. Harris,234
+Solano,46157,U.S. Senate,,DEM,Loretta L. Sanchez,147
+Solano,46158,U.S. Senate,,DEM,Kamala D. Harris,26
+Solano,46158,U.S. Senate,,DEM,Loretta L. Sanchez,17
+Solano,46159,U.S. Senate,,DEM,Kamala D. Harris,56
+Solano,46159,U.S. Senate,,DEM,Loretta L. Sanchez,31
+Solano,46180,U.S. Senate,,DEM,Kamala D. Harris,212
+Solano,46180,U.S. Senate,,DEM,Loretta L. Sanchez,101
+Solano,46185,U.S. Senate,,DEM,Kamala D. Harris,427
+Solano,46185,U.S. Senate,,DEM,Loretta L. Sanchez,199
+Solano,46190,U.S. Senate,,DEM,Kamala D. Harris,632
+Solano,46190,U.S. Senate,,DEM,Loretta L. Sanchez,400
+Solano,46210,U.S. Senate,,DEM,Kamala D. Harris,538
+Solano,46210,U.S. Senate,,DEM,Loretta L. Sanchez,335
+Solano,46270,U.S. Senate,,DEM,Kamala D. Harris,804
+Solano,46270,U.S. Senate,,DEM,Loretta L. Sanchez,487
+Solano,46380,U.S. Senate,,DEM,Kamala D. Harris,664
+Solano,46380,U.S. Senate,,DEM,Loretta L. Sanchez,509
+Solano,46400,U.S. Senate,,DEM,Kamala D. Harris,1042
+Solano,46400,U.S. Senate,,DEM,Loretta L. Sanchez,598
+Solano,46405,U.S. Senate,,DEM,Kamala D. Harris,60
+Solano,46405,U.S. Senate,,DEM,Loretta L. Sanchez,35
+Solano,49730,U.S. Senate,,DEM,Kamala D. Harris,219
+Solano,49730,U.S. Senate,,DEM,Loretta L. Sanchez,161
+Solano,49733,U.S. Senate,,DEM,Kamala D. Harris,462
+Solano,49733,U.S. Senate,,DEM,Loretta L. Sanchez,297
+Solano,49740,U.S. Senate,,DEM,Kamala D. Harris,52
+Solano,49740,U.S. Senate,,DEM,Loretta L. Sanchez,29
+Solano,49742,U.S. Senate,,DEM,Kamala D. Harris,8
+Solano,49742,U.S. Senate,,DEM,Loretta L. Sanchez,9
+Solano,49744,U.S. Senate,,DEM,Kamala D. Harris,181
+Solano,49744,U.S. Senate,,DEM,Loretta L. Sanchez,78
+Solano,53005,U.S. Senate,,DEM,Kamala D. Harris,1355
+Solano,53005,U.S. Senate,,DEM,Loretta L. Sanchez,709
+Solano,53007,U.S. Senate,,DEM,Kamala D. Harris,4
+Solano,53007,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Solano,53070,U.S. Senate,,DEM,Kamala D. Harris,1287
+Solano,53070,U.S. Senate,,DEM,Loretta L. Sanchez,705
+Solano,53075,U.S. Senate,,DEM,Kamala D. Harris,2
+Solano,53075,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Solano,53100,U.S. Senate,,DEM,Kamala D. Harris,1352
+Solano,53100,U.S. Senate,,DEM,Loretta L. Sanchez,828
+Solano,53125,U.S. Senate,,DEM,Kamala D. Harris,1415
+Solano,53125,U.S. Senate,,DEM,Loretta L. Sanchez,763
+Solano,53140,U.S. Senate,,DEM,Kamala D. Harris,995
+Solano,53140,U.S. Senate,,DEM,Loretta L. Sanchez,530
+Solano,54005,U.S. Senate,,DEM,Kamala D. Harris,879
+Solano,54005,U.S. Senate,,DEM,Loretta L. Sanchez,539
+Solano,54020,U.S. Senate,,DEM,Kamala D. Harris,1993
+Solano,54020,U.S. Senate,,DEM,Loretta L. Sanchez,757
+Solano,55005,U.S. Senate,,DEM,Kamala D. Harris,1394
+Solano,55005,U.S. Senate,,DEM,Loretta L. Sanchez,796
+Solano,55010,U.S. Senate,,DEM,Kamala D. Harris,103
+Solano,55010,U.S. Senate,,DEM,Loretta L. Sanchez,46
+Solano,56010,U.S. Senate,,DEM,Kamala D. Harris,1143
+Solano,56010,U.S. Senate,,DEM,Loretta L. Sanchez,512
+Solano,56012,U.S. Senate,,DEM,Kamala D. Harris,68
+Solano,56012,U.S. Senate,,DEM,Loretta L. Sanchez,49
+Solano,56020,U.S. Senate,,DEM,Kamala D. Harris,659
+Solano,56020,U.S. Senate,,DEM,Loretta L. Sanchez,429
+Solano,56050,U.S. Senate,,DEM,Kamala D. Harris,600
+Solano,56050,U.S. Senate,,DEM,Loretta L. Sanchez,338
+Solano,56055,U.S. Senate,,DEM,Kamala D. Harris,0
+Solano,56055,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Solano,56100,U.S. Senate,,DEM,Kamala D. Harris,561
+Solano,56100,U.S. Senate,,DEM,Loretta L. Sanchez,393
+Solano,56105,U.S. Senate,,DEM,Kamala D. Harris,807
+Solano,56105,U.S. Senate,,DEM,Loretta L. Sanchez,454
+Solano,56107,U.S. Senate,,DEM,Kamala D. Harris,876
+Solano,56107,U.S. Senate,,DEM,Loretta L. Sanchez,640
+Solano,56109,U.S. Senate,,DEM,Kamala D. Harris,71
+Solano,56109,U.S. Senate,,DEM,Loretta L. Sanchez,33
+Solano,56110,U.S. Senate,,DEM,Kamala D. Harris,844
+Solano,56110,U.S. Senate,,DEM,Loretta L. Sanchez,474
+Solano,56125,U.S. Senate,,DEM,Kamala D. Harris,916
+Solano,56125,U.S. Senate,,DEM,Loretta L. Sanchez,498
+Solano,56155,U.S. Senate,,DEM,Kamala D. Harris,75
+Solano,56155,U.S. Senate,,DEM,Loretta L. Sanchez,34
+Solano,56165,U.S. Senate,,DEM,Kamala D. Harris,394
+Solano,56165,U.S. Senate,,DEM,Loretta L. Sanchez,228
+Solano,56175,U.S. Senate,,DEM,Kamala D. Harris,467
+Solano,56175,U.S. Senate,,DEM,Loretta L. Sanchez,263
+Solano,56190,U.S. Senate,,DEM,Kamala D. Harris,769
+Solano,56190,U.S. Senate,,DEM,Loretta L. Sanchez,491
+Solano,56210,U.S. Senate,,DEM,Kamala D. Harris,721
+Solano,56210,U.S. Senate,,DEM,Loretta L. Sanchez,400
+Solano,56215,U.S. Senate,,DEM,Kamala D. Harris,6
+Solano,56215,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Solano,59530,U.S. Senate,,DEM,Kamala D. Harris,73
+Solano,59530,U.S. Senate,,DEM,Loretta L. Sanchez,58
+Solano,59700,U.S. Senate,,DEM,Kamala D. Harris,72
+Solano,59700,U.S. Senate,,DEM,Loretta L. Sanchez,61
+Solano,59705,U.S. Senate,,DEM,Kamala D. Harris,59
+Solano,59705,U.S. Senate,,DEM,Loretta L. Sanchez,58
+Solano,99001,U.S. Senate,,DEM,Kamala D. Harris,22
+Solano,99001,U.S. Senate,,DEM,Loretta L. Sanchez,21
+Solano,99002,U.S. Senate,,DEM,Kamala D. Harris,2
+Solano,99002,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Solano,99003,U.S. Senate,,DEM,Kamala D. Harris,12
+Solano,99003,U.S. Senate,,DEM,Loretta L. Sanchez,19
+Solano,99004,U.S. Senate,,DEM,Kamala D. Harris,55
+Solano,99004,U.S. Senate,,DEM,Loretta L. Sanchez,24
+Solano,99005,U.S. Senate,,DEM,Kamala D. Harris,15
+Solano,99005,U.S. Senate,,DEM,Loretta L. Sanchez,11
+Solano,99006,U.S. Senate,,DEM,Kamala D. Harris,58
+Solano,99006,U.S. Senate,,DEM,Loretta L. Sanchez,39
+Solano,99008,U.S. Senate,,DEM,Kamala D. Harris,0
+Solano,99008,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Solano,99009,U.S. Senate,,DEM,Kamala D. Harris,13
+Solano,99009,U.S. Senate,,DEM,Loretta L. Sanchez,11
+Solano,99010,U.S. Senate,,DEM,Kamala D. Harris,73
+Solano,99010,U.S. Senate,,DEM,Loretta L. Sanchez,74
+Solano,99011,U.S. Senate,,DEM,Kamala D. Harris,38
+Solano,99011,U.S. Senate,,DEM,Loretta L. Sanchez,26
+Solano,99015,U.S. Senate,,DEM,Kamala D. Harris,0
+Solano,99015,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Solano,99016,U.S. Senate,,DEM,Kamala D. Harris,32
+Solano,99016,U.S. Senate,,DEM,Loretta L. Sanchez,22
+Solano,99018,U.S. Senate,,DEM,Kamala D. Harris,7
+Solano,99018,U.S. Senate,,DEM,Loretta L. Sanchez,8
+Solano,99020,U.S. Senate,,DEM,Kamala D. Harris,27
+Solano,99020,U.S. Senate,,DEM,Loretta L. Sanchez,24
+Solano,99024,U.S. Senate,,DEM,Kamala D. Harris,41
+Solano,99024,U.S. Senate,,DEM,Loretta L. Sanchez,18
+Solano,99025,U.S. Senate,,DEM,Kamala D. Harris,0
+Solano,99025,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Solano,99027,U.S. Senate,,DEM,Kamala D. Harris,7
+Solano,99027,U.S. Senate,,DEM,Loretta L. Sanchez,8
+Solano,99028,U.S. Senate,,DEM,Kamala D. Harris,2
+Solano,99028,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Solano,99029,U.S. Senate,,DEM,Kamala D. Harris,38
+Solano,99029,U.S. Senate,,DEM,Loretta L. Sanchez,35
+Solano,99031,U.S. Senate,,DEM,Kamala D. Harris,8
+Solano,99031,U.S. Senate,,DEM,Loretta L. Sanchez,5
+Solano,99032,U.S. Senate,,DEM,Kamala D. Harris,61
+Solano,99032,U.S. Senate,,DEM,Loretta L. Sanchez,21
+Solano,99033,U.S. Senate,,DEM,Kamala D. Harris,4
+Solano,99033,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Solano,99034,U.S. Senate,,DEM,Kamala D. Harris,5
+Solano,99034,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Solano,99035,U.S. Senate,,DEM,Kamala D. Harris,7
+Solano,99035,U.S. Senate,,DEM,Loretta L. Sanchez,15
+Solano,99038,U.S. Senate,,DEM,Kamala D. Harris,9
+Solano,99038,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Solano,99039,U.S. Senate,,DEM,Kamala D. Harris,7
+Solano,99039,U.S. Senate,,DEM,Loretta L. Sanchez,7
+Solano,99043,U.S. Senate,,DEM,Kamala D. Harris,2
+Solano,99043,U.S. Senate,,DEM,Loretta L. Sanchez,7
+Solano,99045,U.S. Senate,,DEM,Kamala D. Harris,16
+Solano,99045,U.S. Senate,,DEM,Loretta L. Sanchez,5
+Solano,99046,U.S. Senate,,DEM,Kamala D. Harris,11
+Solano,99046,U.S. Senate,,DEM,Loretta L. Sanchez,9
+Solano,99047,U.S. Senate,,DEM,Kamala D. Harris,3
+Solano,99047,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Solano,99049,U.S. Senate,,DEM,Kamala D. Harris,24
+Solano,99049,U.S. Senate,,DEM,Loretta L. Sanchez,10
+Solano,99051,U.S. Senate,,DEM,Kamala D. Harris,16
+Solano,99051,U.S. Senate,,DEM,Loretta L. Sanchez,8
+Solano,99055,U.S. Senate,,DEM,Kamala D. Harris,1
+Solano,99055,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Solano,99057,U.S. Senate,,DEM,Kamala D. Harris,54
+Solano,99057,U.S. Senate,,DEM,Loretta L. Sanchez,48
+Solano,99059,U.S. Senate,,DEM,Kamala D. Harris,19
+Solano,99059,U.S. Senate,,DEM,Loretta L. Sanchez,6
+Solano,99061,U.S. Senate,,DEM,Kamala D. Harris,34
+Solano,99061,U.S. Senate,,DEM,Loretta L. Sanchez,21
+Solano,99063,U.S. Senate,,DEM,Kamala D. Harris,60
+Solano,99063,U.S. Senate,,DEM,Loretta L. Sanchez,16
+Solano,99067,U.S. Senate,,DEM,Kamala D. Harris,4
+Solano,99067,U.S. Senate,,DEM,Loretta L. Sanchez,5
+Solano,99071,U.S. Senate,,DEM,Kamala D. Harris,6
+Solano,99071,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Solano,99073,U.S. Senate,,DEM,Kamala D. Harris,9
+Solano,99073,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Solano,99075,U.S. Senate,,DEM,Kamala D. Harris,4
+Solano,99075,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Solano,99079,U.S. Senate,,DEM,Kamala D. Harris,5
+Solano,99079,U.S. Senate,,DEM,Loretta L. Sanchez,15
+Solano,99081,U.S. Senate,,DEM,Kamala D. Harris,0
+Solano,99081,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Solano,99083,U.S. Senate,,DEM,Kamala D. Harris,48
+Solano,99083,U.S. Senate,,DEM,Loretta L. Sanchez,34
+Solano,99085,U.S. Senate,,DEM,Kamala D. Harris,15
+Solano,99085,U.S. Senate,,DEM,Loretta L. Sanchez,13
+Solano,99087,U.S. Senate,,DEM,Kamala D. Harris,6
+Solano,99087,U.S. Senate,,DEM,Loretta L. Sanchez,20
+Solano,99089,U.S. Senate,,DEM,Kamala D. Harris,2
+Solano,99089,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Solano,99091,U.S. Senate,,DEM,Kamala D. Harris,12
+Solano,99091,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Solano,99093,U.S. Senate,,DEM,Kamala D. Harris,4
+Solano,99093,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Solano,99095,U.S. Senate,,DEM,Kamala D. Harris,2
+Solano,99095,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Solano,99904,U.S. Senate,,DEM,Kamala D. Harris,0
+Solano,99904,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Solano,99905,U.S. Senate,,DEM,Kamala D. Harris,0
+Solano,99905,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Solano,99907,U.S. Senate,,DEM,Kamala D. Harris,0
+Solano,99907,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Solano,99909,U.S. Senate,,DEM,Kamala D. Harris,0
+Solano,99909,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Solano,99913,U.S. Senate,,DEM,Kamala D. Harris,0
+Solano,99913,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Solano,99915,U.S. Senate,,DEM,Kamala D. Harris,0
+Solano,99915,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Solano,99917,U.S. Senate,,DEM,Kamala D. Harris,0
+Solano,99917,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Solano,99918,U.S. Senate,,DEM,Kamala D. Harris,0
+Solano,99918,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Solano,99919,U.S. Senate,,DEM,Kamala D. Harris,0
+Solano,99919,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Solano,99921,U.S. Senate,,DEM,Kamala D. Harris,0
+Solano,99921,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Solano,99925,U.S. Senate,,DEM,Kamala D. Harris,0
+Solano,99925,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Solano,99926,U.S. Senate,,DEM,Kamala D. Harris,0
+Solano,99926,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Solano,99927,U.S. Senate,,DEM,Kamala D. Harris,0
+Solano,99927,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Solano,99929,U.S. Senate,,DEM,Kamala D. Harris,0
+Solano,99929,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Solano,99930,U.S. Senate,,DEM,Kamala D. Harris,0
+Solano,99930,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Solano,99932,U.S. Senate,,DEM,Kamala D. Harris,0
+Solano,99932,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Solano,99933,U.S. Senate,,DEM,Kamala D. Harris,0
+Solano,99933,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Solano,99941,U.S. Senate,,DEM,Kamala D. Harris,0
+Solano,99941,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Solano,99944,U.S. Senate,,DEM,Kamala D. Harris,0
+Solano,99944,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Solano,99945,U.S. Senate,,DEM,Kamala D. Harris,0
+Solano,99945,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Solano,99947,U.S. Senate,,DEM,Kamala D. Harris,0
+Solano,99947,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Solano,99948,U.S. Senate,,DEM,Kamala D. Harris,18
+Solano,99948,U.S. Senate,,DEM,Loretta L. Sanchez,7
+Solano,99949,U.S. Senate,,DEM,Kamala D. Harris,0
+Solano,99949,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Solano,99952,U.S. Senate,,DEM,Kamala D. Harris,0
+Solano,99952,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Solano,99953,U.S. Senate,,DEM,Kamala D. Harris,0
+Solano,99953,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Solano,99954,U.S. Senate,,DEM,Kamala D. Harris,0
+Solano,99954,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Solano,99955,U.S. Senate,,DEM,Kamala D. Harris,0
+Solano,99955,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Solano,99956,U.S. Senate,,DEM,Kamala D. Harris,0
+Solano,99956,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Solano,99957,U.S. Senate,,DEM,Kamala D. Harris,0
+Solano,99957,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Solano,99958,U.S. Senate,,DEM,Kamala D. Harris,0
+Solano,99958,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Solano,99959,U.S. Senate,,DEM,Kamala D. Harris,0
+Solano,99959,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Solano,99960,U.S. Senate,,DEM,Kamala D. Harris,0
+Solano,99960,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Solano,99961,U.S. Senate,,DEM,Kamala D. Harris,0
+Solano,99961,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Solano,99962,U.S. Senate,,DEM,Kamala D. Harris,0
+Solano,99962,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Solano,99965,U.S. Senate,,DEM,Kamala D. Harris,0
+Solano,99965,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Solano,99969,U.S. Senate,,DEM,Kamala D. Harris,0
+Solano,99969,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Solano,99977,U.S. Senate,,DEM,Kamala D. Harris,0
+Solano,99977,U.S. Senate,,DEM,Loretta L. Sanchez,0

--- a/2016/20161108__ca__general__sonoma__precinct.csv
+++ b/2016/20161108__ca__general__sonoma__precinct.csv
@@ -18359,921 +18359,921 @@ Sonoma,7566,Proposition 67,,N/A,Yes,1180
 Sonoma,7566,Proposition 67,,N/A,No,264
 Sonoma,7567,Proposition 67,,N/A,Yes,1372
 Sonoma,7567,Proposition 67,,N/A,No,314
-Sonoma,1001,U.S. Senate,,DEM,Kamala Harris,148
-Sonoma,1001,U.S. Senate,,DEM,Loretta Sanchez,33
-Sonoma,1002,U.S. Senate,,DEM,Kamala Harris,15
-Sonoma,1002,U.S. Senate,,DEM,Loretta Sanchez,6
-Sonoma,1006,U.S. Senate,,DEM,Kamala Harris,0
-Sonoma,1006,U.S. Senate,,DEM,Loretta Sanchez,2
-Sonoma,1008,U.S. Senate,,DEM,Kamala Harris,95
-Sonoma,1008,U.S. Senate,,DEM,Loretta Sanchez,35
-Sonoma,1009,U.S. Senate,,DEM,Kamala Harris,74
-Sonoma,1009,U.S. Senate,,DEM,Loretta Sanchez,32
-Sonoma,1010,U.S. Senate,,DEM,Kamala Harris,114
-Sonoma,1010,U.S. Senate,,DEM,Loretta Sanchez,47
-Sonoma,1012,U.S. Senate,,DEM,Kamala Harris,11
-Sonoma,1012,U.S. Senate,,DEM,Loretta Sanchez,5
-Sonoma,1017,U.S. Senate,,DEM,Kamala Harris,491
-Sonoma,1017,U.S. Senate,,DEM,Loretta Sanchez,117
-Sonoma,1023,U.S. Senate,,DEM,Kamala Harris,796
-Sonoma,1023,U.S. Senate,,DEM,Loretta Sanchez,306
-Sonoma,1032,U.S. Senate,,DEM,Kamala Harris,102
-Sonoma,1032,U.S. Senate,,DEM,Loretta Sanchez,34
-Sonoma,1033,U.S. Senate,,DEM,Kamala Harris,48
-Sonoma,1033,U.S. Senate,,DEM,Loretta Sanchez,8
-Sonoma,1038,U.S. Senate,,DEM,Kamala Harris,18
-Sonoma,1038,U.S. Senate,,DEM,Loretta Sanchez,5
-Sonoma,1039,U.S. Senate,,DEM,Kamala Harris,0
-Sonoma,1039,U.S. Senate,,DEM,Loretta Sanchez,2
-Sonoma,1040,U.S. Senate,,DEM,Kamala Harris,33
-Sonoma,1040,U.S. Senate,,DEM,Loretta Sanchez,11
-Sonoma,1041,U.S. Senate,,DEM,Kamala Harris,7
-Sonoma,1041,U.S. Senate,,DEM,Loretta Sanchez,1
-Sonoma,1043,U.S. Senate,,DEM,Kamala Harris,4
-Sonoma,1043,U.S. Senate,,DEM,Loretta Sanchez,3
-Sonoma,1044,U.S. Senate,,DEM,Kamala Harris,0
-Sonoma,1044,U.S. Senate,,DEM,Loretta Sanchez,0
-Sonoma,1045,U.S. Senate,,DEM,Kamala Harris,28
-Sonoma,1045,U.S. Senate,,DEM,Loretta Sanchez,6
-Sonoma,1046,U.S. Senate,,DEM,Kamala Harris,0
-Sonoma,1046,U.S. Senate,,DEM,Loretta Sanchez,1
-Sonoma,1049,U.S. Senate,,DEM,Kamala Harris,56
-Sonoma,1049,U.S. Senate,,DEM,Loretta Sanchez,16
-Sonoma,1052,U.S. Senate,,DEM,Kamala Harris,67
-Sonoma,1052,U.S. Senate,,DEM,Loretta Sanchez,21
-Sonoma,1053,U.S. Senate,,DEM,Kamala Harris,111
-Sonoma,1053,U.S. Senate,,DEM,Loretta Sanchez,26
-Sonoma,1054,U.S. Senate,,DEM,Kamala Harris,14
-Sonoma,1054,U.S. Senate,,DEM,Loretta Sanchez,4
-Sonoma,1055,U.S. Senate,,DEM,Kamala Harris,106
-Sonoma,1055,U.S. Senate,,DEM,Loretta Sanchez,39
-Sonoma,1056,U.S. Senate,,DEM,Kamala Harris,159
-Sonoma,1056,U.S. Senate,,DEM,Loretta Sanchez,46
-Sonoma,1057,U.S. Senate,,DEM,Kamala Harris,14
-Sonoma,1057,U.S. Senate,,DEM,Loretta Sanchez,7
-Sonoma,1058,U.S. Senate,,DEM,Kamala Harris,6
-Sonoma,1058,U.S. Senate,,DEM,Loretta Sanchez,1
-Sonoma,1059,U.S. Senate,,DEM,Kamala Harris,0
-Sonoma,1059,U.S. Senate,,DEM,Loretta Sanchez,0
-Sonoma,1061,U.S. Senate,,DEM,Kamala Harris,18
-Sonoma,1061,U.S. Senate,,DEM,Loretta Sanchez,5
-Sonoma,1062,U.S. Senate,,DEM,Kamala Harris,18
-Sonoma,1062,U.S. Senate,,DEM,Loretta Sanchez,2
-Sonoma,1063,U.S. Senate,,DEM,Kamala Harris,33
-Sonoma,1063,U.S. Senate,,DEM,Loretta Sanchez,14
-Sonoma,1064,U.S. Senate,,DEM,Kamala Harris,29
-Sonoma,1064,U.S. Senate,,DEM,Loretta Sanchez,15
-Sonoma,1065,U.S. Senate,,DEM,Kamala Harris,29
-Sonoma,1065,U.S. Senate,,DEM,Loretta Sanchez,18
-Sonoma,1067,U.S. Senate,,DEM,Kamala Harris,33
-Sonoma,1067,U.S. Senate,,DEM,Loretta Sanchez,7
-Sonoma,1069,U.S. Senate,,DEM,Kamala Harris,9
-Sonoma,1069,U.S. Senate,,DEM,Loretta Sanchez,1
-Sonoma,1070,U.S. Senate,,DEM,Kamala Harris,9
-Sonoma,1070,U.S. Senate,,DEM,Loretta Sanchez,4
-Sonoma,1073,U.S. Senate,,DEM,Kamala Harris,8
-Sonoma,1073,U.S. Senate,,DEM,Loretta Sanchez,0
-Sonoma,1075,U.S. Senate,,DEM,Kamala Harris,61
-Sonoma,1075,U.S. Senate,,DEM,Loretta Sanchez,25
-Sonoma,1077,U.S. Senate,,DEM,Kamala Harris,241
-Sonoma,1077,U.S. Senate,,DEM,Loretta Sanchez,89
-Sonoma,1078,U.S. Senate,,DEM,Kamala Harris,21
-Sonoma,1078,U.S. Senate,,DEM,Loretta Sanchez,4
-Sonoma,1079,U.S. Senate,,DEM,Kamala Harris,0
-Sonoma,1079,U.S. Senate,,DEM,Loretta Sanchez,1
-Sonoma,1080,U.S. Senate,,DEM,Kamala Harris,68
-Sonoma,1080,U.S. Senate,,DEM,Loretta Sanchez,29
-Sonoma,1083,U.S. Senate,,DEM,Kamala Harris,0
-Sonoma,1083,U.S. Senate,,DEM,Loretta Sanchez,0
-Sonoma,1084,U.S. Senate,,DEM,Kamala Harris,0
-Sonoma,1084,U.S. Senate,,DEM,Loretta Sanchez,2
-Sonoma,1085,U.S. Senate,,DEM,Kamala Harris,11
-Sonoma,1085,U.S. Senate,,DEM,Loretta Sanchez,3
-Sonoma,1086,U.S. Senate,,DEM,Kamala Harris,22
-Sonoma,1086,U.S. Senate,,DEM,Loretta Sanchez,4
-Sonoma,1103,U.S. Senate,,DEM,Kamala Harris,996
-Sonoma,1103,U.S. Senate,,DEM,Loretta Sanchez,391
-Sonoma,1106,U.S. Senate,,DEM,Kamala Harris,574
-Sonoma,1106,U.S. Senate,,DEM,Loretta Sanchez,185
-Sonoma,1107,U.S. Senate,,DEM,Kamala Harris,1053
-Sonoma,1107,U.S. Senate,,DEM,Loretta Sanchez,323
-Sonoma,1108,U.S. Senate,,DEM,Kamala Harris,839
-Sonoma,1108,U.S. Senate,,DEM,Loretta Sanchez,275
-Sonoma,1110,U.S. Senate,,DEM,Kamala Harris,1026
-Sonoma,1110,U.S. Senate,,DEM,Loretta Sanchez,273
-Sonoma,1111,U.S. Senate,,DEM,Kamala Harris,1172
-Sonoma,1111,U.S. Senate,,DEM,Loretta Sanchez,332
-Sonoma,1112,U.S. Senate,,DEM,Kamala Harris,946
-Sonoma,1112,U.S. Senate,,DEM,Loretta Sanchez,324
-Sonoma,1114,U.S. Senate,,DEM,Kamala Harris,71
-Sonoma,1114,U.S. Senate,,DEM,Loretta Sanchez,48
-Sonoma,1115,U.S. Senate,,DEM,Kamala Harris,106
-Sonoma,1115,U.S. Senate,,DEM,Loretta Sanchez,37
-Sonoma,1116,U.S. Senate,,DEM,Kamala Harris,1038
-Sonoma,1116,U.S. Senate,,DEM,Loretta Sanchez,396
-Sonoma,1121,U.S. Senate,,DEM,Kamala Harris,1051
-Sonoma,1121,U.S. Senate,,DEM,Loretta Sanchez,351
-Sonoma,1122,U.S. Senate,,DEM,Kamala Harris,511
-Sonoma,1122,U.S. Senate,,DEM,Loretta Sanchez,118
-Sonoma,1124,U.S. Senate,,DEM,Kamala Harris,967
-Sonoma,1124,U.S. Senate,,DEM,Loretta Sanchez,210
-Sonoma,1128,U.S. Senate,,DEM,Kamala Harris,699
-Sonoma,1128,U.S. Senate,,DEM,Loretta Sanchez,193
-Sonoma,1129,U.S. Senate,,DEM,Kamala Harris,8
-Sonoma,1129,U.S. Senate,,DEM,Loretta Sanchez,0
-Sonoma,1136,U.S. Senate,,DEM,Kamala Harris,1376
-Sonoma,1136,U.S. Senate,,DEM,Loretta Sanchez,463
-Sonoma,1144,U.S. Senate,,DEM,Kamala Harris,4
-Sonoma,1144,U.S. Senate,,DEM,Loretta Sanchez,2
-Sonoma,1145,U.S. Senate,,DEM,Kamala Harris,496
-Sonoma,1145,U.S. Senate,,DEM,Loretta Sanchez,167
-Sonoma,1146,U.S. Senate,,DEM,Kamala Harris,209
-Sonoma,1146,U.S. Senate,,DEM,Loretta Sanchez,80
-Sonoma,1147,U.S. Senate,,DEM,Kamala Harris,26
-Sonoma,1147,U.S. Senate,,DEM,Loretta Sanchez,17
-Sonoma,1802,U.S. Senate,,DEM,Kamala Harris,1036
-Sonoma,1802,U.S. Senate,,DEM,Loretta Sanchez,307
-Sonoma,1811,U.S. Senate,,DEM,Kamala Harris,73
-Sonoma,1811,U.S. Senate,,DEM,Loretta Sanchez,30
-Sonoma,1812,U.S. Senate,,DEM,Kamala Harris,0
-Sonoma,1812,U.S. Senate,,DEM,Loretta Sanchez,0
-Sonoma,1814,U.S. Senate,,DEM,Kamala Harris,0
-Sonoma,1814,U.S. Senate,,DEM,Loretta Sanchez,0
-Sonoma,2016,U.S. Senate,,DEM,Kamala Harris,116
-Sonoma,2016,U.S. Senate,,DEM,Loretta Sanchez,24
-Sonoma,2020,U.S. Senate,,DEM,Kamala Harris,123
-Sonoma,2020,U.S. Senate,,DEM,Loretta Sanchez,55
-Sonoma,2022,U.S. Senate,,DEM,Kamala Harris,55
-Sonoma,2022,U.S. Senate,,DEM,Loretta Sanchez,38
-Sonoma,2024,U.S. Senate,,DEM,Kamala Harris,117
-Sonoma,2024,U.S. Senate,,DEM,Loretta Sanchez,41
-Sonoma,2026,U.S. Senate,,DEM,Kamala Harris,3
-Sonoma,2026,U.S. Senate,,DEM,Loretta Sanchez,4
-Sonoma,2027,U.S. Senate,,DEM,Kamala Harris,5
-Sonoma,2027,U.S. Senate,,DEM,Loretta Sanchez,0
-Sonoma,2028,U.S. Senate,,DEM,Kamala Harris,4
-Sonoma,2028,U.S. Senate,,DEM,Loretta Sanchez,6
-Sonoma,2029,U.S. Senate,,DEM,Kamala Harris,2
-Sonoma,2029,U.S. Senate,,DEM,Loretta Sanchez,4
-Sonoma,2032,U.S. Senate,,DEM,Kamala Harris,6
-Sonoma,2032,U.S. Senate,,DEM,Loretta Sanchez,2
-Sonoma,2034,U.S. Senate,,DEM,Kamala Harris,4
-Sonoma,2034,U.S. Senate,,DEM,Loretta Sanchez,3
-Sonoma,2036,U.S. Senate,,DEM,Kamala Harris,7
-Sonoma,2036,U.S. Senate,,DEM,Loretta Sanchez,6
-Sonoma,2037,U.S. Senate,,DEM,Kamala Harris,0
-Sonoma,2037,U.S. Senate,,DEM,Loretta Sanchez,0
-Sonoma,2038,U.S. Senate,,DEM,Kamala Harris,11
-Sonoma,2038,U.S. Senate,,DEM,Loretta Sanchez,2
-Sonoma,2039,U.S. Senate,,DEM,Kamala Harris,4
-Sonoma,2039,U.S. Senate,,DEM,Loretta Sanchez,6
-Sonoma,2041,U.S. Senate,,DEM,Kamala Harris,7
-Sonoma,2041,U.S. Senate,,DEM,Loretta Sanchez,1
-Sonoma,2042,U.S. Senate,,DEM,Kamala Harris,15
-Sonoma,2042,U.S. Senate,,DEM,Loretta Sanchez,2
-Sonoma,2301,U.S. Senate,,DEM,Kamala Harris,1048
-Sonoma,2301,U.S. Senate,,DEM,Loretta Sanchez,424
-Sonoma,2502,U.S. Senate,,DEM,Kamala Harris,1237
-Sonoma,2502,U.S. Senate,,DEM,Loretta Sanchez,279
-Sonoma,2503,U.S. Senate,,DEM,Kamala Harris,577
-Sonoma,2503,U.S. Senate,,DEM,Loretta Sanchez,186
-Sonoma,2504,U.S. Senate,,DEM,Kamala Harris,1234
-Sonoma,2504,U.S. Senate,,DEM,Loretta Sanchez,329
-Sonoma,2508,U.S. Senate,,DEM,Kamala Harris,791
-Sonoma,2508,U.S. Senate,,DEM,Loretta Sanchez,224
-Sonoma,2509,U.S. Senate,,DEM,Kamala Harris,918
-Sonoma,2509,U.S. Senate,,DEM,Loretta Sanchez,274
-Sonoma,2514,U.S. Senate,,DEM,Kamala Harris,1246
-Sonoma,2514,U.S. Senate,,DEM,Loretta Sanchez,481
-Sonoma,2515,U.S. Senate,,DEM,Kamala Harris,433
-Sonoma,2515,U.S. Senate,,DEM,Loretta Sanchez,219
-Sonoma,2519,U.S. Senate,,DEM,Kamala Harris,1224
-Sonoma,2519,U.S. Senate,,DEM,Loretta Sanchez,476
-Sonoma,2520,U.S. Senate,,DEM,Kamala Harris,1171
-Sonoma,2520,U.S. Senate,,DEM,Loretta Sanchez,456
-Sonoma,2523,U.S. Senate,,DEM,Kamala Harris,976
-Sonoma,2523,U.S. Senate,,DEM,Loretta Sanchez,363
-Sonoma,2530,U.S. Senate,,DEM,Kamala Harris,1039
-Sonoma,2530,U.S. Senate,,DEM,Loretta Sanchez,386
-Sonoma,2531,U.S. Senate,,DEM,Kamala Harris,832
-Sonoma,2531,U.S. Senate,,DEM,Loretta Sanchez,317
-Sonoma,2536,U.S. Senate,,DEM,Kamala Harris,456
-Sonoma,2536,U.S. Senate,,DEM,Loretta Sanchez,140
-Sonoma,2540,U.S. Senate,,DEM,Kamala Harris,1309
-Sonoma,2540,U.S. Senate,,DEM,Loretta Sanchez,514
-Sonoma,2601,U.S. Senate,,DEM,Kamala Harris,1016
-Sonoma,2601,U.S. Senate,,DEM,Loretta Sanchez,501
-Sonoma,2602,U.S. Senate,,DEM,Kamala Harris,519
-Sonoma,2602,U.S. Senate,,DEM,Loretta Sanchez,292
-Sonoma,2604,U.S. Senate,,DEM,Kamala Harris,1
-Sonoma,2604,U.S. Senate,,DEM,Loretta Sanchez,1
-Sonoma,2606,U.S. Senate,,DEM,Kamala Harris,971
-Sonoma,2606,U.S. Senate,,DEM,Loretta Sanchez,416
-Sonoma,3001,U.S. Senate,,DEM,Kamala Harris,4
-Sonoma,3001,U.S. Senate,,DEM,Loretta Sanchez,3
-Sonoma,3002,U.S. Senate,,DEM,Kamala Harris,7
-Sonoma,3002,U.S. Senate,,DEM,Loretta Sanchez,0
-Sonoma,3003,U.S. Senate,,DEM,Kamala Harris,9
-Sonoma,3003,U.S. Senate,,DEM,Loretta Sanchez,13
-Sonoma,3005,U.S. Senate,,DEM,Kamala Harris,131
-Sonoma,3005,U.S. Senate,,DEM,Loretta Sanchez,85
-Sonoma,3006,U.S. Senate,,DEM,Kamala Harris,16
-Sonoma,3006,U.S. Senate,,DEM,Loretta Sanchez,3
-Sonoma,3011,U.S. Senate,,DEM,Kamala Harris,366
-Sonoma,3011,U.S. Senate,,DEM,Loretta Sanchez,283
-Sonoma,3016,U.S. Senate,,DEM,Kamala Harris,78
-Sonoma,3016,U.S. Senate,,DEM,Loretta Sanchez,60
-Sonoma,3017,U.S. Senate,,DEM,Kamala Harris,26
-Sonoma,3017,U.S. Senate,,DEM,Loretta Sanchez,17
-Sonoma,3020,U.S. Senate,,DEM,Kamala Harris,61
-Sonoma,3020,U.S. Senate,,DEM,Loretta Sanchez,17
-Sonoma,3021,U.S. Senate,,DEM,Kamala Harris,31
-Sonoma,3021,U.S. Senate,,DEM,Loretta Sanchez,24
-Sonoma,3024,U.S. Senate,,DEM,Kamala Harris,16
-Sonoma,3024,U.S. Senate,,DEM,Loretta Sanchez,7
-Sonoma,3025,U.S. Senate,,DEM,Kamala Harris,3
-Sonoma,3025,U.S. Senate,,DEM,Loretta Sanchez,2
-Sonoma,3103,U.S. Senate,,DEM,Kamala Harris,1382
-Sonoma,3103,U.S. Senate,,DEM,Loretta Sanchez,470
-Sonoma,3108,U.S. Senate,,DEM,Kamala Harris,670
-Sonoma,3108,U.S. Senate,,DEM,Loretta Sanchez,379
-Sonoma,3109,U.S. Senate,,DEM,Kamala Harris,514
-Sonoma,3109,U.S. Senate,,DEM,Loretta Sanchez,136
-Sonoma,3112,U.S. Senate,,DEM,Kamala Harris,890
-Sonoma,3112,U.S. Senate,,DEM,Loretta Sanchez,287
-Sonoma,3113,U.S. Senate,,DEM,Kamala Harris,783
-Sonoma,3113,U.S. Senate,,DEM,Loretta Sanchez,414
-Sonoma,3116,U.S. Senate,,DEM,Kamala Harris,490
-Sonoma,3116,U.S. Senate,,DEM,Loretta Sanchez,155
-Sonoma,3120,U.S. Senate,,DEM,Kamala Harris,1027
-Sonoma,3120,U.S. Senate,,DEM,Loretta Sanchez,292
-Sonoma,3123,U.S. Senate,,DEM,Kamala Harris,774
-Sonoma,3123,U.S. Senate,,DEM,Loretta Sanchez,287
-Sonoma,3124,U.S. Senate,,DEM,Kamala Harris,947
-Sonoma,3124,U.S. Senate,,DEM,Loretta Sanchez,249
-Sonoma,3128,U.S. Senate,,DEM,Kamala Harris,1258
-Sonoma,3128,U.S. Senate,,DEM,Loretta Sanchez,344
-Sonoma,3135,U.S. Senate,,DEM,Kamala Harris,801
-Sonoma,3135,U.S. Senate,,DEM,Loretta Sanchez,458
-Sonoma,3136,U.S. Senate,,DEM,Kamala Harris,411
-Sonoma,3136,U.S. Senate,,DEM,Loretta Sanchez,234
-Sonoma,3142,U.S. Senate,,DEM,Kamala Harris,902
-Sonoma,3142,U.S. Senate,,DEM,Loretta Sanchez,375
-Sonoma,3601,U.S. Senate,,DEM,Kamala Harris,852
-Sonoma,3601,U.S. Senate,,DEM,Loretta Sanchez,406
-Sonoma,3602,U.S. Senate,,DEM,Kamala Harris,1051
-Sonoma,3602,U.S. Senate,,DEM,Loretta Sanchez,502
-Sonoma,3603,U.S. Senate,,DEM,Kamala Harris,962
-Sonoma,3603,U.S. Senate,,DEM,Loretta Sanchez,477
-Sonoma,3605,U.S. Senate,,DEM,Kamala Harris,447
-Sonoma,3605,U.S. Senate,,DEM,Loretta Sanchez,214
-Sonoma,3609,U.S. Senate,,DEM,Kamala Harris,1062
-Sonoma,3609,U.S. Senate,,DEM,Loretta Sanchez,416
-Sonoma,3611,U.S. Senate,,DEM,Kamala Harris,906
-Sonoma,3611,U.S. Senate,,DEM,Loretta Sanchez,342
-Sonoma,3614,U.S. Senate,,DEM,Kamala Harris,878
-Sonoma,3614,U.S. Senate,,DEM,Loretta Sanchez,349
-Sonoma,3616,U.S. Senate,,DEM,Kamala Harris,898
-Sonoma,3616,U.S. Senate,,DEM,Loretta Sanchez,371
-Sonoma,3618,U.S. Senate,,DEM,Kamala Harris,921
-Sonoma,3618,U.S. Senate,,DEM,Loretta Sanchez,326
-Sonoma,3621,U.S. Senate,,DEM,Kamala Harris,0
-Sonoma,3621,U.S. Senate,,DEM,Loretta Sanchez,0
-Sonoma,3622,U.S. Senate,,DEM,Kamala Harris,0
-Sonoma,3622,U.S. Senate,,DEM,Loretta Sanchez,0
-Sonoma,4009,U.S. Senate,,DEM,Kamala Harris,112
-Sonoma,4009,U.S. Senate,,DEM,Loretta Sanchez,34
-Sonoma,4012,U.S. Senate,,DEM,Kamala Harris,3
-Sonoma,4012,U.S. Senate,,DEM,Loretta Sanchez,3
-Sonoma,4015,U.S. Senate,,DEM,Kamala Harris,119
-Sonoma,4015,U.S. Senate,,DEM,Loretta Sanchez,54
-Sonoma,4017,U.S. Senate,,DEM,Kamala Harris,37
-Sonoma,4017,U.S. Senate,,DEM,Loretta Sanchez,19
-Sonoma,4018,U.S. Senate,,DEM,Kamala Harris,5
-Sonoma,4018,U.S. Senate,,DEM,Loretta Sanchez,7
-Sonoma,4019,U.S. Senate,,DEM,Kamala Harris,0
-Sonoma,4019,U.S. Senate,,DEM,Loretta Sanchez,5
-Sonoma,4020,U.S. Senate,,DEM,Kamala Harris,0
-Sonoma,4020,U.S. Senate,,DEM,Loretta Sanchez,0
-Sonoma,4027,U.S. Senate,,DEM,Kamala Harris,74
-Sonoma,4027,U.S. Senate,,DEM,Loretta Sanchez,33
-Sonoma,4030,U.S. Senate,,DEM,Kamala Harris,2
-Sonoma,4030,U.S. Senate,,DEM,Loretta Sanchez,0
-Sonoma,4034,U.S. Senate,,DEM,Kamala Harris,72
-Sonoma,4034,U.S. Senate,,DEM,Loretta Sanchez,48
-Sonoma,4037,U.S. Senate,,DEM,Kamala Harris,46
-Sonoma,4037,U.S. Senate,,DEM,Loretta Sanchez,14
-Sonoma,4039,U.S. Senate,,DEM,Kamala Harris,14
-Sonoma,4039,U.S. Senate,,DEM,Loretta Sanchez,8
-Sonoma,4051,U.S. Senate,,DEM,Kamala Harris,122
-Sonoma,4051,U.S. Senate,,DEM,Loretta Sanchez,45
-Sonoma,4052,U.S. Senate,,DEM,Kamala Harris,13
-Sonoma,4052,U.S. Senate,,DEM,Loretta Sanchez,5
-Sonoma,4054,U.S. Senate,,DEM,Kamala Harris,1
-Sonoma,4054,U.S. Senate,,DEM,Loretta Sanchez,0
-Sonoma,4064,U.S. Senate,,DEM,Kamala Harris,24
-Sonoma,4064,U.S. Senate,,DEM,Loretta Sanchez,20
-Sonoma,4065,U.S. Senate,,DEM,Kamala Harris,1
-Sonoma,4065,U.S. Senate,,DEM,Loretta Sanchez,2
-Sonoma,4066,U.S. Senate,,DEM,Kamala Harris,3
-Sonoma,4066,U.S. Senate,,DEM,Loretta Sanchez,2
-Sonoma,4067,U.S. Senate,,DEM,Kamala Harris,29
-Sonoma,4067,U.S. Senate,,DEM,Loretta Sanchez,20
-Sonoma,4070,U.S. Senate,,DEM,Kamala Harris,2
-Sonoma,4070,U.S. Senate,,DEM,Loretta Sanchez,0
-Sonoma,4072,U.S. Senate,,DEM,Kamala Harris,4
-Sonoma,4072,U.S. Senate,,DEM,Loretta Sanchez,0
-Sonoma,4073,U.S. Senate,,DEM,Kamala Harris,0
-Sonoma,4073,U.S. Senate,,DEM,Loretta Sanchez,0
-Sonoma,4074,U.S. Senate,,DEM,Kamala Harris,82
-Sonoma,4074,U.S. Senate,,DEM,Loretta Sanchez,21
-Sonoma,4102,U.S. Senate,,DEM,Kamala Harris,46
-Sonoma,4102,U.S. Senate,,DEM,Loretta Sanchez,18
-Sonoma,4103,U.S. Senate,,DEM,Kamala Harris,659
-Sonoma,4103,U.S. Senate,,DEM,Loretta Sanchez,281
-Sonoma,4104,U.S. Senate,,DEM,Kamala Harris,122
-Sonoma,4104,U.S. Senate,,DEM,Loretta Sanchez,50
-Sonoma,4106,U.S. Senate,,DEM,Kamala Harris,44
-Sonoma,4106,U.S. Senate,,DEM,Loretta Sanchez,27
-Sonoma,4109,U.S. Senate,,DEM,Kamala Harris,859
-Sonoma,4109,U.S. Senate,,DEM,Loretta Sanchez,317
-Sonoma,4110,U.S. Senate,,DEM,Kamala Harris,957
-Sonoma,4110,U.S. Senate,,DEM,Loretta Sanchez,403
-Sonoma,4127,U.S. Senate,,DEM,Kamala Harris,633
-Sonoma,4127,U.S. Senate,,DEM,Loretta Sanchez,275
-Sonoma,4128,U.S. Senate,,DEM,Kamala Harris,54
-Sonoma,4128,U.S. Senate,,DEM,Loretta Sanchez,22
-Sonoma,4129,U.S. Senate,,DEM,Kamala Harris,88
-Sonoma,4129,U.S. Senate,,DEM,Loretta Sanchez,26
-Sonoma,4201,U.S. Senate,,DEM,Kamala Harris,803
-Sonoma,4201,U.S. Senate,,DEM,Loretta Sanchez,472
-Sonoma,4203,U.S. Senate,,DEM,Kamala Harris,503
-Sonoma,4203,U.S. Senate,,DEM,Loretta Sanchez,225
-Sonoma,4204,U.S. Senate,,DEM,Kamala Harris,938
-Sonoma,4204,U.S. Senate,,DEM,Loretta Sanchez,346
-Sonoma,4401,U.S. Senate,,DEM,Kamala Harris,856
-Sonoma,4401,U.S. Senate,,DEM,Loretta Sanchez,393
-Sonoma,4402,U.S. Senate,,DEM,Kamala Harris,1095
-Sonoma,4402,U.S. Senate,,DEM,Loretta Sanchez,339
-Sonoma,4406,U.S. Senate,,DEM,Kamala Harris,735
-Sonoma,4406,U.S. Senate,,DEM,Loretta Sanchez,297
-Sonoma,4407,U.S. Senate,,DEM,Kamala Harris,0
-Sonoma,4407,U.S. Senate,,DEM,Loretta Sanchez,0
-Sonoma,4902,U.S. Senate,,DEM,Kamala Harris,875
-Sonoma,4902,U.S. Senate,,DEM,Loretta Sanchez,408
-Sonoma,4903,U.S. Senate,,DEM,Kamala Harris,731
-Sonoma,4903,U.S. Senate,,DEM,Loretta Sanchez,317
-Sonoma,4904,U.S. Senate,,DEM,Kamala Harris,809
-Sonoma,4904,U.S. Senate,,DEM,Loretta Sanchez,337
-Sonoma,4906,U.S. Senate,,DEM,Kamala Harris,960
-Sonoma,4906,U.S. Senate,,DEM,Loretta Sanchez,412
-Sonoma,4907,U.S. Senate,,DEM,Kamala Harris,958
-Sonoma,4907,U.S. Senate,,DEM,Loretta Sanchez,456
-Sonoma,4908,U.S. Senate,,DEM,Kamala Harris,963
-Sonoma,4908,U.S. Senate,,DEM,Loretta Sanchez,574
-Sonoma,5008,U.S. Senate,,DEM,Kamala Harris,600
-Sonoma,5008,U.S. Senate,,DEM,Loretta Sanchez,385
-Sonoma,5026,U.S. Senate,,DEM,Kamala Harris,17
-Sonoma,5026,U.S. Senate,,DEM,Loretta Sanchez,7
-Sonoma,5029,U.S. Senate,,DEM,Kamala Harris,27
-Sonoma,5029,U.S. Senate,,DEM,Loretta Sanchez,9
-Sonoma,5031,U.S. Senate,,DEM,Kamala Harris,327
-Sonoma,5031,U.S. Senate,,DEM,Loretta Sanchez,69
-Sonoma,5050,U.S. Senate,,DEM,Kamala Harris,0
-Sonoma,5050,U.S. Senate,,DEM,Loretta Sanchez,0
-Sonoma,5052,U.S. Senate,,DEM,Kamala Harris,108
-Sonoma,5052,U.S. Senate,,DEM,Loretta Sanchez,27
-Sonoma,5054,U.S. Senate,,DEM,Kamala Harris,3
-Sonoma,5054,U.S. Senate,,DEM,Loretta Sanchez,0
-Sonoma,5055,U.S. Senate,,DEM,Kamala Harris,36
-Sonoma,5055,U.S. Senate,,DEM,Loretta Sanchez,23
-Sonoma,5056,U.S. Senate,,DEM,Kamala Harris,108
-Sonoma,5056,U.S. Senate,,DEM,Loretta Sanchez,48
-Sonoma,5057,U.S. Senate,,DEM,Kamala Harris,44
-Sonoma,5057,U.S. Senate,,DEM,Loretta Sanchez,23
-Sonoma,5058,U.S. Senate,,DEM,Kamala Harris,43
-Sonoma,5058,U.S. Senate,,DEM,Loretta Sanchez,10
-Sonoma,5059,U.S. Senate,,DEM,Kamala Harris,12
-Sonoma,5059,U.S. Senate,,DEM,Loretta Sanchez,6
-Sonoma,5060,U.S. Senate,,DEM,Kamala Harris,41
-Sonoma,5060,U.S. Senate,,DEM,Loretta Sanchez,6
-Sonoma,5062,U.S. Senate,,DEM,Kamala Harris,72
-Sonoma,5062,U.S. Senate,,DEM,Loretta Sanchez,11
-Sonoma,5063,U.S. Senate,,DEM,Kamala Harris,121
-Sonoma,5063,U.S. Senate,,DEM,Loretta Sanchez,28
-Sonoma,5064,U.S. Senate,,DEM,Kamala Harris,105
-Sonoma,5064,U.S. Senate,,DEM,Loretta Sanchez,38
-Sonoma,5065,U.S. Senate,,DEM,Kamala Harris,23
-Sonoma,5065,U.S. Senate,,DEM,Loretta Sanchez,4
-Sonoma,5067,U.S. Senate,,DEM,Kamala Harris,0
-Sonoma,5067,U.S. Senate,,DEM,Loretta Sanchez,0
-Sonoma,5068,U.S. Senate,,DEM,Kamala Harris,2
-Sonoma,5068,U.S. Senate,,DEM,Loretta Sanchez,0
-Sonoma,5069,U.S. Senate,,DEM,Kamala Harris,58
-Sonoma,5069,U.S. Senate,,DEM,Loretta Sanchez,6
-Sonoma,5070,U.S. Senate,,DEM,Kamala Harris,20
-Sonoma,5070,U.S. Senate,,DEM,Loretta Sanchez,6
-Sonoma,5071,U.S. Senate,,DEM,Kamala Harris,3
-Sonoma,5071,U.S. Senate,,DEM,Loretta Sanchez,2
-Sonoma,5074,U.S. Senate,,DEM,Kamala Harris,3
-Sonoma,5074,U.S. Senate,,DEM,Loretta Sanchez,1
-Sonoma,5075,U.S. Senate,,DEM,Kamala Harris,0
-Sonoma,5075,U.S. Senate,,DEM,Loretta Sanchez,0
-Sonoma,5076,U.S. Senate,,DEM,Kamala Harris,0
-Sonoma,5076,U.S. Senate,,DEM,Loretta Sanchez,0
-Sonoma,5077,U.S. Senate,,DEM,Kamala Harris,212
-Sonoma,5077,U.S. Senate,,DEM,Loretta Sanchez,87
-Sonoma,5104,U.S. Senate,,DEM,Kamala Harris,924
-Sonoma,5104,U.S. Senate,,DEM,Loretta Sanchez,552
-Sonoma,5105,U.S. Senate,,DEM,Kamala Harris,715
-Sonoma,5105,U.S. Senate,,DEM,Loretta Sanchez,441
-Sonoma,5109,U.S. Senate,,DEM,Kamala Harris,833
-Sonoma,5109,U.S. Senate,,DEM,Loretta Sanchez,304
-Sonoma,5111,U.S. Senate,,DEM,Kamala Harris,734
-Sonoma,5111,U.S. Senate,,DEM,Loretta Sanchez,307
-Sonoma,5114,U.S. Senate,,DEM,Kamala Harris,0
-Sonoma,5114,U.S. Senate,,DEM,Loretta Sanchez,0
-Sonoma,5115,U.S. Senate,,DEM,Kamala Harris,341
-Sonoma,5115,U.S. Senate,,DEM,Loretta Sanchez,243
-Sonoma,5116,U.S. Senate,,DEM,Kamala Harris,131
-Sonoma,5116,U.S. Senate,,DEM,Loretta Sanchez,42
-Sonoma,7101,U.S. Senate,,DEM,Kamala Harris,237
-Sonoma,7101,U.S. Senate,,DEM,Loretta Sanchez,81
-Sonoma,7102,U.S. Senate,,DEM,Kamala Harris,28
-Sonoma,7102,U.S. Senate,,DEM,Loretta Sanchez,16
-Sonoma,7103,U.S. Senate,,DEM,Kamala Harris,65
-Sonoma,7103,U.S. Senate,,DEM,Loretta Sanchez,24
-Sonoma,7104,U.S. Senate,,DEM,Kamala Harris,143
-Sonoma,7104,U.S. Senate,,DEM,Loretta Sanchez,33
-Sonoma,7105,U.S. Senate,,DEM,Kamala Harris,7
-Sonoma,7105,U.S. Senate,,DEM,Loretta Sanchez,2
-Sonoma,7106,U.S. Senate,,DEM,Kamala Harris,85
-Sonoma,7106,U.S. Senate,,DEM,Loretta Sanchez,27
-Sonoma,7107,U.S. Senate,,DEM,Kamala Harris,873
-Sonoma,7107,U.S. Senate,,DEM,Loretta Sanchez,228
-Sonoma,7108,U.S. Senate,,DEM,Kamala Harris,0
-Sonoma,7108,U.S. Senate,,DEM,Loretta Sanchez,0
-Sonoma,7109,U.S. Senate,,DEM,Kamala Harris,0
-Sonoma,7109,U.S. Senate,,DEM,Loretta Sanchez,0
-Sonoma,7110,U.S. Senate,,DEM,Kamala Harris,45
-Sonoma,7110,U.S. Senate,,DEM,Loretta Sanchez,12
-Sonoma,7111,U.S. Senate,,DEM,Kamala Harris,982
-Sonoma,7111,U.S. Senate,,DEM,Loretta Sanchez,294
-Sonoma,7112,U.S. Senate,,DEM,Kamala Harris,1025
-Sonoma,7112,U.S. Senate,,DEM,Loretta Sanchez,417
-Sonoma,7113,U.S. Senate,,DEM,Kamala Harris,875
-Sonoma,7113,U.S. Senate,,DEM,Loretta Sanchez,370
-Sonoma,7114,U.S. Senate,,DEM,Kamala Harris,80
-Sonoma,7114,U.S. Senate,,DEM,Loretta Sanchez,24
-Sonoma,7115,U.S. Senate,,DEM,Kamala Harris,85
-Sonoma,7115,U.S. Senate,,DEM,Loretta Sanchez,24
-Sonoma,7116,U.S. Senate,,DEM,Kamala Harris,65
-Sonoma,7116,U.S. Senate,,DEM,Loretta Sanchez,17
-Sonoma,7117,U.S. Senate,,DEM,Kamala Harris,45
-Sonoma,7117,U.S. Senate,,DEM,Loretta Sanchez,9
-Sonoma,7118,U.S. Senate,,DEM,Kamala Harris,279
-Sonoma,7118,U.S. Senate,,DEM,Loretta Sanchez,123
-Sonoma,7119,U.S. Senate,,DEM,Kamala Harris,487
-Sonoma,7119,U.S. Senate,,DEM,Loretta Sanchez,159
-Sonoma,7120,U.S. Senate,,DEM,Kamala Harris,229
-Sonoma,7120,U.S. Senate,,DEM,Loretta Sanchez,77
-Sonoma,7121,U.S. Senate,,DEM,Kamala Harris,12
-Sonoma,7121,U.S. Senate,,DEM,Loretta Sanchez,2
-Sonoma,7122,U.S. Senate,,DEM,Kamala Harris,1195
-Sonoma,7122,U.S. Senate,,DEM,Loretta Sanchez,543
-Sonoma,7123,U.S. Senate,,DEM,Kamala Harris,883
-Sonoma,7123,U.S. Senate,,DEM,Loretta Sanchez,237
-Sonoma,7124,U.S. Senate,,DEM,Kamala Harris,548
-Sonoma,7124,U.S. Senate,,DEM,Loretta Sanchez,205
-Sonoma,7125,U.S. Senate,,DEM,Kamala Harris,213
-Sonoma,7125,U.S. Senate,,DEM,Loretta Sanchez,128
-Sonoma,7126,U.S. Senate,,DEM,Kamala Harris,13
-Sonoma,7126,U.S. Senate,,DEM,Loretta Sanchez,5
-Sonoma,7127,U.S. Senate,,DEM,Kamala Harris,324
-Sonoma,7127,U.S. Senate,,DEM,Loretta Sanchez,110
-Sonoma,7128,U.S. Senate,,DEM,Kamala Harris,54
-Sonoma,7128,U.S. Senate,,DEM,Loretta Sanchez,12
-Sonoma,7129,U.S. Senate,,DEM,Kamala Harris,0
-Sonoma,7129,U.S. Senate,,DEM,Loretta Sanchez,0
-Sonoma,7130,U.S. Senate,,DEM,Kamala Harris,237
-Sonoma,7130,U.S. Senate,,DEM,Loretta Sanchez,82
-Sonoma,7131,U.S. Senate,,DEM,Kamala Harris,73
-Sonoma,7131,U.S. Senate,,DEM,Loretta Sanchez,25
-Sonoma,7132,U.S. Senate,,DEM,Kamala Harris,107
-Sonoma,7132,U.S. Senate,,DEM,Loretta Sanchez,38
-Sonoma,7133,U.S. Senate,,DEM,Kamala Harris,1
-Sonoma,7133,U.S. Senate,,DEM,Loretta Sanchez,0
-Sonoma,7134,U.S. Senate,,DEM,Kamala Harris,1
-Sonoma,7134,U.S. Senate,,DEM,Loretta Sanchez,0
-Sonoma,7135,U.S. Senate,,DEM,Kamala Harris,0
-Sonoma,7135,U.S. Senate,,DEM,Loretta Sanchez,1
-Sonoma,7136,U.S. Senate,,DEM,Kamala Harris,194
-Sonoma,7136,U.S. Senate,,DEM,Loretta Sanchez,52
-Sonoma,7137,U.S. Senate,,DEM,Kamala Harris,132
-Sonoma,7137,U.S. Senate,,DEM,Loretta Sanchez,48
-Sonoma,7138,U.S. Senate,,DEM,Kamala Harris,382
-Sonoma,7138,U.S. Senate,,DEM,Loretta Sanchez,115
-Sonoma,7139,U.S. Senate,,DEM,Kamala Harris,776
-Sonoma,7139,U.S. Senate,,DEM,Loretta Sanchez,175
-Sonoma,7140,U.S. Senate,,DEM,Kamala Harris,881
-Sonoma,7140,U.S. Senate,,DEM,Loretta Sanchez,353
-Sonoma,7141,U.S. Senate,,DEM,Kamala Harris,689
-Sonoma,7141,U.S. Senate,,DEM,Loretta Sanchez,192
-Sonoma,7142,U.S. Senate,,DEM,Kamala Harris,143
-Sonoma,7142,U.S. Senate,,DEM,Loretta Sanchez,44
-Sonoma,7143,U.S. Senate,,DEM,Kamala Harris,404
-Sonoma,7143,U.S. Senate,,DEM,Loretta Sanchez,138
-Sonoma,7144,U.S. Senate,,DEM,Kamala Harris,1418
-Sonoma,7144,U.S. Senate,,DEM,Loretta Sanchez,351
-Sonoma,7145,U.S. Senate,,DEM,Kamala Harris,882
-Sonoma,7145,U.S. Senate,,DEM,Loretta Sanchez,314
-Sonoma,7146,U.S. Senate,,DEM,Kamala Harris,969
-Sonoma,7146,U.S. Senate,,DEM,Loretta Sanchez,311
-Sonoma,7147,U.S. Senate,,DEM,Kamala Harris,1210
-Sonoma,7147,U.S. Senate,,DEM,Loretta Sanchez,397
-Sonoma,7201,U.S. Senate,,DEM,Kamala Harris,159
-Sonoma,7201,U.S. Senate,,DEM,Loretta Sanchez,116
-Sonoma,7202,U.S. Senate,,DEM,Kamala Harris,1
-Sonoma,7202,U.S. Senate,,DEM,Loretta Sanchez,4
-Sonoma,7203,U.S. Senate,,DEM,Kamala Harris,957
-Sonoma,7203,U.S. Senate,,DEM,Loretta Sanchez,326
-Sonoma,7204,U.S. Senate,,DEM,Kamala Harris,33
-Sonoma,7204,U.S. Senate,,DEM,Loretta Sanchez,15
-Sonoma,7205,U.S. Senate,,DEM,Kamala Harris,159
-Sonoma,7205,U.S. Senate,,DEM,Loretta Sanchez,34
-Sonoma,7206,U.S. Senate,,DEM,Kamala Harris,621
-Sonoma,7206,U.S. Senate,,DEM,Loretta Sanchez,268
-Sonoma,7207,U.S. Senate,,DEM,Kamala Harris,533
-Sonoma,7207,U.S. Senate,,DEM,Loretta Sanchez,171
-Sonoma,7208,U.S. Senate,,DEM,Kamala Harris,161
-Sonoma,7208,U.S. Senate,,DEM,Loretta Sanchez,120
-Sonoma,7209,U.S. Senate,,DEM,Kamala Harris,55
-Sonoma,7209,U.S. Senate,,DEM,Loretta Sanchez,21
-Sonoma,7210,U.S. Senate,,DEM,Kamala Harris,324
-Sonoma,7210,U.S. Senate,,DEM,Loretta Sanchez,116
-Sonoma,7211,U.S. Senate,,DEM,Kamala Harris,290
-Sonoma,7211,U.S. Senate,,DEM,Loretta Sanchez,107
-Sonoma,7212,U.S. Senate,,DEM,Kamala Harris,522
-Sonoma,7212,U.S. Senate,,DEM,Loretta Sanchez,161
-Sonoma,7213,U.S. Senate,,DEM,Kamala Harris,10
-Sonoma,7213,U.S. Senate,,DEM,Loretta Sanchez,1
-Sonoma,7214,U.S. Senate,,DEM,Kamala Harris,203
-Sonoma,7214,U.S. Senate,,DEM,Loretta Sanchez,83
-Sonoma,7215,U.S. Senate,,DEM,Kamala Harris,196
-Sonoma,7215,U.S. Senate,,DEM,Loretta Sanchez,93
-Sonoma,7216,U.S. Senate,,DEM,Kamala Harris,146
-Sonoma,7216,U.S. Senate,,DEM,Loretta Sanchez,97
-Sonoma,7217,U.S. Senate,,DEM,Kamala Harris,117
-Sonoma,7217,U.S. Senate,,DEM,Loretta Sanchez,32
-Sonoma,7218,U.S. Senate,,DEM,Kamala Harris,0
-Sonoma,7218,U.S. Senate,,DEM,Loretta Sanchez,0
-Sonoma,7219,U.S. Senate,,DEM,Kamala Harris,27
-Sonoma,7219,U.S. Senate,,DEM,Loretta Sanchez,9
-Sonoma,7220,U.S. Senate,,DEM,Kamala Harris,104
-Sonoma,7220,U.S. Senate,,DEM,Loretta Sanchez,42
-Sonoma,7221,U.S. Senate,,DEM,Kamala Harris,0
-Sonoma,7221,U.S. Senate,,DEM,Loretta Sanchez,1
-Sonoma,7222,U.S. Senate,,DEM,Kamala Harris,153
-Sonoma,7222,U.S. Senate,,DEM,Loretta Sanchez,50
-Sonoma,7223,U.S. Senate,,DEM,Kamala Harris,109
-Sonoma,7223,U.S. Senate,,DEM,Loretta Sanchez,22
-Sonoma,7224,U.S. Senate,,DEM,Kamala Harris,5
-Sonoma,7224,U.S. Senate,,DEM,Loretta Sanchez,5
-Sonoma,7225,U.S. Senate,,DEM,Kamala Harris,0
-Sonoma,7225,U.S. Senate,,DEM,Loretta Sanchez,2
-Sonoma,7226,U.S. Senate,,DEM,Kamala Harris,284
-Sonoma,7226,U.S. Senate,,DEM,Loretta Sanchez,87
-Sonoma,7227,U.S. Senate,,DEM,Kamala Harris,794
-Sonoma,7227,U.S. Senate,,DEM,Loretta Sanchez,228
-Sonoma,7228,U.S. Senate,,DEM,Kamala Harris,12
-Sonoma,7228,U.S. Senate,,DEM,Loretta Sanchez,5
-Sonoma,7229,U.S. Senate,,DEM,Kamala Harris,56
-Sonoma,7229,U.S. Senate,,DEM,Loretta Sanchez,28
-Sonoma,7230,U.S. Senate,,DEM,Kamala Harris,1
-Sonoma,7230,U.S. Senate,,DEM,Loretta Sanchez,1
-Sonoma,7231,U.S. Senate,,DEM,Kamala Harris,168
-Sonoma,7231,U.S. Senate,,DEM,Loretta Sanchez,68
-Sonoma,7232,U.S. Senate,,DEM,Kamala Harris,3
-Sonoma,7232,U.S. Senate,,DEM,Loretta Sanchez,1
-Sonoma,7233,U.S. Senate,,DEM,Kamala Harris,20
-Sonoma,7233,U.S. Senate,,DEM,Loretta Sanchez,7
-Sonoma,7234,U.S. Senate,,DEM,Kamala Harris,0
-Sonoma,7234,U.S. Senate,,DEM,Loretta Sanchez,0
-Sonoma,7235,U.S. Senate,,DEM,Kamala Harris,61
-Sonoma,7235,U.S. Senate,,DEM,Loretta Sanchez,13
-Sonoma,7236,U.S. Senate,,DEM,Kamala Harris,142
-Sonoma,7236,U.S. Senate,,DEM,Loretta Sanchez,43
-Sonoma,7237,U.S. Senate,,DEM,Kamala Harris,3
-Sonoma,7237,U.S. Senate,,DEM,Loretta Sanchez,2
-Sonoma,7238,U.S. Senate,,DEM,Kamala Harris,28
-Sonoma,7238,U.S. Senate,,DEM,Loretta Sanchez,11
-Sonoma,7239,U.S. Senate,,DEM,Kamala Harris,1
-Sonoma,7239,U.S. Senate,,DEM,Loretta Sanchez,1
-Sonoma,7240,U.S. Senate,,DEM,Kamala Harris,25
-Sonoma,7240,U.S. Senate,,DEM,Loretta Sanchez,10
-Sonoma,7241,U.S. Senate,,DEM,Kamala Harris,25
-Sonoma,7241,U.S. Senate,,DEM,Loretta Sanchez,10
-Sonoma,7242,U.S. Senate,,DEM,Kamala Harris,514
-Sonoma,7242,U.S. Senate,,DEM,Loretta Sanchez,204
-Sonoma,7243,U.S. Senate,,DEM,Kamala Harris,702
-Sonoma,7243,U.S. Senate,,DEM,Loretta Sanchez,282
-Sonoma,7244,U.S. Senate,,DEM,Kamala Harris,1380
-Sonoma,7244,U.S. Senate,,DEM,Loretta Sanchez,398
-Sonoma,7245,U.S. Senate,,DEM,Kamala Harris,1308
-Sonoma,7245,U.S. Senate,,DEM,Loretta Sanchez,291
-Sonoma,7246,U.S. Senate,,DEM,Kamala Harris,1025
-Sonoma,7246,U.S. Senate,,DEM,Loretta Sanchez,393
-Sonoma,7247,U.S. Senate,,DEM,Kamala Harris,379
-Sonoma,7247,U.S. Senate,,DEM,Loretta Sanchez,130
-Sonoma,7248,U.S. Senate,,DEM,Kamala Harris,751
-Sonoma,7248,U.S. Senate,,DEM,Loretta Sanchez,308
-Sonoma,7249,U.S. Senate,,DEM,Kamala Harris,488
-Sonoma,7249,U.S. Senate,,DEM,Loretta Sanchez,189
-Sonoma,7250,U.S. Senate,,DEM,Kamala Harris,72
-Sonoma,7250,U.S. Senate,,DEM,Loretta Sanchez,20
-Sonoma,7251,U.S. Senate,,DEM,Kamala Harris,40
-Sonoma,7251,U.S. Senate,,DEM,Loretta Sanchez,21
-Sonoma,7252,U.S. Senate,,DEM,Kamala Harris,305
-Sonoma,7252,U.S. Senate,,DEM,Loretta Sanchez,118
-Sonoma,7253,U.S. Senate,,DEM,Kamala Harris,683
-Sonoma,7253,U.S. Senate,,DEM,Loretta Sanchez,262
-Sonoma,7254,U.S. Senate,,DEM,Kamala Harris,0
-Sonoma,7254,U.S. Senate,,DEM,Loretta Sanchez,1
-Sonoma,7301,U.S. Senate,,DEM,Kamala Harris,4
-Sonoma,7301,U.S. Senate,,DEM,Loretta Sanchez,3
-Sonoma,7302,U.S. Senate,,DEM,Kamala Harris,74
-Sonoma,7302,U.S. Senate,,DEM,Loretta Sanchez,23
-Sonoma,7303,U.S. Senate,,DEM,Kamala Harris,7
-Sonoma,7303,U.S. Senate,,DEM,Loretta Sanchez,4
-Sonoma,7304,U.S. Senate,,DEM,Kamala Harris,14
-Sonoma,7304,U.S. Senate,,DEM,Loretta Sanchez,0
-Sonoma,7305,U.S. Senate,,DEM,Kamala Harris,121
-Sonoma,7305,U.S. Senate,,DEM,Loretta Sanchez,54
-Sonoma,7306,U.S. Senate,,DEM,Kamala Harris,251
-Sonoma,7306,U.S. Senate,,DEM,Loretta Sanchez,58
-Sonoma,7307,U.S. Senate,,DEM,Kamala Harris,925
-Sonoma,7307,U.S. Senate,,DEM,Loretta Sanchez,416
-Sonoma,7308,U.S. Senate,,DEM,Kamala Harris,1143
-Sonoma,7308,U.S. Senate,,DEM,Loretta Sanchez,276
-Sonoma,7309,U.S. Senate,,DEM,Kamala Harris,602
-Sonoma,7309,U.S. Senate,,DEM,Loretta Sanchez,179
-Sonoma,7310,U.S. Senate,,DEM,Kamala Harris,837
-Sonoma,7310,U.S. Senate,,DEM,Loretta Sanchez,234
-Sonoma,7311,U.S. Senate,,DEM,Kamala Harris,89
-Sonoma,7311,U.S. Senate,,DEM,Loretta Sanchez,36
-Sonoma,7312,U.S. Senate,,DEM,Kamala Harris,22
-Sonoma,7312,U.S. Senate,,DEM,Loretta Sanchez,8
-Sonoma,7313,U.S. Senate,,DEM,Kamala Harris,99
-Sonoma,7313,U.S. Senate,,DEM,Loretta Sanchez,52
-Sonoma,7314,U.S. Senate,,DEM,Kamala Harris,1
-Sonoma,7314,U.S. Senate,,DEM,Loretta Sanchez,2
-Sonoma,7315,U.S. Senate,,DEM,Kamala Harris,791
-Sonoma,7315,U.S. Senate,,DEM,Loretta Sanchez,379
-Sonoma,7401,U.S. Senate,,DEM,Kamala Harris,52
-Sonoma,7401,U.S. Senate,,DEM,Loretta Sanchez,17
-Sonoma,7402,U.S. Senate,,DEM,Kamala Harris,210
-Sonoma,7402,U.S. Senate,,DEM,Loretta Sanchez,73
-Sonoma,7403,U.S. Senate,,DEM,Kamala Harris,68
-Sonoma,7403,U.S. Senate,,DEM,Loretta Sanchez,24
-Sonoma,7404,U.S. Senate,,DEM,Kamala Harris,6
-Sonoma,7404,U.S. Senate,,DEM,Loretta Sanchez,1
-Sonoma,7405,U.S. Senate,,DEM,Kamala Harris,10
-Sonoma,7405,U.S. Senate,,DEM,Loretta Sanchez,3
-Sonoma,7406,U.S. Senate,,DEM,Kamala Harris,81
-Sonoma,7406,U.S. Senate,,DEM,Loretta Sanchez,21
-Sonoma,7407,U.S. Senate,,DEM,Kamala Harris,99
-Sonoma,7407,U.S. Senate,,DEM,Loretta Sanchez,34
-Sonoma,7408,U.S. Senate,,DEM,Kamala Harris,244
-Sonoma,7408,U.S. Senate,,DEM,Loretta Sanchez,97
-Sonoma,7409,U.S. Senate,,DEM,Kamala Harris,0
-Sonoma,7409,U.S. Senate,,DEM,Loretta Sanchez,0
-Sonoma,7410,U.S. Senate,,DEM,Kamala Harris,60
-Sonoma,7410,U.S. Senate,,DEM,Loretta Sanchez,29
-Sonoma,7411,U.S. Senate,,DEM,Kamala Harris,2
-Sonoma,7411,U.S. Senate,,DEM,Loretta Sanchez,3
-Sonoma,7412,U.S. Senate,,DEM,Kamala Harris,28
-Sonoma,7412,U.S. Senate,,DEM,Loretta Sanchez,4
-Sonoma,7413,U.S. Senate,,DEM,Kamala Harris,61
-Sonoma,7413,U.S. Senate,,DEM,Loretta Sanchez,37
-Sonoma,7414,U.S. Senate,,DEM,Kamala Harris,129
-Sonoma,7414,U.S. Senate,,DEM,Loretta Sanchez,45
-Sonoma,7415,U.S. Senate,,DEM,Kamala Harris,829
-Sonoma,7415,U.S. Senate,,DEM,Loretta Sanchez,450
-Sonoma,7416,U.S. Senate,,DEM,Kamala Harris,396
-Sonoma,7416,U.S. Senate,,DEM,Loretta Sanchez,134
-Sonoma,7417,U.S. Senate,,DEM,Kamala Harris,393
-Sonoma,7417,U.S. Senate,,DEM,Loretta Sanchez,174
-Sonoma,7418,U.S. Senate,,DEM,Kamala Harris,1066
-Sonoma,7418,U.S. Senate,,DEM,Loretta Sanchez,477
-Sonoma,7419,U.S. Senate,,DEM,Kamala Harris,23
-Sonoma,7419,U.S. Senate,,DEM,Loretta Sanchez,2
-Sonoma,7420,U.S. Senate,,DEM,Kamala Harris,208
-Sonoma,7420,U.S. Senate,,DEM,Loretta Sanchez,115
-Sonoma,7421,U.S. Senate,,DEM,Kamala Harris,265
-Sonoma,7421,U.S. Senate,,DEM,Loretta Sanchez,121
-Sonoma,7422,U.S. Senate,,DEM,Kamala Harris,131
-Sonoma,7422,U.S. Senate,,DEM,Loretta Sanchez,57
-Sonoma,7423,U.S. Senate,,DEM,Kamala Harris,121
-Sonoma,7423,U.S. Senate,,DEM,Loretta Sanchez,56
-Sonoma,7424,U.S. Senate,,DEM,Kamala Harris,423
-Sonoma,7424,U.S. Senate,,DEM,Loretta Sanchez,152
-Sonoma,7425,U.S. Senate,,DEM,Kamala Harris,0
-Sonoma,7425,U.S. Senate,,DEM,Loretta Sanchez,0
-Sonoma,7426,U.S. Senate,,DEM,Kamala Harris,38
-Sonoma,7426,U.S. Senate,,DEM,Loretta Sanchez,15
-Sonoma,7427,U.S. Senate,,DEM,Kamala Harris,37
-Sonoma,7427,U.S. Senate,,DEM,Loretta Sanchez,12
-Sonoma,7428,U.S. Senate,,DEM,Kamala Harris,13
-Sonoma,7428,U.S. Senate,,DEM,Loretta Sanchez,8
-Sonoma,7429,U.S. Senate,,DEM,Kamala Harris,93
-Sonoma,7429,U.S. Senate,,DEM,Loretta Sanchez,52
-Sonoma,7430,U.S. Senate,,DEM,Kamala Harris,134
-Sonoma,7430,U.S. Senate,,DEM,Loretta Sanchez,52
-Sonoma,7431,U.S. Senate,,DEM,Kamala Harris,441
-Sonoma,7431,U.S. Senate,,DEM,Loretta Sanchez,182
-Sonoma,7432,U.S. Senate,,DEM,Kamala Harris,3
-Sonoma,7432,U.S. Senate,,DEM,Loretta Sanchez,1
-Sonoma,7433,U.S. Senate,,DEM,Kamala Harris,52
-Sonoma,7433,U.S. Senate,,DEM,Loretta Sanchez,18
-Sonoma,7434,U.S. Senate,,DEM,Kamala Harris,21
-Sonoma,7434,U.S. Senate,,DEM,Loretta Sanchez,6
-Sonoma,7435,U.S. Senate,,DEM,Kamala Harris,560
-Sonoma,7435,U.S. Senate,,DEM,Loretta Sanchez,252
-Sonoma,7436,U.S. Senate,,DEM,Kamala Harris,36
-Sonoma,7436,U.S. Senate,,DEM,Loretta Sanchez,26
-Sonoma,7437,U.S. Senate,,DEM,Kamala Harris,7
-Sonoma,7437,U.S. Senate,,DEM,Loretta Sanchez,3
-Sonoma,7438,U.S. Senate,,DEM,Kamala Harris,10
-Sonoma,7438,U.S. Senate,,DEM,Loretta Sanchez,3
-Sonoma,7439,U.S. Senate,,DEM,Kamala Harris,6
-Sonoma,7439,U.S. Senate,,DEM,Loretta Sanchez,5
-Sonoma,7440,U.S. Senate,,DEM,Kamala Harris,859
-Sonoma,7440,U.S. Senate,,DEM,Loretta Sanchez,302
-Sonoma,7441,U.S. Senate,,DEM,Kamala Harris,349
-Sonoma,7441,U.S. Senate,,DEM,Loretta Sanchez,134
-Sonoma,7442,U.S. Senate,,DEM,Kamala Harris,799
-Sonoma,7442,U.S. Senate,,DEM,Loretta Sanchez,410
-Sonoma,7443,U.S. Senate,,DEM,Kamala Harris,0
-Sonoma,7443,U.S. Senate,,DEM,Loretta Sanchez,0
-Sonoma,7444,U.S. Senate,,DEM,Kamala Harris,24
-Sonoma,7444,U.S. Senate,,DEM,Loretta Sanchez,14
-Sonoma,7445,U.S. Senate,,DEM,Kamala Harris,5
-Sonoma,7445,U.S. Senate,,DEM,Loretta Sanchez,1
-Sonoma,7446,U.S. Senate,,DEM,Kamala Harris,21
-Sonoma,7446,U.S. Senate,,DEM,Loretta Sanchez,7
-Sonoma,7447,U.S. Senate,,DEM,Kamala Harris,463
-Sonoma,7447,U.S. Senate,,DEM,Loretta Sanchez,165
-Sonoma,7448,U.S. Senate,,DEM,Kamala Harris,755
-Sonoma,7448,U.S. Senate,,DEM,Loretta Sanchez,270
-Sonoma,7449,U.S. Senate,,DEM,Kamala Harris,8
-Sonoma,7449,U.S. Senate,,DEM,Loretta Sanchez,4
-Sonoma,7450,U.S. Senate,,DEM,Kamala Harris,4
-Sonoma,7450,U.S. Senate,,DEM,Loretta Sanchez,2
-Sonoma,7451,U.S. Senate,,DEM,Kamala Harris,15
-Sonoma,7451,U.S. Senate,,DEM,Loretta Sanchez,5
-Sonoma,7452,U.S. Senate,,DEM,Kamala Harris,1070
-Sonoma,7452,U.S. Senate,,DEM,Loretta Sanchez,303
-Sonoma,7453,U.S. Senate,,DEM,Kamala Harris,893
-Sonoma,7453,U.S. Senate,,DEM,Loretta Sanchez,467
-Sonoma,7454,U.S. Senate,,DEM,Kamala Harris,883
-Sonoma,7454,U.S. Senate,,DEM,Loretta Sanchez,475
-Sonoma,7455,U.S. Senate,,DEM,Kamala Harris,0
-Sonoma,7455,U.S. Senate,,DEM,Loretta Sanchez,0
-Sonoma,7456,U.S. Senate,,DEM,Kamala Harris,89
-Sonoma,7456,U.S. Senate,,DEM,Loretta Sanchez,30
-Sonoma,7457,U.S. Senate,,DEM,Kamala Harris,0
-Sonoma,7457,U.S. Senate,,DEM,Loretta Sanchez,2
-Sonoma,7501,U.S. Senate,,DEM,Kamala Harris,306
-Sonoma,7501,U.S. Senate,,DEM,Loretta Sanchez,67
-Sonoma,7502,U.S. Senate,,DEM,Kamala Harris,672
-Sonoma,7502,U.S. Senate,,DEM,Loretta Sanchez,160
-Sonoma,7503,U.S. Senate,,DEM,Kamala Harris,80
-Sonoma,7503,U.S. Senate,,DEM,Loretta Sanchez,24
-Sonoma,7504,U.S. Senate,,DEM,Kamala Harris,942
-Sonoma,7504,U.S. Senate,,DEM,Loretta Sanchez,264
-Sonoma,7505,U.S. Senate,,DEM,Kamala Harris,462
-Sonoma,7505,U.S. Senate,,DEM,Loretta Sanchez,105
-Sonoma,7506,U.S. Senate,,DEM,Kamala Harris,537
-Sonoma,7506,U.S. Senate,,DEM,Loretta Sanchez,123
-Sonoma,7507,U.S. Senate,,DEM,Kamala Harris,632
-Sonoma,7507,U.S. Senate,,DEM,Loretta Sanchez,157
-Sonoma,7508,U.S. Senate,,DEM,Kamala Harris,7
-Sonoma,7508,U.S. Senate,,DEM,Loretta Sanchez,7
-Sonoma,7509,U.S. Senate,,DEM,Kamala Harris,214
-Sonoma,7509,U.S. Senate,,DEM,Loretta Sanchez,62
-Sonoma,7510,U.S. Senate,,DEM,Kamala Harris,567
-Sonoma,7510,U.S. Senate,,DEM,Loretta Sanchez,154
-Sonoma,7511,U.S. Senate,,DEM,Kamala Harris,840
-Sonoma,7511,U.S. Senate,,DEM,Loretta Sanchez,201
-Sonoma,7512,U.S. Senate,,DEM,Kamala Harris,406
-Sonoma,7512,U.S. Senate,,DEM,Loretta Sanchez,88
-Sonoma,7513,U.S. Senate,,DEM,Kamala Harris,321
-Sonoma,7513,U.S. Senate,,DEM,Loretta Sanchez,94
-Sonoma,7514,U.S. Senate,,DEM,Kamala Harris,4
-Sonoma,7514,U.S. Senate,,DEM,Loretta Sanchez,5
-Sonoma,7515,U.S. Senate,,DEM,Kamala Harris,115
-Sonoma,7515,U.S. Senate,,DEM,Loretta Sanchez,46
-Sonoma,7516,U.S. Senate,,DEM,Kamala Harris,21
-Sonoma,7516,U.S. Senate,,DEM,Loretta Sanchez,16
-Sonoma,7517,U.S. Senate,,DEM,Kamala Harris,1
-Sonoma,7517,U.S. Senate,,DEM,Loretta Sanchez,1
-Sonoma,7518,U.S. Senate,,DEM,Kamala Harris,358
-Sonoma,7518,U.S. Senate,,DEM,Loretta Sanchez,121
-Sonoma,7519,U.S. Senate,,DEM,Kamala Harris,115
-Sonoma,7519,U.S. Senate,,DEM,Loretta Sanchez,43
-Sonoma,7520,U.S. Senate,,DEM,Kamala Harris,38
-Sonoma,7520,U.S. Senate,,DEM,Loretta Sanchez,15
-Sonoma,7521,U.S. Senate,,DEM,Kamala Harris,30
-Sonoma,7521,U.S. Senate,,DEM,Loretta Sanchez,20
-Sonoma,7522,U.S. Senate,,DEM,Kamala Harris,1
-Sonoma,7522,U.S. Senate,,DEM,Loretta Sanchez,0
-Sonoma,7523,U.S. Senate,,DEM,Kamala Harris,495
-Sonoma,7523,U.S. Senate,,DEM,Loretta Sanchez,172
-Sonoma,7524,U.S. Senate,,DEM,Kamala Harris,433
-Sonoma,7524,U.S. Senate,,DEM,Loretta Sanchez,154
-Sonoma,7525,U.S. Senate,,DEM,Kamala Harris,819
-Sonoma,7525,U.S. Senate,,DEM,Loretta Sanchez,267
-Sonoma,7526,U.S. Senate,,DEM,Kamala Harris,795
-Sonoma,7526,U.S. Senate,,DEM,Loretta Sanchez,244
-Sonoma,7527,U.S. Senate,,DEM,Kamala Harris,126
-Sonoma,7527,U.S. Senate,,DEM,Loretta Sanchez,51
-Sonoma,7528,U.S. Senate,,DEM,Kamala Harris,46
-Sonoma,7528,U.S. Senate,,DEM,Loretta Sanchez,9
-Sonoma,7529,U.S. Senate,,DEM,Kamala Harris,32
-Sonoma,7529,U.S. Senate,,DEM,Loretta Sanchez,7
-Sonoma,7530,U.S. Senate,,DEM,Kamala Harris,951
-Sonoma,7530,U.S. Senate,,DEM,Loretta Sanchez,245
-Sonoma,7531,U.S. Senate,,DEM,Kamala Harris,961
-Sonoma,7531,U.S. Senate,,DEM,Loretta Sanchez,265
-Sonoma,7532,U.S. Senate,,DEM,Kamala Harris,59
-Sonoma,7532,U.S. Senate,,DEM,Loretta Sanchez,7
-Sonoma,7533,U.S. Senate,,DEM,Kamala Harris,8
-Sonoma,7533,U.S. Senate,,DEM,Loretta Sanchez,3
-Sonoma,7534,U.S. Senate,,DEM,Kamala Harris,47
-Sonoma,7534,U.S. Senate,,DEM,Loretta Sanchez,16
-Sonoma,7535,U.S. Senate,,DEM,Kamala Harris,207
-Sonoma,7535,U.S. Senate,,DEM,Loretta Sanchez,97
-Sonoma,7536,U.S. Senate,,DEM,Kamala Harris,653
-Sonoma,7536,U.S. Senate,,DEM,Loretta Sanchez,395
-Sonoma,7537,U.S. Senate,,DEM,Kamala Harris,46
-Sonoma,7537,U.S. Senate,,DEM,Loretta Sanchez,10
-Sonoma,7538,U.S. Senate,,DEM,Kamala Harris,11
-Sonoma,7538,U.S. Senate,,DEM,Loretta Sanchez,3
-Sonoma,7539,U.S. Senate,,DEM,Kamala Harris,180
-Sonoma,7539,U.S. Senate,,DEM,Loretta Sanchez,164
-Sonoma,7540,U.S. Senate,,DEM,Kamala Harris,38
-Sonoma,7540,U.S. Senate,,DEM,Loretta Sanchez,19
-Sonoma,7541,U.S. Senate,,DEM,Kamala Harris,41
-Sonoma,7541,U.S. Senate,,DEM,Loretta Sanchez,24
-Sonoma,7542,U.S. Senate,,DEM,Kamala Harris,1262
-Sonoma,7542,U.S. Senate,,DEM,Loretta Sanchez,269
-Sonoma,7543,U.S. Senate,,DEM,Kamala Harris,272
-Sonoma,7543,U.S. Senate,,DEM,Loretta Sanchez,82
-Sonoma,7544,U.S. Senate,,DEM,Kamala Harris,5
-Sonoma,7544,U.S. Senate,,DEM,Loretta Sanchez,0
-Sonoma,7545,U.S. Senate,,DEM,Kamala Harris,416
-Sonoma,7545,U.S. Senate,,DEM,Loretta Sanchez,139
-Sonoma,7546,U.S. Senate,,DEM,Kamala Harris,607
-Sonoma,7546,U.S. Senate,,DEM,Loretta Sanchez,181
-Sonoma,7547,U.S. Senate,,DEM,Kamala Harris,10
-Sonoma,7547,U.S. Senate,,DEM,Loretta Sanchez,6
-Sonoma,7548,U.S. Senate,,DEM,Kamala Harris,8
-Sonoma,7548,U.S. Senate,,DEM,Loretta Sanchez,6
-Sonoma,7549,U.S. Senate,,DEM,Kamala Harris,215
-Sonoma,7549,U.S. Senate,,DEM,Loretta Sanchez,30
-Sonoma,7550,U.S. Senate,,DEM,Kamala Harris,147
-Sonoma,7550,U.S. Senate,,DEM,Loretta Sanchez,29
-Sonoma,7551,U.S. Senate,,DEM,Kamala Harris,143
-Sonoma,7551,U.S. Senate,,DEM,Loretta Sanchez,29
-Sonoma,7552,U.S. Senate,,DEM,Kamala Harris,33
-Sonoma,7552,U.S. Senate,,DEM,Loretta Sanchez,5
-Sonoma,7553,U.S. Senate,,DEM,Kamala Harris,2
-Sonoma,7553,U.S. Senate,,DEM,Loretta Sanchez,3
-Sonoma,7554,U.S. Senate,,DEM,Kamala Harris,11
-Sonoma,7554,U.S. Senate,,DEM,Loretta Sanchez,2
-Sonoma,7555,U.S. Senate,,DEM,Kamala Harris,11
-Sonoma,7555,U.S. Senate,,DEM,Loretta Sanchez,3
-Sonoma,7556,U.S. Senate,,DEM,Kamala Harris,398
-Sonoma,7556,U.S. Senate,,DEM,Loretta Sanchez,100
-Sonoma,7557,U.S. Senate,,DEM,Kamala Harris,45
-Sonoma,7557,U.S. Senate,,DEM,Loretta Sanchez,22
-Sonoma,7558,U.S. Senate,,DEM,Kamala Harris,584
-Sonoma,7558,U.S. Senate,,DEM,Loretta Sanchez,158
-Sonoma,7559,U.S. Senate,,DEM,Kamala Harris,72
-Sonoma,7559,U.S. Senate,,DEM,Loretta Sanchez,50
-Sonoma,7560,U.S. Senate,,DEM,Kamala Harris,6
-Sonoma,7560,U.S. Senate,,DEM,Loretta Sanchez,2
-Sonoma,7561,U.S. Senate,,DEM,Kamala Harris,600
-Sonoma,7561,U.S. Senate,,DEM,Loretta Sanchez,386
-Sonoma,7562,U.S. Senate,,DEM,Kamala Harris,632
-Sonoma,7562,U.S. Senate,,DEM,Loretta Sanchez,526
-Sonoma,7563,U.S. Senate,,DEM,Kamala Harris,1226
-Sonoma,7563,U.S. Senate,,DEM,Loretta Sanchez,477
-Sonoma,7564,U.S. Senate,,DEM,Kamala Harris,1042
-Sonoma,7564,U.S. Senate,,DEM,Loretta Sanchez,490
-Sonoma,7565,U.S. Senate,,DEM,Kamala Harris,1041
-Sonoma,7565,U.S. Senate,,DEM,Loretta Sanchez,235
-Sonoma,7566,U.S. Senate,,DEM,Kamala Harris,1106
-Sonoma,7566,U.S. Senate,,DEM,Loretta Sanchez,227
-Sonoma,7567,U.S. Senate,,DEM,Kamala Harris,1346
-Sonoma,7567,U.S. Senate,,DEM,Loretta Sanchez,251
+Sonoma,1001,U.S. Senate,,DEM,Kamala D. Harris,148
+Sonoma,1001,U.S. Senate,,DEM,Loretta L. Sanchez,33
+Sonoma,1002,U.S. Senate,,DEM,Kamala D. Harris,15
+Sonoma,1002,U.S. Senate,,DEM,Loretta L. Sanchez,6
+Sonoma,1006,U.S. Senate,,DEM,Kamala D. Harris,0
+Sonoma,1006,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Sonoma,1008,U.S. Senate,,DEM,Kamala D. Harris,95
+Sonoma,1008,U.S. Senate,,DEM,Loretta L. Sanchez,35
+Sonoma,1009,U.S. Senate,,DEM,Kamala D. Harris,74
+Sonoma,1009,U.S. Senate,,DEM,Loretta L. Sanchez,32
+Sonoma,1010,U.S. Senate,,DEM,Kamala D. Harris,114
+Sonoma,1010,U.S. Senate,,DEM,Loretta L. Sanchez,47
+Sonoma,1012,U.S. Senate,,DEM,Kamala D. Harris,11
+Sonoma,1012,U.S. Senate,,DEM,Loretta L. Sanchez,5
+Sonoma,1017,U.S. Senate,,DEM,Kamala D. Harris,491
+Sonoma,1017,U.S. Senate,,DEM,Loretta L. Sanchez,117
+Sonoma,1023,U.S. Senate,,DEM,Kamala D. Harris,796
+Sonoma,1023,U.S. Senate,,DEM,Loretta L. Sanchez,306
+Sonoma,1032,U.S. Senate,,DEM,Kamala D. Harris,102
+Sonoma,1032,U.S. Senate,,DEM,Loretta L. Sanchez,34
+Sonoma,1033,U.S. Senate,,DEM,Kamala D. Harris,48
+Sonoma,1033,U.S. Senate,,DEM,Loretta L. Sanchez,8
+Sonoma,1038,U.S. Senate,,DEM,Kamala D. Harris,18
+Sonoma,1038,U.S. Senate,,DEM,Loretta L. Sanchez,5
+Sonoma,1039,U.S. Senate,,DEM,Kamala D. Harris,0
+Sonoma,1039,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Sonoma,1040,U.S. Senate,,DEM,Kamala D. Harris,33
+Sonoma,1040,U.S. Senate,,DEM,Loretta L. Sanchez,11
+Sonoma,1041,U.S. Senate,,DEM,Kamala D. Harris,7
+Sonoma,1041,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Sonoma,1043,U.S. Senate,,DEM,Kamala D. Harris,4
+Sonoma,1043,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Sonoma,1044,U.S. Senate,,DEM,Kamala D. Harris,0
+Sonoma,1044,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sonoma,1045,U.S. Senate,,DEM,Kamala D. Harris,28
+Sonoma,1045,U.S. Senate,,DEM,Loretta L. Sanchez,6
+Sonoma,1046,U.S. Senate,,DEM,Kamala D. Harris,0
+Sonoma,1046,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Sonoma,1049,U.S. Senate,,DEM,Kamala D. Harris,56
+Sonoma,1049,U.S. Senate,,DEM,Loretta L. Sanchez,16
+Sonoma,1052,U.S. Senate,,DEM,Kamala D. Harris,67
+Sonoma,1052,U.S. Senate,,DEM,Loretta L. Sanchez,21
+Sonoma,1053,U.S. Senate,,DEM,Kamala D. Harris,111
+Sonoma,1053,U.S. Senate,,DEM,Loretta L. Sanchez,26
+Sonoma,1054,U.S. Senate,,DEM,Kamala D. Harris,14
+Sonoma,1054,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Sonoma,1055,U.S. Senate,,DEM,Kamala D. Harris,106
+Sonoma,1055,U.S. Senate,,DEM,Loretta L. Sanchez,39
+Sonoma,1056,U.S. Senate,,DEM,Kamala D. Harris,159
+Sonoma,1056,U.S. Senate,,DEM,Loretta L. Sanchez,46
+Sonoma,1057,U.S. Senate,,DEM,Kamala D. Harris,14
+Sonoma,1057,U.S. Senate,,DEM,Loretta L. Sanchez,7
+Sonoma,1058,U.S. Senate,,DEM,Kamala D. Harris,6
+Sonoma,1058,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Sonoma,1059,U.S. Senate,,DEM,Kamala D. Harris,0
+Sonoma,1059,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sonoma,1061,U.S. Senate,,DEM,Kamala D. Harris,18
+Sonoma,1061,U.S. Senate,,DEM,Loretta L. Sanchez,5
+Sonoma,1062,U.S. Senate,,DEM,Kamala D. Harris,18
+Sonoma,1062,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Sonoma,1063,U.S. Senate,,DEM,Kamala D. Harris,33
+Sonoma,1063,U.S. Senate,,DEM,Loretta L. Sanchez,14
+Sonoma,1064,U.S. Senate,,DEM,Kamala D. Harris,29
+Sonoma,1064,U.S. Senate,,DEM,Loretta L. Sanchez,15
+Sonoma,1065,U.S. Senate,,DEM,Kamala D. Harris,29
+Sonoma,1065,U.S. Senate,,DEM,Loretta L. Sanchez,18
+Sonoma,1067,U.S. Senate,,DEM,Kamala D. Harris,33
+Sonoma,1067,U.S. Senate,,DEM,Loretta L. Sanchez,7
+Sonoma,1069,U.S. Senate,,DEM,Kamala D. Harris,9
+Sonoma,1069,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Sonoma,1070,U.S. Senate,,DEM,Kamala D. Harris,9
+Sonoma,1070,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Sonoma,1073,U.S. Senate,,DEM,Kamala D. Harris,8
+Sonoma,1073,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sonoma,1075,U.S. Senate,,DEM,Kamala D. Harris,61
+Sonoma,1075,U.S. Senate,,DEM,Loretta L. Sanchez,25
+Sonoma,1077,U.S. Senate,,DEM,Kamala D. Harris,241
+Sonoma,1077,U.S. Senate,,DEM,Loretta L. Sanchez,89
+Sonoma,1078,U.S. Senate,,DEM,Kamala D. Harris,21
+Sonoma,1078,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Sonoma,1079,U.S. Senate,,DEM,Kamala D. Harris,0
+Sonoma,1079,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Sonoma,1080,U.S. Senate,,DEM,Kamala D. Harris,68
+Sonoma,1080,U.S. Senate,,DEM,Loretta L. Sanchez,29
+Sonoma,1083,U.S. Senate,,DEM,Kamala D. Harris,0
+Sonoma,1083,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sonoma,1084,U.S. Senate,,DEM,Kamala D. Harris,0
+Sonoma,1084,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Sonoma,1085,U.S. Senate,,DEM,Kamala D. Harris,11
+Sonoma,1085,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Sonoma,1086,U.S. Senate,,DEM,Kamala D. Harris,22
+Sonoma,1086,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Sonoma,1103,U.S. Senate,,DEM,Kamala D. Harris,996
+Sonoma,1103,U.S. Senate,,DEM,Loretta L. Sanchez,391
+Sonoma,1106,U.S. Senate,,DEM,Kamala D. Harris,574
+Sonoma,1106,U.S. Senate,,DEM,Loretta L. Sanchez,185
+Sonoma,1107,U.S. Senate,,DEM,Kamala D. Harris,1053
+Sonoma,1107,U.S. Senate,,DEM,Loretta L. Sanchez,323
+Sonoma,1108,U.S. Senate,,DEM,Kamala D. Harris,839
+Sonoma,1108,U.S. Senate,,DEM,Loretta L. Sanchez,275
+Sonoma,1110,U.S. Senate,,DEM,Kamala D. Harris,1026
+Sonoma,1110,U.S. Senate,,DEM,Loretta L. Sanchez,273
+Sonoma,1111,U.S. Senate,,DEM,Kamala D. Harris,1172
+Sonoma,1111,U.S. Senate,,DEM,Loretta L. Sanchez,332
+Sonoma,1112,U.S. Senate,,DEM,Kamala D. Harris,946
+Sonoma,1112,U.S. Senate,,DEM,Loretta L. Sanchez,324
+Sonoma,1114,U.S. Senate,,DEM,Kamala D. Harris,71
+Sonoma,1114,U.S. Senate,,DEM,Loretta L. Sanchez,48
+Sonoma,1115,U.S. Senate,,DEM,Kamala D. Harris,106
+Sonoma,1115,U.S. Senate,,DEM,Loretta L. Sanchez,37
+Sonoma,1116,U.S. Senate,,DEM,Kamala D. Harris,1038
+Sonoma,1116,U.S. Senate,,DEM,Loretta L. Sanchez,396
+Sonoma,1121,U.S. Senate,,DEM,Kamala D. Harris,1051
+Sonoma,1121,U.S. Senate,,DEM,Loretta L. Sanchez,351
+Sonoma,1122,U.S. Senate,,DEM,Kamala D. Harris,511
+Sonoma,1122,U.S. Senate,,DEM,Loretta L. Sanchez,118
+Sonoma,1124,U.S. Senate,,DEM,Kamala D. Harris,967
+Sonoma,1124,U.S. Senate,,DEM,Loretta L. Sanchez,210
+Sonoma,1128,U.S. Senate,,DEM,Kamala D. Harris,699
+Sonoma,1128,U.S. Senate,,DEM,Loretta L. Sanchez,193
+Sonoma,1129,U.S. Senate,,DEM,Kamala D. Harris,8
+Sonoma,1129,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sonoma,1136,U.S. Senate,,DEM,Kamala D. Harris,1376
+Sonoma,1136,U.S. Senate,,DEM,Loretta L. Sanchez,463
+Sonoma,1144,U.S. Senate,,DEM,Kamala D. Harris,4
+Sonoma,1144,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Sonoma,1145,U.S. Senate,,DEM,Kamala D. Harris,496
+Sonoma,1145,U.S. Senate,,DEM,Loretta L. Sanchez,167
+Sonoma,1146,U.S. Senate,,DEM,Kamala D. Harris,209
+Sonoma,1146,U.S. Senate,,DEM,Loretta L. Sanchez,80
+Sonoma,1147,U.S. Senate,,DEM,Kamala D. Harris,26
+Sonoma,1147,U.S. Senate,,DEM,Loretta L. Sanchez,17
+Sonoma,1802,U.S. Senate,,DEM,Kamala D. Harris,1036
+Sonoma,1802,U.S. Senate,,DEM,Loretta L. Sanchez,307
+Sonoma,1811,U.S. Senate,,DEM,Kamala D. Harris,73
+Sonoma,1811,U.S. Senate,,DEM,Loretta L. Sanchez,30
+Sonoma,1812,U.S. Senate,,DEM,Kamala D. Harris,0
+Sonoma,1812,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sonoma,1814,U.S. Senate,,DEM,Kamala D. Harris,0
+Sonoma,1814,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sonoma,2016,U.S. Senate,,DEM,Kamala D. Harris,116
+Sonoma,2016,U.S. Senate,,DEM,Loretta L. Sanchez,24
+Sonoma,2020,U.S. Senate,,DEM,Kamala D. Harris,123
+Sonoma,2020,U.S. Senate,,DEM,Loretta L. Sanchez,55
+Sonoma,2022,U.S. Senate,,DEM,Kamala D. Harris,55
+Sonoma,2022,U.S. Senate,,DEM,Loretta L. Sanchez,38
+Sonoma,2024,U.S. Senate,,DEM,Kamala D. Harris,117
+Sonoma,2024,U.S. Senate,,DEM,Loretta L. Sanchez,41
+Sonoma,2026,U.S. Senate,,DEM,Kamala D. Harris,3
+Sonoma,2026,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Sonoma,2027,U.S. Senate,,DEM,Kamala D. Harris,5
+Sonoma,2027,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sonoma,2028,U.S. Senate,,DEM,Kamala D. Harris,4
+Sonoma,2028,U.S. Senate,,DEM,Loretta L. Sanchez,6
+Sonoma,2029,U.S. Senate,,DEM,Kamala D. Harris,2
+Sonoma,2029,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Sonoma,2032,U.S. Senate,,DEM,Kamala D. Harris,6
+Sonoma,2032,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Sonoma,2034,U.S. Senate,,DEM,Kamala D. Harris,4
+Sonoma,2034,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Sonoma,2036,U.S. Senate,,DEM,Kamala D. Harris,7
+Sonoma,2036,U.S. Senate,,DEM,Loretta L. Sanchez,6
+Sonoma,2037,U.S. Senate,,DEM,Kamala D. Harris,0
+Sonoma,2037,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sonoma,2038,U.S. Senate,,DEM,Kamala D. Harris,11
+Sonoma,2038,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Sonoma,2039,U.S. Senate,,DEM,Kamala D. Harris,4
+Sonoma,2039,U.S. Senate,,DEM,Loretta L. Sanchez,6
+Sonoma,2041,U.S. Senate,,DEM,Kamala D. Harris,7
+Sonoma,2041,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Sonoma,2042,U.S. Senate,,DEM,Kamala D. Harris,15
+Sonoma,2042,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Sonoma,2301,U.S. Senate,,DEM,Kamala D. Harris,1048
+Sonoma,2301,U.S. Senate,,DEM,Loretta L. Sanchez,424
+Sonoma,2502,U.S. Senate,,DEM,Kamala D. Harris,1237
+Sonoma,2502,U.S. Senate,,DEM,Loretta L. Sanchez,279
+Sonoma,2503,U.S. Senate,,DEM,Kamala D. Harris,577
+Sonoma,2503,U.S. Senate,,DEM,Loretta L. Sanchez,186
+Sonoma,2504,U.S. Senate,,DEM,Kamala D. Harris,1234
+Sonoma,2504,U.S. Senate,,DEM,Loretta L. Sanchez,329
+Sonoma,2508,U.S. Senate,,DEM,Kamala D. Harris,791
+Sonoma,2508,U.S. Senate,,DEM,Loretta L. Sanchez,224
+Sonoma,2509,U.S. Senate,,DEM,Kamala D. Harris,918
+Sonoma,2509,U.S. Senate,,DEM,Loretta L. Sanchez,274
+Sonoma,2514,U.S. Senate,,DEM,Kamala D. Harris,1246
+Sonoma,2514,U.S. Senate,,DEM,Loretta L. Sanchez,481
+Sonoma,2515,U.S. Senate,,DEM,Kamala D. Harris,433
+Sonoma,2515,U.S. Senate,,DEM,Loretta L. Sanchez,219
+Sonoma,2519,U.S. Senate,,DEM,Kamala D. Harris,1224
+Sonoma,2519,U.S. Senate,,DEM,Loretta L. Sanchez,476
+Sonoma,2520,U.S. Senate,,DEM,Kamala D. Harris,1171
+Sonoma,2520,U.S. Senate,,DEM,Loretta L. Sanchez,456
+Sonoma,2523,U.S. Senate,,DEM,Kamala D. Harris,976
+Sonoma,2523,U.S. Senate,,DEM,Loretta L. Sanchez,363
+Sonoma,2530,U.S. Senate,,DEM,Kamala D. Harris,1039
+Sonoma,2530,U.S. Senate,,DEM,Loretta L. Sanchez,386
+Sonoma,2531,U.S. Senate,,DEM,Kamala D. Harris,832
+Sonoma,2531,U.S. Senate,,DEM,Loretta L. Sanchez,317
+Sonoma,2536,U.S. Senate,,DEM,Kamala D. Harris,456
+Sonoma,2536,U.S. Senate,,DEM,Loretta L. Sanchez,140
+Sonoma,2540,U.S. Senate,,DEM,Kamala D. Harris,1309
+Sonoma,2540,U.S. Senate,,DEM,Loretta L. Sanchez,514
+Sonoma,2601,U.S. Senate,,DEM,Kamala D. Harris,1016
+Sonoma,2601,U.S. Senate,,DEM,Loretta L. Sanchez,501
+Sonoma,2602,U.S. Senate,,DEM,Kamala D. Harris,519
+Sonoma,2602,U.S. Senate,,DEM,Loretta L. Sanchez,292
+Sonoma,2604,U.S. Senate,,DEM,Kamala D. Harris,1
+Sonoma,2604,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Sonoma,2606,U.S. Senate,,DEM,Kamala D. Harris,971
+Sonoma,2606,U.S. Senate,,DEM,Loretta L. Sanchez,416
+Sonoma,3001,U.S. Senate,,DEM,Kamala D. Harris,4
+Sonoma,3001,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Sonoma,3002,U.S. Senate,,DEM,Kamala D. Harris,7
+Sonoma,3002,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sonoma,3003,U.S. Senate,,DEM,Kamala D. Harris,9
+Sonoma,3003,U.S. Senate,,DEM,Loretta L. Sanchez,13
+Sonoma,3005,U.S. Senate,,DEM,Kamala D. Harris,131
+Sonoma,3005,U.S. Senate,,DEM,Loretta L. Sanchez,85
+Sonoma,3006,U.S. Senate,,DEM,Kamala D. Harris,16
+Sonoma,3006,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Sonoma,3011,U.S. Senate,,DEM,Kamala D. Harris,366
+Sonoma,3011,U.S. Senate,,DEM,Loretta L. Sanchez,283
+Sonoma,3016,U.S. Senate,,DEM,Kamala D. Harris,78
+Sonoma,3016,U.S. Senate,,DEM,Loretta L. Sanchez,60
+Sonoma,3017,U.S. Senate,,DEM,Kamala D. Harris,26
+Sonoma,3017,U.S. Senate,,DEM,Loretta L. Sanchez,17
+Sonoma,3020,U.S. Senate,,DEM,Kamala D. Harris,61
+Sonoma,3020,U.S. Senate,,DEM,Loretta L. Sanchez,17
+Sonoma,3021,U.S. Senate,,DEM,Kamala D. Harris,31
+Sonoma,3021,U.S. Senate,,DEM,Loretta L. Sanchez,24
+Sonoma,3024,U.S. Senate,,DEM,Kamala D. Harris,16
+Sonoma,3024,U.S. Senate,,DEM,Loretta L. Sanchez,7
+Sonoma,3025,U.S. Senate,,DEM,Kamala D. Harris,3
+Sonoma,3025,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Sonoma,3103,U.S. Senate,,DEM,Kamala D. Harris,1382
+Sonoma,3103,U.S. Senate,,DEM,Loretta L. Sanchez,470
+Sonoma,3108,U.S. Senate,,DEM,Kamala D. Harris,670
+Sonoma,3108,U.S. Senate,,DEM,Loretta L. Sanchez,379
+Sonoma,3109,U.S. Senate,,DEM,Kamala D. Harris,514
+Sonoma,3109,U.S. Senate,,DEM,Loretta L. Sanchez,136
+Sonoma,3112,U.S. Senate,,DEM,Kamala D. Harris,890
+Sonoma,3112,U.S. Senate,,DEM,Loretta L. Sanchez,287
+Sonoma,3113,U.S. Senate,,DEM,Kamala D. Harris,783
+Sonoma,3113,U.S. Senate,,DEM,Loretta L. Sanchez,414
+Sonoma,3116,U.S. Senate,,DEM,Kamala D. Harris,490
+Sonoma,3116,U.S. Senate,,DEM,Loretta L. Sanchez,155
+Sonoma,3120,U.S. Senate,,DEM,Kamala D. Harris,1027
+Sonoma,3120,U.S. Senate,,DEM,Loretta L. Sanchez,292
+Sonoma,3123,U.S. Senate,,DEM,Kamala D. Harris,774
+Sonoma,3123,U.S. Senate,,DEM,Loretta L. Sanchez,287
+Sonoma,3124,U.S. Senate,,DEM,Kamala D. Harris,947
+Sonoma,3124,U.S. Senate,,DEM,Loretta L. Sanchez,249
+Sonoma,3128,U.S. Senate,,DEM,Kamala D. Harris,1258
+Sonoma,3128,U.S. Senate,,DEM,Loretta L. Sanchez,344
+Sonoma,3135,U.S. Senate,,DEM,Kamala D. Harris,801
+Sonoma,3135,U.S. Senate,,DEM,Loretta L. Sanchez,458
+Sonoma,3136,U.S. Senate,,DEM,Kamala D. Harris,411
+Sonoma,3136,U.S. Senate,,DEM,Loretta L. Sanchez,234
+Sonoma,3142,U.S. Senate,,DEM,Kamala D. Harris,902
+Sonoma,3142,U.S. Senate,,DEM,Loretta L. Sanchez,375
+Sonoma,3601,U.S. Senate,,DEM,Kamala D. Harris,852
+Sonoma,3601,U.S. Senate,,DEM,Loretta L. Sanchez,406
+Sonoma,3602,U.S. Senate,,DEM,Kamala D. Harris,1051
+Sonoma,3602,U.S. Senate,,DEM,Loretta L. Sanchez,502
+Sonoma,3603,U.S. Senate,,DEM,Kamala D. Harris,962
+Sonoma,3603,U.S. Senate,,DEM,Loretta L. Sanchez,477
+Sonoma,3605,U.S. Senate,,DEM,Kamala D. Harris,447
+Sonoma,3605,U.S. Senate,,DEM,Loretta L. Sanchez,214
+Sonoma,3609,U.S. Senate,,DEM,Kamala D. Harris,1062
+Sonoma,3609,U.S. Senate,,DEM,Loretta L. Sanchez,416
+Sonoma,3611,U.S. Senate,,DEM,Kamala D. Harris,906
+Sonoma,3611,U.S. Senate,,DEM,Loretta L. Sanchez,342
+Sonoma,3614,U.S. Senate,,DEM,Kamala D. Harris,878
+Sonoma,3614,U.S. Senate,,DEM,Loretta L. Sanchez,349
+Sonoma,3616,U.S. Senate,,DEM,Kamala D. Harris,898
+Sonoma,3616,U.S. Senate,,DEM,Loretta L. Sanchez,371
+Sonoma,3618,U.S. Senate,,DEM,Kamala D. Harris,921
+Sonoma,3618,U.S. Senate,,DEM,Loretta L. Sanchez,326
+Sonoma,3621,U.S. Senate,,DEM,Kamala D. Harris,0
+Sonoma,3621,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sonoma,3622,U.S. Senate,,DEM,Kamala D. Harris,0
+Sonoma,3622,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sonoma,4009,U.S. Senate,,DEM,Kamala D. Harris,112
+Sonoma,4009,U.S. Senate,,DEM,Loretta L. Sanchez,34
+Sonoma,4012,U.S. Senate,,DEM,Kamala D. Harris,3
+Sonoma,4012,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Sonoma,4015,U.S. Senate,,DEM,Kamala D. Harris,119
+Sonoma,4015,U.S. Senate,,DEM,Loretta L. Sanchez,54
+Sonoma,4017,U.S. Senate,,DEM,Kamala D. Harris,37
+Sonoma,4017,U.S. Senate,,DEM,Loretta L. Sanchez,19
+Sonoma,4018,U.S. Senate,,DEM,Kamala D. Harris,5
+Sonoma,4018,U.S. Senate,,DEM,Loretta L. Sanchez,7
+Sonoma,4019,U.S. Senate,,DEM,Kamala D. Harris,0
+Sonoma,4019,U.S. Senate,,DEM,Loretta L. Sanchez,5
+Sonoma,4020,U.S. Senate,,DEM,Kamala D. Harris,0
+Sonoma,4020,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sonoma,4027,U.S. Senate,,DEM,Kamala D. Harris,74
+Sonoma,4027,U.S. Senate,,DEM,Loretta L. Sanchez,33
+Sonoma,4030,U.S. Senate,,DEM,Kamala D. Harris,2
+Sonoma,4030,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sonoma,4034,U.S. Senate,,DEM,Kamala D. Harris,72
+Sonoma,4034,U.S. Senate,,DEM,Loretta L. Sanchez,48
+Sonoma,4037,U.S. Senate,,DEM,Kamala D. Harris,46
+Sonoma,4037,U.S. Senate,,DEM,Loretta L. Sanchez,14
+Sonoma,4039,U.S. Senate,,DEM,Kamala D. Harris,14
+Sonoma,4039,U.S. Senate,,DEM,Loretta L. Sanchez,8
+Sonoma,4051,U.S. Senate,,DEM,Kamala D. Harris,122
+Sonoma,4051,U.S. Senate,,DEM,Loretta L. Sanchez,45
+Sonoma,4052,U.S. Senate,,DEM,Kamala D. Harris,13
+Sonoma,4052,U.S. Senate,,DEM,Loretta L. Sanchez,5
+Sonoma,4054,U.S. Senate,,DEM,Kamala D. Harris,1
+Sonoma,4054,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sonoma,4064,U.S. Senate,,DEM,Kamala D. Harris,24
+Sonoma,4064,U.S. Senate,,DEM,Loretta L. Sanchez,20
+Sonoma,4065,U.S. Senate,,DEM,Kamala D. Harris,1
+Sonoma,4065,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Sonoma,4066,U.S. Senate,,DEM,Kamala D. Harris,3
+Sonoma,4066,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Sonoma,4067,U.S. Senate,,DEM,Kamala D. Harris,29
+Sonoma,4067,U.S. Senate,,DEM,Loretta L. Sanchez,20
+Sonoma,4070,U.S. Senate,,DEM,Kamala D. Harris,2
+Sonoma,4070,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sonoma,4072,U.S. Senate,,DEM,Kamala D. Harris,4
+Sonoma,4072,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sonoma,4073,U.S. Senate,,DEM,Kamala D. Harris,0
+Sonoma,4073,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sonoma,4074,U.S. Senate,,DEM,Kamala D. Harris,82
+Sonoma,4074,U.S. Senate,,DEM,Loretta L. Sanchez,21
+Sonoma,4102,U.S. Senate,,DEM,Kamala D. Harris,46
+Sonoma,4102,U.S. Senate,,DEM,Loretta L. Sanchez,18
+Sonoma,4103,U.S. Senate,,DEM,Kamala D. Harris,659
+Sonoma,4103,U.S. Senate,,DEM,Loretta L. Sanchez,281
+Sonoma,4104,U.S. Senate,,DEM,Kamala D. Harris,122
+Sonoma,4104,U.S. Senate,,DEM,Loretta L. Sanchez,50
+Sonoma,4106,U.S. Senate,,DEM,Kamala D. Harris,44
+Sonoma,4106,U.S. Senate,,DEM,Loretta L. Sanchez,27
+Sonoma,4109,U.S. Senate,,DEM,Kamala D. Harris,859
+Sonoma,4109,U.S. Senate,,DEM,Loretta L. Sanchez,317
+Sonoma,4110,U.S. Senate,,DEM,Kamala D. Harris,957
+Sonoma,4110,U.S. Senate,,DEM,Loretta L. Sanchez,403
+Sonoma,4127,U.S. Senate,,DEM,Kamala D. Harris,633
+Sonoma,4127,U.S. Senate,,DEM,Loretta L. Sanchez,275
+Sonoma,4128,U.S. Senate,,DEM,Kamala D. Harris,54
+Sonoma,4128,U.S. Senate,,DEM,Loretta L. Sanchez,22
+Sonoma,4129,U.S. Senate,,DEM,Kamala D. Harris,88
+Sonoma,4129,U.S. Senate,,DEM,Loretta L. Sanchez,26
+Sonoma,4201,U.S. Senate,,DEM,Kamala D. Harris,803
+Sonoma,4201,U.S. Senate,,DEM,Loretta L. Sanchez,472
+Sonoma,4203,U.S. Senate,,DEM,Kamala D. Harris,503
+Sonoma,4203,U.S. Senate,,DEM,Loretta L. Sanchez,225
+Sonoma,4204,U.S. Senate,,DEM,Kamala D. Harris,938
+Sonoma,4204,U.S. Senate,,DEM,Loretta L. Sanchez,346
+Sonoma,4401,U.S. Senate,,DEM,Kamala D. Harris,856
+Sonoma,4401,U.S. Senate,,DEM,Loretta L. Sanchez,393
+Sonoma,4402,U.S. Senate,,DEM,Kamala D. Harris,1095
+Sonoma,4402,U.S. Senate,,DEM,Loretta L. Sanchez,339
+Sonoma,4406,U.S. Senate,,DEM,Kamala D. Harris,735
+Sonoma,4406,U.S. Senate,,DEM,Loretta L. Sanchez,297
+Sonoma,4407,U.S. Senate,,DEM,Kamala D. Harris,0
+Sonoma,4407,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sonoma,4902,U.S. Senate,,DEM,Kamala D. Harris,875
+Sonoma,4902,U.S. Senate,,DEM,Loretta L. Sanchez,408
+Sonoma,4903,U.S. Senate,,DEM,Kamala D. Harris,731
+Sonoma,4903,U.S. Senate,,DEM,Loretta L. Sanchez,317
+Sonoma,4904,U.S. Senate,,DEM,Kamala D. Harris,809
+Sonoma,4904,U.S. Senate,,DEM,Loretta L. Sanchez,337
+Sonoma,4906,U.S. Senate,,DEM,Kamala D. Harris,960
+Sonoma,4906,U.S. Senate,,DEM,Loretta L. Sanchez,412
+Sonoma,4907,U.S. Senate,,DEM,Kamala D. Harris,958
+Sonoma,4907,U.S. Senate,,DEM,Loretta L. Sanchez,456
+Sonoma,4908,U.S. Senate,,DEM,Kamala D. Harris,963
+Sonoma,4908,U.S. Senate,,DEM,Loretta L. Sanchez,574
+Sonoma,5008,U.S. Senate,,DEM,Kamala D. Harris,600
+Sonoma,5008,U.S. Senate,,DEM,Loretta L. Sanchez,385
+Sonoma,5026,U.S. Senate,,DEM,Kamala D. Harris,17
+Sonoma,5026,U.S. Senate,,DEM,Loretta L. Sanchez,7
+Sonoma,5029,U.S. Senate,,DEM,Kamala D. Harris,27
+Sonoma,5029,U.S. Senate,,DEM,Loretta L. Sanchez,9
+Sonoma,5031,U.S. Senate,,DEM,Kamala D. Harris,327
+Sonoma,5031,U.S. Senate,,DEM,Loretta L. Sanchez,69
+Sonoma,5050,U.S. Senate,,DEM,Kamala D. Harris,0
+Sonoma,5050,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sonoma,5052,U.S. Senate,,DEM,Kamala D. Harris,108
+Sonoma,5052,U.S. Senate,,DEM,Loretta L. Sanchez,27
+Sonoma,5054,U.S. Senate,,DEM,Kamala D. Harris,3
+Sonoma,5054,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sonoma,5055,U.S. Senate,,DEM,Kamala D. Harris,36
+Sonoma,5055,U.S. Senate,,DEM,Loretta L. Sanchez,23
+Sonoma,5056,U.S. Senate,,DEM,Kamala D. Harris,108
+Sonoma,5056,U.S. Senate,,DEM,Loretta L. Sanchez,48
+Sonoma,5057,U.S. Senate,,DEM,Kamala D. Harris,44
+Sonoma,5057,U.S. Senate,,DEM,Loretta L. Sanchez,23
+Sonoma,5058,U.S. Senate,,DEM,Kamala D. Harris,43
+Sonoma,5058,U.S. Senate,,DEM,Loretta L. Sanchez,10
+Sonoma,5059,U.S. Senate,,DEM,Kamala D. Harris,12
+Sonoma,5059,U.S. Senate,,DEM,Loretta L. Sanchez,6
+Sonoma,5060,U.S. Senate,,DEM,Kamala D. Harris,41
+Sonoma,5060,U.S. Senate,,DEM,Loretta L. Sanchez,6
+Sonoma,5062,U.S. Senate,,DEM,Kamala D. Harris,72
+Sonoma,5062,U.S. Senate,,DEM,Loretta L. Sanchez,11
+Sonoma,5063,U.S. Senate,,DEM,Kamala D. Harris,121
+Sonoma,5063,U.S. Senate,,DEM,Loretta L. Sanchez,28
+Sonoma,5064,U.S. Senate,,DEM,Kamala D. Harris,105
+Sonoma,5064,U.S. Senate,,DEM,Loretta L. Sanchez,38
+Sonoma,5065,U.S. Senate,,DEM,Kamala D. Harris,23
+Sonoma,5065,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Sonoma,5067,U.S. Senate,,DEM,Kamala D. Harris,0
+Sonoma,5067,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sonoma,5068,U.S. Senate,,DEM,Kamala D. Harris,2
+Sonoma,5068,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sonoma,5069,U.S. Senate,,DEM,Kamala D. Harris,58
+Sonoma,5069,U.S. Senate,,DEM,Loretta L. Sanchez,6
+Sonoma,5070,U.S. Senate,,DEM,Kamala D. Harris,20
+Sonoma,5070,U.S. Senate,,DEM,Loretta L. Sanchez,6
+Sonoma,5071,U.S. Senate,,DEM,Kamala D. Harris,3
+Sonoma,5071,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Sonoma,5074,U.S. Senate,,DEM,Kamala D. Harris,3
+Sonoma,5074,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Sonoma,5075,U.S. Senate,,DEM,Kamala D. Harris,0
+Sonoma,5075,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sonoma,5076,U.S. Senate,,DEM,Kamala D. Harris,0
+Sonoma,5076,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sonoma,5077,U.S. Senate,,DEM,Kamala D. Harris,212
+Sonoma,5077,U.S. Senate,,DEM,Loretta L. Sanchez,87
+Sonoma,5104,U.S. Senate,,DEM,Kamala D. Harris,924
+Sonoma,5104,U.S. Senate,,DEM,Loretta L. Sanchez,552
+Sonoma,5105,U.S. Senate,,DEM,Kamala D. Harris,715
+Sonoma,5105,U.S. Senate,,DEM,Loretta L. Sanchez,441
+Sonoma,5109,U.S. Senate,,DEM,Kamala D. Harris,833
+Sonoma,5109,U.S. Senate,,DEM,Loretta L. Sanchez,304
+Sonoma,5111,U.S. Senate,,DEM,Kamala D. Harris,734
+Sonoma,5111,U.S. Senate,,DEM,Loretta L. Sanchez,307
+Sonoma,5114,U.S. Senate,,DEM,Kamala D. Harris,0
+Sonoma,5114,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sonoma,5115,U.S. Senate,,DEM,Kamala D. Harris,341
+Sonoma,5115,U.S. Senate,,DEM,Loretta L. Sanchez,243
+Sonoma,5116,U.S. Senate,,DEM,Kamala D. Harris,131
+Sonoma,5116,U.S. Senate,,DEM,Loretta L. Sanchez,42
+Sonoma,7101,U.S. Senate,,DEM,Kamala D. Harris,237
+Sonoma,7101,U.S. Senate,,DEM,Loretta L. Sanchez,81
+Sonoma,7102,U.S. Senate,,DEM,Kamala D. Harris,28
+Sonoma,7102,U.S. Senate,,DEM,Loretta L. Sanchez,16
+Sonoma,7103,U.S. Senate,,DEM,Kamala D. Harris,65
+Sonoma,7103,U.S. Senate,,DEM,Loretta L. Sanchez,24
+Sonoma,7104,U.S. Senate,,DEM,Kamala D. Harris,143
+Sonoma,7104,U.S. Senate,,DEM,Loretta L. Sanchez,33
+Sonoma,7105,U.S. Senate,,DEM,Kamala D. Harris,7
+Sonoma,7105,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Sonoma,7106,U.S. Senate,,DEM,Kamala D. Harris,85
+Sonoma,7106,U.S. Senate,,DEM,Loretta L. Sanchez,27
+Sonoma,7107,U.S. Senate,,DEM,Kamala D. Harris,873
+Sonoma,7107,U.S. Senate,,DEM,Loretta L. Sanchez,228
+Sonoma,7108,U.S. Senate,,DEM,Kamala D. Harris,0
+Sonoma,7108,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sonoma,7109,U.S. Senate,,DEM,Kamala D. Harris,0
+Sonoma,7109,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sonoma,7110,U.S. Senate,,DEM,Kamala D. Harris,45
+Sonoma,7110,U.S. Senate,,DEM,Loretta L. Sanchez,12
+Sonoma,7111,U.S. Senate,,DEM,Kamala D. Harris,982
+Sonoma,7111,U.S. Senate,,DEM,Loretta L. Sanchez,294
+Sonoma,7112,U.S. Senate,,DEM,Kamala D. Harris,1025
+Sonoma,7112,U.S. Senate,,DEM,Loretta L. Sanchez,417
+Sonoma,7113,U.S. Senate,,DEM,Kamala D. Harris,875
+Sonoma,7113,U.S. Senate,,DEM,Loretta L. Sanchez,370
+Sonoma,7114,U.S. Senate,,DEM,Kamala D. Harris,80
+Sonoma,7114,U.S. Senate,,DEM,Loretta L. Sanchez,24
+Sonoma,7115,U.S. Senate,,DEM,Kamala D. Harris,85
+Sonoma,7115,U.S. Senate,,DEM,Loretta L. Sanchez,24
+Sonoma,7116,U.S. Senate,,DEM,Kamala D. Harris,65
+Sonoma,7116,U.S. Senate,,DEM,Loretta L. Sanchez,17
+Sonoma,7117,U.S. Senate,,DEM,Kamala D. Harris,45
+Sonoma,7117,U.S. Senate,,DEM,Loretta L. Sanchez,9
+Sonoma,7118,U.S. Senate,,DEM,Kamala D. Harris,279
+Sonoma,7118,U.S. Senate,,DEM,Loretta L. Sanchez,123
+Sonoma,7119,U.S. Senate,,DEM,Kamala D. Harris,487
+Sonoma,7119,U.S. Senate,,DEM,Loretta L. Sanchez,159
+Sonoma,7120,U.S. Senate,,DEM,Kamala D. Harris,229
+Sonoma,7120,U.S. Senate,,DEM,Loretta L. Sanchez,77
+Sonoma,7121,U.S. Senate,,DEM,Kamala D. Harris,12
+Sonoma,7121,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Sonoma,7122,U.S. Senate,,DEM,Kamala D. Harris,1195
+Sonoma,7122,U.S. Senate,,DEM,Loretta L. Sanchez,543
+Sonoma,7123,U.S. Senate,,DEM,Kamala D. Harris,883
+Sonoma,7123,U.S. Senate,,DEM,Loretta L. Sanchez,237
+Sonoma,7124,U.S. Senate,,DEM,Kamala D. Harris,548
+Sonoma,7124,U.S. Senate,,DEM,Loretta L. Sanchez,205
+Sonoma,7125,U.S. Senate,,DEM,Kamala D. Harris,213
+Sonoma,7125,U.S. Senate,,DEM,Loretta L. Sanchez,128
+Sonoma,7126,U.S. Senate,,DEM,Kamala D. Harris,13
+Sonoma,7126,U.S. Senate,,DEM,Loretta L. Sanchez,5
+Sonoma,7127,U.S. Senate,,DEM,Kamala D. Harris,324
+Sonoma,7127,U.S. Senate,,DEM,Loretta L. Sanchez,110
+Sonoma,7128,U.S. Senate,,DEM,Kamala D. Harris,54
+Sonoma,7128,U.S. Senate,,DEM,Loretta L. Sanchez,12
+Sonoma,7129,U.S. Senate,,DEM,Kamala D. Harris,0
+Sonoma,7129,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sonoma,7130,U.S. Senate,,DEM,Kamala D. Harris,237
+Sonoma,7130,U.S. Senate,,DEM,Loretta L. Sanchez,82
+Sonoma,7131,U.S. Senate,,DEM,Kamala D. Harris,73
+Sonoma,7131,U.S. Senate,,DEM,Loretta L. Sanchez,25
+Sonoma,7132,U.S. Senate,,DEM,Kamala D. Harris,107
+Sonoma,7132,U.S. Senate,,DEM,Loretta L. Sanchez,38
+Sonoma,7133,U.S. Senate,,DEM,Kamala D. Harris,1
+Sonoma,7133,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sonoma,7134,U.S. Senate,,DEM,Kamala D. Harris,1
+Sonoma,7134,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sonoma,7135,U.S. Senate,,DEM,Kamala D. Harris,0
+Sonoma,7135,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Sonoma,7136,U.S. Senate,,DEM,Kamala D. Harris,194
+Sonoma,7136,U.S. Senate,,DEM,Loretta L. Sanchez,52
+Sonoma,7137,U.S. Senate,,DEM,Kamala D. Harris,132
+Sonoma,7137,U.S. Senate,,DEM,Loretta L. Sanchez,48
+Sonoma,7138,U.S. Senate,,DEM,Kamala D. Harris,382
+Sonoma,7138,U.S. Senate,,DEM,Loretta L. Sanchez,115
+Sonoma,7139,U.S. Senate,,DEM,Kamala D. Harris,776
+Sonoma,7139,U.S. Senate,,DEM,Loretta L. Sanchez,175
+Sonoma,7140,U.S. Senate,,DEM,Kamala D. Harris,881
+Sonoma,7140,U.S. Senate,,DEM,Loretta L. Sanchez,353
+Sonoma,7141,U.S. Senate,,DEM,Kamala D. Harris,689
+Sonoma,7141,U.S. Senate,,DEM,Loretta L. Sanchez,192
+Sonoma,7142,U.S. Senate,,DEM,Kamala D. Harris,143
+Sonoma,7142,U.S. Senate,,DEM,Loretta L. Sanchez,44
+Sonoma,7143,U.S. Senate,,DEM,Kamala D. Harris,404
+Sonoma,7143,U.S. Senate,,DEM,Loretta L. Sanchez,138
+Sonoma,7144,U.S. Senate,,DEM,Kamala D. Harris,1418
+Sonoma,7144,U.S. Senate,,DEM,Loretta L. Sanchez,351
+Sonoma,7145,U.S. Senate,,DEM,Kamala D. Harris,882
+Sonoma,7145,U.S. Senate,,DEM,Loretta L. Sanchez,314
+Sonoma,7146,U.S. Senate,,DEM,Kamala D. Harris,969
+Sonoma,7146,U.S. Senate,,DEM,Loretta L. Sanchez,311
+Sonoma,7147,U.S. Senate,,DEM,Kamala D. Harris,1210
+Sonoma,7147,U.S. Senate,,DEM,Loretta L. Sanchez,397
+Sonoma,7201,U.S. Senate,,DEM,Kamala D. Harris,159
+Sonoma,7201,U.S. Senate,,DEM,Loretta L. Sanchez,116
+Sonoma,7202,U.S. Senate,,DEM,Kamala D. Harris,1
+Sonoma,7202,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Sonoma,7203,U.S. Senate,,DEM,Kamala D. Harris,957
+Sonoma,7203,U.S. Senate,,DEM,Loretta L. Sanchez,326
+Sonoma,7204,U.S. Senate,,DEM,Kamala D. Harris,33
+Sonoma,7204,U.S. Senate,,DEM,Loretta L. Sanchez,15
+Sonoma,7205,U.S. Senate,,DEM,Kamala D. Harris,159
+Sonoma,7205,U.S. Senate,,DEM,Loretta L. Sanchez,34
+Sonoma,7206,U.S. Senate,,DEM,Kamala D. Harris,621
+Sonoma,7206,U.S. Senate,,DEM,Loretta L. Sanchez,268
+Sonoma,7207,U.S. Senate,,DEM,Kamala D. Harris,533
+Sonoma,7207,U.S. Senate,,DEM,Loretta L. Sanchez,171
+Sonoma,7208,U.S. Senate,,DEM,Kamala D. Harris,161
+Sonoma,7208,U.S. Senate,,DEM,Loretta L. Sanchez,120
+Sonoma,7209,U.S. Senate,,DEM,Kamala D. Harris,55
+Sonoma,7209,U.S. Senate,,DEM,Loretta L. Sanchez,21
+Sonoma,7210,U.S. Senate,,DEM,Kamala D. Harris,324
+Sonoma,7210,U.S. Senate,,DEM,Loretta L. Sanchez,116
+Sonoma,7211,U.S. Senate,,DEM,Kamala D. Harris,290
+Sonoma,7211,U.S. Senate,,DEM,Loretta L. Sanchez,107
+Sonoma,7212,U.S. Senate,,DEM,Kamala D. Harris,522
+Sonoma,7212,U.S. Senate,,DEM,Loretta L. Sanchez,161
+Sonoma,7213,U.S. Senate,,DEM,Kamala D. Harris,10
+Sonoma,7213,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Sonoma,7214,U.S. Senate,,DEM,Kamala D. Harris,203
+Sonoma,7214,U.S. Senate,,DEM,Loretta L. Sanchez,83
+Sonoma,7215,U.S. Senate,,DEM,Kamala D. Harris,196
+Sonoma,7215,U.S. Senate,,DEM,Loretta L. Sanchez,93
+Sonoma,7216,U.S. Senate,,DEM,Kamala D. Harris,146
+Sonoma,7216,U.S. Senate,,DEM,Loretta L. Sanchez,97
+Sonoma,7217,U.S. Senate,,DEM,Kamala D. Harris,117
+Sonoma,7217,U.S. Senate,,DEM,Loretta L. Sanchez,32
+Sonoma,7218,U.S. Senate,,DEM,Kamala D. Harris,0
+Sonoma,7218,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sonoma,7219,U.S. Senate,,DEM,Kamala D. Harris,27
+Sonoma,7219,U.S. Senate,,DEM,Loretta L. Sanchez,9
+Sonoma,7220,U.S. Senate,,DEM,Kamala D. Harris,104
+Sonoma,7220,U.S. Senate,,DEM,Loretta L. Sanchez,42
+Sonoma,7221,U.S. Senate,,DEM,Kamala D. Harris,0
+Sonoma,7221,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Sonoma,7222,U.S. Senate,,DEM,Kamala D. Harris,153
+Sonoma,7222,U.S. Senate,,DEM,Loretta L. Sanchez,50
+Sonoma,7223,U.S. Senate,,DEM,Kamala D. Harris,109
+Sonoma,7223,U.S. Senate,,DEM,Loretta L. Sanchez,22
+Sonoma,7224,U.S. Senate,,DEM,Kamala D. Harris,5
+Sonoma,7224,U.S. Senate,,DEM,Loretta L. Sanchez,5
+Sonoma,7225,U.S. Senate,,DEM,Kamala D. Harris,0
+Sonoma,7225,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Sonoma,7226,U.S. Senate,,DEM,Kamala D. Harris,284
+Sonoma,7226,U.S. Senate,,DEM,Loretta L. Sanchez,87
+Sonoma,7227,U.S. Senate,,DEM,Kamala D. Harris,794
+Sonoma,7227,U.S. Senate,,DEM,Loretta L. Sanchez,228
+Sonoma,7228,U.S. Senate,,DEM,Kamala D. Harris,12
+Sonoma,7228,U.S. Senate,,DEM,Loretta L. Sanchez,5
+Sonoma,7229,U.S. Senate,,DEM,Kamala D. Harris,56
+Sonoma,7229,U.S. Senate,,DEM,Loretta L. Sanchez,28
+Sonoma,7230,U.S. Senate,,DEM,Kamala D. Harris,1
+Sonoma,7230,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Sonoma,7231,U.S. Senate,,DEM,Kamala D. Harris,168
+Sonoma,7231,U.S. Senate,,DEM,Loretta L. Sanchez,68
+Sonoma,7232,U.S. Senate,,DEM,Kamala D. Harris,3
+Sonoma,7232,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Sonoma,7233,U.S. Senate,,DEM,Kamala D. Harris,20
+Sonoma,7233,U.S. Senate,,DEM,Loretta L. Sanchez,7
+Sonoma,7234,U.S. Senate,,DEM,Kamala D. Harris,0
+Sonoma,7234,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sonoma,7235,U.S. Senate,,DEM,Kamala D. Harris,61
+Sonoma,7235,U.S. Senate,,DEM,Loretta L. Sanchez,13
+Sonoma,7236,U.S. Senate,,DEM,Kamala D. Harris,142
+Sonoma,7236,U.S. Senate,,DEM,Loretta L. Sanchez,43
+Sonoma,7237,U.S. Senate,,DEM,Kamala D. Harris,3
+Sonoma,7237,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Sonoma,7238,U.S. Senate,,DEM,Kamala D. Harris,28
+Sonoma,7238,U.S. Senate,,DEM,Loretta L. Sanchez,11
+Sonoma,7239,U.S. Senate,,DEM,Kamala D. Harris,1
+Sonoma,7239,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Sonoma,7240,U.S. Senate,,DEM,Kamala D. Harris,25
+Sonoma,7240,U.S. Senate,,DEM,Loretta L. Sanchez,10
+Sonoma,7241,U.S. Senate,,DEM,Kamala D. Harris,25
+Sonoma,7241,U.S. Senate,,DEM,Loretta L. Sanchez,10
+Sonoma,7242,U.S. Senate,,DEM,Kamala D. Harris,514
+Sonoma,7242,U.S. Senate,,DEM,Loretta L. Sanchez,204
+Sonoma,7243,U.S. Senate,,DEM,Kamala D. Harris,702
+Sonoma,7243,U.S. Senate,,DEM,Loretta L. Sanchez,282
+Sonoma,7244,U.S. Senate,,DEM,Kamala D. Harris,1380
+Sonoma,7244,U.S. Senate,,DEM,Loretta L. Sanchez,398
+Sonoma,7245,U.S. Senate,,DEM,Kamala D. Harris,1308
+Sonoma,7245,U.S. Senate,,DEM,Loretta L. Sanchez,291
+Sonoma,7246,U.S. Senate,,DEM,Kamala D. Harris,1025
+Sonoma,7246,U.S. Senate,,DEM,Loretta L. Sanchez,393
+Sonoma,7247,U.S. Senate,,DEM,Kamala D. Harris,379
+Sonoma,7247,U.S. Senate,,DEM,Loretta L. Sanchez,130
+Sonoma,7248,U.S. Senate,,DEM,Kamala D. Harris,751
+Sonoma,7248,U.S. Senate,,DEM,Loretta L. Sanchez,308
+Sonoma,7249,U.S. Senate,,DEM,Kamala D. Harris,488
+Sonoma,7249,U.S. Senate,,DEM,Loretta L. Sanchez,189
+Sonoma,7250,U.S. Senate,,DEM,Kamala D. Harris,72
+Sonoma,7250,U.S. Senate,,DEM,Loretta L. Sanchez,20
+Sonoma,7251,U.S. Senate,,DEM,Kamala D. Harris,40
+Sonoma,7251,U.S. Senate,,DEM,Loretta L. Sanchez,21
+Sonoma,7252,U.S. Senate,,DEM,Kamala D. Harris,305
+Sonoma,7252,U.S. Senate,,DEM,Loretta L. Sanchez,118
+Sonoma,7253,U.S. Senate,,DEM,Kamala D. Harris,683
+Sonoma,7253,U.S. Senate,,DEM,Loretta L. Sanchez,262
+Sonoma,7254,U.S. Senate,,DEM,Kamala D. Harris,0
+Sonoma,7254,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Sonoma,7301,U.S. Senate,,DEM,Kamala D. Harris,4
+Sonoma,7301,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Sonoma,7302,U.S. Senate,,DEM,Kamala D. Harris,74
+Sonoma,7302,U.S. Senate,,DEM,Loretta L. Sanchez,23
+Sonoma,7303,U.S. Senate,,DEM,Kamala D. Harris,7
+Sonoma,7303,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Sonoma,7304,U.S. Senate,,DEM,Kamala D. Harris,14
+Sonoma,7304,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sonoma,7305,U.S. Senate,,DEM,Kamala D. Harris,121
+Sonoma,7305,U.S. Senate,,DEM,Loretta L. Sanchez,54
+Sonoma,7306,U.S. Senate,,DEM,Kamala D. Harris,251
+Sonoma,7306,U.S. Senate,,DEM,Loretta L. Sanchez,58
+Sonoma,7307,U.S. Senate,,DEM,Kamala D. Harris,925
+Sonoma,7307,U.S. Senate,,DEM,Loretta L. Sanchez,416
+Sonoma,7308,U.S. Senate,,DEM,Kamala D. Harris,1143
+Sonoma,7308,U.S. Senate,,DEM,Loretta L. Sanchez,276
+Sonoma,7309,U.S. Senate,,DEM,Kamala D. Harris,602
+Sonoma,7309,U.S. Senate,,DEM,Loretta L. Sanchez,179
+Sonoma,7310,U.S. Senate,,DEM,Kamala D. Harris,837
+Sonoma,7310,U.S. Senate,,DEM,Loretta L. Sanchez,234
+Sonoma,7311,U.S. Senate,,DEM,Kamala D. Harris,89
+Sonoma,7311,U.S. Senate,,DEM,Loretta L. Sanchez,36
+Sonoma,7312,U.S. Senate,,DEM,Kamala D. Harris,22
+Sonoma,7312,U.S. Senate,,DEM,Loretta L. Sanchez,8
+Sonoma,7313,U.S. Senate,,DEM,Kamala D. Harris,99
+Sonoma,7313,U.S. Senate,,DEM,Loretta L. Sanchez,52
+Sonoma,7314,U.S. Senate,,DEM,Kamala D. Harris,1
+Sonoma,7314,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Sonoma,7315,U.S. Senate,,DEM,Kamala D. Harris,791
+Sonoma,7315,U.S. Senate,,DEM,Loretta L. Sanchez,379
+Sonoma,7401,U.S. Senate,,DEM,Kamala D. Harris,52
+Sonoma,7401,U.S. Senate,,DEM,Loretta L. Sanchez,17
+Sonoma,7402,U.S. Senate,,DEM,Kamala D. Harris,210
+Sonoma,7402,U.S. Senate,,DEM,Loretta L. Sanchez,73
+Sonoma,7403,U.S. Senate,,DEM,Kamala D. Harris,68
+Sonoma,7403,U.S. Senate,,DEM,Loretta L. Sanchez,24
+Sonoma,7404,U.S. Senate,,DEM,Kamala D. Harris,6
+Sonoma,7404,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Sonoma,7405,U.S. Senate,,DEM,Kamala D. Harris,10
+Sonoma,7405,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Sonoma,7406,U.S. Senate,,DEM,Kamala D. Harris,81
+Sonoma,7406,U.S. Senate,,DEM,Loretta L. Sanchez,21
+Sonoma,7407,U.S. Senate,,DEM,Kamala D. Harris,99
+Sonoma,7407,U.S. Senate,,DEM,Loretta L. Sanchez,34
+Sonoma,7408,U.S. Senate,,DEM,Kamala D. Harris,244
+Sonoma,7408,U.S. Senate,,DEM,Loretta L. Sanchez,97
+Sonoma,7409,U.S. Senate,,DEM,Kamala D. Harris,0
+Sonoma,7409,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sonoma,7410,U.S. Senate,,DEM,Kamala D. Harris,60
+Sonoma,7410,U.S. Senate,,DEM,Loretta L. Sanchez,29
+Sonoma,7411,U.S. Senate,,DEM,Kamala D. Harris,2
+Sonoma,7411,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Sonoma,7412,U.S. Senate,,DEM,Kamala D. Harris,28
+Sonoma,7412,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Sonoma,7413,U.S. Senate,,DEM,Kamala D. Harris,61
+Sonoma,7413,U.S. Senate,,DEM,Loretta L. Sanchez,37
+Sonoma,7414,U.S. Senate,,DEM,Kamala D. Harris,129
+Sonoma,7414,U.S. Senate,,DEM,Loretta L. Sanchez,45
+Sonoma,7415,U.S. Senate,,DEM,Kamala D. Harris,829
+Sonoma,7415,U.S. Senate,,DEM,Loretta L. Sanchez,450
+Sonoma,7416,U.S. Senate,,DEM,Kamala D. Harris,396
+Sonoma,7416,U.S. Senate,,DEM,Loretta L. Sanchez,134
+Sonoma,7417,U.S. Senate,,DEM,Kamala D. Harris,393
+Sonoma,7417,U.S. Senate,,DEM,Loretta L. Sanchez,174
+Sonoma,7418,U.S. Senate,,DEM,Kamala D. Harris,1066
+Sonoma,7418,U.S. Senate,,DEM,Loretta L. Sanchez,477
+Sonoma,7419,U.S. Senate,,DEM,Kamala D. Harris,23
+Sonoma,7419,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Sonoma,7420,U.S. Senate,,DEM,Kamala D. Harris,208
+Sonoma,7420,U.S. Senate,,DEM,Loretta L. Sanchez,115
+Sonoma,7421,U.S. Senate,,DEM,Kamala D. Harris,265
+Sonoma,7421,U.S. Senate,,DEM,Loretta L. Sanchez,121
+Sonoma,7422,U.S. Senate,,DEM,Kamala D. Harris,131
+Sonoma,7422,U.S. Senate,,DEM,Loretta L. Sanchez,57
+Sonoma,7423,U.S. Senate,,DEM,Kamala D. Harris,121
+Sonoma,7423,U.S. Senate,,DEM,Loretta L. Sanchez,56
+Sonoma,7424,U.S. Senate,,DEM,Kamala D. Harris,423
+Sonoma,7424,U.S. Senate,,DEM,Loretta L. Sanchez,152
+Sonoma,7425,U.S. Senate,,DEM,Kamala D. Harris,0
+Sonoma,7425,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sonoma,7426,U.S. Senate,,DEM,Kamala D. Harris,38
+Sonoma,7426,U.S. Senate,,DEM,Loretta L. Sanchez,15
+Sonoma,7427,U.S. Senate,,DEM,Kamala D. Harris,37
+Sonoma,7427,U.S. Senate,,DEM,Loretta L. Sanchez,12
+Sonoma,7428,U.S. Senate,,DEM,Kamala D. Harris,13
+Sonoma,7428,U.S. Senate,,DEM,Loretta L. Sanchez,8
+Sonoma,7429,U.S. Senate,,DEM,Kamala D. Harris,93
+Sonoma,7429,U.S. Senate,,DEM,Loretta L. Sanchez,52
+Sonoma,7430,U.S. Senate,,DEM,Kamala D. Harris,134
+Sonoma,7430,U.S. Senate,,DEM,Loretta L. Sanchez,52
+Sonoma,7431,U.S. Senate,,DEM,Kamala D. Harris,441
+Sonoma,7431,U.S. Senate,,DEM,Loretta L. Sanchez,182
+Sonoma,7432,U.S. Senate,,DEM,Kamala D. Harris,3
+Sonoma,7432,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Sonoma,7433,U.S. Senate,,DEM,Kamala D. Harris,52
+Sonoma,7433,U.S. Senate,,DEM,Loretta L. Sanchez,18
+Sonoma,7434,U.S. Senate,,DEM,Kamala D. Harris,21
+Sonoma,7434,U.S. Senate,,DEM,Loretta L. Sanchez,6
+Sonoma,7435,U.S. Senate,,DEM,Kamala D. Harris,560
+Sonoma,7435,U.S. Senate,,DEM,Loretta L. Sanchez,252
+Sonoma,7436,U.S. Senate,,DEM,Kamala D. Harris,36
+Sonoma,7436,U.S. Senate,,DEM,Loretta L. Sanchez,26
+Sonoma,7437,U.S. Senate,,DEM,Kamala D. Harris,7
+Sonoma,7437,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Sonoma,7438,U.S. Senate,,DEM,Kamala D. Harris,10
+Sonoma,7438,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Sonoma,7439,U.S. Senate,,DEM,Kamala D. Harris,6
+Sonoma,7439,U.S. Senate,,DEM,Loretta L. Sanchez,5
+Sonoma,7440,U.S. Senate,,DEM,Kamala D. Harris,859
+Sonoma,7440,U.S. Senate,,DEM,Loretta L. Sanchez,302
+Sonoma,7441,U.S. Senate,,DEM,Kamala D. Harris,349
+Sonoma,7441,U.S. Senate,,DEM,Loretta L. Sanchez,134
+Sonoma,7442,U.S. Senate,,DEM,Kamala D. Harris,799
+Sonoma,7442,U.S. Senate,,DEM,Loretta L. Sanchez,410
+Sonoma,7443,U.S. Senate,,DEM,Kamala D. Harris,0
+Sonoma,7443,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sonoma,7444,U.S. Senate,,DEM,Kamala D. Harris,24
+Sonoma,7444,U.S. Senate,,DEM,Loretta L. Sanchez,14
+Sonoma,7445,U.S. Senate,,DEM,Kamala D. Harris,5
+Sonoma,7445,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Sonoma,7446,U.S. Senate,,DEM,Kamala D. Harris,21
+Sonoma,7446,U.S. Senate,,DEM,Loretta L. Sanchez,7
+Sonoma,7447,U.S. Senate,,DEM,Kamala D. Harris,463
+Sonoma,7447,U.S. Senate,,DEM,Loretta L. Sanchez,165
+Sonoma,7448,U.S. Senate,,DEM,Kamala D. Harris,755
+Sonoma,7448,U.S. Senate,,DEM,Loretta L. Sanchez,270
+Sonoma,7449,U.S. Senate,,DEM,Kamala D. Harris,8
+Sonoma,7449,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Sonoma,7450,U.S. Senate,,DEM,Kamala D. Harris,4
+Sonoma,7450,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Sonoma,7451,U.S. Senate,,DEM,Kamala D. Harris,15
+Sonoma,7451,U.S. Senate,,DEM,Loretta L. Sanchez,5
+Sonoma,7452,U.S. Senate,,DEM,Kamala D. Harris,1070
+Sonoma,7452,U.S. Senate,,DEM,Loretta L. Sanchez,303
+Sonoma,7453,U.S. Senate,,DEM,Kamala D. Harris,893
+Sonoma,7453,U.S. Senate,,DEM,Loretta L. Sanchez,467
+Sonoma,7454,U.S. Senate,,DEM,Kamala D. Harris,883
+Sonoma,7454,U.S. Senate,,DEM,Loretta L. Sanchez,475
+Sonoma,7455,U.S. Senate,,DEM,Kamala D. Harris,0
+Sonoma,7455,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sonoma,7456,U.S. Senate,,DEM,Kamala D. Harris,89
+Sonoma,7456,U.S. Senate,,DEM,Loretta L. Sanchez,30
+Sonoma,7457,U.S. Senate,,DEM,Kamala D. Harris,0
+Sonoma,7457,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Sonoma,7501,U.S. Senate,,DEM,Kamala D. Harris,306
+Sonoma,7501,U.S. Senate,,DEM,Loretta L. Sanchez,67
+Sonoma,7502,U.S. Senate,,DEM,Kamala D. Harris,672
+Sonoma,7502,U.S. Senate,,DEM,Loretta L. Sanchez,160
+Sonoma,7503,U.S. Senate,,DEM,Kamala D. Harris,80
+Sonoma,7503,U.S. Senate,,DEM,Loretta L. Sanchez,24
+Sonoma,7504,U.S. Senate,,DEM,Kamala D. Harris,942
+Sonoma,7504,U.S. Senate,,DEM,Loretta L. Sanchez,264
+Sonoma,7505,U.S. Senate,,DEM,Kamala D. Harris,462
+Sonoma,7505,U.S. Senate,,DEM,Loretta L. Sanchez,105
+Sonoma,7506,U.S. Senate,,DEM,Kamala D. Harris,537
+Sonoma,7506,U.S. Senate,,DEM,Loretta L. Sanchez,123
+Sonoma,7507,U.S. Senate,,DEM,Kamala D. Harris,632
+Sonoma,7507,U.S. Senate,,DEM,Loretta L. Sanchez,157
+Sonoma,7508,U.S. Senate,,DEM,Kamala D. Harris,7
+Sonoma,7508,U.S. Senate,,DEM,Loretta L. Sanchez,7
+Sonoma,7509,U.S. Senate,,DEM,Kamala D. Harris,214
+Sonoma,7509,U.S. Senate,,DEM,Loretta L. Sanchez,62
+Sonoma,7510,U.S. Senate,,DEM,Kamala D. Harris,567
+Sonoma,7510,U.S. Senate,,DEM,Loretta L. Sanchez,154
+Sonoma,7511,U.S. Senate,,DEM,Kamala D. Harris,840
+Sonoma,7511,U.S. Senate,,DEM,Loretta L. Sanchez,201
+Sonoma,7512,U.S. Senate,,DEM,Kamala D. Harris,406
+Sonoma,7512,U.S. Senate,,DEM,Loretta L. Sanchez,88
+Sonoma,7513,U.S. Senate,,DEM,Kamala D. Harris,321
+Sonoma,7513,U.S. Senate,,DEM,Loretta L. Sanchez,94
+Sonoma,7514,U.S. Senate,,DEM,Kamala D. Harris,4
+Sonoma,7514,U.S. Senate,,DEM,Loretta L. Sanchez,5
+Sonoma,7515,U.S. Senate,,DEM,Kamala D. Harris,115
+Sonoma,7515,U.S. Senate,,DEM,Loretta L. Sanchez,46
+Sonoma,7516,U.S. Senate,,DEM,Kamala D. Harris,21
+Sonoma,7516,U.S. Senate,,DEM,Loretta L. Sanchez,16
+Sonoma,7517,U.S. Senate,,DEM,Kamala D. Harris,1
+Sonoma,7517,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Sonoma,7518,U.S. Senate,,DEM,Kamala D. Harris,358
+Sonoma,7518,U.S. Senate,,DEM,Loretta L. Sanchez,121
+Sonoma,7519,U.S. Senate,,DEM,Kamala D. Harris,115
+Sonoma,7519,U.S. Senate,,DEM,Loretta L. Sanchez,43
+Sonoma,7520,U.S. Senate,,DEM,Kamala D. Harris,38
+Sonoma,7520,U.S. Senate,,DEM,Loretta L. Sanchez,15
+Sonoma,7521,U.S. Senate,,DEM,Kamala D. Harris,30
+Sonoma,7521,U.S. Senate,,DEM,Loretta L. Sanchez,20
+Sonoma,7522,U.S. Senate,,DEM,Kamala D. Harris,1
+Sonoma,7522,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sonoma,7523,U.S. Senate,,DEM,Kamala D. Harris,495
+Sonoma,7523,U.S. Senate,,DEM,Loretta L. Sanchez,172
+Sonoma,7524,U.S. Senate,,DEM,Kamala D. Harris,433
+Sonoma,7524,U.S. Senate,,DEM,Loretta L. Sanchez,154
+Sonoma,7525,U.S. Senate,,DEM,Kamala D. Harris,819
+Sonoma,7525,U.S. Senate,,DEM,Loretta L. Sanchez,267
+Sonoma,7526,U.S. Senate,,DEM,Kamala D. Harris,795
+Sonoma,7526,U.S. Senate,,DEM,Loretta L. Sanchez,244
+Sonoma,7527,U.S. Senate,,DEM,Kamala D. Harris,126
+Sonoma,7527,U.S. Senate,,DEM,Loretta L. Sanchez,51
+Sonoma,7528,U.S. Senate,,DEM,Kamala D. Harris,46
+Sonoma,7528,U.S. Senate,,DEM,Loretta L. Sanchez,9
+Sonoma,7529,U.S. Senate,,DEM,Kamala D. Harris,32
+Sonoma,7529,U.S. Senate,,DEM,Loretta L. Sanchez,7
+Sonoma,7530,U.S. Senate,,DEM,Kamala D. Harris,951
+Sonoma,7530,U.S. Senate,,DEM,Loretta L. Sanchez,245
+Sonoma,7531,U.S. Senate,,DEM,Kamala D. Harris,961
+Sonoma,7531,U.S. Senate,,DEM,Loretta L. Sanchez,265
+Sonoma,7532,U.S. Senate,,DEM,Kamala D. Harris,59
+Sonoma,7532,U.S. Senate,,DEM,Loretta L. Sanchez,7
+Sonoma,7533,U.S. Senate,,DEM,Kamala D. Harris,8
+Sonoma,7533,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Sonoma,7534,U.S. Senate,,DEM,Kamala D. Harris,47
+Sonoma,7534,U.S. Senate,,DEM,Loretta L. Sanchez,16
+Sonoma,7535,U.S. Senate,,DEM,Kamala D. Harris,207
+Sonoma,7535,U.S. Senate,,DEM,Loretta L. Sanchez,97
+Sonoma,7536,U.S. Senate,,DEM,Kamala D. Harris,653
+Sonoma,7536,U.S. Senate,,DEM,Loretta L. Sanchez,395
+Sonoma,7537,U.S. Senate,,DEM,Kamala D. Harris,46
+Sonoma,7537,U.S. Senate,,DEM,Loretta L. Sanchez,10
+Sonoma,7538,U.S. Senate,,DEM,Kamala D. Harris,11
+Sonoma,7538,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Sonoma,7539,U.S. Senate,,DEM,Kamala D. Harris,180
+Sonoma,7539,U.S. Senate,,DEM,Loretta L. Sanchez,164
+Sonoma,7540,U.S. Senate,,DEM,Kamala D. Harris,38
+Sonoma,7540,U.S. Senate,,DEM,Loretta L. Sanchez,19
+Sonoma,7541,U.S. Senate,,DEM,Kamala D. Harris,41
+Sonoma,7541,U.S. Senate,,DEM,Loretta L. Sanchez,24
+Sonoma,7542,U.S. Senate,,DEM,Kamala D. Harris,1262
+Sonoma,7542,U.S. Senate,,DEM,Loretta L. Sanchez,269
+Sonoma,7543,U.S. Senate,,DEM,Kamala D. Harris,272
+Sonoma,7543,U.S. Senate,,DEM,Loretta L. Sanchez,82
+Sonoma,7544,U.S. Senate,,DEM,Kamala D. Harris,5
+Sonoma,7544,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Sonoma,7545,U.S. Senate,,DEM,Kamala D. Harris,416
+Sonoma,7545,U.S. Senate,,DEM,Loretta L. Sanchez,139
+Sonoma,7546,U.S. Senate,,DEM,Kamala D. Harris,607
+Sonoma,7546,U.S. Senate,,DEM,Loretta L. Sanchez,181
+Sonoma,7547,U.S. Senate,,DEM,Kamala D. Harris,10
+Sonoma,7547,U.S. Senate,,DEM,Loretta L. Sanchez,6
+Sonoma,7548,U.S. Senate,,DEM,Kamala D. Harris,8
+Sonoma,7548,U.S. Senate,,DEM,Loretta L. Sanchez,6
+Sonoma,7549,U.S. Senate,,DEM,Kamala D. Harris,215
+Sonoma,7549,U.S. Senate,,DEM,Loretta L. Sanchez,30
+Sonoma,7550,U.S. Senate,,DEM,Kamala D. Harris,147
+Sonoma,7550,U.S. Senate,,DEM,Loretta L. Sanchez,29
+Sonoma,7551,U.S. Senate,,DEM,Kamala D. Harris,143
+Sonoma,7551,U.S. Senate,,DEM,Loretta L. Sanchez,29
+Sonoma,7552,U.S. Senate,,DEM,Kamala D. Harris,33
+Sonoma,7552,U.S. Senate,,DEM,Loretta L. Sanchez,5
+Sonoma,7553,U.S. Senate,,DEM,Kamala D. Harris,2
+Sonoma,7553,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Sonoma,7554,U.S. Senate,,DEM,Kamala D. Harris,11
+Sonoma,7554,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Sonoma,7555,U.S. Senate,,DEM,Kamala D. Harris,11
+Sonoma,7555,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Sonoma,7556,U.S. Senate,,DEM,Kamala D. Harris,398
+Sonoma,7556,U.S. Senate,,DEM,Loretta L. Sanchez,100
+Sonoma,7557,U.S. Senate,,DEM,Kamala D. Harris,45
+Sonoma,7557,U.S. Senate,,DEM,Loretta L. Sanchez,22
+Sonoma,7558,U.S. Senate,,DEM,Kamala D. Harris,584
+Sonoma,7558,U.S. Senate,,DEM,Loretta L. Sanchez,158
+Sonoma,7559,U.S. Senate,,DEM,Kamala D. Harris,72
+Sonoma,7559,U.S. Senate,,DEM,Loretta L. Sanchez,50
+Sonoma,7560,U.S. Senate,,DEM,Kamala D. Harris,6
+Sonoma,7560,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Sonoma,7561,U.S. Senate,,DEM,Kamala D. Harris,600
+Sonoma,7561,U.S. Senate,,DEM,Loretta L. Sanchez,386
+Sonoma,7562,U.S. Senate,,DEM,Kamala D. Harris,632
+Sonoma,7562,U.S. Senate,,DEM,Loretta L. Sanchez,526
+Sonoma,7563,U.S. Senate,,DEM,Kamala D. Harris,1226
+Sonoma,7563,U.S. Senate,,DEM,Loretta L. Sanchez,477
+Sonoma,7564,U.S. Senate,,DEM,Kamala D. Harris,1042
+Sonoma,7564,U.S. Senate,,DEM,Loretta L. Sanchez,490
+Sonoma,7565,U.S. Senate,,DEM,Kamala D. Harris,1041
+Sonoma,7565,U.S. Senate,,DEM,Loretta L. Sanchez,235
+Sonoma,7566,U.S. Senate,,DEM,Kamala D. Harris,1106
+Sonoma,7566,U.S. Senate,,DEM,Loretta L. Sanchez,227
+Sonoma,7567,U.S. Senate,,DEM,Kamala D. Harris,1346
+Sonoma,7567,U.S. Senate,,DEM,Loretta L. Sanchez,251

--- a/2016/20161108__ca__general__stanislaus__precinct.csv
+++ b/2016/20161108__ca__general__stanislaus__precinct.csv
@@ -8719,439 +8719,439 @@ Stanislaus,932005,Proposition 67,,N/A,Yes,47
 Stanislaus,932005,Proposition 67,,N/A,No,137
 Stanislaus,932012,Proposition 67,,N/A,Yes,15
 Stanislaus,932012,Proposition 67,,N/A,No,20
-Stanislaus,101002,U.S. Senate,,DEM,Kamala Harris,82
-Stanislaus,101002,U.S. Senate,,DEM,Loretta Sanchez,119
-Stanislaus,102001,U.S. Senate,,DEM,Kamala Harris,204
-Stanislaus,102001,U.S. Senate,,DEM,Loretta Sanchez,445
-Stanislaus,102002,U.S. Senate,,DEM,Kamala Harris,74
-Stanislaus,102002,U.S. Senate,,DEM,Loretta Sanchez,74
-Stanislaus,102003,U.S. Senate,,DEM,Kamala Harris,57
-Stanislaus,102003,U.S. Senate,,DEM,Loretta Sanchez,145
-Stanislaus,102005,U.S. Senate,,DEM,Kamala Harris,232
-Stanislaus,102005,U.S. Senate,,DEM,Loretta Sanchez,451
-Stanislaus,102007,U.S. Senate,,DEM,Kamala Harris,95
-Stanislaus,102007,U.S. Senate,,DEM,Loretta Sanchez,120
-Stanislaus,103001,U.S. Senate,,DEM,Kamala Harris,481
-Stanislaus,103001,U.S. Senate,,DEM,Loretta Sanchez,470
-Stanislaus,103002,U.S. Senate,,DEM,Kamala Harris,595
-Stanislaus,103002,U.S. Senate,,DEM,Loretta Sanchez,614
-Stanislaus,103003,U.S. Senate,,DEM,Kamala Harris,401
-Stanislaus,103003,U.S. Senate,,DEM,Loretta Sanchez,445
-Stanislaus,103005,U.S. Senate,,DEM,Kamala Harris,525
-Stanislaus,103005,U.S. Senate,,DEM,Loretta Sanchez,553
-Stanislaus,103006,U.S. Senate,,DEM,Kamala Harris,409
-Stanislaus,103006,U.S. Senate,,DEM,Loretta Sanchez,450
-Stanislaus,103007,U.S. Senate,,DEM,Kamala Harris,552
-Stanislaus,103007,U.S. Senate,,DEM,Loretta Sanchez,470
-Stanislaus,103009,U.S. Senate,,DEM,Kamala Harris,591
-Stanislaus,103009,U.S. Senate,,DEM,Loretta Sanchez,536
-Stanislaus,103010,U.S. Senate,,DEM,Kamala Harris,451
-Stanislaus,103010,U.S. Senate,,DEM,Loretta Sanchez,482
-Stanislaus,103014,U.S. Senate,,DEM,Kamala Harris,415
-Stanislaus,103014,U.S. Senate,,DEM,Loretta Sanchez,462
-Stanislaus,103018,U.S. Senate,,DEM,Kamala Harris,457
-Stanislaus,103018,U.S. Senate,,DEM,Loretta Sanchez,698
-Stanislaus,103026,U.S. Senate,,DEM,Kamala Harris,615
-Stanislaus,103026,U.S. Senate,,DEM,Loretta Sanchez,641
-Stanislaus,104001,U.S. Senate,,DEM,Kamala Harris,180
-Stanislaus,104001,U.S. Senate,,DEM,Loretta Sanchez,112
-Stanislaus,104004,U.S. Senate,,DEM,Kamala Harris,103
-Stanislaus,104004,U.S. Senate,,DEM,Loretta Sanchez,77
-Stanislaus,105002,U.S. Senate,,DEM,Kamala Harris,273
-Stanislaus,105002,U.S. Senate,,DEM,Loretta Sanchez,200
-Stanislaus,105003,U.S. Senate,,DEM,Kamala Harris,253
-Stanislaus,105003,U.S. Senate,,DEM,Loretta Sanchez,204
-Stanislaus,106001,U.S. Senate,,DEM,Kamala Harris,153
-Stanislaus,106001,U.S. Senate,,DEM,Loretta Sanchez,99
-Stanislaus,106003,U.S. Senate,,DEM,Kamala Harris,72
-Stanislaus,106003,U.S. Senate,,DEM,Loretta Sanchez,141
-Stanislaus,106013,U.S. Senate,,DEM,Kamala Harris,118
-Stanislaus,106013,U.S. Senate,,DEM,Loretta Sanchez,78
-Stanislaus,107005,U.S. Senate,,DEM,Kamala Harris,576
-Stanislaus,107005,U.S. Senate,,DEM,Loretta Sanchez,295
-Stanislaus,107007,U.S. Senate,,DEM,Kamala Harris,137
-Stanislaus,107007,U.S. Senate,,DEM,Loretta Sanchez,111
-Stanislaus,108002,U.S. Senate,,DEM,Kamala Harris,223
-Stanislaus,108002,U.S. Senate,,DEM,Loretta Sanchez,145
-Stanislaus,109001,U.S. Senate,,DEM,Kamala Harris,333
-Stanislaus,109001,U.S. Senate,,DEM,Loretta Sanchez,246
-Stanislaus,109003,U.S. Senate,,DEM,Kamala Harris,132
-Stanislaus,109003,U.S. Senate,,DEM,Loretta Sanchez,227
-Stanislaus,110001,U.S. Senate,,DEM,Kamala Harris,504
-Stanislaus,110001,U.S. Senate,,DEM,Loretta Sanchez,332
-Stanislaus,110002,U.S. Senate,,DEM,Kamala Harris,600
-Stanislaus,110002,U.S. Senate,,DEM,Loretta Sanchez,422
-Stanislaus,110008,U.S. Senate,,DEM,Kamala Harris,220
-Stanislaus,110008,U.S. Senate,,DEM,Loretta Sanchez,169
-Stanislaus,111003,U.S. Senate,,DEM,Kamala Harris,429
-Stanislaus,111003,U.S. Senate,,DEM,Loretta Sanchez,454
-Stanislaus,111005,U.S. Senate,,DEM,Kamala Harris,316
-Stanislaus,111005,U.S. Senate,,DEM,Loretta Sanchez,172
-Stanislaus,112001,U.S. Senate,,DEM,Kamala Harris,287
-Stanislaus,112001,U.S. Senate,,DEM,Loretta Sanchez,262
-Stanislaus,112002,U.S. Senate,,DEM,Kamala Harris,119
-Stanislaus,112002,U.S. Senate,,DEM,Loretta Sanchez,123
-Stanislaus,114001,U.S. Senate,,DEM,Kamala Harris,466
-Stanislaus,114001,U.S. Senate,,DEM,Loretta Sanchez,355
-Stanislaus,114003,U.S. Senate,,DEM,Kamala Harris,666
-Stanislaus,114003,U.S. Senate,,DEM,Loretta Sanchez,560
-Stanislaus,115001,U.S. Senate,,DEM,Kamala Harris,1224
-Stanislaus,115001,U.S. Senate,,DEM,Loretta Sanchez,676
-Stanislaus,115003,U.S. Senate,,DEM,Kamala Harris,410
-Stanislaus,115003,U.S. Senate,,DEM,Loretta Sanchez,238
-Stanislaus,117001,U.S. Senate,,DEM,Kamala Harris,415
-Stanislaus,117001,U.S. Senate,,DEM,Loretta Sanchez,333
-Stanislaus,117002,U.S. Senate,,DEM,Kamala Harris,780
-Stanislaus,117002,U.S. Senate,,DEM,Loretta Sanchez,441
-Stanislaus,117003,U.S. Senate,,DEM,Kamala Harris,362
-Stanislaus,117003,U.S. Senate,,DEM,Loretta Sanchez,569
-Stanislaus,117004,U.S. Senate,,DEM,Kamala Harris,376
-Stanislaus,117004,U.S. Senate,,DEM,Loretta Sanchez,691
-Stanislaus,117005,U.S. Senate,,DEM,Kamala Harris,197
-Stanislaus,117005,U.S. Senate,,DEM,Loretta Sanchez,327
-Stanislaus,117006,U.S. Senate,,DEM,Kamala Harris,169
-Stanislaus,117006,U.S. Senate,,DEM,Loretta Sanchez,242
-Stanislaus,117008,U.S. Senate,,DEM,Kamala Harris,592
-Stanislaus,117008,U.S. Senate,,DEM,Loretta Sanchez,662
-Stanislaus,117009,U.S. Senate,,DEM,Kamala Harris,835
-Stanislaus,117009,U.S. Senate,,DEM,Loretta Sanchez,508
-Stanislaus,117012,U.S. Senate,,DEM,Kamala Harris,218
-Stanislaus,117012,U.S. Senate,,DEM,Loretta Sanchez,224
-Stanislaus,117014,U.S. Senate,,DEM,Kamala Harris,583
-Stanislaus,117014,U.S. Senate,,DEM,Loretta Sanchez,368
-Stanislaus,117016,U.S. Senate,,DEM,Kamala Harris,578
-Stanislaus,117016,U.S. Senate,,DEM,Loretta Sanchez,482
-Stanislaus,117017,U.S. Senate,,DEM,Kamala Harris,396
-Stanislaus,117017,U.S. Senate,,DEM,Loretta Sanchez,292
-Stanislaus,117018,U.S. Senate,,DEM,Kamala Harris,978
-Stanislaus,117018,U.S. Senate,,DEM,Loretta Sanchez,562
-Stanislaus,117019,U.S. Senate,,DEM,Kamala Harris,575
-Stanislaus,117019,U.S. Senate,,DEM,Loretta Sanchez,366
-Stanislaus,117021,U.S. Senate,,DEM,Kamala Harris,779
-Stanislaus,117021,U.S. Senate,,DEM,Loretta Sanchez,449
-Stanislaus,117023,U.S. Senate,,DEM,Kamala Harris,74
-Stanislaus,117023,U.S. Senate,,DEM,Loretta Sanchez,127
-Stanislaus,117025,U.S. Senate,,DEM,Kamala Harris,295
-Stanislaus,117025,U.S. Senate,,DEM,Loretta Sanchez,199
-Stanislaus,117027,U.S. Senate,,DEM,Kamala Harris,884
-Stanislaus,117027,U.S. Senate,,DEM,Loretta Sanchez,379
-Stanislaus,117028,U.S. Senate,,DEM,Kamala Harris,691
-Stanislaus,117028,U.S. Senate,,DEM,Loretta Sanchez,428
-Stanislaus,117029,U.S. Senate,,DEM,Kamala Harris,594
-Stanislaus,117029,U.S. Senate,,DEM,Loretta Sanchez,445
-Stanislaus,117030,U.S. Senate,,DEM,Kamala Harris,623
-Stanislaus,117030,U.S. Senate,,DEM,Loretta Sanchez,397
-Stanislaus,117035,U.S. Senate,,DEM,Kamala Harris,676
-Stanislaus,117035,U.S. Senate,,DEM,Loretta Sanchez,361
-Stanislaus,117036,U.S. Senate,,DEM,Kamala Harris,458
-Stanislaus,117036,U.S. Senate,,DEM,Loretta Sanchez,271
-Stanislaus,117040,U.S. Senate,,DEM,Kamala Harris,935
-Stanislaus,117040,U.S. Senate,,DEM,Loretta Sanchez,488
-Stanislaus,117043,U.S. Senate,,DEM,Kamala Harris,849
-Stanislaus,117043,U.S. Senate,,DEM,Loretta Sanchez,466
-Stanislaus,117044,U.S. Senate,,DEM,Kamala Harris,356
-Stanislaus,117044,U.S. Senate,,DEM,Loretta Sanchez,165
-Stanislaus,117047,U.S. Senate,,DEM,Kamala Harris,1002
-Stanislaus,117047,U.S. Senate,,DEM,Loretta Sanchez,534
-Stanislaus,117048,U.S. Senate,,DEM,Kamala Harris,625
-Stanislaus,117048,U.S. Senate,,DEM,Loretta Sanchez,333
-Stanislaus,117050,U.S. Senate,,DEM,Kamala Harris,1028
-Stanislaus,117050,U.S. Senate,,DEM,Loretta Sanchez,558
-Stanislaus,117052,U.S. Senate,,DEM,Kamala Harris,691
-Stanislaus,117052,U.S. Senate,,DEM,Loretta Sanchez,366
-Stanislaus,117053,U.S. Senate,,DEM,Kamala Harris,461
-Stanislaus,117053,U.S. Senate,,DEM,Loretta Sanchez,291
-Stanislaus,117058,U.S. Senate,,DEM,Kamala Harris,706
-Stanislaus,117058,U.S. Senate,,DEM,Loretta Sanchez,468
-Stanislaus,117059,U.S. Senate,,DEM,Kamala Harris,656
-Stanislaus,117059,U.S. Senate,,DEM,Loretta Sanchez,334
-Stanislaus,117062,U.S. Senate,,DEM,Kamala Harris,605
-Stanislaus,117062,U.S. Senate,,DEM,Loretta Sanchez,483
-Stanislaus,117068,U.S. Senate,,DEM,Kamala Harris,682
-Stanislaus,117068,U.S. Senate,,DEM,Loretta Sanchez,401
-Stanislaus,117069,U.S. Senate,,DEM,Kamala Harris,603
-Stanislaus,117069,U.S. Senate,,DEM,Loretta Sanchez,363
-Stanislaus,117073,U.S. Senate,,DEM,Kamala Harris,254
-Stanislaus,117073,U.S. Senate,,DEM,Loretta Sanchez,435
-Stanislaus,117074,U.S. Senate,,DEM,Kamala Harris,961
-Stanislaus,117074,U.S. Senate,,DEM,Loretta Sanchez,563
-Stanislaus,117076,U.S. Senate,,DEM,Kamala Harris,494
-Stanislaus,117076,U.S. Senate,,DEM,Loretta Sanchez,341
-Stanislaus,117078,U.S. Senate,,DEM,Kamala Harris,870
-Stanislaus,117078,U.S. Senate,,DEM,Loretta Sanchez,508
-Stanislaus,117079,U.S. Senate,,DEM,Kamala Harris,641
-Stanislaus,117079,U.S. Senate,,DEM,Loretta Sanchez,387
-Stanislaus,117084,U.S. Senate,,DEM,Kamala Harris,911
-Stanislaus,117084,U.S. Senate,,DEM,Loretta Sanchez,539
-Stanislaus,117090,U.S. Senate,,DEM,Kamala Harris,1000
-Stanislaus,117090,U.S. Senate,,DEM,Loretta Sanchez,565
-Stanislaus,117091,U.S. Senate,,DEM,Kamala Harris,602
-Stanislaus,117091,U.S. Senate,,DEM,Loretta Sanchez,314
-Stanislaus,117093,U.S. Senate,,DEM,Kamala Harris,565
-Stanislaus,117093,U.S. Senate,,DEM,Loretta Sanchez,313
-Stanislaus,117098,U.S. Senate,,DEM,Kamala Harris,643
-Stanislaus,117098,U.S. Senate,,DEM,Loretta Sanchez,383
-Stanislaus,117100,U.S. Senate,,DEM,Kamala Harris,837
-Stanislaus,117100,U.S. Senate,,DEM,Loretta Sanchez,458
-Stanislaus,117104,U.S. Senate,,DEM,Kamala Harris,646
-Stanislaus,117104,U.S. Senate,,DEM,Loretta Sanchez,523
-Stanislaus,117105,U.S. Senate,,DEM,Kamala Harris,526
-Stanislaus,117105,U.S. Senate,,DEM,Loretta Sanchez,475
-Stanislaus,117106,U.S. Senate,,DEM,Kamala Harris,704
-Stanislaus,117106,U.S. Senate,,DEM,Loretta Sanchez,419
-Stanislaus,117107,U.S. Senate,,DEM,Kamala Harris,777
-Stanislaus,117107,U.S. Senate,,DEM,Loretta Sanchez,466
-Stanislaus,117112,U.S. Senate,,DEM,Kamala Harris,861
-Stanislaus,117112,U.S. Senate,,DEM,Loretta Sanchez,558
-Stanislaus,117115,U.S. Senate,,DEM,Kamala Harris,161
-Stanislaus,117115,U.S. Senate,,DEM,Loretta Sanchez,225
-Stanislaus,117119,U.S. Senate,,DEM,Kamala Harris,575
-Stanislaus,117119,U.S. Senate,,DEM,Loretta Sanchez,284
-Stanislaus,117123,U.S. Senate,,DEM,Kamala Harris,407
-Stanislaus,117123,U.S. Senate,,DEM,Loretta Sanchez,201
-Stanislaus,117125,U.S. Senate,,DEM,Kamala Harris,677
-Stanislaus,117125,U.S. Senate,,DEM,Loretta Sanchez,382
-Stanislaus,117165,U.S. Senate,,DEM,Kamala Harris,576
-Stanislaus,117165,U.S. Senate,,DEM,Loretta Sanchez,377
-Stanislaus,117168,U.S. Senate,,DEM,Kamala Harris,100
-Stanislaus,117168,U.S. Senate,,DEM,Loretta Sanchez,170
-Stanislaus,117172,U.S. Senate,,DEM,Kamala Harris,706
-Stanislaus,117172,U.S. Senate,,DEM,Loretta Sanchez,411
-Stanislaus,118001,U.S. Senate,,DEM,Kamala Harris,223
-Stanislaus,118001,U.S. Senate,,DEM,Loretta Sanchez,155
-Stanislaus,119001,U.S. Senate,,DEM,Kamala Harris,263
-Stanislaus,119001,U.S. Senate,,DEM,Loretta Sanchez,263
-Stanislaus,119002,U.S. Senate,,DEM,Kamala Harris,396
-Stanislaus,119002,U.S. Senate,,DEM,Loretta Sanchez,355
-Stanislaus,119003,U.S. Senate,,DEM,Kamala Harris,575
-Stanislaus,119003,U.S. Senate,,DEM,Loretta Sanchez,714
-Stanislaus,120002,U.S. Senate,,DEM,Kamala Harris,136
-Stanislaus,120002,U.S. Senate,,DEM,Loretta Sanchez,72
-Stanislaus,120003,U.S. Senate,,DEM,Kamala Harris,213
-Stanislaus,120003,U.S. Senate,,DEM,Loretta Sanchez,173
-Stanislaus,121001,U.S. Senate,,DEM,Kamala Harris,775
-Stanislaus,121001,U.S. Senate,,DEM,Loretta Sanchez,588
-Stanislaus,121002,U.S. Senate,,DEM,Kamala Harris,901
-Stanislaus,121002,U.S. Senate,,DEM,Loretta Sanchez,678
-Stanislaus,121003,U.S. Senate,,DEM,Kamala Harris,792
-Stanislaus,121003,U.S. Senate,,DEM,Loretta Sanchez,537
-Stanislaus,121005,U.S. Senate,,DEM,Kamala Harris,644
-Stanislaus,121005,U.S. Senate,,DEM,Loretta Sanchez,382
-Stanislaus,121006,U.S. Senate,,DEM,Kamala Harris,698
-Stanislaus,121006,U.S. Senate,,DEM,Loretta Sanchez,389
-Stanislaus,123001,U.S. Senate,,DEM,Kamala Harris,260
-Stanislaus,123001,U.S. Senate,,DEM,Loretta Sanchez,181
-Stanislaus,123004,U.S. Senate,,DEM,Kamala Harris,112
-Stanislaus,123004,U.S. Senate,,DEM,Loretta Sanchez,83
-Stanislaus,123005,U.S. Senate,,DEM,Kamala Harris,94
-Stanislaus,123005,U.S. Senate,,DEM,Loretta Sanchez,163
-Stanislaus,123007,U.S. Senate,,DEM,Kamala Harris,317
-Stanislaus,123007,U.S. Senate,,DEM,Loretta Sanchez,373
-Stanislaus,124001,U.S. Senate,,DEM,Kamala Harris,821
-Stanislaus,124001,U.S. Senate,,DEM,Loretta Sanchez,751
-Stanislaus,124003,U.S. Senate,,DEM,Kamala Harris,439
-Stanislaus,124003,U.S. Senate,,DEM,Loretta Sanchez,673
-Stanislaus,124004,U.S. Senate,,DEM,Kamala Harris,175
-Stanislaus,124004,U.S. Senate,,DEM,Loretta Sanchez,208
-Stanislaus,124008,U.S. Senate,,DEM,Kamala Harris,900
-Stanislaus,124008,U.S. Senate,,DEM,Loretta Sanchez,615
-Stanislaus,124014,U.S. Senate,,DEM,Kamala Harris,496
-Stanislaus,124014,U.S. Senate,,DEM,Loretta Sanchez,435
-Stanislaus,126001,U.S. Senate,,DEM,Kamala Harris,553
-Stanislaus,126001,U.S. Senate,,DEM,Loretta Sanchez,412
-Stanislaus,126002,U.S. Senate,,DEM,Kamala Harris,651
-Stanislaus,126002,U.S. Senate,,DEM,Loretta Sanchez,733
-Stanislaus,126003,U.S. Senate,,DEM,Kamala Harris,420
-Stanislaus,126003,U.S. Senate,,DEM,Loretta Sanchez,547
-Stanislaus,126004,U.S. Senate,,DEM,Kamala Harris,920
-Stanislaus,126004,U.S. Senate,,DEM,Loretta Sanchez,712
-Stanislaus,126010,U.S. Senate,,DEM,Kamala Harris,570
-Stanislaus,126010,U.S. Senate,,DEM,Loretta Sanchez,448
-Stanislaus,127001,U.S. Senate,,DEM,Kamala Harris,668
-Stanislaus,127001,U.S. Senate,,DEM,Loretta Sanchez,539
-Stanislaus,127002,U.S. Senate,,DEM,Kamala Harris,438
-Stanislaus,127002,U.S. Senate,,DEM,Loretta Sanchez,392
-Stanislaus,127004,U.S. Senate,,DEM,Kamala Harris,556
-Stanislaus,127004,U.S. Senate,,DEM,Loretta Sanchez,467
-Stanislaus,127007,U.S. Senate,,DEM,Kamala Harris,451
-Stanislaus,127007,U.S. Senate,,DEM,Loretta Sanchez,434
-Stanislaus,128001,U.S. Senate,,DEM,Kamala Harris,770
-Stanislaus,128001,U.S. Senate,,DEM,Loretta Sanchez,661
-Stanislaus,128003,U.S. Senate,,DEM,Kamala Harris,218
-Stanislaus,128003,U.S. Senate,,DEM,Loretta Sanchez,275
-Stanislaus,128004,U.S. Senate,,DEM,Kamala Harris,312
-Stanislaus,128004,U.S. Senate,,DEM,Loretta Sanchez,447
-Stanislaus,128005,U.S. Senate,,DEM,Kamala Harris,589
-Stanislaus,128005,U.S. Senate,,DEM,Loretta Sanchez,456
-Stanislaus,128006,U.S. Senate,,DEM,Kamala Harris,669
-Stanislaus,128006,U.S. Senate,,DEM,Loretta Sanchez,452
-Stanislaus,128008,U.S. Senate,,DEM,Kamala Harris,900
-Stanislaus,128008,U.S. Senate,,DEM,Loretta Sanchez,561
-Stanislaus,128012,U.S. Senate,,DEM,Kamala Harris,968
-Stanislaus,128012,U.S. Senate,,DEM,Loretta Sanchez,529
-Stanislaus,128013,U.S. Senate,,DEM,Kamala Harris,981
-Stanislaus,128013,U.S. Senate,,DEM,Loretta Sanchez,602
-Stanislaus,128014,U.S. Senate,,DEM,Kamala Harris,297
-Stanislaus,128014,U.S. Senate,,DEM,Loretta Sanchez,235
-Stanislaus,128015,U.S. Senate,,DEM,Kamala Harris,865
-Stanislaus,128015,U.S. Senate,,DEM,Loretta Sanchez,607
-Stanislaus,128016,U.S. Senate,,DEM,Kamala Harris,893
-Stanislaus,128016,U.S. Senate,,DEM,Loretta Sanchez,556
-Stanislaus,128022,U.S. Senate,,DEM,Kamala Harris,721
-Stanislaus,128022,U.S. Senate,,DEM,Loretta Sanchez,496
-Stanislaus,128025,U.S. Senate,,DEM,Kamala Harris,446
-Stanislaus,128025,U.S. Senate,,DEM,Loretta Sanchez,335
-Stanislaus,128028,U.S. Senate,,DEM,Kamala Harris,687
-Stanislaus,128028,U.S. Senate,,DEM,Loretta Sanchez,392
-Stanislaus,128029,U.S. Senate,,DEM,Kamala Harris,510
-Stanislaus,128029,U.S. Senate,,DEM,Loretta Sanchez,315
-Stanislaus,128030,U.S. Senate,,DEM,Kamala Harris,230
-Stanislaus,128030,U.S. Senate,,DEM,Loretta Sanchez,331
-Stanislaus,128038,U.S. Senate,,DEM,Kamala Harris,520
-Stanislaus,128038,U.S. Senate,,DEM,Loretta Sanchez,312
-Stanislaus,128044,U.S. Senate,,DEM,Kamala Harris,434
-Stanislaus,128044,U.S. Senate,,DEM,Loretta Sanchez,313
-Stanislaus,128048,U.S. Senate,,DEM,Kamala Harris,145
-Stanislaus,128048,U.S. Senate,,DEM,Loretta Sanchez,152
-Stanislaus,129001,U.S. Senate,,DEM,Kamala Harris,550
-Stanislaus,129001,U.S. Senate,,DEM,Loretta Sanchez,500
-Stanislaus,129002,U.S. Senate,,DEM,Kamala Harris,522
-Stanislaus,129002,U.S. Senate,,DEM,Loretta Sanchez,436
-Stanislaus,130001,U.S. Senate,,DEM,Kamala Harris,211
-Stanislaus,130001,U.S. Senate,,DEM,Loretta Sanchez,159
-Stanislaus,131002,U.S. Senate,,DEM,Kamala Harris,225
-Stanislaus,131002,U.S. Senate,,DEM,Loretta Sanchez,145
-Stanislaus,131005,U.S. Senate,,DEM,Kamala Harris,175
-Stanislaus,131005,U.S. Senate,,DEM,Loretta Sanchez,115
-Stanislaus,132001,U.S. Senate,,DEM,Kamala Harris,444
-Stanislaus,132001,U.S. Senate,,DEM,Loretta Sanchez,535
-Stanislaus,132003,U.S. Senate,,DEM,Kamala Harris,616
-Stanislaus,132003,U.S. Senate,,DEM,Loretta Sanchez,395
-Stanislaus,730002,U.S. Senate,,DEM,Kamala Harris,56
-Stanislaus,730002,U.S. Senate,,DEM,Loretta Sanchez,44
-Stanislaus,807006,U.S. Senate,,DEM,Kamala Harris,93
-Stanislaus,807006,U.S. Senate,,DEM,Loretta Sanchez,65
-Stanislaus,830002,U.S. Senate,,DEM,Kamala Harris,47
-Stanislaus,830002,U.S. Senate,,DEM,Loretta Sanchez,52
-Stanislaus,832012,U.S. Senate,,DEM,Kamala Harris,75
-Stanislaus,832012,U.S. Senate,,DEM,Loretta Sanchez,36
-Stanislaus,901001,U.S. Senate,,DEM,Kamala Harris,13
-Stanislaus,901001,U.S. Senate,,DEM,Loretta Sanchez,14
-Stanislaus,901003,U.S. Senate,,DEM,Kamala Harris,47
-Stanislaus,901003,U.S. Senate,,DEM,Loretta Sanchez,35
-Stanislaus,902003,U.S. Senate,,DEM,Kamala Harris,32
-Stanislaus,902003,U.S. Senate,,DEM,Loretta Sanchez,30
-Stanislaus,902010,U.S. Senate,,DEM,Kamala Harris,41
-Stanislaus,902010,U.S. Senate,,DEM,Loretta Sanchez,64
-Stanislaus,903011,U.S. Senate,,DEM,Kamala Harris,64
-Stanislaus,903011,U.S. Senate,,DEM,Loretta Sanchez,81
-Stanislaus,903027,U.S. Senate,,DEM,Kamala Harris,0
-Stanislaus,903027,U.S. Senate,,DEM,Loretta Sanchez,0
-Stanislaus,904002,U.S. Senate,,DEM,Kamala Harris,33
-Stanislaus,904002,U.S. Senate,,DEM,Loretta Sanchez,49
-Stanislaus,905004,U.S. Senate,,DEM,Kamala Harris,87
-Stanislaus,905004,U.S. Senate,,DEM,Loretta Sanchez,48
-Stanislaus,906002,U.S. Senate,,DEM,Kamala Harris,49
-Stanislaus,906002,U.S. Senate,,DEM,Loretta Sanchez,47
-Stanislaus,906008,U.S. Senate,,DEM,Kamala Harris,68
-Stanislaus,906008,U.S. Senate,,DEM,Loretta Sanchez,48
-Stanislaus,906016,U.S. Senate,,DEM,Kamala Harris,8
-Stanislaus,906016,U.S. Senate,,DEM,Loretta Sanchez,12
-Stanislaus,907002,U.S. Senate,,DEM,Kamala Harris,34
-Stanislaus,907002,U.S. Senate,,DEM,Loretta Sanchez,31
-Stanislaus,907006,U.S. Senate,,DEM,Kamala Harris,35
-Stanislaus,907006,U.S. Senate,,DEM,Loretta Sanchez,18
-Stanislaus,907011,U.S. Senate,,DEM,Kamala Harris,19
-Stanislaus,907011,U.S. Senate,,DEM,Loretta Sanchez,31
-Stanislaus,908001,U.S. Senate,,DEM,Kamala Harris,4
-Stanislaus,908001,U.S. Senate,,DEM,Loretta Sanchez,0
-Stanislaus,908003,U.S. Senate,,DEM,Kamala Harris,4
-Stanislaus,908003,U.S. Senate,,DEM,Loretta Sanchez,2
-Stanislaus,908004,U.S. Senate,,DEM,Kamala Harris,60
-Stanislaus,908004,U.S. Senate,,DEM,Loretta Sanchez,41
-Stanislaus,908005,U.S. Senate,,DEM,Kamala Harris,46
-Stanislaus,908005,U.S. Senate,,DEM,Loretta Sanchez,74
-Stanislaus,908007,U.S. Senate,,DEM,Kamala Harris,80
-Stanislaus,908007,U.S. Senate,,DEM,Loretta Sanchez,68
-Stanislaus,910003,U.S. Senate,,DEM,Kamala Harris,52
-Stanislaus,910003,U.S. Senate,,DEM,Loretta Sanchez,37
-Stanislaus,910006,U.S. Senate,,DEM,Kamala Harris,61
-Stanislaus,910006,U.S. Senate,,DEM,Loretta Sanchez,24
-Stanislaus,910007,U.S. Senate,,DEM,Kamala Harris,14
-Stanislaus,910007,U.S. Senate,,DEM,Loretta Sanchez,4
-Stanislaus,910022,U.S. Senate,,DEM,Kamala Harris,20
-Stanislaus,910022,U.S. Senate,,DEM,Loretta Sanchez,10
-Stanislaus,911002,U.S. Senate,,DEM,Kamala Harris,0
-Stanislaus,911002,U.S. Senate,,DEM,Loretta Sanchez,0
-Stanislaus,911010,U.S. Senate,,DEM,Kamala Harris,0
-Stanislaus,911010,U.S. Senate,,DEM,Loretta Sanchez,0
-Stanislaus,912003,U.S. Senate,,DEM,Kamala Harris,66
-Stanislaus,912003,U.S. Senate,,DEM,Loretta Sanchez,43
-Stanislaus,912006,U.S. Senate,,DEM,Kamala Harris,30
-Stanislaus,912006,U.S. Senate,,DEM,Loretta Sanchez,33
-Stanislaus,913002,U.S. Senate,,DEM,Kamala Harris,82
-Stanislaus,913002,U.S. Senate,,DEM,Loretta Sanchez,54
-Stanislaus,913003,U.S. Senate,,DEM,Kamala Harris,22
-Stanislaus,913003,U.S. Senate,,DEM,Loretta Sanchez,27
-Stanislaus,914004,U.S. Senate,,DEM,Kamala Harris,0
-Stanislaus,914004,U.S. Senate,,DEM,Loretta Sanchez,0
-Stanislaus,915002,U.S. Senate,,DEM,Kamala Harris,7
-Stanislaus,915002,U.S. Senate,,DEM,Loretta Sanchez,5
-Stanislaus,916002,U.S. Senate,,DEM,Kamala Harris,35
-Stanislaus,916002,U.S. Senate,,DEM,Loretta Sanchez,22
-Stanislaus,916007,U.S. Senate,,DEM,Kamala Harris,70
-Stanislaus,916007,U.S. Senate,,DEM,Loretta Sanchez,28
-Stanislaus,917004,U.S. Senate,,DEM,Kamala Harris,0
-Stanislaus,917004,U.S. Senate,,DEM,Loretta Sanchez,4
-Stanislaus,917049,U.S. Senate,,DEM,Kamala Harris,16
-Stanislaus,917049,U.S. Senate,,DEM,Loretta Sanchez,36
-Stanislaus,917161,U.S. Senate,,DEM,Kamala Harris,11
-Stanislaus,917161,U.S. Senate,,DEM,Loretta Sanchez,17
-Stanislaus,917164,U.S. Senate,,DEM,Kamala Harris,0
-Stanislaus,917164,U.S. Senate,,DEM,Loretta Sanchez,0
-Stanislaus,917196,U.S. Senate,,DEM,Kamala Harris,0
-Stanislaus,917196,U.S. Senate,,DEM,Loretta Sanchez,0
-Stanislaus,917207,U.S. Senate,,DEM,Kamala Harris,3
-Stanislaus,917207,U.S. Senate,,DEM,Loretta Sanchez,1
-Stanislaus,918001,U.S. Senate,,DEM,Kamala Harris,54
-Stanislaus,918001,U.S. Senate,,DEM,Loretta Sanchez,35
-Stanislaus,918003,U.S. Senate,,DEM,Kamala Harris,52
-Stanislaus,918003,U.S. Senate,,DEM,Loretta Sanchez,46
-Stanislaus,919009,U.S. Senate,,DEM,Kamala Harris,0
-Stanislaus,919009,U.S. Senate,,DEM,Loretta Sanchez,0
-Stanislaus,921009,U.S. Senate,,DEM,Kamala Harris,0
-Stanislaus,921009,U.S. Senate,,DEM,Loretta Sanchez,0
-Stanislaus,923003,U.S. Senate,,DEM,Kamala Harris,49
-Stanislaus,923003,U.S. Senate,,DEM,Loretta Sanchez,55
-Stanislaus,923010,U.S. Senate,,DEM,Kamala Harris,61
-Stanislaus,923010,U.S. Senate,,DEM,Loretta Sanchez,64
-Stanislaus,923015,U.S. Senate,,DEM,Kamala Harris,60
-Stanislaus,923015,U.S. Senate,,DEM,Loretta Sanchez,35
-Stanislaus,923020,U.S. Senate,,DEM,Kamala Harris,50
-Stanislaus,923020,U.S. Senate,,DEM,Loretta Sanchez,64
-Stanislaus,923024,U.S. Senate,,DEM,Kamala Harris,32
-Stanislaus,923024,U.S. Senate,,DEM,Loretta Sanchez,41
-Stanislaus,924007,U.S. Senate,,DEM,Kamala Harris,0
-Stanislaus,924007,U.S. Senate,,DEM,Loretta Sanchez,0
-Stanislaus,924027,U.S. Senate,,DEM,Kamala Harris,0
-Stanislaus,924027,U.S. Senate,,DEM,Loretta Sanchez,0
-Stanislaus,926006,U.S. Senate,,DEM,Kamala Harris,30
-Stanislaus,926006,U.S. Senate,,DEM,Loretta Sanchez,39
-Stanislaus,928021,U.S. Senate,,DEM,Kamala Harris,24
-Stanislaus,928021,U.S. Senate,,DEM,Loretta Sanchez,16
-Stanislaus,928023,U.S. Senate,,DEM,Kamala Harris,61
-Stanislaus,928023,U.S. Senate,,DEM,Loretta Sanchez,41
-Stanislaus,928033,U.S. Senate,,DEM,Kamala Harris,12
-Stanislaus,928033,U.S. Senate,,DEM,Loretta Sanchez,6
-Stanislaus,930002,U.S. Senate,,DEM,Kamala Harris,39
-Stanislaus,930002,U.S. Senate,,DEM,Loretta Sanchez,34
-Stanislaus,930003,U.S. Senate,,DEM,Kamala Harris,46
-Stanislaus,930003,U.S. Senate,,DEM,Loretta Sanchez,36
-Stanislaus,931005,U.S. Senate,,DEM,Kamala Harris,52
-Stanislaus,931005,U.S. Senate,,DEM,Loretta Sanchez,34
-Stanislaus,932002,U.S. Senate,,DEM,Kamala Harris,86
-Stanislaus,932002,U.S. Senate,,DEM,Loretta Sanchez,31
-Stanislaus,932005,U.S. Senate,,DEM,Kamala Harris,89
-Stanislaus,932005,U.S. Senate,,DEM,Loretta Sanchez,65
-Stanislaus,932012,U.S. Senate,,DEM,Kamala Harris,15
-Stanislaus,932012,U.S. Senate,,DEM,Loretta Sanchez,15
+Stanislaus,101002,U.S. Senate,,DEM,Kamala D. Harris,82
+Stanislaus,101002,U.S. Senate,,DEM,Loretta L. Sanchez,119
+Stanislaus,102001,U.S. Senate,,DEM,Kamala D. Harris,204
+Stanislaus,102001,U.S. Senate,,DEM,Loretta L. Sanchez,445
+Stanislaus,102002,U.S. Senate,,DEM,Kamala D. Harris,74
+Stanislaus,102002,U.S. Senate,,DEM,Loretta L. Sanchez,74
+Stanislaus,102003,U.S. Senate,,DEM,Kamala D. Harris,57
+Stanislaus,102003,U.S. Senate,,DEM,Loretta L. Sanchez,145
+Stanislaus,102005,U.S. Senate,,DEM,Kamala D. Harris,232
+Stanislaus,102005,U.S. Senate,,DEM,Loretta L. Sanchez,451
+Stanislaus,102007,U.S. Senate,,DEM,Kamala D. Harris,95
+Stanislaus,102007,U.S. Senate,,DEM,Loretta L. Sanchez,120
+Stanislaus,103001,U.S. Senate,,DEM,Kamala D. Harris,481
+Stanislaus,103001,U.S. Senate,,DEM,Loretta L. Sanchez,470
+Stanislaus,103002,U.S. Senate,,DEM,Kamala D. Harris,595
+Stanislaus,103002,U.S. Senate,,DEM,Loretta L. Sanchez,614
+Stanislaus,103003,U.S. Senate,,DEM,Kamala D. Harris,401
+Stanislaus,103003,U.S. Senate,,DEM,Loretta L. Sanchez,445
+Stanislaus,103005,U.S. Senate,,DEM,Kamala D. Harris,525
+Stanislaus,103005,U.S. Senate,,DEM,Loretta L. Sanchez,553
+Stanislaus,103006,U.S. Senate,,DEM,Kamala D. Harris,409
+Stanislaus,103006,U.S. Senate,,DEM,Loretta L. Sanchez,450
+Stanislaus,103007,U.S. Senate,,DEM,Kamala D. Harris,552
+Stanislaus,103007,U.S. Senate,,DEM,Loretta L. Sanchez,470
+Stanislaus,103009,U.S. Senate,,DEM,Kamala D. Harris,591
+Stanislaus,103009,U.S. Senate,,DEM,Loretta L. Sanchez,536
+Stanislaus,103010,U.S. Senate,,DEM,Kamala D. Harris,451
+Stanislaus,103010,U.S. Senate,,DEM,Loretta L. Sanchez,482
+Stanislaus,103014,U.S. Senate,,DEM,Kamala D. Harris,415
+Stanislaus,103014,U.S. Senate,,DEM,Loretta L. Sanchez,462
+Stanislaus,103018,U.S. Senate,,DEM,Kamala D. Harris,457
+Stanislaus,103018,U.S. Senate,,DEM,Loretta L. Sanchez,698
+Stanislaus,103026,U.S. Senate,,DEM,Kamala D. Harris,615
+Stanislaus,103026,U.S. Senate,,DEM,Loretta L. Sanchez,641
+Stanislaus,104001,U.S. Senate,,DEM,Kamala D. Harris,180
+Stanislaus,104001,U.S. Senate,,DEM,Loretta L. Sanchez,112
+Stanislaus,104004,U.S. Senate,,DEM,Kamala D. Harris,103
+Stanislaus,104004,U.S. Senate,,DEM,Loretta L. Sanchez,77
+Stanislaus,105002,U.S. Senate,,DEM,Kamala D. Harris,273
+Stanislaus,105002,U.S. Senate,,DEM,Loretta L. Sanchez,200
+Stanislaus,105003,U.S. Senate,,DEM,Kamala D. Harris,253
+Stanislaus,105003,U.S. Senate,,DEM,Loretta L. Sanchez,204
+Stanislaus,106001,U.S. Senate,,DEM,Kamala D. Harris,153
+Stanislaus,106001,U.S. Senate,,DEM,Loretta L. Sanchez,99
+Stanislaus,106003,U.S. Senate,,DEM,Kamala D. Harris,72
+Stanislaus,106003,U.S. Senate,,DEM,Loretta L. Sanchez,141
+Stanislaus,106013,U.S. Senate,,DEM,Kamala D. Harris,118
+Stanislaus,106013,U.S. Senate,,DEM,Loretta L. Sanchez,78
+Stanislaus,107005,U.S. Senate,,DEM,Kamala D. Harris,576
+Stanislaus,107005,U.S. Senate,,DEM,Loretta L. Sanchez,295
+Stanislaus,107007,U.S. Senate,,DEM,Kamala D. Harris,137
+Stanislaus,107007,U.S. Senate,,DEM,Loretta L. Sanchez,111
+Stanislaus,108002,U.S. Senate,,DEM,Kamala D. Harris,223
+Stanislaus,108002,U.S. Senate,,DEM,Loretta L. Sanchez,145
+Stanislaus,109001,U.S. Senate,,DEM,Kamala D. Harris,333
+Stanislaus,109001,U.S. Senate,,DEM,Loretta L. Sanchez,246
+Stanislaus,109003,U.S. Senate,,DEM,Kamala D. Harris,132
+Stanislaus,109003,U.S. Senate,,DEM,Loretta L. Sanchez,227
+Stanislaus,110001,U.S. Senate,,DEM,Kamala D. Harris,504
+Stanislaus,110001,U.S. Senate,,DEM,Loretta L. Sanchez,332
+Stanislaus,110002,U.S. Senate,,DEM,Kamala D. Harris,600
+Stanislaus,110002,U.S. Senate,,DEM,Loretta L. Sanchez,422
+Stanislaus,110008,U.S. Senate,,DEM,Kamala D. Harris,220
+Stanislaus,110008,U.S. Senate,,DEM,Loretta L. Sanchez,169
+Stanislaus,111003,U.S. Senate,,DEM,Kamala D. Harris,429
+Stanislaus,111003,U.S. Senate,,DEM,Loretta L. Sanchez,454
+Stanislaus,111005,U.S. Senate,,DEM,Kamala D. Harris,316
+Stanislaus,111005,U.S. Senate,,DEM,Loretta L. Sanchez,172
+Stanislaus,112001,U.S. Senate,,DEM,Kamala D. Harris,287
+Stanislaus,112001,U.S. Senate,,DEM,Loretta L. Sanchez,262
+Stanislaus,112002,U.S. Senate,,DEM,Kamala D. Harris,119
+Stanislaus,112002,U.S. Senate,,DEM,Loretta L. Sanchez,123
+Stanislaus,114001,U.S. Senate,,DEM,Kamala D. Harris,466
+Stanislaus,114001,U.S. Senate,,DEM,Loretta L. Sanchez,355
+Stanislaus,114003,U.S. Senate,,DEM,Kamala D. Harris,666
+Stanislaus,114003,U.S. Senate,,DEM,Loretta L. Sanchez,560
+Stanislaus,115001,U.S. Senate,,DEM,Kamala D. Harris,1224
+Stanislaus,115001,U.S. Senate,,DEM,Loretta L. Sanchez,676
+Stanislaus,115003,U.S. Senate,,DEM,Kamala D. Harris,410
+Stanislaus,115003,U.S. Senate,,DEM,Loretta L. Sanchez,238
+Stanislaus,117001,U.S. Senate,,DEM,Kamala D. Harris,415
+Stanislaus,117001,U.S. Senate,,DEM,Loretta L. Sanchez,333
+Stanislaus,117002,U.S. Senate,,DEM,Kamala D. Harris,780
+Stanislaus,117002,U.S. Senate,,DEM,Loretta L. Sanchez,441
+Stanislaus,117003,U.S. Senate,,DEM,Kamala D. Harris,362
+Stanislaus,117003,U.S. Senate,,DEM,Loretta L. Sanchez,569
+Stanislaus,117004,U.S. Senate,,DEM,Kamala D. Harris,376
+Stanislaus,117004,U.S. Senate,,DEM,Loretta L. Sanchez,691
+Stanislaus,117005,U.S. Senate,,DEM,Kamala D. Harris,197
+Stanislaus,117005,U.S. Senate,,DEM,Loretta L. Sanchez,327
+Stanislaus,117006,U.S. Senate,,DEM,Kamala D. Harris,169
+Stanislaus,117006,U.S. Senate,,DEM,Loretta L. Sanchez,242
+Stanislaus,117008,U.S. Senate,,DEM,Kamala D. Harris,592
+Stanislaus,117008,U.S. Senate,,DEM,Loretta L. Sanchez,662
+Stanislaus,117009,U.S. Senate,,DEM,Kamala D. Harris,835
+Stanislaus,117009,U.S. Senate,,DEM,Loretta L. Sanchez,508
+Stanislaus,117012,U.S. Senate,,DEM,Kamala D. Harris,218
+Stanislaus,117012,U.S. Senate,,DEM,Loretta L. Sanchez,224
+Stanislaus,117014,U.S. Senate,,DEM,Kamala D. Harris,583
+Stanislaus,117014,U.S. Senate,,DEM,Loretta L. Sanchez,368
+Stanislaus,117016,U.S. Senate,,DEM,Kamala D. Harris,578
+Stanislaus,117016,U.S. Senate,,DEM,Loretta L. Sanchez,482
+Stanislaus,117017,U.S. Senate,,DEM,Kamala D. Harris,396
+Stanislaus,117017,U.S. Senate,,DEM,Loretta L. Sanchez,292
+Stanislaus,117018,U.S. Senate,,DEM,Kamala D. Harris,978
+Stanislaus,117018,U.S. Senate,,DEM,Loretta L. Sanchez,562
+Stanislaus,117019,U.S. Senate,,DEM,Kamala D. Harris,575
+Stanislaus,117019,U.S. Senate,,DEM,Loretta L. Sanchez,366
+Stanislaus,117021,U.S. Senate,,DEM,Kamala D. Harris,779
+Stanislaus,117021,U.S. Senate,,DEM,Loretta L. Sanchez,449
+Stanislaus,117023,U.S. Senate,,DEM,Kamala D. Harris,74
+Stanislaus,117023,U.S. Senate,,DEM,Loretta L. Sanchez,127
+Stanislaus,117025,U.S. Senate,,DEM,Kamala D. Harris,295
+Stanislaus,117025,U.S. Senate,,DEM,Loretta L. Sanchez,199
+Stanislaus,117027,U.S. Senate,,DEM,Kamala D. Harris,884
+Stanislaus,117027,U.S. Senate,,DEM,Loretta L. Sanchez,379
+Stanislaus,117028,U.S. Senate,,DEM,Kamala D. Harris,691
+Stanislaus,117028,U.S. Senate,,DEM,Loretta L. Sanchez,428
+Stanislaus,117029,U.S. Senate,,DEM,Kamala D. Harris,594
+Stanislaus,117029,U.S. Senate,,DEM,Loretta L. Sanchez,445
+Stanislaus,117030,U.S. Senate,,DEM,Kamala D. Harris,623
+Stanislaus,117030,U.S. Senate,,DEM,Loretta L. Sanchez,397
+Stanislaus,117035,U.S. Senate,,DEM,Kamala D. Harris,676
+Stanislaus,117035,U.S. Senate,,DEM,Loretta L. Sanchez,361
+Stanislaus,117036,U.S. Senate,,DEM,Kamala D. Harris,458
+Stanislaus,117036,U.S. Senate,,DEM,Loretta L. Sanchez,271
+Stanislaus,117040,U.S. Senate,,DEM,Kamala D. Harris,935
+Stanislaus,117040,U.S. Senate,,DEM,Loretta L. Sanchez,488
+Stanislaus,117043,U.S. Senate,,DEM,Kamala D. Harris,849
+Stanislaus,117043,U.S. Senate,,DEM,Loretta L. Sanchez,466
+Stanislaus,117044,U.S. Senate,,DEM,Kamala D. Harris,356
+Stanislaus,117044,U.S. Senate,,DEM,Loretta L. Sanchez,165
+Stanislaus,117047,U.S. Senate,,DEM,Kamala D. Harris,1002
+Stanislaus,117047,U.S. Senate,,DEM,Loretta L. Sanchez,534
+Stanislaus,117048,U.S. Senate,,DEM,Kamala D. Harris,625
+Stanislaus,117048,U.S. Senate,,DEM,Loretta L. Sanchez,333
+Stanislaus,117050,U.S. Senate,,DEM,Kamala D. Harris,1028
+Stanislaus,117050,U.S. Senate,,DEM,Loretta L. Sanchez,558
+Stanislaus,117052,U.S. Senate,,DEM,Kamala D. Harris,691
+Stanislaus,117052,U.S. Senate,,DEM,Loretta L. Sanchez,366
+Stanislaus,117053,U.S. Senate,,DEM,Kamala D. Harris,461
+Stanislaus,117053,U.S. Senate,,DEM,Loretta L. Sanchez,291
+Stanislaus,117058,U.S. Senate,,DEM,Kamala D. Harris,706
+Stanislaus,117058,U.S. Senate,,DEM,Loretta L. Sanchez,468
+Stanislaus,117059,U.S. Senate,,DEM,Kamala D. Harris,656
+Stanislaus,117059,U.S. Senate,,DEM,Loretta L. Sanchez,334
+Stanislaus,117062,U.S. Senate,,DEM,Kamala D. Harris,605
+Stanislaus,117062,U.S. Senate,,DEM,Loretta L. Sanchez,483
+Stanislaus,117068,U.S. Senate,,DEM,Kamala D. Harris,682
+Stanislaus,117068,U.S. Senate,,DEM,Loretta L. Sanchez,401
+Stanislaus,117069,U.S. Senate,,DEM,Kamala D. Harris,603
+Stanislaus,117069,U.S. Senate,,DEM,Loretta L. Sanchez,363
+Stanislaus,117073,U.S. Senate,,DEM,Kamala D. Harris,254
+Stanislaus,117073,U.S. Senate,,DEM,Loretta L. Sanchez,435
+Stanislaus,117074,U.S. Senate,,DEM,Kamala D. Harris,961
+Stanislaus,117074,U.S. Senate,,DEM,Loretta L. Sanchez,563
+Stanislaus,117076,U.S. Senate,,DEM,Kamala D. Harris,494
+Stanislaus,117076,U.S. Senate,,DEM,Loretta L. Sanchez,341
+Stanislaus,117078,U.S. Senate,,DEM,Kamala D. Harris,870
+Stanislaus,117078,U.S. Senate,,DEM,Loretta L. Sanchez,508
+Stanislaus,117079,U.S. Senate,,DEM,Kamala D. Harris,641
+Stanislaus,117079,U.S. Senate,,DEM,Loretta L. Sanchez,387
+Stanislaus,117084,U.S. Senate,,DEM,Kamala D. Harris,911
+Stanislaus,117084,U.S. Senate,,DEM,Loretta L. Sanchez,539
+Stanislaus,117090,U.S. Senate,,DEM,Kamala D. Harris,1000
+Stanislaus,117090,U.S. Senate,,DEM,Loretta L. Sanchez,565
+Stanislaus,117091,U.S. Senate,,DEM,Kamala D. Harris,602
+Stanislaus,117091,U.S. Senate,,DEM,Loretta L. Sanchez,314
+Stanislaus,117093,U.S. Senate,,DEM,Kamala D. Harris,565
+Stanislaus,117093,U.S. Senate,,DEM,Loretta L. Sanchez,313
+Stanislaus,117098,U.S. Senate,,DEM,Kamala D. Harris,643
+Stanislaus,117098,U.S. Senate,,DEM,Loretta L. Sanchez,383
+Stanislaus,117100,U.S. Senate,,DEM,Kamala D. Harris,837
+Stanislaus,117100,U.S. Senate,,DEM,Loretta L. Sanchez,458
+Stanislaus,117104,U.S. Senate,,DEM,Kamala D. Harris,646
+Stanislaus,117104,U.S. Senate,,DEM,Loretta L. Sanchez,523
+Stanislaus,117105,U.S. Senate,,DEM,Kamala D. Harris,526
+Stanislaus,117105,U.S. Senate,,DEM,Loretta L. Sanchez,475
+Stanislaus,117106,U.S. Senate,,DEM,Kamala D. Harris,704
+Stanislaus,117106,U.S. Senate,,DEM,Loretta L. Sanchez,419
+Stanislaus,117107,U.S. Senate,,DEM,Kamala D. Harris,777
+Stanislaus,117107,U.S. Senate,,DEM,Loretta L. Sanchez,466
+Stanislaus,117112,U.S. Senate,,DEM,Kamala D. Harris,861
+Stanislaus,117112,U.S. Senate,,DEM,Loretta L. Sanchez,558
+Stanislaus,117115,U.S. Senate,,DEM,Kamala D. Harris,161
+Stanislaus,117115,U.S. Senate,,DEM,Loretta L. Sanchez,225
+Stanislaus,117119,U.S. Senate,,DEM,Kamala D. Harris,575
+Stanislaus,117119,U.S. Senate,,DEM,Loretta L. Sanchez,284
+Stanislaus,117123,U.S. Senate,,DEM,Kamala D. Harris,407
+Stanislaus,117123,U.S. Senate,,DEM,Loretta L. Sanchez,201
+Stanislaus,117125,U.S. Senate,,DEM,Kamala D. Harris,677
+Stanislaus,117125,U.S. Senate,,DEM,Loretta L. Sanchez,382
+Stanislaus,117165,U.S. Senate,,DEM,Kamala D. Harris,576
+Stanislaus,117165,U.S. Senate,,DEM,Loretta L. Sanchez,377
+Stanislaus,117168,U.S. Senate,,DEM,Kamala D. Harris,100
+Stanislaus,117168,U.S. Senate,,DEM,Loretta L. Sanchez,170
+Stanislaus,117172,U.S. Senate,,DEM,Kamala D. Harris,706
+Stanislaus,117172,U.S. Senate,,DEM,Loretta L. Sanchez,411
+Stanislaus,118001,U.S. Senate,,DEM,Kamala D. Harris,223
+Stanislaus,118001,U.S. Senate,,DEM,Loretta L. Sanchez,155
+Stanislaus,119001,U.S. Senate,,DEM,Kamala D. Harris,263
+Stanislaus,119001,U.S. Senate,,DEM,Loretta L. Sanchez,263
+Stanislaus,119002,U.S. Senate,,DEM,Kamala D. Harris,396
+Stanislaus,119002,U.S. Senate,,DEM,Loretta L. Sanchez,355
+Stanislaus,119003,U.S. Senate,,DEM,Kamala D. Harris,575
+Stanislaus,119003,U.S. Senate,,DEM,Loretta L. Sanchez,714
+Stanislaus,120002,U.S. Senate,,DEM,Kamala D. Harris,136
+Stanislaus,120002,U.S. Senate,,DEM,Loretta L. Sanchez,72
+Stanislaus,120003,U.S. Senate,,DEM,Kamala D. Harris,213
+Stanislaus,120003,U.S. Senate,,DEM,Loretta L. Sanchez,173
+Stanislaus,121001,U.S. Senate,,DEM,Kamala D. Harris,775
+Stanislaus,121001,U.S. Senate,,DEM,Loretta L. Sanchez,588
+Stanislaus,121002,U.S. Senate,,DEM,Kamala D. Harris,901
+Stanislaus,121002,U.S. Senate,,DEM,Loretta L. Sanchez,678
+Stanislaus,121003,U.S. Senate,,DEM,Kamala D. Harris,792
+Stanislaus,121003,U.S. Senate,,DEM,Loretta L. Sanchez,537
+Stanislaus,121005,U.S. Senate,,DEM,Kamala D. Harris,644
+Stanislaus,121005,U.S. Senate,,DEM,Loretta L. Sanchez,382
+Stanislaus,121006,U.S. Senate,,DEM,Kamala D. Harris,698
+Stanislaus,121006,U.S. Senate,,DEM,Loretta L. Sanchez,389
+Stanislaus,123001,U.S. Senate,,DEM,Kamala D. Harris,260
+Stanislaus,123001,U.S. Senate,,DEM,Loretta L. Sanchez,181
+Stanislaus,123004,U.S. Senate,,DEM,Kamala D. Harris,112
+Stanislaus,123004,U.S. Senate,,DEM,Loretta L. Sanchez,83
+Stanislaus,123005,U.S. Senate,,DEM,Kamala D. Harris,94
+Stanislaus,123005,U.S. Senate,,DEM,Loretta L. Sanchez,163
+Stanislaus,123007,U.S. Senate,,DEM,Kamala D. Harris,317
+Stanislaus,123007,U.S. Senate,,DEM,Loretta L. Sanchez,373
+Stanislaus,124001,U.S. Senate,,DEM,Kamala D. Harris,821
+Stanislaus,124001,U.S. Senate,,DEM,Loretta L. Sanchez,751
+Stanislaus,124003,U.S. Senate,,DEM,Kamala D. Harris,439
+Stanislaus,124003,U.S. Senate,,DEM,Loretta L. Sanchez,673
+Stanislaus,124004,U.S. Senate,,DEM,Kamala D. Harris,175
+Stanislaus,124004,U.S. Senate,,DEM,Loretta L. Sanchez,208
+Stanislaus,124008,U.S. Senate,,DEM,Kamala D. Harris,900
+Stanislaus,124008,U.S. Senate,,DEM,Loretta L. Sanchez,615
+Stanislaus,124014,U.S. Senate,,DEM,Kamala D. Harris,496
+Stanislaus,124014,U.S. Senate,,DEM,Loretta L. Sanchez,435
+Stanislaus,126001,U.S. Senate,,DEM,Kamala D. Harris,553
+Stanislaus,126001,U.S. Senate,,DEM,Loretta L. Sanchez,412
+Stanislaus,126002,U.S. Senate,,DEM,Kamala D. Harris,651
+Stanislaus,126002,U.S. Senate,,DEM,Loretta L. Sanchez,733
+Stanislaus,126003,U.S. Senate,,DEM,Kamala D. Harris,420
+Stanislaus,126003,U.S. Senate,,DEM,Loretta L. Sanchez,547
+Stanislaus,126004,U.S. Senate,,DEM,Kamala D. Harris,920
+Stanislaus,126004,U.S. Senate,,DEM,Loretta L. Sanchez,712
+Stanislaus,126010,U.S. Senate,,DEM,Kamala D. Harris,570
+Stanislaus,126010,U.S. Senate,,DEM,Loretta L. Sanchez,448
+Stanislaus,127001,U.S. Senate,,DEM,Kamala D. Harris,668
+Stanislaus,127001,U.S. Senate,,DEM,Loretta L. Sanchez,539
+Stanislaus,127002,U.S. Senate,,DEM,Kamala D. Harris,438
+Stanislaus,127002,U.S. Senate,,DEM,Loretta L. Sanchez,392
+Stanislaus,127004,U.S. Senate,,DEM,Kamala D. Harris,556
+Stanislaus,127004,U.S. Senate,,DEM,Loretta L. Sanchez,467
+Stanislaus,127007,U.S. Senate,,DEM,Kamala D. Harris,451
+Stanislaus,127007,U.S. Senate,,DEM,Loretta L. Sanchez,434
+Stanislaus,128001,U.S. Senate,,DEM,Kamala D. Harris,770
+Stanislaus,128001,U.S. Senate,,DEM,Loretta L. Sanchez,661
+Stanislaus,128003,U.S. Senate,,DEM,Kamala D. Harris,218
+Stanislaus,128003,U.S. Senate,,DEM,Loretta L. Sanchez,275
+Stanislaus,128004,U.S. Senate,,DEM,Kamala D. Harris,312
+Stanislaus,128004,U.S. Senate,,DEM,Loretta L. Sanchez,447
+Stanislaus,128005,U.S. Senate,,DEM,Kamala D. Harris,589
+Stanislaus,128005,U.S. Senate,,DEM,Loretta L. Sanchez,456
+Stanislaus,128006,U.S. Senate,,DEM,Kamala D. Harris,669
+Stanislaus,128006,U.S. Senate,,DEM,Loretta L. Sanchez,452
+Stanislaus,128008,U.S. Senate,,DEM,Kamala D. Harris,900
+Stanislaus,128008,U.S. Senate,,DEM,Loretta L. Sanchez,561
+Stanislaus,128012,U.S. Senate,,DEM,Kamala D. Harris,968
+Stanislaus,128012,U.S. Senate,,DEM,Loretta L. Sanchez,529
+Stanislaus,128013,U.S. Senate,,DEM,Kamala D. Harris,981
+Stanislaus,128013,U.S. Senate,,DEM,Loretta L. Sanchez,602
+Stanislaus,128014,U.S. Senate,,DEM,Kamala D. Harris,297
+Stanislaus,128014,U.S. Senate,,DEM,Loretta L. Sanchez,235
+Stanislaus,128015,U.S. Senate,,DEM,Kamala D. Harris,865
+Stanislaus,128015,U.S. Senate,,DEM,Loretta L. Sanchez,607
+Stanislaus,128016,U.S. Senate,,DEM,Kamala D. Harris,893
+Stanislaus,128016,U.S. Senate,,DEM,Loretta L. Sanchez,556
+Stanislaus,128022,U.S. Senate,,DEM,Kamala D. Harris,721
+Stanislaus,128022,U.S. Senate,,DEM,Loretta L. Sanchez,496
+Stanislaus,128025,U.S. Senate,,DEM,Kamala D. Harris,446
+Stanislaus,128025,U.S. Senate,,DEM,Loretta L. Sanchez,335
+Stanislaus,128028,U.S. Senate,,DEM,Kamala D. Harris,687
+Stanislaus,128028,U.S. Senate,,DEM,Loretta L. Sanchez,392
+Stanislaus,128029,U.S. Senate,,DEM,Kamala D. Harris,510
+Stanislaus,128029,U.S. Senate,,DEM,Loretta L. Sanchez,315
+Stanislaus,128030,U.S. Senate,,DEM,Kamala D. Harris,230
+Stanislaus,128030,U.S. Senate,,DEM,Loretta L. Sanchez,331
+Stanislaus,128038,U.S. Senate,,DEM,Kamala D. Harris,520
+Stanislaus,128038,U.S. Senate,,DEM,Loretta L. Sanchez,312
+Stanislaus,128044,U.S. Senate,,DEM,Kamala D. Harris,434
+Stanislaus,128044,U.S. Senate,,DEM,Loretta L. Sanchez,313
+Stanislaus,128048,U.S. Senate,,DEM,Kamala D. Harris,145
+Stanislaus,128048,U.S. Senate,,DEM,Loretta L. Sanchez,152
+Stanislaus,129001,U.S. Senate,,DEM,Kamala D. Harris,550
+Stanislaus,129001,U.S. Senate,,DEM,Loretta L. Sanchez,500
+Stanislaus,129002,U.S. Senate,,DEM,Kamala D. Harris,522
+Stanislaus,129002,U.S. Senate,,DEM,Loretta L. Sanchez,436
+Stanislaus,130001,U.S. Senate,,DEM,Kamala D. Harris,211
+Stanislaus,130001,U.S. Senate,,DEM,Loretta L. Sanchez,159
+Stanislaus,131002,U.S. Senate,,DEM,Kamala D. Harris,225
+Stanislaus,131002,U.S. Senate,,DEM,Loretta L. Sanchez,145
+Stanislaus,131005,U.S. Senate,,DEM,Kamala D. Harris,175
+Stanislaus,131005,U.S. Senate,,DEM,Loretta L. Sanchez,115
+Stanislaus,132001,U.S. Senate,,DEM,Kamala D. Harris,444
+Stanislaus,132001,U.S. Senate,,DEM,Loretta L. Sanchez,535
+Stanislaus,132003,U.S. Senate,,DEM,Kamala D. Harris,616
+Stanislaus,132003,U.S. Senate,,DEM,Loretta L. Sanchez,395
+Stanislaus,730002,U.S. Senate,,DEM,Kamala D. Harris,56
+Stanislaus,730002,U.S. Senate,,DEM,Loretta L. Sanchez,44
+Stanislaus,807006,U.S. Senate,,DEM,Kamala D. Harris,93
+Stanislaus,807006,U.S. Senate,,DEM,Loretta L. Sanchez,65
+Stanislaus,830002,U.S. Senate,,DEM,Kamala D. Harris,47
+Stanislaus,830002,U.S. Senate,,DEM,Loretta L. Sanchez,52
+Stanislaus,832012,U.S. Senate,,DEM,Kamala D. Harris,75
+Stanislaus,832012,U.S. Senate,,DEM,Loretta L. Sanchez,36
+Stanislaus,901001,U.S. Senate,,DEM,Kamala D. Harris,13
+Stanislaus,901001,U.S. Senate,,DEM,Loretta L. Sanchez,14
+Stanislaus,901003,U.S. Senate,,DEM,Kamala D. Harris,47
+Stanislaus,901003,U.S. Senate,,DEM,Loretta L. Sanchez,35
+Stanislaus,902003,U.S. Senate,,DEM,Kamala D. Harris,32
+Stanislaus,902003,U.S. Senate,,DEM,Loretta L. Sanchez,30
+Stanislaus,902010,U.S. Senate,,DEM,Kamala D. Harris,41
+Stanislaus,902010,U.S. Senate,,DEM,Loretta L. Sanchez,64
+Stanislaus,903011,U.S. Senate,,DEM,Kamala D. Harris,64
+Stanislaus,903011,U.S. Senate,,DEM,Loretta L. Sanchez,81
+Stanislaus,903027,U.S. Senate,,DEM,Kamala D. Harris,0
+Stanislaus,903027,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Stanislaus,904002,U.S. Senate,,DEM,Kamala D. Harris,33
+Stanislaus,904002,U.S. Senate,,DEM,Loretta L. Sanchez,49
+Stanislaus,905004,U.S. Senate,,DEM,Kamala D. Harris,87
+Stanislaus,905004,U.S. Senate,,DEM,Loretta L. Sanchez,48
+Stanislaus,906002,U.S. Senate,,DEM,Kamala D. Harris,49
+Stanislaus,906002,U.S. Senate,,DEM,Loretta L. Sanchez,47
+Stanislaus,906008,U.S. Senate,,DEM,Kamala D. Harris,68
+Stanislaus,906008,U.S. Senate,,DEM,Loretta L. Sanchez,48
+Stanislaus,906016,U.S. Senate,,DEM,Kamala D. Harris,8
+Stanislaus,906016,U.S. Senate,,DEM,Loretta L. Sanchez,12
+Stanislaus,907002,U.S. Senate,,DEM,Kamala D. Harris,34
+Stanislaus,907002,U.S. Senate,,DEM,Loretta L. Sanchez,31
+Stanislaus,907006,U.S. Senate,,DEM,Kamala D. Harris,35
+Stanislaus,907006,U.S. Senate,,DEM,Loretta L. Sanchez,18
+Stanislaus,907011,U.S. Senate,,DEM,Kamala D. Harris,19
+Stanislaus,907011,U.S. Senate,,DEM,Loretta L. Sanchez,31
+Stanislaus,908001,U.S. Senate,,DEM,Kamala D. Harris,4
+Stanislaus,908001,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Stanislaus,908003,U.S. Senate,,DEM,Kamala D. Harris,4
+Stanislaus,908003,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Stanislaus,908004,U.S. Senate,,DEM,Kamala D. Harris,60
+Stanislaus,908004,U.S. Senate,,DEM,Loretta L. Sanchez,41
+Stanislaus,908005,U.S. Senate,,DEM,Kamala D. Harris,46
+Stanislaus,908005,U.S. Senate,,DEM,Loretta L. Sanchez,74
+Stanislaus,908007,U.S. Senate,,DEM,Kamala D. Harris,80
+Stanislaus,908007,U.S. Senate,,DEM,Loretta L. Sanchez,68
+Stanislaus,910003,U.S. Senate,,DEM,Kamala D. Harris,52
+Stanislaus,910003,U.S. Senate,,DEM,Loretta L. Sanchez,37
+Stanislaus,910006,U.S. Senate,,DEM,Kamala D. Harris,61
+Stanislaus,910006,U.S. Senate,,DEM,Loretta L. Sanchez,24
+Stanislaus,910007,U.S. Senate,,DEM,Kamala D. Harris,14
+Stanislaus,910007,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Stanislaus,910022,U.S. Senate,,DEM,Kamala D. Harris,20
+Stanislaus,910022,U.S. Senate,,DEM,Loretta L. Sanchez,10
+Stanislaus,911002,U.S. Senate,,DEM,Kamala D. Harris,0
+Stanislaus,911002,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Stanislaus,911010,U.S. Senate,,DEM,Kamala D. Harris,0
+Stanislaus,911010,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Stanislaus,912003,U.S. Senate,,DEM,Kamala D. Harris,66
+Stanislaus,912003,U.S. Senate,,DEM,Loretta L. Sanchez,43
+Stanislaus,912006,U.S. Senate,,DEM,Kamala D. Harris,30
+Stanislaus,912006,U.S. Senate,,DEM,Loretta L. Sanchez,33
+Stanislaus,913002,U.S. Senate,,DEM,Kamala D. Harris,82
+Stanislaus,913002,U.S. Senate,,DEM,Loretta L. Sanchez,54
+Stanislaus,913003,U.S. Senate,,DEM,Kamala D. Harris,22
+Stanislaus,913003,U.S. Senate,,DEM,Loretta L. Sanchez,27
+Stanislaus,914004,U.S. Senate,,DEM,Kamala D. Harris,0
+Stanislaus,914004,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Stanislaus,915002,U.S. Senate,,DEM,Kamala D. Harris,7
+Stanislaus,915002,U.S. Senate,,DEM,Loretta L. Sanchez,5
+Stanislaus,916002,U.S. Senate,,DEM,Kamala D. Harris,35
+Stanislaus,916002,U.S. Senate,,DEM,Loretta L. Sanchez,22
+Stanislaus,916007,U.S. Senate,,DEM,Kamala D. Harris,70
+Stanislaus,916007,U.S. Senate,,DEM,Loretta L. Sanchez,28
+Stanislaus,917004,U.S. Senate,,DEM,Kamala D. Harris,0
+Stanislaus,917004,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Stanislaus,917049,U.S. Senate,,DEM,Kamala D. Harris,16
+Stanislaus,917049,U.S. Senate,,DEM,Loretta L. Sanchez,36
+Stanislaus,917161,U.S. Senate,,DEM,Kamala D. Harris,11
+Stanislaus,917161,U.S. Senate,,DEM,Loretta L. Sanchez,17
+Stanislaus,917164,U.S. Senate,,DEM,Kamala D. Harris,0
+Stanislaus,917164,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Stanislaus,917196,U.S. Senate,,DEM,Kamala D. Harris,0
+Stanislaus,917196,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Stanislaus,917207,U.S. Senate,,DEM,Kamala D. Harris,3
+Stanislaus,917207,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Stanislaus,918001,U.S. Senate,,DEM,Kamala D. Harris,54
+Stanislaus,918001,U.S. Senate,,DEM,Loretta L. Sanchez,35
+Stanislaus,918003,U.S. Senate,,DEM,Kamala D. Harris,52
+Stanislaus,918003,U.S. Senate,,DEM,Loretta L. Sanchez,46
+Stanislaus,919009,U.S. Senate,,DEM,Kamala D. Harris,0
+Stanislaus,919009,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Stanislaus,921009,U.S. Senate,,DEM,Kamala D. Harris,0
+Stanislaus,921009,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Stanislaus,923003,U.S. Senate,,DEM,Kamala D. Harris,49
+Stanislaus,923003,U.S. Senate,,DEM,Loretta L. Sanchez,55
+Stanislaus,923010,U.S. Senate,,DEM,Kamala D. Harris,61
+Stanislaus,923010,U.S. Senate,,DEM,Loretta L. Sanchez,64
+Stanislaus,923015,U.S. Senate,,DEM,Kamala D. Harris,60
+Stanislaus,923015,U.S. Senate,,DEM,Loretta L. Sanchez,35
+Stanislaus,923020,U.S. Senate,,DEM,Kamala D. Harris,50
+Stanislaus,923020,U.S. Senate,,DEM,Loretta L. Sanchez,64
+Stanislaus,923024,U.S. Senate,,DEM,Kamala D. Harris,32
+Stanislaus,923024,U.S. Senate,,DEM,Loretta L. Sanchez,41
+Stanislaus,924007,U.S. Senate,,DEM,Kamala D. Harris,0
+Stanislaus,924007,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Stanislaus,924027,U.S. Senate,,DEM,Kamala D. Harris,0
+Stanislaus,924027,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Stanislaus,926006,U.S. Senate,,DEM,Kamala D. Harris,30
+Stanislaus,926006,U.S. Senate,,DEM,Loretta L. Sanchez,39
+Stanislaus,928021,U.S. Senate,,DEM,Kamala D. Harris,24
+Stanislaus,928021,U.S. Senate,,DEM,Loretta L. Sanchez,16
+Stanislaus,928023,U.S. Senate,,DEM,Kamala D. Harris,61
+Stanislaus,928023,U.S. Senate,,DEM,Loretta L. Sanchez,41
+Stanislaus,928033,U.S. Senate,,DEM,Kamala D. Harris,12
+Stanislaus,928033,U.S. Senate,,DEM,Loretta L. Sanchez,6
+Stanislaus,930002,U.S. Senate,,DEM,Kamala D. Harris,39
+Stanislaus,930002,U.S. Senate,,DEM,Loretta L. Sanchez,34
+Stanislaus,930003,U.S. Senate,,DEM,Kamala D. Harris,46
+Stanislaus,930003,U.S. Senate,,DEM,Loretta L. Sanchez,36
+Stanislaus,931005,U.S. Senate,,DEM,Kamala D. Harris,52
+Stanislaus,931005,U.S. Senate,,DEM,Loretta L. Sanchez,34
+Stanislaus,932002,U.S. Senate,,DEM,Kamala D. Harris,86
+Stanislaus,932002,U.S. Senate,,DEM,Loretta L. Sanchez,31
+Stanislaus,932005,U.S. Senate,,DEM,Kamala D. Harris,89
+Stanislaus,932005,U.S. Senate,,DEM,Loretta L. Sanchez,65
+Stanislaus,932012,U.S. Senate,,DEM,Kamala D. Harris,15
+Stanislaus,932012,U.S. Senate,,DEM,Loretta L. Sanchez,15

--- a/2016/20161108__ca__general__sutter__precinct.csv
+++ b/2016/20161108__ca__general__sutter__precinct.csv
@@ -2039,105 +2039,105 @@ Sutter,50,Proposition 67,,N/A,Yes,40
 Sutter,50,Proposition 67,,N/A,No,154
 Sutter,51,Proposition 67,,N/A,Yes,21
 Sutter,51,Proposition 67,,N/A,No,57
-Sutter,1,U.S. Senate,,DEM,Kamala Harris,407
-Sutter,1,U.S. Senate,,DEM,Loretta Sanchez,378
-Sutter,2,U.S. Senate,,DEM,Kamala Harris,604
-Sutter,2,U.S. Senate,,DEM,Loretta Sanchez,606
-Sutter,3,U.S. Senate,,DEM,Kamala Harris,322
-Sutter,3,U.S. Senate,,DEM,Loretta Sanchez,229
-Sutter,4,U.S. Senate,,DEM,Kamala Harris,698
-Sutter,4,U.S. Senate,,DEM,Loretta Sanchez,513
-Sutter,5,U.S. Senate,,DEM,Kamala Harris,462
-Sutter,5,U.S. Senate,,DEM,Loretta Sanchez,360
-Sutter,6,U.S. Senate,,DEM,Kamala Harris,103
-Sutter,6,U.S. Senate,,DEM,Loretta Sanchez,80
-Sutter,7,U.S. Senate,,DEM,Kamala Harris,162
-Sutter,7,U.S. Senate,,DEM,Loretta Sanchez,139
-Sutter,8,U.S. Senate,,DEM,Kamala Harris,161
-Sutter,8,U.S. Senate,,DEM,Loretta Sanchez,252
-Sutter,9,U.S. Senate,,DEM,Kamala Harris,271
-Sutter,9,U.S. Senate,,DEM,Loretta Sanchez,191
-Sutter,10,U.S. Senate,,DEM,Kamala Harris,213
-Sutter,10,U.S. Senate,,DEM,Loretta Sanchez,202
-Sutter,11,U.S. Senate,,DEM,Kamala Harris,219
-Sutter,11,U.S. Senate,,DEM,Loretta Sanchez,183
-Sutter,12,U.S. Senate,,DEM,Kamala Harris,526
-Sutter,12,U.S. Senate,,DEM,Loretta Sanchez,393
-Sutter,13,U.S. Senate,,DEM,Kamala Harris,128
-Sutter,13,U.S. Senate,,DEM,Loretta Sanchez,122
-Sutter,14,U.S. Senate,,DEM,Kamala Harris,117
-Sutter,14,U.S. Senate,,DEM,Loretta Sanchez,95
-Sutter,15,U.S. Senate,,DEM,Kamala Harris,541
-Sutter,15,U.S. Senate,,DEM,Loretta Sanchez,357
-Sutter,16,U.S. Senate,,DEM,Kamala Harris,410
-Sutter,16,U.S. Senate,,DEM,Loretta Sanchez,329
-Sutter,17,U.S. Senate,,DEM,Kamala Harris,430
-Sutter,17,U.S. Senate,,DEM,Loretta Sanchez,328
-Sutter,18,U.S. Senate,,DEM,Kamala Harris,390
-Sutter,18,U.S. Senate,,DEM,Loretta Sanchez,236
-Sutter,19,U.S. Senate,,DEM,Kamala Harris,297
-Sutter,19,U.S. Senate,,DEM,Loretta Sanchez,240
-Sutter,20,U.S. Senate,,DEM,Kamala Harris,277
-Sutter,20,U.S. Senate,,DEM,Loretta Sanchez,236
-Sutter,21,U.S. Senate,,DEM,Kamala Harris,585
-Sutter,21,U.S. Senate,,DEM,Loretta Sanchez,297
-Sutter,22,U.S. Senate,,DEM,Kamala Harris,577
-Sutter,22,U.S. Senate,,DEM,Loretta Sanchez,403
-Sutter,23,U.S. Senate,,DEM,Kamala Harris,613
-Sutter,23,U.S. Senate,,DEM,Loretta Sanchez,439
-Sutter,24,U.S. Senate,,DEM,Kamala Harris,730
-Sutter,24,U.S. Senate,,DEM,Loretta Sanchez,412
-Sutter,25,U.S. Senate,,DEM,Kamala Harris,245
-Sutter,25,U.S. Senate,,DEM,Loretta Sanchez,158
-Sutter,26,U.S. Senate,,DEM,Kamala Harris,386
-Sutter,26,U.S. Senate,,DEM,Loretta Sanchez,246
-Sutter,27,U.S. Senate,,DEM,Kamala Harris,309
-Sutter,27,U.S. Senate,,DEM,Loretta Sanchez,300
-Sutter,28,U.S. Senate,,DEM,Kamala Harris,521
-Sutter,28,U.S. Senate,,DEM,Loretta Sanchez,378
-Sutter,29,U.S. Senate,,DEM,Kamala Harris,568
-Sutter,29,U.S. Senate,,DEM,Loretta Sanchez,386
-Sutter,30,U.S. Senate,,DEM,Kamala Harris,424
-Sutter,30,U.S. Senate,,DEM,Loretta Sanchez,309
-Sutter,31,U.S. Senate,,DEM,Kamala Harris,87
-Sutter,31,U.S. Senate,,DEM,Loretta Sanchez,126
-Sutter,32,U.S. Senate,,DEM,Kamala Harris,147
-Sutter,32,U.S. Senate,,DEM,Loretta Sanchez,151
-Sutter,33,U.S. Senate,,DEM,Kamala Harris,262
-Sutter,33,U.S. Senate,,DEM,Loretta Sanchez,259
-Sutter,34,U.S. Senate,,DEM,Kamala Harris,221
-Sutter,34,U.S. Senate,,DEM,Loretta Sanchez,158
-Sutter,35,U.S. Senate,,DEM,Kamala Harris,148
-Sutter,35,U.S. Senate,,DEM,Loretta Sanchez,123
-Sutter,36,U.S. Senate,,DEM,Kamala Harris,98
-Sutter,36,U.S. Senate,,DEM,Loretta Sanchez,58
-Sutter,37,U.S. Senate,,DEM,Kamala Harris,169
-Sutter,37,U.S. Senate,,DEM,Loretta Sanchez,139
-Sutter,38,U.S. Senate,,DEM,Kamala Harris,143
-Sutter,38,U.S. Senate,,DEM,Loretta Sanchez,149
-Sutter,39,U.S. Senate,,DEM,Kamala Harris,177
-Sutter,39,U.S. Senate,,DEM,Loretta Sanchez,114
-Sutter,40,U.S. Senate,,DEM,Kamala Harris,68
-Sutter,40,U.S. Senate,,DEM,Loretta Sanchez,42
-Sutter,41,U.S. Senate,,DEM,Kamala Harris,10
-Sutter,41,U.S. Senate,,DEM,Loretta Sanchez,15
-Sutter,42,U.S. Senate,,DEM,Kamala Harris,285
-Sutter,42,U.S. Senate,,DEM,Loretta Sanchez,222
-Sutter,43,U.S. Senate,,DEM,Kamala Harris,255
-Sutter,43,U.S. Senate,,DEM,Loretta Sanchez,259
-Sutter,44,U.S. Senate,,DEM,Kamala Harris,290
-Sutter,44,U.S. Senate,,DEM,Loretta Sanchez,248
-Sutter,45,U.S. Senate,,DEM,Kamala Harris,181
-Sutter,45,U.S. Senate,,DEM,Loretta Sanchez,147
-Sutter,46,U.S. Senate,,DEM,Kamala Harris,139
-Sutter,46,U.S. Senate,,DEM,Loretta Sanchez,114
-Sutter,47,U.S. Senate,,DEM,Kamala Harris,393
-Sutter,47,U.S. Senate,,DEM,Loretta Sanchez,238
-Sutter,48,U.S. Senate,,DEM,Kamala Harris,17
-Sutter,48,U.S. Senate,,DEM,Loretta Sanchez,20
-Sutter,49,U.S. Senate,,DEM,Kamala Harris,305
-Sutter,49,U.S. Senate,,DEM,Loretta Sanchez,207
-Sutter,50,U.S. Senate,,DEM,Kamala Harris,71
-Sutter,50,U.S. Senate,,DEM,Loretta Sanchez,76
-Sutter,51,U.S. Senate,,DEM,Kamala Harris,29
-Sutter,51,U.S. Senate,,DEM,Loretta Sanchez,38
+Sutter,1,U.S. Senate,,DEM,Kamala D. Harris,407
+Sutter,1,U.S. Senate,,DEM,Loretta L. Sanchez,378
+Sutter,2,U.S. Senate,,DEM,Kamala D. Harris,604
+Sutter,2,U.S. Senate,,DEM,Loretta L. Sanchez,606
+Sutter,3,U.S. Senate,,DEM,Kamala D. Harris,322
+Sutter,3,U.S. Senate,,DEM,Loretta L. Sanchez,229
+Sutter,4,U.S. Senate,,DEM,Kamala D. Harris,698
+Sutter,4,U.S. Senate,,DEM,Loretta L. Sanchez,513
+Sutter,5,U.S. Senate,,DEM,Kamala D. Harris,462
+Sutter,5,U.S. Senate,,DEM,Loretta L. Sanchez,360
+Sutter,6,U.S. Senate,,DEM,Kamala D. Harris,103
+Sutter,6,U.S. Senate,,DEM,Loretta L. Sanchez,80
+Sutter,7,U.S. Senate,,DEM,Kamala D. Harris,162
+Sutter,7,U.S. Senate,,DEM,Loretta L. Sanchez,139
+Sutter,8,U.S. Senate,,DEM,Kamala D. Harris,161
+Sutter,8,U.S. Senate,,DEM,Loretta L. Sanchez,252
+Sutter,9,U.S. Senate,,DEM,Kamala D. Harris,271
+Sutter,9,U.S. Senate,,DEM,Loretta L. Sanchez,191
+Sutter,10,U.S. Senate,,DEM,Kamala D. Harris,213
+Sutter,10,U.S. Senate,,DEM,Loretta L. Sanchez,202
+Sutter,11,U.S. Senate,,DEM,Kamala D. Harris,219
+Sutter,11,U.S. Senate,,DEM,Loretta L. Sanchez,183
+Sutter,12,U.S. Senate,,DEM,Kamala D. Harris,526
+Sutter,12,U.S. Senate,,DEM,Loretta L. Sanchez,393
+Sutter,13,U.S. Senate,,DEM,Kamala D. Harris,128
+Sutter,13,U.S. Senate,,DEM,Loretta L. Sanchez,122
+Sutter,14,U.S. Senate,,DEM,Kamala D. Harris,117
+Sutter,14,U.S. Senate,,DEM,Loretta L. Sanchez,95
+Sutter,15,U.S. Senate,,DEM,Kamala D. Harris,541
+Sutter,15,U.S. Senate,,DEM,Loretta L. Sanchez,357
+Sutter,16,U.S. Senate,,DEM,Kamala D. Harris,410
+Sutter,16,U.S. Senate,,DEM,Loretta L. Sanchez,329
+Sutter,17,U.S. Senate,,DEM,Kamala D. Harris,430
+Sutter,17,U.S. Senate,,DEM,Loretta L. Sanchez,328
+Sutter,18,U.S. Senate,,DEM,Kamala D. Harris,390
+Sutter,18,U.S. Senate,,DEM,Loretta L. Sanchez,236
+Sutter,19,U.S. Senate,,DEM,Kamala D. Harris,297
+Sutter,19,U.S. Senate,,DEM,Loretta L. Sanchez,240
+Sutter,20,U.S. Senate,,DEM,Kamala D. Harris,277
+Sutter,20,U.S. Senate,,DEM,Loretta L. Sanchez,236
+Sutter,21,U.S. Senate,,DEM,Kamala D. Harris,585
+Sutter,21,U.S. Senate,,DEM,Loretta L. Sanchez,297
+Sutter,22,U.S. Senate,,DEM,Kamala D. Harris,577
+Sutter,22,U.S. Senate,,DEM,Loretta L. Sanchez,403
+Sutter,23,U.S. Senate,,DEM,Kamala D. Harris,613
+Sutter,23,U.S. Senate,,DEM,Loretta L. Sanchez,439
+Sutter,24,U.S. Senate,,DEM,Kamala D. Harris,730
+Sutter,24,U.S. Senate,,DEM,Loretta L. Sanchez,412
+Sutter,25,U.S. Senate,,DEM,Kamala D. Harris,245
+Sutter,25,U.S. Senate,,DEM,Loretta L. Sanchez,158
+Sutter,26,U.S. Senate,,DEM,Kamala D. Harris,386
+Sutter,26,U.S. Senate,,DEM,Loretta L. Sanchez,246
+Sutter,27,U.S. Senate,,DEM,Kamala D. Harris,309
+Sutter,27,U.S. Senate,,DEM,Loretta L. Sanchez,300
+Sutter,28,U.S. Senate,,DEM,Kamala D. Harris,521
+Sutter,28,U.S. Senate,,DEM,Loretta L. Sanchez,378
+Sutter,29,U.S. Senate,,DEM,Kamala D. Harris,568
+Sutter,29,U.S. Senate,,DEM,Loretta L. Sanchez,386
+Sutter,30,U.S. Senate,,DEM,Kamala D. Harris,424
+Sutter,30,U.S. Senate,,DEM,Loretta L. Sanchez,309
+Sutter,31,U.S. Senate,,DEM,Kamala D. Harris,87
+Sutter,31,U.S. Senate,,DEM,Loretta L. Sanchez,126
+Sutter,32,U.S. Senate,,DEM,Kamala D. Harris,147
+Sutter,32,U.S. Senate,,DEM,Loretta L. Sanchez,151
+Sutter,33,U.S. Senate,,DEM,Kamala D. Harris,262
+Sutter,33,U.S. Senate,,DEM,Loretta L. Sanchez,259
+Sutter,34,U.S. Senate,,DEM,Kamala D. Harris,221
+Sutter,34,U.S. Senate,,DEM,Loretta L. Sanchez,158
+Sutter,35,U.S. Senate,,DEM,Kamala D. Harris,148
+Sutter,35,U.S. Senate,,DEM,Loretta L. Sanchez,123
+Sutter,36,U.S. Senate,,DEM,Kamala D. Harris,98
+Sutter,36,U.S. Senate,,DEM,Loretta L. Sanchez,58
+Sutter,37,U.S. Senate,,DEM,Kamala D. Harris,169
+Sutter,37,U.S. Senate,,DEM,Loretta L. Sanchez,139
+Sutter,38,U.S. Senate,,DEM,Kamala D. Harris,143
+Sutter,38,U.S. Senate,,DEM,Loretta L. Sanchez,149
+Sutter,39,U.S. Senate,,DEM,Kamala D. Harris,177
+Sutter,39,U.S. Senate,,DEM,Loretta L. Sanchez,114
+Sutter,40,U.S. Senate,,DEM,Kamala D. Harris,68
+Sutter,40,U.S. Senate,,DEM,Loretta L. Sanchez,42
+Sutter,41,U.S. Senate,,DEM,Kamala D. Harris,10
+Sutter,41,U.S. Senate,,DEM,Loretta L. Sanchez,15
+Sutter,42,U.S. Senate,,DEM,Kamala D. Harris,285
+Sutter,42,U.S. Senate,,DEM,Loretta L. Sanchez,222
+Sutter,43,U.S. Senate,,DEM,Kamala D. Harris,255
+Sutter,43,U.S. Senate,,DEM,Loretta L. Sanchez,259
+Sutter,44,U.S. Senate,,DEM,Kamala D. Harris,290
+Sutter,44,U.S. Senate,,DEM,Loretta L. Sanchez,248
+Sutter,45,U.S. Senate,,DEM,Kamala D. Harris,181
+Sutter,45,U.S. Senate,,DEM,Loretta L. Sanchez,147
+Sutter,46,U.S. Senate,,DEM,Kamala D. Harris,139
+Sutter,46,U.S. Senate,,DEM,Loretta L. Sanchez,114
+Sutter,47,U.S. Senate,,DEM,Kamala D. Harris,393
+Sutter,47,U.S. Senate,,DEM,Loretta L. Sanchez,238
+Sutter,48,U.S. Senate,,DEM,Kamala D. Harris,17
+Sutter,48,U.S. Senate,,DEM,Loretta L. Sanchez,20
+Sutter,49,U.S. Senate,,DEM,Kamala D. Harris,305
+Sutter,49,U.S. Senate,,DEM,Loretta L. Sanchez,207
+Sutter,50,U.S. Senate,,DEM,Kamala D. Harris,71
+Sutter,50,U.S. Senate,,DEM,Loretta L. Sanchez,76
+Sutter,51,U.S. Senate,,DEM,Kamala D. Harris,29
+Sutter,51,U.S. Senate,,DEM,Loretta L. Sanchez,38

--- a/2016/20161108__ca__general__tehama__precinct.csv
+++ b/2016/20161108__ca__general__tehama__precinct.csv
@@ -1839,95 +1839,95 @@ Tehama,51510,Proposition 67,,N/A,Yes,250
 Tehama,51510,Proposition 67,,N/A,No,484
 Tehama,53610,Proposition 67,,N/A,Yes,59
 Tehama,53610,Proposition 67,,N/A,No,114
-Tehama,10030,U.S. Senate,,DEM,Kamala Harris,477
-Tehama,10030,U.S. Senate,,DEM,Loretta Sanchez,336
-Tehama,10050,U.S. Senate,,DEM,Kamala Harris,452
-Tehama,10050,U.S. Senate,,DEM,Loretta Sanchez,384
-Tehama,10130,U.S. Senate,,DEM,Kamala Harris,486
-Tehama,10130,U.S. Senate,,DEM,Loretta Sanchez,380
-Tehama,12060,U.S. Senate,,DEM,Kamala Harris,326
-Tehama,12060,U.S. Senate,,DEM,Loretta Sanchez,343
-Tehama,12080,U.S. Senate,,DEM,Kamala Harris,322
-Tehama,12080,U.S. Senate,,DEM,Loretta Sanchez,213
-Tehama,12210,U.S. Senate,,DEM,Kamala Harris,147
-Tehama,12210,U.S. Senate,,DEM,Loretta Sanchez,121
-Tehama,20140,U.S. Senate,,DEM,Kamala Harris,315
-Tehama,20140,U.S. Senate,,DEM,Loretta Sanchez,263
-Tehama,20160,U.S. Senate,,DEM,Kamala Harris,87
-Tehama,20160,U.S. Senate,,DEM,Loretta Sanchez,78
-Tehama,20170,U.S. Senate,,DEM,Kamala Harris,145
-Tehama,20170,U.S. Senate,,DEM,Loretta Sanchez,109
-Tehama,20250,U.S. Senate,,DEM,Kamala Harris,221
-Tehama,20250,U.S. Senate,,DEM,Loretta Sanchez,157
-Tehama,20255,U.S. Senate,,DEM,Kamala Harris,162
-Tehama,20255,U.S. Senate,,DEM,Loretta Sanchez,114
-Tehama,22190,U.S. Senate,,DEM,Kamala Harris,284
-Tehama,22190,U.S. Senate,,DEM,Loretta Sanchez,294
-Tehama,22230,U.S. Senate,,DEM,Kamala Harris,328
-Tehama,22230,U.S. Senate,,DEM,Loretta Sanchez,316
-Tehama,22240,U.S. Senate,,DEM,Kamala Harris,238
-Tehama,22240,U.S. Senate,,DEM,Loretta Sanchez,193
-Tehama,30010,U.S. Senate,,DEM,Kamala Harris,167
-Tehama,30010,U.S. Senate,,DEM,Loretta Sanchez,140
-Tehama,30015,U.S. Senate,,DEM,Kamala Harris,32
-Tehama,30015,U.S. Senate,,DEM,Loretta Sanchez,25
-Tehama,30120,U.S. Senate,,DEM,Kamala Harris,586
-Tehama,30120,U.S. Senate,,DEM,Loretta Sanchez,444
-Tehama,30260,U.S. Senate,,DEM,Kamala Harris,366
-Tehama,30260,U.S. Senate,,DEM,Loretta Sanchez,264
-Tehama,30270,U.S. Senate,,DEM,Kamala Harris,197
-Tehama,30270,U.S. Senate,,DEM,Loretta Sanchez,150
-Tehama,30280,U.S. Senate,,DEM,Kamala Harris,307
-Tehama,30280,U.S. Senate,,DEM,Loretta Sanchez,257
-Tehama,30300,U.S. Senate,,DEM,Kamala Harris,190
-Tehama,30300,U.S. Senate,,DEM,Loretta Sanchez,184
-Tehama,30320,U.S. Senate,,DEM,Kamala Harris,74
-Tehama,30320,U.S. Senate,,DEM,Loretta Sanchez,51
-Tehama,30330,U.S. Senate,,DEM,Kamala Harris,43
-Tehama,30330,U.S. Senate,,DEM,Loretta Sanchez,22
-Tehama,30340,U.S. Senate,,DEM,Kamala Harris,57
-Tehama,30340,U.S. Senate,,DEM,Loretta Sanchez,43
-Tehama,32350,U.S. Senate,,DEM,Kamala Harris,138
-Tehama,32350,U.S. Senate,,DEM,Loretta Sanchez,112
-Tehama,40180,U.S. Senate,,DEM,Kamala Harris,60
-Tehama,40180,U.S. Senate,,DEM,Loretta Sanchez,31
-Tehama,40360,U.S. Senate,,DEM,Kamala Harris,292
-Tehama,40360,U.S. Senate,,DEM,Loretta Sanchez,295
-Tehama,40365,U.S. Senate,,DEM,Kamala Harris,12
-Tehama,40365,U.S. Senate,,DEM,Loretta Sanchez,3
-Tehama,40420,U.S. Senate,,DEM,Kamala Harris,230
-Tehama,40420,U.S. Senate,,DEM,Loretta Sanchez,185
-Tehama,40430,U.S. Senate,,DEM,Kamala Harris,50
-Tehama,40430,U.S. Senate,,DEM,Loretta Sanchez,29
-Tehama,40480,U.S. Senate,,DEM,Kamala Harris,25
-Tehama,40480,U.S. Senate,,DEM,Loretta Sanchez,20
-Tehama,40485,U.S. Senate,,DEM,Kamala Harris,209
-Tehama,40485,U.S. Senate,,DEM,Loretta Sanchez,188
-Tehama,40490,U.S. Senate,,DEM,Kamala Harris,178
-Tehama,40490,U.S. Senate,,DEM,Loretta Sanchez,165
-Tehama,40620,U.S. Senate,,DEM,Kamala Harris,36
-Tehama,40620,U.S. Senate,,DEM,Loretta Sanchez,23
-Tehama,41380,U.S. Senate,,DEM,Kamala Harris,263
-Tehama,41380,U.S. Senate,,DEM,Loretta Sanchez,283
-Tehama,41400,U.S. Senate,,DEM,Kamala Harris,214
-Tehama,41400,U.S. Senate,,DEM,Loretta Sanchez,253
-Tehama,50370,U.S. Senate,,DEM,Kamala Harris,88
-Tehama,50370,U.S. Senate,,DEM,Loretta Sanchez,65
-Tehama,50450,U.S. Senate,,DEM,Kamala Harris,56
-Tehama,50450,U.S. Senate,,DEM,Loretta Sanchez,28
-Tehama,50455,U.S. Senate,,DEM,Kamala Harris,6
-Tehama,50455,U.S. Senate,,DEM,Loretta Sanchez,6
-Tehama,50530,U.S. Senate,,DEM,Kamala Harris,133
-Tehama,50530,U.S. Senate,,DEM,Loretta Sanchez,127
-Tehama,50560,U.S. Senate,,DEM,Kamala Harris,362
-Tehama,50560,U.S. Senate,,DEM,Loretta Sanchez,302
-Tehama,50580,U.S. Senate,,DEM,Kamala Harris,351
-Tehama,50580,U.S. Senate,,DEM,Loretta Sanchez,335
-Tehama,50590,U.S. Senate,,DEM,Kamala Harris,278
-Tehama,50590,U.S. Senate,,DEM,Loretta Sanchez,218
-Tehama,50630,U.S. Senate,,DEM,Kamala Harris,95
-Tehama,50630,U.S. Senate,,DEM,Loretta Sanchez,78
-Tehama,51510,U.S. Senate,,DEM,Kamala Harris,295
-Tehama,51510,U.S. Senate,,DEM,Loretta Sanchez,303
-Tehama,53610,U.S. Senate,,DEM,Kamala Harris,76
-Tehama,53610,U.S. Senate,,DEM,Loretta Sanchez,61
+Tehama,10030,U.S. Senate,,DEM,Kamala D. Harris,477
+Tehama,10030,U.S. Senate,,DEM,Loretta L. Sanchez,336
+Tehama,10050,U.S. Senate,,DEM,Kamala D. Harris,452
+Tehama,10050,U.S. Senate,,DEM,Loretta L. Sanchez,384
+Tehama,10130,U.S. Senate,,DEM,Kamala D. Harris,486
+Tehama,10130,U.S. Senate,,DEM,Loretta L. Sanchez,380
+Tehama,12060,U.S. Senate,,DEM,Kamala D. Harris,326
+Tehama,12060,U.S. Senate,,DEM,Loretta L. Sanchez,343
+Tehama,12080,U.S. Senate,,DEM,Kamala D. Harris,322
+Tehama,12080,U.S. Senate,,DEM,Loretta L. Sanchez,213
+Tehama,12210,U.S. Senate,,DEM,Kamala D. Harris,147
+Tehama,12210,U.S. Senate,,DEM,Loretta L. Sanchez,121
+Tehama,20140,U.S. Senate,,DEM,Kamala D. Harris,315
+Tehama,20140,U.S. Senate,,DEM,Loretta L. Sanchez,263
+Tehama,20160,U.S. Senate,,DEM,Kamala D. Harris,87
+Tehama,20160,U.S. Senate,,DEM,Loretta L. Sanchez,78
+Tehama,20170,U.S. Senate,,DEM,Kamala D. Harris,145
+Tehama,20170,U.S. Senate,,DEM,Loretta L. Sanchez,109
+Tehama,20250,U.S. Senate,,DEM,Kamala D. Harris,221
+Tehama,20250,U.S. Senate,,DEM,Loretta L. Sanchez,157
+Tehama,20255,U.S. Senate,,DEM,Kamala D. Harris,162
+Tehama,20255,U.S. Senate,,DEM,Loretta L. Sanchez,114
+Tehama,22190,U.S. Senate,,DEM,Kamala D. Harris,284
+Tehama,22190,U.S. Senate,,DEM,Loretta L. Sanchez,294
+Tehama,22230,U.S. Senate,,DEM,Kamala D. Harris,328
+Tehama,22230,U.S. Senate,,DEM,Loretta L. Sanchez,316
+Tehama,22240,U.S. Senate,,DEM,Kamala D. Harris,238
+Tehama,22240,U.S. Senate,,DEM,Loretta L. Sanchez,193
+Tehama,30010,U.S. Senate,,DEM,Kamala D. Harris,167
+Tehama,30010,U.S. Senate,,DEM,Loretta L. Sanchez,140
+Tehama,30015,U.S. Senate,,DEM,Kamala D. Harris,32
+Tehama,30015,U.S. Senate,,DEM,Loretta L. Sanchez,25
+Tehama,30120,U.S. Senate,,DEM,Kamala D. Harris,586
+Tehama,30120,U.S. Senate,,DEM,Loretta L. Sanchez,444
+Tehama,30260,U.S. Senate,,DEM,Kamala D. Harris,366
+Tehama,30260,U.S. Senate,,DEM,Loretta L. Sanchez,264
+Tehama,30270,U.S. Senate,,DEM,Kamala D. Harris,197
+Tehama,30270,U.S. Senate,,DEM,Loretta L. Sanchez,150
+Tehama,30280,U.S. Senate,,DEM,Kamala D. Harris,307
+Tehama,30280,U.S. Senate,,DEM,Loretta L. Sanchez,257
+Tehama,30300,U.S. Senate,,DEM,Kamala D. Harris,190
+Tehama,30300,U.S. Senate,,DEM,Loretta L. Sanchez,184
+Tehama,30320,U.S. Senate,,DEM,Kamala D. Harris,74
+Tehama,30320,U.S. Senate,,DEM,Loretta L. Sanchez,51
+Tehama,30330,U.S. Senate,,DEM,Kamala D. Harris,43
+Tehama,30330,U.S. Senate,,DEM,Loretta L. Sanchez,22
+Tehama,30340,U.S. Senate,,DEM,Kamala D. Harris,57
+Tehama,30340,U.S. Senate,,DEM,Loretta L. Sanchez,43
+Tehama,32350,U.S. Senate,,DEM,Kamala D. Harris,138
+Tehama,32350,U.S. Senate,,DEM,Loretta L. Sanchez,112
+Tehama,40180,U.S. Senate,,DEM,Kamala D. Harris,60
+Tehama,40180,U.S. Senate,,DEM,Loretta L. Sanchez,31
+Tehama,40360,U.S. Senate,,DEM,Kamala D. Harris,292
+Tehama,40360,U.S. Senate,,DEM,Loretta L. Sanchez,295
+Tehama,40365,U.S. Senate,,DEM,Kamala D. Harris,12
+Tehama,40365,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Tehama,40420,U.S. Senate,,DEM,Kamala D. Harris,230
+Tehama,40420,U.S. Senate,,DEM,Loretta L. Sanchez,185
+Tehama,40430,U.S. Senate,,DEM,Kamala D. Harris,50
+Tehama,40430,U.S. Senate,,DEM,Loretta L. Sanchez,29
+Tehama,40480,U.S. Senate,,DEM,Kamala D. Harris,25
+Tehama,40480,U.S. Senate,,DEM,Loretta L. Sanchez,20
+Tehama,40485,U.S. Senate,,DEM,Kamala D. Harris,209
+Tehama,40485,U.S. Senate,,DEM,Loretta L. Sanchez,188
+Tehama,40490,U.S. Senate,,DEM,Kamala D. Harris,178
+Tehama,40490,U.S. Senate,,DEM,Loretta L. Sanchez,165
+Tehama,40620,U.S. Senate,,DEM,Kamala D. Harris,36
+Tehama,40620,U.S. Senate,,DEM,Loretta L. Sanchez,23
+Tehama,41380,U.S. Senate,,DEM,Kamala D. Harris,263
+Tehama,41380,U.S. Senate,,DEM,Loretta L. Sanchez,283
+Tehama,41400,U.S. Senate,,DEM,Kamala D. Harris,214
+Tehama,41400,U.S. Senate,,DEM,Loretta L. Sanchez,253
+Tehama,50370,U.S. Senate,,DEM,Kamala D. Harris,88
+Tehama,50370,U.S. Senate,,DEM,Loretta L. Sanchez,65
+Tehama,50450,U.S. Senate,,DEM,Kamala D. Harris,56
+Tehama,50450,U.S. Senate,,DEM,Loretta L. Sanchez,28
+Tehama,50455,U.S. Senate,,DEM,Kamala D. Harris,6
+Tehama,50455,U.S. Senate,,DEM,Loretta L. Sanchez,6
+Tehama,50530,U.S. Senate,,DEM,Kamala D. Harris,133
+Tehama,50530,U.S. Senate,,DEM,Loretta L. Sanchez,127
+Tehama,50560,U.S. Senate,,DEM,Kamala D. Harris,362
+Tehama,50560,U.S. Senate,,DEM,Loretta L. Sanchez,302
+Tehama,50580,U.S. Senate,,DEM,Kamala D. Harris,351
+Tehama,50580,U.S. Senate,,DEM,Loretta L. Sanchez,335
+Tehama,50590,U.S. Senate,,DEM,Kamala D. Harris,278
+Tehama,50590,U.S. Senate,,DEM,Loretta L. Sanchez,218
+Tehama,50630,U.S. Senate,,DEM,Kamala D. Harris,95
+Tehama,50630,U.S. Senate,,DEM,Loretta L. Sanchez,78
+Tehama,51510,U.S. Senate,,DEM,Kamala D. Harris,295
+Tehama,51510,U.S. Senate,,DEM,Loretta L. Sanchez,303
+Tehama,53610,U.S. Senate,,DEM,Kamala D. Harris,76
+Tehama,53610,U.S. Senate,,DEM,Loretta L. Sanchez,61

--- a/2016/20161108__ca__general__trinity__precinct.csv
+++ b/2016/20161108__ca__general__trinity__precinct.csv
@@ -999,53 +999,53 @@ Trinity,WILDWOOD,Proposition 67,,N/A,Yes,7
 Trinity,WILDWOOD,Proposition 67,,N/A,No,15
 Trinity,ZENIA,Proposition 67,,N/A,Yes,29
 Trinity,ZENIA,Proposition 67,,N/A,No,49
-Trinity,BIG_BAR,U.S. Senate,,DEM,Kamala Harris,47
-Trinity,BIG_BAR,U.S. Senate,,DEM,Loretta Sanchez,33
-Trinity,BURNT_RANCH,U.S. Senate,,DEM,Kamala Harris,56
-Trinity,BURNT_RANCH,U.S. Senate,,DEM,Loretta Sanchez,35
-Trinity,COFFEE_CREEK,U.S. Senate,,DEM,Kamala Harris,53
-Trinity,COFFEE_CREEK,U.S. Senate,,DEM,Loretta Sanchez,32
-Trinity,DENNY,U.S. Senate,,DEM,Kamala Harris,71
-Trinity,DENNY,U.S. Senate,,DEM,Loretta Sanchez,32
-Trinity,DOUGLAS_CITY,U.S. Senate,,DEM,Kamala Harris,246
-Trinity,DOUGLAS_CITY,U.S. Senate,,DEM,Loretta Sanchez,171
-Trinity,EAST_WEAVER,U.S. Senate,,DEM,Kamala Harris,161
-Trinity,EAST_WEAVER,U.S. Senate,,DEM,Loretta Sanchez,82
-Trinity,FOREST_GLEN,U.S. Senate,,DEM,Kamala Harris,1
-Trinity,FOREST_GLEN,U.S. Senate,,DEM,Loretta Sanchez,1
-Trinity,HAYFORK,U.S. Senate,,DEM,Kamala Harris,221
-Trinity,HAYFORK,U.S. Senate,,DEM,Loretta Sanchez,157
-Trinity,HYAMPOM,U.S. Senate,,DEM,Kamala Harris,59
-Trinity,HYAMPOM,U.S. Senate,,DEM,Loretta Sanchez,33
-Trinity,INDIAN_CREEK,U.S. Senate,,DEM,Kamala Harris,10
-Trinity,INDIAN_CREEK,U.S. Senate,,DEM,Loretta Sanchez,4
-Trinity,JUNCTION_CITY,U.S. Senate,,DEM,Kamala Harris,207
-Trinity,JUNCTION_CITY,U.S. Senate,,DEM,Loretta Sanchez,124
-Trinity,LEWISTON,U.S. Senate,,DEM,Kamala Harris,261
-Trinity,LEWISTON,U.S. Senate,,DEM,Loretta Sanchez,204
-Trinity,MAD_RIVER,U.S. Senate,,DEM,Kamala Harris,50
-Trinity,MAD_RIVER,U.S. Senate,,DEM,Loretta Sanchez,51
-Trinity,MINERSVILLE,U.S. Senate,,DEM,Kamala Harris,48
-Trinity,MINERSVILLE,U.S. Senate,,DEM,Loretta Sanchez,17
-Trinity,NORTH_WEAVER,U.S. Senate,,DEM,Kamala Harris,145
-Trinity,NORTH_WEAVER,U.S. Senate,,DEM,Loretta Sanchez,79
-Trinity,OREGON_MOUNTAIN,U.S. Senate,,DEM,Kamala Harris,43
-Trinity,OREGON_MOUNTAIN,U.S. Senate,,DEM,Loretta Sanchez,16
-Trinity,POST_MOUNTAIN,U.S. Senate,,DEM,Kamala Harris,35
-Trinity,POST_MOUNTAIN,U.S. Senate,,DEM,Loretta Sanchez,24
-Trinity,RUTH,U.S. Senate,,DEM,Kamala Harris,41
-Trinity,RUTH,U.S. Senate,,DEM,Loretta Sanchez,39
-Trinity,SALYER,U.S. Senate,,DEM,Kamala Harris,80
-Trinity,SALYER,U.S. Senate,,DEM,Loretta Sanchez,49
-Trinity,SOUTH_HAYFORK,U.S. Senate,,DEM,Kamala Harris,198
-Trinity,SOUTH_HAYFORK,U.S. Senate,,DEM,Loretta Sanchez,154
-Trinity,SOUTH_WEAVER,U.S. Senate,,DEM,Kamala Harris,206
-Trinity,SOUTH_WEAVER,U.S. Senate,,DEM,Loretta Sanchez,112
-Trinity,TRINITY_CENTER,U.S. Senate,,DEM,Kamala Harris,52
-Trinity,TRINITY_CENTER,U.S. Senate,,DEM,Loretta Sanchez,54
-Trinity,WEAVERVILLE,U.S. Senate,,DEM,Kamala Harris,373
-Trinity,WEAVERVILLE,U.S. Senate,,DEM,Loretta Sanchez,242
-Trinity,WILDWOOD,U.S. Senate,,DEM,Kamala Harris,5
-Trinity,WILDWOOD,U.S. Senate,,DEM,Loretta Sanchez,9
-Trinity,ZENIA,U.S. Senate,,DEM,Kamala Harris,27
-Trinity,ZENIA,U.S. Senate,,DEM,Loretta Sanchez,41
+Trinity,BIG_BAR,U.S. Senate,,DEM,Kamala D. Harris,47
+Trinity,BIG_BAR,U.S. Senate,,DEM,Loretta L. Sanchez,33
+Trinity,BURNT_RANCH,U.S. Senate,,DEM,Kamala D. Harris,56
+Trinity,BURNT_RANCH,U.S. Senate,,DEM,Loretta L. Sanchez,35
+Trinity,COFFEE_CREEK,U.S. Senate,,DEM,Kamala D. Harris,53
+Trinity,COFFEE_CREEK,U.S. Senate,,DEM,Loretta L. Sanchez,32
+Trinity,DENNY,U.S. Senate,,DEM,Kamala D. Harris,71
+Trinity,DENNY,U.S. Senate,,DEM,Loretta L. Sanchez,32
+Trinity,DOUGLAS_CITY,U.S. Senate,,DEM,Kamala D. Harris,246
+Trinity,DOUGLAS_CITY,U.S. Senate,,DEM,Loretta L. Sanchez,171
+Trinity,EAST_WEAVER,U.S. Senate,,DEM,Kamala D. Harris,161
+Trinity,EAST_WEAVER,U.S. Senate,,DEM,Loretta L. Sanchez,82
+Trinity,FOREST_GLEN,U.S. Senate,,DEM,Kamala D. Harris,1
+Trinity,FOREST_GLEN,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Trinity,HAYFORK,U.S. Senate,,DEM,Kamala D. Harris,221
+Trinity,HAYFORK,U.S. Senate,,DEM,Loretta L. Sanchez,157
+Trinity,HYAMPOM,U.S. Senate,,DEM,Kamala D. Harris,59
+Trinity,HYAMPOM,U.S. Senate,,DEM,Loretta L. Sanchez,33
+Trinity,INDIAN_CREEK,U.S. Senate,,DEM,Kamala D. Harris,10
+Trinity,INDIAN_CREEK,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Trinity,JUNCTION_CITY,U.S. Senate,,DEM,Kamala D. Harris,207
+Trinity,JUNCTION_CITY,U.S. Senate,,DEM,Loretta L. Sanchez,124
+Trinity,LEWISTON,U.S. Senate,,DEM,Kamala D. Harris,261
+Trinity,LEWISTON,U.S. Senate,,DEM,Loretta L. Sanchez,204
+Trinity,MAD_RIVER,U.S. Senate,,DEM,Kamala D. Harris,50
+Trinity,MAD_RIVER,U.S. Senate,,DEM,Loretta L. Sanchez,51
+Trinity,MINERSVILLE,U.S. Senate,,DEM,Kamala D. Harris,48
+Trinity,MINERSVILLE,U.S. Senate,,DEM,Loretta L. Sanchez,17
+Trinity,NORTH_WEAVER,U.S. Senate,,DEM,Kamala D. Harris,145
+Trinity,NORTH_WEAVER,U.S. Senate,,DEM,Loretta L. Sanchez,79
+Trinity,OREGON_MOUNTAIN,U.S. Senate,,DEM,Kamala D. Harris,43
+Trinity,OREGON_MOUNTAIN,U.S. Senate,,DEM,Loretta L. Sanchez,16
+Trinity,POST_MOUNTAIN,U.S. Senate,,DEM,Kamala D. Harris,35
+Trinity,POST_MOUNTAIN,U.S. Senate,,DEM,Loretta L. Sanchez,24
+Trinity,RUTH,U.S. Senate,,DEM,Kamala D. Harris,41
+Trinity,RUTH,U.S. Senate,,DEM,Loretta L. Sanchez,39
+Trinity,SALYER,U.S. Senate,,DEM,Kamala D. Harris,80
+Trinity,SALYER,U.S. Senate,,DEM,Loretta L. Sanchez,49
+Trinity,SOUTH_HAYFORK,U.S. Senate,,DEM,Kamala D. Harris,198
+Trinity,SOUTH_HAYFORK,U.S. Senate,,DEM,Loretta L. Sanchez,154
+Trinity,SOUTH_WEAVER,U.S. Senate,,DEM,Kamala D. Harris,206
+Trinity,SOUTH_WEAVER,U.S. Senate,,DEM,Loretta L. Sanchez,112
+Trinity,TRINITY_CENTER,U.S. Senate,,DEM,Kamala D. Harris,52
+Trinity,TRINITY_CENTER,U.S. Senate,,DEM,Loretta L. Sanchez,54
+Trinity,WEAVERVILLE,U.S. Senate,,DEM,Kamala D. Harris,373
+Trinity,WEAVERVILLE,U.S. Senate,,DEM,Loretta L. Sanchez,242
+Trinity,WILDWOOD,U.S. Senate,,DEM,Kamala D. Harris,5
+Trinity,WILDWOOD,U.S. Senate,,DEM,Loretta L. Sanchez,9
+Trinity,ZENIA,U.S. Senate,,DEM,Kamala D. Harris,27
+Trinity,ZENIA,U.S. Senate,,DEM,Loretta L. Sanchez,41

--- a/2016/20161108__ca__general__tulare__precinct.csv
+++ b/2016/20161108__ca__general__tulare__precinct.csv
@@ -10079,507 +10079,507 @@ Tulare,599823,Proposition 67,,N/A,Yes,31
 Tulare,599823,Proposition 67,,N/A,No,52
 Tulare,599824,Proposition 67,,N/A,Yes,5
 Tulare,599824,Proposition 67,,N/A,No,1
-Tulare,102004,U.S. Senate,,DEM,Kamala Harris,282
-Tulare,102004,U.S. Senate,,DEM,Loretta Sanchez,233
-Tulare,102022,U.S. Senate,,DEM,Kamala Harris,97
-Tulare,102022,U.S. Senate,,DEM,Loretta Sanchez,77
-Tulare,102801,U.S. Senate,,DEM,Kamala Harris,933
-Tulare,102801,U.S. Senate,,DEM,Loretta Sanchez,697
-Tulare,102802,U.S. Senate,,DEM,Kamala Harris,108
-Tulare,102802,U.S. Senate,,DEM,Loretta Sanchez,70
-Tulare,102803,U.S. Senate,,DEM,Kamala Harris,0
-Tulare,102803,U.S. Senate,,DEM,Loretta Sanchez,0
-Tulare,103003,U.S. Senate,,DEM,Kamala Harris,231
-Tulare,103003,U.S. Senate,,DEM,Loretta Sanchez,366
-Tulare,103801,U.S. Senate,,DEM,Kamala Harris,455
-Tulare,103801,U.S. Senate,,DEM,Loretta Sanchez,650
-Tulare,106002,U.S. Senate,,DEM,Kamala Harris,682
-Tulare,106002,U.S. Senate,,DEM,Loretta Sanchez,506
-Tulare,106003,U.S. Senate,,DEM,Kamala Harris,562
-Tulare,106003,U.S. Senate,,DEM,Loretta Sanchez,434
-Tulare,106004,U.S. Senate,,DEM,Kamala Harris,807
-Tulare,106004,U.S. Senate,,DEM,Loretta Sanchez,654
-Tulare,106007,U.S. Senate,,DEM,Kamala Harris,516
-Tulare,106007,U.S. Senate,,DEM,Loretta Sanchez,337
-Tulare,106801,U.S. Senate,,DEM,Kamala Harris,67
-Tulare,106801,U.S. Senate,,DEM,Loretta Sanchez,51
-Tulare,106802,U.S. Senate,,DEM,Kamala Harris,136
-Tulare,106802,U.S. Senate,,DEM,Loretta Sanchez,123
-Tulare,106803,U.S. Senate,,DEM,Kamala Harris,128
-Tulare,106803,U.S. Senate,,DEM,Loretta Sanchez,108
-Tulare,106804,U.S. Senate,,DEM,Kamala Harris,33
-Tulare,106804,U.S. Senate,,DEM,Loretta Sanchez,38
-Tulare,106901,U.S. Senate,,DEM,Kamala Harris,687
-Tulare,106901,U.S. Senate,,DEM,Loretta Sanchez,597
-Tulare,106907,U.S. Senate,,DEM,Kamala Harris,631
-Tulare,106907,U.S. Senate,,DEM,Loretta Sanchez,520
-Tulare,108005,U.S. Senate,,DEM,Kamala Harris,464
-Tulare,108005,U.S. Senate,,DEM,Loretta Sanchez,680
-Tulare,108801,U.S. Senate,,DEM,Kamala Harris,134
-Tulare,108801,U.S. Senate,,DEM,Loretta Sanchez,205
-Tulare,108802,U.S. Senate,,DEM,Kamala Harris,0
-Tulare,108802,U.S. Senate,,DEM,Loretta Sanchez,0
-Tulare,199307,U.S. Senate,,DEM,Kamala Harris,146
-Tulare,199307,U.S. Senate,,DEM,Loretta Sanchez,77
-Tulare,199320,U.S. Senate,,DEM,Kamala Harris,413
-Tulare,199320,U.S. Senate,,DEM,Loretta Sanchez,209
-Tulare,199801,U.S. Senate,,DEM,Kamala Harris,23
-Tulare,199801,U.S. Senate,,DEM,Loretta Sanchez,15
-Tulare,199802,U.S. Senate,,DEM,Kamala Harris,304
-Tulare,199802,U.S. Senate,,DEM,Loretta Sanchez,252
-Tulare,199803,U.S. Senate,,DEM,Kamala Harris,31
-Tulare,199803,U.S. Senate,,DEM,Loretta Sanchez,22
-Tulare,199804,U.S. Senate,,DEM,Kamala Harris,69
-Tulare,199804,U.S. Senate,,DEM,Loretta Sanchez,47
-Tulare,199805,U.S. Senate,,DEM,Kamala Harris,217
-Tulare,199805,U.S. Senate,,DEM,Loretta Sanchez,187
-Tulare,199806,U.S. Senate,,DEM,Kamala Harris,248
-Tulare,199806,U.S. Senate,,DEM,Loretta Sanchez,307
-Tulare,199807,U.S. Senate,,DEM,Kamala Harris,3
-Tulare,199807,U.S. Senate,,DEM,Loretta Sanchez,8
-Tulare,199808,U.S. Senate,,DEM,Kamala Harris,7
-Tulare,199808,U.S. Senate,,DEM,Loretta Sanchez,4
-Tulare,199809,U.S. Senate,,DEM,Kamala Harris,53
-Tulare,199809,U.S. Senate,,DEM,Loretta Sanchez,63
-Tulare,199810,U.S. Senate,,DEM,Kamala Harris,1
-Tulare,199810,U.S. Senate,,DEM,Loretta Sanchez,0
-Tulare,199811,U.S. Senate,,DEM,Kamala Harris,20
-Tulare,199811,U.S. Senate,,DEM,Loretta Sanchez,23
-Tulare,199812,U.S. Senate,,DEM,Kamala Harris,85
-Tulare,199812,U.S. Senate,,DEM,Loretta Sanchez,103
-Tulare,199813,U.S. Senate,,DEM,Kamala Harris,0
-Tulare,199813,U.S. Senate,,DEM,Loretta Sanchez,0
-Tulare,199814,U.S. Senate,,DEM,Kamala Harris,0
-Tulare,199814,U.S. Senate,,DEM,Loretta Sanchez,0
-Tulare,199815,U.S. Senate,,DEM,Kamala Harris,0
-Tulare,199815,U.S. Senate,,DEM,Loretta Sanchez,0
-Tulare,199816,U.S. Senate,,DEM,Kamala Harris,2
-Tulare,199816,U.S. Senate,,DEM,Loretta Sanchez,1
-Tulare,199817,U.S. Senate,,DEM,Kamala Harris,143
-Tulare,199817,U.S. Senate,,DEM,Loretta Sanchez,154
-Tulare,199818,U.S. Senate,,DEM,Kamala Harris,9
-Tulare,199818,U.S. Senate,,DEM,Loretta Sanchez,13
-Tulare,199819,U.S. Senate,,DEM,Kamala Harris,19
-Tulare,199819,U.S. Senate,,DEM,Loretta Sanchez,11
-Tulare,199820,U.S. Senate,,DEM,Kamala Harris,0
-Tulare,199820,U.S. Senate,,DEM,Loretta Sanchez,0
-Tulare,199821,U.S. Senate,,DEM,Kamala Harris,23
-Tulare,199821,U.S. Senate,,DEM,Loretta Sanchez,41
-Tulare,199822,U.S. Senate,,DEM,Kamala Harris,19
-Tulare,199822,U.S. Senate,,DEM,Loretta Sanchez,12
-Tulare,199823,U.S. Senate,,DEM,Kamala Harris,1
-Tulare,199823,U.S. Senate,,DEM,Loretta Sanchez,4
-Tulare,199824,U.S. Senate,,DEM,Kamala Harris,34
-Tulare,199824,U.S. Senate,,DEM,Loretta Sanchez,45
-Tulare,199825,U.S. Senate,,DEM,Kamala Harris,0
-Tulare,199825,U.S. Senate,,DEM,Loretta Sanchez,0
-Tulare,199826,U.S. Senate,,DEM,Kamala Harris,189
-Tulare,199826,U.S. Senate,,DEM,Loretta Sanchez,142
-Tulare,199827,U.S. Senate,,DEM,Kamala Harris,125
-Tulare,199827,U.S. Senate,,DEM,Loretta Sanchez,72
-Tulare,199828,U.S. Senate,,DEM,Kamala Harris,129
-Tulare,199828,U.S. Senate,,DEM,Loretta Sanchez,115
-Tulare,199829,U.S. Senate,,DEM,Kamala Harris,5
-Tulare,199829,U.S. Senate,,DEM,Loretta Sanchez,2
-Tulare,199830,U.S. Senate,,DEM,Kamala Harris,95
-Tulare,199830,U.S. Senate,,DEM,Loretta Sanchez,110
-Tulare,199831,U.S. Senate,,DEM,Kamala Harris,11
-Tulare,199831,U.S. Senate,,DEM,Loretta Sanchez,19
-Tulare,199832,U.S. Senate,,DEM,Kamala Harris,0
-Tulare,199832,U.S. Senate,,DEM,Loretta Sanchez,2
-Tulare,199833,U.S. Senate,,DEM,Kamala Harris,0
-Tulare,199833,U.S. Senate,,DEM,Loretta Sanchez,0
-Tulare,199834,U.S. Senate,,DEM,Kamala Harris,2
-Tulare,199834,U.S. Senate,,DEM,Loretta Sanchez,1
-Tulare,199835,U.S. Senate,,DEM,Kamala Harris,49
-Tulare,199835,U.S. Senate,,DEM,Loretta Sanchez,43
-Tulare,199836,U.S. Senate,,DEM,Kamala Harris,0
-Tulare,199836,U.S. Senate,,DEM,Loretta Sanchez,0
-Tulare,199837,U.S. Senate,,DEM,Kamala Harris,324
-Tulare,199837,U.S. Senate,,DEM,Loretta Sanchez,407
-Tulare,199838,U.S. Senate,,DEM,Kamala Harris,12
-Tulare,199838,U.S. Senate,,DEM,Loretta Sanchez,3
-Tulare,199839,U.S. Senate,,DEM,Kamala Harris,86
-Tulare,199839,U.S. Senate,,DEM,Loretta Sanchez,111
-Tulare,199840,U.S. Senate,,DEM,Kamala Harris,3
-Tulare,199840,U.S. Senate,,DEM,Loretta Sanchez,1
-Tulare,199841,U.S. Senate,,DEM,Kamala Harris,35
-Tulare,199841,U.S. Senate,,DEM,Loretta Sanchez,32
-Tulare,199842,U.S. Senate,,DEM,Kamala Harris,8
-Tulare,199842,U.S. Senate,,DEM,Loretta Sanchez,32
-Tulare,199843,U.S. Senate,,DEM,Kamala Harris,1
-Tulare,199843,U.S. Senate,,DEM,Loretta Sanchez,3
-Tulare,199844,U.S. Senate,,DEM,Kamala Harris,50
-Tulare,199844,U.S. Senate,,DEM,Loretta Sanchez,42
-Tulare,199845,U.S. Senate,,DEM,Kamala Harris,4
-Tulare,199845,U.S. Senate,,DEM,Loretta Sanchez,0
-Tulare,199846,U.S. Senate,,DEM,Kamala Harris,0
-Tulare,199846,U.S. Senate,,DEM,Loretta Sanchez,0
-Tulare,199847,U.S. Senate,,DEM,Kamala Harris,15
-Tulare,199847,U.S. Senate,,DEM,Loretta Sanchez,8
-Tulare,199848,U.S. Senate,,DEM,Kamala Harris,3
-Tulare,199848,U.S. Senate,,DEM,Loretta Sanchez,0
-Tulare,199849,U.S. Senate,,DEM,Kamala Harris,1
-Tulare,199849,U.S. Senate,,DEM,Loretta Sanchez,1
-Tulare,199850,U.S. Senate,,DEM,Kamala Harris,0
-Tulare,199850,U.S. Senate,,DEM,Loretta Sanchez,0
-Tulare,205105,U.S. Senate,,DEM,Kamala Harris,368
-Tulare,205105,U.S. Senate,,DEM,Loretta Sanchez,422
-Tulare,205106,U.S. Senate,,DEM,Kamala Harris,219
-Tulare,205106,U.S. Senate,,DEM,Loretta Sanchez,367
-Tulare,205201,U.S. Senate,,DEM,Kamala Harris,505
-Tulare,205201,U.S. Senate,,DEM,Loretta Sanchez,602
-Tulare,205302,U.S. Senate,,DEM,Kamala Harris,106
-Tulare,205302,U.S. Senate,,DEM,Loretta Sanchez,94
-Tulare,205304,U.S. Senate,,DEM,Kamala Harris,487
-Tulare,205304,U.S. Senate,,DEM,Loretta Sanchez,440
-Tulare,205308,U.S. Senate,,DEM,Kamala Harris,313
-Tulare,205308,U.S. Senate,,DEM,Loretta Sanchez,363
-Tulare,205401,U.S. Senate,,DEM,Kamala Harris,556
-Tulare,205401,U.S. Senate,,DEM,Loretta Sanchez,374
-Tulare,205406,U.S. Senate,,DEM,Kamala Harris,490
-Tulare,205406,U.S. Senate,,DEM,Loretta Sanchez,292
-Tulare,205418,U.S. Senate,,DEM,Kamala Harris,114
-Tulare,205418,U.S. Senate,,DEM,Loretta Sanchez,85
-Tulare,205501,U.S. Senate,,DEM,Kamala Harris,623
-Tulare,205501,U.S. Senate,,DEM,Loretta Sanchez,518
-Tulare,205502,U.S. Senate,,DEM,Kamala Harris,586
-Tulare,205502,U.S. Senate,,DEM,Loretta Sanchez,430
-Tulare,205507,U.S. Senate,,DEM,Kamala Harris,581
-Tulare,205507,U.S. Senate,,DEM,Loretta Sanchez,413
-Tulare,205515,U.S. Senate,,DEM,Kamala Harris,173
-Tulare,205515,U.S. Senate,,DEM,Loretta Sanchez,141
-Tulare,205801,U.S. Senate,,DEM,Kamala Harris,156
-Tulare,205801,U.S. Senate,,DEM,Loretta Sanchez,199
-Tulare,205802,U.S. Senate,,DEM,Kamala Harris,39
-Tulare,205802,U.S. Senate,,DEM,Loretta Sanchez,69
-Tulare,205803,U.S. Senate,,DEM,Kamala Harris,6
-Tulare,205803,U.S. Senate,,DEM,Loretta Sanchez,17
-Tulare,205804,U.S. Senate,,DEM,Kamala Harris,329
-Tulare,205804,U.S. Senate,,DEM,Loretta Sanchez,366
-Tulare,205805,U.S. Senate,,DEM,Kamala Harris,178
-Tulare,205805,U.S. Senate,,DEM,Loretta Sanchez,127
-Tulare,205806,U.S. Senate,,DEM,Kamala Harris,285
-Tulare,205806,U.S. Senate,,DEM,Loretta Sanchez,301
-Tulare,205807,U.S. Senate,,DEM,Kamala Harris,43
-Tulare,205807,U.S. Senate,,DEM,Loretta Sanchez,42
-Tulare,205808,U.S. Senate,,DEM,Kamala Harris,76
-Tulare,205808,U.S. Senate,,DEM,Loretta Sanchez,62
-Tulare,205809,U.S. Senate,,DEM,Kamala Harris,52
-Tulare,205809,U.S. Senate,,DEM,Loretta Sanchez,39
-Tulare,205810,U.S. Senate,,DEM,Kamala Harris,118
-Tulare,205810,U.S. Senate,,DEM,Loretta Sanchez,133
-Tulare,205811,U.S. Senate,,DEM,Kamala Harris,225
-Tulare,205811,U.S. Senate,,DEM,Loretta Sanchez,140
-Tulare,205812,U.S. Senate,,DEM,Kamala Harris,4
-Tulare,205812,U.S. Senate,,DEM,Loretta Sanchez,3
-Tulare,299701,U.S. Senate,,DEM,Kamala Harris,132
-Tulare,299701,U.S. Senate,,DEM,Loretta Sanchez,180
-Tulare,299748,U.S. Senate,,DEM,Kamala Harris,231
-Tulare,299748,U.S. Senate,,DEM,Loretta Sanchez,398
-Tulare,299801,U.S. Senate,,DEM,Kamala Harris,117
-Tulare,299801,U.S. Senate,,DEM,Loretta Sanchez,133
-Tulare,299802,U.S. Senate,,DEM,Kamala Harris,413
-Tulare,299802,U.S. Senate,,DEM,Loretta Sanchez,427
-Tulare,299803,U.S. Senate,,DEM,Kamala Harris,1
-Tulare,299803,U.S. Senate,,DEM,Loretta Sanchez,0
-Tulare,299804,U.S. Senate,,DEM,Kamala Harris,229
-Tulare,299804,U.S. Senate,,DEM,Loretta Sanchez,214
-Tulare,299805,U.S. Senate,,DEM,Kamala Harris,298
-Tulare,299805,U.S. Senate,,DEM,Loretta Sanchez,330
-Tulare,299806,U.S. Senate,,DEM,Kamala Harris,63
-Tulare,299806,U.S. Senate,,DEM,Loretta Sanchez,71
-Tulare,299807,U.S. Senate,,DEM,Kamala Harris,5
-Tulare,299807,U.S. Senate,,DEM,Loretta Sanchez,1
-Tulare,299808,U.S. Senate,,DEM,Kamala Harris,2
-Tulare,299808,U.S. Senate,,DEM,Loretta Sanchez,3
-Tulare,299809,U.S. Senate,,DEM,Kamala Harris,3
-Tulare,299809,U.S. Senate,,DEM,Loretta Sanchez,12
-Tulare,299810,U.S. Senate,,DEM,Kamala Harris,23
-Tulare,299810,U.S. Senate,,DEM,Loretta Sanchez,50
-Tulare,299811,U.S. Senate,,DEM,Kamala Harris,0
-Tulare,299811,U.S. Senate,,DEM,Loretta Sanchez,0
-Tulare,299812,U.S. Senate,,DEM,Kamala Harris,13
-Tulare,299812,U.S. Senate,,DEM,Loretta Sanchez,19
-Tulare,299813,U.S. Senate,,DEM,Kamala Harris,127
-Tulare,299813,U.S. Senate,,DEM,Loretta Sanchez,175
-Tulare,299814,U.S. Senate,,DEM,Kamala Harris,1
-Tulare,299814,U.S. Senate,,DEM,Loretta Sanchez,0
-Tulare,299815,U.S. Senate,,DEM,Kamala Harris,0
-Tulare,299815,U.S. Senate,,DEM,Loretta Sanchez,0
-Tulare,299816,U.S. Senate,,DEM,Kamala Harris,0
-Tulare,299816,U.S. Senate,,DEM,Loretta Sanchez,2
-Tulare,299817,U.S. Senate,,DEM,Kamala Harris,21
-Tulare,299817,U.S. Senate,,DEM,Loretta Sanchez,14
-Tulare,299818,U.S. Senate,,DEM,Kamala Harris,0
-Tulare,299818,U.S. Senate,,DEM,Loretta Sanchez,0
-Tulare,299819,U.S. Senate,,DEM,Kamala Harris,14
-Tulare,299819,U.S. Senate,,DEM,Loretta Sanchez,16
-Tulare,299820,U.S. Senate,,DEM,Kamala Harris,15
-Tulare,299820,U.S. Senate,,DEM,Loretta Sanchez,14
-Tulare,299821,U.S. Senate,,DEM,Kamala Harris,0
-Tulare,299821,U.S. Senate,,DEM,Loretta Sanchez,1
-Tulare,299822,U.S. Senate,,DEM,Kamala Harris,49
-Tulare,299822,U.S. Senate,,DEM,Loretta Sanchez,63
-Tulare,299823,U.S. Senate,,DEM,Kamala Harris,0
-Tulare,299823,U.S. Senate,,DEM,Loretta Sanchez,0
-Tulare,299824,U.S. Senate,,DEM,Kamala Harris,0
-Tulare,299824,U.S. Senate,,DEM,Loretta Sanchez,1
-Tulare,299825,U.S. Senate,,DEM,Kamala Harris,0
-Tulare,299825,U.S. Senate,,DEM,Loretta Sanchez,0
-Tulare,306001,U.S. Senate,,DEM,Kamala Harris,736
-Tulare,306001,U.S. Senate,,DEM,Loretta Sanchez,525
-Tulare,306003,U.S. Senate,,DEM,Kamala Harris,400
-Tulare,306003,U.S. Senate,,DEM,Loretta Sanchez,337
-Tulare,306008,U.S. Senate,,DEM,Kamala Harris,431
-Tulare,306008,U.S. Senate,,DEM,Loretta Sanchez,293
-Tulare,306009,U.S. Senate,,DEM,Kamala Harris,736
-Tulare,306009,U.S. Senate,,DEM,Loretta Sanchez,498
-Tulare,306013,U.S. Senate,,DEM,Kamala Harris,489
-Tulare,306013,U.S. Senate,,DEM,Loretta Sanchez,364
-Tulare,306014,U.S. Senate,,DEM,Kamala Harris,592
-Tulare,306014,U.S. Senate,,DEM,Loretta Sanchez,449
-Tulare,306017,U.S. Senate,,DEM,Kamala Harris,487
-Tulare,306017,U.S. Senate,,DEM,Loretta Sanchez,388
-Tulare,306019,U.S. Senate,,DEM,Kamala Harris,570
-Tulare,306019,U.S. Senate,,DEM,Loretta Sanchez,423
-Tulare,306021,U.S. Senate,,DEM,Kamala Harris,717
-Tulare,306021,U.S. Senate,,DEM,Loretta Sanchez,469
-Tulare,306029,U.S. Senate,,DEM,Kamala Harris,469
-Tulare,306029,U.S. Senate,,DEM,Loretta Sanchez,374
-Tulare,306036,U.S. Senate,,DEM,Kamala Harris,583
-Tulare,306036,U.S. Senate,,DEM,Loretta Sanchez,451
-Tulare,306037,U.S. Senate,,DEM,Kamala Harris,248
-Tulare,306037,U.S. Senate,,DEM,Loretta Sanchez,226
-Tulare,306040,U.S. Senate,,DEM,Kamala Harris,547
-Tulare,306040,U.S. Senate,,DEM,Loretta Sanchez,343
-Tulare,306043,U.S. Senate,,DEM,Kamala Harris,421
-Tulare,306043,U.S. Senate,,DEM,Loretta Sanchez,322
-Tulare,306801,U.S. Senate,,DEM,Kamala Harris,47
-Tulare,306801,U.S. Senate,,DEM,Loretta Sanchez,33
-Tulare,306802,U.S. Senate,,DEM,Kamala Harris,162
-Tulare,306802,U.S. Senate,,DEM,Loretta Sanchez,107
-Tulare,306803,U.S. Senate,,DEM,Kamala Harris,227
-Tulare,306803,U.S. Senate,,DEM,Loretta Sanchez,155
-Tulare,306804,U.S. Senate,,DEM,Kamala Harris,281
-Tulare,306804,U.S. Senate,,DEM,Loretta Sanchez,231
-Tulare,306805,U.S. Senate,,DEM,Kamala Harris,2
-Tulare,306805,U.S. Senate,,DEM,Loretta Sanchez,4
-Tulare,306806,U.S. Senate,,DEM,Kamala Harris,80
-Tulare,306806,U.S. Senate,,DEM,Loretta Sanchez,51
-Tulare,306807,U.S. Senate,,DEM,Kamala Harris,235
-Tulare,306807,U.S. Senate,,DEM,Loretta Sanchez,158
-Tulare,306808,U.S. Senate,,DEM,Kamala Harris,163
-Tulare,306808,U.S. Senate,,DEM,Loretta Sanchez,243
-Tulare,306910,U.S. Senate,,DEM,Kamala Harris,491
-Tulare,306910,U.S. Senate,,DEM,Loretta Sanchez,323
-Tulare,306912,U.S. Senate,,DEM,Kamala Harris,739
-Tulare,306912,U.S. Senate,,DEM,Loretta Sanchez,515
-Tulare,306914,U.S. Senate,,DEM,Kamala Harris,558
-Tulare,306914,U.S. Senate,,DEM,Loretta Sanchez,383
-Tulare,306915,U.S. Senate,,DEM,Kamala Harris,313
-Tulare,306915,U.S. Senate,,DEM,Loretta Sanchez,461
-Tulare,306918,U.S. Senate,,DEM,Kamala Harris,168
-Tulare,306918,U.S. Senate,,DEM,Loretta Sanchez,181
-Tulare,306923,U.S. Senate,,DEM,Kamala Harris,635
-Tulare,306923,U.S. Senate,,DEM,Loretta Sanchez,565
-Tulare,306931,U.S. Senate,,DEM,Kamala Harris,638
-Tulare,306931,U.S. Senate,,DEM,Loretta Sanchez,470
-Tulare,306933,U.S. Senate,,DEM,Kamala Harris,748
-Tulare,306933,U.S. Senate,,DEM,Loretta Sanchez,544
-Tulare,306955,U.S. Senate,,DEM,Kamala Harris,575
-Tulare,306955,U.S. Senate,,DEM,Loretta Sanchez,408
-Tulare,399801,U.S. Senate,,DEM,Kamala Harris,0
-Tulare,399801,U.S. Senate,,DEM,Loretta Sanchez,1
-Tulare,399802,U.S. Senate,,DEM,Kamala Harris,12
-Tulare,399802,U.S. Senate,,DEM,Loretta Sanchez,10
-Tulare,399803,U.S. Senate,,DEM,Kamala Harris,177
-Tulare,399803,U.S. Senate,,DEM,Loretta Sanchez,130
-Tulare,399804,U.S. Senate,,DEM,Kamala Harris,0
-Tulare,399804,U.S. Senate,,DEM,Loretta Sanchez,2
-Tulare,399805,U.S. Senate,,DEM,Kamala Harris,8
-Tulare,399805,U.S. Senate,,DEM,Loretta Sanchez,8
-Tulare,399806,U.S. Senate,,DEM,Kamala Harris,11
-Tulare,399806,U.S. Senate,,DEM,Loretta Sanchez,10
-Tulare,399807,U.S. Senate,,DEM,Kamala Harris,0
-Tulare,399807,U.S. Senate,,DEM,Loretta Sanchez,2
-Tulare,399808,U.S. Senate,,DEM,Kamala Harris,0
-Tulare,399808,U.S. Senate,,DEM,Loretta Sanchez,0
-Tulare,401101,U.S. Senate,,DEM,Kamala Harris,170
-Tulare,401101,U.S. Senate,,DEM,Loretta Sanchez,253
-Tulare,401203,U.S. Senate,,DEM,Kamala Harris,351
-Tulare,401203,U.S. Senate,,DEM,Loretta Sanchez,544
-Tulare,401306,U.S. Senate,,DEM,Kamala Harris,295
-Tulare,401306,U.S. Senate,,DEM,Loretta Sanchez,340
-Tulare,401801,U.S. Senate,,DEM,Kamala Harris,474
-Tulare,401801,U.S. Senate,,DEM,Loretta Sanchez,629
-Tulare,401802,U.S. Senate,,DEM,Kamala Harris,422
-Tulare,401802,U.S. Senate,,DEM,Loretta Sanchez,482
-Tulare,406801,U.S. Senate,,DEM,Kamala Harris,85
-Tulare,406801,U.S. Senate,,DEM,Loretta Sanchez,93
-Tulare,406905,U.S. Senate,,DEM,Kamala Harris,189
-Tulare,406905,U.S. Senate,,DEM,Loretta Sanchez,139
-Tulare,406917,U.S. Senate,,DEM,Kamala Harris,525
-Tulare,406917,U.S. Senate,,DEM,Loretta Sanchez,416
-Tulare,406920,U.S. Senate,,DEM,Kamala Harris,212
-Tulare,406920,U.S. Senate,,DEM,Loretta Sanchez,314
-Tulare,407001,U.S. Senate,,DEM,Kamala Harris,86
-Tulare,407001,U.S. Senate,,DEM,Loretta Sanchez,133
-Tulare,407004,U.S. Senate,,DEM,Kamala Harris,240
-Tulare,407004,U.S. Senate,,DEM,Loretta Sanchez,360
-Tulare,407801,U.S. Senate,,DEM,Kamala Harris,70
-Tulare,407801,U.S. Senate,,DEM,Loretta Sanchez,127
-Tulare,407802,U.S. Senate,,DEM,Kamala Harris,49
-Tulare,407802,U.S. Senate,,DEM,Loretta Sanchez,84
-Tulare,499006,U.S. Senate,,DEM,Kamala Harris,119
-Tulare,499006,U.S. Senate,,DEM,Loretta Sanchez,205
-Tulare,499044,U.S. Senate,,DEM,Kamala Harris,106
-Tulare,499044,U.S. Senate,,DEM,Loretta Sanchez,106
-Tulare,499102,U.S. Senate,,DEM,Kamala Harris,291
-Tulare,499102,U.S. Senate,,DEM,Loretta Sanchez,220
-Tulare,499126,U.S. Senate,,DEM,Kamala Harris,91
-Tulare,499126,U.S. Senate,,DEM,Loretta Sanchez,138
-Tulare,499132,U.S. Senate,,DEM,Kamala Harris,111
-Tulare,499132,U.S. Senate,,DEM,Loretta Sanchez,191
-Tulare,499249,U.S. Senate,,DEM,Kamala Harris,151
-Tulare,499249,U.S. Senate,,DEM,Loretta Sanchez,289
-Tulare,499801,U.S. Senate,,DEM,Kamala Harris,621
-Tulare,499801,U.S. Senate,,DEM,Loretta Sanchez,756
-Tulare,499802,U.S. Senate,,DEM,Kamala Harris,49
-Tulare,499802,U.S. Senate,,DEM,Loretta Sanchez,46
-Tulare,499803,U.S. Senate,,DEM,Kamala Harris,22
-Tulare,499803,U.S. Senate,,DEM,Loretta Sanchez,9
-Tulare,499804,U.S. Senate,,DEM,Kamala Harris,218
-Tulare,499804,U.S. Senate,,DEM,Loretta Sanchez,292
-Tulare,499805,U.S. Senate,,DEM,Kamala Harris,1
-Tulare,499805,U.S. Senate,,DEM,Loretta Sanchez,1
-Tulare,499806,U.S. Senate,,DEM,Kamala Harris,456
-Tulare,499806,U.S. Senate,,DEM,Loretta Sanchez,467
-Tulare,499807,U.S. Senate,,DEM,Kamala Harris,60
-Tulare,499807,U.S. Senate,,DEM,Loretta Sanchez,20
-Tulare,499808,U.S. Senate,,DEM,Kamala Harris,83
-Tulare,499808,U.S. Senate,,DEM,Loretta Sanchez,81
-Tulare,499809,U.S. Senate,,DEM,Kamala Harris,24
-Tulare,499809,U.S. Senate,,DEM,Loretta Sanchez,39
-Tulare,499810,U.S. Senate,,DEM,Kamala Harris,147
-Tulare,499810,U.S. Senate,,DEM,Loretta Sanchez,218
-Tulare,499811,U.S. Senate,,DEM,Kamala Harris,282
-Tulare,499811,U.S. Senate,,DEM,Loretta Sanchez,402
-Tulare,499812,U.S. Senate,,DEM,Kamala Harris,44
-Tulare,499812,U.S. Senate,,DEM,Loretta Sanchez,40
-Tulare,499813,U.S. Senate,,DEM,Kamala Harris,81
-Tulare,499813,U.S. Senate,,DEM,Loretta Sanchez,180
-Tulare,499814,U.S. Senate,,DEM,Kamala Harris,1
-Tulare,499814,U.S. Senate,,DEM,Loretta Sanchez,7
-Tulare,499815,U.S. Senate,,DEM,Kamala Harris,184
-Tulare,499815,U.S. Senate,,DEM,Loretta Sanchez,353
-Tulare,499816,U.S. Senate,,DEM,Kamala Harris,51
-Tulare,499816,U.S. Senate,,DEM,Loretta Sanchez,33
-Tulare,499817,U.S. Senate,,DEM,Kamala Harris,18
-Tulare,499817,U.S. Senate,,DEM,Loretta Sanchez,24
-Tulare,499818,U.S. Senate,,DEM,Kamala Harris,76
-Tulare,499818,U.S. Senate,,DEM,Loretta Sanchez,70
-Tulare,499819,U.S. Senate,,DEM,Kamala Harris,0
-Tulare,499819,U.S. Senate,,DEM,Loretta Sanchez,0
-Tulare,499820,U.S. Senate,,DEM,Kamala Harris,23
-Tulare,499820,U.S. Senate,,DEM,Loretta Sanchez,41
-Tulare,499821,U.S. Senate,,DEM,Kamala Harris,31
-Tulare,499821,U.S. Senate,,DEM,Loretta Sanchez,25
-Tulare,499822,U.S. Senate,,DEM,Kamala Harris,164
-Tulare,499822,U.S. Senate,,DEM,Loretta Sanchez,134
-Tulare,499823,U.S. Senate,,DEM,Kamala Harris,46
-Tulare,499823,U.S. Senate,,DEM,Loretta Sanchez,50
-Tulare,499824,U.S. Senate,,DEM,Kamala Harris,71
-Tulare,499824,U.S. Senate,,DEM,Loretta Sanchez,82
-Tulare,504001,U.S. Senate,,DEM,Kamala Harris,278
-Tulare,504001,U.S. Senate,,DEM,Loretta Sanchez,527
-Tulare,504002,U.S. Senate,,DEM,Kamala Harris,356
-Tulare,504002,U.S. Senate,,DEM,Loretta Sanchez,308
-Tulare,504005,U.S. Senate,,DEM,Kamala Harris,155
-Tulare,504005,U.S. Senate,,DEM,Loretta Sanchez,96
-Tulare,504013,U.S. Senate,,DEM,Kamala Harris,118
-Tulare,504013,U.S. Senate,,DEM,Loretta Sanchez,111
-Tulare,504801,U.S. Senate,,DEM,Kamala Harris,957
-Tulare,504801,U.S. Senate,,DEM,Loretta Sanchez,969
-Tulare,504802,U.S. Senate,,DEM,Kamala Harris,71
-Tulare,504802,U.S. Senate,,DEM,Loretta Sanchez,78
-Tulare,504803,U.S. Senate,,DEM,Kamala Harris,2
-Tulare,504803,U.S. Senate,,DEM,Loretta Sanchez,2
-Tulare,504804,U.S. Senate,,DEM,Kamala Harris,103
-Tulare,504804,U.S. Senate,,DEM,Loretta Sanchez,75
-Tulare,504805,U.S. Senate,,DEM,Kamala Harris,129
-Tulare,504805,U.S. Senate,,DEM,Loretta Sanchez,110
-Tulare,504806,U.S. Senate,,DEM,Kamala Harris,436
-Tulare,504806,U.S. Senate,,DEM,Loretta Sanchez,319
-Tulare,504901,U.S. Senate,,DEM,Kamala Harris,179
-Tulare,504901,U.S. Senate,,DEM,Loretta Sanchez,186
-Tulare,504904,U.S. Senate,,DEM,Kamala Harris,203
-Tulare,504904,U.S. Senate,,DEM,Loretta Sanchez,137
-Tulare,504905,U.S. Senate,,DEM,Kamala Harris,550
-Tulare,504905,U.S. Senate,,DEM,Loretta Sanchez,473
-Tulare,504907,U.S. Senate,,DEM,Kamala Harris,460
-Tulare,504907,U.S. Senate,,DEM,Loretta Sanchez,341
-Tulare,504920,U.S. Senate,,DEM,Kamala Harris,216
-Tulare,504920,U.S. Senate,,DEM,Loretta Sanchez,229
-Tulare,504930,U.S. Senate,,DEM,Kamala Harris,429
-Tulare,504930,U.S. Senate,,DEM,Loretta Sanchez,389
-Tulare,504935,U.S. Senate,,DEM,Kamala Harris,381
-Tulare,504935,U.S. Senate,,DEM,Loretta Sanchez,374
-Tulare,504945,U.S. Senate,,DEM,Kamala Harris,312
-Tulare,504945,U.S. Senate,,DEM,Loretta Sanchez,340
-Tulare,599306,U.S. Senate,,DEM,Kamala Harris,330
-Tulare,599306,U.S. Senate,,DEM,Loretta Sanchez,219
-Tulare,599361,U.S. Senate,,DEM,Kamala Harris,428
-Tulare,599361,U.S. Senate,,DEM,Loretta Sanchez,260
-Tulare,599634,U.S. Senate,,DEM,Kamala Harris,127
-Tulare,599634,U.S. Senate,,DEM,Loretta Sanchez,136
-Tulare,599693,U.S. Senate,,DEM,Kamala Harris,116
-Tulare,599693,U.S. Senate,,DEM,Loretta Sanchez,192
-Tulare,599801,U.S. Senate,,DEM,Kamala Harris,0
-Tulare,599801,U.S. Senate,,DEM,Loretta Sanchez,1
-Tulare,599802,U.S. Senate,,DEM,Kamala Harris,402
-Tulare,599802,U.S. Senate,,DEM,Loretta Sanchez,576
-Tulare,599803,U.S. Senate,,DEM,Kamala Harris,58
-Tulare,599803,U.S. Senate,,DEM,Loretta Sanchez,95
-Tulare,599804,U.S. Senate,,DEM,Kamala Harris,14
-Tulare,599804,U.S. Senate,,DEM,Loretta Sanchez,5
-Tulare,599805,U.S. Senate,,DEM,Kamala Harris,835
-Tulare,599805,U.S. Senate,,DEM,Loretta Sanchez,822
-Tulare,599806,U.S. Senate,,DEM,Kamala Harris,413
-Tulare,599806,U.S. Senate,,DEM,Loretta Sanchez,366
-Tulare,599807,U.S. Senate,,DEM,Kamala Harris,0
-Tulare,599807,U.S. Senate,,DEM,Loretta Sanchez,0
-Tulare,599808,U.S. Senate,,DEM,Kamala Harris,4
-Tulare,599808,U.S. Senate,,DEM,Loretta Sanchez,4
-Tulare,599809,U.S. Senate,,DEM,Kamala Harris,4
-Tulare,599809,U.S. Senate,,DEM,Loretta Sanchez,0
-Tulare,599810,U.S. Senate,,DEM,Kamala Harris,59
-Tulare,599810,U.S. Senate,,DEM,Loretta Sanchez,38
-Tulare,599811,U.S. Senate,,DEM,Kamala Harris,4
-Tulare,599811,U.S. Senate,,DEM,Loretta Sanchez,0
-Tulare,599812,U.S. Senate,,DEM,Kamala Harris,35
-Tulare,599812,U.S. Senate,,DEM,Loretta Sanchez,9
-Tulare,599813,U.S. Senate,,DEM,Kamala Harris,39
-Tulare,599813,U.S. Senate,,DEM,Loretta Sanchez,39
-Tulare,599814,U.S. Senate,,DEM,Kamala Harris,2
-Tulare,599814,U.S. Senate,,DEM,Loretta Sanchez,4
-Tulare,599815,U.S. Senate,,DEM,Kamala Harris,9
-Tulare,599815,U.S. Senate,,DEM,Loretta Sanchez,4
-Tulare,599816,U.S. Senate,,DEM,Kamala Harris,17
-Tulare,599816,U.S. Senate,,DEM,Loretta Sanchez,17
-Tulare,599817,U.S. Senate,,DEM,Kamala Harris,4
-Tulare,599817,U.S. Senate,,DEM,Loretta Sanchez,7
-Tulare,599818,U.S. Senate,,DEM,Kamala Harris,0
-Tulare,599818,U.S. Senate,,DEM,Loretta Sanchez,0
-Tulare,599819,U.S. Senate,,DEM,Kamala Harris,0
-Tulare,599819,U.S. Senate,,DEM,Loretta Sanchez,1
-Tulare,599820,U.S. Senate,,DEM,Kamala Harris,0
-Tulare,599820,U.S. Senate,,DEM,Loretta Sanchez,0
-Tulare,599821,U.S. Senate,,DEM,Kamala Harris,16
-Tulare,599821,U.S. Senate,,DEM,Loretta Sanchez,12
-Tulare,599822,U.S. Senate,,DEM,Kamala Harris,3
-Tulare,599822,U.S. Senate,,DEM,Loretta Sanchez,1
-Tulare,599823,U.S. Senate,,DEM,Kamala Harris,44
-Tulare,599823,U.S. Senate,,DEM,Loretta Sanchez,25
-Tulare,599824,U.S. Senate,,DEM,Kamala Harris,2
-Tulare,599824,U.S. Senate,,DEM,Loretta Sanchez,4
+Tulare,102004,U.S. Senate,,DEM,Kamala D. Harris,282
+Tulare,102004,U.S. Senate,,DEM,Loretta L. Sanchez,233
+Tulare,102022,U.S. Senate,,DEM,Kamala D. Harris,97
+Tulare,102022,U.S. Senate,,DEM,Loretta L. Sanchez,77
+Tulare,102801,U.S. Senate,,DEM,Kamala D. Harris,933
+Tulare,102801,U.S. Senate,,DEM,Loretta L. Sanchez,697
+Tulare,102802,U.S. Senate,,DEM,Kamala D. Harris,108
+Tulare,102802,U.S. Senate,,DEM,Loretta L. Sanchez,70
+Tulare,102803,U.S. Senate,,DEM,Kamala D. Harris,0
+Tulare,102803,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Tulare,103003,U.S. Senate,,DEM,Kamala D. Harris,231
+Tulare,103003,U.S. Senate,,DEM,Loretta L. Sanchez,366
+Tulare,103801,U.S. Senate,,DEM,Kamala D. Harris,455
+Tulare,103801,U.S. Senate,,DEM,Loretta L. Sanchez,650
+Tulare,106002,U.S. Senate,,DEM,Kamala D. Harris,682
+Tulare,106002,U.S. Senate,,DEM,Loretta L. Sanchez,506
+Tulare,106003,U.S. Senate,,DEM,Kamala D. Harris,562
+Tulare,106003,U.S. Senate,,DEM,Loretta L. Sanchez,434
+Tulare,106004,U.S. Senate,,DEM,Kamala D. Harris,807
+Tulare,106004,U.S. Senate,,DEM,Loretta L. Sanchez,654
+Tulare,106007,U.S. Senate,,DEM,Kamala D. Harris,516
+Tulare,106007,U.S. Senate,,DEM,Loretta L. Sanchez,337
+Tulare,106801,U.S. Senate,,DEM,Kamala D. Harris,67
+Tulare,106801,U.S. Senate,,DEM,Loretta L. Sanchez,51
+Tulare,106802,U.S. Senate,,DEM,Kamala D. Harris,136
+Tulare,106802,U.S. Senate,,DEM,Loretta L. Sanchez,123
+Tulare,106803,U.S. Senate,,DEM,Kamala D. Harris,128
+Tulare,106803,U.S. Senate,,DEM,Loretta L. Sanchez,108
+Tulare,106804,U.S. Senate,,DEM,Kamala D. Harris,33
+Tulare,106804,U.S. Senate,,DEM,Loretta L. Sanchez,38
+Tulare,106901,U.S. Senate,,DEM,Kamala D. Harris,687
+Tulare,106901,U.S. Senate,,DEM,Loretta L. Sanchez,597
+Tulare,106907,U.S. Senate,,DEM,Kamala D. Harris,631
+Tulare,106907,U.S. Senate,,DEM,Loretta L. Sanchez,520
+Tulare,108005,U.S. Senate,,DEM,Kamala D. Harris,464
+Tulare,108005,U.S. Senate,,DEM,Loretta L. Sanchez,680
+Tulare,108801,U.S. Senate,,DEM,Kamala D. Harris,134
+Tulare,108801,U.S. Senate,,DEM,Loretta L. Sanchez,205
+Tulare,108802,U.S. Senate,,DEM,Kamala D. Harris,0
+Tulare,108802,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Tulare,199307,U.S. Senate,,DEM,Kamala D. Harris,146
+Tulare,199307,U.S. Senate,,DEM,Loretta L. Sanchez,77
+Tulare,199320,U.S. Senate,,DEM,Kamala D. Harris,413
+Tulare,199320,U.S. Senate,,DEM,Loretta L. Sanchez,209
+Tulare,199801,U.S. Senate,,DEM,Kamala D. Harris,23
+Tulare,199801,U.S. Senate,,DEM,Loretta L. Sanchez,15
+Tulare,199802,U.S. Senate,,DEM,Kamala D. Harris,304
+Tulare,199802,U.S. Senate,,DEM,Loretta L. Sanchez,252
+Tulare,199803,U.S. Senate,,DEM,Kamala D. Harris,31
+Tulare,199803,U.S. Senate,,DEM,Loretta L. Sanchez,22
+Tulare,199804,U.S. Senate,,DEM,Kamala D. Harris,69
+Tulare,199804,U.S. Senate,,DEM,Loretta L. Sanchez,47
+Tulare,199805,U.S. Senate,,DEM,Kamala D. Harris,217
+Tulare,199805,U.S. Senate,,DEM,Loretta L. Sanchez,187
+Tulare,199806,U.S. Senate,,DEM,Kamala D. Harris,248
+Tulare,199806,U.S. Senate,,DEM,Loretta L. Sanchez,307
+Tulare,199807,U.S. Senate,,DEM,Kamala D. Harris,3
+Tulare,199807,U.S. Senate,,DEM,Loretta L. Sanchez,8
+Tulare,199808,U.S. Senate,,DEM,Kamala D. Harris,7
+Tulare,199808,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Tulare,199809,U.S. Senate,,DEM,Kamala D. Harris,53
+Tulare,199809,U.S. Senate,,DEM,Loretta L. Sanchez,63
+Tulare,199810,U.S. Senate,,DEM,Kamala D. Harris,1
+Tulare,199810,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Tulare,199811,U.S. Senate,,DEM,Kamala D. Harris,20
+Tulare,199811,U.S. Senate,,DEM,Loretta L. Sanchez,23
+Tulare,199812,U.S. Senate,,DEM,Kamala D. Harris,85
+Tulare,199812,U.S. Senate,,DEM,Loretta L. Sanchez,103
+Tulare,199813,U.S. Senate,,DEM,Kamala D. Harris,0
+Tulare,199813,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Tulare,199814,U.S. Senate,,DEM,Kamala D. Harris,0
+Tulare,199814,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Tulare,199815,U.S. Senate,,DEM,Kamala D. Harris,0
+Tulare,199815,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Tulare,199816,U.S. Senate,,DEM,Kamala D. Harris,2
+Tulare,199816,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Tulare,199817,U.S. Senate,,DEM,Kamala D. Harris,143
+Tulare,199817,U.S. Senate,,DEM,Loretta L. Sanchez,154
+Tulare,199818,U.S. Senate,,DEM,Kamala D. Harris,9
+Tulare,199818,U.S. Senate,,DEM,Loretta L. Sanchez,13
+Tulare,199819,U.S. Senate,,DEM,Kamala D. Harris,19
+Tulare,199819,U.S. Senate,,DEM,Loretta L. Sanchez,11
+Tulare,199820,U.S. Senate,,DEM,Kamala D. Harris,0
+Tulare,199820,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Tulare,199821,U.S. Senate,,DEM,Kamala D. Harris,23
+Tulare,199821,U.S. Senate,,DEM,Loretta L. Sanchez,41
+Tulare,199822,U.S. Senate,,DEM,Kamala D. Harris,19
+Tulare,199822,U.S. Senate,,DEM,Loretta L. Sanchez,12
+Tulare,199823,U.S. Senate,,DEM,Kamala D. Harris,1
+Tulare,199823,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Tulare,199824,U.S. Senate,,DEM,Kamala D. Harris,34
+Tulare,199824,U.S. Senate,,DEM,Loretta L. Sanchez,45
+Tulare,199825,U.S. Senate,,DEM,Kamala D. Harris,0
+Tulare,199825,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Tulare,199826,U.S. Senate,,DEM,Kamala D. Harris,189
+Tulare,199826,U.S. Senate,,DEM,Loretta L. Sanchez,142
+Tulare,199827,U.S. Senate,,DEM,Kamala D. Harris,125
+Tulare,199827,U.S. Senate,,DEM,Loretta L. Sanchez,72
+Tulare,199828,U.S. Senate,,DEM,Kamala D. Harris,129
+Tulare,199828,U.S. Senate,,DEM,Loretta L. Sanchez,115
+Tulare,199829,U.S. Senate,,DEM,Kamala D. Harris,5
+Tulare,199829,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Tulare,199830,U.S. Senate,,DEM,Kamala D. Harris,95
+Tulare,199830,U.S. Senate,,DEM,Loretta L. Sanchez,110
+Tulare,199831,U.S. Senate,,DEM,Kamala D. Harris,11
+Tulare,199831,U.S. Senate,,DEM,Loretta L. Sanchez,19
+Tulare,199832,U.S. Senate,,DEM,Kamala D. Harris,0
+Tulare,199832,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Tulare,199833,U.S. Senate,,DEM,Kamala D. Harris,0
+Tulare,199833,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Tulare,199834,U.S. Senate,,DEM,Kamala D. Harris,2
+Tulare,199834,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Tulare,199835,U.S. Senate,,DEM,Kamala D. Harris,49
+Tulare,199835,U.S. Senate,,DEM,Loretta L. Sanchez,43
+Tulare,199836,U.S. Senate,,DEM,Kamala D. Harris,0
+Tulare,199836,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Tulare,199837,U.S. Senate,,DEM,Kamala D. Harris,324
+Tulare,199837,U.S. Senate,,DEM,Loretta L. Sanchez,407
+Tulare,199838,U.S. Senate,,DEM,Kamala D. Harris,12
+Tulare,199838,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Tulare,199839,U.S. Senate,,DEM,Kamala D. Harris,86
+Tulare,199839,U.S. Senate,,DEM,Loretta L. Sanchez,111
+Tulare,199840,U.S. Senate,,DEM,Kamala D. Harris,3
+Tulare,199840,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Tulare,199841,U.S. Senate,,DEM,Kamala D. Harris,35
+Tulare,199841,U.S. Senate,,DEM,Loretta L. Sanchez,32
+Tulare,199842,U.S. Senate,,DEM,Kamala D. Harris,8
+Tulare,199842,U.S. Senate,,DEM,Loretta L. Sanchez,32
+Tulare,199843,U.S. Senate,,DEM,Kamala D. Harris,1
+Tulare,199843,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Tulare,199844,U.S. Senate,,DEM,Kamala D. Harris,50
+Tulare,199844,U.S. Senate,,DEM,Loretta L. Sanchez,42
+Tulare,199845,U.S. Senate,,DEM,Kamala D. Harris,4
+Tulare,199845,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Tulare,199846,U.S. Senate,,DEM,Kamala D. Harris,0
+Tulare,199846,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Tulare,199847,U.S. Senate,,DEM,Kamala D. Harris,15
+Tulare,199847,U.S. Senate,,DEM,Loretta L. Sanchez,8
+Tulare,199848,U.S. Senate,,DEM,Kamala D. Harris,3
+Tulare,199848,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Tulare,199849,U.S. Senate,,DEM,Kamala D. Harris,1
+Tulare,199849,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Tulare,199850,U.S. Senate,,DEM,Kamala D. Harris,0
+Tulare,199850,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Tulare,205105,U.S. Senate,,DEM,Kamala D. Harris,368
+Tulare,205105,U.S. Senate,,DEM,Loretta L. Sanchez,422
+Tulare,205106,U.S. Senate,,DEM,Kamala D. Harris,219
+Tulare,205106,U.S. Senate,,DEM,Loretta L. Sanchez,367
+Tulare,205201,U.S. Senate,,DEM,Kamala D. Harris,505
+Tulare,205201,U.S. Senate,,DEM,Loretta L. Sanchez,602
+Tulare,205302,U.S. Senate,,DEM,Kamala D. Harris,106
+Tulare,205302,U.S. Senate,,DEM,Loretta L. Sanchez,94
+Tulare,205304,U.S. Senate,,DEM,Kamala D. Harris,487
+Tulare,205304,U.S. Senate,,DEM,Loretta L. Sanchez,440
+Tulare,205308,U.S. Senate,,DEM,Kamala D. Harris,313
+Tulare,205308,U.S. Senate,,DEM,Loretta L. Sanchez,363
+Tulare,205401,U.S. Senate,,DEM,Kamala D. Harris,556
+Tulare,205401,U.S. Senate,,DEM,Loretta L. Sanchez,374
+Tulare,205406,U.S. Senate,,DEM,Kamala D. Harris,490
+Tulare,205406,U.S. Senate,,DEM,Loretta L. Sanchez,292
+Tulare,205418,U.S. Senate,,DEM,Kamala D. Harris,114
+Tulare,205418,U.S. Senate,,DEM,Loretta L. Sanchez,85
+Tulare,205501,U.S. Senate,,DEM,Kamala D. Harris,623
+Tulare,205501,U.S. Senate,,DEM,Loretta L. Sanchez,518
+Tulare,205502,U.S. Senate,,DEM,Kamala D. Harris,586
+Tulare,205502,U.S. Senate,,DEM,Loretta L. Sanchez,430
+Tulare,205507,U.S. Senate,,DEM,Kamala D. Harris,581
+Tulare,205507,U.S. Senate,,DEM,Loretta L. Sanchez,413
+Tulare,205515,U.S. Senate,,DEM,Kamala D. Harris,173
+Tulare,205515,U.S. Senate,,DEM,Loretta L. Sanchez,141
+Tulare,205801,U.S. Senate,,DEM,Kamala D. Harris,156
+Tulare,205801,U.S. Senate,,DEM,Loretta L. Sanchez,199
+Tulare,205802,U.S. Senate,,DEM,Kamala D. Harris,39
+Tulare,205802,U.S. Senate,,DEM,Loretta L. Sanchez,69
+Tulare,205803,U.S. Senate,,DEM,Kamala D. Harris,6
+Tulare,205803,U.S. Senate,,DEM,Loretta L. Sanchez,17
+Tulare,205804,U.S. Senate,,DEM,Kamala D. Harris,329
+Tulare,205804,U.S. Senate,,DEM,Loretta L. Sanchez,366
+Tulare,205805,U.S. Senate,,DEM,Kamala D. Harris,178
+Tulare,205805,U.S. Senate,,DEM,Loretta L. Sanchez,127
+Tulare,205806,U.S. Senate,,DEM,Kamala D. Harris,285
+Tulare,205806,U.S. Senate,,DEM,Loretta L. Sanchez,301
+Tulare,205807,U.S. Senate,,DEM,Kamala D. Harris,43
+Tulare,205807,U.S. Senate,,DEM,Loretta L. Sanchez,42
+Tulare,205808,U.S. Senate,,DEM,Kamala D. Harris,76
+Tulare,205808,U.S. Senate,,DEM,Loretta L. Sanchez,62
+Tulare,205809,U.S. Senate,,DEM,Kamala D. Harris,52
+Tulare,205809,U.S. Senate,,DEM,Loretta L. Sanchez,39
+Tulare,205810,U.S. Senate,,DEM,Kamala D. Harris,118
+Tulare,205810,U.S. Senate,,DEM,Loretta L. Sanchez,133
+Tulare,205811,U.S. Senate,,DEM,Kamala D. Harris,225
+Tulare,205811,U.S. Senate,,DEM,Loretta L. Sanchez,140
+Tulare,205812,U.S. Senate,,DEM,Kamala D. Harris,4
+Tulare,205812,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Tulare,299701,U.S. Senate,,DEM,Kamala D. Harris,132
+Tulare,299701,U.S. Senate,,DEM,Loretta L. Sanchez,180
+Tulare,299748,U.S. Senate,,DEM,Kamala D. Harris,231
+Tulare,299748,U.S. Senate,,DEM,Loretta L. Sanchez,398
+Tulare,299801,U.S. Senate,,DEM,Kamala D. Harris,117
+Tulare,299801,U.S. Senate,,DEM,Loretta L. Sanchez,133
+Tulare,299802,U.S. Senate,,DEM,Kamala D. Harris,413
+Tulare,299802,U.S. Senate,,DEM,Loretta L. Sanchez,427
+Tulare,299803,U.S. Senate,,DEM,Kamala D. Harris,1
+Tulare,299803,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Tulare,299804,U.S. Senate,,DEM,Kamala D. Harris,229
+Tulare,299804,U.S. Senate,,DEM,Loretta L. Sanchez,214
+Tulare,299805,U.S. Senate,,DEM,Kamala D. Harris,298
+Tulare,299805,U.S. Senate,,DEM,Loretta L. Sanchez,330
+Tulare,299806,U.S. Senate,,DEM,Kamala D. Harris,63
+Tulare,299806,U.S. Senate,,DEM,Loretta L. Sanchez,71
+Tulare,299807,U.S. Senate,,DEM,Kamala D. Harris,5
+Tulare,299807,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Tulare,299808,U.S. Senate,,DEM,Kamala D. Harris,2
+Tulare,299808,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Tulare,299809,U.S. Senate,,DEM,Kamala D. Harris,3
+Tulare,299809,U.S. Senate,,DEM,Loretta L. Sanchez,12
+Tulare,299810,U.S. Senate,,DEM,Kamala D. Harris,23
+Tulare,299810,U.S. Senate,,DEM,Loretta L. Sanchez,50
+Tulare,299811,U.S. Senate,,DEM,Kamala D. Harris,0
+Tulare,299811,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Tulare,299812,U.S. Senate,,DEM,Kamala D. Harris,13
+Tulare,299812,U.S. Senate,,DEM,Loretta L. Sanchez,19
+Tulare,299813,U.S. Senate,,DEM,Kamala D. Harris,127
+Tulare,299813,U.S. Senate,,DEM,Loretta L. Sanchez,175
+Tulare,299814,U.S. Senate,,DEM,Kamala D. Harris,1
+Tulare,299814,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Tulare,299815,U.S. Senate,,DEM,Kamala D. Harris,0
+Tulare,299815,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Tulare,299816,U.S. Senate,,DEM,Kamala D. Harris,0
+Tulare,299816,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Tulare,299817,U.S. Senate,,DEM,Kamala D. Harris,21
+Tulare,299817,U.S. Senate,,DEM,Loretta L. Sanchez,14
+Tulare,299818,U.S. Senate,,DEM,Kamala D. Harris,0
+Tulare,299818,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Tulare,299819,U.S. Senate,,DEM,Kamala D. Harris,14
+Tulare,299819,U.S. Senate,,DEM,Loretta L. Sanchez,16
+Tulare,299820,U.S. Senate,,DEM,Kamala D. Harris,15
+Tulare,299820,U.S. Senate,,DEM,Loretta L. Sanchez,14
+Tulare,299821,U.S. Senate,,DEM,Kamala D. Harris,0
+Tulare,299821,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Tulare,299822,U.S. Senate,,DEM,Kamala D. Harris,49
+Tulare,299822,U.S. Senate,,DEM,Loretta L. Sanchez,63
+Tulare,299823,U.S. Senate,,DEM,Kamala D. Harris,0
+Tulare,299823,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Tulare,299824,U.S. Senate,,DEM,Kamala D. Harris,0
+Tulare,299824,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Tulare,299825,U.S. Senate,,DEM,Kamala D. Harris,0
+Tulare,299825,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Tulare,306001,U.S. Senate,,DEM,Kamala D. Harris,736
+Tulare,306001,U.S. Senate,,DEM,Loretta L. Sanchez,525
+Tulare,306003,U.S. Senate,,DEM,Kamala D. Harris,400
+Tulare,306003,U.S. Senate,,DEM,Loretta L. Sanchez,337
+Tulare,306008,U.S. Senate,,DEM,Kamala D. Harris,431
+Tulare,306008,U.S. Senate,,DEM,Loretta L. Sanchez,293
+Tulare,306009,U.S. Senate,,DEM,Kamala D. Harris,736
+Tulare,306009,U.S. Senate,,DEM,Loretta L. Sanchez,498
+Tulare,306013,U.S. Senate,,DEM,Kamala D. Harris,489
+Tulare,306013,U.S. Senate,,DEM,Loretta L. Sanchez,364
+Tulare,306014,U.S. Senate,,DEM,Kamala D. Harris,592
+Tulare,306014,U.S. Senate,,DEM,Loretta L. Sanchez,449
+Tulare,306017,U.S. Senate,,DEM,Kamala D. Harris,487
+Tulare,306017,U.S. Senate,,DEM,Loretta L. Sanchez,388
+Tulare,306019,U.S. Senate,,DEM,Kamala D. Harris,570
+Tulare,306019,U.S. Senate,,DEM,Loretta L. Sanchez,423
+Tulare,306021,U.S. Senate,,DEM,Kamala D. Harris,717
+Tulare,306021,U.S. Senate,,DEM,Loretta L. Sanchez,469
+Tulare,306029,U.S. Senate,,DEM,Kamala D. Harris,469
+Tulare,306029,U.S. Senate,,DEM,Loretta L. Sanchez,374
+Tulare,306036,U.S. Senate,,DEM,Kamala D. Harris,583
+Tulare,306036,U.S. Senate,,DEM,Loretta L. Sanchez,451
+Tulare,306037,U.S. Senate,,DEM,Kamala D. Harris,248
+Tulare,306037,U.S. Senate,,DEM,Loretta L. Sanchez,226
+Tulare,306040,U.S. Senate,,DEM,Kamala D. Harris,547
+Tulare,306040,U.S. Senate,,DEM,Loretta L. Sanchez,343
+Tulare,306043,U.S. Senate,,DEM,Kamala D. Harris,421
+Tulare,306043,U.S. Senate,,DEM,Loretta L. Sanchez,322
+Tulare,306801,U.S. Senate,,DEM,Kamala D. Harris,47
+Tulare,306801,U.S. Senate,,DEM,Loretta L. Sanchez,33
+Tulare,306802,U.S. Senate,,DEM,Kamala D. Harris,162
+Tulare,306802,U.S. Senate,,DEM,Loretta L. Sanchez,107
+Tulare,306803,U.S. Senate,,DEM,Kamala D. Harris,227
+Tulare,306803,U.S. Senate,,DEM,Loretta L. Sanchez,155
+Tulare,306804,U.S. Senate,,DEM,Kamala D. Harris,281
+Tulare,306804,U.S. Senate,,DEM,Loretta L. Sanchez,231
+Tulare,306805,U.S. Senate,,DEM,Kamala D. Harris,2
+Tulare,306805,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Tulare,306806,U.S. Senate,,DEM,Kamala D. Harris,80
+Tulare,306806,U.S. Senate,,DEM,Loretta L. Sanchez,51
+Tulare,306807,U.S. Senate,,DEM,Kamala D. Harris,235
+Tulare,306807,U.S. Senate,,DEM,Loretta L. Sanchez,158
+Tulare,306808,U.S. Senate,,DEM,Kamala D. Harris,163
+Tulare,306808,U.S. Senate,,DEM,Loretta L. Sanchez,243
+Tulare,306910,U.S. Senate,,DEM,Kamala D. Harris,491
+Tulare,306910,U.S. Senate,,DEM,Loretta L. Sanchez,323
+Tulare,306912,U.S. Senate,,DEM,Kamala D. Harris,739
+Tulare,306912,U.S. Senate,,DEM,Loretta L. Sanchez,515
+Tulare,306914,U.S. Senate,,DEM,Kamala D. Harris,558
+Tulare,306914,U.S. Senate,,DEM,Loretta L. Sanchez,383
+Tulare,306915,U.S. Senate,,DEM,Kamala D. Harris,313
+Tulare,306915,U.S. Senate,,DEM,Loretta L. Sanchez,461
+Tulare,306918,U.S. Senate,,DEM,Kamala D. Harris,168
+Tulare,306918,U.S. Senate,,DEM,Loretta L. Sanchez,181
+Tulare,306923,U.S. Senate,,DEM,Kamala D. Harris,635
+Tulare,306923,U.S. Senate,,DEM,Loretta L. Sanchez,565
+Tulare,306931,U.S. Senate,,DEM,Kamala D. Harris,638
+Tulare,306931,U.S. Senate,,DEM,Loretta L. Sanchez,470
+Tulare,306933,U.S. Senate,,DEM,Kamala D. Harris,748
+Tulare,306933,U.S. Senate,,DEM,Loretta L. Sanchez,544
+Tulare,306955,U.S. Senate,,DEM,Kamala D. Harris,575
+Tulare,306955,U.S. Senate,,DEM,Loretta L. Sanchez,408
+Tulare,399801,U.S. Senate,,DEM,Kamala D. Harris,0
+Tulare,399801,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Tulare,399802,U.S. Senate,,DEM,Kamala D. Harris,12
+Tulare,399802,U.S. Senate,,DEM,Loretta L. Sanchez,10
+Tulare,399803,U.S. Senate,,DEM,Kamala D. Harris,177
+Tulare,399803,U.S. Senate,,DEM,Loretta L. Sanchez,130
+Tulare,399804,U.S. Senate,,DEM,Kamala D. Harris,0
+Tulare,399804,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Tulare,399805,U.S. Senate,,DEM,Kamala D. Harris,8
+Tulare,399805,U.S. Senate,,DEM,Loretta L. Sanchez,8
+Tulare,399806,U.S. Senate,,DEM,Kamala D. Harris,11
+Tulare,399806,U.S. Senate,,DEM,Loretta L. Sanchez,10
+Tulare,399807,U.S. Senate,,DEM,Kamala D. Harris,0
+Tulare,399807,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Tulare,399808,U.S. Senate,,DEM,Kamala D. Harris,0
+Tulare,399808,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Tulare,401101,U.S. Senate,,DEM,Kamala D. Harris,170
+Tulare,401101,U.S. Senate,,DEM,Loretta L. Sanchez,253
+Tulare,401203,U.S. Senate,,DEM,Kamala D. Harris,351
+Tulare,401203,U.S. Senate,,DEM,Loretta L. Sanchez,544
+Tulare,401306,U.S. Senate,,DEM,Kamala D. Harris,295
+Tulare,401306,U.S. Senate,,DEM,Loretta L. Sanchez,340
+Tulare,401801,U.S. Senate,,DEM,Kamala D. Harris,474
+Tulare,401801,U.S. Senate,,DEM,Loretta L. Sanchez,629
+Tulare,401802,U.S. Senate,,DEM,Kamala D. Harris,422
+Tulare,401802,U.S. Senate,,DEM,Loretta L. Sanchez,482
+Tulare,406801,U.S. Senate,,DEM,Kamala D. Harris,85
+Tulare,406801,U.S. Senate,,DEM,Loretta L. Sanchez,93
+Tulare,406905,U.S. Senate,,DEM,Kamala D. Harris,189
+Tulare,406905,U.S. Senate,,DEM,Loretta L. Sanchez,139
+Tulare,406917,U.S. Senate,,DEM,Kamala D. Harris,525
+Tulare,406917,U.S. Senate,,DEM,Loretta L. Sanchez,416
+Tulare,406920,U.S. Senate,,DEM,Kamala D. Harris,212
+Tulare,406920,U.S. Senate,,DEM,Loretta L. Sanchez,314
+Tulare,407001,U.S. Senate,,DEM,Kamala D. Harris,86
+Tulare,407001,U.S. Senate,,DEM,Loretta L. Sanchez,133
+Tulare,407004,U.S. Senate,,DEM,Kamala D. Harris,240
+Tulare,407004,U.S. Senate,,DEM,Loretta L. Sanchez,360
+Tulare,407801,U.S. Senate,,DEM,Kamala D. Harris,70
+Tulare,407801,U.S. Senate,,DEM,Loretta L. Sanchez,127
+Tulare,407802,U.S. Senate,,DEM,Kamala D. Harris,49
+Tulare,407802,U.S. Senate,,DEM,Loretta L. Sanchez,84
+Tulare,499006,U.S. Senate,,DEM,Kamala D. Harris,119
+Tulare,499006,U.S. Senate,,DEM,Loretta L. Sanchez,205
+Tulare,499044,U.S. Senate,,DEM,Kamala D. Harris,106
+Tulare,499044,U.S. Senate,,DEM,Loretta L. Sanchez,106
+Tulare,499102,U.S. Senate,,DEM,Kamala D. Harris,291
+Tulare,499102,U.S. Senate,,DEM,Loretta L. Sanchez,220
+Tulare,499126,U.S. Senate,,DEM,Kamala D. Harris,91
+Tulare,499126,U.S. Senate,,DEM,Loretta L. Sanchez,138
+Tulare,499132,U.S. Senate,,DEM,Kamala D. Harris,111
+Tulare,499132,U.S. Senate,,DEM,Loretta L. Sanchez,191
+Tulare,499249,U.S. Senate,,DEM,Kamala D. Harris,151
+Tulare,499249,U.S. Senate,,DEM,Loretta L. Sanchez,289
+Tulare,499801,U.S. Senate,,DEM,Kamala D. Harris,621
+Tulare,499801,U.S. Senate,,DEM,Loretta L. Sanchez,756
+Tulare,499802,U.S. Senate,,DEM,Kamala D. Harris,49
+Tulare,499802,U.S. Senate,,DEM,Loretta L. Sanchez,46
+Tulare,499803,U.S. Senate,,DEM,Kamala D. Harris,22
+Tulare,499803,U.S. Senate,,DEM,Loretta L. Sanchez,9
+Tulare,499804,U.S. Senate,,DEM,Kamala D. Harris,218
+Tulare,499804,U.S. Senate,,DEM,Loretta L. Sanchez,292
+Tulare,499805,U.S. Senate,,DEM,Kamala D. Harris,1
+Tulare,499805,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Tulare,499806,U.S. Senate,,DEM,Kamala D. Harris,456
+Tulare,499806,U.S. Senate,,DEM,Loretta L. Sanchez,467
+Tulare,499807,U.S. Senate,,DEM,Kamala D. Harris,60
+Tulare,499807,U.S. Senate,,DEM,Loretta L. Sanchez,20
+Tulare,499808,U.S. Senate,,DEM,Kamala D. Harris,83
+Tulare,499808,U.S. Senate,,DEM,Loretta L. Sanchez,81
+Tulare,499809,U.S. Senate,,DEM,Kamala D. Harris,24
+Tulare,499809,U.S. Senate,,DEM,Loretta L. Sanchez,39
+Tulare,499810,U.S. Senate,,DEM,Kamala D. Harris,147
+Tulare,499810,U.S. Senate,,DEM,Loretta L. Sanchez,218
+Tulare,499811,U.S. Senate,,DEM,Kamala D. Harris,282
+Tulare,499811,U.S. Senate,,DEM,Loretta L. Sanchez,402
+Tulare,499812,U.S. Senate,,DEM,Kamala D. Harris,44
+Tulare,499812,U.S. Senate,,DEM,Loretta L. Sanchez,40
+Tulare,499813,U.S. Senate,,DEM,Kamala D. Harris,81
+Tulare,499813,U.S. Senate,,DEM,Loretta L. Sanchez,180
+Tulare,499814,U.S. Senate,,DEM,Kamala D. Harris,1
+Tulare,499814,U.S. Senate,,DEM,Loretta L. Sanchez,7
+Tulare,499815,U.S. Senate,,DEM,Kamala D. Harris,184
+Tulare,499815,U.S. Senate,,DEM,Loretta L. Sanchez,353
+Tulare,499816,U.S. Senate,,DEM,Kamala D. Harris,51
+Tulare,499816,U.S. Senate,,DEM,Loretta L. Sanchez,33
+Tulare,499817,U.S. Senate,,DEM,Kamala D. Harris,18
+Tulare,499817,U.S. Senate,,DEM,Loretta L. Sanchez,24
+Tulare,499818,U.S. Senate,,DEM,Kamala D. Harris,76
+Tulare,499818,U.S. Senate,,DEM,Loretta L. Sanchez,70
+Tulare,499819,U.S. Senate,,DEM,Kamala D. Harris,0
+Tulare,499819,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Tulare,499820,U.S. Senate,,DEM,Kamala D. Harris,23
+Tulare,499820,U.S. Senate,,DEM,Loretta L. Sanchez,41
+Tulare,499821,U.S. Senate,,DEM,Kamala D. Harris,31
+Tulare,499821,U.S. Senate,,DEM,Loretta L. Sanchez,25
+Tulare,499822,U.S. Senate,,DEM,Kamala D. Harris,164
+Tulare,499822,U.S. Senate,,DEM,Loretta L. Sanchez,134
+Tulare,499823,U.S. Senate,,DEM,Kamala D. Harris,46
+Tulare,499823,U.S. Senate,,DEM,Loretta L. Sanchez,50
+Tulare,499824,U.S. Senate,,DEM,Kamala D. Harris,71
+Tulare,499824,U.S. Senate,,DEM,Loretta L. Sanchez,82
+Tulare,504001,U.S. Senate,,DEM,Kamala D. Harris,278
+Tulare,504001,U.S. Senate,,DEM,Loretta L. Sanchez,527
+Tulare,504002,U.S. Senate,,DEM,Kamala D. Harris,356
+Tulare,504002,U.S. Senate,,DEM,Loretta L. Sanchez,308
+Tulare,504005,U.S. Senate,,DEM,Kamala D. Harris,155
+Tulare,504005,U.S. Senate,,DEM,Loretta L. Sanchez,96
+Tulare,504013,U.S. Senate,,DEM,Kamala D. Harris,118
+Tulare,504013,U.S. Senate,,DEM,Loretta L. Sanchez,111
+Tulare,504801,U.S. Senate,,DEM,Kamala D. Harris,957
+Tulare,504801,U.S. Senate,,DEM,Loretta L. Sanchez,969
+Tulare,504802,U.S. Senate,,DEM,Kamala D. Harris,71
+Tulare,504802,U.S. Senate,,DEM,Loretta L. Sanchez,78
+Tulare,504803,U.S. Senate,,DEM,Kamala D. Harris,2
+Tulare,504803,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Tulare,504804,U.S. Senate,,DEM,Kamala D. Harris,103
+Tulare,504804,U.S. Senate,,DEM,Loretta L. Sanchez,75
+Tulare,504805,U.S. Senate,,DEM,Kamala D. Harris,129
+Tulare,504805,U.S. Senate,,DEM,Loretta L. Sanchez,110
+Tulare,504806,U.S. Senate,,DEM,Kamala D. Harris,436
+Tulare,504806,U.S. Senate,,DEM,Loretta L. Sanchez,319
+Tulare,504901,U.S. Senate,,DEM,Kamala D. Harris,179
+Tulare,504901,U.S. Senate,,DEM,Loretta L. Sanchez,186
+Tulare,504904,U.S. Senate,,DEM,Kamala D. Harris,203
+Tulare,504904,U.S. Senate,,DEM,Loretta L. Sanchez,137
+Tulare,504905,U.S. Senate,,DEM,Kamala D. Harris,550
+Tulare,504905,U.S. Senate,,DEM,Loretta L. Sanchez,473
+Tulare,504907,U.S. Senate,,DEM,Kamala D. Harris,460
+Tulare,504907,U.S. Senate,,DEM,Loretta L. Sanchez,341
+Tulare,504920,U.S. Senate,,DEM,Kamala D. Harris,216
+Tulare,504920,U.S. Senate,,DEM,Loretta L. Sanchez,229
+Tulare,504930,U.S. Senate,,DEM,Kamala D. Harris,429
+Tulare,504930,U.S. Senate,,DEM,Loretta L. Sanchez,389
+Tulare,504935,U.S. Senate,,DEM,Kamala D. Harris,381
+Tulare,504935,U.S. Senate,,DEM,Loretta L. Sanchez,374
+Tulare,504945,U.S. Senate,,DEM,Kamala D. Harris,312
+Tulare,504945,U.S. Senate,,DEM,Loretta L. Sanchez,340
+Tulare,599306,U.S. Senate,,DEM,Kamala D. Harris,330
+Tulare,599306,U.S. Senate,,DEM,Loretta L. Sanchez,219
+Tulare,599361,U.S. Senate,,DEM,Kamala D. Harris,428
+Tulare,599361,U.S. Senate,,DEM,Loretta L. Sanchez,260
+Tulare,599634,U.S. Senate,,DEM,Kamala D. Harris,127
+Tulare,599634,U.S. Senate,,DEM,Loretta L. Sanchez,136
+Tulare,599693,U.S. Senate,,DEM,Kamala D. Harris,116
+Tulare,599693,U.S. Senate,,DEM,Loretta L. Sanchez,192
+Tulare,599801,U.S. Senate,,DEM,Kamala D. Harris,0
+Tulare,599801,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Tulare,599802,U.S. Senate,,DEM,Kamala D. Harris,402
+Tulare,599802,U.S. Senate,,DEM,Loretta L. Sanchez,576
+Tulare,599803,U.S. Senate,,DEM,Kamala D. Harris,58
+Tulare,599803,U.S. Senate,,DEM,Loretta L. Sanchez,95
+Tulare,599804,U.S. Senate,,DEM,Kamala D. Harris,14
+Tulare,599804,U.S. Senate,,DEM,Loretta L. Sanchez,5
+Tulare,599805,U.S. Senate,,DEM,Kamala D. Harris,835
+Tulare,599805,U.S. Senate,,DEM,Loretta L. Sanchez,822
+Tulare,599806,U.S. Senate,,DEM,Kamala D. Harris,413
+Tulare,599806,U.S. Senate,,DEM,Loretta L. Sanchez,366
+Tulare,599807,U.S. Senate,,DEM,Kamala D. Harris,0
+Tulare,599807,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Tulare,599808,U.S. Senate,,DEM,Kamala D. Harris,4
+Tulare,599808,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Tulare,599809,U.S. Senate,,DEM,Kamala D. Harris,4
+Tulare,599809,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Tulare,599810,U.S. Senate,,DEM,Kamala D. Harris,59
+Tulare,599810,U.S. Senate,,DEM,Loretta L. Sanchez,38
+Tulare,599811,U.S. Senate,,DEM,Kamala D. Harris,4
+Tulare,599811,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Tulare,599812,U.S. Senate,,DEM,Kamala D. Harris,35
+Tulare,599812,U.S. Senate,,DEM,Loretta L. Sanchez,9
+Tulare,599813,U.S. Senate,,DEM,Kamala D. Harris,39
+Tulare,599813,U.S. Senate,,DEM,Loretta L. Sanchez,39
+Tulare,599814,U.S. Senate,,DEM,Kamala D. Harris,2
+Tulare,599814,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Tulare,599815,U.S. Senate,,DEM,Kamala D. Harris,9
+Tulare,599815,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Tulare,599816,U.S. Senate,,DEM,Kamala D. Harris,17
+Tulare,599816,U.S. Senate,,DEM,Loretta L. Sanchez,17
+Tulare,599817,U.S. Senate,,DEM,Kamala D. Harris,4
+Tulare,599817,U.S. Senate,,DEM,Loretta L. Sanchez,7
+Tulare,599818,U.S. Senate,,DEM,Kamala D. Harris,0
+Tulare,599818,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Tulare,599819,U.S. Senate,,DEM,Kamala D. Harris,0
+Tulare,599819,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Tulare,599820,U.S. Senate,,DEM,Kamala D. Harris,0
+Tulare,599820,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Tulare,599821,U.S. Senate,,DEM,Kamala D. Harris,16
+Tulare,599821,U.S. Senate,,DEM,Loretta L. Sanchez,12
+Tulare,599822,U.S. Senate,,DEM,Kamala D. Harris,3
+Tulare,599822,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Tulare,599823,U.S. Senate,,DEM,Kamala D. Harris,44
+Tulare,599823,U.S. Senate,,DEM,Loretta L. Sanchez,25
+Tulare,599824,U.S. Senate,,DEM,Kamala D. Harris,2
+Tulare,599824,U.S. Senate,,DEM,Loretta L. Sanchez,4

--- a/2016/20161108__ca__general__tuolumne__precinct.csv
+++ b/2016/20161108__ca__general__tuolumne__precinct.csv
@@ -2719,139 +2719,139 @@ Tuolumne,YANKEE_HILL_WEST,Proposition 67,,N/A,Yes,49
 Tuolumne,YANKEE_HILL_WEST,Proposition 67,,N/A,No,77
 Tuolumne,YOSEMT_NS_RL_120_CHERRY,Proposition 67,,N/A,Yes,18
 Tuolumne,YOSEMT_NS_RL_120_CHERRY,Proposition 67,,N/A,No,21
-Tuolumne,AIRPORT,U.S. Senate,,DEM,Kamala Harris,612
-Tuolumne,AIRPORT,U.S. Senate,,DEM,Loretta Sanchez,283
-Tuolumne,ALGERINE,U.S. Senate,,DEM,Kamala Harris,32
-Tuolumne,ALGERINE,U.S. Senate,,DEM,Loretta Sanchez,15
-Tuolumne,APPLE_VALLEY,U.S. Senate,,DEM,Kamala Harris,150
-Tuolumne,APPLE_VALLEY,U.S. Senate,,DEM,Loretta Sanchez,62
-Tuolumne,BALD_MTN,U.S. Senate,,DEM,Kamala Harris,68
-Tuolumne,BALD_MTN,U.S. Senate,,DEM,Loretta Sanchez,31
-Tuolumne,BELLEVIEW_OAKS,U.S. Senate,,DEM,Kamala Harris,463
-Tuolumne,BELLEVIEW_OAKS,U.S. Senate,,DEM,Loretta Sanchez,252
-Tuolumne,BIG_HILL_CEDAR_RIDGE,U.S. Senate,,DEM,Kamala Harris,307
-Tuolumne,BIG_HILL_CEDAR_RIDGE,U.S. Senate,,DEM,Loretta Sanchez,172
-Tuolumne,BIG_HILL_SOUTH,U.S. Senate,,DEM,Kamala Harris,17
-Tuolumne,BIG_HILL_SOUTH,U.S. Senate,,DEM,Loretta Sanchez,11
-Tuolumne,BIG_OAK_GROVE_N_S,U.S. Senate,,DEM,Kamala Harris,436
-Tuolumne,BIG_OAK_GROVE_N_S,U.S. Senate,,DEM,Loretta Sanchez,244
-Tuolumne,BIG_TREES,U.S. Senate,,DEM,Kamala Harris,26
-Tuolumne,BIG_TREES,U.S. Senate,,DEM,Loretta Sanchez,20
-Tuolumne,BUCKHORN,U.S. Senate,,DEM,Kamala Harris,61
-Tuolumne,BUCKHORN,U.S. Senate,,DEM,Loretta Sanchez,35
-Tuolumne,CABEZUT,U.S. Senate,,DEM,Kamala Harris,121
-Tuolumne,CABEZUT,U.S. Senate,,DEM,Loretta Sanchez,53
-Tuolumne,CAMPO_SECO,U.S. Senate,,DEM,Kamala Harris,167
-Tuolumne,CAMPO_SECO,U.S. Senate,,DEM,Loretta Sanchez,101
-Tuolumne,CHERRY_LK_CLAVEY_CTNWD,U.S. Senate,,DEM,Kamala Harris,14
-Tuolumne,CHERRY_LK_CLAVEY_CTNWD,U.S. Senate,,DEM,Loretta Sanchez,3
-Tuolumne,CHINESE_CMP_GRN_SPGS,U.S. Senate,,DEM,Kamala Harris,68
-Tuolumne,CHINESE_CMP_GRN_SPGS,U.S. Senate,,DEM,Loretta Sanchez,49
-Tuolumne,CLINE_CRK_NO_FERRETTI,U.S. Senate,,DEM,Kamala Harris,55
-Tuolumne,CLINE_CRK_NO_FERRETTI,U.S. Senate,,DEM,Loretta Sanchez,36
-Tuolumne,CONFIDENCE,U.S. Senate,,DEM,Kamala Harris,679
-Tuolumne,CONFIDENCE,U.S. Senate,,DEM,Loretta Sanchez,329
-Tuolumne,COUNTRY_CLUB,U.S. Senate,,DEM,Kamala Harris,259
-Tuolumne,COUNTRY_CLUB,U.S. Senate,,DEM,Loretta Sanchez,113
-Tuolumne,CRYSTAL_FALLS_C_F_NO,U.S. Senate,,DEM,Kamala Harris,289
-Tuolumne,CRYSTAL_FALLS_C_F_NO,U.S. Senate,,DEM,Loretta Sanchez,146
-Tuolumne,CRYSTAL_FALLS_SOUTH,U.S. Senate,,DEM,Kamala Harris,63
-Tuolumne,CRYSTAL_FALLS_SOUTH,U.S. Senate,,DEM,Loretta Sanchez,43
-Tuolumne,CUESTA_SERENA,U.S. Senate,,DEM,Kamala Harris,531
-Tuolumne,CUESTA_SERENA,U.S. Senate,,DEM,Loretta Sanchez,233
-Tuolumne,CURTIS_CREEK,U.S. Senate,,DEM,Kamala Harris,92
-Tuolumne,CURTIS_CREEK,U.S. Senate,,DEM,Loretta Sanchez,58
-Tuolumne,DON_PEDRO,U.S. Senate,,DEM,Kamala Harris,242
-Tuolumne,DON_PEDRO,U.S. Senate,,DEM,Loretta Sanchez,139
-Tuolumne,GIBBS_PEPPERMINT,U.S. Senate,,DEM,Kamala Harris,291
-Tuolumne,GIBBS_PEPPERMINT,U.S. Senate,,DEM,Loretta Sanchez,147
-Tuolumne,GOOD_SHEPERD,U.S. Senate,,DEM,Kamala Harris,28
-Tuolumne,GOOD_SHEPERD,U.S. Senate,,DEM,Loretta Sanchez,8
-Tuolumne,GOOD_SHEPHERD_2,U.S. Senate,,DEM,Kamala Harris,27
-Tuolumne,GOOD_SHEPHERD_2,U.S. Senate,,DEM,Loretta Sanchez,14
-Tuolumne,GREENLEY,U.S. Senate,,DEM,Kamala Harris,332
-Tuolumne,GREENLEY,U.S. Senate,,DEM,Loretta Sanchez,140
-Tuolumne,GRIZZLY_HOG_MTN,U.S. Senate,,DEM,Kamala Harris,48
-Tuolumne,GRIZZLY_HOG_MTN,U.S. Senate,,DEM,Loretta Sanchez,33
-Tuolumne,HUNTS,U.S. Senate,,DEM,Kamala Harris,36
-Tuolumne,HUNTS,U.S. Senate,,DEM,Loretta Sanchez,31
-Tuolumne,JACKSONVILLE,U.S. Senate,,DEM,Kamala Harris,34
-Tuolumne,JACKSONVILLE,U.S. Senate,,DEM,Loretta Sanchez,22
-Tuolumne,JAMESTOWN_EAST,U.S. Senate,,DEM,Kamala Harris,354
-Tuolumne,JAMESTOWN_EAST,U.S. Senate,,DEM,Loretta Sanchez,201
-Tuolumne,LAMBERT_LAKE,U.S. Senate,,DEM,Kamala Harris,165
-Tuolumne,LAMBERT_LAKE,U.S. Senate,,DEM,Loretta Sanchez,106
-Tuolumne,LIME_KILN,U.S. Senate,,DEM,Kamala Harris,71
-Tuolumne,LIME_KILN,U.S. Senate,,DEM,Loretta Sanchez,29
-Tuolumne,LONG_BARN,U.S. Senate,,DEM,Kamala Harris,479
-Tuolumne,LONG_BARN,U.S. Senate,,DEM,Loretta Sanchez,297
-Tuolumne,MARSHALL-PONDEROSA,U.S. Senate,,DEM,Kamala Harris,295
-Tuolumne,MARSHALL-PONDEROSA,U.S. Senate,,DEM,Loretta Sanchez,120
-Tuolumne,MIDDLE_CAMP,U.S. Senate,,DEM,Kamala Harris,285
-Tuolumne,MIDDLE_CAMP,U.S. Senate,,DEM,Loretta Sanchez,104
-Tuolumne,MONO_VILLAGE,U.S. Senate,,DEM,Kamala Harris,249
-Tuolumne,MONO_VILLAGE,U.S. Senate,,DEM,Loretta Sanchez,123
-Tuolumne,MONO_VISTA,U.S. Senate,,DEM,Kamala Harris,422
-Tuolumne,MONO_VISTA,U.S. Senate,,DEM,Loretta Sanchez,271
-Tuolumne,MORMCRK_RAWHDE_TUTLE,U.S. Senate,,DEM,Kamala Harris,283
-Tuolumne,MORMCRK_RAWHDE_TUTLE,U.S. Senate,,DEM,Loretta Sanchez,138
-Tuolumne,MT_BROW_SHAWS_FLAT,U.S. Senate,,DEM,Kamala Harris,503
-Tuolumne,MT_BROW_SHAWS_FLAT,U.S. Senate,,DEM,Loretta Sanchez,213
-Tuolumne,MT_EATON,U.S. Senate,,DEM,Kamala Harris,536
-Tuolumne,MT_EATON,U.S. Senate,,DEM,Loretta Sanchez,317
-Tuolumne,NORTH_HESS,U.S. Senate,,DEM,Kamala Harris,29
-Tuolumne,NORTH_HESS,U.S. Senate,,DEM,Loretta Sanchez,14
-Tuolumne,OAK_GARDEN,U.S. Senate,,DEM,Kamala Harris,141
-Tuolumne,OAK_GARDEN,U.S. Senate,,DEM,Loretta Sanchez,83
-Tuolumne,PEORIA_FLAT_QUARTZ,U.S. Senate,,DEM,Kamala Harris,162
-Tuolumne,PEORIA_FLAT_QUARTZ,U.S. Senate,,DEM,Loretta Sanchez,117
-Tuolumne,PHOENIX_LAKE,U.S. Senate,,DEM,Kamala Harris,254
-Tuolumne,PHOENIX_LAKE,U.S. Senate,,DEM,Loretta Sanchez,160
-Tuolumne,PINECREST_EAST,U.S. Senate,,DEM,Kamala Harris,48
-Tuolumne,PINECREST_EAST,U.S. Senate,,DEM,Loretta Sanchez,40
-Tuolumne,PINECREST_WEST,U.S. Senate,,DEM,Kamala Harris,21
-Tuolumne,PINECREST_WEST,U.S. Senate,,DEM,Loretta Sanchez,15
-Tuolumne,PINE_MTN_EAST,U.S. Senate,,DEM,Kamala Harris,384
-Tuolumne,PINE_MTN_EAST,U.S. Senate,,DEM,Loretta Sanchez,139
-Tuolumne,PINE_MTN_SOUTH,U.S. Senate,,DEM,Kamala Harris,72
-Tuolumne,PINE_MTN_SOUTH,U.S. Senate,,DEM,Loretta Sanchez,27
-Tuolumne,POQUITOS-DRAPER,U.S. Senate,,DEM,Kamala Harris,196
-Tuolumne,POQUITOS-DRAPER,U.S. Senate,,DEM,Loretta Sanchez,116
-Tuolumne,PRIEST_CLTRVL_MOCCASIN,U.S. Senate,,DEM,Kamala Harris,23
-Tuolumne,PRIEST_CLTRVL_MOCCASIN,U.S. Senate,,DEM,Loretta Sanchez,25
-Tuolumne,RED_HILLS,U.S. Senate,,DEM,Kamala Harris,32
-Tuolumne,RED_HILLS,U.S. Senate,,DEM,Loretta Sanchez,18
-Tuolumne,RIDGEWOOD,U.S. Senate,,DEM,Kamala Harris,74
-Tuolumne,RIDGEWOOD,U.S. Senate,,DEM,Loretta Sanchez,45
-Tuolumne,SAWMILL_FLAT,U.S. Senate,,DEM,Kamala Harris,30
-Tuolumne,SAWMILL_FLAT,U.S. Senate,,DEM,Loretta Sanchez,19
-Tuolumne,SONORA_EAST,U.S. Senate,,DEM,Kamala Harris,247
-Tuolumne,SONORA_EAST,U.S. Senate,,DEM,Loretta Sanchez,150
-Tuolumne,SONORA_FAIR_WEST,U.S. Senate,,DEM,Kamala Harris,298
-Tuolumne,SONORA_FAIR_WEST,U.S. Senate,,DEM,Loretta Sanchez,137
-Tuolumne,SONORA_HOPE,U.S. Senate,,DEM,Kamala Harris,281
-Tuolumne,SONORA_HOPE,U.S. Senate,,DEM,Loretta Sanchez,163
-Tuolumne,SONORA_SOUTH,U.S. Senate,,DEM,Kamala Harris,12
-Tuolumne,SONORA_SOUTH,U.S. Senate,,DEM,Loretta Sanchez,13
-Tuolumne,SOULSBYVILLE,U.S. Senate,,DEM,Kamala Harris,38
-Tuolumne,SOULSBYVILLE,U.S. Senate,,DEM,Loretta Sanchez,14
-Tuolumne,SOULSBY_CURTIS_CREEK,U.S. Senate,,DEM,Kamala Harris,103
-Tuolumne,SOULSBY_CURTIS_CREEK,U.S. Senate,,DEM,Loretta Sanchez,43
-Tuolumne,SOUTH_FERRETTI,U.S. Senate,,DEM,Kamala Harris,105
-Tuolumne,SOUTH_FERRETTI,U.S. Senate,,DEM,Loretta Sanchez,34
-Tuolumne,TELEGRAPH_HILL,U.S. Senate,,DEM,Kamala Harris,88
-Tuolumne,TELEGRAPH_HILL,U.S. Senate,,DEM,Loretta Sanchez,38
-Tuolumne,TWAIN_HARTE_VALLEY,U.S. Senate,,DEM,Kamala Harris,66
-Tuolumne,TWAIN_HARTE_VALLEY,U.S. Senate,,DEM,Loretta Sanchez,31
-Tuolumne,UNION_HILL,U.S. Senate,,DEM,Kamala Harris,6
-Tuolumne,UNION_HILL,U.S. Senate,,DEM,Loretta Sanchez,7
-Tuolumne,WARDS_FERRY,U.S. Senate,,DEM,Kamala Harris,159
-Tuolumne,WARDS_FERRY,U.S. Senate,,DEM,Loretta Sanchez,78
-Tuolumne,WOODHAMS_CARNE,U.S. Senate,,DEM,Kamala Harris,52
-Tuolumne,WOODHAMS_CARNE,U.S. Senate,,DEM,Loretta Sanchez,26
-Tuolumne,YANKEE_HILL_ES,U.S. Senate,,DEM,Kamala Harris,42
-Tuolumne,YANKEE_HILL_ES,U.S. Senate,,DEM,Loretta Sanchez,10
-Tuolumne,YANKEE_HILL_WEST,U.S. Senate,,DEM,Kamala Harris,68
-Tuolumne,YANKEE_HILL_WEST,U.S. Senate,,DEM,Loretta Sanchez,28
-Tuolumne,YOSEMT_NS_RL_120_CHERRY,U.S. Senate,,DEM,Kamala Harris,18
-Tuolumne,YOSEMT_NS_RL_120_CHERRY,U.S. Senate,,DEM,Loretta Sanchez,13
+Tuolumne,AIRPORT,U.S. Senate,,DEM,Kamala D. Harris,612
+Tuolumne,AIRPORT,U.S. Senate,,DEM,Loretta L. Sanchez,283
+Tuolumne,ALGERINE,U.S. Senate,,DEM,Kamala D. Harris,32
+Tuolumne,ALGERINE,U.S. Senate,,DEM,Loretta L. Sanchez,15
+Tuolumne,APPLE_VALLEY,U.S. Senate,,DEM,Kamala D. Harris,150
+Tuolumne,APPLE_VALLEY,U.S. Senate,,DEM,Loretta L. Sanchez,62
+Tuolumne,BALD_MTN,U.S. Senate,,DEM,Kamala D. Harris,68
+Tuolumne,BALD_MTN,U.S. Senate,,DEM,Loretta L. Sanchez,31
+Tuolumne,BELLEVIEW_OAKS,U.S. Senate,,DEM,Kamala D. Harris,463
+Tuolumne,BELLEVIEW_OAKS,U.S. Senate,,DEM,Loretta L. Sanchez,252
+Tuolumne,BIG_HILL_CEDAR_RIDGE,U.S. Senate,,DEM,Kamala D. Harris,307
+Tuolumne,BIG_HILL_CEDAR_RIDGE,U.S. Senate,,DEM,Loretta L. Sanchez,172
+Tuolumne,BIG_HILL_SOUTH,U.S. Senate,,DEM,Kamala D. Harris,17
+Tuolumne,BIG_HILL_SOUTH,U.S. Senate,,DEM,Loretta L. Sanchez,11
+Tuolumne,BIG_OAK_GROVE_N_S,U.S. Senate,,DEM,Kamala D. Harris,436
+Tuolumne,BIG_OAK_GROVE_N_S,U.S. Senate,,DEM,Loretta L. Sanchez,244
+Tuolumne,BIG_TREES,U.S. Senate,,DEM,Kamala D. Harris,26
+Tuolumne,BIG_TREES,U.S. Senate,,DEM,Loretta L. Sanchez,20
+Tuolumne,BUCKHORN,U.S. Senate,,DEM,Kamala D. Harris,61
+Tuolumne,BUCKHORN,U.S. Senate,,DEM,Loretta L. Sanchez,35
+Tuolumne,CABEZUT,U.S. Senate,,DEM,Kamala D. Harris,121
+Tuolumne,CABEZUT,U.S. Senate,,DEM,Loretta L. Sanchez,53
+Tuolumne,CAMPO_SECO,U.S. Senate,,DEM,Kamala D. Harris,167
+Tuolumne,CAMPO_SECO,U.S. Senate,,DEM,Loretta L. Sanchez,101
+Tuolumne,CHERRY_LK_CLAVEY_CTNWD,U.S. Senate,,DEM,Kamala D. Harris,14
+Tuolumne,CHERRY_LK_CLAVEY_CTNWD,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Tuolumne,CHINESE_CMP_GRN_SPGS,U.S. Senate,,DEM,Kamala D. Harris,68
+Tuolumne,CHINESE_CMP_GRN_SPGS,U.S. Senate,,DEM,Loretta L. Sanchez,49
+Tuolumne,CLINE_CRK_NO_FERRETTI,U.S. Senate,,DEM,Kamala D. Harris,55
+Tuolumne,CLINE_CRK_NO_FERRETTI,U.S. Senate,,DEM,Loretta L. Sanchez,36
+Tuolumne,CONFIDENCE,U.S. Senate,,DEM,Kamala D. Harris,679
+Tuolumne,CONFIDENCE,U.S. Senate,,DEM,Loretta L. Sanchez,329
+Tuolumne,COUNTRY_CLUB,U.S. Senate,,DEM,Kamala D. Harris,259
+Tuolumne,COUNTRY_CLUB,U.S. Senate,,DEM,Loretta L. Sanchez,113
+Tuolumne,CRYSTAL_FALLS_C_F_NO,U.S. Senate,,DEM,Kamala D. Harris,289
+Tuolumne,CRYSTAL_FALLS_C_F_NO,U.S. Senate,,DEM,Loretta L. Sanchez,146
+Tuolumne,CRYSTAL_FALLS_SOUTH,U.S. Senate,,DEM,Kamala D. Harris,63
+Tuolumne,CRYSTAL_FALLS_SOUTH,U.S. Senate,,DEM,Loretta L. Sanchez,43
+Tuolumne,CUESTA_SERENA,U.S. Senate,,DEM,Kamala D. Harris,531
+Tuolumne,CUESTA_SERENA,U.S. Senate,,DEM,Loretta L. Sanchez,233
+Tuolumne,CURTIS_CREEK,U.S. Senate,,DEM,Kamala D. Harris,92
+Tuolumne,CURTIS_CREEK,U.S. Senate,,DEM,Loretta L. Sanchez,58
+Tuolumne,DON_PEDRO,U.S. Senate,,DEM,Kamala D. Harris,242
+Tuolumne,DON_PEDRO,U.S. Senate,,DEM,Loretta L. Sanchez,139
+Tuolumne,GIBBS_PEPPERMINT,U.S. Senate,,DEM,Kamala D. Harris,291
+Tuolumne,GIBBS_PEPPERMINT,U.S. Senate,,DEM,Loretta L. Sanchez,147
+Tuolumne,GOOD_SHEPERD,U.S. Senate,,DEM,Kamala D. Harris,28
+Tuolumne,GOOD_SHEPERD,U.S. Senate,,DEM,Loretta L. Sanchez,8
+Tuolumne,GOOD_SHEPHERD_2,U.S. Senate,,DEM,Kamala D. Harris,27
+Tuolumne,GOOD_SHEPHERD_2,U.S. Senate,,DEM,Loretta L. Sanchez,14
+Tuolumne,GREENLEY,U.S. Senate,,DEM,Kamala D. Harris,332
+Tuolumne,GREENLEY,U.S. Senate,,DEM,Loretta L. Sanchez,140
+Tuolumne,GRIZZLY_HOG_MTN,U.S. Senate,,DEM,Kamala D. Harris,48
+Tuolumne,GRIZZLY_HOG_MTN,U.S. Senate,,DEM,Loretta L. Sanchez,33
+Tuolumne,HUNTS,U.S. Senate,,DEM,Kamala D. Harris,36
+Tuolumne,HUNTS,U.S. Senate,,DEM,Loretta L. Sanchez,31
+Tuolumne,JACKSONVILLE,U.S. Senate,,DEM,Kamala D. Harris,34
+Tuolumne,JACKSONVILLE,U.S. Senate,,DEM,Loretta L. Sanchez,22
+Tuolumne,JAMESTOWN_EAST,U.S. Senate,,DEM,Kamala D. Harris,354
+Tuolumne,JAMESTOWN_EAST,U.S. Senate,,DEM,Loretta L. Sanchez,201
+Tuolumne,LAMBERT_LAKE,U.S. Senate,,DEM,Kamala D. Harris,165
+Tuolumne,LAMBERT_LAKE,U.S. Senate,,DEM,Loretta L. Sanchez,106
+Tuolumne,LIME_KILN,U.S. Senate,,DEM,Kamala D. Harris,71
+Tuolumne,LIME_KILN,U.S. Senate,,DEM,Loretta L. Sanchez,29
+Tuolumne,LONG_BARN,U.S. Senate,,DEM,Kamala D. Harris,479
+Tuolumne,LONG_BARN,U.S. Senate,,DEM,Loretta L. Sanchez,297
+Tuolumne,MARSHALL-PONDEROSA,U.S. Senate,,DEM,Kamala D. Harris,295
+Tuolumne,MARSHALL-PONDEROSA,U.S. Senate,,DEM,Loretta L. Sanchez,120
+Tuolumne,MIDDLE_CAMP,U.S. Senate,,DEM,Kamala D. Harris,285
+Tuolumne,MIDDLE_CAMP,U.S. Senate,,DEM,Loretta L. Sanchez,104
+Tuolumne,MONO_VILLAGE,U.S. Senate,,DEM,Kamala D. Harris,249
+Tuolumne,MONO_VILLAGE,U.S. Senate,,DEM,Loretta L. Sanchez,123
+Tuolumne,MONO_VISTA,U.S. Senate,,DEM,Kamala D. Harris,422
+Tuolumne,MONO_VISTA,U.S. Senate,,DEM,Loretta L. Sanchez,271
+Tuolumne,MORMCRK_RAWHDE_TUTLE,U.S. Senate,,DEM,Kamala D. Harris,283
+Tuolumne,MORMCRK_RAWHDE_TUTLE,U.S. Senate,,DEM,Loretta L. Sanchez,138
+Tuolumne,MT_BROW_SHAWS_FLAT,U.S. Senate,,DEM,Kamala D. Harris,503
+Tuolumne,MT_BROW_SHAWS_FLAT,U.S. Senate,,DEM,Loretta L. Sanchez,213
+Tuolumne,MT_EATON,U.S. Senate,,DEM,Kamala D. Harris,536
+Tuolumne,MT_EATON,U.S. Senate,,DEM,Loretta L. Sanchez,317
+Tuolumne,NORTH_HESS,U.S. Senate,,DEM,Kamala D. Harris,29
+Tuolumne,NORTH_HESS,U.S. Senate,,DEM,Loretta L. Sanchez,14
+Tuolumne,OAK_GARDEN,U.S. Senate,,DEM,Kamala D. Harris,141
+Tuolumne,OAK_GARDEN,U.S. Senate,,DEM,Loretta L. Sanchez,83
+Tuolumne,PEORIA_FLAT_QUARTZ,U.S. Senate,,DEM,Kamala D. Harris,162
+Tuolumne,PEORIA_FLAT_QUARTZ,U.S. Senate,,DEM,Loretta L. Sanchez,117
+Tuolumne,PHOENIX_LAKE,U.S. Senate,,DEM,Kamala D. Harris,254
+Tuolumne,PHOENIX_LAKE,U.S. Senate,,DEM,Loretta L. Sanchez,160
+Tuolumne,PINECREST_EAST,U.S. Senate,,DEM,Kamala D. Harris,48
+Tuolumne,PINECREST_EAST,U.S. Senate,,DEM,Loretta L. Sanchez,40
+Tuolumne,PINECREST_WEST,U.S. Senate,,DEM,Kamala D. Harris,21
+Tuolumne,PINECREST_WEST,U.S. Senate,,DEM,Loretta L. Sanchez,15
+Tuolumne,PINE_MTN_EAST,U.S. Senate,,DEM,Kamala D. Harris,384
+Tuolumne,PINE_MTN_EAST,U.S. Senate,,DEM,Loretta L. Sanchez,139
+Tuolumne,PINE_MTN_SOUTH,U.S. Senate,,DEM,Kamala D. Harris,72
+Tuolumne,PINE_MTN_SOUTH,U.S. Senate,,DEM,Loretta L. Sanchez,27
+Tuolumne,POQUITOS-DRAPER,U.S. Senate,,DEM,Kamala D. Harris,196
+Tuolumne,POQUITOS-DRAPER,U.S. Senate,,DEM,Loretta L. Sanchez,116
+Tuolumne,PRIEST_CLTRVL_MOCCASIN,U.S. Senate,,DEM,Kamala D. Harris,23
+Tuolumne,PRIEST_CLTRVL_MOCCASIN,U.S. Senate,,DEM,Loretta L. Sanchez,25
+Tuolumne,RED_HILLS,U.S. Senate,,DEM,Kamala D. Harris,32
+Tuolumne,RED_HILLS,U.S. Senate,,DEM,Loretta L. Sanchez,18
+Tuolumne,RIDGEWOOD,U.S. Senate,,DEM,Kamala D. Harris,74
+Tuolumne,RIDGEWOOD,U.S. Senate,,DEM,Loretta L. Sanchez,45
+Tuolumne,SAWMILL_FLAT,U.S. Senate,,DEM,Kamala D. Harris,30
+Tuolumne,SAWMILL_FLAT,U.S. Senate,,DEM,Loretta L. Sanchez,19
+Tuolumne,SONORA_EAST,U.S. Senate,,DEM,Kamala D. Harris,247
+Tuolumne,SONORA_EAST,U.S. Senate,,DEM,Loretta L. Sanchez,150
+Tuolumne,SONORA_FAIR_WEST,U.S. Senate,,DEM,Kamala D. Harris,298
+Tuolumne,SONORA_FAIR_WEST,U.S. Senate,,DEM,Loretta L. Sanchez,137
+Tuolumne,SONORA_HOPE,U.S. Senate,,DEM,Kamala D. Harris,281
+Tuolumne,SONORA_HOPE,U.S. Senate,,DEM,Loretta L. Sanchez,163
+Tuolumne,SONORA_SOUTH,U.S. Senate,,DEM,Kamala D. Harris,12
+Tuolumne,SONORA_SOUTH,U.S. Senate,,DEM,Loretta L. Sanchez,13
+Tuolumne,SOULSBYVILLE,U.S. Senate,,DEM,Kamala D. Harris,38
+Tuolumne,SOULSBYVILLE,U.S. Senate,,DEM,Loretta L. Sanchez,14
+Tuolumne,SOULSBY_CURTIS_CREEK,U.S. Senate,,DEM,Kamala D. Harris,103
+Tuolumne,SOULSBY_CURTIS_CREEK,U.S. Senate,,DEM,Loretta L. Sanchez,43
+Tuolumne,SOUTH_FERRETTI,U.S. Senate,,DEM,Kamala D. Harris,105
+Tuolumne,SOUTH_FERRETTI,U.S. Senate,,DEM,Loretta L. Sanchez,34
+Tuolumne,TELEGRAPH_HILL,U.S. Senate,,DEM,Kamala D. Harris,88
+Tuolumne,TELEGRAPH_HILL,U.S. Senate,,DEM,Loretta L. Sanchez,38
+Tuolumne,TWAIN_HARTE_VALLEY,U.S. Senate,,DEM,Kamala D. Harris,66
+Tuolumne,TWAIN_HARTE_VALLEY,U.S. Senate,,DEM,Loretta L. Sanchez,31
+Tuolumne,UNION_HILL,U.S. Senate,,DEM,Kamala D. Harris,6
+Tuolumne,UNION_HILL,U.S. Senate,,DEM,Loretta L. Sanchez,7
+Tuolumne,WARDS_FERRY,U.S. Senate,,DEM,Kamala D. Harris,159
+Tuolumne,WARDS_FERRY,U.S. Senate,,DEM,Loretta L. Sanchez,78
+Tuolumne,WOODHAMS_CARNE,U.S. Senate,,DEM,Kamala D. Harris,52
+Tuolumne,WOODHAMS_CARNE,U.S. Senate,,DEM,Loretta L. Sanchez,26
+Tuolumne,YANKEE_HILL_ES,U.S. Senate,,DEM,Kamala D. Harris,42
+Tuolumne,YANKEE_HILL_ES,U.S. Senate,,DEM,Loretta L. Sanchez,10
+Tuolumne,YANKEE_HILL_WEST,U.S. Senate,,DEM,Kamala D. Harris,68
+Tuolumne,YANKEE_HILL_WEST,U.S. Senate,,DEM,Loretta L. Sanchez,28
+Tuolumne,YOSEMT_NS_RL_120_CHERRY,U.S. Senate,,DEM,Kamala D. Harris,18
+Tuolumne,YOSEMT_NS_RL_120_CHERRY,U.S. Senate,,DEM,Loretta L. Sanchez,13

--- a/2016/20161108__ca__general__ventura__precinct.csv
+++ b/2016/20161108__ca__general__ventura__precinct.csv
@@ -24239,1215 +24239,1215 @@ Ventura,Yrba-Buena-NO202-204,Proposition 67,,N/A,Yes,41
 Ventura,Yrba-Buena-NO202-204,Proposition 67,,N/A,No,41
 Ventura,Yrba-Buena-NO203,Proposition 67,,N/A,Yes,1
 Ventura,Yrba-Buena-NO203,Proposition 67,,N/A,No,0
-Ventura,Avenue-NO101-105,U.S. Senate,,DEM,Kamala Harris,5
-Ventura,Avenue-NO101-105,U.S. Senate,,DEM,Loretta Sanchez,1
-Ventura,Avenue-NO102-103-104,U.S. Senate,,DEM,Kamala Harris,12
-Ventura,Avenue-NO102-103-104,U.S. Senate,,DEM,Loretta Sanchez,3
-Ventura,Bardsdale-NO301,U.S. Senate,,DEM,Kamala Harris,122
-Ventura,Bardsdale-NO301,U.S. Senate,,DEM,Loretta Sanchez,95
-Ventura,Bardsdale-NO302-303-304,U.S. Senate,,DEM,Kamala Harris,33
-Ventura,Bardsdale-NO302-303-304,U.S. Senate,,DEM,Loretta Sanchez,23
-Ventura,Bardsdale-NO401-402-405-406,U.S. Senate,,DEM,Kamala Harris,0
-Ventura,Bardsdale-NO401-402-405-406,U.S. Senate,,DEM,Loretta Sanchez,0
-Ventura,Bardsdale-NO403-404,U.S. Senate,,DEM,Kamala Harris,0
-Ventura,Bardsdale-NO403-404,U.S. Senate,,DEM,Loretta Sanchez,0
-Ventura,Briggs-304,U.S. Senate,,DEM,Kamala Harris,16
-Ventura,Briggs-304,U.S. Senate,,DEM,Loretta Sanchez,5
-Ventura,Briggs-NO101-102-103,U.S. Senate,,DEM,Kamala Harris,80
-Ventura,Briggs-NO101-102-103,U.S. Senate,,DEM,Loretta Sanchez,72
-Ventura,Briggs-NO301,U.S. Senate,,DEM,Kamala Harris,111
-Ventura,Briggs-NO301,U.S. Senate,,DEM,Loretta Sanchez,123
-Ventura,Briggs-NO302-303,U.S. Senate,,DEM,Kamala Harris,8
-Ventura,Briggs-NO302-303,U.S. Senate,,DEM,Loretta Sanchez,12
-Ventura,Calleguas-NO201-212-214,U.S. Senate,,DEM,Kamala Harris,8
-Ventura,Calleguas-NO201-212-214,U.S. Senate,,DEM,Loretta Sanchez,11
-Ventura,Calleguas-NO202-203,U.S. Senate,,DEM,Kamala Harris,0
-Ventura,Calleguas-NO202-203,U.S. Senate,,DEM,Loretta Sanchez,0
-Ventura,Calleguas-NO204,U.S. Senate,,DEM,Kamala Harris,508
-Ventura,Calleguas-NO204,U.S. Senate,,DEM,Loretta Sanchez,211
-Ventura,Calleguas-NO205,U.S. Senate,,DEM,Kamala Harris,18
-Ventura,Calleguas-NO205,U.S. Senate,,DEM,Loretta Sanchez,5
-Ventura,Calleguas-NO206-208,U.S. Senate,,DEM,Kamala Harris,3
-Ventura,Calleguas-NO206-208,U.S. Senate,,DEM,Loretta Sanchez,8
-Ventura,Calleguas-NO207,U.S. Senate,,DEM,Kamala Harris,2
-Ventura,Calleguas-NO207,U.S. Senate,,DEM,Loretta Sanchez,0
-Ventura,Calleguas-NO209-218,U.S. Senate,,DEM,Kamala Harris,0
-Ventura,Calleguas-NO209-218,U.S. Senate,,DEM,Loretta Sanchez,0
-Ventura,Calleguas-NO210,U.S. Senate,,DEM,Kamala Harris,6
-Ventura,Calleguas-NO210,U.S. Senate,,DEM,Loretta Sanchez,3
-Ventura,Calleguas-NO211,U.S. Senate,,DEM,Kamala Harris,0
-Ventura,Calleguas-NO211,U.S. Senate,,DEM,Loretta Sanchez,2
-Ventura,Calleguas-NO216,U.S. Senate,,DEM,Kamala Harris,2
-Ventura,Calleguas-NO216,U.S. Senate,,DEM,Loretta Sanchez,0
-Ventura,Calleguas-NO301-305,U.S. Senate,,DEM,Kamala Harris,9
-Ventura,Calleguas-NO301-305,U.S. Senate,,DEM,Loretta Sanchez,8
-Ventura,Calleguas-NO302-307-309,U.S. Senate,,DEM,Kamala Harris,2
-Ventura,Calleguas-NO302-307-309,U.S. Senate,,DEM,Loretta Sanchez,2
-Ventura,Calleguas-NO303-306-315,U.S. Senate,,DEM,Kamala Harris,7
-Ventura,Calleguas-NO303-306-315,U.S. Senate,,DEM,Loretta Sanchez,8
-Ventura,Calleguas-NO304,U.S. Senate,,DEM,Kamala Harris,4
-Ventura,Calleguas-NO304,U.S. Senate,,DEM,Loretta Sanchez,2
-Ventura,Calleguas-NO312-313-314,U.S. Senate,,DEM,Kamala Harris,3
-Ventura,Calleguas-NO312-313-314,U.S. Senate,,DEM,Loretta Sanchez,0
-Ventura,Calleguas-NO401,U.S. Senate,,DEM,Kamala Harris,0
-Ventura,Calleguas-NO401,U.S. Senate,,DEM,Loretta Sanchez,0
-Ventura,Camarillo-NO301,U.S. Senate,,DEM,Kamala Harris,333
-Ventura,Camarillo-NO301,U.S. Senate,,DEM,Loretta Sanchez,223
-Ventura,Camarillo-NO302,U.S. Senate,,DEM,Kamala Harris,239
-Ventura,Camarillo-NO302,U.S. Senate,,DEM,Loretta Sanchez,113
-Ventura,Camarillo-NO303,U.S. Senate,,DEM,Kamala Harris,846
-Ventura,Camarillo-NO303,U.S. Senate,,DEM,Loretta Sanchez,482
-Ventura,Camarillo-NO305,U.S. Senate,,DEM,Kamala Harris,425
-Ventura,Camarillo-NO305,U.S. Senate,,DEM,Loretta Sanchez,323
-Ventura,Camarillo-NO306,U.S. Senate,,DEM,Kamala Harris,1105
-Ventura,Camarillo-NO306,U.S. Senate,,DEM,Loretta Sanchez,675
-Ventura,Camarillo-NO308,U.S. Senate,,DEM,Kamala Harris,518
-Ventura,Camarillo-NO308,U.S. Senate,,DEM,Loretta Sanchez,366
-Ventura,Camarillo-NO309,U.S. Senate,,DEM,Kamala Harris,619
-Ventura,Camarillo-NO309,U.S. Senate,,DEM,Loretta Sanchez,328
-Ventura,Camarillo-NO310,U.S. Senate,,DEM,Kamala Harris,1149
-Ventura,Camarillo-NO310,U.S. Senate,,DEM,Loretta Sanchez,598
-Ventura,Camarillo-NO312AL-325,U.S. Senate,,DEM,Kamala Harris,762
-Ventura,Camarillo-NO312AL-325,U.S. Senate,,DEM,Loretta Sanchez,399
-Ventura,Camarillo-NO313-320-354,U.S. Senate,,DEM,Kamala Harris,90
-Ventura,Camarillo-NO313-320-354,U.S. Senate,,DEM,Loretta Sanchez,67
-Ventura,Camarillo-NO314,U.S. Senate,,DEM,Kamala Harris,582
-Ventura,Camarillo-NO314,U.S. Senate,,DEM,Loretta Sanchez,370
-Ventura,Camarillo-NO315-344,U.S. Senate,,DEM,Kamala Harris,10
-Ventura,Camarillo-NO315-344,U.S. Senate,,DEM,Loretta Sanchez,4
-Ventura,Camarillo-NO316,U.S. Senate,,DEM,Kamala Harris,422
-Ventura,Camarillo-NO316,U.S. Senate,,DEM,Loretta Sanchez,244
-Ventura,Camarillo-NO317,U.S. Senate,,DEM,Kamala Harris,713
-Ventura,Camarillo-NO317,U.S. Senate,,DEM,Loretta Sanchez,378
-Ventura,Camarillo-NO318,U.S. Senate,,DEM,Kamala Harris,909
-Ventura,Camarillo-NO318,U.S. Senate,,DEM,Loretta Sanchez,567
-Ventura,Camarillo-NO321,U.S. Senate,,DEM,Kamala Harris,809
-Ventura,Camarillo-NO321,U.S. Senate,,DEM,Loretta Sanchez,443
-Ventura,Camarillo-NO322,U.S. Senate,,DEM,Kamala Harris,68
-Ventura,Camarillo-NO322,U.S. Senate,,DEM,Loretta Sanchez,35
-Ventura,Camarillo-NO323,U.S. Senate,,DEM,Kamala Harris,709
-Ventura,Camarillo-NO323,U.S. Senate,,DEM,Loretta Sanchez,406
-Ventura,Camarillo-NO324-330,U.S. Senate,,DEM,Kamala Harris,7
-Ventura,Camarillo-NO324-330,U.S. Senate,,DEM,Loretta Sanchez,15
-Ventura,Camarillo-NO326,U.S. Senate,,DEM,Kamala Harris,833
-Ventura,Camarillo-NO326,U.S. Senate,,DEM,Loretta Sanchez,432
-Ventura,Camarillo-NO327,U.S. Senate,,DEM,Kamala Harris,1383
-Ventura,Camarillo-NO327,U.S. Senate,,DEM,Loretta Sanchez,711
-Ventura,Camarillo-NO329,U.S. Senate,,DEM,Kamala Harris,1438
-Ventura,Camarillo-NO329,U.S. Senate,,DEM,Loretta Sanchez,570
-Ventura,Camarillo-NO331,U.S. Senate,,DEM,Kamala Harris,571
-Ventura,Camarillo-NO331,U.S. Senate,,DEM,Loretta Sanchez,375
-Ventura,Camarillo-NO333,U.S. Senate,,DEM,Kamala Harris,946
-Ventura,Camarillo-NO333,U.S. Senate,,DEM,Loretta Sanchez,506
-Ventura,Camarillo-NO336,U.S. Senate,,DEM,Kamala Harris,0
-Ventura,Camarillo-NO336,U.S. Senate,,DEM,Loretta Sanchez,0
-Ventura,Camarillo-NO337,U.S. Senate,,DEM,Kamala Harris,1351
-Ventura,Camarillo-NO337,U.S. Senate,,DEM,Loretta Sanchez,769
-Ventura,Camarillo-NO338,U.S. Senate,,DEM,Kamala Harris,24
-Ventura,Camarillo-NO338,U.S. Senate,,DEM,Loretta Sanchez,9
-Ventura,Camarillo-NO339-341,U.S. Senate,,DEM,Kamala Harris,57
-Ventura,Camarillo-NO339-341,U.S. Senate,,DEM,Loretta Sanchez,27
-Ventura,Camarillo-NO340-345-346-350,U.S. Senate,,DEM,Kamala Harris,4
-Ventura,Camarillo-NO340-345-346-350,U.S. Senate,,DEM,Loretta Sanchez,1
-Ventura,Camarillo-NO343,U.S. Senate,,DEM,Kamala Harris,90
-Ventura,Camarillo-NO343,U.S. Senate,,DEM,Loretta Sanchez,56
-Ventura,Camarillo-NO347,U.S. Senate,,DEM,Kamala Harris,998
-Ventura,Camarillo-NO347,U.S. Senate,,DEM,Loretta Sanchez,567
-Ventura,Camarillo-NO348,U.S. Senate,,DEM,Kamala Harris,1
-Ventura,Camarillo-NO348,U.S. Senate,,DEM,Loretta Sanchez,0
-Ventura,Camarillo-NO349,U.S. Senate,,DEM,Kamala Harris,7
-Ventura,Camarillo-NO349,U.S. Senate,,DEM,Loretta Sanchez,1
-Ventura,Camarillo-NO351,U.S. Senate,,DEM,Kamala Harris,0
-Ventura,Camarillo-NO351,U.S. Senate,,DEM,Loretta Sanchez,0
-Ventura,Camarillo-NO352,U.S. Senate,,DEM,Kamala Harris,0
-Ventura,Camarillo-NO352,U.S. Senate,,DEM,Loretta Sanchez,0
-Ventura,Camarillo-NO353,U.S. Senate,,DEM,Kamala Harris,0
-Ventura,Camarillo-NO353,U.S. Senate,,DEM,Loretta Sanchez,0
-Ventura,Camarillo-NO355,U.S. Senate,,DEM,Kamala Harris,0
-Ventura,Camarillo-NO355,U.S. Senate,,DEM,Loretta Sanchez,0
-Ventura,Camarillo-NO356,U.S. Senate,,DEM,Kamala Harris,1
-Ventura,Camarillo-NO356,U.S. Senate,,DEM,Loretta Sanchez,2
-Ventura,Camarillo-NO357,U.S. Senate,,DEM,Kamala Harris,0
-Ventura,Camarillo-NO357,U.S. Senate,,DEM,Loretta Sanchez,0
-Ventura,Central-NO301-303,U.S. Senate,,DEM,Kamala Harris,0
-Ventura,Central-NO301-303,U.S. Senate,,DEM,Loretta Sanchez,0
-Ventura,Central-NO304,U.S. Senate,,DEM,Kamala Harris,0
-Ventura,Central-NO304,U.S. Senate,,DEM,Loretta Sanchez,0
-Ventura,Csts-Sprgs-NO101-02-04-37-38,U.S. Senate,,DEM,Kamala Harris,61
-Ventura,Csts-Sprgs-NO101-02-04-37-38,U.S. Senate,,DEM,Loretta Sanchez,29
-Ventura,Csts-Sprgs-NO103-124,U.S. Senate,,DEM,Kamala Harris,36
-Ventura,Csts-Sprgs-NO103-124,U.S. Senate,,DEM,Loretta Sanchez,17
-Ventura,Csts-Sprgs-NO105-140-148,U.S. Senate,,DEM,Kamala Harris,15
-Ventura,Csts-Sprgs-NO105-140-148,U.S. Senate,,DEM,Loretta Sanchez,2
-Ventura,Csts-Sprgs-NO106-108-109,U.S. Senate,,DEM,Kamala Harris,91
-Ventura,Csts-Sprgs-NO106-108-109,U.S. Senate,,DEM,Loretta Sanchez,25
-Ventura,Csts-Sprgs-NO111,U.S. Senate,,DEM,Kamala Harris,99
-Ventura,Csts-Sprgs-NO111,U.S. Senate,,DEM,Loretta Sanchez,57
-Ventura,Csts-Sprgs-NO112-113,U.S. Senate,,DEM,Kamala Harris,3
-Ventura,Csts-Sprgs-NO112-113,U.S. Senate,,DEM,Loretta Sanchez,2
-Ventura,Csts-Sprgs-NO117-118-119,U.S. Senate,,DEM,Kamala Harris,0
-Ventura,Csts-Sprgs-NO117-118-119,U.S. Senate,,DEM,Loretta Sanchez,0
-Ventura,Csts-Sprgs-NO121-123-125,U.S. Senate,,DEM,Kamala Harris,6
-Ventura,Csts-Sprgs-NO121-123-125,U.S. Senate,,DEM,Loretta Sanchez,8
-Ventura,Csts-Sprgs-NO126-128-29-150,U.S. Senate,,DEM,Kamala Harris,28
-Ventura,Csts-Sprgs-NO126-128-29-150,U.S. Senate,,DEM,Loretta Sanchez,7
-Ventura,Csts-Sprgs-NO130-133-135-136,U.S. Senate,,DEM,Kamala Harris,15
-Ventura,Csts-Sprgs-NO130-133-135-136,U.S. Senate,,DEM,Loretta Sanchez,9
-Ventura,Csts-Sprgs-NO149,U.S. Senate,,DEM,Kamala Harris,0
-Ventura,Csts-Sprgs-NO149,U.S. Senate,,DEM,Loretta Sanchez,1
-Ventura,Del-Norte-NO201,U.S. Senate,,DEM,Kamala Harris,26
-Ventura,Del-Norte-NO201,U.S. Senate,,DEM,Loretta Sanchez,19
-Ventura,Del-Norte-NO301,U.S. Senate,,DEM,Kamala Harris,71
-Ventura,Del-Norte-NO301,U.S. Senate,,DEM,Loretta Sanchez,62
-Ventura,Del-Norte-NO501-509,U.S. Senate,,DEM,Kamala Harris,6
-Ventura,Del-Norte-NO501-509,U.S. Senate,,DEM,Loretta Sanchez,14
-Ventura,East-Ojai-NO101,U.S. Senate,,DEM,Kamala Harris,456
-Ventura,East-Ojai-NO101,U.S. Senate,,DEM,Loretta Sanchez,150
-Ventura,East-Ojai-NO102-107-110,U.S. Senate,,DEM,Kamala Harris,13
-Ventura,East-Ojai-NO102-107-110,U.S. Senate,,DEM,Loretta Sanchez,6
-Ventura,East-Ojai-NO103,U.S. Senate,,DEM,Kamala Harris,7
-Ventura,East-Ojai-NO103,U.S. Senate,,DEM,Loretta Sanchez,5
-Ventura,East-Ojai-NO104-106-111,U.S. Senate,,DEM,Kamala Harris,8
-Ventura,East-Ojai-NO104-106-111,U.S. Senate,,DEM,Loretta Sanchez,7
-Ventura,East-Ojai-NO105-115,U.S. Senate,,DEM,Kamala Harris,0
-Ventura,East-Ojai-NO105-115,U.S. Senate,,DEM,Loretta Sanchez,0
-Ventura,East-Ojai-NO112-113,U.S. Senate,,DEM,Kamala Harris,129
-Ventura,East-Ojai-NO112-113,U.S. Senate,,DEM,Loretta Sanchez,39
-Ventura,East-Ojai-NO116-117,U.S. Senate,,DEM,Kamala Harris,4
-Ventura,East-Ojai-NO116-117,U.S. Senate,,DEM,Loretta Sanchez,1
-Ventura,El-Rio-NO101-102-103,U.S. Senate,,DEM,Kamala Harris,0
-Ventura,El-Rio-NO101-102-103,U.S. Senate,,DEM,Loretta Sanchez,0
-Ventura,El-Rio-NO501,U.S. Senate,,DEM,Kamala Harris,561
-Ventura,El-Rio-NO501,U.S. Senate,,DEM,Loretta Sanchez,642
-Ventura,El-Rio-NO502,U.S. Senate,,DEM,Kamala Harris,180
-Ventura,El-Rio-NO502,U.S. Senate,,DEM,Loretta Sanchez,219
-Ventura,El-Rio-NO503-505,U.S. Senate,,DEM,Kamala Harris,12
-Ventura,El-Rio-NO503-505,U.S. Senate,,DEM,Loretta Sanchez,10
-Ventura,El-Rio-NO506,U.S. Senate,,DEM,Kamala Harris,0
-Ventura,El-Rio-NO506,U.S. Senate,,DEM,Loretta Sanchez,0
-Ventura,Fillmore-NO301,U.S. Senate,,DEM,Kamala Harris,279
-Ventura,Fillmore-NO301,U.S. Senate,,DEM,Loretta Sanchez,473
-Ventura,Fillmore-NO302,U.S. Senate,,DEM,Kamala Harris,279
-Ventura,Fillmore-NO302,U.S. Senate,,DEM,Loretta Sanchez,362
-Ventura,Fillmore-NO303,U.S. Senate,,DEM,Kamala Harris,371
-Ventura,Fillmore-NO303,U.S. Senate,,DEM,Loretta Sanchez,352
-Ventura,Fillmore-NO304,U.S. Senate,,DEM,Kamala Harris,964
-Ventura,Fillmore-NO304,U.S. Senate,,DEM,Loretta Sanchez,1092
-Ventura,Fillmore-NO305,U.S. Senate,,DEM,Kamala Harris,129
-Ventura,Fillmore-NO305,U.S. Senate,,DEM,Loretta Sanchez,92
-Ventura,Fillmore-NO306,U.S. Senate,,DEM,Kamala Harris,0
-Ventura,Fillmore-NO306,U.S. Senate,,DEM,Loretta Sanchez,0
-Ventura,Gabbert-NO201,U.S. Senate,,DEM,Kamala Harris,0
-Ventura,Gabbert-NO201,U.S. Senate,,DEM,Loretta Sanchez,0
-Ventura,Gabbert-NO202,U.S. Senate,,DEM,Kamala Harris,9
-Ventura,Gabbert-NO202,U.S. Senate,,DEM,Loretta Sanchez,6
-Ventura,Gabbert-NO203,U.S. Senate,,DEM,Kamala Harris,5
-Ventura,Gabbert-NO203,U.S. Senate,,DEM,Loretta Sanchez,2
-Ventura,Gabbert-NO301,U.S. Senate,,DEM,Kamala Harris,0
-Ventura,Gabbert-NO301,U.S. Senate,,DEM,Loretta Sanchez,0
-Ventura,Gabbert-NO302,U.S. Senate,,DEM,Kamala Harris,0
-Ventura,Gabbert-NO302,U.S. Senate,,DEM,Loretta Sanchez,0
-Ventura,Gabbert-NO401,U.S. Senate,,DEM,Kamala Harris,59
-Ventura,Gabbert-NO401,U.S. Senate,,DEM,Loretta Sanchez,47
-Ventura,Gabbert-NO402-411,U.S. Senate,,DEM,Kamala Harris,3
-Ventura,Gabbert-NO402-411,U.S. Senate,,DEM,Loretta Sanchez,9
-Ventura,Gabbert-NO403,U.S. Senate,,DEM,Kamala Harris,177
-Ventura,Gabbert-NO403,U.S. Senate,,DEM,Loretta Sanchez,106
-Ventura,Gabbert-NO404,U.S. Senate,,DEM,Kamala Harris,9
-Ventura,Gabbert-NO404,U.S. Senate,,DEM,Loretta Sanchez,14
-Ventura,Gabbert-NO405,U.S. Senate,,DEM,Kamala Harris,0
-Ventura,Gabbert-NO405,U.S. Senate,,DEM,Loretta Sanchez,0
-Ventura,Gabbert-NO406-412,U.S. Senate,,DEM,Kamala Harris,4
-Ventura,Gabbert-NO406-412,U.S. Senate,,DEM,Loretta Sanchez,1
-Ventura,Gabbert-NO407,U.S. Senate,,DEM,Kamala Harris,0
-Ventura,Gabbert-NO407,U.S. Senate,,DEM,Loretta Sanchez,0
-Ventura,Gabbert-NO408-409,U.S. Senate,,DEM,Kamala Harris,30
-Ventura,Gabbert-NO408-409,U.S. Senate,,DEM,Loretta Sanchez,29
-Ventura,Gabbert-NO410,U.S. Senate,,DEM,Kamala Harris,11
-Ventura,Gabbert-NO410,U.S. Senate,,DEM,Loretta Sanchez,7
-Ventura,GabbertNO204,U.S. Senate,,DEM,Kamala Harris,1
-Ventura,GabbertNO204,U.S. Senate,,DEM,Loretta Sanchez,1
-Ventura,Goodenough-NO301-Sespe-NO301,U.S. Senate,,DEM,Kamala Harris,162
-Ventura,Goodenough-NO301-Sespe-NO301,U.S. Senate,,DEM,Loretta Sanchez,136
-Ventura,Goodenough-NO302,U.S. Senate,,DEM,Kamala Harris,4
-Ventura,Goodenough-NO302,U.S. Senate,,DEM,Loretta Sanchez,2
-Ventura,Grimes-NO301-302,U.S. Senate,,DEM,Kamala Harris,0
-Ventura,Grimes-NO301-302,U.S. Senate,,DEM,Loretta Sanchez,0
-Ventura,Heights-NO301,U.S. Senate,,DEM,Kamala Harris,319
-Ventura,Heights-NO301,U.S. Senate,,DEM,Loretta Sanchez,214
-Ventura,Heights-NO302,U.S. Senate,,DEM,Kamala Harris,484
-Ventura,Heights-NO302,U.S. Senate,,DEM,Loretta Sanchez,226
-Ventura,Heights-NO304,U.S. Senate,,DEM,Kamala Harris,81
-Ventura,Heights-NO304,U.S. Senate,,DEM,Loretta Sanchez,53
-Ventura,Heights-NO305,U.S. Senate,,DEM,Kamala Harris,29
-Ventura,Heights-NO305,U.S. Senate,,DEM,Loretta Sanchez,15
-Ventura,Heights-NO306,U.S. Senate,,DEM,Kamala Harris,88
-Ventura,Heights-NO306,U.S. Senate,,DEM,Loretta Sanchez,48
-Ventura,Hollywood-NO501,U.S. Senate,,DEM,Kamala Harris,281
-Ventura,Hollywood-NO501,U.S. Senate,,DEM,Loretta Sanchez,137
-Ventura,Islands-NO301,U.S. Senate,,DEM,Kamala Harris,0
-Ventura,Islands-NO301,U.S. Senate,,DEM,Loretta Sanchez,0
-Ventura,Knolls-NO401,U.S. Senate,,DEM,Kamala Harris,484
-Ventura,Knolls-NO401,U.S. Senate,,DEM,Loretta Sanchez,271
-Ventura,Knolls-NO402,U.S. Senate,,DEM,Kamala Harris,6
-Ventura,Knolls-NO402,U.S. Senate,,DEM,Loretta Sanchez,2
-Ventura,Las-Posas-NO201,U.S. Senate,,DEM,Kamala Harris,19
-Ventura,Las-Posas-NO201,U.S. Senate,,DEM,Loretta Sanchez,27
-Ventura,Las-Posas-NO301,U.S. Senate,,DEM,Kamala Harris,204
-Ventura,Las-Posas-NO301,U.S. Senate,,DEM,Loretta Sanchez,146
-Ventura,Las-Posas-NO302,U.S. Senate,,DEM,Kamala Harris,361
-Ventura,Las-Posas-NO302,U.S. Senate,,DEM,Loretta Sanchez,230
-Ventura,Las-Posas-NO303,U.S. Senate,,DEM,Kamala Harris,285
-Ventura,Las-Posas-NO303,U.S. Senate,,DEM,Loretta Sanchez,161
-Ventura,Las-Posas-NO304,U.S. Senate,,DEM,Kamala Harris,4
-Ventura,Las-Posas-NO304,U.S. Senate,,DEM,Loretta Sanchez,2
-Ventura,Las-Posas-NO305,U.S. Senate,,DEM,Kamala Harris,1
-Ventura,Las-Posas-NO305,U.S. Senate,,DEM,Loretta Sanchez,0
-Ventura,Las-Posas-NO306,U.S. Senate,,DEM,Kamala Harris,1
-Ventura,Las-Posas-NO306,U.S. Senate,,DEM,Loretta Sanchez,1
-Ventura,Las-Posas-NO307,U.S. Senate,,DEM,Kamala Harris,0
-Ventura,Las-Posas-NO307,U.S. Senate,,DEM,Loretta Sanchez,0
-Ventura,LkVw-Bell-NO201,U.S. Senate,,DEM,Kamala Harris,642
-Ventura,LkVw-Bell-NO201,U.S. Senate,,DEM,Loretta Sanchez,289
-Ventura,Lockwood-NO301,U.S. Senate,,DEM,Kamala Harris,53
-Ventura,Lockwood-NO301,U.S. Senate,,DEM,Loretta Sanchez,40
-Ventura,Lockwood-NO302-303,U.S. Senate,,DEM,Kamala Harris,0
-Ventura,Lockwood-NO302-303,U.S. Senate,,DEM,Loretta Sanchez,1
-Ventura,Lockwood-NO304,U.S. Senate,,DEM,Kamala Harris,0
-Ventura,Lockwood-NO304,U.S. Senate,,DEM,Loretta Sanchez,0
-Ventura,Lockwood-NO305-306,U.S. Senate,,DEM,Kamala Harris,0
-Ventura,Lockwood-NO305-306,U.S. Senate,,DEM,Loretta Sanchez,0
-Ventura,Lockwood-NO307,U.S. Senate,,DEM,Kamala Harris,0
-Ventura,Lockwood-NO307,U.S. Senate,,DEM,Loretta Sanchez,0
-Ventura,Lv-Ok-Acrs-NO101,U.S. Senate,,DEM,Kamala Harris,104
-Ventura,Lv-Ok-Acrs-NO101,U.S. Senate,,DEM,Loretta Sanchez,54
-Ventura,Lv-Ok-Acrs-NO102-104-107,U.S. Senate,,DEM,Kamala Harris,6
-Ventura,Lv-Ok-Acrs-NO102-104-107,U.S. Senate,,DEM,Loretta Sanchez,3
-Ventura,Lv-Ok-Acrs-NO103-106,U.S. Senate,,DEM,Kamala Harris,70
-Ventura,Lv-Ok-Acrs-NO103-106,U.S. Senate,,DEM,Loretta Sanchez,31
-Ventura,Lv-Ok-Acrs-NO109-110,U.S. Senate,,DEM,Kamala Harris,35
-Ventura,Lv-Ok-Acrs-NO109-110,U.S. Senate,,DEM,Loretta Sanchez,33
-Ventura,Mariano-NO101,U.S. Senate,,DEM,Kamala Harris,0
-Ventura,Mariano-NO101,U.S. Senate,,DEM,Loretta Sanchez,0
-Ventura,Matilija-NO101,U.S. Senate,,DEM,Kamala Harris,18
-Ventura,Matilija-NO101,U.S. Senate,,DEM,Loretta Sanchez,12
-Ventura,Matilija-NO102,U.S. Senate,,DEM,Kamala Harris,216
-Ventura,Matilija-NO102,U.S. Senate,,DEM,Loretta Sanchez,75
-Ventura,Matilija-NO103-107-111-113,U.S. Senate,,DEM,Kamala Harris,12
-Ventura,Matilija-NO103-107-111-113,U.S. Senate,,DEM,Loretta Sanchez,2
-Ventura,Matilija-NO104-125,U.S. Senate,,DEM,Kamala Harris,85
-Ventura,Matilija-NO104-125,U.S. Senate,,DEM,Loretta Sanchez,20
-Ventura,Matilija-NO105,U.S. Senate,,DEM,Kamala Harris,5
-Ventura,Matilija-NO105,U.S. Senate,,DEM,Loretta Sanchez,2
-Ventura,Matilija-NO106-12-16-18-24,U.S. Senate,,DEM,Kamala Harris,27
-Ventura,Matilija-NO106-12-16-18-24,U.S. Senate,,DEM,Loretta Sanchez,12
-Ventura,Matilija-NO108-117,U.S. Senate,,DEM,Kamala Harris,9
-Ventura,Matilija-NO108-117,U.S. Senate,,DEM,Loretta Sanchez,16
-Ventura,Matilija-NO109-114-115,U.S. Senate,,DEM,Kamala Harris,42
-Ventura,Matilija-NO109-114-115,U.S. Senate,,DEM,Loretta Sanchez,10
-Ventura,Matilija-NO110,U.S. Senate,,DEM,Kamala Harris,0
-Ventura,Matilija-NO110,U.S. Senate,,DEM,Loretta Sanchez,1
-Ventura,Matilija-NO121-122-123,U.S. Senate,,DEM,Kamala Harris,9
-Ventura,Matilija-NO121-122-123,U.S. Senate,,DEM,Loretta Sanchez,0
-Ventura,Mill-NO101,U.S. Senate,,DEM,Kamala Harris,381
-Ventura,Mill-NO101,U.S. Senate,,DEM,Loretta Sanchez,317
-Ventura,Mill-NO102-105-106,U.S. Senate,,DEM,Kamala Harris,0
-Ventura,Mill-NO102-105-106,U.S. Senate,,DEM,Loretta Sanchez,0
-Ventura,Mill-NO103,U.S. Senate,,DEM,Kamala Harris,3
-Ventura,Mill-NO103,U.S. Senate,,DEM,Loretta Sanchez,0
-Ventura,Mill-NO104,U.S. Senate,,DEM,Kamala Harris,0
-Ventura,Mill-NO104,U.S. Senate,,DEM,Loretta Sanchez,0
-Ventura,Mill-NO107,U.S. Senate,,DEM,Kamala Harris,0
-Ventura,Mill-NO107,U.S. Senate,,DEM,Loretta Sanchez,0
-Ventura,Mill-NO108,U.S. Senate,,DEM,Kamala Harris,5
-Ventura,Mill-NO108,U.S. Senate,,DEM,Loretta Sanchez,1
-Ventura,Mission-NO101,U.S. Senate,,DEM,Kamala Harris,70
-Ventura,Mission-NO101,U.S. Senate,,DEM,Loretta Sanchez,43
-Ventura,Mission-NO102-103-104,U.S. Senate,,DEM,Kamala Harris,16
-Ventura,Mission-NO102-103-104,U.S. Senate,,DEM,Loretta Sanchez,13
-Ventura,Mnrs-Oaks-NO101,U.S. Senate,,DEM,Kamala Harris,196
-Ventura,Mnrs-Oaks-NO101,U.S. Senate,,DEM,Loretta Sanchez,76
-Ventura,Mnrs-Oaks-NO102,U.S. Senate,,DEM,Kamala Harris,493
-Ventura,Mnrs-Oaks-NO102,U.S. Senate,,DEM,Loretta Sanchez,255
-Ventura,Mnrs-Oaks-NO103-111-112,U.S. Senate,,DEM,Kamala Harris,46
-Ventura,Mnrs-Oaks-NO103-111-112,U.S. Senate,,DEM,Loretta Sanchez,22
-Ventura,Mnrs-Oaks-NO104,U.S. Senate,,DEM,Kamala Harris,119
-Ventura,Mnrs-Oaks-NO104,U.S. Senate,,DEM,Loretta Sanchez,44
-Ventura,Mnrs-Oaks-NO105,U.S. Senate,,DEM,Kamala Harris,119
-Ventura,Mnrs-Oaks-NO105,U.S. Senate,,DEM,Loretta Sanchez,45
-Ventura,Mnrs-Oaks-NO106-108-109,U.S. Senate,,DEM,Kamala Harris,1
-Ventura,Mnrs-Oaks-NO106-108-109,U.S. Senate,,DEM,Loretta Sanchez,1
-Ventura,Mnrs-Oaks-NO107-113,U.S. Senate,,DEM,Kamala Harris,2
-Ventura,Mnrs-Oaks-NO107-113,U.S. Senate,,DEM,Loretta Sanchez,4
-Ventura,Mnrs-Oaks-NO110,U.S. Senate,,DEM,Kamala Harris,0
-Ventura,Mnrs-Oaks-NO110,U.S. Senate,,DEM,Loretta Sanchez,0
-Ventura,Montalvo-NO101-102-103-104,U.S. Senate,,DEM,Kamala Harris,0
-Ventura,Montalvo-NO101-102-103-104,U.S. Senate,,DEM,Loretta Sanchez,4
-Ventura,Moorpark-NO401,U.S. Senate,,DEM,Kamala Harris,1014
-Ventura,Moorpark-NO401,U.S. Senate,,DEM,Loretta Sanchez,610
-Ventura,Moorpark-NO402,U.S. Senate,,DEM,Kamala Harris,556
-Ventura,Moorpark-NO402,U.S. Senate,,DEM,Loretta Sanchez,431
-Ventura,Moorpark-NO403,U.S. Senate,,DEM,Kamala Harris,1
-Ventura,Moorpark-NO403,U.S. Senate,,DEM,Loretta Sanchez,2
-Ventura,Moorpark-NO404,U.S. Senate,,DEM,Kamala Harris,554
-Ventura,Moorpark-NO404,U.S. Senate,,DEM,Loretta Sanchez,581
-Ventura,Moorpark-NO406,U.S. Senate,,DEM,Kamala Harris,1133
-Ventura,Moorpark-NO406,U.S. Senate,,DEM,Loretta Sanchez,579
-Ventura,Moorpark-NO407,U.S. Senate,,DEM,Kamala Harris,536
-Ventura,Moorpark-NO407,U.S. Senate,,DEM,Loretta Sanchez,414
-Ventura,Moorpark-NO408,U.S. Senate,,DEM,Kamala Harris,884
-Ventura,Moorpark-NO408,U.S. Senate,,DEM,Loretta Sanchez,467
-Ventura,Moorpark-NO409,U.S. Senate,,DEM,Kamala Harris,858
-Ventura,Moorpark-NO409,U.S. Senate,,DEM,Loretta Sanchez,424
-Ventura,Moorpark-NO413,U.S. Senate,,DEM,Kamala Harris,1528
-Ventura,Moorpark-NO413,U.S. Senate,,DEM,Loretta Sanchez,734
-Ventura,Moorpark-NO414,U.S. Senate,,DEM,Kamala Harris,1229
-Ventura,Moorpark-NO414,U.S. Senate,,DEM,Loretta Sanchez,718
-Ventura,Moorpark-NO415,U.S. Senate,,DEM,Kamala Harris,374
-Ventura,Moorpark-NO415,U.S. Senate,,DEM,Loretta Sanchez,260
-Ventura,Moorpark-NO416,U.S. Senate,,DEM,Kamala Harris,0
-Ventura,Moorpark-NO416,U.S. Senate,,DEM,Loretta Sanchez,0
-Ventura,Mound-NO101-105,U.S. Senate,,DEM,Kamala Harris,21
-Ventura,Mound-NO101-105,U.S. Senate,,DEM,Loretta Sanchez,9
-Ventura,Mugu-NO201,U.S. Senate,,DEM,Kamala Harris,70
-Ventura,Mugu-NO201,U.S. Senate,,DEM,Loretta Sanchez,45
-Ventura,Mupu-304-305,U.S. Senate,,DEM,Kamala Harris,2
-Ventura,Mupu-304-305,U.S. Senate,,DEM,Loretta Sanchez,0
-Ventura,Mupu-NO301-303,U.S. Senate,,DEM,Kamala Harris,70
-Ventura,Mupu-NO301-303,U.S. Senate,,DEM,Loretta Sanchez,49
-Ventura,Mupu-North-NO301,U.S. Senate,,DEM,Kamala Harris,0
-Ventura,Mupu-North-NO301,U.S. Senate,,DEM,Loretta Sanchez,0
-Ventura,Nylnd-Acrs-NO501,U.S. Senate,,DEM,Kamala Harris,147
-Ventura,Nylnd-Acrs-NO501,U.S. Senate,,DEM,Loretta Sanchez,203
-Ventura,Nylnd-Acrs-NO502,U.S. Senate,,DEM,Kamala Harris,1
-Ventura,Nylnd-Acrs-NO502,U.S. Senate,,DEM,Loretta Sanchez,0
-Ventura,Nylnd-Acrs-NO504,U.S. Senate,,DEM,Kamala Harris,0
-Ventura,Nylnd-Acrs-NO504,U.S. Senate,,DEM,Loretta Sanchez,0
-Ventura,Oak-Park-NO201,U.S. Senate,,DEM,Kamala Harris,516
-Ventura,Oak-Park-NO201,U.S. Senate,,DEM,Loretta Sanchez,204
-Ventura,Oak-Park-NO203,U.S. Senate,,DEM,Kamala Harris,1057
-Ventura,Oak-Park-NO203,U.S. Senate,,DEM,Loretta Sanchez,410
-Ventura,Oak-Park-NO205-207-209,U.S. Senate,,DEM,Kamala Harris,0
-Ventura,Oak-Park-NO205-207-209,U.S. Senate,,DEM,Loretta Sanchez,0
-Ventura,Oak-Park-NO206,U.S. Senate,,DEM,Kamala Harris,1725
-Ventura,Oak-Park-NO206,U.S. Senate,,DEM,Loretta Sanchez,733
-Ventura,Oak-Park-NO210,U.S. Senate,,DEM,Kamala Harris,1058
-Ventura,Oak-Park-NO210,U.S. Senate,,DEM,Loretta Sanchez,442
-Ventura,Oak-Park-NO401,U.S. Senate,,DEM,Kamala Harris,0
-Ventura,Oak-Park-NO401,U.S. Senate,,DEM,Loretta Sanchez,0
-Ventura,Oak-View-NO101,U.S. Senate,,DEM,Kamala Harris,212
-Ventura,Oak-View-NO101,U.S. Senate,,DEM,Loretta Sanchez,162
-Ventura,Oak-View-NO102,U.S. Senate,,DEM,Kamala Harris,271
-Ventura,Oak-View-NO102,U.S. Senate,,DEM,Loretta Sanchez,81
-Ventura,Oak-View-NO103,U.S. Senate,,DEM,Kamala Harris,195
-Ventura,Oak-View-NO103,U.S. Senate,,DEM,Loretta Sanchez,111
-Ventura,Oak-View-NO104,U.S. Senate,,DEM,Kamala Harris,51
-Ventura,Oak-View-NO104,U.S. Senate,,DEM,Loretta Sanchez,33
-Ventura,Oak-View-NO105,U.S. Senate,,DEM,Kamala Harris,102
-Ventura,Oak-View-NO105,U.S. Senate,,DEM,Loretta Sanchez,70
-Ventura,Oak-View-NO106,U.S. Senate,,DEM,Kamala Harris,147
-Ventura,Oak-View-NO106,U.S. Senate,,DEM,Loretta Sanchez,78
-Ventura,Oak-View-NO107,U.S. Senate,,DEM,Kamala Harris,104
-Ventura,Oak-View-NO107,U.S. Senate,,DEM,Loretta Sanchez,41
-Ventura,Oak-View-NO108,U.S. Senate,,DEM,Kamala Harris,0
-Ventura,Oak-View-NO108,U.S. Senate,,DEM,Loretta Sanchez,0
-Ventura,Oak-View-NO109,U.S. Senate,,DEM,Kamala Harris,77
-Ventura,Oak-View-NO109,U.S. Senate,,DEM,Loretta Sanchez,33
-Ventura,Oak-View-NO110-111-113-114,U.S. Senate,,DEM,Kamala Harris,0
-Ventura,Oak-View-NO110-111-113-114,U.S. Senate,,DEM,Loretta Sanchez,5
-Ventura,Oak-View-NO112-116,U.S. Senate,,DEM,Kamala Harris,88
-Ventura,Oak-View-NO112-116,U.S. Senate,,DEM,Loretta Sanchez,43
-Ventura,Oak-View-NO115,U.S. Senate,,DEM,Kamala Harris,3
-Ventura,Oak-View-NO115,U.S. Senate,,DEM,Loretta Sanchez,2
-Ventura,Oak-View-NO117,U.S. Senate,,DEM,Kamala Harris,97
-Ventura,Oak-View-NO117,U.S. Senate,,DEM,Loretta Sanchez,59
-Ventura,Oak-View-NO118-120,U.S. Senate,,DEM,Kamala Harris,37
-Ventura,Oak-View-NO118-120,U.S. Senate,,DEM,Loretta Sanchez,14
-Ventura,Oak-View-NO123,U.S. Senate,,DEM,Kamala Harris,51
-Ventura,Oak-View-NO123,U.S. Senate,,DEM,Loretta Sanchez,40
-Ventura,Oaks-NO202,U.S. Senate,,DEM,Kamala Harris,28
-Ventura,Oaks-NO202,U.S. Senate,,DEM,Loretta Sanchez,32
-Ventura,Ocean-View-NO201-203-213,U.S. Senate,,DEM,Kamala Harris,17
-Ventura,Ocean-View-NO201-203-213,U.S. Senate,,DEM,Loretta Sanchez,10
-Ventura,Ocean-View-NO301-302,U.S. Senate,,DEM,Kamala Harris,2
-Ventura,Ocean-View-NO301-302,U.S. Senate,,DEM,Loretta Sanchez,4
-Ventura,Ocean-View-NO303-307,U.S. Senate,,DEM,Kamala Harris,18
-Ventura,Ocean-View-NO303-307,U.S. Senate,,DEM,Loretta Sanchez,19
-Ventura,Ocean-View-NO501-504-506,U.S. Senate,,DEM,Kamala Harris,14
-Ventura,Ocean-View-NO501-504-506,U.S. Senate,,DEM,Loretta Sanchez,12
-Ventura,Ocean-View-NO502,U.S. Senate,,DEM,Kamala Harris,5
-Ventura,Ocean-View-NO502,U.S. Senate,,DEM,Loretta Sanchez,0
-Ventura,Ocean-View-NO503,U.S. Senate,,DEM,Kamala Harris,1
-Ventura,Ocean-View-NO503,U.S. Senate,,DEM,Loretta Sanchez,2
-Ventura,Ocean-View-NO505,U.S. Senate,,DEM,Kamala Harris,1
-Ventura,Ocean-View-NO505,U.S. Senate,,DEM,Loretta Sanchez,0
-Ventura,Ojai-NO101,U.S. Senate,,DEM,Kamala Harris,65
-Ventura,Ojai-NO101,U.S. Senate,,DEM,Loretta Sanchez,21
-Ventura,Ojai-NO102,U.S. Senate,,DEM,Kamala Harris,497
-Ventura,Ojai-NO102,U.S. Senate,,DEM,Loretta Sanchez,187
-Ventura,Ojai-NO103,U.S. Senate,,DEM,Kamala Harris,164
-Ventura,Ojai-NO103,U.S. Senate,,DEM,Loretta Sanchez,47
-Ventura,Ojai-NO104,U.S. Senate,,DEM,Kamala Harris,401
-Ventura,Ojai-NO104,U.S. Senate,,DEM,Loretta Sanchez,175
-Ventura,Ojai-NO105,U.S. Senate,,DEM,Kamala Harris,1001
-Ventura,Ojai-NO105,U.S. Senate,,DEM,Loretta Sanchez,410
-Ventura,Ojai-NO106,U.S. Senate,,DEM,Kamala Harris,77
-Ventura,Ojai-NO106,U.S. Senate,,DEM,Loretta Sanchez,26
-Ventura,Ojai-NO108-113,U.S. Senate,,DEM,Kamala Harris,93
-Ventura,Ojai-NO108-113,U.S. Senate,,DEM,Loretta Sanchez,33
-Ventura,Ojai-NO110,U.S. Senate,,DEM,Kamala Harris,104
-Ventura,Ojai-NO110,U.S. Senate,,DEM,Loretta Sanchez,32
-Ventura,Ojai-NO111,U.S. Senate,,DEM,Kamala Harris,148
-Ventura,Ojai-NO111,U.S. Senate,,DEM,Loretta Sanchez,75
-Ventura,Ojai-NO112,U.S. Senate,,DEM,Kamala Harris,9
-Ventura,Ojai-NO112,U.S. Senate,,DEM,Loretta Sanchez,1
-Ventura,Oxnard-NO101,U.S. Senate,,DEM,Kamala Harris,355
-Ventura,Oxnard-NO101,U.S. Senate,,DEM,Loretta Sanchez,313
-Ventura,Oxnard-NO102,U.S. Senate,,DEM,Kamala Harris,519
-Ventura,Oxnard-NO102,U.S. Senate,,DEM,Loretta Sanchez,466
-Ventura,Oxnard-NO103,U.S. Senate,,DEM,Kamala Harris,1482
-Ventura,Oxnard-NO103,U.S. Senate,,DEM,Loretta Sanchez,1081
-Ventura,Oxnard-NO105,U.S. Senate,,DEM,Kamala Harris,617
-Ventura,Oxnard-NO105,U.S. Senate,,DEM,Loretta Sanchez,711
-Ventura,Oxnard-NO106,U.S. Senate,,DEM,Kamala Harris,400
-Ventura,Oxnard-NO106,U.S. Senate,,DEM,Loretta Sanchez,393
-Ventura,Oxnard-NO107,U.S. Senate,,DEM,Kamala Harris,12
-Ventura,Oxnard-NO107,U.S. Senate,,DEM,Loretta Sanchez,12
-Ventura,Oxnard-NO108-109,U.S. Senate,,DEM,Kamala Harris,69
-Ventura,Oxnard-NO108-109,U.S. Senate,,DEM,Loretta Sanchez,69
-Ventura,Oxnard-NO110,U.S. Senate,,DEM,Kamala Harris,325
-Ventura,Oxnard-NO110,U.S. Senate,,DEM,Loretta Sanchez,303
-Ventura,Oxnard-NO301,U.S. Senate,,DEM,Kamala Harris,1
-Ventura,Oxnard-NO301,U.S. Senate,,DEM,Loretta Sanchez,0
-Ventura,Oxnard-NO302,U.S. Senate,,DEM,Kamala Harris,0
-Ventura,Oxnard-NO302,U.S. Senate,,DEM,Loretta Sanchez,0
-Ventura,Oxnard-NO303,U.S. Senate,,DEM,Kamala Harris,653
-Ventura,Oxnard-NO303,U.S. Senate,,DEM,Loretta Sanchez,633
-Ventura,Oxnard-NO304,U.S. Senate,,DEM,Kamala Harris,366
-Ventura,Oxnard-NO304,U.S. Senate,,DEM,Loretta Sanchez,268
-Ventura,Oxnard-NO306,U.S. Senate,,DEM,Kamala Harris,672
-Ventura,Oxnard-NO306,U.S. Senate,,DEM,Loretta Sanchez,633
-Ventura,Oxnard-NO307,U.S. Senate,,DEM,Kamala Harris,392
-Ventura,Oxnard-NO307,U.S. Senate,,DEM,Loretta Sanchez,489
-Ventura,Oxnard-NO308-309,U.S. Senate,,DEM,Kamala Harris,17
-Ventura,Oxnard-NO308-309,U.S. Senate,,DEM,Loretta Sanchez,45
-Ventura,Oxnard-NO310,U.S. Senate,,DEM,Kamala Harris,0
-Ventura,Oxnard-NO310,U.S. Senate,,DEM,Loretta Sanchez,0
-Ventura,Oxnard-NO311,U.S. Senate,,DEM,Kamala Harris,0
-Ventura,Oxnard-NO311,U.S. Senate,,DEM,Loretta Sanchez,0
-Ventura,Oxnard-NO313,U.S. Senate,,DEM,Kamala Harris,264
-Ventura,Oxnard-NO313,U.S. Senate,,DEM,Loretta Sanchez,340
-Ventura,Oxnard-NO314-317,U.S. Senate,,DEM,Kamala Harris,0
-Ventura,Oxnard-NO314-317,U.S. Senate,,DEM,Loretta Sanchez,0
-Ventura,Oxnard-NO501,U.S. Senate,,DEM,Kamala Harris,375
-Ventura,Oxnard-NO501,U.S. Senate,,DEM,Loretta Sanchez,405
-Ventura,Oxnard-NO502-508-558,U.S. Senate,,DEM,Kamala Harris,41
-Ventura,Oxnard-NO502-508-558,U.S. Senate,,DEM,Loretta Sanchez,33
-Ventura,Oxnard-NO504,U.S. Senate,,DEM,Kamala Harris,409
-Ventura,Oxnard-NO504,U.S. Senate,,DEM,Loretta Sanchez,434
-Ventura,Oxnard-NO505,U.S. Senate,,DEM,Kamala Harris,489
-Ventura,Oxnard-NO505,U.S. Senate,,DEM,Loretta Sanchez,589
-Ventura,Oxnard-NO506-553,U.S. Senate,,DEM,Kamala Harris,10
-Ventura,Oxnard-NO506-553,U.S. Senate,,DEM,Loretta Sanchez,21
-Ventura,Oxnard-NO507,U.S. Senate,,DEM,Kamala Harris,480
-Ventura,Oxnard-NO507,U.S. Senate,,DEM,Loretta Sanchez,533
-Ventura,Oxnard-NO509,U.S. Senate,,DEM,Kamala Harris,426
-Ventura,Oxnard-NO509,U.S. Senate,,DEM,Loretta Sanchez,425
-Ventura,Oxnard-NO510,U.S. Senate,,DEM,Kamala Harris,6
-Ventura,Oxnard-NO510,U.S. Senate,,DEM,Loretta Sanchez,6
-Ventura,Oxnard-NO511,U.S. Senate,,DEM,Kamala Harris,306
-Ventura,Oxnard-NO511,U.S. Senate,,DEM,Loretta Sanchez,433
-Ventura,Oxnard-NO512,U.S. Senate,,DEM,Kamala Harris,805
-Ventura,Oxnard-NO512,U.S. Senate,,DEM,Loretta Sanchez,615
-Ventura,Oxnard-NO513,U.S. Senate,,DEM,Kamala Harris,404
-Ventura,Oxnard-NO513,U.S. Senate,,DEM,Loretta Sanchez,197
-Ventura,Oxnard-NO514,U.S. Senate,,DEM,Kamala Harris,302
-Ventura,Oxnard-NO514,U.S. Senate,,DEM,Loretta Sanchez,398
-Ventura,Oxnard-NO515,U.S. Senate,,DEM,Kamala Harris,460
-Ventura,Oxnard-NO515,U.S. Senate,,DEM,Loretta Sanchez,466
-Ventura,Oxnard-NO516,U.S. Senate,,DEM,Kamala Harris,0
-Ventura,Oxnard-NO516,U.S. Senate,,DEM,Loretta Sanchez,0
-Ventura,Oxnard-NO517,U.S. Senate,,DEM,Kamala Harris,0
-Ventura,Oxnard-NO517,U.S. Senate,,DEM,Loretta Sanchez,0
-Ventura,Oxnard-NO518,U.S. Senate,,DEM,Kamala Harris,77
-Ventura,Oxnard-NO518,U.S. Senate,,DEM,Loretta Sanchez,104
-Ventura,Oxnard-NO519,U.S. Senate,,DEM,Kamala Harris,323
-Ventura,Oxnard-NO519,U.S. Senate,,DEM,Loretta Sanchez,405
-Ventura,Oxnard-NO521,U.S. Senate,,DEM,Kamala Harris,218
-Ventura,Oxnard-NO521,U.S. Senate,,DEM,Loretta Sanchez,399
-Ventura,Oxnard-NO522,U.S. Senate,,DEM,Kamala Harris,580
-Ventura,Oxnard-NO522,U.S. Senate,,DEM,Loretta Sanchez,758
-Ventura,Oxnard-NO523,U.S. Senate,,DEM,Kamala Harris,22
-Ventura,Oxnard-NO523,U.S. Senate,,DEM,Loretta Sanchez,60
-Ventura,Oxnard-NO524,U.S. Senate,,DEM,Kamala Harris,633
-Ventura,Oxnard-NO524,U.S. Senate,,DEM,Loretta Sanchez,451
-Ventura,Oxnard-NO525,U.S. Senate,,DEM,Kamala Harris,493
-Ventura,Oxnard-NO525,U.S. Senate,,DEM,Loretta Sanchez,550
-Ventura,Oxnard-NO526,U.S. Senate,,DEM,Kamala Harris,835
-Ventura,Oxnard-NO526,U.S. Senate,,DEM,Loretta Sanchez,499
-Ventura,Oxnard-NO527,U.S. Senate,,DEM,Kamala Harris,249
-Ventura,Oxnard-NO527,U.S. Senate,,DEM,Loretta Sanchez,217
-Ventura,Oxnard-NO529,U.S. Senate,,DEM,Kamala Harris,781
-Ventura,Oxnard-NO529,U.S. Senate,,DEM,Loretta Sanchez,902
-Ventura,Oxnard-NO530,U.S. Senate,,DEM,Kamala Harris,533
-Ventura,Oxnard-NO530,U.S. Senate,,DEM,Loretta Sanchez,789
-Ventura,Oxnard-NO533,U.S. Senate,,DEM,Kamala Harris,32
-Ventura,Oxnard-NO533,U.S. Senate,,DEM,Loretta Sanchez,59
-Ventura,Oxnard-NO534,U.S. Senate,,DEM,Kamala Harris,324
-Ventura,Oxnard-NO534,U.S. Senate,,DEM,Loretta Sanchez,255
-Ventura,Oxnard-NO535,U.S. Senate,,DEM,Kamala Harris,726
-Ventura,Oxnard-NO535,U.S. Senate,,DEM,Loretta Sanchez,439
-Ventura,Oxnard-NO536,U.S. Senate,,DEM,Kamala Harris,299
-Ventura,Oxnard-NO536,U.S. Senate,,DEM,Loretta Sanchez,317
-Ventura,Oxnard-NO537,U.S. Senate,,DEM,Kamala Harris,94
-Ventura,Oxnard-NO537,U.S. Senate,,DEM,Loretta Sanchez,51
-Ventura,Oxnard-NO538,U.S. Senate,,DEM,Kamala Harris,434
-Ventura,Oxnard-NO538,U.S. Senate,,DEM,Loretta Sanchez,425
-Ventura,Oxnard-NO540,U.S. Senate,,DEM,Kamala Harris,958
-Ventura,Oxnard-NO540,U.S. Senate,,DEM,Loretta Sanchez,634
-Ventura,Oxnard-NO541,U.S. Senate,,DEM,Kamala Harris,535
-Ventura,Oxnard-NO541,U.S. Senate,,DEM,Loretta Sanchez,463
-Ventura,Oxnard-NO542,U.S. Senate,,DEM,Kamala Harris,366
-Ventura,Oxnard-NO542,U.S. Senate,,DEM,Loretta Sanchez,308
-Ventura,Oxnard-NO544,U.S. Senate,,DEM,Kamala Harris,1230
-Ventura,Oxnard-NO544,U.S. Senate,,DEM,Loretta Sanchez,837
-Ventura,Oxnard-NO545,U.S. Senate,,DEM,Kamala Harris,180
-Ventura,Oxnard-NO545,U.S. Senate,,DEM,Loretta Sanchez,229
-Ventura,Oxnard-NO546,U.S. Senate,,DEM,Kamala Harris,389
-Ventura,Oxnard-NO546,U.S. Senate,,DEM,Loretta Sanchez,296
-Ventura,Oxnard-NO547,U.S. Senate,,DEM,Kamala Harris,432
-Ventura,Oxnard-NO547,U.S. Senate,,DEM,Loretta Sanchez,625
-Ventura,Oxnard-NO548,U.S. Senate,,DEM,Kamala Harris,775
-Ventura,Oxnard-NO548,U.S. Senate,,DEM,Loretta Sanchez,664
-Ventura,Oxnard-NO550,U.S. Senate,,DEM,Kamala Harris,319
-Ventura,Oxnard-NO550,U.S. Senate,,DEM,Loretta Sanchez,373
-Ventura,Oxnard-NO551,U.S. Senate,,DEM,Kamala Harris,379
-Ventura,Oxnard-NO551,U.S. Senate,,DEM,Loretta Sanchez,410
-Ventura,Oxnard-NO552,U.S. Senate,,DEM,Kamala Harris,390
-Ventura,Oxnard-NO552,U.S. Senate,,DEM,Loretta Sanchez,514
-Ventura,Oxnard-NO554,U.S. Senate,,DEM,Kamala Harris,0
-Ventura,Oxnard-NO554,U.S. Senate,,DEM,Loretta Sanchez,3
-Ventura,Oxnard-NO556,U.S. Senate,,DEM,Kamala Harris,15
-Ventura,Oxnard-NO556,U.S. Senate,,DEM,Loretta Sanchez,16
-Ventura,Oxnard-NO557,U.S. Senate,,DEM,Kamala Harris,1055
-Ventura,Oxnard-NO557,U.S. Senate,,DEM,Loretta Sanchez,933
-Ventura,Oxnard-NO560,U.S. Senate,,DEM,Kamala Harris,213
-Ventura,Oxnard-NO560,U.S. Senate,,DEM,Loretta Sanchez,218
-Ventura,Oxnard-NO562,U.S. Senate,,DEM,Kamala Harris,0
-Ventura,Oxnard-NO562,U.S. Senate,,DEM,Loretta Sanchez,0
-Ventura,Oxnard-NO563,U.S. Senate,,DEM,Kamala Harris,0
-Ventura,Oxnard-NO563,U.S. Senate,,DEM,Loretta Sanchez,0
-Ventura,Oxnard-NO564,U.S. Senate,,DEM,Kamala Harris,722
-Ventura,Oxnard-NO564,U.S. Senate,,DEM,Loretta Sanchez,720
-Ventura,Oxnard-NO565,U.S. Senate,,DEM,Kamala Harris,351
-Ventura,Oxnard-NO565,U.S. Senate,,DEM,Loretta Sanchez,163
-Ventura,Oxnard-NO566-568-573-581,U.S. Senate,,DEM,Kamala Harris,21
-Ventura,Oxnard-NO566-568-573-581,U.S. Senate,,DEM,Loretta Sanchez,14
-Ventura,Oxnard-NO570,U.S. Senate,,DEM,Kamala Harris,1157
-Ventura,Oxnard-NO570,U.S. Senate,,DEM,Loretta Sanchez,539
-Ventura,Oxnard-NO571,U.S. Senate,,DEM,Kamala Harris,379
-Ventura,Oxnard-NO571,U.S. Senate,,DEM,Loretta Sanchez,230
-Ventura,Oxnard-NO572-576,U.S. Senate,,DEM,Kamala Harris,0
-Ventura,Oxnard-NO572-576,U.S. Senate,,DEM,Loretta Sanchez,0
-Ventura,Oxnard-NO574,U.S. Senate,,DEM,Kamala Harris,0
-Ventura,Oxnard-NO574,U.S. Senate,,DEM,Loretta Sanchez,0
-Ventura,Oxnard-NO575-580,U.S. Senate,,DEM,Kamala Harris,29
-Ventura,Oxnard-NO575-580,U.S. Senate,,DEM,Loretta Sanchez,22
-Ventura,Oxnard-NO577-578-582,U.S. Senate,,DEM,Kamala Harris,0
-Ventura,Oxnard-NO577-578-582,U.S. Senate,,DEM,Loretta Sanchez,0
-Ventura,Oxnard-NO583,U.S. Senate,,DEM,Kamala Harris,76
-Ventura,Oxnard-NO583,U.S. Senate,,DEM,Loretta Sanchez,93
-Ventura,Ozena-NO101,U.S. Senate,,DEM,Kamala Harris,20
-Ventura,Ozena-NO101,U.S. Senate,,DEM,Loretta Sanchez,7
-Ventura,Pedro-NO101,U.S. Senate,,DEM,Kamala Harris,0
-Ventura,Pedro-NO101,U.S. Senate,,DEM,Loretta Sanchez,0
-Ventura,Pedro-NO501-516,U.S. Senate,,DEM,Kamala Harris,7
-Ventura,Pedro-NO501-516,U.S. Senate,,DEM,Loretta Sanchez,3
-Ventura,Pedro-NO502-504-514,U.S. Senate,,DEM,Kamala Harris,4
-Ventura,Pedro-NO502-504-514,U.S. Senate,,DEM,Loretta Sanchez,10
-Ventura,Pedro-NO503,U.S. Senate,,DEM,Kamala Harris,0
-Ventura,Pedro-NO503,U.S. Senate,,DEM,Loretta Sanchez,0
-Ventura,Pedro-NO508-509,U.S. Senate,,DEM,Kamala Harris,0
-Ventura,Pedro-NO508-509,U.S. Senate,,DEM,Loretta Sanchez,0
-Ventura,Pedro-NO510-511-513,U.S. Senate,,DEM,Kamala Harris,0
-Ventura,Pedro-NO510-511-513,U.S. Senate,,DEM,Loretta Sanchez,0
-Ventura,Pedro-NO520,U.S. Senate,,DEM,Kamala Harris,0
-Ventura,Pedro-NO520,U.S. Senate,,DEM,Loretta Sanchez,0
-Ventura,Piru-NO301,U.S. Senate,,DEM,Kamala Harris,226
-Ventura,Piru-NO301,U.S. Senate,,DEM,Loretta Sanchez,378
-Ventura,Piru-NO302,U.S. Senate,,DEM,Kamala Harris,1
-Ventura,Piru-NO302,U.S. Senate,,DEM,Loretta Sanchez,1
-Ventura,Piru-NO303,U.S. Senate,,DEM,Kamala Harris,1
-Ventura,Piru-NO303,U.S. Senate,,DEM,Loretta Sanchez,7
-Ventura,Piru-NO401-403,U.S. Senate,,DEM,Kamala Harris,0
-Ventura,Piru-NO401-403,U.S. Senate,,DEM,Loretta Sanchez,0
-Ventura,Piru-NO402,U.S. Senate,,DEM,Kamala Harris,0
-Ventura,Piru-NO402,U.S. Senate,,DEM,Loretta Sanchez,0
-Ventura,Piru-NO405-409,U.S. Senate,,DEM,Kamala Harris,0
-Ventura,Piru-NO405-409,U.S. Senate,,DEM,Loretta Sanchez,0
-Ventura,Piru-NO406-407-408,U.S. Senate,,DEM,Kamala Harris,0
-Ventura,Piru-NO406-407-408,U.S. Senate,,DEM,Loretta Sanchez,0
-Ventura,Piru-North-NO301,U.S. Senate,,DEM,Kamala Harris,1
-Ventura,Piru-North-NO301,U.S. Senate,,DEM,Loretta Sanchez,1
-Ventura,Pt-Hue-NO-302,U.S. Senate,,DEM,Kamala Harris,1134
-Ventura,Pt-Hue-NO-302,U.S. Senate,,DEM,Loretta Sanchez,938
-Ventura,Pt-Hue-NO301,U.S. Senate,,DEM,Kamala Harris,49
-Ventura,Pt-Hue-NO301,U.S. Senate,,DEM,Loretta Sanchez,31
-Ventura,Pt-Hue-NO303,U.S. Senate,,DEM,Kamala Harris,5
-Ventura,Pt-Hue-NO303,U.S. Senate,,DEM,Loretta Sanchez,0
-Ventura,Pt-Hue-NO305,U.S. Senate,,DEM,Kamala Harris,480
-Ventura,Pt-Hue-NO305,U.S. Senate,,DEM,Loretta Sanchez,551
-Ventura,Pt-Hue-NO307,U.S. Senate,,DEM,Kamala Harris,1053
-Ventura,Pt-Hue-NO307,U.S. Senate,,DEM,Loretta Sanchez,530
-Ventura,Pt-Hue-NO308,U.S. Senate,,DEM,Kamala Harris,392
-Ventura,Pt-Hue-NO308,U.S. Senate,,DEM,Loretta Sanchez,268
-Ventura,Pt-Hue-NO309,U.S. Senate,,DEM,Kamala Harris,636
-Ventura,Pt-Hue-NO309,U.S. Senate,,DEM,Loretta Sanchez,267
-Ventura,Pt-Hue-NO501,U.S. Senate,,DEM,Kamala Harris,2
-Ventura,Pt-Hue-NO501,U.S. Senate,,DEM,Loretta Sanchez,1
-Ventura,Rice-NO301,U.S. Senate,,DEM,Kamala Harris,3
-Ventura,Rice-NO301,U.S. Senate,,DEM,Loretta Sanchez,3
-Ventura,Rice-NO502,U.S. Senate,,DEM,Kamala Harris,0
-Ventura,Rice-NO502,U.S. Senate,,DEM,Loretta Sanchez,0
-Ventura,Rincon-NO101-104-105-106-107,U.S. Senate,,DEM,Kamala Harris,16
-Ventura,Rincon-NO101-104-105-106-107,U.S. Senate,,DEM,Loretta Sanchez,10
-Ventura,Rincon-NO102,U.S. Senate,,DEM,Kamala Harris,90
-Ventura,Rincon-NO102,U.S. Senate,,DEM,Loretta Sanchez,54
-Ventura,Rincon-NO103,U.S. Senate,,DEM,Kamala Harris,0
-Ventura,Rincon-NO103,U.S. Senate,,DEM,Loretta Sanchez,0
-Ventura,Rincon-NO108-109-117,U.S. Senate,,DEM,Kamala Harris,13
-Ventura,Rincon-NO108-109-117,U.S. Senate,,DEM,Loretta Sanchez,9
-Ventura,Rincon-NO110-111-112,U.S. Senate,,DEM,Kamala Harris,0
-Ventura,Rincon-NO110-111-112,U.S. Senate,,DEM,Loretta Sanchez,0
-Ventura,Rincon-NO113-114-116,U.S. Senate,,DEM,Kamala Harris,100
-Ventura,Rincon-NO113-114-116,U.S. Senate,,DEM,Loretta Sanchez,42
-Ventura,Rincon-NO115,U.S. Senate,,DEM,Kamala Harris,16
-Ventura,Rincon-NO115,U.S. Senate,,DEM,Loretta Sanchez,4
-Ventura,Rio-Mesa-NO101,U.S. Senate,,DEM,Kamala Harris,0
-Ventura,Rio-Mesa-NO101,U.S. Senate,,DEM,Loretta Sanchez,0
-Ventura,Rio-Mesa-NO501-502-503,U.S. Senate,,DEM,Kamala Harris,9
-Ventura,Rio-Mesa-NO501-502-503,U.S. Senate,,DEM,Loretta Sanchez,7
-Ventura,Rio-Mesa-NO504,U.S. Senate,,DEM,Kamala Harris,86
-Ventura,Rio-Mesa-NO504,U.S. Senate,,DEM,Loretta Sanchez,74
-Ventura,Rio-Mesa-NO505-506,U.S. Senate,,DEM,Kamala Harris,0
-Ventura,Rio-Mesa-NO505-506,U.S. Senate,,DEM,Loretta Sanchez,2
-Ventura,Santa-Ana-NO101,U.S. Senate,,DEM,Kamala Harris,70
-Ventura,Santa-Ana-NO101,U.S. Senate,,DEM,Loretta Sanchez,26
-Ventura,Santa-Ana-NO102-105-112,U.S. Senate,,DEM,Kamala Harris,13
-Ventura,Santa-Ana-NO102-105-112,U.S. Senate,,DEM,Loretta Sanchez,4
-Ventura,Santa-Ana-NO103,U.S. Senate,,DEM,Kamala Harris,3
-Ventura,Santa-Ana-NO103,U.S. Senate,,DEM,Loretta Sanchez,3
-Ventura,Santa-Ana-NO104-106-109,U.S. Senate,,DEM,Kamala Harris,14
-Ventura,Santa-Ana-NO104-106-109,U.S. Senate,,DEM,Loretta Sanchez,16
-Ventura,Santa-Ana-NO110,U.S. Senate,,DEM,Kamala Harris,0
-Ventura,Santa-Ana-NO110,U.S. Senate,,DEM,Loretta Sanchez,4
-Ventura,Saticoy-NO101-102-103-105,U.S. Senate,,DEM,Kamala Harris,3
-Ventura,Saticoy-NO101-102-103-105,U.S. Senate,,DEM,Loretta Sanchez,13
-Ventura,Saticoy-NO104,U.S. Senate,,DEM,Kamala Harris,71
-Ventura,Saticoy-NO104,U.S. Senate,,DEM,Loretta Sanchez,113
-Ventura,Saticoy-NO106,U.S. Senate,,DEM,Kamala Harris,0
-Ventura,Saticoy-NO106,U.S. Senate,,DEM,Loretta Sanchez,0
-Ventura,Sespe-No-NO301,U.S. Senate,,DEM,Kamala Harris,0
-Ventura,Sespe-No-NO301,U.S. Senate,,DEM,Loretta Sanchez,0
-Ventura,Sherwood-NO201,U.S. Senate,,DEM,Kamala Harris,469
-Ventura,Sherwood-NO201,U.S. Senate,,DEM,Loretta Sanchez,263
-Ventura,Sherwood-NO203-204-215-216,U.S. Senate,,DEM,Kamala Harris,35
-Ventura,Sherwood-NO203-204-215-216,U.S. Senate,,DEM,Loretta Sanchez,26
-Ventura,Sherwood-NO205-206-208-213,U.S. Senate,,DEM,Kamala Harris,8
-Ventura,Sherwood-NO205-206-208-213,U.S. Senate,,DEM,Loretta Sanchez,8
-Ventura,Sherwood-NO207,U.S. Senate,,DEM,Kamala Harris,15
-Ventura,Sherwood-NO207,U.S. Senate,,DEM,Loretta Sanchez,16
-Ventura,Sherwood-NO209,U.S. Senate,,DEM,Kamala Harris,0
-Ventura,Sherwood-NO209,U.S. Senate,,DEM,Loretta Sanchez,1
-Ventura,Sherwood-NO210-214,U.S. Senate,,DEM,Kamala Harris,13
-Ventura,Sherwood-NO210-214,U.S. Senate,,DEM,Loretta Sanchez,12
-Ventura,Sherwood-NO211,U.S. Senate,,DEM,Kamala Harris,2
-Ventura,Sherwood-NO211,U.S. Senate,,DEM,Loretta Sanchez,0
-Ventura,Sherwood-NO212,U.S. Senate,,DEM,Kamala Harris,0
-Ventura,Sherwood-NO212,U.S. Senate,,DEM,Loretta Sanchez,0
-Ventura,Simi-NO-402,U.S. Senate,,DEM,Kamala Harris,633
-Ventura,Simi-NO-402,U.S. Senate,,DEM,Loretta Sanchez,526
-Ventura,Simi-NO403,U.S. Senate,,DEM,Kamala Harris,542
-Ventura,Simi-NO403,U.S. Senate,,DEM,Loretta Sanchez,306
-Ventura,Simi-NO404,U.S. Senate,,DEM,Kamala Harris,542
-Ventura,Simi-NO404,U.S. Senate,,DEM,Loretta Sanchez,364
-Ventura,Simi-NO405,U.S. Senate,,DEM,Kamala Harris,395
-Ventura,Simi-NO405,U.S. Senate,,DEM,Loretta Sanchez,245
-Ventura,Simi-NO406,U.S. Senate,,DEM,Kamala Harris,494
-Ventura,Simi-NO406,U.S. Senate,,DEM,Loretta Sanchez,342
-Ventura,Simi-NO407,U.S. Senate,,DEM,Kamala Harris,636
-Ventura,Simi-NO407,U.S. Senate,,DEM,Loretta Sanchez,447
-Ventura,Simi-NO409,U.S. Senate,,DEM,Kamala Harris,533
-Ventura,Simi-NO409,U.S. Senate,,DEM,Loretta Sanchez,358
-Ventura,Simi-NO410,U.S. Senate,,DEM,Kamala Harris,762
-Ventura,Simi-NO410,U.S. Senate,,DEM,Loretta Sanchez,431
-Ventura,Simi-NO412,U.S. Senate,,DEM,Kamala Harris,444
-Ventura,Simi-NO412,U.S. Senate,,DEM,Loretta Sanchez,299
-Ventura,Simi-NO413,U.S. Senate,,DEM,Kamala Harris,917
-Ventura,Simi-NO413,U.S. Senate,,DEM,Loretta Sanchez,548
-Ventura,Simi-NO415,U.S. Senate,,DEM,Kamala Harris,383
-Ventura,Simi-NO415,U.S. Senate,,DEM,Loretta Sanchez,300
-Ventura,Simi-NO416,U.S. Senate,,DEM,Kamala Harris,958
-Ventura,Simi-NO416,U.S. Senate,,DEM,Loretta Sanchez,592
-Ventura,Simi-NO418,U.S. Senate,,DEM,Kamala Harris,570
-Ventura,Simi-NO418,U.S. Senate,,DEM,Loretta Sanchez,418
-Ventura,Simi-NO421AL-420,U.S. Senate,,DEM,Kamala Harris,693
-Ventura,Simi-NO421AL-420,U.S. Senate,,DEM,Loretta Sanchez,439
-Ventura,Simi-NO422,U.S. Senate,,DEM,Kamala Harris,1101
-Ventura,Simi-NO422,U.S. Senate,,DEM,Loretta Sanchez,656
-Ventura,Simi-NO424,U.S. Senate,,DEM,Kamala Harris,765
-Ventura,Simi-NO424,U.S. Senate,,DEM,Loretta Sanchez,477
-Ventura,Simi-NO427,U.S. Senate,,DEM,Kamala Harris,808
-Ventura,Simi-NO427,U.S. Senate,,DEM,Loretta Sanchez,557
-Ventura,Simi-NO428,U.S. Senate,,DEM,Kamala Harris,656
-Ventura,Simi-NO428,U.S. Senate,,DEM,Loretta Sanchez,387
-Ventura,Simi-NO429,U.S. Senate,,DEM,Kamala Harris,486
-Ventura,Simi-NO429,U.S. Senate,,DEM,Loretta Sanchez,304
-Ventura,Simi-NO430,U.S. Senate,,DEM,Kamala Harris,748
-Ventura,Simi-NO430,U.S. Senate,,DEM,Loretta Sanchez,499
-Ventura,Simi-NO432,U.S. Senate,,DEM,Kamala Harris,1150
-Ventura,Simi-NO432,U.S. Senate,,DEM,Loretta Sanchez,625
-Ventura,Simi-NO433,U.S. Senate,,DEM,Kamala Harris,840
-Ventura,Simi-NO433,U.S. Senate,,DEM,Loretta Sanchez,547
-Ventura,Simi-NO435,U.S. Senate,,DEM,Kamala Harris,1039
-Ventura,Simi-NO435,U.S. Senate,,DEM,Loretta Sanchez,579
-Ventura,Simi-NO437,U.S. Senate,,DEM,Kamala Harris,1498
-Ventura,Simi-NO437,U.S. Senate,,DEM,Loretta Sanchez,815
-Ventura,Simi-NO440,U.S. Senate,,DEM,Kamala Harris,588
-Ventura,Simi-NO440,U.S. Senate,,DEM,Loretta Sanchez,409
-Ventura,Simi-NO441-464-466,U.S. Senate,,DEM,Kamala Harris,0
-Ventura,Simi-NO441-464-466,U.S. Senate,,DEM,Loretta Sanchez,0
-Ventura,Simi-NO442,U.S. Senate,,DEM,Kamala Harris,1256
-Ventura,Simi-NO442,U.S. Senate,,DEM,Loretta Sanchez,647
-Ventura,Simi-NO443,U.S. Senate,,DEM,Kamala Harris,760
-Ventura,Simi-NO443,U.S. Senate,,DEM,Loretta Sanchez,398
-Ventura,Simi-NO444,U.S. Senate,,DEM,Kamala Harris,724
-Ventura,Simi-NO444,U.S. Senate,,DEM,Loretta Sanchez,355
-Ventura,Simi-NO445,U.S. Senate,,DEM,Kamala Harris,616
-Ventura,Simi-NO445,U.S. Senate,,DEM,Loretta Sanchez,298
-Ventura,Simi-NO446,U.S. Senate,,DEM,Kamala Harris,708
-Ventura,Simi-NO446,U.S. Senate,,DEM,Loretta Sanchez,421
-Ventura,Simi-NO447,U.S. Senate,,DEM,Kamala Harris,555
-Ventura,Simi-NO447,U.S. Senate,,DEM,Loretta Sanchez,330
-Ventura,Simi-NO448,U.S. Senate,,DEM,Kamala Harris,906
-Ventura,Simi-NO448,U.S. Senate,,DEM,Loretta Sanchez,558
-Ventura,Simi-NO449,U.S. Senate,,DEM,Kamala Harris,1067
-Ventura,Simi-NO449,U.S. Senate,,DEM,Loretta Sanchez,696
-Ventura,Simi-NO450-453-454,U.S. Senate,,DEM,Kamala Harris,65
-Ventura,Simi-NO450-453-454,U.S. Senate,,DEM,Loretta Sanchez,35
-Ventura,Simi-NO451,U.S. Senate,,DEM,Kamala Harris,326
-Ventura,Simi-NO451,U.S. Senate,,DEM,Loretta Sanchez,222
-Ventura,Simi-NO452,U.S. Senate,,DEM,Kamala Harris,908
-Ventura,Simi-NO452,U.S. Senate,,DEM,Loretta Sanchez,459
-Ventura,Simi-NO456,U.S. Senate,,DEM,Kamala Harris,657
-Ventura,Simi-NO456,U.S. Senate,,DEM,Loretta Sanchez,384
-Ventura,Simi-NO460,U.S. Senate,,DEM,Kamala Harris,1003
-Ventura,Simi-NO460,U.S. Senate,,DEM,Loretta Sanchez,527
-Ventura,Simi-NO461,U.S. Senate,,DEM,Kamala Harris,1
-Ventura,Simi-NO461,U.S. Senate,,DEM,Loretta Sanchez,4
-Ventura,Simi-NO462,U.S. Senate,,DEM,Kamala Harris,0
-Ventura,Simi-NO462,U.S. Senate,,DEM,Loretta Sanchez,1
-Ventura,Simi-NO463,U.S. Senate,,DEM,Kamala Harris,420
-Ventura,Simi-NO463,U.S. Senate,,DEM,Loretta Sanchez,357
-Ventura,Simi-NO467,U.S. Senate,,DEM,Kamala Harris,177
-Ventura,Simi-NO467,U.S. Senate,,DEM,Loretta Sanchez,92
-Ventura,Simi-NO468,U.S. Senate,,DEM,Kamala Harris,452
-Ventura,Simi-NO468,U.S. Senate,,DEM,Loretta Sanchez,277
-Ventura,Sinaloa-NO401,U.S. Senate,,DEM,Kamala Harris,129
-Ventura,Sinaloa-NO401,U.S. Senate,,DEM,Loretta Sanchez,105
-Ventura,Sinaloa-NO402,U.S. Senate,,DEM,Kamala Harris,0
-Ventura,Sinaloa-NO402,U.S. Senate,,DEM,Loretta Sanchez,0
-Ventura,Sinaloa-NO403,U.S. Senate,,DEM,Kamala Harris,5
-Ventura,Sinaloa-NO403,U.S. Senate,,DEM,Loretta Sanchez,1
-Ventura,Sinaloa-NO404,U.S. Senate,,DEM,Kamala Harris,7
-Ventura,Sinaloa-NO404,U.S. Senate,,DEM,Loretta Sanchez,7
-Ventura,Slvr-Strd-NO501,U.S. Senate,,DEM,Kamala Harris,681
-Ventura,Slvr-Strd-NO501,U.S. Senate,,DEM,Loretta Sanchez,317
-Ventura,Somis-NO201-204-210,U.S. Senate,,DEM,Kamala Harris,573
-Ventura,Somis-NO201-204-210,U.S. Senate,,DEM,Loretta Sanchez,349
-Ventura,Somis-NO202-211,U.S. Senate,,DEM,Kamala Harris,13
-Ventura,Somis-NO202-211,U.S. Senate,,DEM,Loretta Sanchez,21
-Ventura,Somis-NO203-207-209,U.S. Senate,,DEM,Kamala Harris,22
-Ventura,Somis-NO203-207-209,U.S. Senate,,DEM,Loretta Sanchez,24
-Ventura,Somis-NO205-214,U.S. Senate,,DEM,Kamala Harris,42
-Ventura,Somis-NO205-214,U.S. Senate,,DEM,Loretta Sanchez,23
-Ventura,Somis-NO206-215,U.S. Senate,,DEM,Kamala Harris,19
-Ventura,Somis-NO206-215,U.S. Senate,,DEM,Loretta Sanchez,19
-Ventura,Somis-NO212-213-216,U.S. Senate,,DEM,Kamala Harris,3
-Ventura,Somis-NO212-213-216,U.S. Senate,,DEM,Loretta Sanchez,4
-Ventura,Somis-NO301,U.S. Senate,,DEM,Kamala Harris,2
-Ventura,Somis-NO301,U.S. Senate,,DEM,Loretta Sanchez,2
-Ventura,Somis-NO302-311,U.S. Senate,,DEM,Kamala Harris,0
-Ventura,Somis-NO302-311,U.S. Senate,,DEM,Loretta Sanchez,0
-Ventura,Somis-NO303-305-307,U.S. Senate,,DEM,Kamala Harris,0
-Ventura,Somis-NO303-305-307,U.S. Senate,,DEM,Loretta Sanchez,7
-Ventura,Somis-NO304,U.S. Senate,,DEM,Kamala Harris,0
-Ventura,Somis-NO304,U.S. Senate,,DEM,Loretta Sanchez,0
-Ventura,Somis-NO308-309-310,U.S. Senate,,DEM,Kamala Harris,0
-Ventura,Somis-NO308-309-310,U.S. Senate,,DEM,Loretta Sanchez,0
-Ventura,Somis-NO401-403,U.S. Senate,,DEM,Kamala Harris,35
-Ventura,Somis-NO401-403,U.S. Senate,,DEM,Loretta Sanchez,35
-Ventura,Somis-NO402,U.S. Senate,,DEM,Kamala Harris,0
-Ventura,Somis-NO402,U.S. Senate,,DEM,Loretta Sanchez,0
-Ventura,Sta-Clara-NO301-302-304,U.S. Senate,,DEM,Kamala Harris,40
-Ventura,Sta-Clara-NO301-302-304,U.S. Senate,,DEM,Loretta Sanchez,28
-Ventura,Sta-Clara-NO303,U.S. Senate,,DEM,Kamala Harris,0
-Ventura,Sta-Clara-NO303,U.S. Senate,,DEM,Loretta Sanchez,0
-Ventura,Sta-Paula-NO301,U.S. Senate,,DEM,Kamala Harris,593
-Ventura,Sta-Paula-NO301,U.S. Senate,,DEM,Loretta Sanchez,516
-Ventura,Sta-Paula-NO302,U.S. Senate,,DEM,Kamala Harris,406
-Ventura,Sta-Paula-NO302,U.S. Senate,,DEM,Loretta Sanchez,393
-Ventura,Sta-Paula-NO303,U.S. Senate,,DEM,Kamala Harris,476
-Ventura,Sta-Paula-NO303,U.S. Senate,,DEM,Loretta Sanchez,517
-Ventura,Sta-Paula-NO304,U.S. Senate,,DEM,Kamala Harris,468
-Ventura,Sta-Paula-NO304,U.S. Senate,,DEM,Loretta Sanchez,706
-Ventura,Sta-Paula-NO305,U.S. Senate,,DEM,Kamala Harris,192
-Ventura,Sta-Paula-NO305,U.S. Senate,,DEM,Loretta Sanchez,436
-Ventura,Sta-Paula-NO306,U.S. Senate,,DEM,Kamala Harris,0
-Ventura,Sta-Paula-NO306,U.S. Senate,,DEM,Loretta Sanchez,0
-Ventura,Sta-Paula-NO307,U.S. Senate,,DEM,Kamala Harris,615
-Ventura,Sta-Paula-NO307,U.S. Senate,,DEM,Loretta Sanchez,695
-Ventura,Sta-Paula-NO308,U.S. Senate,,DEM,Kamala Harris,271
-Ventura,Sta-Paula-NO308,U.S. Senate,,DEM,Loretta Sanchez,269
-Ventura,Sta-Paula-NO309,U.S. Senate,,DEM,Kamala Harris,267
-Ventura,Sta-Paula-NO309,U.S. Senate,,DEM,Loretta Sanchez,273
-Ventura,Sta-Paula-NO310,U.S. Senate,,DEM,Kamala Harris,239
-Ventura,Sta-Paula-NO310,U.S. Senate,,DEM,Loretta Sanchez,421
-Ventura,Sta-Paula-NO311,U.S. Senate,,DEM,Kamala Harris,32
-Ventura,Sta-Paula-NO311,U.S. Senate,,DEM,Loretta Sanchez,31
-Ventura,Sta-Paula-NO312,U.S. Senate,,DEM,Kamala Harris,124
-Ventura,Sta-Paula-NO312,U.S. Senate,,DEM,Loretta Sanchez,213
-Ventura,Sta-Paula-NO313-314,U.S. Senate,,DEM,Kamala Harris,91
-Ventura,Sta-Paula-NO313-314,U.S. Senate,,DEM,Loretta Sanchez,62
-Ventura,Sta-Paula-NO315,U.S. Senate,,DEM,Kamala Harris,3
-Ventura,Sta-Paula-NO315,U.S. Senate,,DEM,Loretta Sanchez,8
-Ventura,Sta-Rosa-NO201,U.S. Senate,,DEM,Kamala Harris,912
-Ventura,Sta-Rosa-NO201,U.S. Senate,,DEM,Loretta Sanchez,599
-Ventura,Sta-Rosa-NO203,U.S. Senate,,DEM,Kamala Harris,2
-Ventura,Sta-Rosa-NO203,U.S. Senate,,DEM,Loretta Sanchez,5
-Ventura,Sta-Rosa-NO204,U.S. Senate,,DEM,Kamala Harris,0
-Ventura,Sta-Rosa-NO204,U.S. Senate,,DEM,Loretta Sanchez,2
-Ventura,Sta-Rosa-NO401-402,U.S. Senate,,DEM,Kamala Harris,25
-Ventura,Sta-Rosa-NO401-402,U.S. Senate,,DEM,Loretta Sanchez,20
-Ventura,Tapo-NO401-403,U.S. Senate,,DEM,Kamala Harris,20
-Ventura,Tapo-NO401-403,U.S. Senate,,DEM,Loretta Sanchez,14
-Ventura,Tapo-NO402,U.S. Senate,,DEM,Kamala Harris,1
-Ventura,Tapo-NO402,U.S. Senate,,DEM,Loretta Sanchez,1
-Ventura,Tapo-NO404,U.S. Senate,,DEM,Kamala Harris,0
-Ventura,Tapo-NO404,U.S. Senate,,DEM,Loretta Sanchez,0
-Ventura,Tapo-NO405,U.S. Senate,,DEM,Kamala Harris,0
-Ventura,Tapo-NO405,U.S. Senate,,DEM,Loretta Sanchez,0
-Ventura,Tapo-NO406-411-413-414-419,U.S. Senate,,DEM,Kamala Harris,33
-Ventura,Tapo-NO406-411-413-414-419,U.S. Senate,,DEM,Loretta Sanchez,28
-Ventura,Tapo-NO409,U.S. Senate,,DEM,Kamala Harris,99
-Ventura,Tapo-NO409,U.S. Senate,,DEM,Loretta Sanchez,57
-Ventura,Tapo-NO412,U.S. Senate,,DEM,Kamala Harris,45
-Ventura,Tapo-NO412,U.S. Senate,,DEM,Loretta Sanchez,24
-Ventura,Tapo-NO415,U.S. Senate,,DEM,Kamala Harris,0
-Ventura,Tapo-NO415,U.S. Senate,,DEM,Loretta Sanchez,0
-Ventura,Tapo-NO416,U.S. Senate,,DEM,Kamala Harris,0
-Ventura,Tapo-NO416,U.S. Senate,,DEM,Loretta Sanchez,0
-Ventura,Tapo-NO417,U.S. Senate,,DEM,Kamala Harris,0
-Ventura,Tapo-NO417,U.S. Senate,,DEM,Loretta Sanchez,0
-Ventura,Tapo-NO418,U.S. Senate,,DEM,Kamala Harris,0
-Ventura,Tapo-NO418,U.S. Senate,,DEM,Loretta Sanchez,0
-Ventura,Teag-McKev-NO301-302-303,U.S. Senate,,DEM,Kamala Harris,55
-Ventura,Teag-McKev-NO301-302-303,U.S. Senate,,DEM,Loretta Sanchez,35
-Ventura,Teag-McKev-NO305,U.S. Senate,,DEM,Kamala Harris,0
-Ventura,Teag-McKev-NO305,U.S. Senate,,DEM,Loretta Sanchez,0
-Ventura,Thou-Oaks-233,U.S. Senate,,DEM,Kamala Harris,631
-Ventura,Thou-Oaks-233,U.S. Senate,,DEM,Loretta Sanchez,321
-Ventura,Thou-Oaks-NO201,U.S. Senate,,DEM,Kamala Harris,746
-Ventura,Thou-Oaks-NO201,U.S. Senate,,DEM,Loretta Sanchez,486
-Ventura,Thou-Oaks-NO202,U.S. Senate,,DEM,Kamala Harris,565
-Ventura,Thou-Oaks-NO202,U.S. Senate,,DEM,Loretta Sanchez,324
-Ventura,Thou-Oaks-NO203,U.S. Senate,,DEM,Kamala Harris,630
-Ventura,Thou-Oaks-NO203,U.S. Senate,,DEM,Loretta Sanchez,363
-Ventura,Thou-Oaks-NO204,U.S. Senate,,DEM,Kamala Harris,242
-Ventura,Thou-Oaks-NO204,U.S. Senate,,DEM,Loretta Sanchez,138
-Ventura,Thou-Oaks-NO205,U.S. Senate,,DEM,Kamala Harris,635
-Ventura,Thou-Oaks-NO205,U.S. Senate,,DEM,Loretta Sanchez,371
-Ventura,Thou-Oaks-NO206,U.S. Senate,,DEM,Kamala Harris,377
-Ventura,Thou-Oaks-NO206,U.S. Senate,,DEM,Loretta Sanchez,207
-Ventura,Thou-Oaks-NO207,U.S. Senate,,DEM,Kamala Harris,429
-Ventura,Thou-Oaks-NO207,U.S. Senate,,DEM,Loretta Sanchez,203
-Ventura,Thou-Oaks-NO208,U.S. Senate,,DEM,Kamala Harris,772
-Ventura,Thou-Oaks-NO208,U.S. Senate,,DEM,Loretta Sanchez,577
-Ventura,Thou-Oaks-NO209,U.S. Senate,,DEM,Kamala Harris,482
-Ventura,Thou-Oaks-NO209,U.S. Senate,,DEM,Loretta Sanchez,274
-Ventura,Thou-Oaks-NO210,U.S. Senate,,DEM,Kamala Harris,429
-Ventura,Thou-Oaks-NO210,U.S. Senate,,DEM,Loretta Sanchez,222
-Ventura,Thou-Oaks-NO211,U.S. Senate,,DEM,Kamala Harris,801
-Ventura,Thou-Oaks-NO211,U.S. Senate,,DEM,Loretta Sanchez,361
-Ventura,Thou-Oaks-NO213,U.S. Senate,,DEM,Kamala Harris,837
-Ventura,Thou-Oaks-NO213,U.S. Senate,,DEM,Loretta Sanchez,467
-Ventura,Thou-Oaks-NO214,U.S. Senate,,DEM,Kamala Harris,639
-Ventura,Thou-Oaks-NO214,U.S. Senate,,DEM,Loretta Sanchez,367
-Ventura,Thou-Oaks-NO215,U.S. Senate,,DEM,Kamala Harris,853
-Ventura,Thou-Oaks-NO215,U.S. Senate,,DEM,Loretta Sanchez,417
-Ventura,Thou-Oaks-NO216,U.S. Senate,,DEM,Kamala Harris,283
-Ventura,Thou-Oaks-NO216,U.S. Senate,,DEM,Loretta Sanchez,96
-Ventura,Thou-Oaks-NO217,U.S. Senate,,DEM,Kamala Harris,341
-Ventura,Thou-Oaks-NO217,U.S. Senate,,DEM,Loretta Sanchez,167
-Ventura,Thou-Oaks-NO218,U.S. Senate,,DEM,Kamala Harris,350
-Ventura,Thou-Oaks-NO218,U.S. Senate,,DEM,Loretta Sanchez,305
-Ventura,Thou-Oaks-NO219,U.S. Senate,,DEM,Kamala Harris,971
-Ventura,Thou-Oaks-NO219,U.S. Senate,,DEM,Loretta Sanchez,464
-Ventura,Thou-Oaks-NO221,U.S. Senate,,DEM,Kamala Harris,361
-Ventura,Thou-Oaks-NO221,U.S. Senate,,DEM,Loretta Sanchez,248
-Ventura,Thou-Oaks-NO222,U.S. Senate,,DEM,Kamala Harris,508
-Ventura,Thou-Oaks-NO222,U.S. Senate,,DEM,Loretta Sanchez,297
-Ventura,Thou-Oaks-NO225,U.S. Senate,,DEM,Kamala Harris,796
-Ventura,Thou-Oaks-NO225,U.S. Senate,,DEM,Loretta Sanchez,385
-Ventura,Thou-Oaks-NO226,U.S. Senate,,DEM,Kamala Harris,625
-Ventura,Thou-Oaks-NO226,U.S. Senate,,DEM,Loretta Sanchez,396
-Ventura,Thou-Oaks-NO227,U.S. Senate,,DEM,Kamala Harris,696
-Ventura,Thou-Oaks-NO227,U.S. Senate,,DEM,Loretta Sanchez,307
-Ventura,Thou-Oaks-NO228,U.S. Senate,,DEM,Kamala Harris,972
-Ventura,Thou-Oaks-NO228,U.S. Senate,,DEM,Loretta Sanchez,431
-Ventura,Thou-Oaks-NO230,U.S. Senate,,DEM,Kamala Harris,428
-Ventura,Thou-Oaks-NO230,U.S. Senate,,DEM,Loretta Sanchez,240
-Ventura,Thou-Oaks-NO232,U.S. Senate,,DEM,Kamala Harris,854
-Ventura,Thou-Oaks-NO232,U.S. Senate,,DEM,Loretta Sanchez,430
-Ventura,Thou-Oaks-NO234,U.S. Senate,,DEM,Kamala Harris,679
-Ventura,Thou-Oaks-NO234,U.S. Senate,,DEM,Loretta Sanchez,317
-Ventura,Thou-Oaks-NO235,U.S. Senate,,DEM,Kamala Harris,567
-Ventura,Thou-Oaks-NO235,U.S. Senate,,DEM,Loretta Sanchez,238
-Ventura,Thou-Oaks-NO236,U.S. Senate,,DEM,Kamala Harris,1016
-Ventura,Thou-Oaks-NO236,U.S. Senate,,DEM,Loretta Sanchez,487
-Ventura,Thou-Oaks-NO237,U.S. Senate,,DEM,Kamala Harris,1432
-Ventura,Thou-Oaks-NO237,U.S. Senate,,DEM,Loretta Sanchez,796
-Ventura,Thou-Oaks-NO240,U.S. Senate,,DEM,Kamala Harris,630
-Ventura,Thou-Oaks-NO240,U.S. Senate,,DEM,Loretta Sanchez,313
-Ventura,Thou-Oaks-NO242,U.S. Senate,,DEM,Kamala Harris,463
-Ventura,Thou-Oaks-NO242,U.S. Senate,,DEM,Loretta Sanchez,213
-Ventura,Thou-Oaks-NO244,U.S. Senate,,DEM,Kamala Harris,903
-Ventura,Thou-Oaks-NO244,U.S. Senate,,DEM,Loretta Sanchez,370
-Ventura,Thou-Oaks-NO245,U.S. Senate,,DEM,Kamala Harris,855
-Ventura,Thou-Oaks-NO245,U.S. Senate,,DEM,Loretta Sanchez,431
-Ventura,Thou-Oaks-NO246,U.S. Senate,,DEM,Kamala Harris,1011
-Ventura,Thou-Oaks-NO246,U.S. Senate,,DEM,Loretta Sanchez,548
-Ventura,Thou-Oaks-NO248,U.S. Senate,,DEM,Kamala Harris,779
-Ventura,Thou-Oaks-NO248,U.S. Senate,,DEM,Loretta Sanchez,363
-Ventura,Thou-Oaks-NO249A-264,U.S. Senate,,DEM,Kamala Harris,2553
-Ventura,Thou-Oaks-NO249A-264,U.S. Senate,,DEM,Loretta Sanchez,1056
-Ventura,Thou-Oaks-NO250,U.S. Senate,,DEM,Kamala Harris,49
-Ventura,Thou-Oaks-NO250,U.S. Senate,,DEM,Loretta Sanchez,29
-Ventura,Thou-Oaks-NO252,U.S. Senate,,DEM,Kamala Harris,452
-Ventura,Thou-Oaks-NO252,U.S. Senate,,DEM,Loretta Sanchez,182
-Ventura,Thou-Oaks-NO253,U.S. Senate,,DEM,Kamala Harris,545
-Ventura,Thou-Oaks-NO253,U.S. Senate,,DEM,Loretta Sanchez,259
-Ventura,Thou-Oaks-NO254,U.S. Senate,,DEM,Kamala Harris,702
-Ventura,Thou-Oaks-NO254,U.S. Senate,,DEM,Loretta Sanchez,342
-Ventura,Thou-Oaks-NO255,U.S. Senate,,DEM,Kamala Harris,831
-Ventura,Thou-Oaks-NO255,U.S. Senate,,DEM,Loretta Sanchez,423
-Ventura,Thou-Oaks-NO257,U.S. Senate,,DEM,Kamala Harris,211
-Ventura,Thou-Oaks-NO257,U.S. Senate,,DEM,Loretta Sanchez,98
-Ventura,Thou-Oaks-NO258,U.S. Senate,,DEM,Kamala Harris,234
-Ventura,Thou-Oaks-NO258,U.S. Senate,,DEM,Loretta Sanchez,106
-Ventura,Thou-Oaks-NO260,U.S. Senate,,DEM,Kamala Harris,903
-Ventura,Thou-Oaks-NO260,U.S. Senate,,DEM,Loretta Sanchez,495
-Ventura,Thou-Oaks-NO262,U.S. Senate,,DEM,Kamala Harris,1154
-Ventura,Thou-Oaks-NO262,U.S. Senate,,DEM,Loretta Sanchez,547
-Ventura,Thou-Oaks-NO263,U.S. Senate,,DEM,Kamala Harris,593
-Ventura,Thou-Oaks-NO263,U.S. Senate,,DEM,Loretta Sanchez,347
-Ventura,Thou-Oaks-NO265,U.S. Senate,,DEM,Kamala Harris,991
-Ventura,Thou-Oaks-NO265,U.S. Senate,,DEM,Loretta Sanchez,464
-Ventura,Thou-Oaks-NO266,U.S. Senate,,DEM,Kamala Harris,407
-Ventura,Thou-Oaks-NO266,U.S. Senate,,DEM,Loretta Sanchez,161
-Ventura,Thou-Oaks-NO267-269-276-277,U.S. Senate,,DEM,Kamala Harris,13
-Ventura,Thou-Oaks-NO267-269-276-277,U.S. Senate,,DEM,Loretta Sanchez,5
-Ventura,Thou-Oaks-NO270,U.S. Senate,,DEM,Kamala Harris,332
-Ventura,Thou-Oaks-NO270,U.S. Senate,,DEM,Loretta Sanchez,179
-Ventura,Thou-Oaks-NO271-272,U.S. Senate,,DEM,Kamala Harris,58
-Ventura,Thou-Oaks-NO271-272,U.S. Senate,,DEM,Loretta Sanchez,41
-Ventura,Thou-Oaks-NO273-275,U.S. Senate,,DEM,Kamala Harris,0
-Ventura,Thou-Oaks-NO273-275,U.S. Senate,,DEM,Loretta Sanchez,0
-Ventura,Thou-Oaks-NO279,U.S. Senate,,DEM,Kamala Harris,904
-Ventura,Thou-Oaks-NO279,U.S. Senate,,DEM,Loretta Sanchez,477
-Ventura,Tico-103,U.S. Senate,,DEM,Kamala Harris,337
-Ventura,Tico-103,U.S. Senate,,DEM,Loretta Sanchez,144
-Ventura,Tico-NO101-106,U.S. Senate,,DEM,Kamala Harris,12
-Ventura,Tico-NO101-106,U.S. Senate,,DEM,Loretta Sanchez,8
-Ventura,Tico-NO102-118,U.S. Senate,,DEM,Kamala Harris,51
-Ventura,Tico-NO102-118,U.S. Senate,,DEM,Loretta Sanchez,14
-Ventura,Tico-NO104-111,U.S. Senate,,DEM,Kamala Harris,310
-Ventura,Tico-NO104-111,U.S. Senate,,DEM,Loretta Sanchez,148
-Ventura,Tico-NO105,U.S. Senate,,DEM,Kamala Harris,0
-Ventura,Tico-NO105,U.S. Senate,,DEM,Loretta Sanchez,0
-Ventura,Tico-NO107,U.S. Senate,,DEM,Kamala Harris,2
-Ventura,Tico-NO107,U.S. Senate,,DEM,Loretta Sanchez,2
-Ventura,Tico-NO108-112-114-116,U.S. Senate,,DEM,Kamala Harris,31
-Ventura,Tico-NO108-112-114-116,U.S. Senate,,DEM,Loretta Sanchez,21
-Ventura,Tico-NO109,U.S. Senate,,DEM,Kamala Harris,82
-Ventura,Tico-NO109,U.S. Senate,,DEM,Loretta Sanchez,42
-Ventura,Tico-NO110-134,U.S. Senate,,DEM,Kamala Harris,434
-Ventura,Tico-NO110-134,U.S. Senate,,DEM,Loretta Sanchez,224
-Ventura,Tico-NO113,U.S. Senate,,DEM,Kamala Harris,16
-Ventura,Tico-NO113,U.S. Senate,,DEM,Loretta Sanchez,5
-Ventura,Tico-NO120-122-124-126,U.S. Senate,,DEM,Kamala Harris,8
-Ventura,Tico-NO120-122-124-126,U.S. Senate,,DEM,Loretta Sanchez,1
-Ventura,Tico-NO127-143,U.S. Senate,,DEM,Kamala Harris,20
-Ventura,Tico-NO127-143,U.S. Senate,,DEM,Loretta Sanchez,12
-Ventura,Tico-NO129,U.S. Senate,,DEM,Kamala Harris,156
-Ventura,Tico-NO129,U.S. Senate,,DEM,Loretta Sanchez,69
-Ventura,Tico-NO130-137,U.S. Senate,,DEM,Kamala Harris,36
-Ventura,Tico-NO130-137,U.S. Senate,,DEM,Loretta Sanchez,19
-Ventura,Tico-NO132-139-141-144,U.S. Senate,,DEM,Kamala Harris,10
-Ventura,Tico-NO132-139-141-144,U.S. Senate,,DEM,Loretta Sanchez,11
-Ventura,Tico-NO135,U.S. Senate,,DEM,Kamala Harris,91
-Ventura,Tico-NO135,U.S. Senate,,DEM,Loretta Sanchez,55
-Ventura,Tico-NO140,U.S. Senate,,DEM,Kamala Harris,99
-Ventura,Tico-NO140,U.S. Senate,,DEM,Loretta Sanchez,55
-Ventura,Tico-NO145,U.S. Senate,,DEM,Kamala Harris,0
-Ventura,Tico-NO145,U.S. Senate,,DEM,Loretta Sanchez,1
-Ventura,Timber-NO201,U.S. Senate,,DEM,Kamala Harris,347
-Ventura,Timber-NO201,U.S. Senate,,DEM,Loretta Sanchez,171
-Ventura,Timber-NO203-204-206,U.S. Senate,,DEM,Kamala Harris,8
-Ventura,Timber-NO203-204-206,U.S. Senate,,DEM,Loretta Sanchez,9
-Ventura,Timber-NO205-207-217,U.S. Senate,,DEM,Kamala Harris,1
-Ventura,Timber-NO205-207-217,U.S. Senate,,DEM,Loretta Sanchez,0
-Ventura,Timber-NO208,U.S. Senate,,DEM,Kamala Harris,666
-Ventura,Timber-NO208,U.S. Senate,,DEM,Loretta Sanchez,347
-Ventura,Timber-NO209,U.S. Senate,,DEM,Kamala Harris,582
-Ventura,Timber-NO209,U.S. Senate,,DEM,Loretta Sanchez,337
-Ventura,Timber-NO210,U.S. Senate,,DEM,Kamala Harris,228
-Ventura,Timber-NO210,U.S. Senate,,DEM,Loretta Sanchez,143
-Ventura,Timber-NO211-212-213,U.S. Senate,,DEM,Kamala Harris,20
-Ventura,Timber-NO211-212-213,U.S. Senate,,DEM,Loretta Sanchez,5
-Ventura,Timber-NO215,U.S. Senate,,DEM,Kamala Harris,0
-Ventura,Timber-NO215,U.S. Senate,,DEM,Loretta Sanchez,0
-Ventura,Timber-NO216,U.S. Senate,,DEM,Kamala Harris,0
-Ventura,Timber-NO216,U.S. Senate,,DEM,Loretta Sanchez,0
-Ventura,Topa-Topa-NO101-106-107,U.S. Senate,,DEM,Kamala Harris,29
-Ventura,Topa-Topa-NO101-106-107,U.S. Senate,,DEM,Loretta Sanchez,14
-Ventura,Topa-Topa-NO102-104-108,U.S. Senate,,DEM,Kamala Harris,7
-Ventura,Topa-Topa-NO102-104-108,U.S. Senate,,DEM,Loretta Sanchez,1
-Ventura,Topa-Topa-NO103,U.S. Senate,,DEM,Kamala Harris,230
-Ventura,Topa-Topa-NO103,U.S. Senate,,DEM,Loretta Sanchez,103
-Ventura,Topa-Topa-NO105,U.S. Senate,,DEM,Kamala Harris,84
-Ventura,Topa-Topa-NO105,U.S. Senate,,DEM,Loretta Sanchez,38
-Ventura,Ventura-NO101,U.S. Senate,,DEM,Kamala Harris,819
-Ventura,Ventura-NO101,U.S. Senate,,DEM,Loretta Sanchez,356
-Ventura,Ventura-NO102,U.S. Senate,,DEM,Kamala Harris,41
-Ventura,Ventura-NO102,U.S. Senate,,DEM,Loretta Sanchez,38
-Ventura,Ventura-NO103,U.S. Senate,,DEM,Kamala Harris,478
-Ventura,Ventura-NO103,U.S. Senate,,DEM,Loretta Sanchez,178
-Ventura,Ventura-NO104,U.S. Senate,,DEM,Kamala Harris,0
-Ventura,Ventura-NO104,U.S. Senate,,DEM,Loretta Sanchez,0
-Ventura,Ventura-NO105,U.S. Senate,,DEM,Kamala Harris,659
-Ventura,Ventura-NO105,U.S. Senate,,DEM,Loretta Sanchez,308
-Ventura,Ventura-NO106,U.S. Senate,,DEM,Kamala Harris,851
-Ventura,Ventura-NO106,U.S. Senate,,DEM,Loretta Sanchez,439
-Ventura,Ventura-NO107,U.S. Senate,,DEM,Kamala Harris,64
-Ventura,Ventura-NO107,U.S. Senate,,DEM,Loretta Sanchez,22
-Ventura,Ventura-NO108,U.S. Senate,,DEM,Kamala Harris,887
-Ventura,Ventura-NO108,U.S. Senate,,DEM,Loretta Sanchez,487
-Ventura,Ventura-NO110,U.S. Senate,,DEM,Kamala Harris,364
-Ventura,Ventura-NO110,U.S. Senate,,DEM,Loretta Sanchez,219
-Ventura,Ventura-NO111,U.S. Senate,,DEM,Kamala Harris,512
-Ventura,Ventura-NO111,U.S. Senate,,DEM,Loretta Sanchez,304
-Ventura,Ventura-NO113,U.S. Senate,,DEM,Kamala Harris,703
-Ventura,Ventura-NO113,U.S. Senate,,DEM,Loretta Sanchez,370
-Ventura,Ventura-NO114,U.S. Senate,,DEM,Kamala Harris,0
-Ventura,Ventura-NO114,U.S. Senate,,DEM,Loretta Sanchez,0
-Ventura,Ventura-NO115,U.S. Senate,,DEM,Kamala Harris,668
-Ventura,Ventura-NO115,U.S. Senate,,DEM,Loretta Sanchez,392
-Ventura,Ventura-NO116,U.S. Senate,,DEM,Kamala Harris,780
-Ventura,Ventura-NO116,U.S. Senate,,DEM,Loretta Sanchez,417
-Ventura,Ventura-NO117,U.S. Senate,,DEM,Kamala Harris,460
-Ventura,Ventura-NO117,U.S. Senate,,DEM,Loretta Sanchez,302
-Ventura,Ventura-NO118,U.S. Senate,,DEM,Kamala Harris,659
-Ventura,Ventura-NO118,U.S. Senate,,DEM,Loretta Sanchez,390
-Ventura,Ventura-NO119,U.S. Senate,,DEM,Kamala Harris,437
-Ventura,Ventura-NO119,U.S. Senate,,DEM,Loretta Sanchez,222
-Ventura,Ventura-NO120,U.S. Senate,,DEM,Kamala Harris,686
-Ventura,Ventura-NO120,U.S. Senate,,DEM,Loretta Sanchez,357
-Ventura,Ventura-NO121-148-160,U.S. Senate,,DEM,Kamala Harris,117
-Ventura,Ventura-NO121-148-160,U.S. Senate,,DEM,Loretta Sanchez,37
-Ventura,Ventura-NO123,U.S. Senate,,DEM,Kamala Harris,1143
-Ventura,Ventura-NO123,U.S. Senate,,DEM,Loretta Sanchez,622
-Ventura,Ventura-NO125,U.S. Senate,,DEM,Kamala Harris,1055
-Ventura,Ventura-NO125,U.S. Senate,,DEM,Loretta Sanchez,631
-Ventura,Ventura-NO127,U.S. Senate,,DEM,Kamala Harris,838
-Ventura,Ventura-NO127,U.S. Senate,,DEM,Loretta Sanchez,312
-Ventura,Ventura-NO128,U.S. Senate,,DEM,Kamala Harris,349
-Ventura,Ventura-NO128,U.S. Senate,,DEM,Loretta Sanchez,248
-Ventura,Ventura-NO129,U.S. Senate,,DEM,Kamala Harris,612
-Ventura,Ventura-NO129,U.S. Senate,,DEM,Loretta Sanchez,312
-Ventura,Ventura-NO130,U.S. Senate,,DEM,Kamala Harris,422
-Ventura,Ventura-NO130,U.S. Senate,,DEM,Loretta Sanchez,340
-Ventura,Ventura-NO131,U.S. Senate,,DEM,Kamala Harris,1270
-Ventura,Ventura-NO131,U.S. Senate,,DEM,Loretta Sanchez,744
-Ventura,Ventura-NO133,U.S. Senate,,DEM,Kamala Harris,501
-Ventura,Ventura-NO133,U.S. Senate,,DEM,Loretta Sanchez,285
-Ventura,Ventura-NO134,U.S. Senate,,DEM,Kamala Harris,458
-Ventura,Ventura-NO134,U.S. Senate,,DEM,Loretta Sanchez,198
-Ventura,Ventura-NO137,U.S. Senate,,DEM,Kamala Harris,504
-Ventura,Ventura-NO137,U.S. Senate,,DEM,Loretta Sanchez,265
-Ventura,Ventura-NO138,U.S. Senate,,DEM,Kamala Harris,680
-Ventura,Ventura-NO138,U.S. Senate,,DEM,Loretta Sanchez,418
-Ventura,Ventura-NO139,U.S. Senate,,DEM,Kamala Harris,633
-Ventura,Ventura-NO139,U.S. Senate,,DEM,Loretta Sanchez,361
-Ventura,Ventura-NO140,U.S. Senate,,DEM,Kamala Harris,1092
-Ventura,Ventura-NO140,U.S. Senate,,DEM,Loretta Sanchez,744
-Ventura,Ventura-NO142,U.S. Senate,,DEM,Kamala Harris,618
-Ventura,Ventura-NO142,U.S. Senate,,DEM,Loretta Sanchez,268
-Ventura,Ventura-NO143,U.S. Senate,,DEM,Kamala Harris,696
-Ventura,Ventura-NO143,U.S. Senate,,DEM,Loretta Sanchez,376
-Ventura,Ventura-NO144,U.S. Senate,,DEM,Kamala Harris,718
-Ventura,Ventura-NO144,U.S. Senate,,DEM,Loretta Sanchez,450
-Ventura,Ventura-NO145,U.S. Senate,,DEM,Kamala Harris,614
-Ventura,Ventura-NO145,U.S. Senate,,DEM,Loretta Sanchez,467
-Ventura,Ventura-NO146,U.S. Senate,,DEM,Kamala Harris,249
-Ventura,Ventura-NO146,U.S. Senate,,DEM,Loretta Sanchez,142
-Ventura,Ventura-NO150,U.S. Senate,,DEM,Kamala Harris,0
-Ventura,Ventura-NO150,U.S. Senate,,DEM,Loretta Sanchez,0
-Ventura,Ventura-NO151,U.S. Senate,,DEM,Kamala Harris,918
-Ventura,Ventura-NO151,U.S. Senate,,DEM,Loretta Sanchez,601
-Ventura,Ventura-NO153,U.S. Senate,,DEM,Kamala Harris,751
-Ventura,Ventura-NO153,U.S. Senate,,DEM,Loretta Sanchez,366
-Ventura,Ventura-NO155,U.S. Senate,,DEM,Kamala Harris,664
-Ventura,Ventura-NO155,U.S. Senate,,DEM,Loretta Sanchez,271
-Ventura,Ventura-NO156,U.S. Senate,,DEM,Kamala Harris,490
-Ventura,Ventura-NO156,U.S. Senate,,DEM,Loretta Sanchez,484
-Ventura,Ventura-NO157,U.S. Senate,,DEM,Kamala Harris,254
-Ventura,Ventura-NO157,U.S. Senate,,DEM,Loretta Sanchez,272
-Ventura,Ventura-NO158,U.S. Senate,,DEM,Kamala Harris,258
-Ventura,Ventura-NO158,U.S. Senate,,DEM,Loretta Sanchez,144
-Ventura,Ventura-NO162,U.S. Senate,,DEM,Kamala Harris,0
-Ventura,Ventura-NO162,U.S. Senate,,DEM,Loretta Sanchez,0
-Ventura,Ventura-NO163-170,U.S. Senate,,DEM,Kamala Harris,8
-Ventura,Ventura-NO163-170,U.S. Senate,,DEM,Loretta Sanchez,3
-Ventura,Ventura-NO165,U.S. Senate,,DEM,Kamala Harris,942
-Ventura,Ventura-NO165,U.S. Senate,,DEM,Loretta Sanchez,640
-Ventura,Ventura-NO166,U.S. Senate,,DEM,Kamala Harris,81
-Ventura,Ventura-NO166,U.S. Senate,,DEM,Loretta Sanchez,28
-Ventura,Ventura-NO168,U.S. Senate,,DEM,Kamala Harris,931
-Ventura,Ventura-NO168,U.S. Senate,,DEM,Loretta Sanchez,517
-Ventura,Ventura-NO169,U.S. Senate,,DEM,Kamala Harris,0
-Ventura,Ventura-NO169,U.S. Senate,,DEM,Loretta Sanchez,0
-Ventura,Ventura-NO171,U.S. Senate,,DEM,Kamala Harris,99
-Ventura,Ventura-NO171,U.S. Senate,,DEM,Loretta Sanchez,57
-Ventura,Ventura-NO172,U.S. Senate,,DEM,Kamala Harris,225
-Ventura,Ventura-NO172,U.S. Senate,,DEM,Loretta Sanchez,198
-Ventura,Ventura-NO173,U.S. Senate,,DEM,Kamala Harris,55
-Ventura,Ventura-NO173,U.S. Senate,,DEM,Loretta Sanchez,37
-Ventura,Ventura-NO174,U.S. Senate,,DEM,Kamala Harris,596
-Ventura,Ventura-NO174,U.S. Senate,,DEM,Loretta Sanchez,255
-Ventura,Ventura-NO175,U.S. Senate,,DEM,Kamala Harris,164
-Ventura,Ventura-NO175,U.S. Senate,,DEM,Loretta Sanchez,82
-Ventura,Ventura-NO176,U.S. Senate,,DEM,Kamala Harris,222
-Ventura,Ventura-NO176,U.S. Senate,,DEM,Loretta Sanchez,93
-Ventura,Ventura-NO177,U.S. Senate,,DEM,Kamala Harris,88
-Ventura,Ventura-NO177,U.S. Senate,,DEM,Loretta Sanchez,39
-Ventura,Ventura-NO179,U.S. Senate,,DEM,Kamala Harris,0
-Ventura,Ventura-NO179,U.S. Senate,,DEM,Loretta Sanchez,0
-Ventura,Ventura-NO181,U.S. Senate,,DEM,Kamala Harris,0
-Ventura,Ventura-NO181,U.S. Senate,,DEM,Loretta Sanchez,1
-Ventura,Yrba-Buena-NO201,U.S. Senate,,DEM,Kamala Harris,113
-Ventura,Yrba-Buena-NO201,U.S. Senate,,DEM,Loretta Sanchez,43
-Ventura,Yrba-Buena-NO202-204,U.S. Senate,,DEM,Kamala Harris,62
-Ventura,Yrba-Buena-NO202-204,U.S. Senate,,DEM,Loretta Sanchez,16
-Ventura,Yrba-Buena-NO203,U.S. Senate,,DEM,Kamala Harris,1
-Ventura,Yrba-Buena-NO203,U.S. Senate,,DEM,Loretta Sanchez,0
+Ventura,Avenue-NO101-105,U.S. Senate,,DEM,Kamala D. Harris,5
+Ventura,Avenue-NO101-105,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Ventura,Avenue-NO102-103-104,U.S. Senate,,DEM,Kamala D. Harris,12
+Ventura,Avenue-NO102-103-104,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Ventura,Bardsdale-NO301,U.S. Senate,,DEM,Kamala D. Harris,122
+Ventura,Bardsdale-NO301,U.S. Senate,,DEM,Loretta L. Sanchez,95
+Ventura,Bardsdale-NO302-303-304,U.S. Senate,,DEM,Kamala D. Harris,33
+Ventura,Bardsdale-NO302-303-304,U.S. Senate,,DEM,Loretta L. Sanchez,23
+Ventura,Bardsdale-NO401-402-405-406,U.S. Senate,,DEM,Kamala D. Harris,0
+Ventura,Bardsdale-NO401-402-405-406,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Ventura,Bardsdale-NO403-404,U.S. Senate,,DEM,Kamala D. Harris,0
+Ventura,Bardsdale-NO403-404,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Ventura,Briggs-304,U.S. Senate,,DEM,Kamala D. Harris,16
+Ventura,Briggs-304,U.S. Senate,,DEM,Loretta L. Sanchez,5
+Ventura,Briggs-NO101-102-103,U.S. Senate,,DEM,Kamala D. Harris,80
+Ventura,Briggs-NO101-102-103,U.S. Senate,,DEM,Loretta L. Sanchez,72
+Ventura,Briggs-NO301,U.S. Senate,,DEM,Kamala D. Harris,111
+Ventura,Briggs-NO301,U.S. Senate,,DEM,Loretta L. Sanchez,123
+Ventura,Briggs-NO302-303,U.S. Senate,,DEM,Kamala D. Harris,8
+Ventura,Briggs-NO302-303,U.S. Senate,,DEM,Loretta L. Sanchez,12
+Ventura,Calleguas-NO201-212-214,U.S. Senate,,DEM,Kamala D. Harris,8
+Ventura,Calleguas-NO201-212-214,U.S. Senate,,DEM,Loretta L. Sanchez,11
+Ventura,Calleguas-NO202-203,U.S. Senate,,DEM,Kamala D. Harris,0
+Ventura,Calleguas-NO202-203,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Ventura,Calleguas-NO204,U.S. Senate,,DEM,Kamala D. Harris,508
+Ventura,Calleguas-NO204,U.S. Senate,,DEM,Loretta L. Sanchez,211
+Ventura,Calleguas-NO205,U.S. Senate,,DEM,Kamala D. Harris,18
+Ventura,Calleguas-NO205,U.S. Senate,,DEM,Loretta L. Sanchez,5
+Ventura,Calleguas-NO206-208,U.S. Senate,,DEM,Kamala D. Harris,3
+Ventura,Calleguas-NO206-208,U.S. Senate,,DEM,Loretta L. Sanchez,8
+Ventura,Calleguas-NO207,U.S. Senate,,DEM,Kamala D. Harris,2
+Ventura,Calleguas-NO207,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Ventura,Calleguas-NO209-218,U.S. Senate,,DEM,Kamala D. Harris,0
+Ventura,Calleguas-NO209-218,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Ventura,Calleguas-NO210,U.S. Senate,,DEM,Kamala D. Harris,6
+Ventura,Calleguas-NO210,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Ventura,Calleguas-NO211,U.S. Senate,,DEM,Kamala D. Harris,0
+Ventura,Calleguas-NO211,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Ventura,Calleguas-NO216,U.S. Senate,,DEM,Kamala D. Harris,2
+Ventura,Calleguas-NO216,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Ventura,Calleguas-NO301-305,U.S. Senate,,DEM,Kamala D. Harris,9
+Ventura,Calleguas-NO301-305,U.S. Senate,,DEM,Loretta L. Sanchez,8
+Ventura,Calleguas-NO302-307-309,U.S. Senate,,DEM,Kamala D. Harris,2
+Ventura,Calleguas-NO302-307-309,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Ventura,Calleguas-NO303-306-315,U.S. Senate,,DEM,Kamala D. Harris,7
+Ventura,Calleguas-NO303-306-315,U.S. Senate,,DEM,Loretta L. Sanchez,8
+Ventura,Calleguas-NO304,U.S. Senate,,DEM,Kamala D. Harris,4
+Ventura,Calleguas-NO304,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Ventura,Calleguas-NO312-313-314,U.S. Senate,,DEM,Kamala D. Harris,3
+Ventura,Calleguas-NO312-313-314,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Ventura,Calleguas-NO401,U.S. Senate,,DEM,Kamala D. Harris,0
+Ventura,Calleguas-NO401,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Ventura,Camarillo-NO301,U.S. Senate,,DEM,Kamala D. Harris,333
+Ventura,Camarillo-NO301,U.S. Senate,,DEM,Loretta L. Sanchez,223
+Ventura,Camarillo-NO302,U.S. Senate,,DEM,Kamala D. Harris,239
+Ventura,Camarillo-NO302,U.S. Senate,,DEM,Loretta L. Sanchez,113
+Ventura,Camarillo-NO303,U.S. Senate,,DEM,Kamala D. Harris,846
+Ventura,Camarillo-NO303,U.S. Senate,,DEM,Loretta L. Sanchez,482
+Ventura,Camarillo-NO305,U.S. Senate,,DEM,Kamala D. Harris,425
+Ventura,Camarillo-NO305,U.S. Senate,,DEM,Loretta L. Sanchez,323
+Ventura,Camarillo-NO306,U.S. Senate,,DEM,Kamala D. Harris,1105
+Ventura,Camarillo-NO306,U.S. Senate,,DEM,Loretta L. Sanchez,675
+Ventura,Camarillo-NO308,U.S. Senate,,DEM,Kamala D. Harris,518
+Ventura,Camarillo-NO308,U.S. Senate,,DEM,Loretta L. Sanchez,366
+Ventura,Camarillo-NO309,U.S. Senate,,DEM,Kamala D. Harris,619
+Ventura,Camarillo-NO309,U.S. Senate,,DEM,Loretta L. Sanchez,328
+Ventura,Camarillo-NO310,U.S. Senate,,DEM,Kamala D. Harris,1149
+Ventura,Camarillo-NO310,U.S. Senate,,DEM,Loretta L. Sanchez,598
+Ventura,Camarillo-NO312AL-325,U.S. Senate,,DEM,Kamala D. Harris,762
+Ventura,Camarillo-NO312AL-325,U.S. Senate,,DEM,Loretta L. Sanchez,399
+Ventura,Camarillo-NO313-320-354,U.S. Senate,,DEM,Kamala D. Harris,90
+Ventura,Camarillo-NO313-320-354,U.S. Senate,,DEM,Loretta L. Sanchez,67
+Ventura,Camarillo-NO314,U.S. Senate,,DEM,Kamala D. Harris,582
+Ventura,Camarillo-NO314,U.S. Senate,,DEM,Loretta L. Sanchez,370
+Ventura,Camarillo-NO315-344,U.S. Senate,,DEM,Kamala D. Harris,10
+Ventura,Camarillo-NO315-344,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Ventura,Camarillo-NO316,U.S. Senate,,DEM,Kamala D. Harris,422
+Ventura,Camarillo-NO316,U.S. Senate,,DEM,Loretta L. Sanchez,244
+Ventura,Camarillo-NO317,U.S. Senate,,DEM,Kamala D. Harris,713
+Ventura,Camarillo-NO317,U.S. Senate,,DEM,Loretta L. Sanchez,378
+Ventura,Camarillo-NO318,U.S. Senate,,DEM,Kamala D. Harris,909
+Ventura,Camarillo-NO318,U.S. Senate,,DEM,Loretta L. Sanchez,567
+Ventura,Camarillo-NO321,U.S. Senate,,DEM,Kamala D. Harris,809
+Ventura,Camarillo-NO321,U.S. Senate,,DEM,Loretta L. Sanchez,443
+Ventura,Camarillo-NO322,U.S. Senate,,DEM,Kamala D. Harris,68
+Ventura,Camarillo-NO322,U.S. Senate,,DEM,Loretta L. Sanchez,35
+Ventura,Camarillo-NO323,U.S. Senate,,DEM,Kamala D. Harris,709
+Ventura,Camarillo-NO323,U.S. Senate,,DEM,Loretta L. Sanchez,406
+Ventura,Camarillo-NO324-330,U.S. Senate,,DEM,Kamala D. Harris,7
+Ventura,Camarillo-NO324-330,U.S. Senate,,DEM,Loretta L. Sanchez,15
+Ventura,Camarillo-NO326,U.S. Senate,,DEM,Kamala D. Harris,833
+Ventura,Camarillo-NO326,U.S. Senate,,DEM,Loretta L. Sanchez,432
+Ventura,Camarillo-NO327,U.S. Senate,,DEM,Kamala D. Harris,1383
+Ventura,Camarillo-NO327,U.S. Senate,,DEM,Loretta L. Sanchez,711
+Ventura,Camarillo-NO329,U.S. Senate,,DEM,Kamala D. Harris,1438
+Ventura,Camarillo-NO329,U.S. Senate,,DEM,Loretta L. Sanchez,570
+Ventura,Camarillo-NO331,U.S. Senate,,DEM,Kamala D. Harris,571
+Ventura,Camarillo-NO331,U.S. Senate,,DEM,Loretta L. Sanchez,375
+Ventura,Camarillo-NO333,U.S. Senate,,DEM,Kamala D. Harris,946
+Ventura,Camarillo-NO333,U.S. Senate,,DEM,Loretta L. Sanchez,506
+Ventura,Camarillo-NO336,U.S. Senate,,DEM,Kamala D. Harris,0
+Ventura,Camarillo-NO336,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Ventura,Camarillo-NO337,U.S. Senate,,DEM,Kamala D. Harris,1351
+Ventura,Camarillo-NO337,U.S. Senate,,DEM,Loretta L. Sanchez,769
+Ventura,Camarillo-NO338,U.S. Senate,,DEM,Kamala D. Harris,24
+Ventura,Camarillo-NO338,U.S. Senate,,DEM,Loretta L. Sanchez,9
+Ventura,Camarillo-NO339-341,U.S. Senate,,DEM,Kamala D. Harris,57
+Ventura,Camarillo-NO339-341,U.S. Senate,,DEM,Loretta L. Sanchez,27
+Ventura,Camarillo-NO340-345-346-350,U.S. Senate,,DEM,Kamala D. Harris,4
+Ventura,Camarillo-NO340-345-346-350,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Ventura,Camarillo-NO343,U.S. Senate,,DEM,Kamala D. Harris,90
+Ventura,Camarillo-NO343,U.S. Senate,,DEM,Loretta L. Sanchez,56
+Ventura,Camarillo-NO347,U.S. Senate,,DEM,Kamala D. Harris,998
+Ventura,Camarillo-NO347,U.S. Senate,,DEM,Loretta L. Sanchez,567
+Ventura,Camarillo-NO348,U.S. Senate,,DEM,Kamala D. Harris,1
+Ventura,Camarillo-NO348,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Ventura,Camarillo-NO349,U.S. Senate,,DEM,Kamala D. Harris,7
+Ventura,Camarillo-NO349,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Ventura,Camarillo-NO351,U.S. Senate,,DEM,Kamala D. Harris,0
+Ventura,Camarillo-NO351,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Ventura,Camarillo-NO352,U.S. Senate,,DEM,Kamala D. Harris,0
+Ventura,Camarillo-NO352,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Ventura,Camarillo-NO353,U.S. Senate,,DEM,Kamala D. Harris,0
+Ventura,Camarillo-NO353,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Ventura,Camarillo-NO355,U.S. Senate,,DEM,Kamala D. Harris,0
+Ventura,Camarillo-NO355,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Ventura,Camarillo-NO356,U.S. Senate,,DEM,Kamala D. Harris,1
+Ventura,Camarillo-NO356,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Ventura,Camarillo-NO357,U.S. Senate,,DEM,Kamala D. Harris,0
+Ventura,Camarillo-NO357,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Ventura,Central-NO301-303,U.S. Senate,,DEM,Kamala D. Harris,0
+Ventura,Central-NO301-303,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Ventura,Central-NO304,U.S. Senate,,DEM,Kamala D. Harris,0
+Ventura,Central-NO304,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Ventura,Csts-Sprgs-NO101-02-04-37-38,U.S. Senate,,DEM,Kamala D. Harris,61
+Ventura,Csts-Sprgs-NO101-02-04-37-38,U.S. Senate,,DEM,Loretta L. Sanchez,29
+Ventura,Csts-Sprgs-NO103-124,U.S. Senate,,DEM,Kamala D. Harris,36
+Ventura,Csts-Sprgs-NO103-124,U.S. Senate,,DEM,Loretta L. Sanchez,17
+Ventura,Csts-Sprgs-NO105-140-148,U.S. Senate,,DEM,Kamala D. Harris,15
+Ventura,Csts-Sprgs-NO105-140-148,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Ventura,Csts-Sprgs-NO106-108-109,U.S. Senate,,DEM,Kamala D. Harris,91
+Ventura,Csts-Sprgs-NO106-108-109,U.S. Senate,,DEM,Loretta L. Sanchez,25
+Ventura,Csts-Sprgs-NO111,U.S. Senate,,DEM,Kamala D. Harris,99
+Ventura,Csts-Sprgs-NO111,U.S. Senate,,DEM,Loretta L. Sanchez,57
+Ventura,Csts-Sprgs-NO112-113,U.S. Senate,,DEM,Kamala D. Harris,3
+Ventura,Csts-Sprgs-NO112-113,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Ventura,Csts-Sprgs-NO117-118-119,U.S. Senate,,DEM,Kamala D. Harris,0
+Ventura,Csts-Sprgs-NO117-118-119,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Ventura,Csts-Sprgs-NO121-123-125,U.S. Senate,,DEM,Kamala D. Harris,6
+Ventura,Csts-Sprgs-NO121-123-125,U.S. Senate,,DEM,Loretta L. Sanchez,8
+Ventura,Csts-Sprgs-NO126-128-29-150,U.S. Senate,,DEM,Kamala D. Harris,28
+Ventura,Csts-Sprgs-NO126-128-29-150,U.S. Senate,,DEM,Loretta L. Sanchez,7
+Ventura,Csts-Sprgs-NO130-133-135-136,U.S. Senate,,DEM,Kamala D. Harris,15
+Ventura,Csts-Sprgs-NO130-133-135-136,U.S. Senate,,DEM,Loretta L. Sanchez,9
+Ventura,Csts-Sprgs-NO149,U.S. Senate,,DEM,Kamala D. Harris,0
+Ventura,Csts-Sprgs-NO149,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Ventura,Del-Norte-NO201,U.S. Senate,,DEM,Kamala D. Harris,26
+Ventura,Del-Norte-NO201,U.S. Senate,,DEM,Loretta L. Sanchez,19
+Ventura,Del-Norte-NO301,U.S. Senate,,DEM,Kamala D. Harris,71
+Ventura,Del-Norte-NO301,U.S. Senate,,DEM,Loretta L. Sanchez,62
+Ventura,Del-Norte-NO501-509,U.S. Senate,,DEM,Kamala D. Harris,6
+Ventura,Del-Norte-NO501-509,U.S. Senate,,DEM,Loretta L. Sanchez,14
+Ventura,East-Ojai-NO101,U.S. Senate,,DEM,Kamala D. Harris,456
+Ventura,East-Ojai-NO101,U.S. Senate,,DEM,Loretta L. Sanchez,150
+Ventura,East-Ojai-NO102-107-110,U.S. Senate,,DEM,Kamala D. Harris,13
+Ventura,East-Ojai-NO102-107-110,U.S. Senate,,DEM,Loretta L. Sanchez,6
+Ventura,East-Ojai-NO103,U.S. Senate,,DEM,Kamala D. Harris,7
+Ventura,East-Ojai-NO103,U.S. Senate,,DEM,Loretta L. Sanchez,5
+Ventura,East-Ojai-NO104-106-111,U.S. Senate,,DEM,Kamala D. Harris,8
+Ventura,East-Ojai-NO104-106-111,U.S. Senate,,DEM,Loretta L. Sanchez,7
+Ventura,East-Ojai-NO105-115,U.S. Senate,,DEM,Kamala D. Harris,0
+Ventura,East-Ojai-NO105-115,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Ventura,East-Ojai-NO112-113,U.S. Senate,,DEM,Kamala D. Harris,129
+Ventura,East-Ojai-NO112-113,U.S. Senate,,DEM,Loretta L. Sanchez,39
+Ventura,East-Ojai-NO116-117,U.S. Senate,,DEM,Kamala D. Harris,4
+Ventura,East-Ojai-NO116-117,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Ventura,El-Rio-NO101-102-103,U.S. Senate,,DEM,Kamala D. Harris,0
+Ventura,El-Rio-NO101-102-103,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Ventura,El-Rio-NO501,U.S. Senate,,DEM,Kamala D. Harris,561
+Ventura,El-Rio-NO501,U.S. Senate,,DEM,Loretta L. Sanchez,642
+Ventura,El-Rio-NO502,U.S. Senate,,DEM,Kamala D. Harris,180
+Ventura,El-Rio-NO502,U.S. Senate,,DEM,Loretta L. Sanchez,219
+Ventura,El-Rio-NO503-505,U.S. Senate,,DEM,Kamala D. Harris,12
+Ventura,El-Rio-NO503-505,U.S. Senate,,DEM,Loretta L. Sanchez,10
+Ventura,El-Rio-NO506,U.S. Senate,,DEM,Kamala D. Harris,0
+Ventura,El-Rio-NO506,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Ventura,Fillmore-NO301,U.S. Senate,,DEM,Kamala D. Harris,279
+Ventura,Fillmore-NO301,U.S. Senate,,DEM,Loretta L. Sanchez,473
+Ventura,Fillmore-NO302,U.S. Senate,,DEM,Kamala D. Harris,279
+Ventura,Fillmore-NO302,U.S. Senate,,DEM,Loretta L. Sanchez,362
+Ventura,Fillmore-NO303,U.S. Senate,,DEM,Kamala D. Harris,371
+Ventura,Fillmore-NO303,U.S. Senate,,DEM,Loretta L. Sanchez,352
+Ventura,Fillmore-NO304,U.S. Senate,,DEM,Kamala D. Harris,964
+Ventura,Fillmore-NO304,U.S. Senate,,DEM,Loretta L. Sanchez,1092
+Ventura,Fillmore-NO305,U.S. Senate,,DEM,Kamala D. Harris,129
+Ventura,Fillmore-NO305,U.S. Senate,,DEM,Loretta L. Sanchez,92
+Ventura,Fillmore-NO306,U.S. Senate,,DEM,Kamala D. Harris,0
+Ventura,Fillmore-NO306,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Ventura,Gabbert-NO201,U.S. Senate,,DEM,Kamala D. Harris,0
+Ventura,Gabbert-NO201,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Ventura,Gabbert-NO202,U.S. Senate,,DEM,Kamala D. Harris,9
+Ventura,Gabbert-NO202,U.S. Senate,,DEM,Loretta L. Sanchez,6
+Ventura,Gabbert-NO203,U.S. Senate,,DEM,Kamala D. Harris,5
+Ventura,Gabbert-NO203,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Ventura,Gabbert-NO301,U.S. Senate,,DEM,Kamala D. Harris,0
+Ventura,Gabbert-NO301,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Ventura,Gabbert-NO302,U.S. Senate,,DEM,Kamala D. Harris,0
+Ventura,Gabbert-NO302,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Ventura,Gabbert-NO401,U.S. Senate,,DEM,Kamala D. Harris,59
+Ventura,Gabbert-NO401,U.S. Senate,,DEM,Loretta L. Sanchez,47
+Ventura,Gabbert-NO402-411,U.S. Senate,,DEM,Kamala D. Harris,3
+Ventura,Gabbert-NO402-411,U.S. Senate,,DEM,Loretta L. Sanchez,9
+Ventura,Gabbert-NO403,U.S. Senate,,DEM,Kamala D. Harris,177
+Ventura,Gabbert-NO403,U.S. Senate,,DEM,Loretta L. Sanchez,106
+Ventura,Gabbert-NO404,U.S. Senate,,DEM,Kamala D. Harris,9
+Ventura,Gabbert-NO404,U.S. Senate,,DEM,Loretta L. Sanchez,14
+Ventura,Gabbert-NO405,U.S. Senate,,DEM,Kamala D. Harris,0
+Ventura,Gabbert-NO405,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Ventura,Gabbert-NO406-412,U.S. Senate,,DEM,Kamala D. Harris,4
+Ventura,Gabbert-NO406-412,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Ventura,Gabbert-NO407,U.S. Senate,,DEM,Kamala D. Harris,0
+Ventura,Gabbert-NO407,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Ventura,Gabbert-NO408-409,U.S. Senate,,DEM,Kamala D. Harris,30
+Ventura,Gabbert-NO408-409,U.S. Senate,,DEM,Loretta L. Sanchez,29
+Ventura,Gabbert-NO410,U.S. Senate,,DEM,Kamala D. Harris,11
+Ventura,Gabbert-NO410,U.S. Senate,,DEM,Loretta L. Sanchez,7
+Ventura,GabbertNO204,U.S. Senate,,DEM,Kamala D. Harris,1
+Ventura,GabbertNO204,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Ventura,Goodenough-NO301-Sespe-NO301,U.S. Senate,,DEM,Kamala D. Harris,162
+Ventura,Goodenough-NO301-Sespe-NO301,U.S. Senate,,DEM,Loretta L. Sanchez,136
+Ventura,Goodenough-NO302,U.S. Senate,,DEM,Kamala D. Harris,4
+Ventura,Goodenough-NO302,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Ventura,Grimes-NO301-302,U.S. Senate,,DEM,Kamala D. Harris,0
+Ventura,Grimes-NO301-302,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Ventura,Heights-NO301,U.S. Senate,,DEM,Kamala D. Harris,319
+Ventura,Heights-NO301,U.S. Senate,,DEM,Loretta L. Sanchez,214
+Ventura,Heights-NO302,U.S. Senate,,DEM,Kamala D. Harris,484
+Ventura,Heights-NO302,U.S. Senate,,DEM,Loretta L. Sanchez,226
+Ventura,Heights-NO304,U.S. Senate,,DEM,Kamala D. Harris,81
+Ventura,Heights-NO304,U.S. Senate,,DEM,Loretta L. Sanchez,53
+Ventura,Heights-NO305,U.S. Senate,,DEM,Kamala D. Harris,29
+Ventura,Heights-NO305,U.S. Senate,,DEM,Loretta L. Sanchez,15
+Ventura,Heights-NO306,U.S. Senate,,DEM,Kamala D. Harris,88
+Ventura,Heights-NO306,U.S. Senate,,DEM,Loretta L. Sanchez,48
+Ventura,Hollywood-NO501,U.S. Senate,,DEM,Kamala D. Harris,281
+Ventura,Hollywood-NO501,U.S. Senate,,DEM,Loretta L. Sanchez,137
+Ventura,Islands-NO301,U.S. Senate,,DEM,Kamala D. Harris,0
+Ventura,Islands-NO301,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Ventura,Knolls-NO401,U.S. Senate,,DEM,Kamala D. Harris,484
+Ventura,Knolls-NO401,U.S. Senate,,DEM,Loretta L. Sanchez,271
+Ventura,Knolls-NO402,U.S. Senate,,DEM,Kamala D. Harris,6
+Ventura,Knolls-NO402,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Ventura,Las-Posas-NO201,U.S. Senate,,DEM,Kamala D. Harris,19
+Ventura,Las-Posas-NO201,U.S. Senate,,DEM,Loretta L. Sanchez,27
+Ventura,Las-Posas-NO301,U.S. Senate,,DEM,Kamala D. Harris,204
+Ventura,Las-Posas-NO301,U.S. Senate,,DEM,Loretta L. Sanchez,146
+Ventura,Las-Posas-NO302,U.S. Senate,,DEM,Kamala D. Harris,361
+Ventura,Las-Posas-NO302,U.S. Senate,,DEM,Loretta L. Sanchez,230
+Ventura,Las-Posas-NO303,U.S. Senate,,DEM,Kamala D. Harris,285
+Ventura,Las-Posas-NO303,U.S. Senate,,DEM,Loretta L. Sanchez,161
+Ventura,Las-Posas-NO304,U.S. Senate,,DEM,Kamala D. Harris,4
+Ventura,Las-Posas-NO304,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Ventura,Las-Posas-NO305,U.S. Senate,,DEM,Kamala D. Harris,1
+Ventura,Las-Posas-NO305,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Ventura,Las-Posas-NO306,U.S. Senate,,DEM,Kamala D. Harris,1
+Ventura,Las-Posas-NO306,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Ventura,Las-Posas-NO307,U.S. Senate,,DEM,Kamala D. Harris,0
+Ventura,Las-Posas-NO307,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Ventura,LkVw-Bell-NO201,U.S. Senate,,DEM,Kamala D. Harris,642
+Ventura,LkVw-Bell-NO201,U.S. Senate,,DEM,Loretta L. Sanchez,289
+Ventura,Lockwood-NO301,U.S. Senate,,DEM,Kamala D. Harris,53
+Ventura,Lockwood-NO301,U.S. Senate,,DEM,Loretta L. Sanchez,40
+Ventura,Lockwood-NO302-303,U.S. Senate,,DEM,Kamala D. Harris,0
+Ventura,Lockwood-NO302-303,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Ventura,Lockwood-NO304,U.S. Senate,,DEM,Kamala D. Harris,0
+Ventura,Lockwood-NO304,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Ventura,Lockwood-NO305-306,U.S. Senate,,DEM,Kamala D. Harris,0
+Ventura,Lockwood-NO305-306,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Ventura,Lockwood-NO307,U.S. Senate,,DEM,Kamala D. Harris,0
+Ventura,Lockwood-NO307,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Ventura,Lv-Ok-Acrs-NO101,U.S. Senate,,DEM,Kamala D. Harris,104
+Ventura,Lv-Ok-Acrs-NO101,U.S. Senate,,DEM,Loretta L. Sanchez,54
+Ventura,Lv-Ok-Acrs-NO102-104-107,U.S. Senate,,DEM,Kamala D. Harris,6
+Ventura,Lv-Ok-Acrs-NO102-104-107,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Ventura,Lv-Ok-Acrs-NO103-106,U.S. Senate,,DEM,Kamala D. Harris,70
+Ventura,Lv-Ok-Acrs-NO103-106,U.S. Senate,,DEM,Loretta L. Sanchez,31
+Ventura,Lv-Ok-Acrs-NO109-110,U.S. Senate,,DEM,Kamala D. Harris,35
+Ventura,Lv-Ok-Acrs-NO109-110,U.S. Senate,,DEM,Loretta L. Sanchez,33
+Ventura,Mariano-NO101,U.S. Senate,,DEM,Kamala D. Harris,0
+Ventura,Mariano-NO101,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Ventura,Matilija-NO101,U.S. Senate,,DEM,Kamala D. Harris,18
+Ventura,Matilija-NO101,U.S. Senate,,DEM,Loretta L. Sanchez,12
+Ventura,Matilija-NO102,U.S. Senate,,DEM,Kamala D. Harris,216
+Ventura,Matilija-NO102,U.S. Senate,,DEM,Loretta L. Sanchez,75
+Ventura,Matilija-NO103-107-111-113,U.S. Senate,,DEM,Kamala D. Harris,12
+Ventura,Matilija-NO103-107-111-113,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Ventura,Matilija-NO104-125,U.S. Senate,,DEM,Kamala D. Harris,85
+Ventura,Matilija-NO104-125,U.S. Senate,,DEM,Loretta L. Sanchez,20
+Ventura,Matilija-NO105,U.S. Senate,,DEM,Kamala D. Harris,5
+Ventura,Matilija-NO105,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Ventura,Matilija-NO106-12-16-18-24,U.S. Senate,,DEM,Kamala D. Harris,27
+Ventura,Matilija-NO106-12-16-18-24,U.S. Senate,,DEM,Loretta L. Sanchez,12
+Ventura,Matilija-NO108-117,U.S. Senate,,DEM,Kamala D. Harris,9
+Ventura,Matilija-NO108-117,U.S. Senate,,DEM,Loretta L. Sanchez,16
+Ventura,Matilija-NO109-114-115,U.S. Senate,,DEM,Kamala D. Harris,42
+Ventura,Matilija-NO109-114-115,U.S. Senate,,DEM,Loretta L. Sanchez,10
+Ventura,Matilija-NO110,U.S. Senate,,DEM,Kamala D. Harris,0
+Ventura,Matilija-NO110,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Ventura,Matilija-NO121-122-123,U.S. Senate,,DEM,Kamala D. Harris,9
+Ventura,Matilija-NO121-122-123,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Ventura,Mill-NO101,U.S. Senate,,DEM,Kamala D. Harris,381
+Ventura,Mill-NO101,U.S. Senate,,DEM,Loretta L. Sanchez,317
+Ventura,Mill-NO102-105-106,U.S. Senate,,DEM,Kamala D. Harris,0
+Ventura,Mill-NO102-105-106,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Ventura,Mill-NO103,U.S. Senate,,DEM,Kamala D. Harris,3
+Ventura,Mill-NO103,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Ventura,Mill-NO104,U.S. Senate,,DEM,Kamala D. Harris,0
+Ventura,Mill-NO104,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Ventura,Mill-NO107,U.S. Senate,,DEM,Kamala D. Harris,0
+Ventura,Mill-NO107,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Ventura,Mill-NO108,U.S. Senate,,DEM,Kamala D. Harris,5
+Ventura,Mill-NO108,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Ventura,Mission-NO101,U.S. Senate,,DEM,Kamala D. Harris,70
+Ventura,Mission-NO101,U.S. Senate,,DEM,Loretta L. Sanchez,43
+Ventura,Mission-NO102-103-104,U.S. Senate,,DEM,Kamala D. Harris,16
+Ventura,Mission-NO102-103-104,U.S. Senate,,DEM,Loretta L. Sanchez,13
+Ventura,Mnrs-Oaks-NO101,U.S. Senate,,DEM,Kamala D. Harris,196
+Ventura,Mnrs-Oaks-NO101,U.S. Senate,,DEM,Loretta L. Sanchez,76
+Ventura,Mnrs-Oaks-NO102,U.S. Senate,,DEM,Kamala D. Harris,493
+Ventura,Mnrs-Oaks-NO102,U.S. Senate,,DEM,Loretta L. Sanchez,255
+Ventura,Mnrs-Oaks-NO103-111-112,U.S. Senate,,DEM,Kamala D. Harris,46
+Ventura,Mnrs-Oaks-NO103-111-112,U.S. Senate,,DEM,Loretta L. Sanchez,22
+Ventura,Mnrs-Oaks-NO104,U.S. Senate,,DEM,Kamala D. Harris,119
+Ventura,Mnrs-Oaks-NO104,U.S. Senate,,DEM,Loretta L. Sanchez,44
+Ventura,Mnrs-Oaks-NO105,U.S. Senate,,DEM,Kamala D. Harris,119
+Ventura,Mnrs-Oaks-NO105,U.S. Senate,,DEM,Loretta L. Sanchez,45
+Ventura,Mnrs-Oaks-NO106-108-109,U.S. Senate,,DEM,Kamala D. Harris,1
+Ventura,Mnrs-Oaks-NO106-108-109,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Ventura,Mnrs-Oaks-NO107-113,U.S. Senate,,DEM,Kamala D. Harris,2
+Ventura,Mnrs-Oaks-NO107-113,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Ventura,Mnrs-Oaks-NO110,U.S. Senate,,DEM,Kamala D. Harris,0
+Ventura,Mnrs-Oaks-NO110,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Ventura,Montalvo-NO101-102-103-104,U.S. Senate,,DEM,Kamala D. Harris,0
+Ventura,Montalvo-NO101-102-103-104,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Ventura,Moorpark-NO401,U.S. Senate,,DEM,Kamala D. Harris,1014
+Ventura,Moorpark-NO401,U.S. Senate,,DEM,Loretta L. Sanchez,610
+Ventura,Moorpark-NO402,U.S. Senate,,DEM,Kamala D. Harris,556
+Ventura,Moorpark-NO402,U.S. Senate,,DEM,Loretta L. Sanchez,431
+Ventura,Moorpark-NO403,U.S. Senate,,DEM,Kamala D. Harris,1
+Ventura,Moorpark-NO403,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Ventura,Moorpark-NO404,U.S. Senate,,DEM,Kamala D. Harris,554
+Ventura,Moorpark-NO404,U.S. Senate,,DEM,Loretta L. Sanchez,581
+Ventura,Moorpark-NO406,U.S. Senate,,DEM,Kamala D. Harris,1133
+Ventura,Moorpark-NO406,U.S. Senate,,DEM,Loretta L. Sanchez,579
+Ventura,Moorpark-NO407,U.S. Senate,,DEM,Kamala D. Harris,536
+Ventura,Moorpark-NO407,U.S. Senate,,DEM,Loretta L. Sanchez,414
+Ventura,Moorpark-NO408,U.S. Senate,,DEM,Kamala D. Harris,884
+Ventura,Moorpark-NO408,U.S. Senate,,DEM,Loretta L. Sanchez,467
+Ventura,Moorpark-NO409,U.S. Senate,,DEM,Kamala D. Harris,858
+Ventura,Moorpark-NO409,U.S. Senate,,DEM,Loretta L. Sanchez,424
+Ventura,Moorpark-NO413,U.S. Senate,,DEM,Kamala D. Harris,1528
+Ventura,Moorpark-NO413,U.S. Senate,,DEM,Loretta L. Sanchez,734
+Ventura,Moorpark-NO414,U.S. Senate,,DEM,Kamala D. Harris,1229
+Ventura,Moorpark-NO414,U.S. Senate,,DEM,Loretta L. Sanchez,718
+Ventura,Moorpark-NO415,U.S. Senate,,DEM,Kamala D. Harris,374
+Ventura,Moorpark-NO415,U.S. Senate,,DEM,Loretta L. Sanchez,260
+Ventura,Moorpark-NO416,U.S. Senate,,DEM,Kamala D. Harris,0
+Ventura,Moorpark-NO416,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Ventura,Mound-NO101-105,U.S. Senate,,DEM,Kamala D. Harris,21
+Ventura,Mound-NO101-105,U.S. Senate,,DEM,Loretta L. Sanchez,9
+Ventura,Mugu-NO201,U.S. Senate,,DEM,Kamala D. Harris,70
+Ventura,Mugu-NO201,U.S. Senate,,DEM,Loretta L. Sanchez,45
+Ventura,Mupu-304-305,U.S. Senate,,DEM,Kamala D. Harris,2
+Ventura,Mupu-304-305,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Ventura,Mupu-NO301-303,U.S. Senate,,DEM,Kamala D. Harris,70
+Ventura,Mupu-NO301-303,U.S. Senate,,DEM,Loretta L. Sanchez,49
+Ventura,Mupu-North-NO301,U.S. Senate,,DEM,Kamala D. Harris,0
+Ventura,Mupu-North-NO301,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Ventura,Nylnd-Acrs-NO501,U.S. Senate,,DEM,Kamala D. Harris,147
+Ventura,Nylnd-Acrs-NO501,U.S. Senate,,DEM,Loretta L. Sanchez,203
+Ventura,Nylnd-Acrs-NO502,U.S. Senate,,DEM,Kamala D. Harris,1
+Ventura,Nylnd-Acrs-NO502,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Ventura,Nylnd-Acrs-NO504,U.S. Senate,,DEM,Kamala D. Harris,0
+Ventura,Nylnd-Acrs-NO504,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Ventura,Oak-Park-NO201,U.S. Senate,,DEM,Kamala D. Harris,516
+Ventura,Oak-Park-NO201,U.S. Senate,,DEM,Loretta L. Sanchez,204
+Ventura,Oak-Park-NO203,U.S. Senate,,DEM,Kamala D. Harris,1057
+Ventura,Oak-Park-NO203,U.S. Senate,,DEM,Loretta L. Sanchez,410
+Ventura,Oak-Park-NO205-207-209,U.S. Senate,,DEM,Kamala D. Harris,0
+Ventura,Oak-Park-NO205-207-209,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Ventura,Oak-Park-NO206,U.S. Senate,,DEM,Kamala D. Harris,1725
+Ventura,Oak-Park-NO206,U.S. Senate,,DEM,Loretta L. Sanchez,733
+Ventura,Oak-Park-NO210,U.S. Senate,,DEM,Kamala D. Harris,1058
+Ventura,Oak-Park-NO210,U.S. Senate,,DEM,Loretta L. Sanchez,442
+Ventura,Oak-Park-NO401,U.S. Senate,,DEM,Kamala D. Harris,0
+Ventura,Oak-Park-NO401,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Ventura,Oak-View-NO101,U.S. Senate,,DEM,Kamala D. Harris,212
+Ventura,Oak-View-NO101,U.S. Senate,,DEM,Loretta L. Sanchez,162
+Ventura,Oak-View-NO102,U.S. Senate,,DEM,Kamala D. Harris,271
+Ventura,Oak-View-NO102,U.S. Senate,,DEM,Loretta L. Sanchez,81
+Ventura,Oak-View-NO103,U.S. Senate,,DEM,Kamala D. Harris,195
+Ventura,Oak-View-NO103,U.S. Senate,,DEM,Loretta L. Sanchez,111
+Ventura,Oak-View-NO104,U.S. Senate,,DEM,Kamala D. Harris,51
+Ventura,Oak-View-NO104,U.S. Senate,,DEM,Loretta L. Sanchez,33
+Ventura,Oak-View-NO105,U.S. Senate,,DEM,Kamala D. Harris,102
+Ventura,Oak-View-NO105,U.S. Senate,,DEM,Loretta L. Sanchez,70
+Ventura,Oak-View-NO106,U.S. Senate,,DEM,Kamala D. Harris,147
+Ventura,Oak-View-NO106,U.S. Senate,,DEM,Loretta L. Sanchez,78
+Ventura,Oak-View-NO107,U.S. Senate,,DEM,Kamala D. Harris,104
+Ventura,Oak-View-NO107,U.S. Senate,,DEM,Loretta L. Sanchez,41
+Ventura,Oak-View-NO108,U.S. Senate,,DEM,Kamala D. Harris,0
+Ventura,Oak-View-NO108,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Ventura,Oak-View-NO109,U.S. Senate,,DEM,Kamala D. Harris,77
+Ventura,Oak-View-NO109,U.S. Senate,,DEM,Loretta L. Sanchez,33
+Ventura,Oak-View-NO110-111-113-114,U.S. Senate,,DEM,Kamala D. Harris,0
+Ventura,Oak-View-NO110-111-113-114,U.S. Senate,,DEM,Loretta L. Sanchez,5
+Ventura,Oak-View-NO112-116,U.S. Senate,,DEM,Kamala D. Harris,88
+Ventura,Oak-View-NO112-116,U.S. Senate,,DEM,Loretta L. Sanchez,43
+Ventura,Oak-View-NO115,U.S. Senate,,DEM,Kamala D. Harris,3
+Ventura,Oak-View-NO115,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Ventura,Oak-View-NO117,U.S. Senate,,DEM,Kamala D. Harris,97
+Ventura,Oak-View-NO117,U.S. Senate,,DEM,Loretta L. Sanchez,59
+Ventura,Oak-View-NO118-120,U.S. Senate,,DEM,Kamala D. Harris,37
+Ventura,Oak-View-NO118-120,U.S. Senate,,DEM,Loretta L. Sanchez,14
+Ventura,Oak-View-NO123,U.S. Senate,,DEM,Kamala D. Harris,51
+Ventura,Oak-View-NO123,U.S. Senate,,DEM,Loretta L. Sanchez,40
+Ventura,Oaks-NO202,U.S. Senate,,DEM,Kamala D. Harris,28
+Ventura,Oaks-NO202,U.S. Senate,,DEM,Loretta L. Sanchez,32
+Ventura,Ocean-View-NO201-203-213,U.S. Senate,,DEM,Kamala D. Harris,17
+Ventura,Ocean-View-NO201-203-213,U.S. Senate,,DEM,Loretta L. Sanchez,10
+Ventura,Ocean-View-NO301-302,U.S. Senate,,DEM,Kamala D. Harris,2
+Ventura,Ocean-View-NO301-302,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Ventura,Ocean-View-NO303-307,U.S. Senate,,DEM,Kamala D. Harris,18
+Ventura,Ocean-View-NO303-307,U.S. Senate,,DEM,Loretta L. Sanchez,19
+Ventura,Ocean-View-NO501-504-506,U.S. Senate,,DEM,Kamala D. Harris,14
+Ventura,Ocean-View-NO501-504-506,U.S. Senate,,DEM,Loretta L. Sanchez,12
+Ventura,Ocean-View-NO502,U.S. Senate,,DEM,Kamala D. Harris,5
+Ventura,Ocean-View-NO502,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Ventura,Ocean-View-NO503,U.S. Senate,,DEM,Kamala D. Harris,1
+Ventura,Ocean-View-NO503,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Ventura,Ocean-View-NO505,U.S. Senate,,DEM,Kamala D. Harris,1
+Ventura,Ocean-View-NO505,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Ventura,Ojai-NO101,U.S. Senate,,DEM,Kamala D. Harris,65
+Ventura,Ojai-NO101,U.S. Senate,,DEM,Loretta L. Sanchez,21
+Ventura,Ojai-NO102,U.S. Senate,,DEM,Kamala D. Harris,497
+Ventura,Ojai-NO102,U.S. Senate,,DEM,Loretta L. Sanchez,187
+Ventura,Ojai-NO103,U.S. Senate,,DEM,Kamala D. Harris,164
+Ventura,Ojai-NO103,U.S. Senate,,DEM,Loretta L. Sanchez,47
+Ventura,Ojai-NO104,U.S. Senate,,DEM,Kamala D. Harris,401
+Ventura,Ojai-NO104,U.S. Senate,,DEM,Loretta L. Sanchez,175
+Ventura,Ojai-NO105,U.S. Senate,,DEM,Kamala D. Harris,1001
+Ventura,Ojai-NO105,U.S. Senate,,DEM,Loretta L. Sanchez,410
+Ventura,Ojai-NO106,U.S. Senate,,DEM,Kamala D. Harris,77
+Ventura,Ojai-NO106,U.S. Senate,,DEM,Loretta L. Sanchez,26
+Ventura,Ojai-NO108-113,U.S. Senate,,DEM,Kamala D. Harris,93
+Ventura,Ojai-NO108-113,U.S. Senate,,DEM,Loretta L. Sanchez,33
+Ventura,Ojai-NO110,U.S. Senate,,DEM,Kamala D. Harris,104
+Ventura,Ojai-NO110,U.S. Senate,,DEM,Loretta L. Sanchez,32
+Ventura,Ojai-NO111,U.S. Senate,,DEM,Kamala D. Harris,148
+Ventura,Ojai-NO111,U.S. Senate,,DEM,Loretta L. Sanchez,75
+Ventura,Ojai-NO112,U.S. Senate,,DEM,Kamala D. Harris,9
+Ventura,Ojai-NO112,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Ventura,Oxnard-NO101,U.S. Senate,,DEM,Kamala D. Harris,355
+Ventura,Oxnard-NO101,U.S. Senate,,DEM,Loretta L. Sanchez,313
+Ventura,Oxnard-NO102,U.S. Senate,,DEM,Kamala D. Harris,519
+Ventura,Oxnard-NO102,U.S. Senate,,DEM,Loretta L. Sanchez,466
+Ventura,Oxnard-NO103,U.S. Senate,,DEM,Kamala D. Harris,1482
+Ventura,Oxnard-NO103,U.S. Senate,,DEM,Loretta L. Sanchez,1081
+Ventura,Oxnard-NO105,U.S. Senate,,DEM,Kamala D. Harris,617
+Ventura,Oxnard-NO105,U.S. Senate,,DEM,Loretta L. Sanchez,711
+Ventura,Oxnard-NO106,U.S. Senate,,DEM,Kamala D. Harris,400
+Ventura,Oxnard-NO106,U.S. Senate,,DEM,Loretta L. Sanchez,393
+Ventura,Oxnard-NO107,U.S. Senate,,DEM,Kamala D. Harris,12
+Ventura,Oxnard-NO107,U.S. Senate,,DEM,Loretta L. Sanchez,12
+Ventura,Oxnard-NO108-109,U.S. Senate,,DEM,Kamala D. Harris,69
+Ventura,Oxnard-NO108-109,U.S. Senate,,DEM,Loretta L. Sanchez,69
+Ventura,Oxnard-NO110,U.S. Senate,,DEM,Kamala D. Harris,325
+Ventura,Oxnard-NO110,U.S. Senate,,DEM,Loretta L. Sanchez,303
+Ventura,Oxnard-NO301,U.S. Senate,,DEM,Kamala D. Harris,1
+Ventura,Oxnard-NO301,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Ventura,Oxnard-NO302,U.S. Senate,,DEM,Kamala D. Harris,0
+Ventura,Oxnard-NO302,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Ventura,Oxnard-NO303,U.S. Senate,,DEM,Kamala D. Harris,653
+Ventura,Oxnard-NO303,U.S. Senate,,DEM,Loretta L. Sanchez,633
+Ventura,Oxnard-NO304,U.S. Senate,,DEM,Kamala D. Harris,366
+Ventura,Oxnard-NO304,U.S. Senate,,DEM,Loretta L. Sanchez,268
+Ventura,Oxnard-NO306,U.S. Senate,,DEM,Kamala D. Harris,672
+Ventura,Oxnard-NO306,U.S. Senate,,DEM,Loretta L. Sanchez,633
+Ventura,Oxnard-NO307,U.S. Senate,,DEM,Kamala D. Harris,392
+Ventura,Oxnard-NO307,U.S. Senate,,DEM,Loretta L. Sanchez,489
+Ventura,Oxnard-NO308-309,U.S. Senate,,DEM,Kamala D. Harris,17
+Ventura,Oxnard-NO308-309,U.S. Senate,,DEM,Loretta L. Sanchez,45
+Ventura,Oxnard-NO310,U.S. Senate,,DEM,Kamala D. Harris,0
+Ventura,Oxnard-NO310,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Ventura,Oxnard-NO311,U.S. Senate,,DEM,Kamala D. Harris,0
+Ventura,Oxnard-NO311,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Ventura,Oxnard-NO313,U.S. Senate,,DEM,Kamala D. Harris,264
+Ventura,Oxnard-NO313,U.S. Senate,,DEM,Loretta L. Sanchez,340
+Ventura,Oxnard-NO314-317,U.S. Senate,,DEM,Kamala D. Harris,0
+Ventura,Oxnard-NO314-317,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Ventura,Oxnard-NO501,U.S. Senate,,DEM,Kamala D. Harris,375
+Ventura,Oxnard-NO501,U.S. Senate,,DEM,Loretta L. Sanchez,405
+Ventura,Oxnard-NO502-508-558,U.S. Senate,,DEM,Kamala D. Harris,41
+Ventura,Oxnard-NO502-508-558,U.S. Senate,,DEM,Loretta L. Sanchez,33
+Ventura,Oxnard-NO504,U.S. Senate,,DEM,Kamala D. Harris,409
+Ventura,Oxnard-NO504,U.S. Senate,,DEM,Loretta L. Sanchez,434
+Ventura,Oxnard-NO505,U.S. Senate,,DEM,Kamala D. Harris,489
+Ventura,Oxnard-NO505,U.S. Senate,,DEM,Loretta L. Sanchez,589
+Ventura,Oxnard-NO506-553,U.S. Senate,,DEM,Kamala D. Harris,10
+Ventura,Oxnard-NO506-553,U.S. Senate,,DEM,Loretta L. Sanchez,21
+Ventura,Oxnard-NO507,U.S. Senate,,DEM,Kamala D. Harris,480
+Ventura,Oxnard-NO507,U.S. Senate,,DEM,Loretta L. Sanchez,533
+Ventura,Oxnard-NO509,U.S. Senate,,DEM,Kamala D. Harris,426
+Ventura,Oxnard-NO509,U.S. Senate,,DEM,Loretta L. Sanchez,425
+Ventura,Oxnard-NO510,U.S. Senate,,DEM,Kamala D. Harris,6
+Ventura,Oxnard-NO510,U.S. Senate,,DEM,Loretta L. Sanchez,6
+Ventura,Oxnard-NO511,U.S. Senate,,DEM,Kamala D. Harris,306
+Ventura,Oxnard-NO511,U.S. Senate,,DEM,Loretta L. Sanchez,433
+Ventura,Oxnard-NO512,U.S. Senate,,DEM,Kamala D. Harris,805
+Ventura,Oxnard-NO512,U.S. Senate,,DEM,Loretta L. Sanchez,615
+Ventura,Oxnard-NO513,U.S. Senate,,DEM,Kamala D. Harris,404
+Ventura,Oxnard-NO513,U.S. Senate,,DEM,Loretta L. Sanchez,197
+Ventura,Oxnard-NO514,U.S. Senate,,DEM,Kamala D. Harris,302
+Ventura,Oxnard-NO514,U.S. Senate,,DEM,Loretta L. Sanchez,398
+Ventura,Oxnard-NO515,U.S. Senate,,DEM,Kamala D. Harris,460
+Ventura,Oxnard-NO515,U.S. Senate,,DEM,Loretta L. Sanchez,466
+Ventura,Oxnard-NO516,U.S. Senate,,DEM,Kamala D. Harris,0
+Ventura,Oxnard-NO516,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Ventura,Oxnard-NO517,U.S. Senate,,DEM,Kamala D. Harris,0
+Ventura,Oxnard-NO517,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Ventura,Oxnard-NO518,U.S. Senate,,DEM,Kamala D. Harris,77
+Ventura,Oxnard-NO518,U.S. Senate,,DEM,Loretta L. Sanchez,104
+Ventura,Oxnard-NO519,U.S. Senate,,DEM,Kamala D. Harris,323
+Ventura,Oxnard-NO519,U.S. Senate,,DEM,Loretta L. Sanchez,405
+Ventura,Oxnard-NO521,U.S. Senate,,DEM,Kamala D. Harris,218
+Ventura,Oxnard-NO521,U.S. Senate,,DEM,Loretta L. Sanchez,399
+Ventura,Oxnard-NO522,U.S. Senate,,DEM,Kamala D. Harris,580
+Ventura,Oxnard-NO522,U.S. Senate,,DEM,Loretta L. Sanchez,758
+Ventura,Oxnard-NO523,U.S. Senate,,DEM,Kamala D. Harris,22
+Ventura,Oxnard-NO523,U.S. Senate,,DEM,Loretta L. Sanchez,60
+Ventura,Oxnard-NO524,U.S. Senate,,DEM,Kamala D. Harris,633
+Ventura,Oxnard-NO524,U.S. Senate,,DEM,Loretta L. Sanchez,451
+Ventura,Oxnard-NO525,U.S. Senate,,DEM,Kamala D. Harris,493
+Ventura,Oxnard-NO525,U.S. Senate,,DEM,Loretta L. Sanchez,550
+Ventura,Oxnard-NO526,U.S. Senate,,DEM,Kamala D. Harris,835
+Ventura,Oxnard-NO526,U.S. Senate,,DEM,Loretta L. Sanchez,499
+Ventura,Oxnard-NO527,U.S. Senate,,DEM,Kamala D. Harris,249
+Ventura,Oxnard-NO527,U.S. Senate,,DEM,Loretta L. Sanchez,217
+Ventura,Oxnard-NO529,U.S. Senate,,DEM,Kamala D. Harris,781
+Ventura,Oxnard-NO529,U.S. Senate,,DEM,Loretta L. Sanchez,902
+Ventura,Oxnard-NO530,U.S. Senate,,DEM,Kamala D. Harris,533
+Ventura,Oxnard-NO530,U.S. Senate,,DEM,Loretta L. Sanchez,789
+Ventura,Oxnard-NO533,U.S. Senate,,DEM,Kamala D. Harris,32
+Ventura,Oxnard-NO533,U.S. Senate,,DEM,Loretta L. Sanchez,59
+Ventura,Oxnard-NO534,U.S. Senate,,DEM,Kamala D. Harris,324
+Ventura,Oxnard-NO534,U.S. Senate,,DEM,Loretta L. Sanchez,255
+Ventura,Oxnard-NO535,U.S. Senate,,DEM,Kamala D. Harris,726
+Ventura,Oxnard-NO535,U.S. Senate,,DEM,Loretta L. Sanchez,439
+Ventura,Oxnard-NO536,U.S. Senate,,DEM,Kamala D. Harris,299
+Ventura,Oxnard-NO536,U.S. Senate,,DEM,Loretta L. Sanchez,317
+Ventura,Oxnard-NO537,U.S. Senate,,DEM,Kamala D. Harris,94
+Ventura,Oxnard-NO537,U.S. Senate,,DEM,Loretta L. Sanchez,51
+Ventura,Oxnard-NO538,U.S. Senate,,DEM,Kamala D. Harris,434
+Ventura,Oxnard-NO538,U.S. Senate,,DEM,Loretta L. Sanchez,425
+Ventura,Oxnard-NO540,U.S. Senate,,DEM,Kamala D. Harris,958
+Ventura,Oxnard-NO540,U.S. Senate,,DEM,Loretta L. Sanchez,634
+Ventura,Oxnard-NO541,U.S. Senate,,DEM,Kamala D. Harris,535
+Ventura,Oxnard-NO541,U.S. Senate,,DEM,Loretta L. Sanchez,463
+Ventura,Oxnard-NO542,U.S. Senate,,DEM,Kamala D. Harris,366
+Ventura,Oxnard-NO542,U.S. Senate,,DEM,Loretta L. Sanchez,308
+Ventura,Oxnard-NO544,U.S. Senate,,DEM,Kamala D. Harris,1230
+Ventura,Oxnard-NO544,U.S. Senate,,DEM,Loretta L. Sanchez,837
+Ventura,Oxnard-NO545,U.S. Senate,,DEM,Kamala D. Harris,180
+Ventura,Oxnard-NO545,U.S. Senate,,DEM,Loretta L. Sanchez,229
+Ventura,Oxnard-NO546,U.S. Senate,,DEM,Kamala D. Harris,389
+Ventura,Oxnard-NO546,U.S. Senate,,DEM,Loretta L. Sanchez,296
+Ventura,Oxnard-NO547,U.S. Senate,,DEM,Kamala D. Harris,432
+Ventura,Oxnard-NO547,U.S. Senate,,DEM,Loretta L. Sanchez,625
+Ventura,Oxnard-NO548,U.S. Senate,,DEM,Kamala D. Harris,775
+Ventura,Oxnard-NO548,U.S. Senate,,DEM,Loretta L. Sanchez,664
+Ventura,Oxnard-NO550,U.S. Senate,,DEM,Kamala D. Harris,319
+Ventura,Oxnard-NO550,U.S. Senate,,DEM,Loretta L. Sanchez,373
+Ventura,Oxnard-NO551,U.S. Senate,,DEM,Kamala D. Harris,379
+Ventura,Oxnard-NO551,U.S. Senate,,DEM,Loretta L. Sanchez,410
+Ventura,Oxnard-NO552,U.S. Senate,,DEM,Kamala D. Harris,390
+Ventura,Oxnard-NO552,U.S. Senate,,DEM,Loretta L. Sanchez,514
+Ventura,Oxnard-NO554,U.S. Senate,,DEM,Kamala D. Harris,0
+Ventura,Oxnard-NO554,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Ventura,Oxnard-NO556,U.S. Senate,,DEM,Kamala D. Harris,15
+Ventura,Oxnard-NO556,U.S. Senate,,DEM,Loretta L. Sanchez,16
+Ventura,Oxnard-NO557,U.S. Senate,,DEM,Kamala D. Harris,1055
+Ventura,Oxnard-NO557,U.S. Senate,,DEM,Loretta L. Sanchez,933
+Ventura,Oxnard-NO560,U.S. Senate,,DEM,Kamala D. Harris,213
+Ventura,Oxnard-NO560,U.S. Senate,,DEM,Loretta L. Sanchez,218
+Ventura,Oxnard-NO562,U.S. Senate,,DEM,Kamala D. Harris,0
+Ventura,Oxnard-NO562,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Ventura,Oxnard-NO563,U.S. Senate,,DEM,Kamala D. Harris,0
+Ventura,Oxnard-NO563,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Ventura,Oxnard-NO564,U.S. Senate,,DEM,Kamala D. Harris,722
+Ventura,Oxnard-NO564,U.S. Senate,,DEM,Loretta L. Sanchez,720
+Ventura,Oxnard-NO565,U.S. Senate,,DEM,Kamala D. Harris,351
+Ventura,Oxnard-NO565,U.S. Senate,,DEM,Loretta L. Sanchez,163
+Ventura,Oxnard-NO566-568-573-581,U.S. Senate,,DEM,Kamala D. Harris,21
+Ventura,Oxnard-NO566-568-573-581,U.S. Senate,,DEM,Loretta L. Sanchez,14
+Ventura,Oxnard-NO570,U.S. Senate,,DEM,Kamala D. Harris,1157
+Ventura,Oxnard-NO570,U.S. Senate,,DEM,Loretta L. Sanchez,539
+Ventura,Oxnard-NO571,U.S. Senate,,DEM,Kamala D. Harris,379
+Ventura,Oxnard-NO571,U.S. Senate,,DEM,Loretta L. Sanchez,230
+Ventura,Oxnard-NO572-576,U.S. Senate,,DEM,Kamala D. Harris,0
+Ventura,Oxnard-NO572-576,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Ventura,Oxnard-NO574,U.S. Senate,,DEM,Kamala D. Harris,0
+Ventura,Oxnard-NO574,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Ventura,Oxnard-NO575-580,U.S. Senate,,DEM,Kamala D. Harris,29
+Ventura,Oxnard-NO575-580,U.S. Senate,,DEM,Loretta L. Sanchez,22
+Ventura,Oxnard-NO577-578-582,U.S. Senate,,DEM,Kamala D. Harris,0
+Ventura,Oxnard-NO577-578-582,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Ventura,Oxnard-NO583,U.S. Senate,,DEM,Kamala D. Harris,76
+Ventura,Oxnard-NO583,U.S. Senate,,DEM,Loretta L. Sanchez,93
+Ventura,Ozena-NO101,U.S. Senate,,DEM,Kamala D. Harris,20
+Ventura,Ozena-NO101,U.S. Senate,,DEM,Loretta L. Sanchez,7
+Ventura,Pedro-NO101,U.S. Senate,,DEM,Kamala D. Harris,0
+Ventura,Pedro-NO101,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Ventura,Pedro-NO501-516,U.S. Senate,,DEM,Kamala D. Harris,7
+Ventura,Pedro-NO501-516,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Ventura,Pedro-NO502-504-514,U.S. Senate,,DEM,Kamala D. Harris,4
+Ventura,Pedro-NO502-504-514,U.S. Senate,,DEM,Loretta L. Sanchez,10
+Ventura,Pedro-NO503,U.S. Senate,,DEM,Kamala D. Harris,0
+Ventura,Pedro-NO503,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Ventura,Pedro-NO508-509,U.S. Senate,,DEM,Kamala D. Harris,0
+Ventura,Pedro-NO508-509,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Ventura,Pedro-NO510-511-513,U.S. Senate,,DEM,Kamala D. Harris,0
+Ventura,Pedro-NO510-511-513,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Ventura,Pedro-NO520,U.S. Senate,,DEM,Kamala D. Harris,0
+Ventura,Pedro-NO520,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Ventura,Piru-NO301,U.S. Senate,,DEM,Kamala D. Harris,226
+Ventura,Piru-NO301,U.S. Senate,,DEM,Loretta L. Sanchez,378
+Ventura,Piru-NO302,U.S. Senate,,DEM,Kamala D. Harris,1
+Ventura,Piru-NO302,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Ventura,Piru-NO303,U.S. Senate,,DEM,Kamala D. Harris,1
+Ventura,Piru-NO303,U.S. Senate,,DEM,Loretta L. Sanchez,7
+Ventura,Piru-NO401-403,U.S. Senate,,DEM,Kamala D. Harris,0
+Ventura,Piru-NO401-403,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Ventura,Piru-NO402,U.S. Senate,,DEM,Kamala D. Harris,0
+Ventura,Piru-NO402,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Ventura,Piru-NO405-409,U.S. Senate,,DEM,Kamala D. Harris,0
+Ventura,Piru-NO405-409,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Ventura,Piru-NO406-407-408,U.S. Senate,,DEM,Kamala D. Harris,0
+Ventura,Piru-NO406-407-408,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Ventura,Piru-North-NO301,U.S. Senate,,DEM,Kamala D. Harris,1
+Ventura,Piru-North-NO301,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Ventura,Pt-Hue-NO-302,U.S. Senate,,DEM,Kamala D. Harris,1134
+Ventura,Pt-Hue-NO-302,U.S. Senate,,DEM,Loretta L. Sanchez,938
+Ventura,Pt-Hue-NO301,U.S. Senate,,DEM,Kamala D. Harris,49
+Ventura,Pt-Hue-NO301,U.S. Senate,,DEM,Loretta L. Sanchez,31
+Ventura,Pt-Hue-NO303,U.S. Senate,,DEM,Kamala D. Harris,5
+Ventura,Pt-Hue-NO303,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Ventura,Pt-Hue-NO305,U.S. Senate,,DEM,Kamala D. Harris,480
+Ventura,Pt-Hue-NO305,U.S. Senate,,DEM,Loretta L. Sanchez,551
+Ventura,Pt-Hue-NO307,U.S. Senate,,DEM,Kamala D. Harris,1053
+Ventura,Pt-Hue-NO307,U.S. Senate,,DEM,Loretta L. Sanchez,530
+Ventura,Pt-Hue-NO308,U.S. Senate,,DEM,Kamala D. Harris,392
+Ventura,Pt-Hue-NO308,U.S. Senate,,DEM,Loretta L. Sanchez,268
+Ventura,Pt-Hue-NO309,U.S. Senate,,DEM,Kamala D. Harris,636
+Ventura,Pt-Hue-NO309,U.S. Senate,,DEM,Loretta L. Sanchez,267
+Ventura,Pt-Hue-NO501,U.S. Senate,,DEM,Kamala D. Harris,2
+Ventura,Pt-Hue-NO501,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Ventura,Rice-NO301,U.S. Senate,,DEM,Kamala D. Harris,3
+Ventura,Rice-NO301,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Ventura,Rice-NO502,U.S. Senate,,DEM,Kamala D. Harris,0
+Ventura,Rice-NO502,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Ventura,Rincon-NO101-104-105-106-107,U.S. Senate,,DEM,Kamala D. Harris,16
+Ventura,Rincon-NO101-104-105-106-107,U.S. Senate,,DEM,Loretta L. Sanchez,10
+Ventura,Rincon-NO102,U.S. Senate,,DEM,Kamala D. Harris,90
+Ventura,Rincon-NO102,U.S. Senate,,DEM,Loretta L. Sanchez,54
+Ventura,Rincon-NO103,U.S. Senate,,DEM,Kamala D. Harris,0
+Ventura,Rincon-NO103,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Ventura,Rincon-NO108-109-117,U.S. Senate,,DEM,Kamala D. Harris,13
+Ventura,Rincon-NO108-109-117,U.S. Senate,,DEM,Loretta L. Sanchez,9
+Ventura,Rincon-NO110-111-112,U.S. Senate,,DEM,Kamala D. Harris,0
+Ventura,Rincon-NO110-111-112,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Ventura,Rincon-NO113-114-116,U.S. Senate,,DEM,Kamala D. Harris,100
+Ventura,Rincon-NO113-114-116,U.S. Senate,,DEM,Loretta L. Sanchez,42
+Ventura,Rincon-NO115,U.S. Senate,,DEM,Kamala D. Harris,16
+Ventura,Rincon-NO115,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Ventura,Rio-Mesa-NO101,U.S. Senate,,DEM,Kamala D. Harris,0
+Ventura,Rio-Mesa-NO101,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Ventura,Rio-Mesa-NO501-502-503,U.S. Senate,,DEM,Kamala D. Harris,9
+Ventura,Rio-Mesa-NO501-502-503,U.S. Senate,,DEM,Loretta L. Sanchez,7
+Ventura,Rio-Mesa-NO504,U.S. Senate,,DEM,Kamala D. Harris,86
+Ventura,Rio-Mesa-NO504,U.S. Senate,,DEM,Loretta L. Sanchez,74
+Ventura,Rio-Mesa-NO505-506,U.S. Senate,,DEM,Kamala D. Harris,0
+Ventura,Rio-Mesa-NO505-506,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Ventura,Santa-Ana-NO101,U.S. Senate,,DEM,Kamala D. Harris,70
+Ventura,Santa-Ana-NO101,U.S. Senate,,DEM,Loretta L. Sanchez,26
+Ventura,Santa-Ana-NO102-105-112,U.S. Senate,,DEM,Kamala D. Harris,13
+Ventura,Santa-Ana-NO102-105-112,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Ventura,Santa-Ana-NO103,U.S. Senate,,DEM,Kamala D. Harris,3
+Ventura,Santa-Ana-NO103,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Ventura,Santa-Ana-NO104-106-109,U.S. Senate,,DEM,Kamala D. Harris,14
+Ventura,Santa-Ana-NO104-106-109,U.S. Senate,,DEM,Loretta L. Sanchez,16
+Ventura,Santa-Ana-NO110,U.S. Senate,,DEM,Kamala D. Harris,0
+Ventura,Santa-Ana-NO110,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Ventura,Saticoy-NO101-102-103-105,U.S. Senate,,DEM,Kamala D. Harris,3
+Ventura,Saticoy-NO101-102-103-105,U.S. Senate,,DEM,Loretta L. Sanchez,13
+Ventura,Saticoy-NO104,U.S. Senate,,DEM,Kamala D. Harris,71
+Ventura,Saticoy-NO104,U.S. Senate,,DEM,Loretta L. Sanchez,113
+Ventura,Saticoy-NO106,U.S. Senate,,DEM,Kamala D. Harris,0
+Ventura,Saticoy-NO106,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Ventura,Sespe-No-NO301,U.S. Senate,,DEM,Kamala D. Harris,0
+Ventura,Sespe-No-NO301,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Ventura,Sherwood-NO201,U.S. Senate,,DEM,Kamala D. Harris,469
+Ventura,Sherwood-NO201,U.S. Senate,,DEM,Loretta L. Sanchez,263
+Ventura,Sherwood-NO203-204-215-216,U.S. Senate,,DEM,Kamala D. Harris,35
+Ventura,Sherwood-NO203-204-215-216,U.S. Senate,,DEM,Loretta L. Sanchez,26
+Ventura,Sherwood-NO205-206-208-213,U.S. Senate,,DEM,Kamala D. Harris,8
+Ventura,Sherwood-NO205-206-208-213,U.S. Senate,,DEM,Loretta L. Sanchez,8
+Ventura,Sherwood-NO207,U.S. Senate,,DEM,Kamala D. Harris,15
+Ventura,Sherwood-NO207,U.S. Senate,,DEM,Loretta L. Sanchez,16
+Ventura,Sherwood-NO209,U.S. Senate,,DEM,Kamala D. Harris,0
+Ventura,Sherwood-NO209,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Ventura,Sherwood-NO210-214,U.S. Senate,,DEM,Kamala D. Harris,13
+Ventura,Sherwood-NO210-214,U.S. Senate,,DEM,Loretta L. Sanchez,12
+Ventura,Sherwood-NO211,U.S. Senate,,DEM,Kamala D. Harris,2
+Ventura,Sherwood-NO211,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Ventura,Sherwood-NO212,U.S. Senate,,DEM,Kamala D. Harris,0
+Ventura,Sherwood-NO212,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Ventura,Simi-NO-402,U.S. Senate,,DEM,Kamala D. Harris,633
+Ventura,Simi-NO-402,U.S. Senate,,DEM,Loretta L. Sanchez,526
+Ventura,Simi-NO403,U.S. Senate,,DEM,Kamala D. Harris,542
+Ventura,Simi-NO403,U.S. Senate,,DEM,Loretta L. Sanchez,306
+Ventura,Simi-NO404,U.S. Senate,,DEM,Kamala D. Harris,542
+Ventura,Simi-NO404,U.S. Senate,,DEM,Loretta L. Sanchez,364
+Ventura,Simi-NO405,U.S. Senate,,DEM,Kamala D. Harris,395
+Ventura,Simi-NO405,U.S. Senate,,DEM,Loretta L. Sanchez,245
+Ventura,Simi-NO406,U.S. Senate,,DEM,Kamala D. Harris,494
+Ventura,Simi-NO406,U.S. Senate,,DEM,Loretta L. Sanchez,342
+Ventura,Simi-NO407,U.S. Senate,,DEM,Kamala D. Harris,636
+Ventura,Simi-NO407,U.S. Senate,,DEM,Loretta L. Sanchez,447
+Ventura,Simi-NO409,U.S. Senate,,DEM,Kamala D. Harris,533
+Ventura,Simi-NO409,U.S. Senate,,DEM,Loretta L. Sanchez,358
+Ventura,Simi-NO410,U.S. Senate,,DEM,Kamala D. Harris,762
+Ventura,Simi-NO410,U.S. Senate,,DEM,Loretta L. Sanchez,431
+Ventura,Simi-NO412,U.S. Senate,,DEM,Kamala D. Harris,444
+Ventura,Simi-NO412,U.S. Senate,,DEM,Loretta L. Sanchez,299
+Ventura,Simi-NO413,U.S. Senate,,DEM,Kamala D. Harris,917
+Ventura,Simi-NO413,U.S. Senate,,DEM,Loretta L. Sanchez,548
+Ventura,Simi-NO415,U.S. Senate,,DEM,Kamala D. Harris,383
+Ventura,Simi-NO415,U.S. Senate,,DEM,Loretta L. Sanchez,300
+Ventura,Simi-NO416,U.S. Senate,,DEM,Kamala D. Harris,958
+Ventura,Simi-NO416,U.S. Senate,,DEM,Loretta L. Sanchez,592
+Ventura,Simi-NO418,U.S. Senate,,DEM,Kamala D. Harris,570
+Ventura,Simi-NO418,U.S. Senate,,DEM,Loretta L. Sanchez,418
+Ventura,Simi-NO421AL-420,U.S. Senate,,DEM,Kamala D. Harris,693
+Ventura,Simi-NO421AL-420,U.S. Senate,,DEM,Loretta L. Sanchez,439
+Ventura,Simi-NO422,U.S. Senate,,DEM,Kamala D. Harris,1101
+Ventura,Simi-NO422,U.S. Senate,,DEM,Loretta L. Sanchez,656
+Ventura,Simi-NO424,U.S. Senate,,DEM,Kamala D. Harris,765
+Ventura,Simi-NO424,U.S. Senate,,DEM,Loretta L. Sanchez,477
+Ventura,Simi-NO427,U.S. Senate,,DEM,Kamala D. Harris,808
+Ventura,Simi-NO427,U.S. Senate,,DEM,Loretta L. Sanchez,557
+Ventura,Simi-NO428,U.S. Senate,,DEM,Kamala D. Harris,656
+Ventura,Simi-NO428,U.S. Senate,,DEM,Loretta L. Sanchez,387
+Ventura,Simi-NO429,U.S. Senate,,DEM,Kamala D. Harris,486
+Ventura,Simi-NO429,U.S. Senate,,DEM,Loretta L. Sanchez,304
+Ventura,Simi-NO430,U.S. Senate,,DEM,Kamala D. Harris,748
+Ventura,Simi-NO430,U.S. Senate,,DEM,Loretta L. Sanchez,499
+Ventura,Simi-NO432,U.S. Senate,,DEM,Kamala D. Harris,1150
+Ventura,Simi-NO432,U.S. Senate,,DEM,Loretta L. Sanchez,625
+Ventura,Simi-NO433,U.S. Senate,,DEM,Kamala D. Harris,840
+Ventura,Simi-NO433,U.S. Senate,,DEM,Loretta L. Sanchez,547
+Ventura,Simi-NO435,U.S. Senate,,DEM,Kamala D. Harris,1039
+Ventura,Simi-NO435,U.S. Senate,,DEM,Loretta L. Sanchez,579
+Ventura,Simi-NO437,U.S. Senate,,DEM,Kamala D. Harris,1498
+Ventura,Simi-NO437,U.S. Senate,,DEM,Loretta L. Sanchez,815
+Ventura,Simi-NO440,U.S. Senate,,DEM,Kamala D. Harris,588
+Ventura,Simi-NO440,U.S. Senate,,DEM,Loretta L. Sanchez,409
+Ventura,Simi-NO441-464-466,U.S. Senate,,DEM,Kamala D. Harris,0
+Ventura,Simi-NO441-464-466,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Ventura,Simi-NO442,U.S. Senate,,DEM,Kamala D. Harris,1256
+Ventura,Simi-NO442,U.S. Senate,,DEM,Loretta L. Sanchez,647
+Ventura,Simi-NO443,U.S. Senate,,DEM,Kamala D. Harris,760
+Ventura,Simi-NO443,U.S. Senate,,DEM,Loretta L. Sanchez,398
+Ventura,Simi-NO444,U.S. Senate,,DEM,Kamala D. Harris,724
+Ventura,Simi-NO444,U.S. Senate,,DEM,Loretta L. Sanchez,355
+Ventura,Simi-NO445,U.S. Senate,,DEM,Kamala D. Harris,616
+Ventura,Simi-NO445,U.S. Senate,,DEM,Loretta L. Sanchez,298
+Ventura,Simi-NO446,U.S. Senate,,DEM,Kamala D. Harris,708
+Ventura,Simi-NO446,U.S. Senate,,DEM,Loretta L. Sanchez,421
+Ventura,Simi-NO447,U.S. Senate,,DEM,Kamala D. Harris,555
+Ventura,Simi-NO447,U.S. Senate,,DEM,Loretta L. Sanchez,330
+Ventura,Simi-NO448,U.S. Senate,,DEM,Kamala D. Harris,906
+Ventura,Simi-NO448,U.S. Senate,,DEM,Loretta L. Sanchez,558
+Ventura,Simi-NO449,U.S. Senate,,DEM,Kamala D. Harris,1067
+Ventura,Simi-NO449,U.S. Senate,,DEM,Loretta L. Sanchez,696
+Ventura,Simi-NO450-453-454,U.S. Senate,,DEM,Kamala D. Harris,65
+Ventura,Simi-NO450-453-454,U.S. Senate,,DEM,Loretta L. Sanchez,35
+Ventura,Simi-NO451,U.S. Senate,,DEM,Kamala D. Harris,326
+Ventura,Simi-NO451,U.S. Senate,,DEM,Loretta L. Sanchez,222
+Ventura,Simi-NO452,U.S. Senate,,DEM,Kamala D. Harris,908
+Ventura,Simi-NO452,U.S. Senate,,DEM,Loretta L. Sanchez,459
+Ventura,Simi-NO456,U.S. Senate,,DEM,Kamala D. Harris,657
+Ventura,Simi-NO456,U.S. Senate,,DEM,Loretta L. Sanchez,384
+Ventura,Simi-NO460,U.S. Senate,,DEM,Kamala D. Harris,1003
+Ventura,Simi-NO460,U.S. Senate,,DEM,Loretta L. Sanchez,527
+Ventura,Simi-NO461,U.S. Senate,,DEM,Kamala D. Harris,1
+Ventura,Simi-NO461,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Ventura,Simi-NO462,U.S. Senate,,DEM,Kamala D. Harris,0
+Ventura,Simi-NO462,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Ventura,Simi-NO463,U.S. Senate,,DEM,Kamala D. Harris,420
+Ventura,Simi-NO463,U.S. Senate,,DEM,Loretta L. Sanchez,357
+Ventura,Simi-NO467,U.S. Senate,,DEM,Kamala D. Harris,177
+Ventura,Simi-NO467,U.S. Senate,,DEM,Loretta L. Sanchez,92
+Ventura,Simi-NO468,U.S. Senate,,DEM,Kamala D. Harris,452
+Ventura,Simi-NO468,U.S. Senate,,DEM,Loretta L. Sanchez,277
+Ventura,Sinaloa-NO401,U.S. Senate,,DEM,Kamala D. Harris,129
+Ventura,Sinaloa-NO401,U.S. Senate,,DEM,Loretta L. Sanchez,105
+Ventura,Sinaloa-NO402,U.S. Senate,,DEM,Kamala D. Harris,0
+Ventura,Sinaloa-NO402,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Ventura,Sinaloa-NO403,U.S. Senate,,DEM,Kamala D. Harris,5
+Ventura,Sinaloa-NO403,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Ventura,Sinaloa-NO404,U.S. Senate,,DEM,Kamala D. Harris,7
+Ventura,Sinaloa-NO404,U.S. Senate,,DEM,Loretta L. Sanchez,7
+Ventura,Slvr-Strd-NO501,U.S. Senate,,DEM,Kamala D. Harris,681
+Ventura,Slvr-Strd-NO501,U.S. Senate,,DEM,Loretta L. Sanchez,317
+Ventura,Somis-NO201-204-210,U.S. Senate,,DEM,Kamala D. Harris,573
+Ventura,Somis-NO201-204-210,U.S. Senate,,DEM,Loretta L. Sanchez,349
+Ventura,Somis-NO202-211,U.S. Senate,,DEM,Kamala D. Harris,13
+Ventura,Somis-NO202-211,U.S. Senate,,DEM,Loretta L. Sanchez,21
+Ventura,Somis-NO203-207-209,U.S. Senate,,DEM,Kamala D. Harris,22
+Ventura,Somis-NO203-207-209,U.S. Senate,,DEM,Loretta L. Sanchez,24
+Ventura,Somis-NO205-214,U.S. Senate,,DEM,Kamala D. Harris,42
+Ventura,Somis-NO205-214,U.S. Senate,,DEM,Loretta L. Sanchez,23
+Ventura,Somis-NO206-215,U.S. Senate,,DEM,Kamala D. Harris,19
+Ventura,Somis-NO206-215,U.S. Senate,,DEM,Loretta L. Sanchez,19
+Ventura,Somis-NO212-213-216,U.S. Senate,,DEM,Kamala D. Harris,3
+Ventura,Somis-NO212-213-216,U.S. Senate,,DEM,Loretta L. Sanchez,4
+Ventura,Somis-NO301,U.S. Senate,,DEM,Kamala D. Harris,2
+Ventura,Somis-NO301,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Ventura,Somis-NO302-311,U.S. Senate,,DEM,Kamala D. Harris,0
+Ventura,Somis-NO302-311,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Ventura,Somis-NO303-305-307,U.S. Senate,,DEM,Kamala D. Harris,0
+Ventura,Somis-NO303-305-307,U.S. Senate,,DEM,Loretta L. Sanchez,7
+Ventura,Somis-NO304,U.S. Senate,,DEM,Kamala D. Harris,0
+Ventura,Somis-NO304,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Ventura,Somis-NO308-309-310,U.S. Senate,,DEM,Kamala D. Harris,0
+Ventura,Somis-NO308-309-310,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Ventura,Somis-NO401-403,U.S. Senate,,DEM,Kamala D. Harris,35
+Ventura,Somis-NO401-403,U.S. Senate,,DEM,Loretta L. Sanchez,35
+Ventura,Somis-NO402,U.S. Senate,,DEM,Kamala D. Harris,0
+Ventura,Somis-NO402,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Ventura,Sta-Clara-NO301-302-304,U.S. Senate,,DEM,Kamala D. Harris,40
+Ventura,Sta-Clara-NO301-302-304,U.S. Senate,,DEM,Loretta L. Sanchez,28
+Ventura,Sta-Clara-NO303,U.S. Senate,,DEM,Kamala D. Harris,0
+Ventura,Sta-Clara-NO303,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Ventura,Sta-Paula-NO301,U.S. Senate,,DEM,Kamala D. Harris,593
+Ventura,Sta-Paula-NO301,U.S. Senate,,DEM,Loretta L. Sanchez,516
+Ventura,Sta-Paula-NO302,U.S. Senate,,DEM,Kamala D. Harris,406
+Ventura,Sta-Paula-NO302,U.S. Senate,,DEM,Loretta L. Sanchez,393
+Ventura,Sta-Paula-NO303,U.S. Senate,,DEM,Kamala D. Harris,476
+Ventura,Sta-Paula-NO303,U.S. Senate,,DEM,Loretta L. Sanchez,517
+Ventura,Sta-Paula-NO304,U.S. Senate,,DEM,Kamala D. Harris,468
+Ventura,Sta-Paula-NO304,U.S. Senate,,DEM,Loretta L. Sanchez,706
+Ventura,Sta-Paula-NO305,U.S. Senate,,DEM,Kamala D. Harris,192
+Ventura,Sta-Paula-NO305,U.S. Senate,,DEM,Loretta L. Sanchez,436
+Ventura,Sta-Paula-NO306,U.S. Senate,,DEM,Kamala D. Harris,0
+Ventura,Sta-Paula-NO306,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Ventura,Sta-Paula-NO307,U.S. Senate,,DEM,Kamala D. Harris,615
+Ventura,Sta-Paula-NO307,U.S. Senate,,DEM,Loretta L. Sanchez,695
+Ventura,Sta-Paula-NO308,U.S. Senate,,DEM,Kamala D. Harris,271
+Ventura,Sta-Paula-NO308,U.S. Senate,,DEM,Loretta L. Sanchez,269
+Ventura,Sta-Paula-NO309,U.S. Senate,,DEM,Kamala D. Harris,267
+Ventura,Sta-Paula-NO309,U.S. Senate,,DEM,Loretta L. Sanchez,273
+Ventura,Sta-Paula-NO310,U.S. Senate,,DEM,Kamala D. Harris,239
+Ventura,Sta-Paula-NO310,U.S. Senate,,DEM,Loretta L. Sanchez,421
+Ventura,Sta-Paula-NO311,U.S. Senate,,DEM,Kamala D. Harris,32
+Ventura,Sta-Paula-NO311,U.S. Senate,,DEM,Loretta L. Sanchez,31
+Ventura,Sta-Paula-NO312,U.S. Senate,,DEM,Kamala D. Harris,124
+Ventura,Sta-Paula-NO312,U.S. Senate,,DEM,Loretta L. Sanchez,213
+Ventura,Sta-Paula-NO313-314,U.S. Senate,,DEM,Kamala D. Harris,91
+Ventura,Sta-Paula-NO313-314,U.S. Senate,,DEM,Loretta L. Sanchez,62
+Ventura,Sta-Paula-NO315,U.S. Senate,,DEM,Kamala D. Harris,3
+Ventura,Sta-Paula-NO315,U.S. Senate,,DEM,Loretta L. Sanchez,8
+Ventura,Sta-Rosa-NO201,U.S. Senate,,DEM,Kamala D. Harris,912
+Ventura,Sta-Rosa-NO201,U.S. Senate,,DEM,Loretta L. Sanchez,599
+Ventura,Sta-Rosa-NO203,U.S. Senate,,DEM,Kamala D. Harris,2
+Ventura,Sta-Rosa-NO203,U.S. Senate,,DEM,Loretta L. Sanchez,5
+Ventura,Sta-Rosa-NO204,U.S. Senate,,DEM,Kamala D. Harris,0
+Ventura,Sta-Rosa-NO204,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Ventura,Sta-Rosa-NO401-402,U.S. Senate,,DEM,Kamala D. Harris,25
+Ventura,Sta-Rosa-NO401-402,U.S. Senate,,DEM,Loretta L. Sanchez,20
+Ventura,Tapo-NO401-403,U.S. Senate,,DEM,Kamala D. Harris,20
+Ventura,Tapo-NO401-403,U.S. Senate,,DEM,Loretta L. Sanchez,14
+Ventura,Tapo-NO402,U.S. Senate,,DEM,Kamala D. Harris,1
+Ventura,Tapo-NO402,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Ventura,Tapo-NO404,U.S. Senate,,DEM,Kamala D. Harris,0
+Ventura,Tapo-NO404,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Ventura,Tapo-NO405,U.S. Senate,,DEM,Kamala D. Harris,0
+Ventura,Tapo-NO405,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Ventura,Tapo-NO406-411-413-414-419,U.S. Senate,,DEM,Kamala D. Harris,33
+Ventura,Tapo-NO406-411-413-414-419,U.S. Senate,,DEM,Loretta L. Sanchez,28
+Ventura,Tapo-NO409,U.S. Senate,,DEM,Kamala D. Harris,99
+Ventura,Tapo-NO409,U.S. Senate,,DEM,Loretta L. Sanchez,57
+Ventura,Tapo-NO412,U.S. Senate,,DEM,Kamala D. Harris,45
+Ventura,Tapo-NO412,U.S. Senate,,DEM,Loretta L. Sanchez,24
+Ventura,Tapo-NO415,U.S. Senate,,DEM,Kamala D. Harris,0
+Ventura,Tapo-NO415,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Ventura,Tapo-NO416,U.S. Senate,,DEM,Kamala D. Harris,0
+Ventura,Tapo-NO416,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Ventura,Tapo-NO417,U.S. Senate,,DEM,Kamala D. Harris,0
+Ventura,Tapo-NO417,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Ventura,Tapo-NO418,U.S. Senate,,DEM,Kamala D. Harris,0
+Ventura,Tapo-NO418,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Ventura,Teag-McKev-NO301-302-303,U.S. Senate,,DEM,Kamala D. Harris,55
+Ventura,Teag-McKev-NO301-302-303,U.S. Senate,,DEM,Loretta L. Sanchez,35
+Ventura,Teag-McKev-NO305,U.S. Senate,,DEM,Kamala D. Harris,0
+Ventura,Teag-McKev-NO305,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Ventura,Thou-Oaks-233,U.S. Senate,,DEM,Kamala D. Harris,631
+Ventura,Thou-Oaks-233,U.S. Senate,,DEM,Loretta L. Sanchez,321
+Ventura,Thou-Oaks-NO201,U.S. Senate,,DEM,Kamala D. Harris,746
+Ventura,Thou-Oaks-NO201,U.S. Senate,,DEM,Loretta L. Sanchez,486
+Ventura,Thou-Oaks-NO202,U.S. Senate,,DEM,Kamala D. Harris,565
+Ventura,Thou-Oaks-NO202,U.S. Senate,,DEM,Loretta L. Sanchez,324
+Ventura,Thou-Oaks-NO203,U.S. Senate,,DEM,Kamala D. Harris,630
+Ventura,Thou-Oaks-NO203,U.S. Senate,,DEM,Loretta L. Sanchez,363
+Ventura,Thou-Oaks-NO204,U.S. Senate,,DEM,Kamala D. Harris,242
+Ventura,Thou-Oaks-NO204,U.S. Senate,,DEM,Loretta L. Sanchez,138
+Ventura,Thou-Oaks-NO205,U.S. Senate,,DEM,Kamala D. Harris,635
+Ventura,Thou-Oaks-NO205,U.S. Senate,,DEM,Loretta L. Sanchez,371
+Ventura,Thou-Oaks-NO206,U.S. Senate,,DEM,Kamala D. Harris,377
+Ventura,Thou-Oaks-NO206,U.S. Senate,,DEM,Loretta L. Sanchez,207
+Ventura,Thou-Oaks-NO207,U.S. Senate,,DEM,Kamala D. Harris,429
+Ventura,Thou-Oaks-NO207,U.S. Senate,,DEM,Loretta L. Sanchez,203
+Ventura,Thou-Oaks-NO208,U.S. Senate,,DEM,Kamala D. Harris,772
+Ventura,Thou-Oaks-NO208,U.S. Senate,,DEM,Loretta L. Sanchez,577
+Ventura,Thou-Oaks-NO209,U.S. Senate,,DEM,Kamala D. Harris,482
+Ventura,Thou-Oaks-NO209,U.S. Senate,,DEM,Loretta L. Sanchez,274
+Ventura,Thou-Oaks-NO210,U.S. Senate,,DEM,Kamala D. Harris,429
+Ventura,Thou-Oaks-NO210,U.S. Senate,,DEM,Loretta L. Sanchez,222
+Ventura,Thou-Oaks-NO211,U.S. Senate,,DEM,Kamala D. Harris,801
+Ventura,Thou-Oaks-NO211,U.S. Senate,,DEM,Loretta L. Sanchez,361
+Ventura,Thou-Oaks-NO213,U.S. Senate,,DEM,Kamala D. Harris,837
+Ventura,Thou-Oaks-NO213,U.S. Senate,,DEM,Loretta L. Sanchez,467
+Ventura,Thou-Oaks-NO214,U.S. Senate,,DEM,Kamala D. Harris,639
+Ventura,Thou-Oaks-NO214,U.S. Senate,,DEM,Loretta L. Sanchez,367
+Ventura,Thou-Oaks-NO215,U.S. Senate,,DEM,Kamala D. Harris,853
+Ventura,Thou-Oaks-NO215,U.S. Senate,,DEM,Loretta L. Sanchez,417
+Ventura,Thou-Oaks-NO216,U.S. Senate,,DEM,Kamala D. Harris,283
+Ventura,Thou-Oaks-NO216,U.S. Senate,,DEM,Loretta L. Sanchez,96
+Ventura,Thou-Oaks-NO217,U.S. Senate,,DEM,Kamala D. Harris,341
+Ventura,Thou-Oaks-NO217,U.S. Senate,,DEM,Loretta L. Sanchez,167
+Ventura,Thou-Oaks-NO218,U.S. Senate,,DEM,Kamala D. Harris,350
+Ventura,Thou-Oaks-NO218,U.S. Senate,,DEM,Loretta L. Sanchez,305
+Ventura,Thou-Oaks-NO219,U.S. Senate,,DEM,Kamala D. Harris,971
+Ventura,Thou-Oaks-NO219,U.S. Senate,,DEM,Loretta L. Sanchez,464
+Ventura,Thou-Oaks-NO221,U.S. Senate,,DEM,Kamala D. Harris,361
+Ventura,Thou-Oaks-NO221,U.S. Senate,,DEM,Loretta L. Sanchez,248
+Ventura,Thou-Oaks-NO222,U.S. Senate,,DEM,Kamala D. Harris,508
+Ventura,Thou-Oaks-NO222,U.S. Senate,,DEM,Loretta L. Sanchez,297
+Ventura,Thou-Oaks-NO225,U.S. Senate,,DEM,Kamala D. Harris,796
+Ventura,Thou-Oaks-NO225,U.S. Senate,,DEM,Loretta L. Sanchez,385
+Ventura,Thou-Oaks-NO226,U.S. Senate,,DEM,Kamala D. Harris,625
+Ventura,Thou-Oaks-NO226,U.S. Senate,,DEM,Loretta L. Sanchez,396
+Ventura,Thou-Oaks-NO227,U.S. Senate,,DEM,Kamala D. Harris,696
+Ventura,Thou-Oaks-NO227,U.S. Senate,,DEM,Loretta L. Sanchez,307
+Ventura,Thou-Oaks-NO228,U.S. Senate,,DEM,Kamala D. Harris,972
+Ventura,Thou-Oaks-NO228,U.S. Senate,,DEM,Loretta L. Sanchez,431
+Ventura,Thou-Oaks-NO230,U.S. Senate,,DEM,Kamala D. Harris,428
+Ventura,Thou-Oaks-NO230,U.S. Senate,,DEM,Loretta L. Sanchez,240
+Ventura,Thou-Oaks-NO232,U.S. Senate,,DEM,Kamala D. Harris,854
+Ventura,Thou-Oaks-NO232,U.S. Senate,,DEM,Loretta L. Sanchez,430
+Ventura,Thou-Oaks-NO234,U.S. Senate,,DEM,Kamala D. Harris,679
+Ventura,Thou-Oaks-NO234,U.S. Senate,,DEM,Loretta L. Sanchez,317
+Ventura,Thou-Oaks-NO235,U.S. Senate,,DEM,Kamala D. Harris,567
+Ventura,Thou-Oaks-NO235,U.S. Senate,,DEM,Loretta L. Sanchez,238
+Ventura,Thou-Oaks-NO236,U.S. Senate,,DEM,Kamala D. Harris,1016
+Ventura,Thou-Oaks-NO236,U.S. Senate,,DEM,Loretta L. Sanchez,487
+Ventura,Thou-Oaks-NO237,U.S. Senate,,DEM,Kamala D. Harris,1432
+Ventura,Thou-Oaks-NO237,U.S. Senate,,DEM,Loretta L. Sanchez,796
+Ventura,Thou-Oaks-NO240,U.S. Senate,,DEM,Kamala D. Harris,630
+Ventura,Thou-Oaks-NO240,U.S. Senate,,DEM,Loretta L. Sanchez,313
+Ventura,Thou-Oaks-NO242,U.S. Senate,,DEM,Kamala D. Harris,463
+Ventura,Thou-Oaks-NO242,U.S. Senate,,DEM,Loretta L. Sanchez,213
+Ventura,Thou-Oaks-NO244,U.S. Senate,,DEM,Kamala D. Harris,903
+Ventura,Thou-Oaks-NO244,U.S. Senate,,DEM,Loretta L. Sanchez,370
+Ventura,Thou-Oaks-NO245,U.S. Senate,,DEM,Kamala D. Harris,855
+Ventura,Thou-Oaks-NO245,U.S. Senate,,DEM,Loretta L. Sanchez,431
+Ventura,Thou-Oaks-NO246,U.S. Senate,,DEM,Kamala D. Harris,1011
+Ventura,Thou-Oaks-NO246,U.S. Senate,,DEM,Loretta L. Sanchez,548
+Ventura,Thou-Oaks-NO248,U.S. Senate,,DEM,Kamala D. Harris,779
+Ventura,Thou-Oaks-NO248,U.S. Senate,,DEM,Loretta L. Sanchez,363
+Ventura,Thou-Oaks-NO249A-264,U.S. Senate,,DEM,Kamala D. Harris,2553
+Ventura,Thou-Oaks-NO249A-264,U.S. Senate,,DEM,Loretta L. Sanchez,1056
+Ventura,Thou-Oaks-NO250,U.S. Senate,,DEM,Kamala D. Harris,49
+Ventura,Thou-Oaks-NO250,U.S. Senate,,DEM,Loretta L. Sanchez,29
+Ventura,Thou-Oaks-NO252,U.S. Senate,,DEM,Kamala D. Harris,452
+Ventura,Thou-Oaks-NO252,U.S. Senate,,DEM,Loretta L. Sanchez,182
+Ventura,Thou-Oaks-NO253,U.S. Senate,,DEM,Kamala D. Harris,545
+Ventura,Thou-Oaks-NO253,U.S. Senate,,DEM,Loretta L. Sanchez,259
+Ventura,Thou-Oaks-NO254,U.S. Senate,,DEM,Kamala D. Harris,702
+Ventura,Thou-Oaks-NO254,U.S. Senate,,DEM,Loretta L. Sanchez,342
+Ventura,Thou-Oaks-NO255,U.S. Senate,,DEM,Kamala D. Harris,831
+Ventura,Thou-Oaks-NO255,U.S. Senate,,DEM,Loretta L. Sanchez,423
+Ventura,Thou-Oaks-NO257,U.S. Senate,,DEM,Kamala D. Harris,211
+Ventura,Thou-Oaks-NO257,U.S. Senate,,DEM,Loretta L. Sanchez,98
+Ventura,Thou-Oaks-NO258,U.S. Senate,,DEM,Kamala D. Harris,234
+Ventura,Thou-Oaks-NO258,U.S. Senate,,DEM,Loretta L. Sanchez,106
+Ventura,Thou-Oaks-NO260,U.S. Senate,,DEM,Kamala D. Harris,903
+Ventura,Thou-Oaks-NO260,U.S. Senate,,DEM,Loretta L. Sanchez,495
+Ventura,Thou-Oaks-NO262,U.S. Senate,,DEM,Kamala D. Harris,1154
+Ventura,Thou-Oaks-NO262,U.S. Senate,,DEM,Loretta L. Sanchez,547
+Ventura,Thou-Oaks-NO263,U.S. Senate,,DEM,Kamala D. Harris,593
+Ventura,Thou-Oaks-NO263,U.S. Senate,,DEM,Loretta L. Sanchez,347
+Ventura,Thou-Oaks-NO265,U.S. Senate,,DEM,Kamala D. Harris,991
+Ventura,Thou-Oaks-NO265,U.S. Senate,,DEM,Loretta L. Sanchez,464
+Ventura,Thou-Oaks-NO266,U.S. Senate,,DEM,Kamala D. Harris,407
+Ventura,Thou-Oaks-NO266,U.S. Senate,,DEM,Loretta L. Sanchez,161
+Ventura,Thou-Oaks-NO267-269-276-277,U.S. Senate,,DEM,Kamala D. Harris,13
+Ventura,Thou-Oaks-NO267-269-276-277,U.S. Senate,,DEM,Loretta L. Sanchez,5
+Ventura,Thou-Oaks-NO270,U.S. Senate,,DEM,Kamala D. Harris,332
+Ventura,Thou-Oaks-NO270,U.S. Senate,,DEM,Loretta L. Sanchez,179
+Ventura,Thou-Oaks-NO271-272,U.S. Senate,,DEM,Kamala D. Harris,58
+Ventura,Thou-Oaks-NO271-272,U.S. Senate,,DEM,Loretta L. Sanchez,41
+Ventura,Thou-Oaks-NO273-275,U.S. Senate,,DEM,Kamala D. Harris,0
+Ventura,Thou-Oaks-NO273-275,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Ventura,Thou-Oaks-NO279,U.S. Senate,,DEM,Kamala D. Harris,904
+Ventura,Thou-Oaks-NO279,U.S. Senate,,DEM,Loretta L. Sanchez,477
+Ventura,Tico-103,U.S. Senate,,DEM,Kamala D. Harris,337
+Ventura,Tico-103,U.S. Senate,,DEM,Loretta L. Sanchez,144
+Ventura,Tico-NO101-106,U.S. Senate,,DEM,Kamala D. Harris,12
+Ventura,Tico-NO101-106,U.S. Senate,,DEM,Loretta L. Sanchez,8
+Ventura,Tico-NO102-118,U.S. Senate,,DEM,Kamala D. Harris,51
+Ventura,Tico-NO102-118,U.S. Senate,,DEM,Loretta L. Sanchez,14
+Ventura,Tico-NO104-111,U.S. Senate,,DEM,Kamala D. Harris,310
+Ventura,Tico-NO104-111,U.S. Senate,,DEM,Loretta L. Sanchez,148
+Ventura,Tico-NO105,U.S. Senate,,DEM,Kamala D. Harris,0
+Ventura,Tico-NO105,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Ventura,Tico-NO107,U.S. Senate,,DEM,Kamala D. Harris,2
+Ventura,Tico-NO107,U.S. Senate,,DEM,Loretta L. Sanchez,2
+Ventura,Tico-NO108-112-114-116,U.S. Senate,,DEM,Kamala D. Harris,31
+Ventura,Tico-NO108-112-114-116,U.S. Senate,,DEM,Loretta L. Sanchez,21
+Ventura,Tico-NO109,U.S. Senate,,DEM,Kamala D. Harris,82
+Ventura,Tico-NO109,U.S. Senate,,DEM,Loretta L. Sanchez,42
+Ventura,Tico-NO110-134,U.S. Senate,,DEM,Kamala D. Harris,434
+Ventura,Tico-NO110-134,U.S. Senate,,DEM,Loretta L. Sanchez,224
+Ventura,Tico-NO113,U.S. Senate,,DEM,Kamala D. Harris,16
+Ventura,Tico-NO113,U.S. Senate,,DEM,Loretta L. Sanchez,5
+Ventura,Tico-NO120-122-124-126,U.S. Senate,,DEM,Kamala D. Harris,8
+Ventura,Tico-NO120-122-124-126,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Ventura,Tico-NO127-143,U.S. Senate,,DEM,Kamala D. Harris,20
+Ventura,Tico-NO127-143,U.S. Senate,,DEM,Loretta L. Sanchez,12
+Ventura,Tico-NO129,U.S. Senate,,DEM,Kamala D. Harris,156
+Ventura,Tico-NO129,U.S. Senate,,DEM,Loretta L. Sanchez,69
+Ventura,Tico-NO130-137,U.S. Senate,,DEM,Kamala D. Harris,36
+Ventura,Tico-NO130-137,U.S. Senate,,DEM,Loretta L. Sanchez,19
+Ventura,Tico-NO132-139-141-144,U.S. Senate,,DEM,Kamala D. Harris,10
+Ventura,Tico-NO132-139-141-144,U.S. Senate,,DEM,Loretta L. Sanchez,11
+Ventura,Tico-NO135,U.S. Senate,,DEM,Kamala D. Harris,91
+Ventura,Tico-NO135,U.S. Senate,,DEM,Loretta L. Sanchez,55
+Ventura,Tico-NO140,U.S. Senate,,DEM,Kamala D. Harris,99
+Ventura,Tico-NO140,U.S. Senate,,DEM,Loretta L. Sanchez,55
+Ventura,Tico-NO145,U.S. Senate,,DEM,Kamala D. Harris,0
+Ventura,Tico-NO145,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Ventura,Timber-NO201,U.S. Senate,,DEM,Kamala D. Harris,347
+Ventura,Timber-NO201,U.S. Senate,,DEM,Loretta L. Sanchez,171
+Ventura,Timber-NO203-204-206,U.S. Senate,,DEM,Kamala D. Harris,8
+Ventura,Timber-NO203-204-206,U.S. Senate,,DEM,Loretta L. Sanchez,9
+Ventura,Timber-NO205-207-217,U.S. Senate,,DEM,Kamala D. Harris,1
+Ventura,Timber-NO205-207-217,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Ventura,Timber-NO208,U.S. Senate,,DEM,Kamala D. Harris,666
+Ventura,Timber-NO208,U.S. Senate,,DEM,Loretta L. Sanchez,347
+Ventura,Timber-NO209,U.S. Senate,,DEM,Kamala D. Harris,582
+Ventura,Timber-NO209,U.S. Senate,,DEM,Loretta L. Sanchez,337
+Ventura,Timber-NO210,U.S. Senate,,DEM,Kamala D. Harris,228
+Ventura,Timber-NO210,U.S. Senate,,DEM,Loretta L. Sanchez,143
+Ventura,Timber-NO211-212-213,U.S. Senate,,DEM,Kamala D. Harris,20
+Ventura,Timber-NO211-212-213,U.S. Senate,,DEM,Loretta L. Sanchez,5
+Ventura,Timber-NO215,U.S. Senate,,DEM,Kamala D. Harris,0
+Ventura,Timber-NO215,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Ventura,Timber-NO216,U.S. Senate,,DEM,Kamala D. Harris,0
+Ventura,Timber-NO216,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Ventura,Topa-Topa-NO101-106-107,U.S. Senate,,DEM,Kamala D. Harris,29
+Ventura,Topa-Topa-NO101-106-107,U.S. Senate,,DEM,Loretta L. Sanchez,14
+Ventura,Topa-Topa-NO102-104-108,U.S. Senate,,DEM,Kamala D. Harris,7
+Ventura,Topa-Topa-NO102-104-108,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Ventura,Topa-Topa-NO103,U.S. Senate,,DEM,Kamala D. Harris,230
+Ventura,Topa-Topa-NO103,U.S. Senate,,DEM,Loretta L. Sanchez,103
+Ventura,Topa-Topa-NO105,U.S. Senate,,DEM,Kamala D. Harris,84
+Ventura,Topa-Topa-NO105,U.S. Senate,,DEM,Loretta L. Sanchez,38
+Ventura,Ventura-NO101,U.S. Senate,,DEM,Kamala D. Harris,819
+Ventura,Ventura-NO101,U.S. Senate,,DEM,Loretta L. Sanchez,356
+Ventura,Ventura-NO102,U.S. Senate,,DEM,Kamala D. Harris,41
+Ventura,Ventura-NO102,U.S. Senate,,DEM,Loretta L. Sanchez,38
+Ventura,Ventura-NO103,U.S. Senate,,DEM,Kamala D. Harris,478
+Ventura,Ventura-NO103,U.S. Senate,,DEM,Loretta L. Sanchez,178
+Ventura,Ventura-NO104,U.S. Senate,,DEM,Kamala D. Harris,0
+Ventura,Ventura-NO104,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Ventura,Ventura-NO105,U.S. Senate,,DEM,Kamala D. Harris,659
+Ventura,Ventura-NO105,U.S. Senate,,DEM,Loretta L. Sanchez,308
+Ventura,Ventura-NO106,U.S. Senate,,DEM,Kamala D. Harris,851
+Ventura,Ventura-NO106,U.S. Senate,,DEM,Loretta L. Sanchez,439
+Ventura,Ventura-NO107,U.S. Senate,,DEM,Kamala D. Harris,64
+Ventura,Ventura-NO107,U.S. Senate,,DEM,Loretta L. Sanchez,22
+Ventura,Ventura-NO108,U.S. Senate,,DEM,Kamala D. Harris,887
+Ventura,Ventura-NO108,U.S. Senate,,DEM,Loretta L. Sanchez,487
+Ventura,Ventura-NO110,U.S. Senate,,DEM,Kamala D. Harris,364
+Ventura,Ventura-NO110,U.S. Senate,,DEM,Loretta L. Sanchez,219
+Ventura,Ventura-NO111,U.S. Senate,,DEM,Kamala D. Harris,512
+Ventura,Ventura-NO111,U.S. Senate,,DEM,Loretta L. Sanchez,304
+Ventura,Ventura-NO113,U.S. Senate,,DEM,Kamala D. Harris,703
+Ventura,Ventura-NO113,U.S. Senate,,DEM,Loretta L. Sanchez,370
+Ventura,Ventura-NO114,U.S. Senate,,DEM,Kamala D. Harris,0
+Ventura,Ventura-NO114,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Ventura,Ventura-NO115,U.S. Senate,,DEM,Kamala D. Harris,668
+Ventura,Ventura-NO115,U.S. Senate,,DEM,Loretta L. Sanchez,392
+Ventura,Ventura-NO116,U.S. Senate,,DEM,Kamala D. Harris,780
+Ventura,Ventura-NO116,U.S. Senate,,DEM,Loretta L. Sanchez,417
+Ventura,Ventura-NO117,U.S. Senate,,DEM,Kamala D. Harris,460
+Ventura,Ventura-NO117,U.S. Senate,,DEM,Loretta L. Sanchez,302
+Ventura,Ventura-NO118,U.S. Senate,,DEM,Kamala D. Harris,659
+Ventura,Ventura-NO118,U.S. Senate,,DEM,Loretta L. Sanchez,390
+Ventura,Ventura-NO119,U.S. Senate,,DEM,Kamala D. Harris,437
+Ventura,Ventura-NO119,U.S. Senate,,DEM,Loretta L. Sanchez,222
+Ventura,Ventura-NO120,U.S. Senate,,DEM,Kamala D. Harris,686
+Ventura,Ventura-NO120,U.S. Senate,,DEM,Loretta L. Sanchez,357
+Ventura,Ventura-NO121-148-160,U.S. Senate,,DEM,Kamala D. Harris,117
+Ventura,Ventura-NO121-148-160,U.S. Senate,,DEM,Loretta L. Sanchez,37
+Ventura,Ventura-NO123,U.S. Senate,,DEM,Kamala D. Harris,1143
+Ventura,Ventura-NO123,U.S. Senate,,DEM,Loretta L. Sanchez,622
+Ventura,Ventura-NO125,U.S. Senate,,DEM,Kamala D. Harris,1055
+Ventura,Ventura-NO125,U.S. Senate,,DEM,Loretta L. Sanchez,631
+Ventura,Ventura-NO127,U.S. Senate,,DEM,Kamala D. Harris,838
+Ventura,Ventura-NO127,U.S. Senate,,DEM,Loretta L. Sanchez,312
+Ventura,Ventura-NO128,U.S. Senate,,DEM,Kamala D. Harris,349
+Ventura,Ventura-NO128,U.S. Senate,,DEM,Loretta L. Sanchez,248
+Ventura,Ventura-NO129,U.S. Senate,,DEM,Kamala D. Harris,612
+Ventura,Ventura-NO129,U.S. Senate,,DEM,Loretta L. Sanchez,312
+Ventura,Ventura-NO130,U.S. Senate,,DEM,Kamala D. Harris,422
+Ventura,Ventura-NO130,U.S. Senate,,DEM,Loretta L. Sanchez,340
+Ventura,Ventura-NO131,U.S. Senate,,DEM,Kamala D. Harris,1270
+Ventura,Ventura-NO131,U.S. Senate,,DEM,Loretta L. Sanchez,744
+Ventura,Ventura-NO133,U.S. Senate,,DEM,Kamala D. Harris,501
+Ventura,Ventura-NO133,U.S. Senate,,DEM,Loretta L. Sanchez,285
+Ventura,Ventura-NO134,U.S. Senate,,DEM,Kamala D. Harris,458
+Ventura,Ventura-NO134,U.S. Senate,,DEM,Loretta L. Sanchez,198
+Ventura,Ventura-NO137,U.S. Senate,,DEM,Kamala D. Harris,504
+Ventura,Ventura-NO137,U.S. Senate,,DEM,Loretta L. Sanchez,265
+Ventura,Ventura-NO138,U.S. Senate,,DEM,Kamala D. Harris,680
+Ventura,Ventura-NO138,U.S. Senate,,DEM,Loretta L. Sanchez,418
+Ventura,Ventura-NO139,U.S. Senate,,DEM,Kamala D. Harris,633
+Ventura,Ventura-NO139,U.S. Senate,,DEM,Loretta L. Sanchez,361
+Ventura,Ventura-NO140,U.S. Senate,,DEM,Kamala D. Harris,1092
+Ventura,Ventura-NO140,U.S. Senate,,DEM,Loretta L. Sanchez,744
+Ventura,Ventura-NO142,U.S. Senate,,DEM,Kamala D. Harris,618
+Ventura,Ventura-NO142,U.S. Senate,,DEM,Loretta L. Sanchez,268
+Ventura,Ventura-NO143,U.S. Senate,,DEM,Kamala D. Harris,696
+Ventura,Ventura-NO143,U.S. Senate,,DEM,Loretta L. Sanchez,376
+Ventura,Ventura-NO144,U.S. Senate,,DEM,Kamala D. Harris,718
+Ventura,Ventura-NO144,U.S. Senate,,DEM,Loretta L. Sanchez,450
+Ventura,Ventura-NO145,U.S. Senate,,DEM,Kamala D. Harris,614
+Ventura,Ventura-NO145,U.S. Senate,,DEM,Loretta L. Sanchez,467
+Ventura,Ventura-NO146,U.S. Senate,,DEM,Kamala D. Harris,249
+Ventura,Ventura-NO146,U.S. Senate,,DEM,Loretta L. Sanchez,142
+Ventura,Ventura-NO150,U.S. Senate,,DEM,Kamala D. Harris,0
+Ventura,Ventura-NO150,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Ventura,Ventura-NO151,U.S. Senate,,DEM,Kamala D. Harris,918
+Ventura,Ventura-NO151,U.S. Senate,,DEM,Loretta L. Sanchez,601
+Ventura,Ventura-NO153,U.S. Senate,,DEM,Kamala D. Harris,751
+Ventura,Ventura-NO153,U.S. Senate,,DEM,Loretta L. Sanchez,366
+Ventura,Ventura-NO155,U.S. Senate,,DEM,Kamala D. Harris,664
+Ventura,Ventura-NO155,U.S. Senate,,DEM,Loretta L. Sanchez,271
+Ventura,Ventura-NO156,U.S. Senate,,DEM,Kamala D. Harris,490
+Ventura,Ventura-NO156,U.S. Senate,,DEM,Loretta L. Sanchez,484
+Ventura,Ventura-NO157,U.S. Senate,,DEM,Kamala D. Harris,254
+Ventura,Ventura-NO157,U.S. Senate,,DEM,Loretta L. Sanchez,272
+Ventura,Ventura-NO158,U.S. Senate,,DEM,Kamala D. Harris,258
+Ventura,Ventura-NO158,U.S. Senate,,DEM,Loretta L. Sanchez,144
+Ventura,Ventura-NO162,U.S. Senate,,DEM,Kamala D. Harris,0
+Ventura,Ventura-NO162,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Ventura,Ventura-NO163-170,U.S. Senate,,DEM,Kamala D. Harris,8
+Ventura,Ventura-NO163-170,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Ventura,Ventura-NO165,U.S. Senate,,DEM,Kamala D. Harris,942
+Ventura,Ventura-NO165,U.S. Senate,,DEM,Loretta L. Sanchez,640
+Ventura,Ventura-NO166,U.S. Senate,,DEM,Kamala D. Harris,81
+Ventura,Ventura-NO166,U.S. Senate,,DEM,Loretta L. Sanchez,28
+Ventura,Ventura-NO168,U.S. Senate,,DEM,Kamala D. Harris,931
+Ventura,Ventura-NO168,U.S. Senate,,DEM,Loretta L. Sanchez,517
+Ventura,Ventura-NO169,U.S. Senate,,DEM,Kamala D. Harris,0
+Ventura,Ventura-NO169,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Ventura,Ventura-NO171,U.S. Senate,,DEM,Kamala D. Harris,99
+Ventura,Ventura-NO171,U.S. Senate,,DEM,Loretta L. Sanchez,57
+Ventura,Ventura-NO172,U.S. Senate,,DEM,Kamala D. Harris,225
+Ventura,Ventura-NO172,U.S. Senate,,DEM,Loretta L. Sanchez,198
+Ventura,Ventura-NO173,U.S. Senate,,DEM,Kamala D. Harris,55
+Ventura,Ventura-NO173,U.S. Senate,,DEM,Loretta L. Sanchez,37
+Ventura,Ventura-NO174,U.S. Senate,,DEM,Kamala D. Harris,596
+Ventura,Ventura-NO174,U.S. Senate,,DEM,Loretta L. Sanchez,255
+Ventura,Ventura-NO175,U.S. Senate,,DEM,Kamala D. Harris,164
+Ventura,Ventura-NO175,U.S. Senate,,DEM,Loretta L. Sanchez,82
+Ventura,Ventura-NO176,U.S. Senate,,DEM,Kamala D. Harris,222
+Ventura,Ventura-NO176,U.S. Senate,,DEM,Loretta L. Sanchez,93
+Ventura,Ventura-NO177,U.S. Senate,,DEM,Kamala D. Harris,88
+Ventura,Ventura-NO177,U.S. Senate,,DEM,Loretta L. Sanchez,39
+Ventura,Ventura-NO179,U.S. Senate,,DEM,Kamala D. Harris,0
+Ventura,Ventura-NO179,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Ventura,Ventura-NO181,U.S. Senate,,DEM,Kamala D. Harris,0
+Ventura,Ventura-NO181,U.S. Senate,,DEM,Loretta L. Sanchez,1
+Ventura,Yrba-Buena-NO201,U.S. Senate,,DEM,Kamala D. Harris,113
+Ventura,Yrba-Buena-NO201,U.S. Senate,,DEM,Loretta L. Sanchez,43
+Ventura,Yrba-Buena-NO202-204,U.S. Senate,,DEM,Kamala D. Harris,62
+Ventura,Yrba-Buena-NO202-204,U.S. Senate,,DEM,Loretta L. Sanchez,16
+Ventura,Yrba-Buena-NO203,U.S. Senate,,DEM,Kamala D. Harris,1
+Ventura,Yrba-Buena-NO203,U.S. Senate,,DEM,Loretta L. Sanchez,0

--- a/2016/20161108__ca__general__yolo__precinct.csv
+++ b/2016/20161108__ca__general__yolo__precinct.csv
@@ -5319,269 +5319,269 @@ Yolo,100132,Proposition 67,,N/A,Yes,14
 Yolo,100132,Proposition 67,,N/A,No,17
 Yolo,100133,Proposition 67,,N/A,Yes,6
 Yolo,100133,Proposition 67,,N/A,No,4
-Yolo,100001,U.S. Senate,,DEM,Kamala Harris,528
-Yolo,100001,U.S. Senate,,DEM,Loretta Sanchez,287
-Yolo,100002,U.S. Senate,,DEM,Kamala Harris,485
-Yolo,100002,U.S. Senate,,DEM,Loretta Sanchez,297
-Yolo,100003,U.S. Senate,,DEM,Kamala Harris,519
-Yolo,100003,U.S. Senate,,DEM,Loretta Sanchez,423
-Yolo,100004,U.S. Senate,,DEM,Kamala Harris,345
-Yolo,100004,U.S. Senate,,DEM,Loretta Sanchez,216
-Yolo,100005,U.S. Senate,,DEM,Kamala Harris,336
-Yolo,100005,U.S. Senate,,DEM,Loretta Sanchez,192
-Yolo,100006,U.S. Senate,,DEM,Kamala Harris,775
-Yolo,100006,U.S. Senate,,DEM,Loretta Sanchez,400
-Yolo,100007,U.S. Senate,,DEM,Kamala Harris,618
-Yolo,100007,U.S. Senate,,DEM,Loretta Sanchez,322
-Yolo,100008,U.S. Senate,,DEM,Kamala Harris,455
-Yolo,100008,U.S. Senate,,DEM,Loretta Sanchez,230
-Yolo,100009,U.S. Senate,,DEM,Kamala Harris,921
-Yolo,100009,U.S. Senate,,DEM,Loretta Sanchez,406
-Yolo,100010,U.S. Senate,,DEM,Kamala Harris,823
-Yolo,100010,U.S. Senate,,DEM,Loretta Sanchez,380
-Yolo,100011,U.S. Senate,,DEM,Kamala Harris,478
-Yolo,100011,U.S. Senate,,DEM,Loretta Sanchez,291
-Yolo,100012,U.S. Senate,,DEM,Kamala Harris,770
-Yolo,100012,U.S. Senate,,DEM,Loretta Sanchez,370
-Yolo,100013,U.S. Senate,,DEM,Kamala Harris,1060
-Yolo,100013,U.S. Senate,,DEM,Loretta Sanchez,500
-Yolo,100014,U.S. Senate,,DEM,Kamala Harris,655
-Yolo,100014,U.S. Senate,,DEM,Loretta Sanchez,328
-Yolo,100015,U.S. Senate,,DEM,Kamala Harris,268
-Yolo,100015,U.S. Senate,,DEM,Loretta Sanchez,275
-Yolo,100016,U.S. Senate,,DEM,Kamala Harris,304
-Yolo,100016,U.S. Senate,,DEM,Loretta Sanchez,235
-Yolo,100017,U.S. Senate,,DEM,Kamala Harris,450
-Yolo,100017,U.S. Senate,,DEM,Loretta Sanchez,421
-Yolo,100018,U.S. Senate,,DEM,Kamala Harris,560
-Yolo,100018,U.S. Senate,,DEM,Loretta Sanchez,223
-Yolo,100019,U.S. Senate,,DEM,Kamala Harris,359
-Yolo,100019,U.S. Senate,,DEM,Loretta Sanchez,96
-Yolo,100020,U.S. Senate,,DEM,Kamala Harris,640
-Yolo,100020,U.S. Senate,,DEM,Loretta Sanchez,125
-Yolo,100021,U.S. Senate,,DEM,Kamala Harris,643
-Yolo,100021,U.S. Senate,,DEM,Loretta Sanchez,213
-Yolo,100022,U.S. Senate,,DEM,Kamala Harris,867
-Yolo,100022,U.S. Senate,,DEM,Loretta Sanchez,242
-Yolo,100023,U.S. Senate,,DEM,Kamala Harris,910
-Yolo,100023,U.S. Senate,,DEM,Loretta Sanchez,295
-Yolo,100024,U.S. Senate,,DEM,Kamala Harris,516
-Yolo,100024,U.S. Senate,,DEM,Loretta Sanchez,157
-Yolo,100025,U.S. Senate,,DEM,Kamala Harris,1177
-Yolo,100025,U.S. Senate,,DEM,Loretta Sanchez,317
-Yolo,100026,U.S. Senate,,DEM,Kamala Harris,801
-Yolo,100026,U.S. Senate,,DEM,Loretta Sanchez,285
-Yolo,100027,U.S. Senate,,DEM,Kamala Harris,583
-Yolo,100027,U.S. Senate,,DEM,Loretta Sanchez,182
-Yolo,100028,U.S. Senate,,DEM,Kamala Harris,501
-Yolo,100028,U.S. Senate,,DEM,Loretta Sanchez,216
-Yolo,100029,U.S. Senate,,DEM,Kamala Harris,467
-Yolo,100029,U.S. Senate,,DEM,Loretta Sanchez,134
-Yolo,100030,U.S. Senate,,DEM,Kamala Harris,705
-Yolo,100030,U.S. Senate,,DEM,Loretta Sanchez,191
-Yolo,100031,U.S. Senate,,DEM,Kamala Harris,184
-Yolo,100031,U.S. Senate,,DEM,Loretta Sanchez,70
-Yolo,100032,U.S. Senate,,DEM,Kamala Harris,292
-Yolo,100032,U.S. Senate,,DEM,Loretta Sanchez,215
-Yolo,100033,U.S. Senate,,DEM,Kamala Harris,444
-Yolo,100033,U.S. Senate,,DEM,Loretta Sanchez,306
-Yolo,100034,U.S. Senate,,DEM,Kamala Harris,476
-Yolo,100034,U.S. Senate,,DEM,Loretta Sanchez,188
-Yolo,100035,U.S. Senate,,DEM,Kamala Harris,530
-Yolo,100035,U.S. Senate,,DEM,Loretta Sanchez,181
-Yolo,100036,U.S. Senate,,DEM,Kamala Harris,625
-Yolo,100036,U.S. Senate,,DEM,Loretta Sanchez,226
-Yolo,100037,U.S. Senate,,DEM,Kamala Harris,363
-Yolo,100037,U.S. Senate,,DEM,Loretta Sanchez,89
-Yolo,100038,U.S. Senate,,DEM,Kamala Harris,555
-Yolo,100038,U.S. Senate,,DEM,Loretta Sanchez,252
-Yolo,100039,U.S. Senate,,DEM,Kamala Harris,651
-Yolo,100039,U.S. Senate,,DEM,Loretta Sanchez,148
-Yolo,100040,U.S. Senate,,DEM,Kamala Harris,550
-Yolo,100040,U.S. Senate,,DEM,Loretta Sanchez,158
-Yolo,100041,U.S. Senate,,DEM,Kamala Harris,579
-Yolo,100041,U.S. Senate,,DEM,Loretta Sanchez,164
-Yolo,100042,U.S. Senate,,DEM,Kamala Harris,407
-Yolo,100042,U.S. Senate,,DEM,Loretta Sanchez,176
-Yolo,100043,U.S. Senate,,DEM,Kamala Harris,1165
-Yolo,100043,U.S. Senate,,DEM,Loretta Sanchez,345
-Yolo,100044,U.S. Senate,,DEM,Kamala Harris,779
-Yolo,100044,U.S. Senate,,DEM,Loretta Sanchez,234
-Yolo,100045,U.S. Senate,,DEM,Kamala Harris,429
-Yolo,100045,U.S. Senate,,DEM,Loretta Sanchez,171
-Yolo,100046,U.S. Senate,,DEM,Kamala Harris,693
-Yolo,100046,U.S. Senate,,DEM,Loretta Sanchez,237
-Yolo,100047,U.S. Senate,,DEM,Kamala Harris,516
-Yolo,100047,U.S. Senate,,DEM,Loretta Sanchez,140
-Yolo,100048,U.S. Senate,,DEM,Kamala Harris,488
-Yolo,100048,U.S. Senate,,DEM,Loretta Sanchez,113
-Yolo,100049,U.S. Senate,,DEM,Kamala Harris,860
-Yolo,100049,U.S. Senate,,DEM,Loretta Sanchez,284
-Yolo,100050,U.S. Senate,,DEM,Kamala Harris,350
-Yolo,100050,U.S. Senate,,DEM,Loretta Sanchez,98
-Yolo,100051,U.S. Senate,,DEM,Kamala Harris,941
-Yolo,100051,U.S. Senate,,DEM,Loretta Sanchez,270
-Yolo,100052,U.S. Senate,,DEM,Kamala Harris,598
-Yolo,100052,U.S. Senate,,DEM,Loretta Sanchez,228
-Yolo,100053,U.S. Senate,,DEM,Kamala Harris,401
-Yolo,100053,U.S. Senate,,DEM,Loretta Sanchez,94
-Yolo,100054,U.S. Senate,,DEM,Kamala Harris,951
-Yolo,100054,U.S. Senate,,DEM,Loretta Sanchez,293
-Yolo,100055,U.S. Senate,,DEM,Kamala Harris,605
-Yolo,100055,U.S. Senate,,DEM,Loretta Sanchez,239
-Yolo,100056,U.S. Senate,,DEM,Kamala Harris,77
-Yolo,100056,U.S. Senate,,DEM,Loretta Sanchez,46
-Yolo,100057,U.S. Senate,,DEM,Kamala Harris,436
-Yolo,100057,U.S. Senate,,DEM,Loretta Sanchez,193
-Yolo,100058,U.S. Senate,,DEM,Kamala Harris,670
-Yolo,100058,U.S. Senate,,DEM,Loretta Sanchez,343
-Yolo,100059,U.S. Senate,,DEM,Kamala Harris,479
-Yolo,100059,U.S. Senate,,DEM,Loretta Sanchez,264
-Yolo,100060,U.S. Senate,,DEM,Kamala Harris,483
-Yolo,100060,U.S. Senate,,DEM,Loretta Sanchez,228
-Yolo,100061,U.S. Senate,,DEM,Kamala Harris,467
-Yolo,100061,U.S. Senate,,DEM,Loretta Sanchez,276
-Yolo,100062,U.S. Senate,,DEM,Kamala Harris,201
-Yolo,100062,U.S. Senate,,DEM,Loretta Sanchez,154
-Yolo,100063,U.S. Senate,,DEM,Kamala Harris,391
-Yolo,100063,U.S. Senate,,DEM,Loretta Sanchez,192
-Yolo,100064,U.S. Senate,,DEM,Kamala Harris,348
-Yolo,100064,U.S. Senate,,DEM,Loretta Sanchez,227
-Yolo,100065,U.S. Senate,,DEM,Kamala Harris,370
-Yolo,100065,U.S. Senate,,DEM,Loretta Sanchez,163
-Yolo,100066,U.S. Senate,,DEM,Kamala Harris,215
-Yolo,100066,U.S. Senate,,DEM,Loretta Sanchez,167
-Yolo,100067,U.S. Senate,,DEM,Kamala Harris,202
-Yolo,100067,U.S. Senate,,DEM,Loretta Sanchez,130
-Yolo,100068,U.S. Senate,,DEM,Kamala Harris,259
-Yolo,100068,U.S. Senate,,DEM,Loretta Sanchez,237
-Yolo,100069,U.S. Senate,,DEM,Kamala Harris,277
-Yolo,100069,U.S. Senate,,DEM,Loretta Sanchez,211
-Yolo,100070,U.S. Senate,,DEM,Kamala Harris,1217
-Yolo,100070,U.S. Senate,,DEM,Loretta Sanchez,573
-Yolo,100071,U.S. Senate,,DEM,Kamala Harris,335
-Yolo,100071,U.S. Senate,,DEM,Loretta Sanchez,192
-Yolo,100072,U.S. Senate,,DEM,Kamala Harris,444
-Yolo,100072,U.S. Senate,,DEM,Loretta Sanchez,352
-Yolo,100073,U.S. Senate,,DEM,Kamala Harris,231
-Yolo,100073,U.S. Senate,,DEM,Loretta Sanchez,156
-Yolo,100074,U.S. Senate,,DEM,Kamala Harris,457
-Yolo,100074,U.S. Senate,,DEM,Loretta Sanchez,410
-Yolo,100075,U.S. Senate,,DEM,Kamala Harris,337
-Yolo,100075,U.S. Senate,,DEM,Loretta Sanchez,241
-Yolo,100076,U.S. Senate,,DEM,Kamala Harris,335
-Yolo,100076,U.S. Senate,,DEM,Loretta Sanchez,273
-Yolo,100077,U.S. Senate,,DEM,Kamala Harris,253
-Yolo,100077,U.S. Senate,,DEM,Loretta Sanchez,147
-Yolo,100078,U.S. Senate,,DEM,Kamala Harris,301
-Yolo,100078,U.S. Senate,,DEM,Loretta Sanchez,198
-Yolo,100079,U.S. Senate,,DEM,Kamala Harris,591
-Yolo,100079,U.S. Senate,,DEM,Loretta Sanchez,509
-Yolo,100080,U.S. Senate,,DEM,Kamala Harris,807
-Yolo,100080,U.S. Senate,,DEM,Loretta Sanchez,573
-Yolo,100081,U.S. Senate,,DEM,Kamala Harris,438
-Yolo,100081,U.S. Senate,,DEM,Loretta Sanchez,284
-Yolo,100082,U.S. Senate,,DEM,Kamala Harris,290
-Yolo,100082,U.S. Senate,,DEM,Loretta Sanchez,199
-Yolo,100083,U.S. Senate,,DEM,Kamala Harris,68
-Yolo,100083,U.S. Senate,,DEM,Loretta Sanchez,62
-Yolo,100084,U.S. Senate,,DEM,Kamala Harris,294
-Yolo,100084,U.S. Senate,,DEM,Loretta Sanchez,146
-Yolo,100085,U.S. Senate,,DEM,Kamala Harris,375
-Yolo,100085,U.S. Senate,,DEM,Loretta Sanchez,257
-Yolo,100086,U.S. Senate,,DEM,Kamala Harris,281
-Yolo,100086,U.S. Senate,,DEM,Loretta Sanchez,223
-Yolo,100087,U.S. Senate,,DEM,Kamala Harris,240
-Yolo,100087,U.S. Senate,,DEM,Loretta Sanchez,188
-Yolo,100088,U.S. Senate,,DEM,Kamala Harris,165
-Yolo,100088,U.S. Senate,,DEM,Loretta Sanchez,122
-Yolo,100089,U.S. Senate,,DEM,Kamala Harris,144
-Yolo,100089,U.S. Senate,,DEM,Loretta Sanchez,58
-Yolo,100090,U.S. Senate,,DEM,Kamala Harris,124
-Yolo,100090,U.S. Senate,,DEM,Loretta Sanchez,88
-Yolo,100091,U.S. Senate,,DEM,Kamala Harris,114
-Yolo,100091,U.S. Senate,,DEM,Loretta Sanchez,45
-Yolo,100092,U.S. Senate,,DEM,Kamala Harris,210
-Yolo,100092,U.S. Senate,,DEM,Loretta Sanchez,127
-Yolo,100093,U.S. Senate,,DEM,Kamala Harris,219
-Yolo,100093,U.S. Senate,,DEM,Loretta Sanchez,160
-Yolo,100094,U.S. Senate,,DEM,Kamala Harris,165
-Yolo,100094,U.S. Senate,,DEM,Loretta Sanchez,167
-Yolo,100095,U.S. Senate,,DEM,Kamala Harris,200
-Yolo,100095,U.S. Senate,,DEM,Loretta Sanchez,89
-Yolo,100096,U.S. Senate,,DEM,Kamala Harris,155
-Yolo,100096,U.S. Senate,,DEM,Loretta Sanchez,167
-Yolo,100097,U.S. Senate,,DEM,Kamala Harris,32
-Yolo,100097,U.S. Senate,,DEM,Loretta Sanchez,10
-Yolo,100098,U.S. Senate,,DEM,Kamala Harris,63
-Yolo,100098,U.S. Senate,,DEM,Loretta Sanchez,43
-Yolo,100099,U.S. Senate,,DEM,Kamala Harris,162
-Yolo,100099,U.S. Senate,,DEM,Loretta Sanchez,91
-Yolo,100100,U.S. Senate,,DEM,Kamala Harris,101
-Yolo,100100,U.S. Senate,,DEM,Loretta Sanchez,90
-Yolo,100101,U.S. Senate,,DEM,Kamala Harris,128
-Yolo,100101,U.S. Senate,,DEM,Loretta Sanchez,73
-Yolo,100102,U.S. Senate,,DEM,Kamala Harris,36
-Yolo,100102,U.S. Senate,,DEM,Loretta Sanchez,26
-Yolo,100103,U.S. Senate,,DEM,Kamala Harris,242
-Yolo,100103,U.S. Senate,,DEM,Loretta Sanchez,190
-Yolo,100104,U.S. Senate,,DEM,Kamala Harris,0
-Yolo,100104,U.S. Senate,,DEM,Loretta Sanchez,0
-Yolo,100105,U.S. Senate,,DEM,Kamala Harris,58
-Yolo,100105,U.S. Senate,,DEM,Loretta Sanchez,34
-Yolo,100106,U.S. Senate,,DEM,Kamala Harris,5
-Yolo,100106,U.S. Senate,,DEM,Loretta Sanchez,0
-Yolo,100107,U.S. Senate,,DEM,Kamala Harris,0
-Yolo,100107,U.S. Senate,,DEM,Loretta Sanchez,0
-Yolo,100108,U.S. Senate,,DEM,Kamala Harris,0
-Yolo,100108,U.S. Senate,,DEM,Loretta Sanchez,0
-Yolo,100109,U.S. Senate,,DEM,Kamala Harris,7
-Yolo,100109,U.S. Senate,,DEM,Loretta Sanchez,5
-Yolo,100110,U.S. Senate,,DEM,Kamala Harris,0
-Yolo,100110,U.S. Senate,,DEM,Loretta Sanchez,0
-Yolo,100111,U.S. Senate,,DEM,Kamala Harris,0
-Yolo,100111,U.S. Senate,,DEM,Loretta Sanchez,0
-Yolo,100112,U.S. Senate,,DEM,Kamala Harris,32
-Yolo,100112,U.S. Senate,,DEM,Loretta Sanchez,20
-Yolo,100113,U.S. Senate,,DEM,Kamala Harris,2
-Yolo,100113,U.S. Senate,,DEM,Loretta Sanchez,3
-Yolo,100114,U.S. Senate,,DEM,Kamala Harris,47
-Yolo,100114,U.S. Senate,,DEM,Loretta Sanchez,40
-Yolo,100115,U.S. Senate,,DEM,Kamala Harris,172
-Yolo,100115,U.S. Senate,,DEM,Loretta Sanchez,57
-Yolo,100116,U.S. Senate,,DEM,Kamala Harris,22
-Yolo,100116,U.S. Senate,,DEM,Loretta Sanchez,8
-Yolo,100117,U.S. Senate,,DEM,Kamala Harris,0
-Yolo,100117,U.S. Senate,,DEM,Loretta Sanchez,0
-Yolo,100118,U.S. Senate,,DEM,Kamala Harris,169
-Yolo,100118,U.S. Senate,,DEM,Loretta Sanchez,96
-Yolo,100119,U.S. Senate,,DEM,Kamala Harris,24
-Yolo,100119,U.S. Senate,,DEM,Loretta Sanchez,20
-Yolo,100120,U.S. Senate,,DEM,Kamala Harris,0
-Yolo,100120,U.S. Senate,,DEM,Loretta Sanchez,0
-Yolo,100121,U.S. Senate,,DEM,Kamala Harris,0
-Yolo,100121,U.S. Senate,,DEM,Loretta Sanchez,0
-Yolo,100122,U.S. Senate,,DEM,Kamala Harris,54
-Yolo,100122,U.S. Senate,,DEM,Loretta Sanchez,65
-Yolo,100123,U.S. Senate,,DEM,Kamala Harris,0
-Yolo,100123,U.S. Senate,,DEM,Loretta Sanchez,0
-Yolo,100124,U.S. Senate,,DEM,Kamala Harris,142
-Yolo,100124,U.S. Senate,,DEM,Loretta Sanchez,35
-Yolo,100125,U.S. Senate,,DEM,Kamala Harris,151
-Yolo,100125,U.S. Senate,,DEM,Loretta Sanchez,85
-Yolo,100126,U.S. Senate,,DEM,Kamala Harris,174
-Yolo,100126,U.S. Senate,,DEM,Loretta Sanchez,103
-Yolo,100127,U.S. Senate,,DEM,Kamala Harris,213
-Yolo,100127,U.S. Senate,,DEM,Loretta Sanchez,173
-Yolo,100128,U.S. Senate,,DEM,Kamala Harris,115
-Yolo,100128,U.S. Senate,,DEM,Loretta Sanchez,78
-Yolo,100129,U.S. Senate,,DEM,Kamala Harris,23
-Yolo,100129,U.S. Senate,,DEM,Loretta Sanchez,22
-Yolo,100130,U.S. Senate,,DEM,Kamala Harris,80
-Yolo,100130,U.S. Senate,,DEM,Loretta Sanchez,30
-Yolo,100131,U.S. Senate,,DEM,Kamala Harris,12
-Yolo,100131,U.S. Senate,,DEM,Loretta Sanchez,11
-Yolo,100132,U.S. Senate,,DEM,Kamala Harris,12
-Yolo,100132,U.S. Senate,,DEM,Loretta Sanchez,15
-Yolo,100133,U.S. Senate,,DEM,Kamala Harris,7
-Yolo,100133,U.S. Senate,,DEM,Loretta Sanchez,1
+Yolo,100001,U.S. Senate,,DEM,Kamala D. Harris,528
+Yolo,100001,U.S. Senate,,DEM,Loretta L. Sanchez,287
+Yolo,100002,U.S. Senate,,DEM,Kamala D. Harris,485
+Yolo,100002,U.S. Senate,,DEM,Loretta L. Sanchez,297
+Yolo,100003,U.S. Senate,,DEM,Kamala D. Harris,519
+Yolo,100003,U.S. Senate,,DEM,Loretta L. Sanchez,423
+Yolo,100004,U.S. Senate,,DEM,Kamala D. Harris,345
+Yolo,100004,U.S. Senate,,DEM,Loretta L. Sanchez,216
+Yolo,100005,U.S. Senate,,DEM,Kamala D. Harris,336
+Yolo,100005,U.S. Senate,,DEM,Loretta L. Sanchez,192
+Yolo,100006,U.S. Senate,,DEM,Kamala D. Harris,775
+Yolo,100006,U.S. Senate,,DEM,Loretta L. Sanchez,400
+Yolo,100007,U.S. Senate,,DEM,Kamala D. Harris,618
+Yolo,100007,U.S. Senate,,DEM,Loretta L. Sanchez,322
+Yolo,100008,U.S. Senate,,DEM,Kamala D. Harris,455
+Yolo,100008,U.S. Senate,,DEM,Loretta L. Sanchez,230
+Yolo,100009,U.S. Senate,,DEM,Kamala D. Harris,921
+Yolo,100009,U.S. Senate,,DEM,Loretta L. Sanchez,406
+Yolo,100010,U.S. Senate,,DEM,Kamala D. Harris,823
+Yolo,100010,U.S. Senate,,DEM,Loretta L. Sanchez,380
+Yolo,100011,U.S. Senate,,DEM,Kamala D. Harris,478
+Yolo,100011,U.S. Senate,,DEM,Loretta L. Sanchez,291
+Yolo,100012,U.S. Senate,,DEM,Kamala D. Harris,770
+Yolo,100012,U.S. Senate,,DEM,Loretta L. Sanchez,370
+Yolo,100013,U.S. Senate,,DEM,Kamala D. Harris,1060
+Yolo,100013,U.S. Senate,,DEM,Loretta L. Sanchez,500
+Yolo,100014,U.S. Senate,,DEM,Kamala D. Harris,655
+Yolo,100014,U.S. Senate,,DEM,Loretta L. Sanchez,328
+Yolo,100015,U.S. Senate,,DEM,Kamala D. Harris,268
+Yolo,100015,U.S. Senate,,DEM,Loretta L. Sanchez,275
+Yolo,100016,U.S. Senate,,DEM,Kamala D. Harris,304
+Yolo,100016,U.S. Senate,,DEM,Loretta L. Sanchez,235
+Yolo,100017,U.S. Senate,,DEM,Kamala D. Harris,450
+Yolo,100017,U.S. Senate,,DEM,Loretta L. Sanchez,421
+Yolo,100018,U.S. Senate,,DEM,Kamala D. Harris,560
+Yolo,100018,U.S. Senate,,DEM,Loretta L. Sanchez,223
+Yolo,100019,U.S. Senate,,DEM,Kamala D. Harris,359
+Yolo,100019,U.S. Senate,,DEM,Loretta L. Sanchez,96
+Yolo,100020,U.S. Senate,,DEM,Kamala D. Harris,640
+Yolo,100020,U.S. Senate,,DEM,Loretta L. Sanchez,125
+Yolo,100021,U.S. Senate,,DEM,Kamala D. Harris,643
+Yolo,100021,U.S. Senate,,DEM,Loretta L. Sanchez,213
+Yolo,100022,U.S. Senate,,DEM,Kamala D. Harris,867
+Yolo,100022,U.S. Senate,,DEM,Loretta L. Sanchez,242
+Yolo,100023,U.S. Senate,,DEM,Kamala D. Harris,910
+Yolo,100023,U.S. Senate,,DEM,Loretta L. Sanchez,295
+Yolo,100024,U.S. Senate,,DEM,Kamala D. Harris,516
+Yolo,100024,U.S. Senate,,DEM,Loretta L. Sanchez,157
+Yolo,100025,U.S. Senate,,DEM,Kamala D. Harris,1177
+Yolo,100025,U.S. Senate,,DEM,Loretta L. Sanchez,317
+Yolo,100026,U.S. Senate,,DEM,Kamala D. Harris,801
+Yolo,100026,U.S. Senate,,DEM,Loretta L. Sanchez,285
+Yolo,100027,U.S. Senate,,DEM,Kamala D. Harris,583
+Yolo,100027,U.S. Senate,,DEM,Loretta L. Sanchez,182
+Yolo,100028,U.S. Senate,,DEM,Kamala D. Harris,501
+Yolo,100028,U.S. Senate,,DEM,Loretta L. Sanchez,216
+Yolo,100029,U.S. Senate,,DEM,Kamala D. Harris,467
+Yolo,100029,U.S. Senate,,DEM,Loretta L. Sanchez,134
+Yolo,100030,U.S. Senate,,DEM,Kamala D. Harris,705
+Yolo,100030,U.S. Senate,,DEM,Loretta L. Sanchez,191
+Yolo,100031,U.S. Senate,,DEM,Kamala D. Harris,184
+Yolo,100031,U.S. Senate,,DEM,Loretta L. Sanchez,70
+Yolo,100032,U.S. Senate,,DEM,Kamala D. Harris,292
+Yolo,100032,U.S. Senate,,DEM,Loretta L. Sanchez,215
+Yolo,100033,U.S. Senate,,DEM,Kamala D. Harris,444
+Yolo,100033,U.S. Senate,,DEM,Loretta L. Sanchez,306
+Yolo,100034,U.S. Senate,,DEM,Kamala D. Harris,476
+Yolo,100034,U.S. Senate,,DEM,Loretta L. Sanchez,188
+Yolo,100035,U.S. Senate,,DEM,Kamala D. Harris,530
+Yolo,100035,U.S. Senate,,DEM,Loretta L. Sanchez,181
+Yolo,100036,U.S. Senate,,DEM,Kamala D. Harris,625
+Yolo,100036,U.S. Senate,,DEM,Loretta L. Sanchez,226
+Yolo,100037,U.S. Senate,,DEM,Kamala D. Harris,363
+Yolo,100037,U.S. Senate,,DEM,Loretta L. Sanchez,89
+Yolo,100038,U.S. Senate,,DEM,Kamala D. Harris,555
+Yolo,100038,U.S. Senate,,DEM,Loretta L. Sanchez,252
+Yolo,100039,U.S. Senate,,DEM,Kamala D. Harris,651
+Yolo,100039,U.S. Senate,,DEM,Loretta L. Sanchez,148
+Yolo,100040,U.S. Senate,,DEM,Kamala D. Harris,550
+Yolo,100040,U.S. Senate,,DEM,Loretta L. Sanchez,158
+Yolo,100041,U.S. Senate,,DEM,Kamala D. Harris,579
+Yolo,100041,U.S. Senate,,DEM,Loretta L. Sanchez,164
+Yolo,100042,U.S. Senate,,DEM,Kamala D. Harris,407
+Yolo,100042,U.S. Senate,,DEM,Loretta L. Sanchez,176
+Yolo,100043,U.S. Senate,,DEM,Kamala D. Harris,1165
+Yolo,100043,U.S. Senate,,DEM,Loretta L. Sanchez,345
+Yolo,100044,U.S. Senate,,DEM,Kamala D. Harris,779
+Yolo,100044,U.S. Senate,,DEM,Loretta L. Sanchez,234
+Yolo,100045,U.S. Senate,,DEM,Kamala D. Harris,429
+Yolo,100045,U.S. Senate,,DEM,Loretta L. Sanchez,171
+Yolo,100046,U.S. Senate,,DEM,Kamala D. Harris,693
+Yolo,100046,U.S. Senate,,DEM,Loretta L. Sanchez,237
+Yolo,100047,U.S. Senate,,DEM,Kamala D. Harris,516
+Yolo,100047,U.S. Senate,,DEM,Loretta L. Sanchez,140
+Yolo,100048,U.S. Senate,,DEM,Kamala D. Harris,488
+Yolo,100048,U.S. Senate,,DEM,Loretta L. Sanchez,113
+Yolo,100049,U.S. Senate,,DEM,Kamala D. Harris,860
+Yolo,100049,U.S. Senate,,DEM,Loretta L. Sanchez,284
+Yolo,100050,U.S. Senate,,DEM,Kamala D. Harris,350
+Yolo,100050,U.S. Senate,,DEM,Loretta L. Sanchez,98
+Yolo,100051,U.S. Senate,,DEM,Kamala D. Harris,941
+Yolo,100051,U.S. Senate,,DEM,Loretta L. Sanchez,270
+Yolo,100052,U.S. Senate,,DEM,Kamala D. Harris,598
+Yolo,100052,U.S. Senate,,DEM,Loretta L. Sanchez,228
+Yolo,100053,U.S. Senate,,DEM,Kamala D. Harris,401
+Yolo,100053,U.S. Senate,,DEM,Loretta L. Sanchez,94
+Yolo,100054,U.S. Senate,,DEM,Kamala D. Harris,951
+Yolo,100054,U.S. Senate,,DEM,Loretta L. Sanchez,293
+Yolo,100055,U.S. Senate,,DEM,Kamala D. Harris,605
+Yolo,100055,U.S. Senate,,DEM,Loretta L. Sanchez,239
+Yolo,100056,U.S. Senate,,DEM,Kamala D. Harris,77
+Yolo,100056,U.S. Senate,,DEM,Loretta L. Sanchez,46
+Yolo,100057,U.S. Senate,,DEM,Kamala D. Harris,436
+Yolo,100057,U.S. Senate,,DEM,Loretta L. Sanchez,193
+Yolo,100058,U.S. Senate,,DEM,Kamala D. Harris,670
+Yolo,100058,U.S. Senate,,DEM,Loretta L. Sanchez,343
+Yolo,100059,U.S. Senate,,DEM,Kamala D. Harris,479
+Yolo,100059,U.S. Senate,,DEM,Loretta L. Sanchez,264
+Yolo,100060,U.S. Senate,,DEM,Kamala D. Harris,483
+Yolo,100060,U.S. Senate,,DEM,Loretta L. Sanchez,228
+Yolo,100061,U.S. Senate,,DEM,Kamala D. Harris,467
+Yolo,100061,U.S. Senate,,DEM,Loretta L. Sanchez,276
+Yolo,100062,U.S. Senate,,DEM,Kamala D. Harris,201
+Yolo,100062,U.S. Senate,,DEM,Loretta L. Sanchez,154
+Yolo,100063,U.S. Senate,,DEM,Kamala D. Harris,391
+Yolo,100063,U.S. Senate,,DEM,Loretta L. Sanchez,192
+Yolo,100064,U.S. Senate,,DEM,Kamala D. Harris,348
+Yolo,100064,U.S. Senate,,DEM,Loretta L. Sanchez,227
+Yolo,100065,U.S. Senate,,DEM,Kamala D. Harris,370
+Yolo,100065,U.S. Senate,,DEM,Loretta L. Sanchez,163
+Yolo,100066,U.S. Senate,,DEM,Kamala D. Harris,215
+Yolo,100066,U.S. Senate,,DEM,Loretta L. Sanchez,167
+Yolo,100067,U.S. Senate,,DEM,Kamala D. Harris,202
+Yolo,100067,U.S. Senate,,DEM,Loretta L. Sanchez,130
+Yolo,100068,U.S. Senate,,DEM,Kamala D. Harris,259
+Yolo,100068,U.S. Senate,,DEM,Loretta L. Sanchez,237
+Yolo,100069,U.S. Senate,,DEM,Kamala D. Harris,277
+Yolo,100069,U.S. Senate,,DEM,Loretta L. Sanchez,211
+Yolo,100070,U.S. Senate,,DEM,Kamala D. Harris,1217
+Yolo,100070,U.S. Senate,,DEM,Loretta L. Sanchez,573
+Yolo,100071,U.S. Senate,,DEM,Kamala D. Harris,335
+Yolo,100071,U.S. Senate,,DEM,Loretta L. Sanchez,192
+Yolo,100072,U.S. Senate,,DEM,Kamala D. Harris,444
+Yolo,100072,U.S. Senate,,DEM,Loretta L. Sanchez,352
+Yolo,100073,U.S. Senate,,DEM,Kamala D. Harris,231
+Yolo,100073,U.S. Senate,,DEM,Loretta L. Sanchez,156
+Yolo,100074,U.S. Senate,,DEM,Kamala D. Harris,457
+Yolo,100074,U.S. Senate,,DEM,Loretta L. Sanchez,410
+Yolo,100075,U.S. Senate,,DEM,Kamala D. Harris,337
+Yolo,100075,U.S. Senate,,DEM,Loretta L. Sanchez,241
+Yolo,100076,U.S. Senate,,DEM,Kamala D. Harris,335
+Yolo,100076,U.S. Senate,,DEM,Loretta L. Sanchez,273
+Yolo,100077,U.S. Senate,,DEM,Kamala D. Harris,253
+Yolo,100077,U.S. Senate,,DEM,Loretta L. Sanchez,147
+Yolo,100078,U.S. Senate,,DEM,Kamala D. Harris,301
+Yolo,100078,U.S. Senate,,DEM,Loretta L. Sanchez,198
+Yolo,100079,U.S. Senate,,DEM,Kamala D. Harris,591
+Yolo,100079,U.S. Senate,,DEM,Loretta L. Sanchez,509
+Yolo,100080,U.S. Senate,,DEM,Kamala D. Harris,807
+Yolo,100080,U.S. Senate,,DEM,Loretta L. Sanchez,573
+Yolo,100081,U.S. Senate,,DEM,Kamala D. Harris,438
+Yolo,100081,U.S. Senate,,DEM,Loretta L. Sanchez,284
+Yolo,100082,U.S. Senate,,DEM,Kamala D. Harris,290
+Yolo,100082,U.S. Senate,,DEM,Loretta L. Sanchez,199
+Yolo,100083,U.S. Senate,,DEM,Kamala D. Harris,68
+Yolo,100083,U.S. Senate,,DEM,Loretta L. Sanchez,62
+Yolo,100084,U.S. Senate,,DEM,Kamala D. Harris,294
+Yolo,100084,U.S. Senate,,DEM,Loretta L. Sanchez,146
+Yolo,100085,U.S. Senate,,DEM,Kamala D. Harris,375
+Yolo,100085,U.S. Senate,,DEM,Loretta L. Sanchez,257
+Yolo,100086,U.S. Senate,,DEM,Kamala D. Harris,281
+Yolo,100086,U.S. Senate,,DEM,Loretta L. Sanchez,223
+Yolo,100087,U.S. Senate,,DEM,Kamala D. Harris,240
+Yolo,100087,U.S. Senate,,DEM,Loretta L. Sanchez,188
+Yolo,100088,U.S. Senate,,DEM,Kamala D. Harris,165
+Yolo,100088,U.S. Senate,,DEM,Loretta L. Sanchez,122
+Yolo,100089,U.S. Senate,,DEM,Kamala D. Harris,144
+Yolo,100089,U.S. Senate,,DEM,Loretta L. Sanchez,58
+Yolo,100090,U.S. Senate,,DEM,Kamala D. Harris,124
+Yolo,100090,U.S. Senate,,DEM,Loretta L. Sanchez,88
+Yolo,100091,U.S. Senate,,DEM,Kamala D. Harris,114
+Yolo,100091,U.S. Senate,,DEM,Loretta L. Sanchez,45
+Yolo,100092,U.S. Senate,,DEM,Kamala D. Harris,210
+Yolo,100092,U.S. Senate,,DEM,Loretta L. Sanchez,127
+Yolo,100093,U.S. Senate,,DEM,Kamala D. Harris,219
+Yolo,100093,U.S. Senate,,DEM,Loretta L. Sanchez,160
+Yolo,100094,U.S. Senate,,DEM,Kamala D. Harris,165
+Yolo,100094,U.S. Senate,,DEM,Loretta L. Sanchez,167
+Yolo,100095,U.S. Senate,,DEM,Kamala D. Harris,200
+Yolo,100095,U.S. Senate,,DEM,Loretta L. Sanchez,89
+Yolo,100096,U.S. Senate,,DEM,Kamala D. Harris,155
+Yolo,100096,U.S. Senate,,DEM,Loretta L. Sanchez,167
+Yolo,100097,U.S. Senate,,DEM,Kamala D. Harris,32
+Yolo,100097,U.S. Senate,,DEM,Loretta L. Sanchez,10
+Yolo,100098,U.S. Senate,,DEM,Kamala D. Harris,63
+Yolo,100098,U.S. Senate,,DEM,Loretta L. Sanchez,43
+Yolo,100099,U.S. Senate,,DEM,Kamala D. Harris,162
+Yolo,100099,U.S. Senate,,DEM,Loretta L. Sanchez,91
+Yolo,100100,U.S. Senate,,DEM,Kamala D. Harris,101
+Yolo,100100,U.S. Senate,,DEM,Loretta L. Sanchez,90
+Yolo,100101,U.S. Senate,,DEM,Kamala D. Harris,128
+Yolo,100101,U.S. Senate,,DEM,Loretta L. Sanchez,73
+Yolo,100102,U.S. Senate,,DEM,Kamala D. Harris,36
+Yolo,100102,U.S. Senate,,DEM,Loretta L. Sanchez,26
+Yolo,100103,U.S. Senate,,DEM,Kamala D. Harris,242
+Yolo,100103,U.S. Senate,,DEM,Loretta L. Sanchez,190
+Yolo,100104,U.S. Senate,,DEM,Kamala D. Harris,0
+Yolo,100104,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Yolo,100105,U.S. Senate,,DEM,Kamala D. Harris,58
+Yolo,100105,U.S. Senate,,DEM,Loretta L. Sanchez,34
+Yolo,100106,U.S. Senate,,DEM,Kamala D. Harris,5
+Yolo,100106,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Yolo,100107,U.S. Senate,,DEM,Kamala D. Harris,0
+Yolo,100107,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Yolo,100108,U.S. Senate,,DEM,Kamala D. Harris,0
+Yolo,100108,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Yolo,100109,U.S. Senate,,DEM,Kamala D. Harris,7
+Yolo,100109,U.S. Senate,,DEM,Loretta L. Sanchez,5
+Yolo,100110,U.S. Senate,,DEM,Kamala D. Harris,0
+Yolo,100110,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Yolo,100111,U.S. Senate,,DEM,Kamala D. Harris,0
+Yolo,100111,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Yolo,100112,U.S. Senate,,DEM,Kamala D. Harris,32
+Yolo,100112,U.S. Senate,,DEM,Loretta L. Sanchez,20
+Yolo,100113,U.S. Senate,,DEM,Kamala D. Harris,2
+Yolo,100113,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Yolo,100114,U.S. Senate,,DEM,Kamala D. Harris,47
+Yolo,100114,U.S. Senate,,DEM,Loretta L. Sanchez,40
+Yolo,100115,U.S. Senate,,DEM,Kamala D. Harris,172
+Yolo,100115,U.S. Senate,,DEM,Loretta L. Sanchez,57
+Yolo,100116,U.S. Senate,,DEM,Kamala D. Harris,22
+Yolo,100116,U.S. Senate,,DEM,Loretta L. Sanchez,8
+Yolo,100117,U.S. Senate,,DEM,Kamala D. Harris,0
+Yolo,100117,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Yolo,100118,U.S. Senate,,DEM,Kamala D. Harris,169
+Yolo,100118,U.S. Senate,,DEM,Loretta L. Sanchez,96
+Yolo,100119,U.S. Senate,,DEM,Kamala D. Harris,24
+Yolo,100119,U.S. Senate,,DEM,Loretta L. Sanchez,20
+Yolo,100120,U.S. Senate,,DEM,Kamala D. Harris,0
+Yolo,100120,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Yolo,100121,U.S. Senate,,DEM,Kamala D. Harris,0
+Yolo,100121,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Yolo,100122,U.S. Senate,,DEM,Kamala D. Harris,54
+Yolo,100122,U.S. Senate,,DEM,Loretta L. Sanchez,65
+Yolo,100123,U.S. Senate,,DEM,Kamala D. Harris,0
+Yolo,100123,U.S. Senate,,DEM,Loretta L. Sanchez,0
+Yolo,100124,U.S. Senate,,DEM,Kamala D. Harris,142
+Yolo,100124,U.S. Senate,,DEM,Loretta L. Sanchez,35
+Yolo,100125,U.S. Senate,,DEM,Kamala D. Harris,151
+Yolo,100125,U.S. Senate,,DEM,Loretta L. Sanchez,85
+Yolo,100126,U.S. Senate,,DEM,Kamala D. Harris,174
+Yolo,100126,U.S. Senate,,DEM,Loretta L. Sanchez,103
+Yolo,100127,U.S. Senate,,DEM,Kamala D. Harris,213
+Yolo,100127,U.S. Senate,,DEM,Loretta L. Sanchez,173
+Yolo,100128,U.S. Senate,,DEM,Kamala D. Harris,115
+Yolo,100128,U.S. Senate,,DEM,Loretta L. Sanchez,78
+Yolo,100129,U.S. Senate,,DEM,Kamala D. Harris,23
+Yolo,100129,U.S. Senate,,DEM,Loretta L. Sanchez,22
+Yolo,100130,U.S. Senate,,DEM,Kamala D. Harris,80
+Yolo,100130,U.S. Senate,,DEM,Loretta L. Sanchez,30
+Yolo,100131,U.S. Senate,,DEM,Kamala D. Harris,12
+Yolo,100131,U.S. Senate,,DEM,Loretta L. Sanchez,11
+Yolo,100132,U.S. Senate,,DEM,Kamala D. Harris,12
+Yolo,100132,U.S. Senate,,DEM,Loretta L. Sanchez,15
+Yolo,100133,U.S. Senate,,DEM,Kamala D. Harris,7
+Yolo,100133,U.S. Senate,,DEM,Loretta L. Sanchez,1

--- a/2016/20161108__ca__general__yuba__precinct.csv
+++ b/2016/20161108__ca__general__yuba__precinct.csv
@@ -1799,93 +1799,93 @@ Yuba,5013,Proposition 67,,N/A,Yes,63
 Yuba,5013,Proposition 67,,N/A,No,92
 Yuba,5014,Proposition 67,,N/A,Yes,174
 Yuba,5014,Proposition 67,,N/A,No,138
-Yuba,1001,U.S. Senate,,DEM,Kamala Harris,213
-Yuba,1001,U.S. Senate,,DEM,Loretta Sanchez,188
-Yuba,1002,U.S. Senate,,DEM,Kamala Harris,260
-Yuba,1002,U.S. Senate,,DEM,Loretta Sanchez,199
-Yuba,1003,U.S. Senate,,DEM,Kamala Harris,132
-Yuba,1003,U.S. Senate,,DEM,Loretta Sanchez,113
-Yuba,1004,U.S. Senate,,DEM,Kamala Harris,220
-Yuba,1004,U.S. Senate,,DEM,Loretta Sanchez,250
-Yuba,1005,U.S. Senate,,DEM,Kamala Harris,116
-Yuba,1005,U.S. Senate,,DEM,Loretta Sanchez,124
-Yuba,1006,U.S. Senate,,DEM,Kamala Harris,204
-Yuba,1006,U.S. Senate,,DEM,Loretta Sanchez,156
-Yuba,1007,U.S. Senate,,DEM,Kamala Harris,406
-Yuba,1007,U.S. Senate,,DEM,Loretta Sanchez,328
-Yuba,2001,U.S. Senate,,DEM,Kamala Harris,215
-Yuba,2001,U.S. Senate,,DEM,Loretta Sanchez,187
-Yuba,2002,U.S. Senate,,DEM,Kamala Harris,260
-Yuba,2002,U.S. Senate,,DEM,Loretta Sanchez,190
-Yuba,2003,U.S. Senate,,DEM,Kamala Harris,285
-Yuba,2003,U.S. Senate,,DEM,Loretta Sanchez,236
-Yuba,2004,U.S. Senate,,DEM,Kamala Harris,297
-Yuba,2004,U.S. Senate,,DEM,Loretta Sanchez,203
-Yuba,2005,U.S. Senate,,DEM,Kamala Harris,256
-Yuba,2005,U.S. Senate,,DEM,Loretta Sanchez,180
-Yuba,2006,U.S. Senate,,DEM,Kamala Harris,221
-Yuba,2006,U.S. Senate,,DEM,Loretta Sanchez,193
-Yuba,2007,U.S. Senate,,DEM,Kamala Harris,231
-Yuba,2007,U.S. Senate,,DEM,Loretta Sanchez,193
-Yuba,3001,U.S. Senate,,DEM,Kamala Harris,200
-Yuba,3001,U.S. Senate,,DEM,Loretta Sanchez,190
-Yuba,3002,U.S. Senate,,DEM,Kamala Harris,202
-Yuba,3002,U.S. Senate,,DEM,Loretta Sanchez,162
-Yuba,3003,U.S. Senate,,DEM,Kamala Harris,254
-Yuba,3003,U.S. Senate,,DEM,Loretta Sanchez,215
-Yuba,3004,U.S. Senate,,DEM,Kamala Harris,255
-Yuba,3004,U.S. Senate,,DEM,Loretta Sanchez,231
-Yuba,3005,U.S. Senate,,DEM,Kamala Harris,318
-Yuba,3005,U.S. Senate,,DEM,Loretta Sanchez,257
-Yuba,3006,U.S. Senate,,DEM,Kamala Harris,139
-Yuba,3006,U.S. Senate,,DEM,Loretta Sanchez,76
-Yuba,3007,U.S. Senate,,DEM,Kamala Harris,19
-Yuba,3007,U.S. Senate,,DEM,Loretta Sanchez,25
-Yuba,3008,U.S. Senate,,DEM,Kamala Harris,188
-Yuba,3008,U.S. Senate,,DEM,Loretta Sanchez,146
-Yuba,4001,U.S. Senate,,DEM,Kamala Harris,487
-Yuba,4001,U.S. Senate,,DEM,Loretta Sanchez,339
-Yuba,4002,U.S. Senate,,DEM,Kamala Harris,366
-Yuba,4002,U.S. Senate,,DEM,Loretta Sanchez,290
-Yuba,4003,U.S. Senate,,DEM,Kamala Harris,298
-Yuba,4003,U.S. Senate,,DEM,Loretta Sanchez,232
-Yuba,4004,U.S. Senate,,DEM,Kamala Harris,55
-Yuba,4004,U.S. Senate,,DEM,Loretta Sanchez,34
-Yuba,4005,U.S. Senate,,DEM,Kamala Harris,46
-Yuba,4005,U.S. Senate,,DEM,Loretta Sanchez,38
-Yuba,4006,U.S. Senate,,DEM,Kamala Harris,294
-Yuba,4006,U.S. Senate,,DEM,Loretta Sanchez,239
-Yuba,4007,U.S. Senate,,DEM,Kamala Harris,245
-Yuba,4007,U.S. Senate,,DEM,Loretta Sanchez,197
-Yuba,4008,U.S. Senate,,DEM,Kamala Harris,225
-Yuba,4008,U.S. Senate,,DEM,Loretta Sanchez,218
-Yuba,4009,U.S. Senate,,DEM,Kamala Harris,229
-Yuba,4009,U.S. Senate,,DEM,Loretta Sanchez,151
-Yuba,5001,U.S. Senate,,DEM,Kamala Harris,176
-Yuba,5001,U.S. Senate,,DEM,Loretta Sanchez,98
-Yuba,5002,U.S. Senate,,DEM,Kamala Harris,86
-Yuba,5002,U.S. Senate,,DEM,Loretta Sanchez,50
-Yuba,5003,U.S. Senate,,DEM,Kamala Harris,73
-Yuba,5003,U.S. Senate,,DEM,Loretta Sanchez,59
-Yuba,5004,U.S. Senate,,DEM,Kamala Harris,377
-Yuba,5004,U.S. Senate,,DEM,Loretta Sanchez,202
-Yuba,5005,U.S. Senate,,DEM,Kamala Harris,283
-Yuba,5005,U.S. Senate,,DEM,Loretta Sanchez,200
-Yuba,5006,U.S. Senate,,DEM,Kamala Harris,213
-Yuba,5006,U.S. Senate,,DEM,Loretta Sanchez,180
-Yuba,5007,U.S. Senate,,DEM,Kamala Harris,211
-Yuba,5007,U.S. Senate,,DEM,Loretta Sanchez,130
-Yuba,5008,U.S. Senate,,DEM,Kamala Harris,241
-Yuba,5008,U.S. Senate,,DEM,Loretta Sanchez,168
-Yuba,5009,U.S. Senate,,DEM,Kamala Harris,173
-Yuba,5009,U.S. Senate,,DEM,Loretta Sanchez,181
-Yuba,5010,U.S. Senate,,DEM,Kamala Harris,296
-Yuba,5010,U.S. Senate,,DEM,Loretta Sanchez,238
-Yuba,5011,U.S. Senate,,DEM,Kamala Harris,294
-Yuba,5011,U.S. Senate,,DEM,Loretta Sanchez,223
-Yuba,5012,U.S. Senate,,DEM,Kamala Harris,191
-Yuba,5012,U.S. Senate,,DEM,Loretta Sanchez,148
-Yuba,5013,U.S. Senate,,DEM,Kamala Harris,73
-Yuba,5013,U.S. Senate,,DEM,Loretta Sanchez,43
-Yuba,5014,U.S. Senate,,DEM,Kamala Harris,176
-Yuba,5014,U.S. Senate,,DEM,Loretta Sanchez,89
+Yuba,1001,U.S. Senate,,DEM,Kamala D. Harris,213
+Yuba,1001,U.S. Senate,,DEM,Loretta L. Sanchez,188
+Yuba,1002,U.S. Senate,,DEM,Kamala D. Harris,260
+Yuba,1002,U.S. Senate,,DEM,Loretta L. Sanchez,199
+Yuba,1003,U.S. Senate,,DEM,Kamala D. Harris,132
+Yuba,1003,U.S. Senate,,DEM,Loretta L. Sanchez,113
+Yuba,1004,U.S. Senate,,DEM,Kamala D. Harris,220
+Yuba,1004,U.S. Senate,,DEM,Loretta L. Sanchez,250
+Yuba,1005,U.S. Senate,,DEM,Kamala D. Harris,116
+Yuba,1005,U.S. Senate,,DEM,Loretta L. Sanchez,124
+Yuba,1006,U.S. Senate,,DEM,Kamala D. Harris,204
+Yuba,1006,U.S. Senate,,DEM,Loretta L. Sanchez,156
+Yuba,1007,U.S. Senate,,DEM,Kamala D. Harris,406
+Yuba,1007,U.S. Senate,,DEM,Loretta L. Sanchez,328
+Yuba,2001,U.S. Senate,,DEM,Kamala D. Harris,215
+Yuba,2001,U.S. Senate,,DEM,Loretta L. Sanchez,187
+Yuba,2002,U.S. Senate,,DEM,Kamala D. Harris,260
+Yuba,2002,U.S. Senate,,DEM,Loretta L. Sanchez,190
+Yuba,2003,U.S. Senate,,DEM,Kamala D. Harris,285
+Yuba,2003,U.S. Senate,,DEM,Loretta L. Sanchez,236
+Yuba,2004,U.S. Senate,,DEM,Kamala D. Harris,297
+Yuba,2004,U.S. Senate,,DEM,Loretta L. Sanchez,203
+Yuba,2005,U.S. Senate,,DEM,Kamala D. Harris,256
+Yuba,2005,U.S. Senate,,DEM,Loretta L. Sanchez,180
+Yuba,2006,U.S. Senate,,DEM,Kamala D. Harris,221
+Yuba,2006,U.S. Senate,,DEM,Loretta L. Sanchez,193
+Yuba,2007,U.S. Senate,,DEM,Kamala D. Harris,231
+Yuba,2007,U.S. Senate,,DEM,Loretta L. Sanchez,193
+Yuba,3001,U.S. Senate,,DEM,Kamala D. Harris,200
+Yuba,3001,U.S. Senate,,DEM,Loretta L. Sanchez,190
+Yuba,3002,U.S. Senate,,DEM,Kamala D. Harris,202
+Yuba,3002,U.S. Senate,,DEM,Loretta L. Sanchez,162
+Yuba,3003,U.S. Senate,,DEM,Kamala D. Harris,254
+Yuba,3003,U.S. Senate,,DEM,Loretta L. Sanchez,215
+Yuba,3004,U.S. Senate,,DEM,Kamala D. Harris,255
+Yuba,3004,U.S. Senate,,DEM,Loretta L. Sanchez,231
+Yuba,3005,U.S. Senate,,DEM,Kamala D. Harris,318
+Yuba,3005,U.S. Senate,,DEM,Loretta L. Sanchez,257
+Yuba,3006,U.S. Senate,,DEM,Kamala D. Harris,139
+Yuba,3006,U.S. Senate,,DEM,Loretta L. Sanchez,76
+Yuba,3007,U.S. Senate,,DEM,Kamala D. Harris,19
+Yuba,3007,U.S. Senate,,DEM,Loretta L. Sanchez,25
+Yuba,3008,U.S. Senate,,DEM,Kamala D. Harris,188
+Yuba,3008,U.S. Senate,,DEM,Loretta L. Sanchez,146
+Yuba,4001,U.S. Senate,,DEM,Kamala D. Harris,487
+Yuba,4001,U.S. Senate,,DEM,Loretta L. Sanchez,339
+Yuba,4002,U.S. Senate,,DEM,Kamala D. Harris,366
+Yuba,4002,U.S. Senate,,DEM,Loretta L. Sanchez,290
+Yuba,4003,U.S. Senate,,DEM,Kamala D. Harris,298
+Yuba,4003,U.S. Senate,,DEM,Loretta L. Sanchez,232
+Yuba,4004,U.S. Senate,,DEM,Kamala D. Harris,55
+Yuba,4004,U.S. Senate,,DEM,Loretta L. Sanchez,34
+Yuba,4005,U.S. Senate,,DEM,Kamala D. Harris,46
+Yuba,4005,U.S. Senate,,DEM,Loretta L. Sanchez,38
+Yuba,4006,U.S. Senate,,DEM,Kamala D. Harris,294
+Yuba,4006,U.S. Senate,,DEM,Loretta L. Sanchez,239
+Yuba,4007,U.S. Senate,,DEM,Kamala D. Harris,245
+Yuba,4007,U.S. Senate,,DEM,Loretta L. Sanchez,197
+Yuba,4008,U.S. Senate,,DEM,Kamala D. Harris,225
+Yuba,4008,U.S. Senate,,DEM,Loretta L. Sanchez,218
+Yuba,4009,U.S. Senate,,DEM,Kamala D. Harris,229
+Yuba,4009,U.S. Senate,,DEM,Loretta L. Sanchez,151
+Yuba,5001,U.S. Senate,,DEM,Kamala D. Harris,176
+Yuba,5001,U.S. Senate,,DEM,Loretta L. Sanchez,98
+Yuba,5002,U.S. Senate,,DEM,Kamala D. Harris,86
+Yuba,5002,U.S. Senate,,DEM,Loretta L. Sanchez,50
+Yuba,5003,U.S. Senate,,DEM,Kamala D. Harris,73
+Yuba,5003,U.S. Senate,,DEM,Loretta L. Sanchez,59
+Yuba,5004,U.S. Senate,,DEM,Kamala D. Harris,377
+Yuba,5004,U.S. Senate,,DEM,Loretta L. Sanchez,202
+Yuba,5005,U.S. Senate,,DEM,Kamala D. Harris,283
+Yuba,5005,U.S. Senate,,DEM,Loretta L. Sanchez,200
+Yuba,5006,U.S. Senate,,DEM,Kamala D. Harris,213
+Yuba,5006,U.S. Senate,,DEM,Loretta L. Sanchez,180
+Yuba,5007,U.S. Senate,,DEM,Kamala D. Harris,211
+Yuba,5007,U.S. Senate,,DEM,Loretta L. Sanchez,130
+Yuba,5008,U.S. Senate,,DEM,Kamala D. Harris,241
+Yuba,5008,U.S. Senate,,DEM,Loretta L. Sanchez,168
+Yuba,5009,U.S. Senate,,DEM,Kamala D. Harris,173
+Yuba,5009,U.S. Senate,,DEM,Loretta L. Sanchez,181
+Yuba,5010,U.S. Senate,,DEM,Kamala D. Harris,296
+Yuba,5010,U.S. Senate,,DEM,Loretta L. Sanchez,238
+Yuba,5011,U.S. Senate,,DEM,Kamala D. Harris,294
+Yuba,5011,U.S. Senate,,DEM,Loretta L. Sanchez,223
+Yuba,5012,U.S. Senate,,DEM,Kamala D. Harris,191
+Yuba,5012,U.S. Senate,,DEM,Loretta L. Sanchez,148
+Yuba,5013,U.S. Senate,,DEM,Kamala D. Harris,73
+Yuba,5013,U.S. Senate,,DEM,Loretta L. Sanchez,43
+Yuba,5014,U.S. Senate,,DEM,Kamala D. Harris,176
+Yuba,5014,U.S. Senate,,DEM,Loretta L. Sanchez,89


### PR DESCRIPTION
For the U.S. Senate General election, county results code the candidates as 'Kamala D. Harris' and 'Loretta L. Sanchez' while the precint results code them as 'Kamala Harris' and 'Loretta Sanchez'  Update the precinct results to use the names from the county results from the CA SoS.

Fixes #41 