### PR TITLE
Fix test failure in 2016 Primary.

### DIFF
--- a/2016/20160607__ca__primary.csv
+++ b/2016/20160607__ca__primary.csv
@@ -4132,7 +4132,7 @@ Los Angeles,U.S. House,44,DEM,Marcus C. Musante,2366
 Los Angeles,U.S. House,44,REP,Ronald Siegel,5565
 Los Angeles,U.S. House,44,DEM,Armando Sotomayor,10087
 Los Angeles,U.S. House,47,REP,Sanford W. Kahn,9723
-Los Angeles,U.S. House,47,DEM,Alan  Lowenthal,61130
+Los Angeles,U.S. House,47,DEM,Alan Lowenthal,61130
 Los Angeles,U.S. House,47,REP,Andy Whallon,14582
 Los Angeles,U.S. House,47,NPP,Rich Camp,4
 Los Angeles,State Senate,21,DEM,Steve Hill,11809
@@ -4767,7 +4767,7 @@ Orange,U.S. House,46,NPP,Nancy Trinidad Marin,3306
 Orange,U.S. House,46,DEM,Joe Dunn,11596
 Orange,U.S. House,46,REP,Bob Peterson,11781
 Orange,U.S. House,47,REP,Sanford W. Kahn,6641
-Orange,U.S. House,47,DEM,Alan  Lowenthal,29465
+Orange,U.S. House,47,DEM,Alan Lowenthal,29465
 Orange,U.S. House,47,REP,Andy Whallon,15472
 Orange,U.S. House,47,NPP,Rich Camp,5
 Orange,U.S. House,48,REP,Dana Rohrabacher,92815

--- a/src/parse_primary_2016.py
+++ b/src/parse_primary_2016.py
@@ -25,7 +25,8 @@ office_dict = {'United States Representative': 'U.S. House',
                'State Assembly Member': 'State Assembly'}
 
 # Clean up candidate names
-candidate_dict = {'Ron  Unz': 'Ron Unz'}
+candidate_dict = {'Ron  Unz': 'Ron Unz',
+                  'Alan  Lowenthal': 'Alan Lowenthal'}
 
 # Columns to select
 columns = ['COUNTY_NAME', 'office', 'district',


### PR DESCRIPTION
CA SoS files have the 47th House District candidate coded as Alan  Lowenthal (note two spaces).  Update the parsing code to clean this name up, and rerun to regenerate the clean data.  Alan Lowenthal's vote totals now match.