### PR TITLE
Add dummy write-in rows for San Bernardino.

### DIFF
--- a/2016/20161108__ca__general__san_bernardino__precinct.csv
+++ b/2016/20161108__ca__general__san_bernardino__precinct.csv
@@ -10733,6 +10733,11 @@ San Bernardino,YUV0275,President,,LIB,Gary Johnson,52
 San Bernardino,YUV0275,President,,GRN,Jill Stein,32
 San Bernardino,YUV0275,President,,PF,Gloria Estela La Riva,4
 San Bernardino,YUV0275,President,,WI,Write-In,0
+San Bernardino,Write-In,President,,DEM,Hillary Clinton,15
+San Bernardino,Write-In,President,,REP/AI,Donald J. Trump,15
+San Bernardino,Write-In,President,,LIB,Gary Johnson,2
+San Bernardino,Write-In,President,,GRN,Jill Stein,1
+San Bernardino,Write-In,President,,PF,Gloria Estela La Riva,1
 San Bernardino,ADE0110,Proposition 51,,N/A,Yes,0
 San Bernardino,ADE0110,Proposition 51,,N/A,No,0
 San Bernardino,ADE0111,Proposition 51,,N/A,Yes,0


### PR DESCRIPTION
Write-ins for candidates on the ballot are consolidated and reported as a total, so we'll add the dummy row in order to make the totals correct.

Fixes #54 