### PR TITLE
Improve test quality.

### DIFF
--- a/tests/test_2015.py
+++ b/tests/test_2015.py
@@ -5,75 +5,48 @@ import pandas
 import pytest
 
 
+columns = ['candidate', 'county', 'district', 'office', 'votes']
+
+
 def test_special_primary():
     state_files = glob.glob('2015/*__ca__special__primary.csv')
     for state_file in state_files:
-        state_data = pandas.read_csv(state_file)
+        state_data = pandas.read_csv(state_file, na_values='')
 
         for county_file in glob.glob('2015/*__ca__special__primary__*__precinct.csv'):
-            county_data = pandas.read_csv(county_file)
+            county_data = pandas.read_csv(county_file, na_values='')
 
             # Each county file should only contain a single county.
             assert len(county_data.drop_duplicates(
                 ['county']).county.values) == 1
 
             county = county_data.drop_duplicates(['county']).county.values[0]
-            contest_columns = ['office', 'district']
-            contests = county_data.drop_duplicates(
-                contest_columns)[contest_columns].values
+            county_cmp = county_data[columns].groupby(
+                columns[:-1]).sum()
+            state_cmp = state_data[state_data.county == county][
+                columns].groupby(columns[:-1]).sum()
 
-            for office, district in contests:
-                candidates = county_data.loc[
-                    county_data.office == office].candidate.unique()
-
-                # The sum over the precincts for each county should be the same
-                # as the county-level vote totals.
-                county_votes = {
-                    candidate: county_data.loc[
-                        county_data.candidate == candidate].votes.sum()
-                    for candidate in candidates}
-                votes = {
-                    candidate: state_data.loc[
-                        (state_data.candidate == candidate) & (state_data.county == county)].votes.sum()
-                    for candidate in candidates
-                }
-
-                assert votes == county_votes, "%s for %s failed" % (
-                    office, county)
+            assert state_cmp.to_dict()['votes'] == county_cmp.to_dict()[
+                'votes'], '%s failed' % county
 
 
 def test_special_general():
     state_files = glob.glob('2015/*__ca__special__general.csv')
     for state_file in state_files:
-        state_data = pandas.read_csv(state_file)
+        state_data = pandas.read_csv(state_file, na_values='')
 
         for county_file in glob.glob('2015/*__ca__special__general__*__precinct.csv'):
-            county_data = pandas.read_csv(county_file)
+            county_data = pandas.read_csv(county_file, na_values='')
 
             # Each county file should only contain a single county.
             assert len(county_data.drop_duplicates(
                 ['county']).county.values) == 1
 
             county = county_data.drop_duplicates(['county']).county.values[0]
-            contest_columns = ['office', 'district']
-            contests = county_data.drop_duplicates(
-                contest_columns)[contest_columns].values
+            county_cmp = county_data[columns].groupby(
+                columns[:-1]).sum()
+            state_cmp = state_data[state_data.county == county][
+                columns].groupby(columns[:-1]).sum()
 
-            for office, district in contests:
-                candidates = county_data.loc[
-                    county_data.office == office].candidate.unique()
-
-                # The sum over the precincts for each county should be the same
-                # as the county-level vote totals.
-                county_votes = {
-                    candidate: county_data.loc[
-                        county_data.candidate == candidate].votes.sum()
-                    for candidate in candidates}
-                votes = {
-                    candidate: state_data.loc[
-                        (state_data.candidate == candidate) & (state_data.county == county)].votes.sum()
-                    for candidate in candidates
-                }
-
-                assert votes == county_votes, "%s for %s failed" % (
-                    office, county)
+            assert state_cmp.to_dict()['votes'] == county_cmp.to_dict()[
+                'votes'], '%s failed' % county

--- a/tests/test_2016.py
+++ b/tests/test_2016.py
@@ -5,75 +5,48 @@ import pandas
 import pytest
 
 
+columns = ['candidate', 'county', 'district', 'office', 'votes']
+
+
 def test_primary():
     state_files = glob.glob('2016/*__ca__primary.csv')
     for state_file in state_files:
-        state_data = pandas.read_csv(state_file)
+        state_data = pandas.read_csv(state_file, na_values='')
 
         for county_file in glob.glob('2016/*__ca__primary__*__precinct.csv'):
-            county_data = pandas.read_csv(county_file)
+            county_data = pandas.read_csv(county_file, na_values='')
 
             # Each county file should only contain a single county.
             assert len(county_data.drop_duplicates(
                 ['county']).county.values) == 1
 
             county = county_data.drop_duplicates(['county']).county.values[0]
-            contest_columns = ['office', 'district']
-            contests = county_data.drop_duplicates(
-                contest_columns)[contest_columns].values
+            county_data = county_data[columns].groupby(
+                columns[:-1]).sum()
+            state_cmp = state_data[state_data.county == county][
+                columns].groupby(columns[:-1]).sum()
 
-            for office, district in contests:
-                candidates = county_data.loc[
-                    county_data.office == office].candidate.unique()
-
-                # The sum over the precincts for each county should be the same
-                # as the county-level vote totals.
-                county_votes = {
-                    candidate: county_data.loc[
-                        county_data.candidate == candidate].votes.sum()
-                    for candidate in candidates}
-                votes = {
-                    candidate: state_data.loc[
-                        (state_data.candidate == candidate) & (state_data.county == county)].votes.sum()
-                    for candidate in candidates
-                }
-
-                assert votes == county_votes, "%s for %s failed" % (
-                    office, county)
+            assert state_cmp.to_dict()['votes'] == county_data.to_dict()[
+                'votes'], '%s failed' % county
 
 
 def test_general():
     state_files = glob.glob('2016/*__ca__general.csv')
     for state_file in state_files:
-        state_data = pandas.read_csv(state_file)
+        state_data = pandas.read_csv(state_file, na_values='')
 
         for county_file in glob.glob('2016/*__ca__general__*__precinct.csv'):
-            county_data = pandas.read_csv(county_file)
+            county_data = pandas.read_csv(county_file, na_values='')
 
             # Each county file should only contain a single county.
             assert len(county_data.drop_duplicates(
                 ['county']).county.values) == 1
 
             county = county_data.drop_duplicates(['county']).county.values[0]
-            contest_columns = ['office', 'district']
-            contests = county_data.drop_duplicates(
-                contest_columns)[contest_columns].values
+            county_data = county_data[columns].groupby(
+                columns[:-1]).sum()
+            state_cmp = state_data[state_data.county == county][
+                columns].groupby(columns[:-1]).sum()
 
-            for office, district in contests:
-                candidates = county_data.loc[
-                    county_data.office == office].candidate.unique()
-
-                # The sum over the precincts for each county should be the same
-                # as the county-level vote totals.
-                county_votes = {
-                    candidate: county_data.loc[
-                        (county_data.office == office) & (county_data.candidate == candidate)].votes.sum()
-                    for candidate in candidates if candidate != 'Write-In'}
-                votes = {
-                    candidate: state_data.loc[
-                        (state_data.office == office) & (state_data.candidate == candidate) & (state_data.county == county)].votes.sum()
-                    for candidate in candidates if candidate != 'Write-In'
-                }
-
-                assert votes == county_votes, "%s for %s failed" % (
-                    office, county)
+            assert state_cmp.to_dict()['votes'] == county_data.to_dict()[
+                'votes'], '%s failed' % county


### PR DESCRIPTION
The current tests are super-slow, so this cleans them up by just summing after groupby() and then turning them into dictionaries for comparison.  The dictionary comparison gives a more human-readable failure message than comparing the dataframes.