### PR TITLE
Handle Humboldt county absentee precincts.

### DIFF
--- a/2016/20160607__ca__primary__humboldt__precinct.csv
+++ b/2016/20160607__ca__primary__humboldt__precinct.csv
@@ -1,872 +1,554 @@
 county,precinct,office,district,party,candidate,votes
 Humboldt,1CS-1,President,,AIP,Alan Spears,1
-Humboldt,1CS-1,President,,REP,Ben Carson,1
-Humboldt,1CS-1,President,,DEM,Bernie Sanders,83
-Humboldt,1CS-1,President,,REP,Donald Trump,21
-Humboldt,1CS-1,President,,DEM,Hillary Clinton,36
+Humboldt,1CS-1,President,,AIP,Arthur Harris,1
+Humboldt,1CS-1,President,,REP,Ben Carson,6
+Humboldt,1CS-1,President,,DEM,Bernie Sanders,169
+Humboldt,1CS-1,President,,GRN,Darryl Cherney,1
+Humboldt,1CS-1,President,,REP,Donald Trump,79
+Humboldt,1CS-1,President,,DEM,Hillary Clinton,94
 Humboldt,1CS-1,President,,AIP,J.R. Myers,1
+Humboldt,1CS-1,President,,AIP,James Hedges,1
+Humboldt,1CS-1,President,,GRN,Jill Stein,2
+Humboldt,1CS-1,President,,REP,Jim Gilmore,1
 Humboldt,1CS-1,President,,LIB,John McAfee,1
-Humboldt,1CS-1,President,,REP,John R. Kasich,4
+Humboldt,1CS-1,President,,REP,John R. Kasich,12
 Humboldt,1CS-1,President,,DEM,Keith Judd,1
-Humboldt,1CS-1,President,,REP,Ted Cruz,2
-Humboldt,1CS-1,President,,AIP,Wiley Drake,1
-Humboldt,1CS-1,Proposition 50,,,No,27
-Humboldt,1CS-1,Proposition 50,,,Yes,114
-Humboldt,1CS-1,State Assembly,2,DEM,Jim Wood,121
-Humboldt,1CS-1,U.S. House,2,REP,Dale K. Mensing,21
-Humboldt,1CS-1,U.S. House,2,DEM,Erin A. Schrode,17
-Humboldt,1CS-1,U.S. House,2,DEM,Jared W. Huffman,99
-Humboldt,1CS-1,U.S. House,2,IND,Matthew Robert Wookey,14
-Humboldt,1CS-1,U.S. Senate,,IND,Clive Grey,3
-Humboldt,1CS-1,U.S. Senate,,REP,Don Krampe,1
-Humboldt,1CS-1,U.S. Senate,,REP,Duf Sundheim,5
+Humboldt,1CS-1,President,,REP,Ted Cruz,8
+Humboldt,1CS-1,President,,AIP,Wiley Drake,2
+Humboldt,1CS-1,President,,DEM,Willie Wilson,1
+Humboldt,1CS-1,Proposition 50,,,No,62
+Humboldt,1CS-1,Proposition 50,,,Yes,305
+Humboldt,1CS-1,State Assembly,2,DEM,Jim Wood,291
+Humboldt,1CS-1,U.S. House,2,REP,Dale K. Mensing,85
+Humboldt,1CS-1,U.S. House,2,DEM,Erin A. Schrode,27
+Humboldt,1CS-1,U.S. House,2,DEM,Jared W. Huffman,250
+Humboldt,1CS-1,U.S. House,2,IND,Matthew Robert Wookey,29
+Humboldt,1CS-1,U.S. Senate,,IND,Clive Grey,6
+Humboldt,1CS-1,U.S. Senate,,IND,Don J. Grundmann,2
+Humboldt,1CS-1,U.S. Senate,,REP,Don Krampe,4
+Humboldt,1CS-1,U.S. Senate,,REP,Duf Sundheim,20
 Humboldt,1CS-1,U.S. Senate,,IND,Eleanor García,1
-Humboldt,1CS-1,U.S. Senate,,LIB,Gail K. Lightfoot,5
-Humboldt,1CS-1,U.S. Senate,,REP,Greg Conlon,3
+Humboldt,1CS-1,U.S. Senate,,DEM,Emory Rodgers,1
+Humboldt,1CS-1,U.S. Senate,,LIB,Gail K. Lightfoot,10
+Humboldt,1CS-1,U.S. Senate,,IND,Gar Myers,1
+Humboldt,1CS-1,U.S. Senate,,REP,George C. Yang,2
+Humboldt,1CS-1,U.S. Senate,,REP,Greg Conlon,11
 Humboldt,1CS-1,U.S. Senate,,DEM,Herbert G. Peters,2
-Humboldt,1CS-1,U.S. Senate,,REP,Jarrell Williamson,1
+Humboldt,1CS-1,U.S. Senate,,REP,Jarrell Williamson,2
 Humboldt,1CS-1,U.S. Senate,,IND,Jason Hanania,1
-Humboldt,1CS-1,U.S. Senate,,IND,Jason Kraus,1
-Humboldt,1CS-1,U.S. Senate,,REP,Jerry J. Laws,5
-Humboldt,1CS-1,U.S. Senate,,DEM,Kamala D. Harris,49
+Humboldt,1CS-1,U.S. Senate,,IND,Jason Kraus,2
+Humboldt,1CS-1,U.S. Senate,,REP,Jerry J. Laws,15
+Humboldt,1CS-1,U.S. Senate,,DEM,Kamala D. Harris,139
+Humboldt,1CS-1,U.S. Senate,,REP,Karen Roseberry,2
 Humboldt,1CS-1,U.S. Senate,,IND,Ling Ling Shi,1
-Humboldt,1CS-1,U.S. Senate,,DEM,Loretta L. Sanchez,32
+Humboldt,1CS-1,U.S. Senate,,DEM,Loretta L. Sanchez,62
+Humboldt,1CS-1,U.S. Senate,,LIB,Mark Matthew Herd,1
 Humboldt,1CS-1,U.S. Senate,,DEM,Massie Munroe,3
-Humboldt,1CS-1,U.S. Senate,,IND,Mike Beitiks,2
-Humboldt,1CS-1,U.S. Senate,,GRN,Pamela Elizondo,11
-Humboldt,1CS-1,U.S. Senate,,REP,Phil Wyman,9
-Humboldt,1CS-1,U.S. Senate,,DEM,President Cristina Grappo,2
-Humboldt,1CS-1,U.S. Senate,,DEM,Steve Stokes,10
-Humboldt,1CS-1,U.S. Senate,,REP,Thomas G. Del Beccaro,2
-Humboldt,1CS-1,U.S. Senate,,REP,Tom Palzer,1
-Humboldt,1CS-1,U.S. Senate,,REP,Von Hougo,1
-Humboldt,1CS-1_A,President,,AIP,Arthur Harris,1
-Humboldt,1CS-1_A,President,,REP,Ben Carson,5
-Humboldt,1CS-1_A,President,,DEM,Bernie Sanders,86
-Humboldt,1CS-1_A,President,,GRN,Darryl Cherney,1
-Humboldt,1CS-1_A,President,,REP,Donald Trump,58
-Humboldt,1CS-1_A,President,,DEM,Hillary Clinton,58
-Humboldt,1CS-1_A,President,,AIP,James Hedges,1
-Humboldt,1CS-1_A,President,,GRN,Jill Stein,2
-Humboldt,1CS-1_A,President,,REP,Jim Gilmore,1
-Humboldt,1CS-1_A,President,,REP,John R. Kasich,8
-Humboldt,1CS-1_A,President,,REP,Ted Cruz,6
-Humboldt,1CS-1_A,President,,AIP,Wiley Drake,1
-Humboldt,1CS-1_A,President,,DEM,Willie Wilson,1
-Humboldt,1CS-1_A,Proposition 50,,,No,35
-Humboldt,1CS-1_A,Proposition 50,,,Yes,191
-Humboldt,1CS-1_A,State Assembly,2,DEM,Jim Wood,170
-Humboldt,1CS-1_A,U.S. House,2,REP,Dale K. Mensing,64
-Humboldt,1CS-1_A,U.S. House,2,DEM,Erin A. Schrode,10
-Humboldt,1CS-1_A,U.S. House,2,DEM,Jared W. Huffman,151
-Humboldt,1CS-1_A,U.S. House,2,IND,Matthew Robert Wookey,15
-Humboldt,1CS-1_A,U.S. Senate,,IND,Clive Grey,3
-Humboldt,1CS-1_A,U.S. Senate,,IND,Don J. Grundmann,2
-Humboldt,1CS-1_A,U.S. Senate,,REP,Don Krampe,3
-Humboldt,1CS-1_A,U.S. Senate,,REP,Duf Sundheim,15
-Humboldt,1CS-1_A,U.S. Senate,,DEM,Emory Rodgers,1
-Humboldt,1CS-1_A,U.S. Senate,,LIB,Gail K. Lightfoot,5
-Humboldt,1CS-1_A,U.S. Senate,,IND,Gar Myers,1
-Humboldt,1CS-1_A,U.S. Senate,,REP,George C. Yang,2
-Humboldt,1CS-1_A,U.S. Senate,,REP,Greg Conlon,8
-Humboldt,1CS-1_A,U.S. Senate,,REP,Jarrell Williamson,1
-Humboldt,1CS-1_A,U.S. Senate,,IND,Jason Kraus,1
-Humboldt,1CS-1_A,U.S. Senate,,REP,Jerry J. Laws,10
-Humboldt,1CS-1_A,U.S. Senate,,DEM,Kamala D. Harris,90
-Humboldt,1CS-1_A,U.S. Senate,,REP,Karen Roseberry,2
-Humboldt,1CS-1_A,U.S. Senate,,DEM,Loretta L. Sanchez,30
-Humboldt,1CS-1_A,U.S. Senate,,LIB,Mark Matthew Herd,1
-Humboldt,1CS-1_A,U.S. Senate,,IND,Mike Beitiks,4
-Humboldt,1CS-1_A,U.S. Senate,,GRN,Pamela Elizondo,5
-Humboldt,1CS-1_A,U.S. Senate,,REP,Phil Wyman,11
-Humboldt,1CS-1_A,U.S. Senate,,DEM,President Cristina Grappo,1
-Humboldt,1CS-1_A,U.S. Senate,,REP,Ron Unz,1
-Humboldt,1CS-1_A,U.S. Senate,,DEM,Steve Stokes,11
-Humboldt,1CS-1_A,U.S. Senate,,REP,Thomas G. Del Beccaro,4
-Humboldt,1CS-1_A,U.S. Senate,,REP,Tom Palzer,3
-Humboldt,1CS-1_A,U.S. Senate,,REP,Von Hougo,3
-Humboldt,1CS-2,President,,REP,Ben Carson,3
-Humboldt,1CS-2,President,,DEM,Bernie Sanders,71
-Humboldt,1CS-2,President,,REP,Donald Trump,31
-Humboldt,1CS-2,President,,LIB,Gary Johnson,1
-Humboldt,1CS-2,President,,DEM,Hillary Clinton,41
+Humboldt,1CS-1,U.S. Senate,,IND,Mike Beitiks,6
+Humboldt,1CS-1,U.S. Senate,,GRN,Pamela Elizondo,16
+Humboldt,1CS-1,U.S. Senate,,REP,Phil Wyman,20
+Humboldt,1CS-1,U.S. Senate,,DEM,President Cristina Grappo,3
+Humboldt,1CS-1,U.S. Senate,,REP,Ron Unz,1
+Humboldt,1CS-1,U.S. Senate,,DEM,Steve Stokes,21
+Humboldt,1CS-1,U.S. Senate,,REP,Thomas G. Del Beccaro,6
+Humboldt,1CS-1,U.S. Senate,,REP,Tom Palzer,4
+Humboldt,1CS-1,U.S. Senate,,REP,Von Hougo,4
+Humboldt,1CS-2,President,,REP,Ben Carson,8
+Humboldt,1CS-2,President,,DEM,Bernie Sanders,159
+Humboldt,1CS-2,President,,REP,Donald Trump,109
+Humboldt,1CS-2,President,,LIB,Gary Johnson,2
+Humboldt,1CS-2,President,,DEM,Hillary Clinton,102
 Humboldt,1CS-2,President,,AIP,James Hedges,1
 Humboldt,1CS-2,President,,GRN,Jill Stein,1
-Humboldt,1CS-2,President,,REP,John R. Kasich,8
-Humboldt,1CS-2,President,,REP,Ted Cruz,6
-Humboldt,1CS-2,Proposition 50,,,No,37
-Humboldt,1CS-2,Proposition 50,,,Yes,124
-Humboldt,1CS-2,State Assembly,2,DEM,Jim Wood,130
-Humboldt,1CS-2,U.S. House,2,REP,Dale K. Mensing,35
-Humboldt,1CS-2,U.S. House,2,DEM,Erin A. Schrode,14
-Humboldt,1CS-2,U.S. House,2,DEM,Jared W. Huffman,99
-Humboldt,1CS-2,U.S. House,2,IND,Matthew Robert Wookey,18
+Humboldt,1CS-2,President,,REP,John R. Kasich,19
+Humboldt,1CS-2,President,,AIP,Robert Ornelas,1
+Humboldt,1CS-2,President,,REP,Ted Cruz,15
+Humboldt,1CS-2,Proposition 50,,,No,78
+Humboldt,1CS-2,Proposition 50,,,Yes,338
+Humboldt,1CS-2,State Assembly,2,DEM,Jim Wood,317
+Humboldt,1CS-2,U.S. House,2,REP,Dale K. Mensing,109
+Humboldt,1CS-2,U.S. House,2,DEM,Erin A. Schrode,31
+Humboldt,1CS-2,U.S. House,2,DEM,Jared W. Huffman,257
+Humboldt,1CS-2,U.S. House,2,IND,Matthew Robert Wookey,27
 Humboldt,1CS-2,U.S. Senate,,IND,Clive Grey,2
 Humboldt,1CS-2,U.S. Senate,,REP,Don Krampe,1
-Humboldt,1CS-2,U.S. Senate,,REP,Duf Sundheim,8
+Humboldt,1CS-2,U.S. Senate,,REP,Duf Sundheim,34
 Humboldt,1CS-2,U.S. Senate,,IND,Eleanor García,2
 Humboldt,1CS-2,U.S. Senate,,DEM,Emory Rodgers,1
-Humboldt,1CS-2,U.S. Senate,,LIB,Gail K. Lightfoot,4
-Humboldt,1CS-2,U.S. Senate,,REP,Greg Conlon,10
+Humboldt,1CS-2,U.S. Senate,,LIB,Gail K. Lightfoot,13
+Humboldt,1CS-2,U.S. Senate,,REP,Greg Conlon,24
 Humboldt,1CS-2,U.S. Senate,,REP,Jarrell Williamson,1
-Humboldt,1CS-2,U.S. Senate,,IND,Jason Hanania,1
-Humboldt,1CS-2,U.S. Senate,,REP,Jerry J. Laws,9
-Humboldt,1CS-2,U.S. Senate,,DEM,Kamala D. Harris,53
-Humboldt,1CS-2,U.S. Senate,,REP,Karen Roseberry,1
+Humboldt,1CS-2,U.S. Senate,,IND,Jason Hanania,4
+Humboldt,1CS-2,U.S. Senate,,IND,Jason Kraus,3
+Humboldt,1CS-2,U.S. Senate,,REP,Jerry J. Laws,21
+Humboldt,1CS-2,U.S. Senate,,DEM,Kamala D. Harris,140
+Humboldt,1CS-2,U.S. Senate,,REP,Karen Roseberry,3
 Humboldt,1CS-2,U.S. Senate,,IND,Ling Ling Shi,1
-Humboldt,1CS-2,U.S. Senate,,DEM,Loretta L. Sanchez,23
-Humboldt,1CS-2,U.S. Senate,,LIB,Mark Matthew Herd,1
-Humboldt,1CS-2,U.S. Senate,,DEM,Massie Munroe,4
-Humboldt,1CS-2,U.S. Senate,,IND,Mike Beitiks,4
-Humboldt,1CS-2,U.S. Senate,,GRN,Pamela Elizondo,5
+Humboldt,1CS-2,U.S. Senate,,DEM,Loretta L. Sanchez,55
+Humboldt,1CS-2,U.S. Senate,,LIB,Mark Matthew Herd,3
+Humboldt,1CS-2,U.S. Senate,,DEM,Massie Munroe,7
+Humboldt,1CS-2,U.S. Senate,,IND,Mike Beitiks,6
+Humboldt,1CS-2,U.S. Senate,,GRN,Pamela Elizondo,12
 Humboldt,1CS-2,U.S. Senate,,IND,Paul Merritt,1
-Humboldt,1CS-2,U.S. Senate,,REP,Phil Wyman,8
+Humboldt,1CS-2,U.S. Senate,,REP,Phil Wyman,33
 Humboldt,1CS-2,U.S. Senate,,DEM,President Cristina Grappo,1
-Humboldt,1CS-2,U.S. Senate,,REP,Ron Unz,3
-Humboldt,1CS-2,U.S. Senate,,DEM,Steve Stokes,15
-Humboldt,1CS-2,U.S. Senate,,REP,Thomas G. Del Beccaro,4
-Humboldt,1CS-2,U.S. Senate,,REP,Tom Palzer,2
-Humboldt,1CS-2,U.S. Senate,,REP,Von Hougo,1
-Humboldt,1CS-2_A,President,,REP,Ben Carson,5
-Humboldt,1CS-2_A,President,,DEM,Bernie Sanders,88
-Humboldt,1CS-2_A,President,,REP,Donald Trump,78
-Humboldt,1CS-2_A,President,,LIB,Gary Johnson,1
-Humboldt,1CS-2_A,President,,DEM,Hillary Clinton,61
-Humboldt,1CS-2_A,President,,REP,John R. Kasich,11
-Humboldt,1CS-2_A,President,,AIP,Robert Ornelas,1
-Humboldt,1CS-2_A,President,,REP,Ted Cruz,9
-Humboldt,1CS-2_A,Proposition 50,,,No,41
-Humboldt,1CS-2_A,Proposition 50,,,Yes,214
-Humboldt,1CS-2_A,State Assembly,2,DEM,Jim Wood,187
-Humboldt,1CS-2_A,U.S. House,2,REP,Dale K. Mensing,74
-Humboldt,1CS-2_A,U.S. House,2,DEM,Erin A. Schrode,17
-Humboldt,1CS-2_A,U.S. House,2,DEM,Jared W. Huffman,158
-Humboldt,1CS-2_A,U.S. House,2,IND,Matthew Robert Wookey,9
-Humboldt,1CS-2_A,U.S. Senate,,REP,Duf Sundheim,26
-Humboldt,1CS-2_A,U.S. Senate,,LIB,Gail K. Lightfoot,9
-Humboldt,1CS-2_A,U.S. Senate,,REP,Greg Conlon,14
-Humboldt,1CS-2_A,U.S. Senate,,IND,Jason Hanania,3
-Humboldt,1CS-2_A,U.S. Senate,,IND,Jason Kraus,3
-Humboldt,1CS-2_A,U.S. Senate,,REP,Jerry J. Laws,12
-Humboldt,1CS-2_A,U.S. Senate,,DEM,Kamala D. Harris,87
-Humboldt,1CS-2_A,U.S. Senate,,REP,Karen Roseberry,2
-Humboldt,1CS-2_A,U.S. Senate,,DEM,Loretta L. Sanchez,32
-Humboldt,1CS-2_A,U.S. Senate,,LIB,Mark Matthew Herd,2
-Humboldt,1CS-2_A,U.S. Senate,,DEM,Massie Munroe,3
-Humboldt,1CS-2_A,U.S. Senate,,IND,Mike Beitiks,2
-Humboldt,1CS-2_A,U.S. Senate,,GRN,Pamela Elizondo,7
-Humboldt,1CS-2_A,U.S. Senate,,REP,Phil Wyman,25
-Humboldt,1CS-2_A,U.S. Senate,,REP,Ron Unz,7
-Humboldt,1CS-2_A,U.S. Senate,,DEM,Steve Stokes,5
-Humboldt,1CS-2_A,U.S. Senate,,REP,Thomas G. Del Beccaro,5
-Humboldt,1CS-2_A,U.S. Senate,,REP,Tom Palzer,4
-Humboldt,1CS-2_A,U.S. Senate,,REP,Von Hougo,3
-Humboldt,1CS-3,President,,REP,Ben Carson,4
-Humboldt,1CS-3,President,,DEM,Bernie Sanders,56
-Humboldt,1CS-3,President,,REP,Donald Trump,49
-Humboldt,1CS-3,President,,DEM,Hillary Clinton,34
-Humboldt,1CS-3,President,,REP,John R. Kasich,8
+Humboldt,1CS-2,U.S. Senate,,REP,Ron Unz,10
+Humboldt,1CS-2,U.S. Senate,,DEM,Steve Stokes,20
+Humboldt,1CS-2,U.S. Senate,,REP,Thomas G. Del Beccaro,9
+Humboldt,1CS-2,U.S. Senate,,REP,Tom Palzer,6
+Humboldt,1CS-2,U.S. Senate,,REP,Von Hougo,4
+Humboldt,1CS-3,President,,REP,Ben Carson,11
+Humboldt,1CS-3,President,,DEM,Bernie Sanders,126
+Humboldt,1CS-3,President,,GRN,Darryl Cherney,2
+Humboldt,1CS-3,President,,REP,Donald Trump,106
+Humboldt,1CS-3,President,,DEM,Hillary Clinton,100
+Humboldt,1CS-3,President,,REP,Jim Gilmore,1
+Humboldt,1CS-3,President,,REP,John R. Kasich,17
 Humboldt,1CS-3,President,,DEM,Michael Steinberg,1
-Humboldt,1CS-3,President,,REP,Ted Cruz,11
+Humboldt,1CS-3,President,,REP,Ted Cruz,22
 Humboldt,1CS-3,President,,DEM,Willie Wilson,1
-Humboldt,1CS-3,Proposition 50,,,No,34
-Humboldt,1CS-3,Proposition 50,,,Yes,127
-Humboldt,1CS-3,State Assembly,2,DEM,Jim Wood,125
-Humboldt,1CS-3,U.S. House,2,REP,Dale K. Mensing,47
-Humboldt,1CS-3,U.S. House,2,DEM,Erin A. Schrode,10
-Humboldt,1CS-3,U.S. House,2,DEM,Jared W. Huffman,106
-Humboldt,1CS-3,U.S. House,2,IND,Matthew Robert Wookey,10
+Humboldt,1CS-3,Proposition 50,,,No,87
+Humboldt,1CS-3,Proposition 50,,,Yes,306
+Humboldt,1CS-3,State Assembly,2,DEM,Jim Wood,302
+Humboldt,1CS-3,U.S. House,2,REP,Dale K. Mensing,115
+Humboldt,1CS-3,U.S. House,2,DEM,Erin A. Schrode,25
+Humboldt,1CS-3,U.S. House,2,DEM,Jared W. Huffman,263
+Humboldt,1CS-3,U.S. House,2,IND,Matthew Robert Wookey,17
 Humboldt,1CS-3,U.S. Senate,,IND,Clive Grey,1
-Humboldt,1CS-3,U.S. Senate,,REP,Don Krampe,1
-Humboldt,1CS-3,U.S. Senate,,REP,Duf Sundheim,13
+Humboldt,1CS-3,U.S. Senate,,IND,Don J. Grundmann,1
+Humboldt,1CS-3,U.S. Senate,,REP,Don Krampe,7
+Humboldt,1CS-3,U.S. Senate,,REP,Duf Sundheim,30
 Humboldt,1CS-3,U.S. Senate,,IND,Eleanor García,1
-Humboldt,1CS-3,U.S. Senate,,LIB,Gail K. Lightfoot,5
-Humboldt,1CS-3,U.S. Senate,,REP,Greg Conlon,16
-Humboldt,1CS-3,U.S. Senate,,REP,Jarrell Williamson,1
+Humboldt,1CS-3,U.S. Senate,,LIB,Gail K. Lightfoot,10
+Humboldt,1CS-3,U.S. Senate,,REP,Greg Conlon,31
+Humboldt,1CS-3,U.S. Senate,,DEM,Herbert G. Peters,1
+Humboldt,1CS-3,U.S. Senate,,REP,Jarrell Williamson,6
 Humboldt,1CS-3,U.S. Senate,,IND,Jason Hanania,1
 Humboldt,1CS-3,U.S. Senate,,IND,Jason Kraus,1
-Humboldt,1CS-3,U.S. Senate,,REP,Jerry J. Laws,14
-Humboldt,1CS-3,U.S. Senate,,DEM,Kamala D. Harris,64
-Humboldt,1CS-3,U.S. Senate,,REP,Karen Roseberry,1
-Humboldt,1CS-3,U.S. Senate,,IND,Ling Ling Shi,2
-Humboldt,1CS-3,U.S. Senate,,DEM,Loretta L. Sanchez,15
+Humboldt,1CS-3,U.S. Senate,,REP,Jerry J. Laws,26
+Humboldt,1CS-3,U.S. Senate,,DEM,Kamala D. Harris,154
+Humboldt,1CS-3,U.S. Senate,,REP,Karen Roseberry,4
+Humboldt,1CS-3,U.S. Senate,,IND,Ling Ling Shi,4
+Humboldt,1CS-3,U.S. Senate,,DEM,Loretta L. Sanchez,55
+Humboldt,1CS-3,U.S. Senate,,LIB,Mark Matthew Herd,1
 Humboldt,1CS-3,U.S. Senate,,DEM,Massie Munroe,1
-Humboldt,1CS-3,U.S. Senate,,IND,Mike Beitiks,4
-Humboldt,1CS-3,U.S. Senate,,GRN,Pamela Elizondo,2
-Humboldt,1CS-3,U.S. Senate,,IND,Paul Merritt,2
-Humboldt,1CS-3,U.S. Senate,,REP,Phil Wyman,11
+Humboldt,1CS-3,U.S. Senate,,IND,Mike Beitiks,6
+Humboldt,1CS-3,U.S. Senate,,GRN,Pamela Elizondo,4
+Humboldt,1CS-3,U.S. Senate,,IND,Paul Merritt,3
+Humboldt,1CS-3,U.S. Senate,,REP,Phil Wyman,29
 Humboldt,1CS-3,U.S. Senate,,REP,Ron Unz,2
-Humboldt,1CS-3,U.S. Senate,,DEM,Steve Stokes,3
-Humboldt,1CS-3,U.S. Senate,,REP,Thomas G. Del Beccaro,3
-Humboldt,1CS-3,U.S. Senate,,REP,Tom Palzer,1
+Humboldt,1CS-3,U.S. Senate,,IND,Scott A. Vineberg,1
+Humboldt,1CS-3,U.S. Senate,,DEM,Steve Stokes,6
+Humboldt,1CS-3,U.S. Senate,,REP,Thomas G. Del Beccaro,11
+Humboldt,1CS-3,U.S. Senate,,REP,Tom Palzer,3
 Humboldt,1CS-3,U.S. Senate,,REP,Von Hougo,1
-Humboldt,1CS-3_A,President,,REP,Ben Carson,7
-Humboldt,1CS-3_A,President,,DEM,Bernie Sanders,70
-Humboldt,1CS-3_A,President,,GRN,Darryl Cherney,2
-Humboldt,1CS-3_A,President,,REP,Donald Trump,57
-Humboldt,1CS-3_A,President,,DEM,Hillary Clinton,66
-Humboldt,1CS-3_A,President,,REP,Jim Gilmore,1
-Humboldt,1CS-3_A,President,,REP,John R. Kasich,9
-Humboldt,1CS-3_A,President,,REP,Ted Cruz,11
-Humboldt,1CS-3_A,Proposition 50,,,No,53
-Humboldt,1CS-3_A,Proposition 50,,,Yes,179
-Humboldt,1CS-3_A,State Assembly,2,DEM,Jim Wood,177
-Humboldt,1CS-3_A,U.S. House,2,REP,Dale K. Mensing,68
-Humboldt,1CS-3_A,U.S. House,2,DEM,Erin A. Schrode,15
-Humboldt,1CS-3_A,U.S. House,2,DEM,Jared W. Huffman,157
-Humboldt,1CS-3_A,U.S. House,2,IND,Matthew Robert Wookey,7
-Humboldt,1CS-3_A,U.S. Senate,,IND,Don J. Grundmann,1
-Humboldt,1CS-3_A,U.S. Senate,,REP,Don Krampe,6
-Humboldt,1CS-3_A,U.S. Senate,,REP,Duf Sundheim,17
-Humboldt,1CS-3_A,U.S. Senate,,LIB,Gail K. Lightfoot,5
-Humboldt,1CS-3_A,U.S. Senate,,REP,Greg Conlon,15
-Humboldt,1CS-3_A,U.S. Senate,,DEM,Herbert G. Peters,1
-Humboldt,1CS-3_A,U.S. Senate,,REP,Jarrell Williamson,5
-Humboldt,1CS-3_A,U.S. Senate,,REP,Jerry J. Laws,12
-Humboldt,1CS-3_A,U.S. Senate,,DEM,Kamala D. Harris,90
-Humboldt,1CS-3_A,U.S. Senate,,REP,Karen Roseberry,3
-Humboldt,1CS-3_A,U.S. Senate,,IND,Ling Ling Shi,2
-Humboldt,1CS-3_A,U.S. Senate,,DEM,Loretta L. Sanchez,40
-Humboldt,1CS-3_A,U.S. Senate,,LIB,Mark Matthew Herd,1
-Humboldt,1CS-3_A,U.S. Senate,,IND,Mike Beitiks,2
-Humboldt,1CS-3_A,U.S. Senate,,GRN,Pamela Elizondo,2
-Humboldt,1CS-3_A,U.S. Senate,,IND,Paul Merritt,1
-Humboldt,1CS-3_A,U.S. Senate,,REP,Phil Wyman,18
-Humboldt,1CS-3_A,U.S. Senate,,IND,Scott A. Vineberg,1
-Humboldt,1CS-3_A,U.S. Senate,,DEM,Steve Stokes,3
-Humboldt,1CS-3_A,U.S. Senate,,REP,Thomas G. Del Beccaro,8
-Humboldt,1CS-3_A,U.S. Senate,,REP,Tom Palzer,2
-Humboldt,1CS-4,President,,REP,Ben Carson,4
-Humboldt,1CS-4,President,,DEM,Bernie Sanders,102
+Humboldt,1CS-4,President,,AIP,Alan Spears,2
+Humboldt,1CS-4,President,,REP,Ben Carson,8
+Humboldt,1CS-4,President,,DEM,Bernie Sanders,172
 Humboldt,1CS-4,President,,GRN,Darryl Cherney,1
-Humboldt,1CS-4,President,,REP,Donald Trump,41
-Humboldt,1CS-4,President,,DEM,Hillary Clinton,28
-Humboldt,1CS-4,President,,GRN,Jill Stein,1
-Humboldt,1CS-4,President,,REP,John R. Kasich,4
-Humboldt,1CS-4,President,,DEM,Keith Judd,1
-Humboldt,1CS-4,President,,REP,Ted Cruz,9
+Humboldt,1CS-4,President,,REP,Donald Trump,105
+Humboldt,1CS-4,President,,LIB,Gary Johnson,1
+Humboldt,1CS-4,President,,DEM,Hillary Clinton,82
+Humboldt,1CS-4,President,,GRN,Jill Stein,2
+Humboldt,1CS-4,President,,LIB,John McAfee,1
+Humboldt,1CS-4,President,,REP,John R. Kasich,15
+Humboldt,1CS-4,President,,DEM,Keith Judd,2
+Humboldt,1CS-4,President,,REP,Ted Cruz,22
 Humboldt,1CS-4,President,,AIP,Wiley Drake,1
-Humboldt,1CS-4,Proposition 50,,,No,43
-Humboldt,1CS-4,Proposition 50,,,Yes,132
-Humboldt,1CS-4,State Assembly,2,DEM,Jim Wood,143
-Humboldt,1CS-4,U.S. House,2,REP,Dale K. Mensing,42
-Humboldt,1CS-4,U.S. House,2,DEM,Erin A. Schrode,18
-Humboldt,1CS-4,U.S. House,2,DEM,Jared W. Huffman,107
-Humboldt,1CS-4,U.S. House,2,IND,Matthew Robert Wookey,22
+Humboldt,1CS-4,Proposition 50,,,No,90
+Humboldt,1CS-4,Proposition 50,,,Yes,317
+Humboldt,1CS-4,State Assembly,2,DEM,Jim Wood,298
+Humboldt,1CS-4,U.S. House,2,REP,Dale K. Mensing,116
+Humboldt,1CS-4,U.S. House,2,DEM,Erin A. Schrode,30
+Humboldt,1CS-4,U.S. House,2,DEM,Jared W. Huffman,239
+Humboldt,1CS-4,U.S. House,2,IND,Matthew Robert Wookey,36
 Humboldt,1CS-4,U.S. Senate,,IND,Clive Grey,3
-Humboldt,1CS-4,U.S. Senate,,IND,Don J. Grundmann,1
-Humboldt,1CS-4,U.S. Senate,,REP,Don Krampe,6
-Humboldt,1CS-4,U.S. Senate,,REP,Duf Sundheim,12
-Humboldt,1CS-4,U.S. Senate,,IND,Eleanor García,3
-Humboldt,1CS-4,U.S. Senate,,LIB,Gail K. Lightfoot,5
-Humboldt,1CS-4,U.S. Senate,,REP,Greg Conlon,8
-Humboldt,1CS-4,U.S. Senate,,REP,Jarrell Williamson,1
-Humboldt,1CS-4,U.S. Senate,,REP,Jerry J. Laws,11
-Humboldt,1CS-4,U.S. Senate,,DEM,Kamala D. Harris,47
-Humboldt,1CS-4,U.S. Senate,,REP,Karen Roseberry,3
+Humboldt,1CS-4,U.S. Senate,,IND,Don J. Grundmann,2
+Humboldt,1CS-4,U.S. Senate,,REP,Don Krampe,8
+Humboldt,1CS-4,U.S. Senate,,REP,Duf Sundheim,32
+Humboldt,1CS-4,U.S. Senate,,IND,Eleanor García,5
+Humboldt,1CS-4,U.S. Senate,,LIB,Gail K. Lightfoot,9
+Humboldt,1CS-4,U.S. Senate,,REP,Greg Conlon,26
+Humboldt,1CS-4,U.S. Senate,,REP,Jarrell Williamson,6
+Humboldt,1CS-4,U.S. Senate,,REP,Jerry J. Laws,20
+Humboldt,1CS-4,U.S. Senate,,PAF,John Thompson Parker,1
+Humboldt,1CS-4,U.S. Senate,,DEM,Kamala D. Harris,128
+Humboldt,1CS-4,U.S. Senate,,REP,Karen Roseberry,7
 Humboldt,1CS-4,U.S. Senate,,IND,Ling Ling Shi,1
-Humboldt,1CS-4,U.S. Senate,,DEM,Loretta L. Sanchez,28
-Humboldt,1CS-4,U.S. Senate,,LIB,Mark Matthew Herd,2
-Humboldt,1CS-4,U.S. Senate,,DEM,Massie Munroe,3
-Humboldt,1CS-4,U.S. Senate,,IND,Mike Beitiks,3
-Humboldt,1CS-4,U.S. Senate,,GRN,Pamela Elizondo,12
-Humboldt,1CS-4,U.S. Senate,,REP,Phil Wyman,13
+Humboldt,1CS-4,U.S. Senate,,DEM,Loretta L. Sanchez,57
+Humboldt,1CS-4,U.S. Senate,,LIB,Mark Matthew Herd,4
+Humboldt,1CS-4,U.S. Senate,,DEM,Massie Munroe,6
+Humboldt,1CS-4,U.S. Senate,,IND,Mike Beitiks,4
+Humboldt,1CS-4,U.S. Senate,,GRN,Pamela Elizondo,14
+Humboldt,1CS-4,U.S. Senate,,IND,Paul Merritt,2
+Humboldt,1CS-4,U.S. Senate,,REP,Phil Wyman,28
 Humboldt,1CS-4,U.S. Senate,,DEM,President Cristina Grappo,1
-Humboldt,1CS-4,U.S. Senate,,REP,Ron Unz,1
-Humboldt,1CS-4,U.S. Senate,,DEM,Steve Stokes,13
-Humboldt,1CS-4,U.S. Senate,,REP,Thomas G. Del Beccaro,2
-Humboldt,1CS-4,U.S. Senate,,IND,Tim Gildersleeve,1
-Humboldt,1CS-4,U.S. Senate,,REP,Tom Palzer,1
-Humboldt,1CS-4,U.S. Senate,,REP,Von Hougo,3
-Humboldt,1CS-4_A,President,,AIP,Alan Spears,2
-Humboldt,1CS-4_A,President,,REP,Ben Carson,4
-Humboldt,1CS-4_A,President,,DEM,Bernie Sanders,70
-Humboldt,1CS-4_A,President,,REP,Donald Trump,64
-Humboldt,1CS-4_A,President,,LIB,Gary Johnson,1
-Humboldt,1CS-4_A,President,,DEM,Hillary Clinton,54
-Humboldt,1CS-4_A,President,,GRN,Jill Stein,1
-Humboldt,1CS-4_A,President,,LIB,John McAfee,1
-Humboldt,1CS-4_A,President,,REP,John R. Kasich,11
-Humboldt,1CS-4_A,President,,DEM,Keith Judd,1
-Humboldt,1CS-4_A,President,,REP,Ted Cruz,13
-Humboldt,1CS-4_A,Proposition 50,,,No,47
-Humboldt,1CS-4_A,Proposition 50,,,Yes,185
-Humboldt,1CS-4_A,State Assembly,2,DEM,Jim Wood,155
-Humboldt,1CS-4_A,U.S. House,2,REP,Dale K. Mensing,74
-Humboldt,1CS-4_A,U.S. House,2,DEM,Erin A. Schrode,12
-Humboldt,1CS-4_A,U.S. House,2,DEM,Jared W. Huffman,132
-Humboldt,1CS-4_A,U.S. House,2,IND,Matthew Robert Wookey,14
-Humboldt,1CS-4_A,U.S. Senate,,IND,Don J. Grundmann,1
-Humboldt,1CS-4_A,U.S. Senate,,REP,Don Krampe,2
-Humboldt,1CS-4_A,U.S. Senate,,REP,Duf Sundheim,20
-Humboldt,1CS-4_A,U.S. Senate,,IND,Eleanor García,2
-Humboldt,1CS-4_A,U.S. Senate,,LIB,Gail K. Lightfoot,4
-Humboldt,1CS-4_A,U.S. Senate,,REP,Greg Conlon,18
-Humboldt,1CS-4_A,U.S. Senate,,REP,Jarrell Williamson,5
-Humboldt,1CS-4_A,U.S. Senate,,REP,Jerry J. Laws,9
-Humboldt,1CS-4_A,U.S. Senate,,PAF,John Thompson Parker,1
-Humboldt,1CS-4_A,U.S. Senate,,DEM,Kamala D. Harris,81
-Humboldt,1CS-4_A,U.S. Senate,,REP,Karen Roseberry,4
-Humboldt,1CS-4_A,U.S. Senate,,DEM,Loretta L. Sanchez,29
-Humboldt,1CS-4_A,U.S. Senate,,LIB,Mark Matthew Herd,2
-Humboldt,1CS-4_A,U.S. Senate,,DEM,Massie Munroe,3
-Humboldt,1CS-4_A,U.S. Senate,,IND,Mike Beitiks,1
-Humboldt,1CS-4_A,U.S. Senate,,GRN,Pamela Elizondo,2
-Humboldt,1CS-4_A,U.S. Senate,,IND,Paul Merritt,2
-Humboldt,1CS-4_A,U.S. Senate,,REP,Phil Wyman,15
-Humboldt,1CS-4_A,U.S. Senate,,REP,Ron Unz,1
-Humboldt,1CS-4_A,U.S. Senate,,DEM,Steve Stokes,13
-Humboldt,1CS-4_A,U.S. Senate,,REP,Thomas G. Del Beccaro,4
-Humboldt,1CS-4_A,U.S. Senate,,IND,Tim Gildersleeve,1
-Humboldt,1CS-4_A,U.S. Senate,,REP,Tom Palzer,4
-Humboldt,1CS-4_A,U.S. Senate,,REP,Von Hougo,7
+Humboldt,1CS-4,U.S. Senate,,REP,Ron Unz,2
+Humboldt,1CS-4,U.S. Senate,,DEM,Steve Stokes,26
+Humboldt,1CS-4,U.S. Senate,,REP,Thomas G. Del Beccaro,6
+Humboldt,1CS-4,U.S. Senate,,IND,Tim Gildersleeve,2
+Humboldt,1CS-4,U.S. Senate,,REP,Tom Palzer,5
+Humboldt,1CS-4,U.S. Senate,,REP,Von Hougo,10
 Humboldt,1E-36,President,,AIP,Alan Spears,1
-Humboldt,1E-36,President,,REP,Ben Carson,1
-Humboldt,1E-36,President,,DEM,Bernie Sanders,112
-Humboldt,1E-36,President,,REP,Donald Trump,31
-Humboldt,1E-36,President,,LIB,Gary Johnson,2
-Humboldt,1E-36,President,,DEM,Hillary Clinton,41
+Humboldt,1E-36,President,,REP,Ben Carson,2
+Humboldt,1E-36,President,,DEM,Bernie Sanders,239
+Humboldt,1E-36,President,,GRN,Darryl Cherney,1
+Humboldt,1E-36,President,,REP,Donald Trump,99
+Humboldt,1E-36,President,,LIB,Gary Johnson,3
+Humboldt,1E-36,President,,DEM,Henry Hewes,1
+Humboldt,1E-36,President,,DEM,Hillary Clinton,118
 Humboldt,1E-36,President,,GRN,Jill Stein,1
-Humboldt,1E-36,President,,REP,John R. Kasich,4
-Humboldt,1E-36,President,,REP,Ted Cruz,5
-Humboldt,1E-36,Proposition 50,,,No,41
-Humboldt,1E-36,Proposition 50,,,Yes,141
-Humboldt,1E-36,State Assembly,2,DEM,Jim Wood,137
-Humboldt,1E-36,U.S. House,2,REP,Dale K. Mensing,31
-Humboldt,1E-36,U.S. House,2,DEM,Erin A. Schrode,10
-Humboldt,1E-36,U.S. House,2,DEM,Jared W. Huffman,127
-Humboldt,1E-36,U.S. House,2,IND,Matthew Robert Wookey,22
+Humboldt,1E-36,President,,REP,John R. Kasich,20
+Humboldt,1E-36,President,,LIB,Marc Feldman,1
+Humboldt,1E-36,President,,DEM,Michael Steinberg,3
+Humboldt,1E-36,President,,AIP,Robert Ornelas,1
+Humboldt,1E-36,President,,REP,Ted Cruz,13
+Humboldt,1E-36,President,,DEM,Willie Wilson,1
+Humboldt,1E-36,Proposition 50,,,No,97
+Humboldt,1E-36,Proposition 50,,,Yes,377
+Humboldt,1E-36,State Assembly,2,DEM,Jim Wood,364
+Humboldt,1E-36,U.S. House,2,REP,Dale K. Mensing,93
+Humboldt,1E-36,U.S. House,2,DEM,Erin A. Schrode,38
+Humboldt,1E-36,U.S. House,2,DEM,Jared W. Huffman,325
+Humboldt,1E-36,U.S. House,2,IND,Matthew Robert Wookey,44
 Humboldt,1E-36,U.S. Senate,,IND,Clive Grey,2
 Humboldt,1E-36,U.S. Senate,,IND,Don J. Grundmann,1
-Humboldt,1E-36,U.S. Senate,,REP,Don Krampe,2
-Humboldt,1E-36,U.S. Senate,,REP,Duf Sundheim,8
+Humboldt,1E-36,U.S. Senate,,REP,Don Krampe,6
+Humboldt,1E-36,U.S. Senate,,REP,Duf Sundheim,19
 Humboldt,1E-36,U.S. Senate,,DEM,Emory Rodgers,1
-Humboldt,1E-36,U.S. Senate,,LIB,Gail K. Lightfoot,14
-Humboldt,1E-36,U.S. Senate,,REP,George C. Yang,1
-Humboldt,1E-36,U.S. Senate,,REP,Greg Conlon,8
-Humboldt,1E-36,U.S. Senate,,REP,Jerry J. Laws,7
-Humboldt,1E-36,U.S. Senate,,DEM,Kamala D. Harris,75
-Humboldt,1E-36,U.S. Senate,,REP,Karen Roseberry,1
-Humboldt,1E-36,U.S. Senate,,IND,Ling Ling Shi,1
-Humboldt,1E-36,U.S. Senate,,DEM,Loretta L. Sanchez,27
-Humboldt,1E-36,U.S. Senate,,LIB,Mark Matthew Herd,2
-Humboldt,1E-36,U.S. Senate,,DEM,Massie Munroe,5
-Humboldt,1E-36,U.S. Senate,,GRN,Pamela Elizondo,7
+Humboldt,1E-36,U.S. Senate,,LIB,Gail K. Lightfoot,21
+Humboldt,1E-36,U.S. Senate,,REP,George C. Yang,3
+Humboldt,1E-36,U.S. Senate,,REP,Greg Conlon,26
+Humboldt,1E-36,U.S. Senate,,DEM,Herbert G. Peters,1
+Humboldt,1E-36,U.S. Senate,,REP,Jarrell Williamson,3
+Humboldt,1E-36,U.S. Senate,,IND,Jason Kraus,1
+Humboldt,1E-36,U.S. Senate,,REP,Jerry J. Laws,23
+Humboldt,1E-36,U.S. Senate,,DEM,Kamala D. Harris,201
+Humboldt,1E-36,U.S. Senate,,REP,Karen Roseberry,3
+Humboldt,1E-36,U.S. Senate,,IND,Ling Ling Shi,4
+Humboldt,1E-36,U.S. Senate,,DEM,Loretta L. Sanchez,79
+Humboldt,1E-36,U.S. Senate,,LIB,Mark Matthew Herd,5
+Humboldt,1E-36,U.S. Senate,,DEM,Massie Munroe,9
+Humboldt,1E-36,U.S. Senate,,IND,Mike Beitiks,4
+Humboldt,1E-36,U.S. Senate,,GRN,Pamela Elizondo,16
 Humboldt,1E-36,U.S. Senate,,IND,Paul Merritt,1
-Humboldt,1E-36,U.S. Senate,,REP,Phil Wyman,4
-Humboldt,1E-36,U.S. Senate,,DEM,President Cristina Grappo,1
+Humboldt,1E-36,U.S. Senate,,REP,Phil Wyman,33
+Humboldt,1E-36,U.S. Senate,,DEM,President Cristina Grappo,2
 Humboldt,1E-36,U.S. Senate,,REP,Ron Unz,1
-Humboldt,1E-36,U.S. Senate,,DEM,Steve Stokes,9
-Humboldt,1E-36,U.S. Senate,,REP,Thomas G. Del Beccaro,2
-Humboldt,1E-36,U.S. Senate,,REP,Von Hougo,1
-Humboldt,1E-36_A,President,,REP,Ben Carson,1
-Humboldt,1E-36_A,President,,DEM,Bernie Sanders,127
-Humboldt,1E-36_A,President,,GRN,Darryl Cherney,1
-Humboldt,1E-36_A,President,,REP,Donald Trump,68
-Humboldt,1E-36_A,President,,LIB,Gary Johnson,1
-Humboldt,1E-36_A,President,,DEM,Henry Hewes,1
-Humboldt,1E-36_A,President,,DEM,Hillary Clinton,77
-Humboldt,1E-36_A,President,,REP,John R. Kasich,16
-Humboldt,1E-36_A,President,,LIB,Marc Feldman,1
-Humboldt,1E-36_A,President,,DEM,Michael Steinberg,3
-Humboldt,1E-36_A,President,,AIP,Robert Ornelas,1
-Humboldt,1E-36_A,President,,REP,Ted Cruz,8
-Humboldt,1E-36_A,President,,DEM,Willie Wilson,1
-Humboldt,1E-36_A,Proposition 50,,,No,56
-Humboldt,1E-36_A,Proposition 50,,,Yes,236
-Humboldt,1E-36_A,State Assembly,2,DEM,Jim Wood,227
-Humboldt,1E-36_A,U.S. House,2,REP,Dale K. Mensing,62
-Humboldt,1E-36_A,U.S. House,2,DEM,Erin A. Schrode,28
-Humboldt,1E-36_A,U.S. House,2,DEM,Jared W. Huffman,198
-Humboldt,1E-36_A,U.S. House,2,IND,Matthew Robert Wookey,22
-Humboldt,1E-36_A,U.S. Senate,,REP,Don Krampe,4
-Humboldt,1E-36_A,U.S. Senate,,REP,Duf Sundheim,11
-Humboldt,1E-36_A,U.S. Senate,,LIB,Gail K. Lightfoot,7
-Humboldt,1E-36_A,U.S. Senate,,REP,George C. Yang,2
-Humboldt,1E-36_A,U.S. Senate,,REP,Greg Conlon,18
-Humboldt,1E-36_A,U.S. Senate,,DEM,Herbert G. Peters,1
-Humboldt,1E-36_A,U.S. Senate,,REP,Jarrell Williamson,3
-Humboldt,1E-36_A,U.S. Senate,,IND,Jason Kraus,1
-Humboldt,1E-36_A,U.S. Senate,,REP,Jerry J. Laws,16
-Humboldt,1E-36_A,U.S. Senate,,DEM,Kamala D. Harris,126
-Humboldt,1E-36_A,U.S. Senate,,REP,Karen Roseberry,2
-Humboldt,1E-36_A,U.S. Senate,,IND,Ling Ling Shi,3
-Humboldt,1E-36_A,U.S. Senate,,DEM,Loretta L. Sanchez,52
-Humboldt,1E-36_A,U.S. Senate,,LIB,Mark Matthew Herd,3
-Humboldt,1E-36_A,U.S. Senate,,DEM,Massie Munroe,4
-Humboldt,1E-36_A,U.S. Senate,,IND,Mike Beitiks,4
-Humboldt,1E-36_A,U.S. Senate,,GRN,Pamela Elizondo,9
-Humboldt,1E-36_A,U.S. Senate,,REP,Phil Wyman,29
-Humboldt,1E-36_A,U.S. Senate,,DEM,President Cristina Grappo,1
-Humboldt,1E-36_A,U.S. Senate,,DEM,Steve Stokes,6
-Humboldt,1E-36_A,U.S. Senate,,REP,Thomas G. Del Beccaro,3
-Humboldt,1E-36_A,U.S. Senate,,REP,Tom Palzer,2
-Humboldt,1E-36_A,U.S. Senate,,REP,Von Hougo,1
-Humboldt,1E-43,President,,REP,Ben Carson,1
-Humboldt,1E-43,President,,DEM,Bernie Sanders,82
-Humboldt,1E-43,President,,REP,Donald Trump,22
-Humboldt,1E-43,President,,DEM,Hillary Clinton,61
-Humboldt,1E-43,President,,GRN,Jill Stein,1
-Humboldt,1E-43,President,,REP,Jim Gilmore,2
-Humboldt,1E-43,President,,REP,John R. Kasich,7
+Humboldt,1E-36,U.S. Senate,,DEM,Steve Stokes,15
+Humboldt,1E-36,U.S. Senate,,REP,Thomas G. Del Beccaro,5
+Humboldt,1E-36,U.S. Senate,,REP,Tom Palzer,2
+Humboldt,1E-36,U.S. Senate,,REP,Von Hougo,2
+Humboldt,1E-43,President,,AIP,Arthur Harris,1
+Humboldt,1E-43,President,,REP,Ben Carson,6
+Humboldt,1E-43,President,,DEM,Bernie Sanders,183
+Humboldt,1E-43,President,,REP,Donald Trump,82
+Humboldt,1E-43,President,,LIB,Gary Johnson,1
+Humboldt,1E-43,President,,DEM,Henry Hewes,1
+Humboldt,1E-43,President,,DEM,Hillary Clinton,128
+Humboldt,1E-43,President,,GRN,Jill Stein,2
+Humboldt,1E-43,President,,REP,Jim Gilmore,4
+Humboldt,1E-43,President,,REP,John R. Kasich,12
 Humboldt,1E-43,President,,PAF,Lynn S. Kahn,1
 Humboldt,1E-43,President,,LIB,Marc Feldman,1
-Humboldt,1E-43,President,,REP,Ted Cruz,4
-Humboldt,1E-43,Proposition 50,,,No,47
-Humboldt,1E-43,Proposition 50,,,Yes,128
-Humboldt,1E-43,State Assembly,2,DEM,Jim Wood,145
-Humboldt,1E-43,U.S. House,2,REP,Dale K. Mensing,25
-Humboldt,1E-43,U.S. House,2,DEM,Erin A. Schrode,15
-Humboldt,1E-43,U.S. House,2,DEM,Jared W. Huffman,135
-Humboldt,1E-43,U.S. House,2,IND,Matthew Robert Wookey,12
+Humboldt,1E-43,President,,REP,Ted Cruz,18
+Humboldt,1E-43,Proposition 50,,,No,98
+Humboldt,1E-43,Proposition 50,,,Yes,332
+Humboldt,1E-43,State Assembly,2,DEM,Jim Wood,342
+Humboldt,1E-43,U.S. House,2,REP,Dale K. Mensing,91
+Humboldt,1E-43,U.S. House,2,DEM,Erin A. Schrode,36
+Humboldt,1E-43,U.S. House,2,DEM,Jared W. Huffman,305
+Humboldt,1E-43,U.S. House,2,IND,Matthew Robert Wookey,25
 Humboldt,1E-43,U.S. Senate,,IND,Clive Grey,2
 Humboldt,1E-43,U.S. Senate,,IND,Don J. Grundmann,1
-Humboldt,1E-43,U.S. Senate,,REP,Duf Sundheim,10
+Humboldt,1E-43,U.S. Senate,,REP,Don Krampe,4
+Humboldt,1E-43,U.S. Senate,,REP,Duf Sundheim,25
 Humboldt,1E-43,U.S. Senate,,IND,Eleanor García,1
 Humboldt,1E-43,U.S. Senate,,DEM,Emory Rodgers,3
-Humboldt,1E-43,U.S. Senate,,LIB,Gail K. Lightfoot,7
-Humboldt,1E-43,U.S. Senate,,REP,Greg Conlon,7
+Humboldt,1E-43,U.S. Senate,,LIB,Gail K. Lightfoot,9
+Humboldt,1E-43,U.S. Senate,,REP,Greg Conlon,19
 Humboldt,1E-43,U.S. Senate,,DEM,Herbert G. Peters,1
-Humboldt,1E-43,U.S. Senate,,REP,Jarrell Williamson,6
+Humboldt,1E-43,U.S. Senate,,REP,Jarrell Williamson,7
 Humboldt,1E-43,U.S. Senate,,IND,Jason Hanania,1
-Humboldt,1E-43,U.S. Senate,,IND,Jason Kraus,3
-Humboldt,1E-43,U.S. Senate,,REP,Jerry J. Laws,2
+Humboldt,1E-43,U.S. Senate,,IND,Jason Kraus,5
+Humboldt,1E-43,U.S. Senate,,REP,Jerry J. Laws,19
 Humboldt,1E-43,U.S. Senate,,PAF,John Thompson Parker,1
-Humboldt,1E-43,U.S. Senate,,DEM,Kamala D. Harris,83
-Humboldt,1E-43,U.S. Senate,,REP,Karen Roseberry,1
-Humboldt,1E-43,U.S. Senate,,DEM,Loretta L. Sanchez,23
-Humboldt,1E-43,U.S. Senate,,DEM,Massie Munroe,6
-Humboldt,1E-43,U.S. Senate,,GRN,Pamela Elizondo,6
-Humboldt,1E-43,U.S. Senate,,REP,Phil Wyman,5
-Humboldt,1E-43,U.S. Senate,,DEM,Steve Stokes,8
-Humboldt,1E-43,U.S. Senate,,REP,Thomas G. Del Beccaro,3
-Humboldt,1E-43_A,President,,AIP,Arthur Harris,1
-Humboldt,1E-43_A,President,,REP,Ben Carson,5
-Humboldt,1E-43_A,President,,DEM,Bernie Sanders,101
-Humboldt,1E-43_A,President,,REP,Donald Trump,60
-Humboldt,1E-43_A,President,,LIB,Gary Johnson,1
-Humboldt,1E-43_A,President,,DEM,Henry Hewes,1
-Humboldt,1E-43_A,President,,DEM,Hillary Clinton,67
-Humboldt,1E-43_A,President,,GRN,Jill Stein,1
-Humboldt,1E-43_A,President,,REP,Jim Gilmore,2
-Humboldt,1E-43_A,President,,REP,John R. Kasich,5
-Humboldt,1E-43_A,President,,REP,Ted Cruz,14
-Humboldt,1E-43_A,Proposition 50,,,No,51
-Humboldt,1E-43_A,Proposition 50,,,Yes,204
-Humboldt,1E-43_A,State Assembly,2,DEM,Jim Wood,197
-Humboldt,1E-43_A,U.S. House,2,REP,Dale K. Mensing,66
-Humboldt,1E-43_A,U.S. House,2,DEM,Erin A. Schrode,21
-Humboldt,1E-43_A,U.S. House,2,DEM,Jared W. Huffman,170
-Humboldt,1E-43_A,U.S. House,2,IND,Matthew Robert Wookey,13
-Humboldt,1E-43_A,U.S. Senate,,REP,Don Krampe,4
-Humboldt,1E-43_A,U.S. Senate,,REP,Duf Sundheim,15
-Humboldt,1E-43_A,U.S. Senate,,LIB,Gail K. Lightfoot,2
-Humboldt,1E-43_A,U.S. Senate,,REP,Greg Conlon,12
-Humboldt,1E-43_A,U.S. Senate,,REP,Jarrell Williamson,1
-Humboldt,1E-43_A,U.S. Senate,,IND,Jason Kraus,2
-Humboldt,1E-43_A,U.S. Senate,,REP,Jerry J. Laws,17
-Humboldt,1E-43_A,U.S. Senate,,DEM,Kamala D. Harris,89
-Humboldt,1E-43_A,U.S. Senate,,REP,Karen Roseberry,5
-Humboldt,1E-43_A,U.S. Senate,,DEM,Loretta L. Sanchez,52
-Humboldt,1E-43_A,U.S. Senate,,LIB,Mark Matthew Herd,1
-Humboldt,1E-43_A,U.S. Senate,,DEM,Massie Munroe,1
-Humboldt,1E-43_A,U.S. Senate,,IND,Mike Beitiks,2
-Humboldt,1E-43_A,U.S. Senate,,GRN,Pamela Elizondo,7
-Humboldt,1E-43_A,U.S. Senate,,REP,Phil Wyman,19
-Humboldt,1E-43_A,U.S. Senate,,DEM,President Cristina Grappo,1
-Humboldt,1E-43_A,U.S. Senate,,REP,Ron Unz,3
-Humboldt,1E-43_A,U.S. Senate,,IND,Scott A. Vineberg,1
-Humboldt,1E-43_A,U.S. Senate,,DEM,Steve Stokes,16
-Humboldt,1E-43_A,U.S. Senate,,REP,Thomas G. Del Beccaro,7
-Humboldt,1E-43_A,U.S. Senate,,REP,Tom Palzer,5
-Humboldt,1E-43_A,U.S. Senate,,REP,Von Hougo,4
+Humboldt,1E-43,U.S. Senate,,DEM,Kamala D. Harris,172
+Humboldt,1E-43,U.S. Senate,,REP,Karen Roseberry,6
+Humboldt,1E-43,U.S. Senate,,DEM,Loretta L. Sanchez,75
+Humboldt,1E-43,U.S. Senate,,LIB,Mark Matthew Herd,1
+Humboldt,1E-43,U.S. Senate,,DEM,Massie Munroe,7
+Humboldt,1E-43,U.S. Senate,,IND,Mike Beitiks,2
+Humboldt,1E-43,U.S. Senate,,GRN,Pamela Elizondo,13
+Humboldt,1E-43,U.S. Senate,,REP,Phil Wyman,24
+Humboldt,1E-43,U.S. Senate,,DEM,President Cristina Grappo,1
+Humboldt,1E-43,U.S. Senate,,REP,Ron Unz,3
+Humboldt,1E-43,U.S. Senate,,IND,Scott A. Vineberg,1
+Humboldt,1E-43,U.S. Senate,,DEM,Steve Stokes,24
+Humboldt,1E-43,U.S. Senate,,REP,Thomas G. Del Beccaro,10
+Humboldt,1E-43,U.S. Senate,,REP,Tom Palzer,5
+Humboldt,1E-43,U.S. Senate,,REP,Von Hougo,4
 Humboldt,1E-45,President,,LIB,Austin Petersen,1
-Humboldt,1E-45,President,,REP,Ben Carson,5
-Humboldt,1E-45,President,,DEM,Bernie Sanders,82
+Humboldt,1E-45,President,,REP,Ben Carson,8
+Humboldt,1E-45,President,,DEM,Bernie Sanders,183
 Humboldt,1E-45,President,,LIB,Darryl W. Perry,1
-Humboldt,1E-45,President,,REP,Donald Trump,43
-Humboldt,1E-45,President,,DEM,Hillary Clinton,38
-Humboldt,1E-45,President,,REP,Jim Gilmore,1
-Humboldt,1E-45,President,,REP,John R. Kasich,5
-Humboldt,1E-45,President,,REP,Ted Cruz,4
-Humboldt,1E-45,Proposition 50,,,No,32
-Humboldt,1E-45,Proposition 50,,,Yes,133
-Humboldt,1E-45,State Assembly,2,DEM,Jim Wood,135
-Humboldt,1E-45,U.S. House,2,REP,Dale K. Mensing,43
-Humboldt,1E-45,U.S. House,2,DEM,Erin A. Schrode,12
-Humboldt,1E-45,U.S. House,2,DEM,Jared W. Huffman,107
-Humboldt,1E-45,U.S. House,2,IND,Matthew Robert Wookey,17
-Humboldt,1E-45,U.S. Senate,,REP,Don Krampe,2
-Humboldt,1E-45,U.S. Senate,,REP,Duf Sundheim,22
-Humboldt,1E-45,U.S. Senate,,LIB,Gail K. Lightfoot,5
+Humboldt,1E-45,President,,REP,Donald Trump,137
+Humboldt,1E-45,President,,DEM,Hillary Clinton,95
+Humboldt,1E-45,President,,REP,Jim Gilmore,2
+Humboldt,1E-45,President,,REP,John R. Kasich,19
+Humboldt,1E-45,President,,DEM,Keith Judd,1
+Humboldt,1E-45,President,,DEM,Michael Steinberg,1
+Humboldt,1E-45,President,,REP,Ted Cruz,16
+Humboldt,1E-45,Proposition 50,,,No,81
+Humboldt,1E-45,Proposition 50,,,Yes,364
+Humboldt,1E-45,State Assembly,2,DEM,Jim Wood,322
+Humboldt,1E-45,U.S. House,2,REP,Dale K. Mensing,134
+Humboldt,1E-45,U.S. House,2,DEM,Erin A. Schrode,30
+Humboldt,1E-45,U.S. House,2,DEM,Jared W. Huffman,274
+Humboldt,1E-45,U.S. House,2,IND,Matthew Robert Wookey,23
+Humboldt,1E-45,U.S. Senate,,IND,Don J. Grundmann,1
+Humboldt,1E-45,U.S. Senate,,REP,Don Krampe,6
+Humboldt,1E-45,U.S. Senate,,REP,Duf Sundheim,52
+Humboldt,1E-45,U.S. Senate,,LIB,Gail K. Lightfoot,8
 Humboldt,1E-45,U.S. Senate,,IND,Gar Myers,1
-Humboldt,1E-45,U.S. Senate,,REP,George C. Yang,2
-Humboldt,1E-45,U.S. Senate,,REP,Greg Conlon,8
+Humboldt,1E-45,U.S. Senate,,REP,George C. Yang,6
+Humboldt,1E-45,U.S. Senate,,REP,Greg Conlon,21
 Humboldt,1E-45,U.S. Senate,,DEM,Herbert G. Peters,1
-Humboldt,1E-45,U.S. Senate,,REP,Jerry J. Laws,13
-Humboldt,1E-45,U.S. Senate,,DEM,Kamala D. Harris,61
-Humboldt,1E-45,U.S. Senate,,REP,Karen Roseberry,2
-Humboldt,1E-45,U.S. Senate,,IND,Ling Ling Shi,1
-Humboldt,1E-45,U.S. Senate,,DEM,Loretta L. Sanchez,21
+Humboldt,1E-45,U.S. Senate,,REP,Jarrell Williamson,3
+Humboldt,1E-45,U.S. Senate,,IND,Jason Kraus,1
+Humboldt,1E-45,U.S. Senate,,REP,Jerry J. Laws,33
+Humboldt,1E-45,U.S. Senate,,PAF,John Thompson Parker,1
+Humboldt,1E-45,U.S. Senate,,DEM,Kamala D. Harris,165
+Humboldt,1E-45,U.S. Senate,,REP,Karen Roseberry,7
+Humboldt,1E-45,U.S. Senate,,IND,Ling Ling Shi,2
+Humboldt,1E-45,U.S. Senate,,DEM,Loretta L. Sanchez,47
 Humboldt,1E-45,U.S. Senate,,LIB,Mark Matthew Herd,1
-Humboldt,1E-45,U.S. Senate,,DEM,Massie Munroe,3
+Humboldt,1E-45,U.S. Senate,,DEM,Massie Munroe,8
 Humboldt,1E-45,U.S. Senate,,IND,Mike Beitiks,1
-Humboldt,1E-45,U.S. Senate,,GRN,Pamela Elizondo,10
-Humboldt,1E-45,U.S. Senate,,REP,Phil Wyman,5
-Humboldt,1E-45,U.S. Senate,,DEM,Steve Stokes,9
-Humboldt,1E-45,U.S. Senate,,REP,Thomas G. Del Beccaro,7
-Humboldt,1E-45,U.S. Senate,,REP,Von Hougo,1
-Humboldt,1E-45_A,President,,REP,Ben Carson,3
-Humboldt,1E-45_A,President,,DEM,Bernie Sanders,101
-Humboldt,1E-45_A,President,,REP,Donald Trump,94
-Humboldt,1E-45_A,President,,DEM,Hillary Clinton,57
-Humboldt,1E-45_A,President,,REP,Jim Gilmore,1
-Humboldt,1E-45_A,President,,REP,John R. Kasich,14
-Humboldt,1E-45_A,President,,DEM,Keith Judd,1
-Humboldt,1E-45_A,President,,DEM,Michael Steinberg,1
-Humboldt,1E-45_A,President,,REP,Ted Cruz,12
-Humboldt,1E-45_A,Proposition 50,,,No,49
-Humboldt,1E-45_A,Proposition 50,,,Yes,231
-Humboldt,1E-45_A,State Assembly,2,DEM,Jim Wood,187
-Humboldt,1E-45_A,U.S. House,2,REP,Dale K. Mensing,91
-Humboldt,1E-45_A,U.S. House,2,DEM,Erin A. Schrode,18
-Humboldt,1E-45_A,U.S. House,2,DEM,Jared W. Huffman,167
-Humboldt,1E-45_A,U.S. House,2,IND,Matthew Robert Wookey,6
-Humboldt,1E-45_A,U.S. Senate,,IND,Don J. Grundmann,1
-Humboldt,1E-45_A,U.S. Senate,,REP,Don Krampe,4
-Humboldt,1E-45_A,U.S. Senate,,REP,Duf Sundheim,30
-Humboldt,1E-45_A,U.S. Senate,,LIB,Gail K. Lightfoot,3
-Humboldt,1E-45_A,U.S. Senate,,REP,George C. Yang,4
-Humboldt,1E-45_A,U.S. Senate,,REP,Greg Conlon,13
-Humboldt,1E-45_A,U.S. Senate,,REP,Jarrell Williamson,3
-Humboldt,1E-45_A,U.S. Senate,,IND,Jason Kraus,1
-Humboldt,1E-45_A,U.S. Senate,,REP,Jerry J. Laws,20
-Humboldt,1E-45_A,U.S. Senate,,PAF,John Thompson Parker,1
-Humboldt,1E-45_A,U.S. Senate,,DEM,Kamala D. Harris,104
-Humboldt,1E-45_A,U.S. Senate,,REP,Karen Roseberry,5
-Humboldt,1E-45_A,U.S. Senate,,IND,Ling Ling Shi,1
-Humboldt,1E-45_A,U.S. Senate,,DEM,Loretta L. Sanchez,26
-Humboldt,1E-45_A,U.S. Senate,,DEM,Massie Munroe,5
-Humboldt,1E-45_A,U.S. Senate,,GRN,Pamela Elizondo,5
-Humboldt,1E-45_A,U.S. Senate,,REP,Phil Wyman,29
-Humboldt,1E-45_A,U.S. Senate,,REP,Ron Unz,3
-Humboldt,1E-45_A,U.S. Senate,,DEM,Steve Stokes,6
-Humboldt,1E-45_A,U.S. Senate,,REP,Thomas G. Del Beccaro,7
-Humboldt,1E-45_A,U.S. Senate,,REP,Tom Palzer,2
-Humboldt,1E-45_A,U.S. Senate,,REP,Von Hougo,2
-Humboldt,1E-55,President,,REP,Ben Carson,3
-Humboldt,1E-55,President,,DEM,Bernie Sanders,74
-Humboldt,1E-55,President,,REP,Donald Trump,19
-Humboldt,1E-55,President,,LIB,Gary Johnson,1
-Humboldt,1E-55,President,,DEM,Hillary Clinton,32
-Humboldt,1E-55,President,,REP,John R. Kasich,3
+Humboldt,1E-45,U.S. Senate,,GRN,Pamela Elizondo,15
+Humboldt,1E-45,U.S. Senate,,REP,Phil Wyman,34
+Humboldt,1E-45,U.S. Senate,,REP,Ron Unz,3
+Humboldt,1E-45,U.S. Senate,,DEM,Steve Stokes,15
+Humboldt,1E-45,U.S. Senate,,REP,Thomas G. Del Beccaro,14
+Humboldt,1E-45,U.S. Senate,,REP,Tom Palzer,2
+Humboldt,1E-45,U.S. Senate,,REP,Von Hougo,3
+Humboldt,1E-55,President,,LIB,Austin Petersen,1
+Humboldt,1E-55,President,,REP,Ben Carson,5
+Humboldt,1E-55,President,,DEM,Bernie Sanders,153
+Humboldt,1E-55,President,,REP,Donald Trump,60
+Humboldt,1E-55,President,,LIB,Gary Johnson,2
+Humboldt,1E-55,President,,DEM,Henry Hewes,1
+Humboldt,1E-55,President,,DEM,Hillary Clinton,75
+Humboldt,1E-55,President,,GRN,Jill Stein,2
+Humboldt,1E-55,President,,REP,John R. Kasich,9
 Humboldt,1E-55,President,,LIB,Joy Waymire,1
 Humboldt,1E-55,President,,DEM,Keith Judd,2
-Humboldt,1E-55,President,,REP,Ted Cruz,7
-Humboldt,1E-55,Proposition 50,,,No,24
-Humboldt,1E-55,Proposition 50,,,Yes,104
-Humboldt,1E-55,State Assembly,2,DEM,Jim Wood,105
-Humboldt,1E-55,U.S. House,2,REP,Dale K. Mensing,28
-Humboldt,1E-55,U.S. House,2,DEM,Erin A. Schrode,17
-Humboldt,1E-55,U.S. House,2,DEM,Jared W. Huffman,79
-Humboldt,1E-55,U.S. House,2,IND,Matthew Robert Wookey,13
+Humboldt,1E-55,President,,DEM,Michael Steinberg,1
+Humboldt,1E-55,President,,REP,Ted Cruz,13
+Humboldt,1E-55,Proposition 50,,,No,52
+Humboldt,1E-55,Proposition 50,,,Yes,250
+Humboldt,1E-55,State Assembly,2,DEM,Jim Wood,240
+Humboldt,1E-55,U.S. House,2,REP,Dale K. Mensing,65
+Humboldt,1E-55,U.S. House,2,DEM,Erin A. Schrode,27
+Humboldt,1E-55,U.S. House,2,DEM,Jared W. Huffman,201
+Humboldt,1E-55,U.S. House,2,IND,Matthew Robert Wookey,28
 Humboldt,1E-55,U.S. Senate,,IND,Clive Grey,1
-Humboldt,1E-55,U.S. Senate,,REP,Duf Sundheim,2
-Humboldt,1E-55,U.S. Senate,,DEM,Emory Rodgers,2
-Humboldt,1E-55,U.S. Senate,,LIB,Gail K. Lightfoot,4
-Humboldt,1E-55,U.S. Senate,,REP,George C. Yang,1
-Humboldt,1E-55,U.S. Senate,,REP,Greg Conlon,11
+Humboldt,1E-55,U.S. Senate,,REP,Don Krampe,3
+Humboldt,1E-55,U.S. Senate,,REP,Duf Sundheim,13
+Humboldt,1E-55,U.S. Senate,,DEM,Emory Rodgers,3
+Humboldt,1E-55,U.S. Senate,,LIB,Gail K. Lightfoot,7
+Humboldt,1E-55,U.S. Senate,,REP,George C. Yang,4
+Humboldt,1E-55,U.S. Senate,,REP,Greg Conlon,17
 Humboldt,1E-55,U.S. Senate,,DEM,Herbert G. Peters,1
-Humboldt,1E-55,U.S. Senate,,REP,Jarrell Williamson,1
-Humboldt,1E-55,U.S. Senate,,IND,Jason Kraus,2
-Humboldt,1E-55,U.S. Senate,,REP,Jerry J. Laws,3
-Humboldt,1E-55,U.S. Senate,,DEM,Kamala D. Harris,46
-Humboldt,1E-55,U.S. Senate,,REP,Karen Roseberry,2
-Humboldt,1E-55,U.S. Senate,,IND,Ling Ling Shi,2
-Humboldt,1E-55,U.S. Senate,,DEM,Loretta L. Sanchez,26
-Humboldt,1E-55,U.S. Senate,,IND,Mike Beitiks,3
-Humboldt,1E-55,U.S. Senate,,GRN,Pamela Elizondo,7
-Humboldt,1E-55,U.S. Senate,,IND,Paul Merritt,1
-Humboldt,1E-55,U.S. Senate,,REP,Phil Wyman,8
+Humboldt,1E-55,U.S. Senate,,REP,Jarrell Williamson,4
+Humboldt,1E-55,U.S. Senate,,IND,Jason Hanania,2
+Humboldt,1E-55,U.S. Senate,,IND,Jason Kraus,3
+Humboldt,1E-55,U.S. Senate,,REP,Jerry J. Laws,7
+Humboldt,1E-55,U.S. Senate,,DEM,Kamala D. Harris,119
+Humboldt,1E-55,U.S. Senate,,REP,Karen Roseberry,3
+Humboldt,1E-55,U.S. Senate,,IND,Ling Ling Shi,3
+Humboldt,1E-55,U.S. Senate,,DEM,Loretta L. Sanchez,58
+Humboldt,1E-55,U.S. Senate,,LIB,Mark Matthew Herd,3
+Humboldt,1E-55,U.S. Senate,,DEM,Massie Munroe,1
+Humboldt,1E-55,U.S. Senate,,IND,Mike Beitiks,6
+Humboldt,1E-55,U.S. Senate,,GRN,Pamela Elizondo,13
+Humboldt,1E-55,U.S. Senate,,IND,Paul Merritt,3
+Humboldt,1E-55,U.S. Senate,,REP,Phil Wyman,21
 Humboldt,1E-55,U.S. Senate,,REP,Ron Unz,1
-Humboldt,1E-55,U.S. Senate,,DEM,Steve Stokes,5
-Humboldt,1E-55,U.S. Senate,,REP,Thomas G. Del Beccaro,2
-Humboldt,1E-55,U.S. Senate,,REP,Von Hougo,2
-Humboldt,1E-55_A,President,,LIB,Austin Petersen,1
-Humboldt,1E-55_A,President,,REP,Ben Carson,2
-Humboldt,1E-55_A,President,,DEM,Bernie Sanders,79
-Humboldt,1E-55_A,President,,REP,Donald Trump,41
-Humboldt,1E-55_A,President,,LIB,Gary Johnson,1
-Humboldt,1E-55_A,President,,DEM,Henry Hewes,1
-Humboldt,1E-55_A,President,,DEM,Hillary Clinton,43
-Humboldt,1E-55_A,President,,GRN,Jill Stein,2
-Humboldt,1E-55_A,President,,REP,John R. Kasich,6
-Humboldt,1E-55_A,President,,DEM,Michael Steinberg,1
-Humboldt,1E-55_A,President,,REP,Ted Cruz,6
-Humboldt,1E-55_A,Proposition 50,,,No,28
-Humboldt,1E-55_A,Proposition 50,,,Yes,146
-Humboldt,1E-55_A,State Assembly,2,DEM,Jim Wood,135
-Humboldt,1E-55_A,U.S. House,2,REP,Dale K. Mensing,37
-Humboldt,1E-55_A,U.S. House,2,DEM,Erin A. Schrode,10
-Humboldt,1E-55_A,U.S. House,2,DEM,Jared W. Huffman,122
-Humboldt,1E-55_A,U.S. House,2,IND,Matthew Robert Wookey,15
-Humboldt,1E-55_A,U.S. Senate,,REP,Don Krampe,3
-Humboldt,1E-55_A,U.S. Senate,,REP,Duf Sundheim,11
-Humboldt,1E-55_A,U.S. Senate,,DEM,Emory Rodgers,1
-Humboldt,1E-55_A,U.S. Senate,,LIB,Gail K. Lightfoot,3
-Humboldt,1E-55_A,U.S. Senate,,REP,George C. Yang,3
-Humboldt,1E-55_A,U.S. Senate,,REP,Greg Conlon,6
-Humboldt,1E-55_A,U.S. Senate,,REP,Jarrell Williamson,3
-Humboldt,1E-55_A,U.S. Senate,,IND,Jason Hanania,2
-Humboldt,1E-55_A,U.S. Senate,,IND,Jason Kraus,1
-Humboldt,1E-55_A,U.S. Senate,,REP,Jerry J. Laws,4
-Humboldt,1E-55_A,U.S. Senate,,DEM,Kamala D. Harris,73
-Humboldt,1E-55_A,U.S. Senate,,REP,Karen Roseberry,1
-Humboldt,1E-55_A,U.S. Senate,,IND,Ling Ling Shi,1
-Humboldt,1E-55_A,U.S. Senate,,DEM,Loretta L. Sanchez,32
-Humboldt,1E-55_A,U.S. Senate,,LIB,Mark Matthew Herd,3
-Humboldt,1E-55_A,U.S. Senate,,DEM,Massie Munroe,1
-Humboldt,1E-55_A,U.S. Senate,,IND,Mike Beitiks,3
-Humboldt,1E-55_A,U.S. Senate,,GRN,Pamela Elizondo,6
-Humboldt,1E-55_A,U.S. Senate,,IND,Paul Merritt,2
-Humboldt,1E-55_A,U.S. Senate,,REP,Phil Wyman,13
-Humboldt,1E-55_A,U.S. Senate,,DEM,Steve Stokes,9
-Humboldt,1E-55_A,U.S. Senate,,REP,Thomas G. Del Beccaro,5
-Humboldt,1E-55_A,U.S. Senate,,REP,Tom Palzer,1
-Humboldt,1E-55_A,U.S. Senate,,REP,Von Hougo,3
-Humboldt,1ES-1,President,,REP,Ben Carson,2
-Humboldt,1ES-1,President,,DEM,Bernie Sanders,132
-Humboldt,1ES-1,President,,REP,Donald Trump,29
-Humboldt,1ES-1,President,,DEM,Hillary Clinton,49
-Humboldt,1ES-1,President,,AIP,J.R. Myers,1
+Humboldt,1E-55,U.S. Senate,,DEM,Steve Stokes,14
+Humboldt,1E-55,U.S. Senate,,REP,Thomas G. Del Beccaro,7
+Humboldt,1E-55,U.S. Senate,,REP,Tom Palzer,1
+Humboldt,1E-55,U.S. Senate,,REP,Von Hougo,5
+Humboldt,1ES-1,President,,REP,Ben Carson,3
+Humboldt,1ES-1,President,,DEM,Bernie Sanders,275
+Humboldt,1ES-1,President,,REP,Donald Trump,95
+Humboldt,1ES-1,President,,LIB,Gary Johnson,2
+Humboldt,1ES-1,President,,DEM,Hillary Clinton,109
+Humboldt,1ES-1,President,,AIP,J.R. Myers,2
+Humboldt,1ES-1,President,,REP,Jim Gilmore,2
 Humboldt,1ES-1,President,,LIB,John McAfee,1
-Humboldt,1ES-1,President,,REP,John R. Kasich,5
+Humboldt,1ES-1,President,,REP,John R. Kasich,15
+Humboldt,1ES-1,President,,LIB,Marc Feldman,1
+Humboldt,1ES-1,President,,DEM,Michael Steinberg,3
 Humboldt,1ES-1,President,,PAF,Monica Moorehead,1
-Humboldt,1ES-1,President,,REP,Ted Cruz,2
+Humboldt,1ES-1,President,,AIP,Robert Ornelas,1
+Humboldt,1ES-1,President,,REP,Ted Cruz,14
+Humboldt,1ES-1,President,,AIP,Wiley Drake,1
 Humboldt,1ES-1,President,,DEM,Willie Wilson,1
-Humboldt,1ES-1,Proposition 50,,,No,32
-Humboldt,1ES-1,Proposition 50,,,Yes,171
-Humboldt,1ES-1,State Assembly,2,DEM,Jim Wood,187
-Humboldt,1ES-1,U.S. House,2,REP,Dale K. Mensing,33
-Humboldt,1ES-1,U.S. House,2,DEM,Erin A. Schrode,30
-Humboldt,1ES-1,U.S. House,2,DEM,Jared W. Huffman,137
-Humboldt,1ES-1,U.S. House,2,IND,Matthew Robert Wookey,16
-Humboldt,1ES-1,U.S. Senate,,IND,Clive Grey,2
-Humboldt,1ES-1,U.S. Senate,,REP,Don Krampe,1
-Humboldt,1ES-1,U.S. Senate,,REP,Duf Sundheim,10
-Humboldt,1ES-1,U.S. Senate,,IND,Eleanor García,1
-Humboldt,1ES-1,U.S. Senate,,LIB,Gail K. Lightfoot,5
+Humboldt,1ES-1,Proposition 50,,,No,93
+Humboldt,1ES-1,Proposition 50,,,Yes,419
+Humboldt,1ES-1,State Assembly,2,DEM,Jim Wood,421
+Humboldt,1ES-1,U.S. House,2,REP,Dale K. Mensing,95
+Humboldt,1ES-1,U.S. House,2,DEM,Erin A. Schrode,61
+Humboldt,1ES-1,U.S. House,2,DEM,Jared W. Huffman,331
+Humboldt,1ES-1,U.S. House,2,IND,Matthew Robert Wookey,40
+Humboldt,1ES-1,U.S. Senate,,IND,Clive Grey,5
+Humboldt,1ES-1,U.S. Senate,,REP,Don Krampe,3
+Humboldt,1ES-1,U.S. Senate,,REP,Duf Sundheim,25
+Humboldt,1ES-1,U.S. Senate,,IND,Eleanor García,2
+Humboldt,1ES-1,U.S. Senate,,LIB,Gail K. Lightfoot,14
+Humboldt,1ES-1,U.S. Senate,,IND,Gar Myers,1
 Humboldt,1ES-1,U.S. Senate,,REP,George C. Yang,1
-Humboldt,1ES-1,U.S. Senate,,REP,Greg Conlon,3
-Humboldt,1ES-1,U.S. Senate,,REP,Jarrell Williamson,1
-Humboldt,1ES-1,U.S. Senate,,IND,Jason Hanania,1
-Humboldt,1ES-1,U.S. Senate,,REP,Jerry J. Laws,13
+Humboldt,1ES-1,U.S. Senate,,REP,Greg Conlon,9
+Humboldt,1ES-1,U.S. Senate,,DEM,Herbert G. Peters,1
+Humboldt,1ES-1,U.S. Senate,,REP,Jarrell Williamson,4
+Humboldt,1ES-1,U.S. Senate,,IND,Jason Hanania,2
+Humboldt,1ES-1,U.S. Senate,,IND,Jason Kraus,2
+Humboldt,1ES-1,U.S. Senate,,REP,Jerry J. Laws,29
 Humboldt,1ES-1,U.S. Senate,,PAF,John Thompson Parker,1
-Humboldt,1ES-1,U.S. Senate,,DEM,Kamala D. Harris,79
-Humboldt,1ES-1,U.S. Senate,,IND,Ling Ling Shi,1
-Humboldt,1ES-1,U.S. Senate,,DEM,Loretta L. Sanchez,37
-Humboldt,1ES-1,U.S. Senate,,LIB,Mark Matthew Herd,4
-Humboldt,1ES-1,U.S. Senate,,DEM,Massie Munroe,6
-Humboldt,1ES-1,U.S. Senate,,IND,Mike Beitiks,2
-Humboldt,1ES-1,U.S. Senate,,GRN,Pamela Elizondo,16
-Humboldt,1ES-1,U.S. Senate,,REP,Phil Wyman,10
+Humboldt,1ES-1,U.S. Senate,,DEM,Kamala D. Harris,185
+Humboldt,1ES-1,U.S. Senate,,REP,Karen Roseberry,3
+Humboldt,1ES-1,U.S. Senate,,IND,Ling Ling Shi,2
+Humboldt,1ES-1,U.S. Senate,,DEM,Loretta L. Sanchez,86
+Humboldt,1ES-1,U.S. Senate,,LIB,Mark Matthew Herd,8
+Humboldt,1ES-1,U.S. Senate,,DEM,Massie Munroe,14
+Humboldt,1ES-1,U.S. Senate,,IND,Mike Beitiks,3
+Humboldt,1ES-1,U.S. Senate,,GRN,Pamela Elizondo,28
+Humboldt,1ES-1,U.S. Senate,,IND,Paul Merritt,5
+Humboldt,1ES-1,U.S. Senate,,REP,Phil Wyman,33
 Humboldt,1ES-1,U.S. Senate,,DEM,President Cristina Grappo,1
-Humboldt,1ES-1,U.S. Senate,,REP,Ron Unz,2
-Humboldt,1ES-1,U.S. Senate,,DEM,Steve Stokes,12
-Humboldt,1ES-1,U.S. Senate,,REP,Thomas G. Del Beccaro,2
-Humboldt,1ES-1,U.S. Senate,,REP,Von Hougo,2
-Humboldt,1ES-1_A,President,,REP,Ben Carson,1
-Humboldt,1ES-1_A,President,,DEM,Bernie Sanders,143
-Humboldt,1ES-1_A,President,,REP,Donald Trump,66
-Humboldt,1ES-1_A,President,,LIB,Gary Johnson,2
-Humboldt,1ES-1_A,President,,DEM,Hillary Clinton,60
-Humboldt,1ES-1_A,President,,AIP,J.R. Myers,1
-Humboldt,1ES-1_A,President,,REP,Jim Gilmore,2
-Humboldt,1ES-1_A,President,,REP,John R. Kasich,10
-Humboldt,1ES-1_A,President,,LIB,Marc Feldman,1
-Humboldt,1ES-1_A,President,,DEM,Michael Steinberg,3
-Humboldt,1ES-1_A,President,,AIP,Robert Ornelas,1
-Humboldt,1ES-1_A,President,,REP,Ted Cruz,12
-Humboldt,1ES-1_A,President,,AIP,Wiley Drake,1
-Humboldt,1ES-1_A,Proposition 50,,,No,61
-Humboldt,1ES-1_A,Proposition 50,,,Yes,248
-Humboldt,1ES-1_A,State Assembly,2,DEM,Jim Wood,234
-Humboldt,1ES-1_A,U.S. House,2,REP,Dale K. Mensing,62
-Humboldt,1ES-1_A,U.S. House,2,DEM,Erin A. Schrode,31
-Humboldt,1ES-1_A,U.S. House,2,DEM,Jared W. Huffman,194
-Humboldt,1ES-1_A,U.S. House,2,IND,Matthew Robert Wookey,24
-Humboldt,1ES-1_A,U.S. Senate,,IND,Clive Grey,3
-Humboldt,1ES-1_A,U.S. Senate,,REP,Don Krampe,2
-Humboldt,1ES-1_A,U.S. Senate,,REP,Duf Sundheim,15
-Humboldt,1ES-1_A,U.S. Senate,,IND,Eleanor García,1
-Humboldt,1ES-1_A,U.S. Senate,,LIB,Gail K. Lightfoot,9
-Humboldt,1ES-1_A,U.S. Senate,,IND,Gar Myers,1
-Humboldt,1ES-1_A,U.S. Senate,,REP,Greg Conlon,6
-Humboldt,1ES-1_A,U.S. Senate,,DEM,Herbert G. Peters,1
-Humboldt,1ES-1_A,U.S. Senate,,REP,Jarrell Williamson,3
-Humboldt,1ES-1_A,U.S. Senate,,IND,Jason Hanania,1
-Humboldt,1ES-1_A,U.S. Senate,,IND,Jason Kraus,2
-Humboldt,1ES-1_A,U.S. Senate,,REP,Jerry J. Laws,16
-Humboldt,1ES-1_A,U.S. Senate,,DEM,Kamala D. Harris,106
-Humboldt,1ES-1_A,U.S. Senate,,REP,Karen Roseberry,3
-Humboldt,1ES-1_A,U.S. Senate,,IND,Ling Ling Shi,1
-Humboldt,1ES-1_A,U.S. Senate,,DEM,Loretta L. Sanchez,49
-Humboldt,1ES-1_A,U.S. Senate,,LIB,Mark Matthew Herd,4
-Humboldt,1ES-1_A,U.S. Senate,,DEM,Massie Munroe,8
-Humboldt,1ES-1_A,U.S. Senate,,IND,Mike Beitiks,1
-Humboldt,1ES-1_A,U.S. Senate,,GRN,Pamela Elizondo,12
-Humboldt,1ES-1_A,U.S. Senate,,IND,Paul Merritt,5
-Humboldt,1ES-1_A,U.S. Senate,,REP,Phil Wyman,23
-Humboldt,1ES-1_A,U.S. Senate,,REP,Ron Unz,1
-Humboldt,1ES-1_A,U.S. Senate,,IND,Scott A. Vineberg,1
-Humboldt,1ES-1_A,U.S. Senate,,DEM,Steve Stokes,16
-Humboldt,1ES-1_A,U.S. Senate,,REP,Thomas G. Del Beccaro,7
-Humboldt,1ES-1_A,U.S. Senate,,REP,Tom Palzer,2
-Humboldt,1ES-1_A,U.S. Senate,,REP,Von Hougo,5
-Humboldt,1F--1,President,,REP,Ben Carson,6
-Humboldt,1F--1,President,,DEM,Bernie Sanders,63
-Humboldt,1F--1,President,,REP,Donald Trump,56
-Humboldt,1F--1,President,,LIB,Gary Johnson,1
-Humboldt,1F--1,President,,DEM,Hillary Clinton,56
-Humboldt,1F--1,President,,REP,John R. Kasich,9
-Humboldt,1F--1,President,,REP,Ted Cruz,13
-Humboldt,1F--1,Proposition 50,,,No,50
-Humboldt,1F--1,Proposition 50,,,Yes,137
-Humboldt,1F--1,State Assembly,2,DEM,Jim Wood,147
-Humboldt,1F--1,U.S. House,2,REP,Dale K. Mensing,54
-Humboldt,1F--1,U.S. House,2,DEM,Erin A. Schrode,11
-Humboldt,1F--1,U.S. House,2,DEM,Jared W. Huffman,128
-Humboldt,1F--1,U.S. House,2,IND,Matthew Robert Wookey,8
+Humboldt,1ES-1,U.S. Senate,,REP,Ron Unz,3
+Humboldt,1ES-1,U.S. Senate,,IND,Scott A. Vineberg,1
+Humboldt,1ES-1,U.S. Senate,,DEM,Steve Stokes,28
+Humboldt,1ES-1,U.S. Senate,,REP,Thomas G. Del Beccaro,9
+Humboldt,1ES-1,U.S. Senate,,REP,Tom Palzer,2
+Humboldt,1ES-1,U.S. Senate,,REP,Von Hougo,7
+Humboldt,1F--1,President,,AIP,Arthur Harris,1
+Humboldt,1F--1,President,,REP,Ben Carson,9
+Humboldt,1F--1,President,,DEM,Bernie Sanders,177
+Humboldt,1F--1,President,,REP,Donald Trump,140
+Humboldt,1F--1,President,,LIB,Gary Johnson,2
+Humboldt,1F--1,President,,DEM,Henry Hewes,2
+Humboldt,1F--1,President,,DEM,Hillary Clinton,134
+Humboldt,1F--1,President,,REP,John R. Kasich,21
+Humboldt,1F--1,President,,DEM,Keith Judd,1
+Humboldt,1F--1,President,,DEM,Michael Steinberg,2
+Humboldt,1F--1,President,,REP,Ted Cruz,28
+Humboldt,1F--1,President,,AIP,Wiley Drake,1
+Humboldt,1F--1,President,,DEM,Willie Wilson,2
+Humboldt,1F--1,Proposition 50,,,No,99
+Humboldt,1F--1,Proposition 50,,,Yes,394
+Humboldt,1F--1,State Assembly,2,DEM,Jim Wood,394
+Humboldt,1F--1,U.S. House,2,REP,Dale K. Mensing,127
+Humboldt,1F--1,U.S. House,2,DEM,Erin A. Schrode,36
+Humboldt,1F--1,U.S. House,2,DEM,Jared W. Huffman,339
+Humboldt,1F--1,U.S. House,2,IND,Matthew Robert Wookey,22
 Humboldt,1F--1,U.S. Senate,,IND,Clive Grey,1
-Humboldt,1F--1,U.S. Senate,,REP,Duf Sundheim,12
+Humboldt,1F--1,U.S. Senate,,REP,Don Krampe,10
+Humboldt,1F--1,U.S. Senate,,REP,Duf Sundheim,34
 Humboldt,1F--1,U.S. Senate,,IND,Eleanor García,1
-Humboldt,1F--1,U.S. Senate,,LIB,Gail K. Lightfoot,7
-Humboldt,1F--1,U.S. Senate,,REP,Greg Conlon,13
-Humboldt,1F--1,U.S. Senate,,REP,Jarrell Williamson,2
-Humboldt,1F--1,U.S. Senate,,IND,Jason Hanania,1
-Humboldt,1F--1,U.S. Senate,,REP,Jerry J. Laws,11
-Humboldt,1F--1,U.S. Senate,,DEM,Kamala D. Harris,58
-Humboldt,1F--1,U.S. Senate,,REP,Karen Roseberry,3
-Humboldt,1F--1,U.S. Senate,,IND,Ling Ling Shi,1
-Humboldt,1F--1,U.S. Senate,,DEM,Loretta L. Sanchez,34
-Humboldt,1F--1,U.S. Senate,,IND,Mike Beitiks,7
-Humboldt,1F--1,U.S. Senate,,GRN,Pamela Elizondo,4
-Humboldt,1F--1,U.S. Senate,,REP,Phil Wyman,18
+Humboldt,1F--1,U.S. Senate,,LIB,Gail K. Lightfoot,13
+Humboldt,1F--1,U.S. Senate,,IND,Gar Myers,1
+Humboldt,1F--1,U.S. Senate,,REP,George C. Yang,2
+Humboldt,1F--1,U.S. Senate,,REP,Greg Conlon,25
+Humboldt,1F--1,U.S. Senate,,DEM,Herbert G. Peters,1
+Humboldt,1F--1,U.S. Senate,,REP,Jarrell Williamson,4
+Humboldt,1F--1,U.S. Senate,,IND,Jason Hanania,2
+Humboldt,1F--1,U.S. Senate,,IND,Jason Kraus,1
+Humboldt,1F--1,U.S. Senate,,REP,Jerry J. Laws,35
+Humboldt,1F--1,U.S. Senate,,DEM,Kamala D. Harris,187
+Humboldt,1F--1,U.S. Senate,,REP,Karen Roseberry,4
+Humboldt,1F--1,U.S. Senate,,IND,Ling Ling Shi,2
+Humboldt,1F--1,U.S. Senate,,DEM,Loretta L. Sanchez,78
+Humboldt,1F--1,U.S. Senate,,DEM,Massie Munroe,2
+Humboldt,1F--1,U.S. Senate,,IND,Mike Beitiks,8
+Humboldt,1F--1,U.S. Senate,,GRN,Pamela Elizondo,6
+Humboldt,1F--1,U.S. Senate,,IND,Paul Merritt,1
+Humboldt,1F--1,U.S. Senate,,REP,Phil Wyman,40
 Humboldt,1F--1,U.S. Senate,,DEM,President Cristina Grappo,1
-Humboldt,1F--1,U.S. Senate,,REP,Ron Unz,2
-Humboldt,1F--1,U.S. Senate,,DEM,Steve Stokes,12
-Humboldt,1F--1,U.S. Senate,,REP,Thomas G. Del Beccaro,9
-Humboldt,1F--1,U.S. Senate,,REP,Tom Palzer,1
-Humboldt,1F--1,U.S. Senate,,REP,Von Hougo,1
-Humboldt,1F--1_A,President,,AIP,Arthur Harris,1
-Humboldt,1F--1_A,President,,REP,Ben Carson,3
-Humboldt,1F--1_A,President,,DEM,Bernie Sanders,114
-Humboldt,1F--1_A,President,,REP,Donald Trump,84
-Humboldt,1F--1_A,President,,LIB,Gary Johnson,1
-Humboldt,1F--1_A,President,,DEM,Henry Hewes,2
-Humboldt,1F--1_A,President,,DEM,Hillary Clinton,78
-Humboldt,1F--1_A,President,,REP,John R. Kasich,12
-Humboldt,1F--1_A,President,,DEM,Keith Judd,1
-Humboldt,1F--1_A,President,,DEM,Michael Steinberg,2
-Humboldt,1F--1_A,President,,REP,Ted Cruz,15
-Humboldt,1F--1_A,President,,AIP,Wiley Drake,1
-Humboldt,1F--1_A,President,,DEM,Willie Wilson,2
-Humboldt,1F--1_A,Proposition 50,,,No,49
-Humboldt,1F--1_A,Proposition 50,,,Yes,257
-Humboldt,1F--1_A,State Assembly,2,DEM,Jim Wood,247
-Humboldt,1F--1_A,U.S. House,2,REP,Dale K. Mensing,73
-Humboldt,1F--1_A,U.S. House,2,DEM,Erin A. Schrode,25
-Humboldt,1F--1_A,U.S. House,2,DEM,Jared W. Huffman,211
-Humboldt,1F--1_A,U.S. House,2,IND,Matthew Robert Wookey,14
-Humboldt,1F--1_A,U.S. Senate,,REP,Don Krampe,10
-Humboldt,1F--1_A,U.S. Senate,,REP,Duf Sundheim,22
-Humboldt,1F--1_A,U.S. Senate,,LIB,Gail K. Lightfoot,6
-Humboldt,1F--1_A,U.S. Senate,,IND,Gar Myers,1
-Humboldt,1F--1_A,U.S. Senate,,REP,George C. Yang,2
-Humboldt,1F--1_A,U.S. Senate,,REP,Greg Conlon,12
-Humboldt,1F--1_A,U.S. Senate,,DEM,Herbert G. Peters,1
-Humboldt,1F--1_A,U.S. Senate,,REP,Jarrell Williamson,2
-Humboldt,1F--1_A,U.S. Senate,,IND,Jason Hanania,1
-Humboldt,1F--1_A,U.S. Senate,,IND,Jason Kraus,1
-Humboldt,1F--1_A,U.S. Senate,,REP,Jerry J. Laws,24
-Humboldt,1F--1_A,U.S. Senate,,DEM,Kamala D. Harris,129
-Humboldt,1F--1_A,U.S. Senate,,REP,Karen Roseberry,1
-Humboldt,1F--1_A,U.S. Senate,,IND,Ling Ling Shi,1
-Humboldt,1F--1_A,U.S. Senate,,DEM,Loretta L. Sanchez,44
-Humboldt,1F--1_A,U.S. Senate,,DEM,Massie Munroe,2
-Humboldt,1F--1_A,U.S. Senate,,IND,Mike Beitiks,1
-Humboldt,1F--1_A,U.S. Senate,,GRN,Pamela Elizondo,2
-Humboldt,1F--1_A,U.S. Senate,,IND,Paul Merritt,1
-Humboldt,1F--1_A,U.S. Senate,,REP,Phil Wyman,22
-Humboldt,1F--1_A,U.S. Senate,,REP,Ron Unz,2
-Humboldt,1F--1_A,U.S. Senate,,DEM,Steve Stokes,6
-Humboldt,1F--1_A,U.S. Senate,,REP,Thomas G. Del Beccaro,13
-Humboldt,1F--1_A,U.S. Senate,,IND,Tim Gildersleeve,2
-Humboldt,1F--1_A,U.S. Senate,,REP,Tom Palzer,2
-Humboldt,1F--1_A,U.S. Senate,,REP,Von Hougo,3
-Humboldt,1FS,President,,REP,Ben Carson,11
-Humboldt,1FS,President,,DEM,Bernie Sanders,64
-Humboldt,1FS,President,,REP,Donald Trump,54
-Humboldt,1FS,President,,LIB,Gary Johnson,1
-Humboldt,1FS,President,,DEM,Hillary Clinton,18
-Humboldt,1FS,President,,REP,John R. Kasich,2
+Humboldt,1F--1,U.S. Senate,,REP,Ron Unz,4
+Humboldt,1F--1,U.S. Senate,,DEM,Steve Stokes,18
+Humboldt,1F--1,U.S. Senate,,REP,Thomas G. Del Beccaro,22
+Humboldt,1F--1,U.S. Senate,,IND,Tim Gildersleeve,2
+Humboldt,1F--1,U.S. Senate,,REP,Tom Palzer,3
+Humboldt,1F--1,U.S. Senate,,REP,Von Hougo,4
+Humboldt,1FS,President,,REP,Ben Carson,14
+Humboldt,1FS,President,,DEM,Bernie Sanders,104
+Humboldt,1FS,President,,REP,Donald Trump,151
+Humboldt,1FS,President,,LIB,Gary Johnson,2
+Humboldt,1FS,President,,DEM,Hillary Clinton,57
+Humboldt,1FS,President,,REP,Jim Gilmore,1
+Humboldt,1FS,President,,REP,John R. Kasich,11
+Humboldt,1FS,President,,DEM,Michael Steinberg,1
 Humboldt,1FS,President,,LIB,Rhett White Feather Smith,1
 Humboldt,1FS,President,,DEM,Roque De La Fuente,1
-Humboldt,1FS,President,,REP,Ted Cruz,8
+Humboldt,1FS,President,,REP,Ted Cruz,20
+Humboldt,1FS,President,,AIP,Wiley Drake,1
 Humboldt,1FS,President,,DEM,Willie Wilson,2
-Humboldt,1FS,Proposition 50,,,No,31
-Humboldt,1FS,Proposition 50,,,Yes,110
-Humboldt,1FS,State Assembly,2,DEM,Jim Wood,116
-Humboldt,1FS,U.S. House,2,REP,Dale K. Mensing,54
-Humboldt,1FS,U.S. House,2,DEM,Erin A. Schrode,6
-Humboldt,1FS,U.S. House,2,DEM,Jared W. Huffman,93
-Humboldt,1FS,U.S. House,2,IND,Matthew Robert Wookey,8
-Humboldt,1FS,U.S. Senate,,IND,Clive Grey,1
-Humboldt,1FS,U.S. Senate,,IND,Don J. Grundmann,3
-Humboldt,1FS,U.S. Senate,,REP,Don Krampe,1
-Humboldt,1FS,U.S. Senate,,REP,Duf Sundheim,14
+Humboldt,1FS,Proposition 50,,,No,61
+Humboldt,1FS,Proposition 50,,,Yes,288
+Humboldt,1FS,State Assembly,2,DEM,Jim Wood,267
+Humboldt,1FS,U.S. House,2,REP,Dale K. Mensing,136
+Humboldt,1FS,U.S. House,2,DEM,Erin A. Schrode,16
+Humboldt,1FS,U.S. House,2,DEM,Jared W. Huffman,210
+Humboldt,1FS,U.S. House,2,IND,Matthew Robert Wookey,18
+Humboldt,1FS,U.S. Senate,,IND,Clive Grey,4
+Humboldt,1FS,U.S. Senate,,IND,Don J. Grundmann,5
+Humboldt,1FS,U.S. Senate,,REP,Don Krampe,4
+Humboldt,1FS,U.S. Senate,,REP,Duf Sundheim,31
 Humboldt,1FS,U.S. Senate,,IND,Eleanor García,1
-Humboldt,1FS,U.S. Senate,,LIB,Gail K. Lightfoot,6
+Humboldt,1FS,U.S. Senate,,LIB,Gail K. Lightfoot,11
 Humboldt,1FS,U.S. Senate,,IND,Gar Myers,1
-Humboldt,1FS,U.S. Senate,,REP,George C. Yang,2
-Humboldt,1FS,U.S. Senate,,REP,Greg Conlon,5
+Humboldt,1FS,U.S. Senate,,REP,George C. Yang,3
+Humboldt,1FS,U.S. Senate,,REP,Greg Conlon,10
 Humboldt,1FS,U.S. Senate,,IND,Jason Hanania,1
 Humboldt,1FS,U.S. Senate,,IND,Jason Kraus,3
-Humboldt,1FS,U.S. Senate,,REP,Jerry J. Laws,11
+Humboldt,1FS,U.S. Senate,,REP,Jerry J. Laws,22
 Humboldt,1FS,U.S. Senate,,PAF,John Thompson Parker,1
-Humboldt,1FS,U.S. Senate,,DEM,Kamala D. Harris,33
-Humboldt,1FS,U.S. Senate,,REP,Karen Roseberry,1
+Humboldt,1FS,U.S. Senate,,DEM,Kamala D. Harris,92
+Humboldt,1FS,U.S. Senate,,REP,Karen Roseberry,3
 Humboldt,1FS,U.S. Senate,,IND,Ling Ling Shi,1
-Humboldt,1FS,U.S. Senate,,DEM,Loretta L. Sanchez,25
-Humboldt,1FS,U.S. Senate,,DEM,Massie Munroe,2
-Humboldt,1FS,U.S. Senate,,IND,Mike Beitiks,1
-Humboldt,1FS,U.S. Senate,,GRN,Pamela Elizondo,4
+Humboldt,1FS,U.S. Senate,,DEM,Loretta L. Sanchez,48
+Humboldt,1FS,U.S. Senate,,DEM,Massie Munroe,3
+Humboldt,1FS,U.S. Senate,,IND,Mike Beitiks,5
+Humboldt,1FS,U.S. Senate,,GRN,Pamela Elizondo,6
 Humboldt,1FS,U.S. Senate,,IND,Paul Merritt,1
-Humboldt,1FS,U.S. Senate,,REP,Phil Wyman,21
+Humboldt,1FS,U.S. Senate,,REP,Phil Wyman,75
 Humboldt,1FS,U.S. Senate,,DEM,President Cristina Grappo,1
 Humboldt,1FS,U.S. Senate,,REP,Ron Unz,1
-Humboldt,1FS,U.S. Senate,,DEM,Steve Stokes,3
-Humboldt,1FS,U.S. Senate,,REP,Thomas G. Del Beccaro,11
-Humboldt,1FS,U.S. Senate,,REP,Tom Palzer,1
+Humboldt,1FS,U.S. Senate,,DEM,Steve Stokes,12
+Humboldt,1FS,U.S. Senate,,REP,Thomas G. Del Beccaro,20
+Humboldt,1FS,U.S. Senate,,REP,Tom Palzer,6
+Humboldt,1FS,U.S. Senate,,REP,Von Hougo,2
 Humboldt,1FS-1,President,,REP,Ben Carson,4
-Humboldt,1FS-1,President,,DEM,Bernie Sanders,28
-Humboldt,1FS-1,President,,REP,Donald Trump,29
+Humboldt,1FS-1,President,,DEM,Bernie Sanders,31
+Humboldt,1FS-1,President,,REP,Donald Trump,30
 Humboldt,1FS-1,President,,DEM,Hillary Clinton,13
 Humboldt,1FS-1,President,,GRN,Jill Stein,1
 Humboldt,1FS-1,President,,REP,John R. Kasich,4
 Humboldt,1FS-1,President,,REP,Ted Cruz,3
 Humboldt,1FS-1,President,,AIP,Wiley Drake,1
-Humboldt,1FS-1,Proposition 50,,,No,22
-Humboldt,1FS-1,Proposition 50,,,Yes,62
-Humboldt,1FS-1,State Assembly,2,DEM,Jim Wood,54
-Humboldt,1FS-1,U.S. House,2,REP,Dale K. Mensing,25
-Humboldt,1FS-1,U.S. House,2,DEM,Erin A. Schrode,9
-Humboldt,1FS-1,U.S. House,2,DEM,Jared W. Huffman,37
-Humboldt,1FS-1,U.S. House,2,IND,Matthew Robert Wookey,8
-Humboldt,1FS-1,U.S. Senate,,IND,Clive Grey,1
+Humboldt,1FS-1,Proposition 50,,,No,23
+Humboldt,1FS-1,Proposition 50,,,Yes,64
+Humboldt,1FS-1,State Assembly,2,DEM,Jim Wood,56
+Humboldt,1FS-1,U.S. House,2,REP,Dale K. Mensing,26
+Humboldt,1FS-1,U.S. House,2,DEM,Erin A. Schrode,10
+Humboldt,1FS-1,U.S. House,2,DEM,Jared W. Huffman,38
+Humboldt,1FS-1,U.S. House,2,IND,Matthew Robert Wookey,9
+Humboldt,1FS-1,U.S. Senate,,IND,Clive Grey,2
 Humboldt,1FS-1,U.S. Senate,,IND,Don J. Grundmann,1
 Humboldt,1FS-1,U.S. Senate,,REP,Don Krampe,1
-Humboldt,1FS-1,U.S. Senate,,REP,Duf Sundheim,6
+Humboldt,1FS-1,U.S. Senate,,REP,Duf Sundheim,7
 Humboldt,1FS-1,U.S. Senate,,LIB,Gail K. Lightfoot,1
 Humboldt,1FS-1,U.S. Senate,,REP,Greg Conlon,4
 Humboldt,1FS-1,U.S. Senate,,REP,Jarrell Williamson,1
@@ -876,27 +558,14 @@ Humboldt,1FS-1,U.S. Senate,,DEM,Kamala D. Harris,21
 Humboldt,1FS-1,U.S. Senate,,IND,Ling Ling Shi,1
 Humboldt,1FS-1,U.S. Senate,,DEM,Loretta L. Sanchez,14
 Humboldt,1FS-1,U.S. Senate,,DEM,Massie Munroe,1
-Humboldt,1FS-1,U.S. Senate,,IND,Mike Beitiks,1
-Humboldt,1FS-1,U.S. Senate,,GRN,Pamela Elizondo,4
+Humboldt,1FS-1,U.S. Senate,,IND,Mike Beitiks,2
+Humboldt,1FS-1,U.S. Senate,,GRN,Pamela Elizondo,5
 Humboldt,1FS-1,U.S. Senate,,REP,Phil Wyman,11
 Humboldt,1FS-1,U.S. Senate,,REP,Ron Unz,1
 Humboldt,1FS-1,U.S. Senate,,DEM,Steve Stokes,2
 Humboldt,1FS-1,U.S. Senate,,REP,Thomas G. Del Beccaro,2
 Humboldt,1FS-1,U.S. Senate,,IND,Tim Gildersleeve,1
 Humboldt,1FS-1,U.S. Senate,,REP,Von Hougo,1
-Humboldt,1FS-1_A,President,,DEM,Bernie Sanders,3
-Humboldt,1FS-1_A,President,,REP,Donald Trump,1
-Humboldt,1FS-1_A,Proposition 50,,,No,1
-Humboldt,1FS-1_A,Proposition 50,,,Yes,2
-Humboldt,1FS-1_A,State Assembly,2,DEM,Jim Wood,2
-Humboldt,1FS-1_A,U.S. House,2,REP,Dale K. Mensing,1
-Humboldt,1FS-1_A,U.S. House,2,DEM,Erin A. Schrode,1
-Humboldt,1FS-1_A,U.S. House,2,DEM,Jared W. Huffman,1
-Humboldt,1FS-1_A,U.S. House,2,IND,Matthew Robert Wookey,1
-Humboldt,1FS-1_A,U.S. Senate,,IND,Clive Grey,1
-Humboldt,1FS-1_A,U.S. Senate,,REP,Duf Sundheim,1
-Humboldt,1FS-1_A,U.S. Senate,,IND,Mike Beitiks,1
-Humboldt,1FS-1_A,U.S. Senate,,GRN,Pamela Elizondo,1
 Humboldt,1FS-4,President,,LIB,Austin Petersen,1
 Humboldt,1FS-4,President,,REP,Ben Carson,2
 Humboldt,1FS-4,President,,DEM,Bernie Sanders,40
@@ -961,125 +630,54 @@ Humboldt,1FS-9,U.S. Senate,,GRN,Pamela Elizondo,4
 Humboldt,1FS-9,U.S. Senate,,REP,Phil Wyman,8
 Humboldt,1FS-9,U.S. Senate,,DEM,Steve Stokes,2
 Humboldt,1FS-9,U.S. Senate,,REP,Thomas G. Del Beccaro,4
-Humboldt,1FS_A,President,,REP,Ben Carson,3
-Humboldt,1FS_A,President,,DEM,Bernie Sanders,40
-Humboldt,1FS_A,President,,REP,Donald Trump,97
-Humboldt,1FS_A,President,,LIB,Gary Johnson,1
-Humboldt,1FS_A,President,,DEM,Hillary Clinton,39
-Humboldt,1FS_A,President,,REP,Jim Gilmore,1
-Humboldt,1FS_A,President,,REP,John R. Kasich,9
-Humboldt,1FS_A,President,,DEM,Michael Steinberg,1
-Humboldt,1FS_A,President,,REP,Ted Cruz,12
-Humboldt,1FS_A,President,,AIP,Wiley Drake,1
-Humboldt,1FS_A,Proposition 50,,,No,30
-Humboldt,1FS_A,Proposition 50,,,Yes,178
-Humboldt,1FS_A,State Assembly,2,DEM,Jim Wood,151
-Humboldt,1FS_A,U.S. House,2,REP,Dale K. Mensing,82
-Humboldt,1FS_A,U.S. House,2,DEM,Erin A. Schrode,10
-Humboldt,1FS_A,U.S. House,2,DEM,Jared W. Huffman,117
-Humboldt,1FS_A,U.S. House,2,IND,Matthew Robert Wookey,10
-Humboldt,1FS_A,U.S. Senate,,IND,Clive Grey,3
-Humboldt,1FS_A,U.S. Senate,,IND,Don J. Grundmann,2
-Humboldt,1FS_A,U.S. Senate,,REP,Don Krampe,3
-Humboldt,1FS_A,U.S. Senate,,REP,Duf Sundheim,17
-Humboldt,1FS_A,U.S. Senate,,LIB,Gail K. Lightfoot,5
-Humboldt,1FS_A,U.S. Senate,,REP,George C. Yang,1
-Humboldt,1FS_A,U.S. Senate,,REP,Greg Conlon,5
-Humboldt,1FS_A,U.S. Senate,,REP,Jerry J. Laws,11
-Humboldt,1FS_A,U.S. Senate,,DEM,Kamala D. Harris,59
-Humboldt,1FS_A,U.S. Senate,,REP,Karen Roseberry,2
-Humboldt,1FS_A,U.S. Senate,,DEM,Loretta L. Sanchez,23
-Humboldt,1FS_A,U.S. Senate,,DEM,Massie Munroe,1
-Humboldt,1FS_A,U.S. Senate,,IND,Mike Beitiks,4
-Humboldt,1FS_A,U.S. Senate,,GRN,Pamela Elizondo,2
-Humboldt,1FS_A,U.S. Senate,,REP,Phil Wyman,54
-Humboldt,1FS_A,U.S. Senate,,DEM,Steve Stokes,9
-Humboldt,1FS_A,U.S. Senate,,REP,Thomas G. Del Beccaro,9
-Humboldt,1FS_A,U.S. Senate,,REP,Tom Palzer,5
-Humboldt,1FS_A,U.S. Senate,,REP,Von Hougo,2
-Humboldt,1LU,President,,REP,Ben Carson,4
-Humboldt,1LU,President,,DEM,Bernie Sanders,77
-Humboldt,1LU,President,,REP,Donald Trump,48
-Humboldt,1LU,President,,LIB,Gary Johnson,1
-Humboldt,1LU,President,,DEM,Hillary Clinton,31
-Humboldt,1LU,President,,GRN,Jill Stein,1
-Humboldt,1LU,President,,REP,John R. Kasich,6
+Humboldt,1LU,President,,REP,Ben Carson,7
+Humboldt,1LU,President,,DEM,Bernie Sanders,154
+Humboldt,1LU,President,,REP,Donald Trump,100
+Humboldt,1LU,President,,LIB,Gary Johnson,3
+Humboldt,1LU,President,,DEM,Hillary Clinton,72
+Humboldt,1LU,President,,GRN,Jill Stein,6
+Humboldt,1LU,President,,REP,John R. Kasich,12
 Humboldt,1LU,President,,DEM,Keith Judd,1
+Humboldt,1LU,President,,DEM,Michael Steinberg,1
 Humboldt,1LU,President,,DEM,Roque De La Fuente,1
-Humboldt,1LU,President,,REP,Ted Cruz,6
-Humboldt,1LU,President,,DEM,Willie Wilson,1
-Humboldt,1LU,Proposition 50,,,No,39
-Humboldt,1LU,Proposition 50,,,Yes,131
-Humboldt,1LU,State Assembly,2,DEM,Jim Wood,130
-Humboldt,1LU,U.S. House,2,REP,Dale K. Mensing,47
-Humboldt,1LU,U.S. House,2,DEM,Erin A. Schrode,13
-Humboldt,1LU,U.S. House,2,DEM,Jared W. Huffman,105
-Humboldt,1LU,U.S. House,2,IND,Matthew Robert Wookey,12
+Humboldt,1LU,President,,REP,Ted Cruz,12
+Humboldt,1LU,President,,DEM,Willie Wilson,2
+Humboldt,1LU,Proposition 50,,,No,79
+Humboldt,1LU,Proposition 50,,,Yes,289
+Humboldt,1LU,State Assembly,2,DEM,Jim Wood,273
+Humboldt,1LU,U.S. House,2,REP,Dale K. Mensing,95
+Humboldt,1LU,U.S. House,2,DEM,Erin A. Schrode,28
+Humboldt,1LU,U.S. House,2,DEM,Jared W. Huffman,223
+Humboldt,1LU,U.S. House,2,IND,Matthew Robert Wookey,26
+Humboldt,1LU,U.S. Senate,,IND,Clive Grey,1
 Humboldt,1LU,U.S. Senate,,IND,Don J. Grundmann,2
-Humboldt,1LU,U.S. Senate,,REP,Don Krampe,1
-Humboldt,1LU,U.S. Senate,,REP,Duf Sundheim,8
+Humboldt,1LU,U.S. Senate,,REP,Don Krampe,2
+Humboldt,1LU,U.S. Senate,,REP,Duf Sundheim,23
+Humboldt,1LU,U.S. Senate,,IND,Eleanor García,1
 Humboldt,1LU,U.S. Senate,,DEM,Emory Rodgers,1
-Humboldt,1LU,U.S. Senate,,LIB,Gail K. Lightfoot,10
-Humboldt,1LU,U.S. Senate,,REP,Greg Conlon,6
+Humboldt,1LU,U.S. Senate,,LIB,Gail K. Lightfoot,15
+Humboldt,1LU,U.S. Senate,,REP,Greg Conlon,17
 Humboldt,1LU,U.S. Senate,,DEM,Herbert G. Peters,1
 Humboldt,1LU,U.S. Senate,,REP,Jarrell Williamson,1
-Humboldt,1LU,U.S. Senate,,REP,Jerry J. Laws,12
+Humboldt,1LU,U.S. Senate,,IND,Jason Kraus,3
+Humboldt,1LU,U.S. Senate,,REP,Jerry J. Laws,20
 Humboldt,1LU,U.S. Senate,,PAF,John Thompson Parker,1
-Humboldt,1LU,U.S. Senate,,DEM,Kamala D. Harris,41
-Humboldt,1LU,U.S. Senate,,REP,Karen Roseberry,2
-Humboldt,1LU,U.S. Senate,,IND,Ling Ling Shi,1
-Humboldt,1LU,U.S. Senate,,DEM,Loretta L. Sanchez,28
-Humboldt,1LU,U.S. Senate,,DEM,Massie Munroe,1
-Humboldt,1LU,U.S. Senate,,IND,Mike Beitiks,2
-Humboldt,1LU,U.S. Senate,,GRN,Pamela Elizondo,10
-Humboldt,1LU,U.S. Senate,,IND,Paul Merritt,1
-Humboldt,1LU,U.S. Senate,,REP,Phil Wyman,26
-Humboldt,1LU,U.S. Senate,,REP,Ron Unz,2
-Humboldt,1LU,U.S. Senate,,IND,Scott A. Vineberg,1
-Humboldt,1LU,U.S. Senate,,DEM,Steve Stokes,6
-Humboldt,1LU,U.S. Senate,,REP,Thomas G. Del Beccaro,6
+Humboldt,1LU,U.S. Senate,,DEM,Kamala D. Harris,93
+Humboldt,1LU,U.S. Senate,,REP,Karen Roseberry,5
+Humboldt,1LU,U.S. Senate,,IND,Ling Ling Shi,2
+Humboldt,1LU,U.S. Senate,,DEM,Loretta L. Sanchez,69
+Humboldt,1LU,U.S. Senate,,DEM,Massie Munroe,3
+Humboldt,1LU,U.S. Senate,,IND,Mike Beitiks,6
+Humboldt,1LU,U.S. Senate,,GRN,Pamela Elizondo,17
+Humboldt,1LU,U.S. Senate,,IND,Paul Merritt,2
+Humboldt,1LU,U.S. Senate,,REP,Phil Wyman,44
+Humboldt,1LU,U.S. Senate,,REP,Ron Unz,3
+Humboldt,1LU,U.S. Senate,,IND,Scott A. Vineberg,2
+Humboldt,1LU,U.S. Senate,,DEM,Steve Stokes,16
+Humboldt,1LU,U.S. Senate,,REP,Thomas G. Del Beccaro,9
 Humboldt,1LU,U.S. Senate,,IND,Tim Gildersleeve,1
-Humboldt,1LU,U.S. Senate,,REP,Von Hougo,1
-Humboldt,1LU_A,President,,REP,Ben Carson,3
-Humboldt,1LU_A,President,,DEM,Bernie Sanders,77
-Humboldt,1LU_A,President,,REP,Donald Trump,52
-Humboldt,1LU_A,President,,LIB,Gary Johnson,2
-Humboldt,1LU_A,President,,DEM,Hillary Clinton,41
-Humboldt,1LU_A,President,,GRN,Jill Stein,5
-Humboldt,1LU_A,President,,REP,John R. Kasich,6
-Humboldt,1LU_A,President,,DEM,Michael Steinberg,1
-Humboldt,1LU_A,President,,REP,Ted Cruz,6
-Humboldt,1LU_A,President,,DEM,Willie Wilson,1
-Humboldt,1LU_A,Proposition 50,,,No,40
-Humboldt,1LU_A,Proposition 50,,,Yes,158
-Humboldt,1LU_A,State Assembly,2,DEM,Jim Wood,143
-Humboldt,1LU_A,U.S. House,2,REP,Dale K. Mensing,48
-Humboldt,1LU_A,U.S. House,2,DEM,Erin A. Schrode,15
-Humboldt,1LU_A,U.S. House,2,DEM,Jared W. Huffman,118
-Humboldt,1LU_A,U.S. House,2,IND,Matthew Robert Wookey,14
-Humboldt,1LU_A,U.S. Senate,,IND,Clive Grey,1
-Humboldt,1LU_A,U.S. Senate,,REP,Don Krampe,1
-Humboldt,1LU_A,U.S. Senate,,REP,Duf Sundheim,15
-Humboldt,1LU_A,U.S. Senate,,IND,Eleanor García,1
-Humboldt,1LU_A,U.S. Senate,,LIB,Gail K. Lightfoot,5
-Humboldt,1LU_A,U.S. Senate,,REP,Greg Conlon,11
-Humboldt,1LU_A,U.S. Senate,,IND,Jason Kraus,3
-Humboldt,1LU_A,U.S. Senate,,REP,Jerry J. Laws,8
-Humboldt,1LU_A,U.S. Senate,,DEM,Kamala D. Harris,52
-Humboldt,1LU_A,U.S. Senate,,REP,Karen Roseberry,3
-Humboldt,1LU_A,U.S. Senate,,IND,Ling Ling Shi,1
-Humboldt,1LU_A,U.S. Senate,,DEM,Loretta L. Sanchez,41
-Humboldt,1LU_A,U.S. Senate,,DEM,Massie Munroe,2
-Humboldt,1LU_A,U.S. Senate,,IND,Mike Beitiks,4
-Humboldt,1LU_A,U.S. Senate,,GRN,Pamela Elizondo,7
-Humboldt,1LU_A,U.S. Senate,,IND,Paul Merritt,1
-Humboldt,1LU_A,U.S. Senate,,REP,Phil Wyman,18
-Humboldt,1LU_A,U.S. Senate,,REP,Ron Unz,1
-Humboldt,1LU_A,U.S. Senate,,IND,Scott A. Vineberg,1
-Humboldt,1LU_A,U.S. Senate,,DEM,Steve Stokes,10
-Humboldt,1LU_A,U.S. Senate,,REP,Thomas G. Del Beccaro,3
-Humboldt,1LU_A,U.S. Senate,,REP,Tom Palzer,1
-Humboldt,1LU_A,U.S. Senate,,REP,Von Hougo,3
+Humboldt,1LU,U.S. Senate,,REP,Tom Palzer,1
+Humboldt,1LU,U.S. Senate,,REP,Von Hougo,4
 Humboldt,1MU,President,,REP,Ben Carson,2
 Humboldt,1MU,President,,DEM,Bernie Sanders,76
 Humboldt,1MU,President,,REP,Donald Trump,18
@@ -1168,272 +766,160 @@ Humboldt,1RV-2,U.S. Senate,,DEM,Massie Munroe,2
 Humboldt,1RV-2,U.S. Senate,,REP,Phil Wyman,10
 Humboldt,1RV-2,U.S. Senate,,DEM,Steve Stokes,2
 Humboldt,1RV-2,U.S. Senate,,REP,Von Hougo,2
-Humboldt,1SB-1,President,,REP,Ben Carson,5
-Humboldt,1SB-1,President,,DEM,Bernie Sanders,123
+Humboldt,1SB-1,President,,REP,Ben Carson,10
+Humboldt,1SB-1,President,,DEM,Bernie Sanders,252
 Humboldt,1SB-1,President,,GRN,Darryl Cherney,2
-Humboldt,1SB-1,President,,REP,Donald Trump,48
+Humboldt,1SB-1,President,,REP,Donald Trump,182
 Humboldt,1SB-1,President,,LIB,Gary Johnson,1
-Humboldt,1SB-1,President,,DEM,Henry Hewes,1
-Humboldt,1SB-1,President,,DEM,Hillary Clinton,51
-Humboldt,1SB-1,President,,GRN,Jill Stein,1
+Humboldt,1SB-1,President,,DEM,Henry Hewes,2
+Humboldt,1SB-1,President,,DEM,Hillary Clinton,141
+Humboldt,1SB-1,President,,GRN,Jill Stein,4
 Humboldt,1SB-1,President,,REP,Jim Gilmore,2
-Humboldt,1SB-1,President,,REP,John R. Kasich,7
-Humboldt,1SB-1,President,,REP,Ted Cruz,7
-Humboldt,1SB-1,Proposition 50,,,No,46
-Humboldt,1SB-1,Proposition 50,,,Yes,196
-Humboldt,1SB-1,State Assembly,2,DEM,Jim Wood,196
-Humboldt,1SB-1,U.S. House,2,REP,Dale K. Mensing,65
-Humboldt,1SB-1,U.S. House,2,DEM,Erin A. Schrode,20
-Humboldt,1SB-1,U.S. House,2,DEM,Jared W. Huffman,144
-Humboldt,1SB-1,U.S. House,2,IND,Matthew Robert Wookey,24
-Humboldt,1SB-1,U.S. Senate,,IND,Clive Grey,2
-Humboldt,1SB-1,U.S. Senate,,REP,Don Krampe,3
-Humboldt,1SB-1,U.S. Senate,,REP,Duf Sundheim,7
-Humboldt,1SB-1,U.S. Senate,,IND,Eleanor García,3
-Humboldt,1SB-1,U.S. Senate,,LIB,Gail K. Lightfoot,9
+Humboldt,1SB-1,President,,REP,John R. Kasich,25
+Humboldt,1SB-1,President,,DEM,Michael Steinberg,1
+Humboldt,1SB-1,President,,AIP,Robert Ornelas,2
+Humboldt,1SB-1,President,,REP,Ted Cruz,20
+Humboldt,1SB-1,President,,AIP,Wiley Drake,1
+Humboldt,1SB-1,Proposition 50,,,No,108
+Humboldt,1SB-1,Proposition 50,,,Yes,527
+Humboldt,1SB-1,State Assembly,2,DEM,Jim Wood,469
+Humboldt,1SB-1,U.S. House,2,REP,Dale K. Mensing,180
+Humboldt,1SB-1,U.S. House,2,DEM,Erin A. Schrode,41
+Humboldt,1SB-1,U.S. House,2,DEM,Jared W. Huffman,389
+Humboldt,1SB-1,U.S. House,2,IND,Matthew Robert Wookey,43
+Humboldt,1SB-1,U.S. Senate,,IND,Clive Grey,3
+Humboldt,1SB-1,U.S. Senate,,REP,Don Krampe,6
+Humboldt,1SB-1,U.S. Senate,,REP,Duf Sundheim,37
+Humboldt,1SB-1,U.S. Senate,,IND,Eleanor García,6
+Humboldt,1SB-1,U.S. Senate,,DEM,Emory Rodgers,1
+Humboldt,1SB-1,U.S. Senate,,LIB,Gail K. Lightfoot,15
 Humboldt,1SB-1,U.S. Senate,,IND,Gar Myers,1
-Humboldt,1SB-1,U.S. Senate,,REP,George C. Yang,2
-Humboldt,1SB-1,U.S. Senate,,REP,Greg Conlon,13
-Humboldt,1SB-1,U.S. Senate,,REP,Jarrell Williamson,2
+Humboldt,1SB-1,U.S. Senate,,REP,George C. Yang,8
+Humboldt,1SB-1,U.S. Senate,,REP,Greg Conlon,49
+Humboldt,1SB-1,U.S. Senate,,DEM,Herbert G. Peters,1
+Humboldt,1SB-1,U.S. Senate,,REP,Jarrell Williamson,3
 Humboldt,1SB-1,U.S. Senate,,IND,Jason Hanania,2
 Humboldt,1SB-1,U.S. Senate,,IND,Jason Kraus,3
-Humboldt,1SB-1,U.S. Senate,,REP,Jerry J. Laws,18
+Humboldt,1SB-1,U.S. Senate,,REP,Jerry J. Laws,42
 Humboldt,1SB-1,U.S. Senate,,PAF,John Thompson Parker,1
-Humboldt,1SB-1,U.S. Senate,,DEM,Kamala D. Harris,76
-Humboldt,1SB-1,U.S. Senate,,REP,Karen Roseberry,2
-Humboldt,1SB-1,U.S. Senate,,IND,Ling Ling Shi,3
-Humboldt,1SB-1,U.S. Senate,,DEM,Loretta L. Sanchez,41
-Humboldt,1SB-1,U.S. Senate,,LIB,Mark Matthew Herd,1
-Humboldt,1SB-1,U.S. Senate,,IND,Mike Beitiks,3
-Humboldt,1SB-1,U.S. Senate,,GRN,Pamela Elizondo,7
-Humboldt,1SB-1,U.S. Senate,,IND,Paul Merritt,1
-Humboldt,1SB-1,U.S. Senate,,REP,Phil Wyman,17
-Humboldt,1SB-1,U.S. Senate,,DEM,President Cristina Grappo,1
-Humboldt,1SB-1,U.S. Senate,,REP,Ron Unz,3
-Humboldt,1SB-1,U.S. Senate,,DEM,Steve Stokes,17
-Humboldt,1SB-1,U.S. Senate,,REP,Thomas G. Del Beccaro,5
-Humboldt,1SB-1,U.S. Senate,,IND,Tim Gildersleeve,1
-Humboldt,1SB-1,U.S. Senate,,REP,Tom Palzer,2
-Humboldt,1SB-1,U.S. Senate,,REP,Von Hougo,4
-Humboldt,1SB-1_A,President,,REP,Ben Carson,5
-Humboldt,1SB-1_A,President,,DEM,Bernie Sanders,129
-Humboldt,1SB-1_A,President,,REP,Donald Trump,134
-Humboldt,1SB-1_A,President,,DEM,Henry Hewes,1
-Humboldt,1SB-1_A,President,,DEM,Hillary Clinton,90
-Humboldt,1SB-1_A,President,,GRN,Jill Stein,3
-Humboldt,1SB-1_A,President,,REP,John R. Kasich,18
-Humboldt,1SB-1_A,President,,DEM,Michael Steinberg,1
-Humboldt,1SB-1_A,President,,AIP,Robert Ornelas,2
-Humboldt,1SB-1_A,President,,REP,Ted Cruz,13
-Humboldt,1SB-1_A,President,,AIP,Wiley Drake,1
-Humboldt,1SB-1_A,Proposition 50,,,No,62
-Humboldt,1SB-1_A,Proposition 50,,,Yes,331
-Humboldt,1SB-1_A,State Assembly,2,DEM,Jim Wood,273
-Humboldt,1SB-1_A,U.S. House,2,REP,Dale K. Mensing,115
-Humboldt,1SB-1_A,U.S. House,2,DEM,Erin A. Schrode,21
-Humboldt,1SB-1_A,U.S. House,2,DEM,Jared W. Huffman,245
-Humboldt,1SB-1_A,U.S. House,2,IND,Matthew Robert Wookey,19
-Humboldt,1SB-1_A,U.S. Senate,,IND,Clive Grey,1
-Humboldt,1SB-1_A,U.S. Senate,,REP,Don Krampe,3
-Humboldt,1SB-1_A,U.S. Senate,,REP,Duf Sundheim,30
-Humboldt,1SB-1_A,U.S. Senate,,IND,Eleanor García,3
-Humboldt,1SB-1_A,U.S. Senate,,DEM,Emory Rodgers,1
-Humboldt,1SB-1_A,U.S. Senate,,LIB,Gail K. Lightfoot,6
-Humboldt,1SB-1_A,U.S. Senate,,REP,George C. Yang,6
-Humboldt,1SB-1_A,U.S. Senate,,REP,Greg Conlon,36
-Humboldt,1SB-1_A,U.S. Senate,,DEM,Herbert G. Peters,1
-Humboldt,1SB-1_A,U.S. Senate,,REP,Jarrell Williamson,1
-Humboldt,1SB-1_A,U.S. Senate,,REP,Jerry J. Laws,24
-Humboldt,1SB-1_A,U.S. Senate,,DEM,Kamala D. Harris,126
-Humboldt,1SB-1_A,U.S. Senate,,REP,Karen Roseberry,5
-Humboldt,1SB-1_A,U.S. Senate,,IND,Ling Ling Shi,1
-Humboldt,1SB-1_A,U.S. Senate,,DEM,Loretta L. Sanchez,55
-Humboldt,1SB-1_A,U.S. Senate,,LIB,Mark Matthew Herd,3
-Humboldt,1SB-1_A,U.S. Senate,,DEM,Massie Munroe,2
-Humboldt,1SB-1_A,U.S. Senate,,IND,Mike Beitiks,3
-Humboldt,1SB-1_A,U.S. Senate,,GRN,Pamela Elizondo,5
-Humboldt,1SB-1_A,U.S. Senate,,IND,Paul Merritt,1
-Humboldt,1SB-1_A,U.S. Senate,,REP,Phil Wyman,40
-Humboldt,1SB-1_A,U.S. Senate,,DEM,President Cristina Grappo,1
-Humboldt,1SB-1_A,U.S. Senate,,REP,Ron Unz,2
-Humboldt,1SB-1_A,U.S. Senate,,IND,Scott A. Vineberg,1
-Humboldt,1SB-1_A,U.S. Senate,,DEM,Steve Stokes,18
-Humboldt,1SB-1_A,U.S. Senate,,REP,Thomas G. Del Beccaro,9
-Humboldt,1SB-1_A,U.S. Senate,,IND,Tim Gildersleeve,2
-Humboldt,1SB-1_A,U.S. Senate,,REP,Tom Palzer,2
-Humboldt,1SB-1_A,U.S. Senate,,REP,Von Hougo,4
+Humboldt,1SB-1,U.S. Senate,,DEM,Kamala D. Harris,202
+Humboldt,1SB-1,U.S. Senate,,REP,Karen Roseberry,7
+Humboldt,1SB-1,U.S. Senate,,IND,Ling Ling Shi,4
+Humboldt,1SB-1,U.S. Senate,,DEM,Loretta L. Sanchez,96
+Humboldt,1SB-1,U.S. Senate,,LIB,Mark Matthew Herd,4
+Humboldt,1SB-1,U.S. Senate,,DEM,Massie Munroe,2
+Humboldt,1SB-1,U.S. Senate,,IND,Mike Beitiks,6
+Humboldt,1SB-1,U.S. Senate,,GRN,Pamela Elizondo,12
+Humboldt,1SB-1,U.S. Senate,,IND,Paul Merritt,2
+Humboldt,1SB-1,U.S. Senate,,REP,Phil Wyman,57
+Humboldt,1SB-1,U.S. Senate,,DEM,President Cristina Grappo,2
+Humboldt,1SB-1,U.S. Senate,,REP,Ron Unz,5
+Humboldt,1SB-1,U.S. Senate,,IND,Scott A. Vineberg,1
+Humboldt,1SB-1,U.S. Senate,,DEM,Steve Stokes,35
+Humboldt,1SB-1,U.S. Senate,,REP,Thomas G. Del Beccaro,14
+Humboldt,1SB-1,U.S. Senate,,IND,Tim Gildersleeve,3
+Humboldt,1SB-1,U.S. Senate,,REP,Tom Palzer,4
+Humboldt,1SB-1,U.S. Senate,,REP,Von Hougo,8
 Humboldt,1SB-4,President,,AIP,Arthur Harris,1
-Humboldt,1SB-4,President,,REP,Ben Carson,1
-Humboldt,1SB-4,President,,DEM,Bernie Sanders,94
-Humboldt,1SB-4,President,,REP,Donald Trump,31
-Humboldt,1SB-4,President,,DEM,Hillary Clinton,41
-Humboldt,1SB-4,President,,REP,John R. Kasich,3
+Humboldt,1SB-4,President,,REP,Ben Carson,9
+Humboldt,1SB-4,President,,DEM,Bernie Sanders,225
+Humboldt,1SB-4,President,,REP,Donald Trump,133
+Humboldt,1SB-4,President,,LIB,Gary Johnson,1
+Humboldt,1SB-4,President,,PAF,Gloria Estela La Riva,2
+Humboldt,1SB-4,President,,DEM,Hillary Clinton,136
+Humboldt,1SB-4,President,,REP,Jim Gilmore,3
+Humboldt,1SB-4,President,,REP,John R. Kasich,10
 Humboldt,1SB-4,President,,DEM,Keith Judd,1
-Humboldt,1SB-4,President,,AIP,Robert Ornelas,1
-Humboldt,1SB-4,President,,REP,Ted Cruz,6
+Humboldt,1SB-4,President,,LIB,Rhett White Feather Smith,2
+Humboldt,1SB-4,President,,AIP,Robert Ornelas,2
+Humboldt,1SB-4,President,,REP,Ted Cruz,26
+Humboldt,1SB-4,President,,AIP,Wiley Drake,1
 Humboldt,1SB-4,President,,DEM,Willie Wilson,1
-Humboldt,1SB-4,Proposition 50,,,No,49
-Humboldt,1SB-4,Proposition 50,,,Yes,127
-Humboldt,1SB-4,State Assembly,2,DEM,Jim Wood,140
-Humboldt,1SB-4,U.S. House,2,REP,Dale K. Mensing,35
-Humboldt,1SB-4,U.S. House,2,DEM,Erin A. Schrode,16
-Humboldt,1SB-4,U.S. House,2,DEM,Jared W. Huffman,105
-Humboldt,1SB-4,U.S. House,2,IND,Matthew Robert Wookey,19
-Humboldt,1SB-4,U.S. Senate,,IND,Clive Grey,1
-Humboldt,1SB-4,U.S. Senate,,REP,Don Krampe,2
-Humboldt,1SB-4,U.S. Senate,,REP,Duf Sundheim,11
-Humboldt,1SB-4,U.S. Senate,,IND,Eleanor García,2
-Humboldt,1SB-4,U.S. Senate,,LIB,Gail K. Lightfoot,6
-Humboldt,1SB-4,U.S. Senate,,REP,George C. Yang,2
-Humboldt,1SB-4,U.S. Senate,,REP,Greg Conlon,4
-Humboldt,1SB-4,U.S. Senate,,REP,Jarrell Williamson,1
-Humboldt,1SB-4,U.S. Senate,,IND,Jason Hanania,1
+Humboldt,1SB-4,Proposition 50,,,No,115
+Humboldt,1SB-4,Proposition 50,,,Yes,436
+Humboldt,1SB-4,State Assembly,2,DEM,Jim Wood,414
+Humboldt,1SB-4,U.S. House,2,REP,Dale K. Mensing,137
+Humboldt,1SB-4,U.S. House,2,DEM,Erin A. Schrode,39
+Humboldt,1SB-4,U.S. House,2,DEM,Jared W. Huffman,335
+Humboldt,1SB-4,U.S. House,2,IND,Matthew Robert Wookey,52
+Humboldt,1SB-4,U.S. Senate,,IND,Clive Grey,2
+Humboldt,1SB-4,U.S. Senate,,IND,Don J. Grundmann,1
+Humboldt,1SB-4,U.S. Senate,,REP,Don Krampe,6
+Humboldt,1SB-4,U.S. Senate,,REP,Duf Sundheim,33
+Humboldt,1SB-4,U.S. Senate,,IND,Eleanor García,4
+Humboldt,1SB-4,U.S. Senate,,DEM,Emory Rodgers,1
+Humboldt,1SB-4,U.S. Senate,,LIB,Gail K. Lightfoot,12
+Humboldt,1SB-4,U.S. Senate,,REP,George C. Yang,5
+Humboldt,1SB-4,U.S. Senate,,REP,Greg Conlon,26
+Humboldt,1SB-4,U.S. Senate,,REP,Jarrell Williamson,5
+Humboldt,1SB-4,U.S. Senate,,IND,Jason Hanania,2
 Humboldt,1SB-4,U.S. Senate,,IND,Jason Kraus,1
-Humboldt,1SB-4,U.S. Senate,,REP,Jerry J. Laws,7
+Humboldt,1SB-4,U.S. Senate,,REP,Jerry J. Laws,30
 Humboldt,1SB-4,U.S. Senate,,PAF,John Thompson Parker,1
-Humboldt,1SB-4,U.S. Senate,,DEM,Kamala D. Harris,55
+Humboldt,1SB-4,U.S. Senate,,DEM,Kamala D. Harris,190
+Humboldt,1SB-4,U.S. Senate,,REP,Karen Roseberry,4
 Humboldt,1SB-4,U.S. Senate,,IND,Ling Ling Shi,1
-Humboldt,1SB-4,U.S. Senate,,DEM,Loretta L. Sanchez,37
-Humboldt,1SB-4,U.S. Senate,,LIB,Mark Matthew Herd,1
-Humboldt,1SB-4,U.S. Senate,,DEM,Massie Munroe,3
-Humboldt,1SB-4,U.S. Senate,,IND,Mike Beitiks,4
-Humboldt,1SB-4,U.S. Senate,,GRN,Pamela Elizondo,6
-Humboldt,1SB-4,U.S. Senate,,REP,Phil Wyman,10
-Humboldt,1SB-4,U.S. Senate,,DEM,President Cristina Grappo,1
-Humboldt,1SB-4,U.S. Senate,,REP,Ron Unz,1
-Humboldt,1SB-4,U.S. Senate,,DEM,Steve Stokes,8
-Humboldt,1SB-4,U.S. Senate,,REP,Thomas G. Del Beccaro,5
-Humboldt,1SB-4,U.S. Senate,,REP,Von Hougo,1
-Humboldt,1SB-4_A,President,,REP,Ben Carson,8
-Humboldt,1SB-4_A,President,,DEM,Bernie Sanders,131
-Humboldt,1SB-4_A,President,,REP,Donald Trump,102
-Humboldt,1SB-4_A,President,,LIB,Gary Johnson,1
-Humboldt,1SB-4_A,President,,PAF,Gloria Estela La Riva,2
-Humboldt,1SB-4_A,President,,DEM,Hillary Clinton,95
-Humboldt,1SB-4_A,President,,REP,Jim Gilmore,3
-Humboldt,1SB-4_A,President,,REP,John R. Kasich,7
-Humboldt,1SB-4_A,President,,LIB,Rhett White Feather Smith,2
-Humboldt,1SB-4_A,President,,AIP,Robert Ornelas,1
-Humboldt,1SB-4_A,President,,REP,Ted Cruz,20
-Humboldt,1SB-4_A,President,,AIP,Wiley Drake,1
-Humboldt,1SB-4_A,Proposition 50,,,No,66
-Humboldt,1SB-4_A,Proposition 50,,,Yes,309
-Humboldt,1SB-4_A,State Assembly,2,DEM,Jim Wood,274
-Humboldt,1SB-4_A,U.S. House,2,REP,Dale K. Mensing,102
-Humboldt,1SB-4_A,U.S. House,2,DEM,Erin A. Schrode,23
-Humboldt,1SB-4_A,U.S. House,2,DEM,Jared W. Huffman,230
-Humboldt,1SB-4_A,U.S. House,2,IND,Matthew Robert Wookey,33
-Humboldt,1SB-4_A,U.S. Senate,,IND,Clive Grey,1
-Humboldt,1SB-4_A,U.S. Senate,,IND,Don J. Grundmann,1
-Humboldt,1SB-4_A,U.S. Senate,,REP,Don Krampe,4
-Humboldt,1SB-4_A,U.S. Senate,,REP,Duf Sundheim,22
-Humboldt,1SB-4_A,U.S. Senate,,IND,Eleanor García,2
-Humboldt,1SB-4_A,U.S. Senate,,DEM,Emory Rodgers,1
-Humboldt,1SB-4_A,U.S. Senate,,LIB,Gail K. Lightfoot,6
-Humboldt,1SB-4_A,U.S. Senate,,REP,George C. Yang,3
-Humboldt,1SB-4_A,U.S. Senate,,REP,Greg Conlon,22
-Humboldt,1SB-4_A,U.S. Senate,,REP,Jarrell Williamson,4
-Humboldt,1SB-4_A,U.S. Senate,,IND,Jason Hanania,1
-Humboldt,1SB-4_A,U.S. Senate,,REP,Jerry J. Laws,23
-Humboldt,1SB-4_A,U.S. Senate,,DEM,Kamala D. Harris,135
-Humboldt,1SB-4_A,U.S. Senate,,REP,Karen Roseberry,4
-Humboldt,1SB-4_A,U.S. Senate,,DEM,Loretta L. Sanchez,58
-Humboldt,1SB-4_A,U.S. Senate,,LIB,Mark Matthew Herd,2
-Humboldt,1SB-4_A,U.S. Senate,,DEM,Massie Munroe,3
-Humboldt,1SB-4_A,U.S. Senate,,IND,Mike Beitiks,7
-Humboldt,1SB-4_A,U.S. Senate,,GRN,Pamela Elizondo,5
-Humboldt,1SB-4_A,U.S. Senate,,REP,Phil Wyman,32
-Humboldt,1SB-4_A,U.S. Senate,,DEM,President Cristina Grappo,2
-Humboldt,1SB-4_A,U.S. Senate,,REP,Ron Unz,1
-Humboldt,1SB-4_A,U.S. Senate,,DEM,Steve Stokes,18
-Humboldt,1SB-4_A,U.S. Senate,,REP,Thomas G. Del Beccaro,9
-Humboldt,1SB-4_A,U.S. Senate,,IND,Tim Gildersleeve,1
-Humboldt,1SB-4_A,U.S. Senate,,REP,Tom Palzer,6
-Humboldt,1SB-4_A,U.S. Senate,,REP,Von Hougo,9
-Humboldt,1SB10,President,,REP,Ben Carson,2
-Humboldt,1SB10,President,,DEM,Bernie Sanders,104
-Humboldt,1SB10,President,,REP,Donald Trump,30
-Humboldt,1SB10,President,,LIB,Gary Johnson,1
-Humboldt,1SB10,President,,DEM,Hillary Clinton,46
+Humboldt,1SB-4,U.S. Senate,,DEM,Loretta L. Sanchez,95
+Humboldt,1SB-4,U.S. Senate,,LIB,Mark Matthew Herd,3
+Humboldt,1SB-4,U.S. Senate,,DEM,Massie Munroe,6
+Humboldt,1SB-4,U.S. Senate,,IND,Mike Beitiks,11
+Humboldt,1SB-4,U.S. Senate,,GRN,Pamela Elizondo,11
+Humboldt,1SB-4,U.S. Senate,,REP,Phil Wyman,42
+Humboldt,1SB-4,U.S. Senate,,DEM,President Cristina Grappo,3
+Humboldt,1SB-4,U.S. Senate,,REP,Ron Unz,2
+Humboldt,1SB-4,U.S. Senate,,DEM,Steve Stokes,26
+Humboldt,1SB-4,U.S. Senate,,REP,Thomas G. Del Beccaro,14
+Humboldt,1SB-4,U.S. Senate,,IND,Tim Gildersleeve,1
+Humboldt,1SB-4,U.S. Senate,,REP,Tom Palzer,6
+Humboldt,1SB-4,U.S. Senate,,REP,Von Hougo,10
+Humboldt,1SB10,President,,REP,Ben Carson,7
+Humboldt,1SB10,President,,DEM,Bernie Sanders,222
+Humboldt,1SB10,President,,REP,Donald Trump,115
+Humboldt,1SB10,President,,LIB,Gary Johnson,2
+Humboldt,1SB10,President,,DEM,Henry Hewes,1
+Humboldt,1SB10,President,,DEM,Hillary Clinton,120
 Humboldt,1SB10,President,,LIB,John McAfee,1
-Humboldt,1SB10,President,,REP,John R. Kasich,6
-Humboldt,1SB10,President,,DEM,Michael Steinberg,2
+Humboldt,1SB10,President,,REP,John R. Kasich,19
+Humboldt,1SB10,President,,DEM,Michael Steinberg,3
 Humboldt,1SB10,President,,LIB,Rhett White Feather Smith,1
-Humboldt,1SB10,President,,REP,Ted Cruz,7
-Humboldt,1SB10,Proposition 50,,,No,38
-Humboldt,1SB10,Proposition 50,,,Yes,156
-Humboldt,1SB10,State Assembly,2,DEM,Jim Wood,151
-Humboldt,1SB10,U.S. House,2,REP,Dale K. Mensing,39
-Humboldt,1SB10,U.S. House,2,DEM,Erin A. Schrode,16
-Humboldt,1SB10,U.S. House,2,DEM,Jared W. Huffman,134
-Humboldt,1SB10,U.S. House,2,IND,Matthew Robert Wookey,14
-Humboldt,1SB10,U.S. Senate,,IND,Clive Grey,1
-Humboldt,1SB10,U.S. Senate,,IND,Don J. Grundmann,1
+Humboldt,1SB10,President,,REP,Ted Cruz,29
+Humboldt,1SB10,Proposition 50,,,No,97
+Humboldt,1SB10,Proposition 50,,,Yes,418
+Humboldt,1SB10,State Assembly,2,DEM,Jim Wood,371
+Humboldt,1SB10,U.S. House,2,REP,Dale K. Mensing,124
+Humboldt,1SB10,U.S. House,2,DEM,Erin A. Schrode,29
+Humboldt,1SB10,U.S. House,2,DEM,Jared W. Huffman,345
+Humboldt,1SB10,U.S. House,2,IND,Matthew Robert Wookey,32
+Humboldt,1SB10,U.S. Senate,,IND,Clive Grey,5
+Humboldt,1SB10,U.S. Senate,,IND,Don J. Grundmann,3
 Humboldt,1SB10,U.S. Senate,,REP,Don Krampe,3
-Humboldt,1SB10,U.S. Senate,,REP,Duf Sundheim,14
-Humboldt,1SB10,U.S. Senate,,LIB,Gail K. Lightfoot,8
+Humboldt,1SB10,U.S. Senate,,REP,Duf Sundheim,37
+Humboldt,1SB10,U.S. Senate,,IND,Eleanor García,4
+Humboldt,1SB10,U.S. Senate,,LIB,Gail K. Lightfoot,20
 Humboldt,1SB10,U.S. Senate,,IND,Gar Myers,2
-Humboldt,1SB10,U.S. Senate,,REP,Greg Conlon,5
-Humboldt,1SB10,U.S. Senate,,REP,Jarrell Williamson,3
-Humboldt,1SB10,U.S. Senate,,IND,Jason Hanania,4
-Humboldt,1SB10,U.S. Senate,,IND,Jason Kraus,2
-Humboldt,1SB10,U.S. Senate,,REP,Jerry J. Laws,7
-Humboldt,1SB10,U.S. Senate,,DEM,Kamala D. Harris,73
-Humboldt,1SB10,U.S. Senate,,REP,Karen Roseberry,1
-Humboldt,1SB10,U.S. Senate,,IND,Ling Ling Shi,1
-Humboldt,1SB10,U.S. Senate,,DEM,Loretta L. Sanchez,29
-Humboldt,1SB10,U.S. Senate,,DEM,Massie Munroe,1
+Humboldt,1SB10,U.S. Senate,,REP,George C. Yang,3
+Humboldt,1SB10,U.S. Senate,,REP,Greg Conlon,28
+Humboldt,1SB10,U.S. Senate,,DEM,Herbert G. Peters,1
+Humboldt,1SB10,U.S. Senate,,REP,Jarrell Williamson,7
+Humboldt,1SB10,U.S. Senate,,IND,Jason Hanania,5
+Humboldt,1SB10,U.S. Senate,,IND,Jason Kraus,3
+Humboldt,1SB10,U.S. Senate,,REP,Jerry J. Laws,22
+Humboldt,1SB10,U.S. Senate,,DEM,Kamala D. Harris,191
+Humboldt,1SB10,U.S. Senate,,REP,Karen Roseberry,3
+Humboldt,1SB10,U.S. Senate,,IND,Ling Ling Shi,2
+Humboldt,1SB10,U.S. Senate,,DEM,Loretta L. Sanchez,71
+Humboldt,1SB10,U.S. Senate,,LIB,Mark Matthew Herd,1
+Humboldt,1SB10,U.S. Senate,,DEM,Massie Munroe,9
 Humboldt,1SB10,U.S. Senate,,IND,Mike Beitiks,1
-Humboldt,1SB10,U.S. Senate,,GRN,Pamela Elizondo,4
-Humboldt,1SB10,U.S. Senate,,IND,Paul Merritt,1
-Humboldt,1SB10,U.S. Senate,,REP,Phil Wyman,15
-Humboldt,1SB10,U.S. Senate,,DEM,President Cristina Grappo,1
-Humboldt,1SB10,U.S. Senate,,DEM,Steve Stokes,14
-Humboldt,1SB10,U.S. Senate,,REP,Thomas G. Del Beccaro,5
-Humboldt,1SB10,U.S. Senate,,REP,Von Hougo,1
-Humboldt,1SB10_A,President,,REP,Ben Carson,5
-Humboldt,1SB10_A,President,,DEM,Bernie Sanders,118
-Humboldt,1SB10_A,President,,REP,Donald Trump,85
-Humboldt,1SB10_A,President,,LIB,Gary Johnson,1
-Humboldt,1SB10_A,President,,DEM,Henry Hewes,1
-Humboldt,1SB10_A,President,,DEM,Hillary Clinton,74
-Humboldt,1SB10_A,President,,REP,John R. Kasich,13
-Humboldt,1SB10_A,President,,DEM,Michael Steinberg,1
-Humboldt,1SB10_A,President,,REP,Ted Cruz,22
-Humboldt,1SB10_A,Proposition 50,,,No,59
-Humboldt,1SB10_A,Proposition 50,,,Yes,262
-Humboldt,1SB10_A,State Assembly,2,DEM,Jim Wood,220
-Humboldt,1SB10_A,U.S. House,2,REP,Dale K. Mensing,85
-Humboldt,1SB10_A,U.S. House,2,DEM,Erin A. Schrode,13
-Humboldt,1SB10_A,U.S. House,2,DEM,Jared W. Huffman,211
-Humboldt,1SB10_A,U.S. House,2,IND,Matthew Robert Wookey,18
-Humboldt,1SB10_A,U.S. Senate,,IND,Clive Grey,4
-Humboldt,1SB10_A,U.S. Senate,,IND,Don J. Grundmann,2
-Humboldt,1SB10_A,U.S. Senate,,REP,Duf Sundheim,23
-Humboldt,1SB10_A,U.S. Senate,,IND,Eleanor García,4
-Humboldt,1SB10_A,U.S. Senate,,LIB,Gail K. Lightfoot,12
-Humboldt,1SB10_A,U.S. Senate,,REP,George C. Yang,3
-Humboldt,1SB10_A,U.S. Senate,,REP,Greg Conlon,23
-Humboldt,1SB10_A,U.S. Senate,,DEM,Herbert G. Peters,1
-Humboldt,1SB10_A,U.S. Senate,,REP,Jarrell Williamson,4
-Humboldt,1SB10_A,U.S. Senate,,IND,Jason Hanania,1
-Humboldt,1SB10_A,U.S. Senate,,IND,Jason Kraus,1
-Humboldt,1SB10_A,U.S. Senate,,REP,Jerry J. Laws,15
-Humboldt,1SB10_A,U.S. Senate,,DEM,Kamala D. Harris,118
-Humboldt,1SB10_A,U.S. Senate,,REP,Karen Roseberry,2
-Humboldt,1SB10_A,U.S. Senate,,IND,Ling Ling Shi,1
-Humboldt,1SB10_A,U.S. Senate,,DEM,Loretta L. Sanchez,42
-Humboldt,1SB10_A,U.S. Senate,,LIB,Mark Matthew Herd,1
-Humboldt,1SB10_A,U.S. Senate,,DEM,Massie Munroe,8
-Humboldt,1SB10_A,U.S. Senate,,GRN,Pamela Elizondo,2
-Humboldt,1SB10_A,U.S. Senate,,IND,Paul Merritt,2
-Humboldt,1SB10_A,U.S. Senate,,REP,Phil Wyman,28
-Humboldt,1SB10_A,U.S. Senate,,DEM,President Cristina Grappo,1
-Humboldt,1SB10_A,U.S. Senate,,REP,Ron Unz,7
-Humboldt,1SB10_A,U.S. Senate,,DEM,Steve Stokes,5
-Humboldt,1SB10_A,U.S. Senate,,REP,Thomas G. Del Beccaro,9
-Humboldt,1SB10_A,U.S. Senate,,REP,Tom Palzer,3
-Humboldt,1SB10_A,U.S. Senate,,REP,Von Hougo,3
+Humboldt,1SB10,U.S. Senate,,GRN,Pamela Elizondo,6
+Humboldt,1SB10,U.S. Senate,,IND,Paul Merritt,3
+Humboldt,1SB10,U.S. Senate,,REP,Phil Wyman,43
+Humboldt,1SB10,U.S. Senate,,DEM,President Cristina Grappo,2
+Humboldt,1SB10,U.S. Senate,,REP,Ron Unz,7
+Humboldt,1SB10,U.S. Senate,,DEM,Steve Stokes,19
+Humboldt,1SB10,U.S. Senate,,REP,Thomas G. Del Beccaro,14
+Humboldt,1SB10,U.S. Senate,,REP,Tom Palzer,3
+Humboldt,1SB10,U.S. Senate,,REP,Von Hougo,4
 Humboldt,1SB12,President,,REP,Ben Carson,1
 Humboldt,1SB12,President,,DEM,Bernie Sanders,17
 Humboldt,1SB12,President,,REP,Donald Trump,14
@@ -1459,898 +945,539 @@ Humboldt,1SB12,U.S. Senate,,DEM,President Cristina Grappo,1
 Humboldt,1SB12,U.S. Senate,,DEM,Steve Stokes,3
 Humboldt,1SB12,U.S. Senate,,REP,Tom Palzer,1
 Humboldt,1SU,President,,AIP,Alan Spears,1
-Humboldt,1SU,President,,REP,Ben Carson,2
-Humboldt,1SU,President,,DEM,Bernie Sanders,32
-Humboldt,1SU,President,,REP,Donald Trump,34
-Humboldt,1SU,President,,DEM,Hillary Clinton,12
-Humboldt,1SU,President,,REP,John R. Kasich,1
+Humboldt,1SU,President,,REP,Ben Carson,4
+Humboldt,1SU,President,,DEM,Bernie Sanders,75
+Humboldt,1SU,President,,REP,Donald Trump,78
+Humboldt,1SU,President,,DEM,Hillary Clinton,32
+Humboldt,1SU,President,,REP,John R. Kasich,2
+Humboldt,1SU,President,,DEM,Keith Judd,2
+Humboldt,1SU,President,,DEM,Michael Steinberg,1
 Humboldt,1SU,President,,LIB,Rhett White Feather Smith,1
-Humboldt,1SU,President,,REP,Ted Cruz,7
+Humboldt,1SU,President,,REP,Ted Cruz,13
 Humboldt,1SU,President,,AIP,Wiley Drake,1
 Humboldt,1SU,President,,DEM,Willie Wilson,1
-Humboldt,1SU,Proposition 50,,,No,15
-Humboldt,1SU,Proposition 50,,,Yes,72
-Humboldt,1SU,State Assembly,2,DEM,Jim Wood,61
-Humboldt,1SU,U.S. House,2,REP,Dale K. Mensing,35
-Humboldt,1SU,U.S. House,2,DEM,Erin A. Schrode,6
-Humboldt,1SU,U.S. House,2,DEM,Jared W. Huffman,40
-Humboldt,1SU,U.S. House,2,IND,Matthew Robert Wookey,11
+Humboldt,1SU,Proposition 50,,,No,34
+Humboldt,1SU,Proposition 50,,,Yes,172
+Humboldt,1SU,State Assembly,2,DEM,Jim Wood,151
+Humboldt,1SU,U.S. House,2,REP,Dale K. Mensing,70
+Humboldt,1SU,U.S. House,2,DEM,Erin A. Schrode,17
+Humboldt,1SU,U.S. House,2,DEM,Jared W. Huffman,102
+Humboldt,1SU,U.S. House,2,IND,Matthew Robert Wookey,27
 Humboldt,1SU,U.S. Senate,,IND,Clive Grey,1
-Humboldt,1SU,U.S. Senate,,IND,Don J. Grundmann,1
-Humboldt,1SU,U.S. Senate,,REP,Don Krampe,4
-Humboldt,1SU,U.S. Senate,,REP,Duf Sundheim,11
-Humboldt,1SU,U.S. Senate,,LIB,Gail K. Lightfoot,5
-Humboldt,1SU,U.S. Senate,,REP,George C. Yang,1
-Humboldt,1SU,U.S. Senate,,REP,Greg Conlon,4
+Humboldt,1SU,U.S. Senate,,IND,Don J. Grundmann,2
+Humboldt,1SU,U.S. Senate,,REP,Don Krampe,5
+Humboldt,1SU,U.S. Senate,,REP,Duf Sundheim,19
+Humboldt,1SU,U.S. Senate,,DEM,Emory Rodgers,2
+Humboldt,1SU,U.S. Senate,,LIB,Gail K. Lightfoot,9
+Humboldt,1SU,U.S. Senate,,REP,George C. Yang,2
+Humboldt,1SU,U.S. Senate,,REP,Greg Conlon,7
 Humboldt,1SU,U.S. Senate,,REP,Jarrell Williamson,1
-Humboldt,1SU,U.S. Senate,,IND,Jason Kraus,1
-Humboldt,1SU,U.S. Senate,,REP,Jerry J. Laws,9
+Humboldt,1SU,U.S. Senate,,IND,Jason Kraus,6
+Humboldt,1SU,U.S. Senate,,REP,Jerry J. Laws,15
 Humboldt,1SU,U.S. Senate,,PAF,John Thompson Parker,1
-Humboldt,1SU,U.S. Senate,,DEM,Kamala D. Harris,24
-Humboldt,1SU,U.S. Senate,,REP,Karen Roseberry,4
-Humboldt,1SU,U.S. Senate,,IND,Ling Ling Shi,1
-Humboldt,1SU,U.S. Senate,,DEM,Loretta L. Sanchez,6
-Humboldt,1SU,U.S. Senate,,DEM,Massie Munroe,1
-Humboldt,1SU,U.S. Senate,,IND,Mike Beitiks,2
-Humboldt,1SU,U.S. Senate,,GRN,Pamela Elizondo,1
-Humboldt,1SU,U.S. Senate,,REP,Phil Wyman,8
-Humboldt,1SU,U.S. Senate,,REP,Ron Unz,2
-Humboldt,1SU,U.S. Senate,,DEM,Steve Stokes,4
-Humboldt,1SU,U.S. Senate,,REP,Thomas G. Del Beccaro,1
-Humboldt,1SU,U.S. Senate,,REP,Von Hougo,1
-Humboldt,1SU_A,President,,REP,Ben Carson,2
-Humboldt,1SU_A,President,,DEM,Bernie Sanders,43
-Humboldt,1SU_A,President,,REP,Donald Trump,44
-Humboldt,1SU_A,President,,DEM,Hillary Clinton,20
-Humboldt,1SU_A,President,,REP,John R. Kasich,1
-Humboldt,1SU_A,President,,DEM,Keith Judd,2
-Humboldt,1SU_A,President,,DEM,Michael Steinberg,1
-Humboldt,1SU_A,President,,REP,Ted Cruz,6
-Humboldt,1SU_A,Proposition 50,,,No,19
-Humboldt,1SU_A,Proposition 50,,,Yes,100
-Humboldt,1SU_A,State Assembly,2,DEM,Jim Wood,90
-Humboldt,1SU_A,U.S. House,2,REP,Dale K. Mensing,35
-Humboldt,1SU_A,U.S. House,2,DEM,Erin A. Schrode,11
-Humboldt,1SU_A,U.S. House,2,DEM,Jared W. Huffman,62
-Humboldt,1SU_A,U.S. House,2,IND,Matthew Robert Wookey,16
-Humboldt,1SU_A,U.S. Senate,,IND,Don J. Grundmann,1
-Humboldt,1SU_A,U.S. Senate,,REP,Don Krampe,1
-Humboldt,1SU_A,U.S. Senate,,REP,Duf Sundheim,8
-Humboldt,1SU_A,U.S. Senate,,DEM,Emory Rodgers,2
-Humboldt,1SU_A,U.S. Senate,,LIB,Gail K. Lightfoot,4
-Humboldt,1SU_A,U.S. Senate,,REP,George C. Yang,1
-Humboldt,1SU_A,U.S. Senate,,REP,Greg Conlon,3
-Humboldt,1SU_A,U.S. Senate,,IND,Jason Kraus,5
-Humboldt,1SU_A,U.S. Senate,,REP,Jerry J. Laws,6
-Humboldt,1SU_A,U.S. Senate,,DEM,Kamala D. Harris,31
-Humboldt,1SU_A,U.S. Senate,,REP,Karen Roseberry,5
-Humboldt,1SU_A,U.S. Senate,,IND,Ling Ling Shi,2
-Humboldt,1SU_A,U.S. Senate,,DEM,Loretta L. Sanchez,15
-Humboldt,1SU_A,U.S. Senate,,DEM,Massie Munroe,1
-Humboldt,1SU_A,U.S. Senate,,IND,Mike Beitiks,3
-Humboldt,1SU_A,U.S. Senate,,GRN,Pamela Elizondo,5
-Humboldt,1SU_A,U.S. Senate,,REP,Phil Wyman,16
-Humboldt,1SU_A,U.S. Senate,,DEM,President Cristina Grappo,1
-Humboldt,1SU_A,U.S. Senate,,REP,Ron Unz,1
-Humboldt,1SU_A,U.S. Senate,,DEM,Steve Stokes,2
-Humboldt,1SU_A,U.S. Senate,,REP,Thomas G. Del Beccaro,4
-Humboldt,1SU_A,U.S. Senate,,REP,Tom Palzer,3
-Humboldt,1SU_A,U.S. Senate,,REP,Von Hougo,1
-Humboldt,2BV-1,President,,REP,Ben Carson,1
-Humboldt,2BV-1,President,,DEM,Bernie Sanders,37
-Humboldt,2BV-1,President,,REP,Donald Trump,11
-Humboldt,2BV-1,President,,DEM,Hillary Clinton,8
+Humboldt,1SU,U.S. Senate,,DEM,Kamala D. Harris,55
+Humboldt,1SU,U.S. Senate,,REP,Karen Roseberry,9
+Humboldt,1SU,U.S. Senate,,IND,Ling Ling Shi,3
+Humboldt,1SU,U.S. Senate,,DEM,Loretta L. Sanchez,21
+Humboldt,1SU,U.S. Senate,,DEM,Massie Munroe,2
+Humboldt,1SU,U.S. Senate,,IND,Mike Beitiks,5
+Humboldt,1SU,U.S. Senate,,GRN,Pamela Elizondo,6
+Humboldt,1SU,U.S. Senate,,REP,Phil Wyman,24
+Humboldt,1SU,U.S. Senate,,DEM,President Cristina Grappo,1
+Humboldt,1SU,U.S. Senate,,REP,Ron Unz,3
+Humboldt,1SU,U.S. Senate,,DEM,Steve Stokes,6
+Humboldt,1SU,U.S. Senate,,REP,Thomas G. Del Beccaro,5
+Humboldt,1SU,U.S. Senate,,REP,Tom Palzer,3
+Humboldt,1SU,U.S. Senate,,REP,Von Hougo,2
+Humboldt,2BV-1,President,,AIP,Alan Spears,1
+Humboldt,2BV-1,President,,REP,Ben Carson,2
+Humboldt,2BV-1,President,,DEM,Bernie Sanders,70
+Humboldt,2BV-1,President,,REP,Donald Trump,34
+Humboldt,2BV-1,President,,LIB,Gary Johnson,1
+Humboldt,2BV-1,President,,DEM,Hillary Clinton,31
 Humboldt,2BV-1,President,,GRN,Jill Stein,3
-Humboldt,2BV-1,President,,REP,Ted Cruz,3
-Humboldt,2BV-1,Proposition 50,,,No,6
-Humboldt,2BV-1,Proposition 50,,,Yes,56
-Humboldt,2BV-1,State Assembly,2,DEM,Jim Wood,52
-Humboldt,2BV-1,U.S. House,2,REP,Dale K. Mensing,9
-Humboldt,2BV-1,U.S. House,2,DEM,Erin A. Schrode,7
-Humboldt,2BV-1,U.S. House,2,DEM,Jared W. Huffman,43
-Humboldt,2BV-1,U.S. House,2,IND,Matthew Robert Wookey,7
+Humboldt,2BV-1,President,,REP,John R. Kasich,1
+Humboldt,2BV-1,President,,DEM,Keith Judd,2
+Humboldt,2BV-1,President,,REP,Ted Cruz,7
+Humboldt,2BV-1,Proposition 50,,,No,27
+Humboldt,2BV-1,Proposition 50,,,Yes,131
+Humboldt,2BV-1,State Assembly,2,DEM,Jim Wood,121
+Humboldt,2BV-1,U.S. House,2,REP,Dale K. Mensing,34
+Humboldt,2BV-1,U.S. House,2,DEM,Erin A. Schrode,13
+Humboldt,2BV-1,U.S. House,2,DEM,Jared W. Huffman,100
+Humboldt,2BV-1,U.S. House,2,IND,Matthew Robert Wookey,18
 Humboldt,2BV-1,U.S. Senate,,IND,Clive Grey,1
 Humboldt,2BV-1,U.S. Senate,,IND,Don J. Grundmann,1
-Humboldt,2BV-1,U.S. Senate,,REP,Don Krampe,1
-Humboldt,2BV-1,U.S. Senate,,REP,Duf Sundheim,1
-Humboldt,2BV-1,U.S. Senate,,LIB,Gail K. Lightfoot,3
-Humboldt,2BV-1,U.S. Senate,,IND,Gar Myers,1
-Humboldt,2BV-1,U.S. Senate,,REP,Greg Conlon,1
+Humboldt,2BV-1,U.S. Senate,,REP,Don Krampe,3
+Humboldt,2BV-1,U.S. Senate,,REP,Duf Sundheim,8
+Humboldt,2BV-1,U.S. Senate,,LIB,Gail K. Lightfoot,5
+Humboldt,2BV-1,U.S. Senate,,IND,Gar Myers,2
+Humboldt,2BV-1,U.S. Senate,,REP,George C. Yang,2
+Humboldt,2BV-1,U.S. Senate,,REP,Greg Conlon,8
 Humboldt,2BV-1,U.S. Senate,,DEM,Herbert G. Peters,1
-Humboldt,2BV-1,U.S. Senate,,REP,Jarrell Williamson,1
-Humboldt,2BV-1,U.S. Senate,,IND,Jason Kraus,1
-Humboldt,2BV-1,U.S. Senate,,REP,Jerry J. Laws,3
-Humboldt,2BV-1,U.S. Senate,,DEM,Kamala D. Harris,15
-Humboldt,2BV-1,U.S. Senate,,DEM,Loretta L. Sanchez,12
+Humboldt,2BV-1,U.S. Senate,,REP,Jarrell Williamson,2
+Humboldt,2BV-1,U.S. Senate,,IND,Jason Kraus,5
+Humboldt,2BV-1,U.S. Senate,,REP,Jerry J. Laws,7
+Humboldt,2BV-1,U.S. Senate,,DEM,Kamala D. Harris,47
+Humboldt,2BV-1,U.S. Senate,,IND,Ling Ling Shi,2
+Humboldt,2BV-1,U.S. Senate,,DEM,Loretta L. Sanchez,22
 Humboldt,2BV-1,U.S. Senate,,LIB,Mark Matthew Herd,1
-Humboldt,2BV-1,U.S. Senate,,DEM,Massie Munroe,4
+Humboldt,2BV-1,U.S. Senate,,DEM,Massie Munroe,5
 Humboldt,2BV-1,U.S. Senate,,IND,Mike Beitiks,1
-Humboldt,2BV-1,U.S. Senate,,GRN,Pamela Elizondo,6
-Humboldt,2BV-1,U.S. Senate,,REP,Phil Wyman,4
-Humboldt,2BV-1,U.S. Senate,,DEM,Steve Stokes,4
-Humboldt,2BV-1,U.S. Senate,,REP,Von Hougo,1
-Humboldt,2BV-1_A,President,,AIP,Alan Spears,1
-Humboldt,2BV-1_A,President,,REP,Ben Carson,1
-Humboldt,2BV-1_A,President,,DEM,Bernie Sanders,33
-Humboldt,2BV-1_A,President,,REP,Donald Trump,23
-Humboldt,2BV-1_A,President,,LIB,Gary Johnson,1
-Humboldt,2BV-1_A,President,,DEM,Hillary Clinton,23
-Humboldt,2BV-1_A,President,,REP,John R. Kasich,1
-Humboldt,2BV-1_A,President,,DEM,Keith Judd,2
-Humboldt,2BV-1_A,President,,REP,Ted Cruz,4
-Humboldt,2BV-1_A,Proposition 50,,,No,21
-Humboldt,2BV-1_A,Proposition 50,,,Yes,75
-Humboldt,2BV-1_A,State Assembly,2,DEM,Jim Wood,69
-Humboldt,2BV-1_A,U.S. House,2,REP,Dale K. Mensing,25
-Humboldt,2BV-1_A,U.S. House,2,DEM,Erin A. Schrode,6
-Humboldt,2BV-1_A,U.S. House,2,DEM,Jared W. Huffman,57
-Humboldt,2BV-1_A,U.S. House,2,IND,Matthew Robert Wookey,11
-Humboldt,2BV-1_A,U.S. Senate,,REP,Don Krampe,2
-Humboldt,2BV-1_A,U.S. Senate,,REP,Duf Sundheim,7
-Humboldt,2BV-1_A,U.S. Senate,,LIB,Gail K. Lightfoot,2
-Humboldt,2BV-1_A,U.S. Senate,,IND,Gar Myers,1
-Humboldt,2BV-1_A,U.S. Senate,,REP,George C. Yang,2
-Humboldt,2BV-1_A,U.S. Senate,,REP,Greg Conlon,7
-Humboldt,2BV-1_A,U.S. Senate,,REP,Jarrell Williamson,1
-Humboldt,2BV-1_A,U.S. Senate,,IND,Jason Kraus,4
-Humboldt,2BV-1_A,U.S. Senate,,REP,Jerry J. Laws,4
-Humboldt,2BV-1_A,U.S. Senate,,DEM,Kamala D. Harris,32
-Humboldt,2BV-1_A,U.S. Senate,,IND,Ling Ling Shi,2
-Humboldt,2BV-1_A,U.S. Senate,,DEM,Loretta L. Sanchez,10
-Humboldt,2BV-1_A,U.S. Senate,,DEM,Massie Munroe,1
-Humboldt,2BV-1_A,U.S. Senate,,GRN,Pamela Elizondo,2
-Humboldt,2BV-1_A,U.S. Senate,,IND,Paul Merritt,2
-Humboldt,2BV-1_A,U.S. Senate,,REP,Phil Wyman,6
-Humboldt,2BV-1_A,U.S. Senate,,REP,Ron Unz,2
-Humboldt,2BV-1_A,U.S. Senate,,DEM,Steve Stokes,7
-Humboldt,2BV-1_A,U.S. Senate,,REP,Thomas G. Del Beccaro,1
-Humboldt,2BV-1_A,U.S. Senate,,REP,Von Hougo,2
-Humboldt,2CU,President,,REP,Ben Carson,2
-Humboldt,2CU,President,,DEM,Bernie Sanders,30
-Humboldt,2CU,President,,REP,Donald Trump,22
-Humboldt,2CU,President,,DEM,Hillary Clinton,12
-Humboldt,2CU,President,,REP,John R. Kasich,2
+Humboldt,2BV-1,U.S. Senate,,GRN,Pamela Elizondo,8
+Humboldt,2BV-1,U.S. Senate,,IND,Paul Merritt,2
+Humboldt,2BV-1,U.S. Senate,,REP,Phil Wyman,10
+Humboldt,2BV-1,U.S. Senate,,REP,Ron Unz,2
+Humboldt,2BV-1,U.S. Senate,,DEM,Steve Stokes,11
+Humboldt,2BV-1,U.S. Senate,,REP,Thomas G. Del Beccaro,1
+Humboldt,2BV-1,U.S. Senate,,REP,Von Hougo,3
+Humboldt,2CU,President,,REP,Ben Carson,3
+Humboldt,2CU,President,,DEM,Bernie Sanders,79
+Humboldt,2CU,President,,REP,Donald Trump,65
+Humboldt,2CU,President,,DEM,Hillary Clinton,42
+Humboldt,2CU,President,,REP,John R. Kasich,3
 Humboldt,2CU,President,,DEM,Keith Judd,1
-Humboldt,2CU,President,,DEM,Michael Steinberg,1
-Humboldt,2CU,President,,REP,Ted Cruz,6
-Humboldt,2CU,Proposition 50,,,No,22
-Humboldt,2CU,Proposition 50,,,Yes,49
-Humboldt,2CU,State Assembly,2,DEM,Jim Wood,59
-Humboldt,2CU,U.S. House,2,REP,Dale K. Mensing,26
-Humboldt,2CU,U.S. House,2,DEM,Erin A. Schrode,2
-Humboldt,2CU,U.S. House,2,DEM,Jared W. Huffman,46
-Humboldt,2CU,U.S. House,2,IND,Matthew Robert Wookey,6
+Humboldt,2CU,President,,DEM,Michael Steinberg,2
+Humboldt,2CU,President,,REP,Ted Cruz,12
+Humboldt,2CU,Proposition 50,,,No,64
+Humboldt,2CU,Proposition 50,,,Yes,143
+Humboldt,2CU,State Assembly,2,DEM,Jim Wood,147
+Humboldt,2CU,U.S. House,2,REP,Dale K. Mensing,64
+Humboldt,2CU,U.S. House,2,DEM,Erin A. Schrode,13
+Humboldt,2CU,U.S. House,2,DEM,Jared W. Huffman,127
+Humboldt,2CU,U.S. House,2,IND,Matthew Robert Wookey,15
+Humboldt,2CU,U.S. Senate,,IND,Clive Grey,2
 Humboldt,2CU,U.S. Senate,,IND,Don J. Grundmann,2
-Humboldt,2CU,U.S. Senate,,REP,Don Krampe,2
-Humboldt,2CU,U.S. Senate,,REP,Duf Sundheim,2
-Humboldt,2CU,U.S. Senate,,IND,Eleanor García,1
-Humboldt,2CU,U.S. Senate,,LIB,Gail K. Lightfoot,6
-Humboldt,2CU,U.S. Senate,,REP,Greg Conlon,7
-Humboldt,2CU,U.S. Senate,,IND,Jason Hanania,1
-Humboldt,2CU,U.S. Senate,,REP,Jerry J. Laws,5
-Humboldt,2CU,U.S. Senate,,DEM,Kamala D. Harris,22
-Humboldt,2CU,U.S. Senate,,DEM,Loretta L. Sanchez,12
-Humboldt,2CU,U.S. Senate,,IND,Mike Beitiks,1
-Humboldt,2CU,U.S. Senate,,GRN,Pamela Elizondo,2
+Humboldt,2CU,U.S. Senate,,REP,Don Krampe,8
+Humboldt,2CU,U.S. Senate,,REP,Duf Sundheim,9
+Humboldt,2CU,U.S. Senate,,IND,Eleanor García,2
+Humboldt,2CU,U.S. Senate,,LIB,Gail K. Lightfoot,9
+Humboldt,2CU,U.S. Senate,,REP,Greg Conlon,10
+Humboldt,2CU,U.S. Senate,,IND,Jason Hanania,2
+Humboldt,2CU,U.S. Senate,,IND,Jason Kraus,1
+Humboldt,2CU,U.S. Senate,,REP,Jerry J. Laws,12
+Humboldt,2CU,U.S. Senate,,PAF,John Thompson Parker,1
+Humboldt,2CU,U.S. Senate,,DEM,Kamala D. Harris,68
+Humboldt,2CU,U.S. Senate,,DEM,Loretta L. Sanchez,30
+Humboldt,2CU,U.S. Senate,,LIB,Mark Matthew Herd,2
+Humboldt,2CU,U.S. Senate,,IND,Mike Beitiks,2
+Humboldt,2CU,U.S. Senate,,GRN,Pamela Elizondo,4
 Humboldt,2CU,U.S. Senate,,IND,Paul Merritt,1
-Humboldt,2CU,U.S. Senate,,REP,Phil Wyman,8
-Humboldt,2CU,U.S. Senate,,DEM,Steve Stokes,3
-Humboldt,2CU,U.S. Senate,,REP,Thomas G. Del Beccaro,3
-Humboldt,2CU,U.S. Senate,,REP,Tom Palzer,2
-Humboldt,2CU,U.S. Senate,,REP,Von Hougo,1
-Humboldt,2CU_A,President,,REP,Ben Carson,1
-Humboldt,2CU_A,President,,DEM,Bernie Sanders,49
-Humboldt,2CU_A,President,,REP,Donald Trump,43
-Humboldt,2CU_A,President,,DEM,Hillary Clinton,30
-Humboldt,2CU_A,President,,REP,John R. Kasich,1
-Humboldt,2CU_A,President,,DEM,Michael Steinberg,1
-Humboldt,2CU_A,President,,REP,Ted Cruz,6
-Humboldt,2CU_A,Proposition 50,,,No,42
-Humboldt,2CU_A,Proposition 50,,,Yes,94
-Humboldt,2CU_A,State Assembly,2,DEM,Jim Wood,88
-Humboldt,2CU_A,U.S. House,2,REP,Dale K. Mensing,38
-Humboldt,2CU_A,U.S. House,2,DEM,Erin A. Schrode,11
-Humboldt,2CU_A,U.S. House,2,DEM,Jared W. Huffman,81
-Humboldt,2CU_A,U.S. House,2,IND,Matthew Robert Wookey,9
-Humboldt,2CU_A,U.S. Senate,,IND,Clive Grey,2
-Humboldt,2CU_A,U.S. Senate,,REP,Don Krampe,6
-Humboldt,2CU_A,U.S. Senate,,REP,Duf Sundheim,7
-Humboldt,2CU_A,U.S. Senate,,IND,Eleanor García,1
-Humboldt,2CU_A,U.S. Senate,,LIB,Gail K. Lightfoot,3
-Humboldt,2CU_A,U.S. Senate,,REP,Greg Conlon,3
-Humboldt,2CU_A,U.S. Senate,,IND,Jason Hanania,1
-Humboldt,2CU_A,U.S. Senate,,IND,Jason Kraus,1
-Humboldt,2CU_A,U.S. Senate,,REP,Jerry J. Laws,7
-Humboldt,2CU_A,U.S. Senate,,PAF,John Thompson Parker,1
-Humboldt,2CU_A,U.S. Senate,,DEM,Kamala D. Harris,46
-Humboldt,2CU_A,U.S. Senate,,DEM,Loretta L. Sanchez,18
-Humboldt,2CU_A,U.S. Senate,,LIB,Mark Matthew Herd,2
-Humboldt,2CU_A,U.S. Senate,,IND,Mike Beitiks,1
-Humboldt,2CU_A,U.S. Senate,,GRN,Pamela Elizondo,2
-Humboldt,2CU_A,U.S. Senate,,REP,Phil Wyman,15
-Humboldt,2CU_A,U.S. Senate,,DEM,President Cristina Grappo,1
-Humboldt,2CU_A,U.S. Senate,,REP,Ron Unz,2
-Humboldt,2CU_A,U.S. Senate,,DEM,Steve Stokes,2
-Humboldt,2CU_A,U.S. Senate,,REP,Thomas G. Del Beccaro,6
-Humboldt,2CU_A,U.S. Senate,,IND,Tim Gildersleeve,1
-Humboldt,2CU_A,U.S. Senate,,REP,Tom Palzer,2
-Humboldt,2CU_A,U.S. Senate,,REP,Von Hougo,3
-Humboldt,2F--2,President,,REP,Ben Carson,4
-Humboldt,2F--2,President,,DEM,Bernie Sanders,48
-Humboldt,2F--2,President,,REP,Donald Trump,28
-Humboldt,2F--2,President,,DEM,Hillary Clinton,30
+Humboldt,2CU,U.S. Senate,,REP,Phil Wyman,23
+Humboldt,2CU,U.S. Senate,,DEM,President Cristina Grappo,1
+Humboldt,2CU,U.S. Senate,,REP,Ron Unz,2
+Humboldt,2CU,U.S. Senate,,DEM,Steve Stokes,5
+Humboldt,2CU,U.S. Senate,,REP,Thomas G. Del Beccaro,9
+Humboldt,2CU,U.S. Senate,,IND,Tim Gildersleeve,1
+Humboldt,2CU,U.S. Senate,,REP,Tom Palzer,4
+Humboldt,2CU,U.S. Senate,,REP,Von Hougo,4
+Humboldt,2F--2,President,,REP,Ben Carson,11
+Humboldt,2F--2,President,,DEM,Bernie Sanders,139
+Humboldt,2F--2,President,,GRN,Darryl Cherney,1
+Humboldt,2F--2,President,,REP,Donald Trump,139
+Humboldt,2F--2,President,,DEM,Henry Hewes,2
+Humboldt,2F--2,President,,DEM,Hillary Clinton,115
+Humboldt,2F--2,President,,AIP,J.R. Myers,2
 Humboldt,2F--2,President,,LIB,"Jack Robinson, Jr.",1
 Humboldt,2F--2,President,,AIP,James Hedges,1
-Humboldt,2F--2,President,,REP,Jim Gilmore,1
+Humboldt,2F--2,President,,GRN,Jill Stein,1
+Humboldt,2F--2,President,,REP,Jim Gilmore,2
 Humboldt,2F--2,President,,LIB,John McAfee,1
-Humboldt,2F--2,President,,REP,John R. Kasich,5
+Humboldt,2F--2,President,,REP,John R. Kasich,22
 Humboldt,2F--2,President,,LIB,Joy Waymire,1
-Humboldt,2F--2,President,,DEM,Michael Steinberg,1
-Humboldt,2F--2,President,,REP,Ted Cruz,5
-Humboldt,2F--2,President,,AIP,Thomas Hoefling,2
+Humboldt,2F--2,President,,DEM,Michael Steinberg,4
+Humboldt,2F--2,President,,PAF,Monica Moorehead,1
+Humboldt,2F--2,President,,REP,Ted Cruz,16
+Humboldt,2F--2,President,,AIP,Thomas Hoefling,3
 Humboldt,2F--2,President,,DEM,Willie Wilson,1
-Humboldt,2F--2,Proposition 50,,,No,27
-Humboldt,2F--2,Proposition 50,,,Yes,95
-Humboldt,2F--2,State Assembly,2,DEM,Jim Wood,91
-Humboldt,2F--2,U.S. House,2,REP,Dale K. Mensing,28
-Humboldt,2F--2,U.S. House,2,DEM,Erin A. Schrode,9
-Humboldt,2F--2,U.S. House,2,DEM,Jared W. Huffman,79
-Humboldt,2F--2,U.S. House,2,IND,Matthew Robert Wookey,11
-Humboldt,2F--2,U.S. Senate,,IND,Clive Grey,1
-Humboldt,2F--2,U.S. Senate,,REP,Don Krampe,1
-Humboldt,2F--2,U.S. Senate,,REP,Duf Sundheim,2
-Humboldt,2F--2,U.S. Senate,,DEM,Emory Rodgers,1
-Humboldt,2F--2,U.S. Senate,,LIB,Gail K. Lightfoot,12
-Humboldt,2F--2,U.S. Senate,,REP,George C. Yang,1
-Humboldt,2F--2,U.S. Senate,,REP,Greg Conlon,8
-Humboldt,2F--2,U.S. Senate,,DEM,Herbert G. Peters,1
+Humboldt,2F--2,Proposition 50,,,No,94
+Humboldt,2F--2,Proposition 50,,,Yes,359
+Humboldt,2F--2,State Assembly,2,DEM,Jim Wood,336
+Humboldt,2F--2,U.S. House,2,REP,Dale K. Mensing,133
+Humboldt,2F--2,U.S. House,2,DEM,Erin A. Schrode,35
+Humboldt,2F--2,U.S. House,2,DEM,Jared W. Huffman,280
+Humboldt,2F--2,U.S. House,2,IND,Matthew Robert Wookey,32
+Humboldt,2F--2,U.S. Senate,,IND,Clive Grey,2
+Humboldt,2F--2,U.S. Senate,,IND,Don J. Grundmann,2
+Humboldt,2F--2,U.S. Senate,,REP,Don Krampe,9
+Humboldt,2F--2,U.S. Senate,,REP,Duf Sundheim,29
+Humboldt,2F--2,U.S. Senate,,IND,Eleanor García,2
+Humboldt,2F--2,U.S. Senate,,DEM,Emory Rodgers,2
+Humboldt,2F--2,U.S. Senate,,LIB,Gail K. Lightfoot,21
+Humboldt,2F--2,U.S. Senate,,REP,George C. Yang,6
+Humboldt,2F--2,U.S. Senate,,REP,Greg Conlon,32
+Humboldt,2F--2,U.S. Senate,,DEM,Herbert G. Peters,3
 Humboldt,2F--2,U.S. Senate,,REP,Jarrell Williamson,1
-Humboldt,2F--2,U.S. Senate,,IND,Jason Kraus,1
-Humboldt,2F--2,U.S. Senate,,REP,Jerry J. Laws,12
-Humboldt,2F--2,U.S. Senate,,DEM,Kamala D. Harris,35
-Humboldt,2F--2,U.S. Senate,,IND,Ling Ling Shi,1
-Humboldt,2F--2,U.S. Senate,,DEM,Loretta L. Sanchez,15
-Humboldt,2F--2,U.S. Senate,,DEM,Massie Munroe,2
+Humboldt,2F--2,U.S. Senate,,IND,Jason Kraus,4
+Humboldt,2F--2,U.S. Senate,,REP,Jerry J. Laws,29
+Humboldt,2F--2,U.S. Senate,,PAF,John Thompson Parker,1
+Humboldt,2F--2,U.S. Senate,,DEM,Kamala D. Harris,149
+Humboldt,2F--2,U.S. Senate,,REP,Karen Roseberry,5
+Humboldt,2F--2,U.S. Senate,,IND,Ling Ling Shi,2
+Humboldt,2F--2,U.S. Senate,,DEM,Loretta L. Sanchez,52
+Humboldt,2F--2,U.S. Senate,,DEM,Massie Munroe,6
 Humboldt,2F--2,U.S. Senate,,IND,Mike Beitiks,2
-Humboldt,2F--2,U.S. Senate,,GRN,Pamela Elizondo,7
-Humboldt,2F--2,U.S. Senate,,IND,Paul Merritt,1
-Humboldt,2F--2,U.S. Senate,,REP,Phil Wyman,5
+Humboldt,2F--2,U.S. Senate,,GRN,Pamela Elizondo,10
+Humboldt,2F--2,U.S. Senate,,IND,Paul Merritt,5
+Humboldt,2F--2,U.S. Senate,,REP,Phil Wyman,36
+Humboldt,2F--2,U.S. Senate,,REP,Ron Unz,6
 Humboldt,2F--2,U.S. Senate,,IND,Scott A. Vineberg,1
-Humboldt,2F--2,U.S. Senate,,DEM,Steve Stokes,11
-Humboldt,2F--2,U.S. Senate,,REP,Thomas G. Del Beccaro,3
-Humboldt,2F--2,U.S. Senate,,REP,Von Hougo,2
-Humboldt,2F--2_A,President,,REP,Ben Carson,7
-Humboldt,2F--2_A,President,,DEM,Bernie Sanders,91
-Humboldt,2F--2_A,President,,GRN,Darryl Cherney,1
-Humboldt,2F--2_A,President,,REP,Donald Trump,111
-Humboldt,2F--2_A,President,,DEM,Henry Hewes,2
-Humboldt,2F--2_A,President,,DEM,Hillary Clinton,85
-Humboldt,2F--2_A,President,,AIP,J.R. Myers,2
-Humboldt,2F--2_A,President,,GRN,Jill Stein,1
-Humboldt,2F--2_A,President,,REP,Jim Gilmore,1
-Humboldt,2F--2_A,President,,REP,John R. Kasich,17
-Humboldt,2F--2_A,President,,DEM,Michael Steinberg,3
-Humboldt,2F--2_A,President,,PAF,Monica Moorehead,1
-Humboldt,2F--2_A,President,,REP,Ted Cruz,11
-Humboldt,2F--2_A,President,,AIP,Thomas Hoefling,1
-Humboldt,2F--2_A,Proposition 50,,,No,67
-Humboldt,2F--2_A,Proposition 50,,,Yes,264
-Humboldt,2F--2_A,State Assembly,2,DEM,Jim Wood,245
-Humboldt,2F--2_A,U.S. House,2,REP,Dale K. Mensing,105
-Humboldt,2F--2_A,U.S. House,2,DEM,Erin A. Schrode,26
-Humboldt,2F--2_A,U.S. House,2,DEM,Jared W. Huffman,201
-Humboldt,2F--2_A,U.S. House,2,IND,Matthew Robert Wookey,21
-Humboldt,2F--2_A,U.S. Senate,,IND,Clive Grey,1
-Humboldt,2F--2_A,U.S. Senate,,IND,Don J. Grundmann,2
-Humboldt,2F--2_A,U.S. Senate,,REP,Don Krampe,8
-Humboldt,2F--2_A,U.S. Senate,,REP,Duf Sundheim,27
-Humboldt,2F--2_A,U.S. Senate,,IND,Eleanor García,2
-Humboldt,2F--2_A,U.S. Senate,,DEM,Emory Rodgers,1
-Humboldt,2F--2_A,U.S. Senate,,LIB,Gail K. Lightfoot,9
-Humboldt,2F--2_A,U.S. Senate,,REP,George C. Yang,5
-Humboldt,2F--2_A,U.S. Senate,,REP,Greg Conlon,24
-Humboldt,2F--2_A,U.S. Senate,,DEM,Herbert G. Peters,2
-Humboldt,2F--2_A,U.S. Senate,,IND,Jason Kraus,3
-Humboldt,2F--2_A,U.S. Senate,,REP,Jerry J. Laws,17
-Humboldt,2F--2_A,U.S. Senate,,PAF,John Thompson Parker,1
-Humboldt,2F--2_A,U.S. Senate,,DEM,Kamala D. Harris,114
-Humboldt,2F--2_A,U.S. Senate,,REP,Karen Roseberry,5
-Humboldt,2F--2_A,U.S. Senate,,IND,Ling Ling Shi,1
-Humboldt,2F--2_A,U.S. Senate,,DEM,Loretta L. Sanchez,37
-Humboldt,2F--2_A,U.S. Senate,,DEM,Massie Munroe,4
-Humboldt,2F--2_A,U.S. Senate,,GRN,Pamela Elizondo,3
-Humboldt,2F--2_A,U.S. Senate,,IND,Paul Merritt,4
-Humboldt,2F--2_A,U.S. Senate,,REP,Phil Wyman,31
-Humboldt,2F--2_A,U.S. Senate,,REP,Ron Unz,6
-Humboldt,2F--2_A,U.S. Senate,,DEM,Steve Stokes,10
-Humboldt,2F--2_A,U.S. Senate,,REP,Thomas G. Del Beccaro,10
-Humboldt,2F--2_A,U.S. Senate,,IND,Tim Gildersleeve,1
-Humboldt,2F--2_A,U.S. Senate,,REP,Tom Palzer,2
-Humboldt,2F--2_A,U.S. Senate,,REP,Von Hougo,3
-Humboldt,2F--3,President,,REP,Ben Carson,3
-Humboldt,2F--3,President,,DEM,Bernie Sanders,58
-Humboldt,2F--3,President,,REP,Donald Trump,25
+Humboldt,2F--2,U.S. Senate,,DEM,Steve Stokes,21
+Humboldt,2F--2,U.S. Senate,,REP,Thomas G. Del Beccaro,13
+Humboldt,2F--2,U.S. Senate,,IND,Tim Gildersleeve,1
+Humboldt,2F--2,U.S. Senate,,REP,Tom Palzer,2
+Humboldt,2F--2,U.S. Senate,,REP,Von Hougo,5
+Humboldt,2F--3,President,,REP,Ben Carson,7
+Humboldt,2F--3,President,,DEM,Bernie Sanders,125
+Humboldt,2F--3,President,,REP,Donald Trump,76
 Humboldt,2F--3,President,,LIB,Gary Johnson,1
-Humboldt,2F--3,President,,DEM,Hillary Clinton,27
+Humboldt,2F--3,President,,DEM,Henry Hewes,2
+Humboldt,2F--3,President,,DEM,Hillary Clinton,86
 Humboldt,2F--3,President,,LIB,"Jack Robinson, Jr.",1
+Humboldt,2F--3,President,,GRN,Jill Stein,1
 Humboldt,2F--3,President,,LIB,John McAfee,1
-Humboldt,2F--3,President,,REP,John R. Kasich,1
-Humboldt,2F--3,Proposition 50,,,No,21
-Humboldt,2F--3,Proposition 50,,,Yes,93
-Humboldt,2F--3,State Assembly,2,DEM,Jim Wood,93
-Humboldt,2F--3,U.S. House,2,REP,Dale K. Mensing,24
-Humboldt,2F--3,U.S. House,2,DEM,Erin A. Schrode,8
-Humboldt,2F--3,U.S. House,2,DEM,Jared W. Huffman,71
-Humboldt,2F--3,U.S. House,2,IND,Matthew Robert Wookey,13
-Humboldt,2F--3,U.S. Senate,,IND,Clive Grey,1
-Humboldt,2F--3,U.S. Senate,,IND,Don J. Grundmann,1
-Humboldt,2F--3,U.S. Senate,,REP,Don Krampe,2
-Humboldt,2F--3,U.S. Senate,,REP,Duf Sundheim,2
-Humboldt,2F--3,U.S. Senate,,LIB,Gail K. Lightfoot,5
-Humboldt,2F--3,U.S. Senate,,REP,George C. Yang,2
-Humboldt,2F--3,U.S. Senate,,REP,Greg Conlon,6
-Humboldt,2F--3,U.S. Senate,,REP,Jarrell Williamson,2
+Humboldt,2F--3,President,,REP,John R. Kasich,11
+Humboldt,2F--3,President,,DEM,Keith Judd,1
+Humboldt,2F--3,President,,DEM,Michael Steinberg,3
+Humboldt,2F--3,President,,REP,Ted Cruz,9
+Humboldt,2F--3,President,,DEM,Willie Wilson,1
+Humboldt,2F--3,Proposition 50,,,No,51
+Humboldt,2F--3,Proposition 50,,,Yes,277
+Humboldt,2F--3,State Assembly,2,DEM,Jim Wood,249
+Humboldt,2F--3,U.S. House,2,REP,Dale K. Mensing,78
+Humboldt,2F--3,U.S. House,2,DEM,Erin A. Schrode,25
+Humboldt,2F--3,U.S. House,2,DEM,Jared W. Huffman,213
+Humboldt,2F--3,U.S. House,2,IND,Matthew Robert Wookey,26
+Humboldt,2F--3,U.S. Senate,,IND,Clive Grey,2
+Humboldt,2F--3,U.S. Senate,,IND,Don J. Grundmann,2
+Humboldt,2F--3,U.S. Senate,,REP,Don Krampe,5
+Humboldt,2F--3,U.S. Senate,,REP,Duf Sundheim,18
+Humboldt,2F--3,U.S. Senate,,IND,Eleanor García,2
+Humboldt,2F--3,U.S. Senate,,LIB,Gail K. Lightfoot,7
+Humboldt,2F--3,U.S. Senate,,REP,George C. Yang,4
+Humboldt,2F--3,U.S. Senate,,REP,Greg Conlon,21
+Humboldt,2F--3,U.S. Senate,,DEM,Herbert G. Peters,1
+Humboldt,2F--3,U.S. Senate,,REP,Jarrell Williamson,3
+Humboldt,2F--3,U.S. Senate,,IND,Jason Hanania,3
 Humboldt,2F--3,U.S. Senate,,IND,Jason Kraus,2
-Humboldt,2F--3,U.S. Senate,,REP,Jerry J. Laws,4
-Humboldt,2F--3,U.S. Senate,,DEM,Kamala D. Harris,41
-Humboldt,2F--3,U.S. Senate,,REP,Karen Roseberry,2
+Humboldt,2F--3,U.S. Senate,,REP,Jerry J. Laws,13
+Humboldt,2F--3,U.S. Senate,,DEM,Kamala D. Harris,108
+Humboldt,2F--3,U.S. Senate,,REP,Karen Roseberry,7
 Humboldt,2F--3,U.S. Senate,,IND,Ling Ling Shi,2
-Humboldt,2F--3,U.S. Senate,,DEM,Loretta L. Sanchez,15
-Humboldt,2F--3,U.S. Senate,,LIB,Mark Matthew Herd,1
-Humboldt,2F--3,U.S. Senate,,DEM,Massie Munroe,2
-Humboldt,2F--3,U.S. Senate,,GRN,Pamela Elizondo,7
-Humboldt,2F--3,U.S. Senate,,IND,Paul Merritt,1
-Humboldt,2F--3,U.S. Senate,,REP,Phil Wyman,5
-Humboldt,2F--3,U.S. Senate,,REP,Ron Unz,2
-Humboldt,2F--3,U.S. Senate,,DEM,Steve Stokes,9
-Humboldt,2F--3,U.S. Senate,,REP,Thomas G. Del Beccaro,1
-Humboldt,2F--3,U.S. Senate,,REP,Von Hougo,1
-Humboldt,2F--3_A,President,,REP,Ben Carson,4
-Humboldt,2F--3_A,President,,DEM,Bernie Sanders,67
-Humboldt,2F--3_A,President,,REP,Donald Trump,51
-Humboldt,2F--3_A,President,,DEM,Henry Hewes,2
-Humboldt,2F--3_A,President,,DEM,Hillary Clinton,59
-Humboldt,2F--3_A,President,,GRN,Jill Stein,1
-Humboldt,2F--3_A,President,,REP,John R. Kasich,10
-Humboldt,2F--3_A,President,,DEM,Keith Judd,1
-Humboldt,2F--3_A,President,,DEM,Michael Steinberg,3
-Humboldt,2F--3_A,President,,REP,Ted Cruz,9
-Humboldt,2F--3_A,President,,DEM,Willie Wilson,1
-Humboldt,2F--3_A,Proposition 50,,,No,30
-Humboldt,2F--3_A,Proposition 50,,,Yes,184
-Humboldt,2F--3_A,State Assembly,2,DEM,Jim Wood,156
-Humboldt,2F--3_A,U.S. House,2,REP,Dale K. Mensing,54
-Humboldt,2F--3_A,U.S. House,2,DEM,Erin A. Schrode,17
-Humboldt,2F--3_A,U.S. House,2,DEM,Jared W. Huffman,142
-Humboldt,2F--3_A,U.S. House,2,IND,Matthew Robert Wookey,13
-Humboldt,2F--3_A,U.S. Senate,,IND,Clive Grey,1
-Humboldt,2F--3_A,U.S. Senate,,IND,Don J. Grundmann,1
-Humboldt,2F--3_A,U.S. Senate,,REP,Don Krampe,3
-Humboldt,2F--3_A,U.S. Senate,,REP,Duf Sundheim,16
-Humboldt,2F--3_A,U.S. Senate,,IND,Eleanor García,2
-Humboldt,2F--3_A,U.S. Senate,,LIB,Gail K. Lightfoot,2
-Humboldt,2F--3_A,U.S. Senate,,REP,George C. Yang,2
-Humboldt,2F--3_A,U.S. Senate,,REP,Greg Conlon,15
-Humboldt,2F--3_A,U.S. Senate,,DEM,Herbert G. Peters,1
-Humboldt,2F--3_A,U.S. Senate,,REP,Jarrell Williamson,1
-Humboldt,2F--3_A,U.S. Senate,,IND,Jason Hanania,3
-Humboldt,2F--3_A,U.S. Senate,,REP,Jerry J. Laws,9
-Humboldt,2F--3_A,U.S. Senate,,DEM,Kamala D. Harris,67
-Humboldt,2F--3_A,U.S. Senate,,REP,Karen Roseberry,5
-Humboldt,2F--3_A,U.S. Senate,,DEM,Loretta L. Sanchez,39
-Humboldt,2F--3_A,U.S. Senate,,LIB,Mark Matthew Herd,1
-Humboldt,2F--3_A,U.S. Senate,,DEM,Massie Munroe,2
-Humboldt,2F--3_A,U.S. Senate,,GRN,Pamela Elizondo,3
-Humboldt,2F--3_A,U.S. Senate,,IND,Paul Merritt,1
-Humboldt,2F--3_A,U.S. Senate,,REP,Phil Wyman,8
-Humboldt,2F--3_A,U.S. Senate,,REP,Ron Unz,1
-Humboldt,2F--3_A,U.S. Senate,,IND,Scott A. Vineberg,1
-Humboldt,2F--3_A,U.S. Senate,,DEM,Steve Stokes,18
-Humboldt,2F--3_A,U.S. Senate,,REP,Thomas G. Del Beccaro,7
-Humboldt,2F--3_A,U.S. Senate,,REP,Von Hougo,1
+Humboldt,2F--3,U.S. Senate,,DEM,Loretta L. Sanchez,54
+Humboldt,2F--3,U.S. Senate,,LIB,Mark Matthew Herd,2
+Humboldt,2F--3,U.S. Senate,,DEM,Massie Munroe,4
+Humboldt,2F--3,U.S. Senate,,GRN,Pamela Elizondo,10
+Humboldt,2F--3,U.S. Senate,,IND,Paul Merritt,2
+Humboldt,2F--3,U.S. Senate,,REP,Phil Wyman,13
+Humboldt,2F--3,U.S. Senate,,REP,Ron Unz,3
+Humboldt,2F--3,U.S. Senate,,IND,Scott A. Vineberg,1
+Humboldt,2F--3,U.S. Senate,,DEM,Steve Stokes,27
+Humboldt,2F--3,U.S. Senate,,REP,Thomas G. Del Beccaro,8
+Humboldt,2F--3,U.S. Senate,,REP,Von Hougo,2
 Humboldt,2F--4,President,,AIP,Alan Spears,1
-Humboldt,2F--4,President,,REP,Ben Carson,3
-Humboldt,2F--4,President,,DEM,Bernie Sanders,70
-Humboldt,2F--4,President,,REP,Donald Trump,35
-Humboldt,2F--4,President,,DEM,Hillary Clinton,43
-Humboldt,2F--4,President,,REP,John R. Kasich,8
-Humboldt,2F--4,President,,REP,Ted Cruz,7
-Humboldt,2F--4,Proposition 50,,,No,37
-Humboldt,2F--4,Proposition 50,,,Yes,136
-Humboldt,2F--4,State Assembly,2,DEM,Jim Wood,144
-Humboldt,2F--4,U.S. House,2,REP,Dale K. Mensing,37
-Humboldt,2F--4,U.S. House,2,DEM,Erin A. Schrode,16
-Humboldt,2F--4,U.S. House,2,DEM,Jared W. Huffman,105
-Humboldt,2F--4,U.S. House,2,IND,Matthew Robert Wookey,19
+Humboldt,2F--4,President,,REP,Ben Carson,10
+Humboldt,2F--4,President,,DEM,Bernie Sanders,147
+Humboldt,2F--4,President,,GRN,Darryl Cherney,1
+Humboldt,2F--4,President,,REP,Donald Trump,115
+Humboldt,2F--4,President,,DEM,Hillary Clinton,92
+Humboldt,2F--4,President,,REP,John R. Kasich,16
+Humboldt,2F--4,President,,DEM,Michael Steinberg,1
+Humboldt,2F--4,President,,REP,Ted Cruz,17
+Humboldt,2F--4,President,,DEM,Willie Wilson,4
+Humboldt,2F--4,Proposition 50,,,No,85
+Humboldt,2F--4,Proposition 50,,,Yes,347
+Humboldt,2F--4,State Assembly,2,DEM,Jim Wood,333
+Humboldt,2F--4,U.S. House,2,REP,Dale K. Mensing,101
+Humboldt,2F--4,U.S. House,2,DEM,Erin A. Schrode,31
+Humboldt,2F--4,U.S. House,2,DEM,Jared W. Huffman,251
+Humboldt,2F--4,U.S. House,2,IND,Matthew Robert Wookey,48
 Humboldt,2F--4,U.S. Senate,,IND,Clive Grey,1
-Humboldt,2F--4,U.S. Senate,,IND,Don J. Grundmann,2
-Humboldt,2F--4,U.S. Senate,,REP,Don Krampe,2
-Humboldt,2F--4,U.S. Senate,,REP,Duf Sundheim,5
-Humboldt,2F--4,U.S. Senate,,DEM,Emory Rodgers,1
-Humboldt,2F--4,U.S. Senate,,LIB,Gail K. Lightfoot,7
+Humboldt,2F--4,U.S. Senate,,IND,Don J. Grundmann,4
+Humboldt,2F--4,U.S. Senate,,REP,Don Krampe,8
+Humboldt,2F--4,U.S. Senate,,REP,Duf Sundheim,24
+Humboldt,2F--4,U.S. Senate,,IND,Eleanor García,1
+Humboldt,2F--4,U.S. Senate,,DEM,Emory Rodgers,2
+Humboldt,2F--4,U.S. Senate,,LIB,Gail K. Lightfoot,18
 Humboldt,2F--4,U.S. Senate,,IND,Gar Myers,1
-Humboldt,2F--4,U.S. Senate,,REP,George C. Yang,2
-Humboldt,2F--4,U.S. Senate,,REP,Greg Conlon,7
-Humboldt,2F--4,U.S. Senate,,REP,Jarrell Williamson,2
-Humboldt,2F--4,U.S. Senate,,IND,Jason Kraus,2
-Humboldt,2F--4,U.S. Senate,,REP,Jerry J. Laws,10
-Humboldt,2F--4,U.S. Senate,,DEM,Kamala D. Harris,56
-Humboldt,2F--4,U.S. Senate,,DEM,Loretta L. Sanchez,26
-Humboldt,2F--4,U.S. Senate,,DEM,Massie Munroe,3
-Humboldt,2F--4,U.S. Senate,,IND,Mike Beitiks,6
-Humboldt,2F--4,U.S. Senate,,GRN,Pamela Elizondo,6
-Humboldt,2F--4,U.S. Senate,,IND,Paul Merritt,2
-Humboldt,2F--4,U.S. Senate,,REP,Phil Wyman,12
+Humboldt,2F--4,U.S. Senate,,REP,George C. Yang,3
+Humboldt,2F--4,U.S. Senate,,REP,Greg Conlon,22
+Humboldt,2F--4,U.S. Senate,,REP,Jarrell Williamson,5
+Humboldt,2F--4,U.S. Senate,,IND,Jason Hanania,1
+Humboldt,2F--4,U.S. Senate,,IND,Jason Kraus,4
+Humboldt,2F--4,U.S. Senate,,REP,Jerry J. Laws,22
+Humboldt,2F--4,U.S. Senate,,DEM,Kamala D. Harris,126
+Humboldt,2F--4,U.S. Senate,,REP,Karen Roseberry,2
+Humboldt,2F--4,U.S. Senate,,IND,Ling Ling Shi,1
+Humboldt,2F--4,U.S. Senate,,DEM,Loretta L. Sanchez,56
+Humboldt,2F--4,U.S. Senate,,LIB,Mark Matthew Herd,1
+Humboldt,2F--4,U.S. Senate,,DEM,Massie Munroe,6
+Humboldt,2F--4,U.S. Senate,,IND,Mike Beitiks,11
+Humboldt,2F--4,U.S. Senate,,GRN,Pamela Elizondo,14
+Humboldt,2F--4,U.S. Senate,,IND,Paul Merritt,8
+Humboldt,2F--4,U.S. Senate,,REP,Phil Wyman,34
 Humboldt,2F--4,U.S. Senate,,DEM,President Cristina Grappo,1
-Humboldt,2F--4,U.S. Senate,,REP,Ron Unz,2
+Humboldt,2F--4,U.S. Senate,,REP,Ron Unz,7
 Humboldt,2F--4,U.S. Senate,,IND,Scott A. Vineberg,1
-Humboldt,2F--4,U.S. Senate,,DEM,Steve Stokes,11
-Humboldt,2F--4,U.S. Senate,,REP,Thomas G. Del Beccaro,3
+Humboldt,2F--4,U.S. Senate,,DEM,Steve Stokes,20
+Humboldt,2F--4,U.S. Senate,,REP,Thomas G. Del Beccaro,10
+Humboldt,2F--4,U.S. Senate,,IND,Tim Gildersleeve,1
 Humboldt,2F--4,U.S. Senate,,REP,Tom Palzer,2
-Humboldt,2F--4,U.S. Senate,,REP,Von Hougo,1
-Humboldt,2F--4_A,President,,REP,Ben Carson,7
-Humboldt,2F--4_A,President,,DEM,Bernie Sanders,77
-Humboldt,2F--4_A,President,,GRN,Darryl Cherney,1
-Humboldt,2F--4_A,President,,REP,Donald Trump,80
-Humboldt,2F--4_A,President,,DEM,Hillary Clinton,49
-Humboldt,2F--4_A,President,,REP,John R. Kasich,8
-Humboldt,2F--4_A,President,,DEM,Michael Steinberg,1
-Humboldt,2F--4_A,President,,REP,Ted Cruz,10
-Humboldt,2F--4_A,President,,DEM,Willie Wilson,4
-Humboldt,2F--4_A,Proposition 50,,,No,48
-Humboldt,2F--4_A,Proposition 50,,,Yes,211
-Humboldt,2F--4_A,State Assembly,2,DEM,Jim Wood,189
-Humboldt,2F--4_A,U.S. House,2,REP,Dale K. Mensing,64
-Humboldt,2F--4_A,U.S. House,2,DEM,Erin A. Schrode,15
-Humboldt,2F--4_A,U.S. House,2,DEM,Jared W. Huffman,146
-Humboldt,2F--4_A,U.S. House,2,IND,Matthew Robert Wookey,29
-Humboldt,2F--4_A,U.S. Senate,,IND,Don J. Grundmann,2
-Humboldt,2F--4_A,U.S. Senate,,REP,Don Krampe,6
-Humboldt,2F--4_A,U.S. Senate,,REP,Duf Sundheim,19
-Humboldt,2F--4_A,U.S. Senate,,IND,Eleanor García,1
-Humboldt,2F--4_A,U.S. Senate,,DEM,Emory Rodgers,1
-Humboldt,2F--4_A,U.S. Senate,,LIB,Gail K. Lightfoot,11
-Humboldt,2F--4_A,U.S. Senate,,REP,George C. Yang,1
-Humboldt,2F--4_A,U.S. Senate,,REP,Greg Conlon,15
-Humboldt,2F--4_A,U.S. Senate,,REP,Jarrell Williamson,3
-Humboldt,2F--4_A,U.S. Senate,,IND,Jason Hanania,1
-Humboldt,2F--4_A,U.S. Senate,,IND,Jason Kraus,2
-Humboldt,2F--4_A,U.S. Senate,,REP,Jerry J. Laws,12
-Humboldt,2F--4_A,U.S. Senate,,DEM,Kamala D. Harris,70
-Humboldt,2F--4_A,U.S. Senate,,REP,Karen Roseberry,2
-Humboldt,2F--4_A,U.S. Senate,,IND,Ling Ling Shi,1
-Humboldt,2F--4_A,U.S. Senate,,DEM,Loretta L. Sanchez,30
-Humboldt,2F--4_A,U.S. Senate,,LIB,Mark Matthew Herd,1
-Humboldt,2F--4_A,U.S. Senate,,DEM,Massie Munroe,3
-Humboldt,2F--4_A,U.S. Senate,,IND,Mike Beitiks,5
-Humboldt,2F--4_A,U.S. Senate,,GRN,Pamela Elizondo,8
-Humboldt,2F--4_A,U.S. Senate,,IND,Paul Merritt,6
-Humboldt,2F--4_A,U.S. Senate,,REP,Phil Wyman,22
-Humboldt,2F--4_A,U.S. Senate,,REP,Ron Unz,5
-Humboldt,2F--4_A,U.S. Senate,,DEM,Steve Stokes,9
-Humboldt,2F--4_A,U.S. Senate,,REP,Thomas G. Del Beccaro,7
-Humboldt,2F--4_A,U.S. Senate,,IND,Tim Gildersleeve,1
-Humboldt,2F--4_A,U.S. Senate,,REP,Von Hougo,2
-Humboldt,2F-R1,President,,REP,Ben Carson,3
-Humboldt,2F-R1,President,,DEM,Bernie Sanders,73
-Humboldt,2F-R1,President,,REP,Donald Trump,56
+Humboldt,2F--4,U.S. Senate,,REP,Von Hougo,3
+Humboldt,2F-R1,President,,AIP,Alan Spears,1
+Humboldt,2F-R1,President,,LIB,Austin Petersen,1
+Humboldt,2F-R1,President,,REP,Ben Carson,16
+Humboldt,2F-R1,President,,DEM,Bernie Sanders,149
+Humboldt,2F-R1,President,,REP,Donald Trump,169
+Humboldt,2F-R1,President,,LIB,Gary Johnson,1
 Humboldt,2F-R1,President,,DEM,Henry Hewes,1
-Humboldt,2F-R1,President,,DEM,Hillary Clinton,49
+Humboldt,2F-R1,President,,DEM,Hillary Clinton,110
 Humboldt,2F-R1,President,,AIP,J.R. Myers,1
 Humboldt,2F-R1,President,,GRN,Jill Stein,1
-Humboldt,2F-R1,President,,REP,John R. Kasich,4
+Humboldt,2F-R1,President,,REP,Jim Gilmore,1
+Humboldt,2F-R1,President,,LIB,John Hale,1
+Humboldt,2F-R1,President,,REP,John R. Kasich,14
 Humboldt,2F-R1,President,,AIP,Robert Ornelas,1
-Humboldt,2F-R1,President,,REP,Ted Cruz,10
-Humboldt,2F-R1,Proposition 50,,,No,49
-Humboldt,2F-R1,Proposition 50,,,Yes,149
-Humboldt,2F-R1,State Assembly,2,DEM,Jim Wood,153
-Humboldt,2F-R1,U.S. House,2,REP,Dale K. Mensing,55
-Humboldt,2F-R1,U.S. House,2,DEM,Erin A. Schrode,15
-Humboldt,2F-R1,U.S. House,2,DEM,Jared W. Huffman,119
-Humboldt,2F-R1,U.S. House,2,IND,Matthew Robert Wookey,20
-Humboldt,2F-R1,U.S. Senate,,IND,Clive Grey,1
-Humboldt,2F-R1,U.S. Senate,,IND,Don J. Grundmann,2
-Humboldt,2F-R1,U.S. Senate,,REP,Don Krampe,2
-Humboldt,2F-R1,U.S. Senate,,REP,Duf Sundheim,12
+Humboldt,2F-R1,President,,REP,Ted Cruz,26
+Humboldt,2F-R1,Proposition 50,,,No,131
+Humboldt,2F-R1,Proposition 50,,,Yes,412
+Humboldt,2F-R1,State Assembly,2,DEM,Jim Wood,386
+Humboldt,2F-R1,U.S. House,2,REP,Dale K. Mensing,173
+Humboldt,2F-R1,U.S. House,2,DEM,Erin A. Schrode,32
+Humboldt,2F-R1,U.S. House,2,DEM,Jared W. Huffman,304
+Humboldt,2F-R1,U.S. House,2,IND,Matthew Robert Wookey,43
+Humboldt,2F-R1,U.S. Senate,,IND,Clive Grey,3
+Humboldt,2F-R1,U.S. Senate,,IND,Don J. Grundmann,5
+Humboldt,2F-R1,U.S. Senate,,REP,Don Krampe,10
+Humboldt,2F-R1,U.S. Senate,,REP,Duf Sundheim,41
 Humboldt,2F-R1,U.S. Senate,,IND,Eleanor García,3
-Humboldt,2F-R1,U.S. Senate,,LIB,Gail K. Lightfoot,7
-Humboldt,2F-R1,U.S. Senate,,REP,George C. Yang,1
-Humboldt,2F-R1,U.S. Senate,,REP,Greg Conlon,6
-Humboldt,2F-R1,U.S. Senate,,REP,Jarrell Williamson,7
-Humboldt,2F-R1,U.S. Senate,,IND,Jason Hanania,1
-Humboldt,2F-R1,U.S. Senate,,REP,Jerry J. Laws,13
-Humboldt,2F-R1,U.S. Senate,,DEM,Kamala D. Harris,39
-Humboldt,2F-R1,U.S. Senate,,REP,Karen Roseberry,2
+Humboldt,2F-R1,U.S. Senate,,DEM,Emory Rodgers,1
+Humboldt,2F-R1,U.S. Senate,,LIB,Gail K. Lightfoot,18
+Humboldt,2F-R1,U.S. Senate,,REP,George C. Yang,4
+Humboldt,2F-R1,U.S. Senate,,REP,Greg Conlon,21
+Humboldt,2F-R1,U.S. Senate,,REP,Jarrell Williamson,10
+Humboldt,2F-R1,U.S. Senate,,IND,Jason Hanania,2
+Humboldt,2F-R1,U.S. Senate,,IND,Jason Kraus,5
+Humboldt,2F-R1,U.S. Senate,,REP,Jerry J. Laws,39
+Humboldt,2F-R1,U.S. Senate,,DEM,Kamala D. Harris,136
+Humboldt,2F-R1,U.S. Senate,,REP,Karen Roseberry,4
 Humboldt,2F-R1,U.S. Senate,,IND,Ling Ling Shi,4
-Humboldt,2F-R1,U.S. Senate,,DEM,Loretta L. Sanchez,38
-Humboldt,2F-R1,U.S. Senate,,LIB,Mark Matthew Herd,1
-Humboldt,2F-R1,U.S. Senate,,DEM,Massie Munroe,4
-Humboldt,2F-R1,U.S. Senate,,IND,Mike Beitiks,5
-Humboldt,2F-R1,U.S. Senate,,GRN,Pamela Elizondo,8
-Humboldt,2F-R1,U.S. Senate,,IND,Paul Merritt,2
-Humboldt,2F-R1,U.S. Senate,,REP,Phil Wyman,29
-Humboldt,2F-R1,U.S. Senate,,DEM,President Cristina Grappo,1
-Humboldt,2F-R1,U.S. Senate,,REP,Ron Unz,1
-Humboldt,2F-R1,U.S. Senate,,DEM,Steve Stokes,8
-Humboldt,2F-R1,U.S. Senate,,REP,Thomas G. Del Beccaro,2
-Humboldt,2F-R1,U.S. Senate,,REP,Tom Palzer,2
-Humboldt,2F-R1,U.S. Senate,,REP,Von Hougo,1
-Humboldt,2F-R1_A,President,,AIP,Alan Spears,1
-Humboldt,2F-R1_A,President,,LIB,Austin Petersen,1
-Humboldt,2F-R1_A,President,,REP,Ben Carson,13
-Humboldt,2F-R1_A,President,,DEM,Bernie Sanders,76
-Humboldt,2F-R1_A,President,,REP,Donald Trump,113
-Humboldt,2F-R1_A,President,,LIB,Gary Johnson,1
-Humboldt,2F-R1_A,President,,DEM,Hillary Clinton,61
-Humboldt,2F-R1_A,President,,REP,Jim Gilmore,1
-Humboldt,2F-R1_A,President,,LIB,John Hale,1
-Humboldt,2F-R1_A,President,,REP,John R. Kasich,10
-Humboldt,2F-R1_A,President,,REP,Ted Cruz,16
-Humboldt,2F-R1_A,Proposition 50,,,No,82
-Humboldt,2F-R1_A,Proposition 50,,,Yes,263
-Humboldt,2F-R1_A,State Assembly,2,DEM,Jim Wood,233
-Humboldt,2F-R1_A,U.S. House,2,REP,Dale K. Mensing,118
-Humboldt,2F-R1_A,U.S. House,2,DEM,Erin A. Schrode,17
-Humboldt,2F-R1_A,U.S. House,2,DEM,Jared W. Huffman,185
-Humboldt,2F-R1_A,U.S. House,2,IND,Matthew Robert Wookey,23
-Humboldt,2F-R1_A,U.S. Senate,,IND,Clive Grey,2
-Humboldt,2F-R1_A,U.S. Senate,,IND,Don J. Grundmann,3
-Humboldt,2F-R1_A,U.S. Senate,,REP,Don Krampe,8
-Humboldt,2F-R1_A,U.S. Senate,,REP,Duf Sundheim,29
-Humboldt,2F-R1_A,U.S. Senate,,DEM,Emory Rodgers,1
-Humboldt,2F-R1_A,U.S. Senate,,LIB,Gail K. Lightfoot,11
-Humboldt,2F-R1_A,U.S. Senate,,REP,George C. Yang,3
-Humboldt,2F-R1_A,U.S. Senate,,REP,Greg Conlon,15
-Humboldt,2F-R1_A,U.S. Senate,,REP,Jarrell Williamson,3
-Humboldt,2F-R1_A,U.S. Senate,,IND,Jason Hanania,1
-Humboldt,2F-R1_A,U.S. Senate,,IND,Jason Kraus,5
-Humboldt,2F-R1_A,U.S. Senate,,REP,Jerry J. Laws,26
-Humboldt,2F-R1_A,U.S. Senate,,DEM,Kamala D. Harris,97
-Humboldt,2F-R1_A,U.S. Senate,,REP,Karen Roseberry,2
-Humboldt,2F-R1_A,U.S. Senate,,DEM,Loretta L. Sanchez,34
-Humboldt,2F-R1_A,U.S. Senate,,LIB,Mark Matthew Herd,1
-Humboldt,2F-R1_A,U.S. Senate,,DEM,Massie Munroe,2
-Humboldt,2F-R1_A,U.S. Senate,,IND,Mike Beitiks,1
-Humboldt,2F-R1_A,U.S. Senate,,GRN,Pamela Elizondo,5
-Humboldt,2F-R1_A,U.S. Senate,,IND,Paul Merritt,2
-Humboldt,2F-R1_A,U.S. Senate,,REP,Phil Wyman,38
-Humboldt,2F-R1_A,U.S. Senate,,DEM,President Cristina Grappo,3
-Humboldt,2F-R1_A,U.S. Senate,,REP,Ron Unz,4
-Humboldt,2F-R1_A,U.S. Senate,,DEM,Steve Stokes,11
-Humboldt,2F-R1_A,U.S. Senate,,REP,Thomas G. Del Beccaro,9
-Humboldt,2F-R1_A,U.S. Senate,,REP,Tom Palzer,7
-Humboldt,2F-R1_A,U.S. Senate,,REP,Von Hougo,4
-Humboldt,2F-R2,President,,AIP,Alan Spears,1
+Humboldt,2F-R1,U.S. Senate,,DEM,Loretta L. Sanchez,72
+Humboldt,2F-R1,U.S. Senate,,LIB,Mark Matthew Herd,2
+Humboldt,2F-R1,U.S. Senate,,DEM,Massie Munroe,6
+Humboldt,2F-R1,U.S. Senate,,IND,Mike Beitiks,6
+Humboldt,2F-R1,U.S. Senate,,GRN,Pamela Elizondo,13
+Humboldt,2F-R1,U.S. Senate,,IND,Paul Merritt,4
+Humboldt,2F-R1,U.S. Senate,,REP,Phil Wyman,67
+Humboldt,2F-R1,U.S. Senate,,DEM,President Cristina Grappo,4
+Humboldt,2F-R1,U.S. Senate,,REP,Ron Unz,5
+Humboldt,2F-R1,U.S. Senate,,DEM,Steve Stokes,19
+Humboldt,2F-R1,U.S. Senate,,REP,Thomas G. Del Beccaro,11
+Humboldt,2F-R1,U.S. Senate,,REP,Tom Palzer,9
+Humboldt,2F-R1,U.S. Senate,,REP,Von Hougo,5
+Humboldt,2F-R2,President,,AIP,Alan Spears,2
 Humboldt,2F-R2,President,,AIP,Arthur Harris,1
-Humboldt,2F-R2,President,,REP,Ben Carson,2
-Humboldt,2F-R2,President,,DEM,Bernie Sanders,32
-Humboldt,2F-R2,President,,REP,Donald Trump,31
+Humboldt,2F-R2,President,,REP,Ben Carson,6
+Humboldt,2F-R2,President,,DEM,Bernie Sanders,99
+Humboldt,2F-R2,President,,REP,Donald Trump,123
 Humboldt,2F-R2,President,,LIB,Gary Johnson,1
-Humboldt,2F-R2,President,,DEM,Hillary Clinton,15
+Humboldt,2F-R2,President,,DEM,Hillary Clinton,54
 Humboldt,2F-R2,President,,REP,Jim Gilmore,1
-Humboldt,2F-R2,President,,REP,John R. Kasich,7
-Humboldt,2F-R2,President,,DEM,Michael Steinberg,1
-Humboldt,2F-R2,President,,AIP,Robert Ornelas,1
+Humboldt,2F-R2,President,,REP,John R. Kasich,16
+Humboldt,2F-R2,President,,DEM,Michael Steinberg,2
+Humboldt,2F-R2,President,,AIP,Robert Ornelas,2
 Humboldt,2F-R2,President,,DEM,Roque De La Fuente,1
-Humboldt,2F-R2,President,,REP,Ted Cruz,8
-Humboldt,2F-R2,Proposition 50,,,No,25
-Humboldt,2F-R2,Proposition 50,,,Yes,72
-Humboldt,2F-R2,State Assembly,2,DEM,Jim Wood,75
-Humboldt,2F-R2,U.S. House,2,REP,Dale K. Mensing,37
-Humboldt,2F-R2,U.S. House,2,DEM,Erin A. Schrode,2
-Humboldt,2F-R2,U.S. House,2,DEM,Jared W. Huffman,49
-Humboldt,2F-R2,U.S. House,2,IND,Matthew Robert Wookey,15
-Humboldt,2F-R2,U.S. Senate,,IND,Don J. Grundmann,1
-Humboldt,2F-R2,U.S. Senate,,REP,Don Krampe,1
-Humboldt,2F-R2,U.S. Senate,,REP,Duf Sundheim,8
+Humboldt,2F-R2,President,,REP,Ted Cruz,21
+Humboldt,2F-R2,President,,AIP,Thomas Hoefling,1
+Humboldt,2F-R2,President,,DEM,Willie Wilson,3
+Humboldt,2F-R2,Proposition 50,,,No,71
+Humboldt,2F-R2,Proposition 50,,,Yes,261
+Humboldt,2F-R2,State Assembly,2,DEM,Jim Wood,241
+Humboldt,2F-R2,U.S. House,2,REP,Dale K. Mensing,119
+Humboldt,2F-R2,U.S. House,2,DEM,Erin A. Schrode,18
+Humboldt,2F-R2,U.S. House,2,DEM,Jared W. Huffman,182
+Humboldt,2F-R2,U.S. House,2,IND,Matthew Robert Wookey,31
+Humboldt,2F-R2,U.S. Senate,,IND,Clive Grey,2
+Humboldt,2F-R2,U.S. Senate,,IND,Don J. Grundmann,2
+Humboldt,2F-R2,U.S. Senate,,REP,Don Krampe,2
+Humboldt,2F-R2,U.S. Senate,,REP,Duf Sundheim,33
 Humboldt,2F-R2,U.S. Senate,,IND,Eleanor García,1
-Humboldt,2F-R2,U.S. Senate,,LIB,Gail K. Lightfoot,3
-Humboldt,2F-R2,U.S. Senate,,IND,Gar Myers,1
-Humboldt,2F-R2,U.S. Senate,,REP,Greg Conlon,8
-Humboldt,2F-R2,U.S. Senate,,IND,Jason Kraus,1
-Humboldt,2F-R2,U.S. Senate,,REP,Jerry J. Laws,7
-Humboldt,2F-R2,U.S. Senate,,DEM,Kamala D. Harris,20
-Humboldt,2F-R2,U.S. Senate,,REP,Karen Roseberry,1
-Humboldt,2F-R2,U.S. Senate,,DEM,Loretta L. Sanchez,12
-Humboldt,2F-R2,U.S. Senate,,GRN,Pamela Elizondo,5
+Humboldt,2F-R2,U.S. Senate,,DEM,Emory Rodgers,1
+Humboldt,2F-R2,U.S. Senate,,LIB,Gail K. Lightfoot,9
+Humboldt,2F-R2,U.S. Senate,,IND,Gar Myers,2
+Humboldt,2F-R2,U.S. Senate,,REP,Greg Conlon,25
+Humboldt,2F-R2,U.S. Senate,,REP,Jarrell Williamson,5
+Humboldt,2F-R2,U.S. Senate,,IND,Jason Kraus,3
+Humboldt,2F-R2,U.S. Senate,,REP,Jerry J. Laws,25
+Humboldt,2F-R2,U.S. Senate,,DEM,Kamala D. Harris,89
+Humboldt,2F-R2,U.S. Senate,,REP,Karen Roseberry,3
+Humboldt,2F-R2,U.S. Senate,,IND,Ling Ling Shi,1
+Humboldt,2F-R2,U.S. Senate,,DEM,Loretta L. Sanchez,38
+Humboldt,2F-R2,U.S. Senate,,LIB,Mark Matthew Herd,1
+Humboldt,2F-R2,U.S. Senate,,DEM,Massie Munroe,2
+Humboldt,2F-R2,U.S. Senate,,IND,Mike Beitiks,1
+Humboldt,2F-R2,U.S. Senate,,GRN,Pamela Elizondo,7
 Humboldt,2F-R2,U.S. Senate,,IND,Paul Merritt,1
-Humboldt,2F-R2,U.S. Senate,,REP,Phil Wyman,6
+Humboldt,2F-R2,U.S. Senate,,REP,Phil Wyman,33
 Humboldt,2F-R2,U.S. Senate,,DEM,President Cristina Grappo,2
-Humboldt,2F-R2,U.S. Senate,,REP,Ron Unz,2
-Humboldt,2F-R2,U.S. Senate,,DEM,Steve Stokes,4
-Humboldt,2F-R2,U.S. Senate,,REP,Thomas G. Del Beccaro,3
-Humboldt,2F-R2,U.S. Senate,,REP,Tom Palzer,2
-Humboldt,2F-R2,U.S. Senate,,REP,Von Hougo,2
-Humboldt,2F-R2_A,President,,AIP,Alan Spears,1
-Humboldt,2F-R2_A,President,,REP,Ben Carson,4
-Humboldt,2F-R2_A,President,,DEM,Bernie Sanders,67
-Humboldt,2F-R2_A,President,,REP,Donald Trump,92
-Humboldt,2F-R2_A,President,,DEM,Hillary Clinton,39
-Humboldt,2F-R2_A,President,,REP,John R. Kasich,9
-Humboldt,2F-R2_A,President,,DEM,Michael Steinberg,1
-Humboldt,2F-R2_A,President,,AIP,Robert Ornelas,1
-Humboldt,2F-R2_A,President,,REP,Ted Cruz,13
-Humboldt,2F-R2_A,President,,AIP,Thomas Hoefling,1
-Humboldt,2F-R2_A,President,,DEM,Willie Wilson,3
-Humboldt,2F-R2_A,Proposition 50,,,No,46
-Humboldt,2F-R2_A,Proposition 50,,,Yes,189
-Humboldt,2F-R2_A,State Assembly,2,DEM,Jim Wood,166
-Humboldt,2F-R2_A,U.S. House,2,REP,Dale K. Mensing,82
-Humboldt,2F-R2_A,U.S. House,2,DEM,Erin A. Schrode,16
-Humboldt,2F-R2_A,U.S. House,2,DEM,Jared W. Huffman,133
-Humboldt,2F-R2_A,U.S. House,2,IND,Matthew Robert Wookey,16
-Humboldt,2F-R2_A,U.S. Senate,,IND,Clive Grey,2
-Humboldt,2F-R2_A,U.S. Senate,,IND,Don J. Grundmann,1
-Humboldt,2F-R2_A,U.S. Senate,,REP,Don Krampe,1
-Humboldt,2F-R2_A,U.S. Senate,,REP,Duf Sundheim,25
-Humboldt,2F-R2_A,U.S. Senate,,DEM,Emory Rodgers,1
-Humboldt,2F-R2_A,U.S. Senate,,LIB,Gail K. Lightfoot,6
-Humboldt,2F-R2_A,U.S. Senate,,IND,Gar Myers,1
-Humboldt,2F-R2_A,U.S. Senate,,REP,Greg Conlon,17
-Humboldt,2F-R2_A,U.S. Senate,,REP,Jarrell Williamson,5
-Humboldt,2F-R2_A,U.S. Senate,,IND,Jason Kraus,2
-Humboldt,2F-R2_A,U.S. Senate,,REP,Jerry J. Laws,18
-Humboldt,2F-R2_A,U.S. Senate,,DEM,Kamala D. Harris,69
-Humboldt,2F-R2_A,U.S. Senate,,REP,Karen Roseberry,2
-Humboldt,2F-R2_A,U.S. Senate,,IND,Ling Ling Shi,1
-Humboldt,2F-R2_A,U.S. Senate,,DEM,Loretta L. Sanchez,26
-Humboldt,2F-R2_A,U.S. Senate,,LIB,Mark Matthew Herd,1
-Humboldt,2F-R2_A,U.S. Senate,,DEM,Massie Munroe,2
-Humboldt,2F-R2_A,U.S. Senate,,IND,Mike Beitiks,1
-Humboldt,2F-R2_A,U.S. Senate,,GRN,Pamela Elizondo,2
-Humboldt,2F-R2_A,U.S. Senate,,REP,Phil Wyman,27
-Humboldt,2F-R2_A,U.S. Senate,,REP,Ron Unz,1
-Humboldt,2F-R2_A,U.S. Senate,,IND,Scott A. Vineberg,1
-Humboldt,2F-R2_A,U.S. Senate,,DEM,Steve Stokes,9
-Humboldt,2F-R2_A,U.S. Senate,,REP,Thomas G. Del Beccaro,8
-Humboldt,2F-R2_A,U.S. Senate,,IND,Tim Gildersleeve,1
-Humboldt,2F-R2_A,U.S. Senate,,REP,Tom Palzer,9
-Humboldt,2F-R2_A,U.S. Senate,,REP,Von Hougo,2
+Humboldt,2F-R2,U.S. Senate,,REP,Ron Unz,3
+Humboldt,2F-R2,U.S. Senate,,IND,Scott A. Vineberg,1
+Humboldt,2F-R2,U.S. Senate,,DEM,Steve Stokes,13
+Humboldt,2F-R2,U.S. Senate,,REP,Thomas G. Del Beccaro,11
+Humboldt,2F-R2,U.S. Senate,,IND,Tim Gildersleeve,1
+Humboldt,2F-R2,U.S. Senate,,REP,Tom Palzer,11
+Humboldt,2F-R2,U.S. Senate,,REP,Von Hougo,4
+Humboldt,2F-R3,President,,AIP,Alan Spears,1
 Humboldt,2F-R3,President,,AIP,Arthur Harris,1
-Humboldt,2F-R3,President,,REP,Ben Carson,11
-Humboldt,2F-R3,President,,DEM,Bernie Sanders,51
-Humboldt,2F-R3,President,,REP,Donald Trump,36
+Humboldt,2F-R3,President,,REP,Ben Carson,15
+Humboldt,2F-R3,President,,DEM,Bernie Sanders,97
+Humboldt,2F-R3,President,,REP,Donald Trump,121
 Humboldt,2F-R3,President,,LIB,Gary Johnson,3
-Humboldt,2F-R3,President,,DEM,Hillary Clinton,15
-Humboldt,2F-R3,President,,DEM,Keith Judd,1
-Humboldt,2F-R3,President,,REP,Ted Cruz,5
-Humboldt,2F-R3,President,,DEM,Willie Wilson,1
-Humboldt,2F-R3,Proposition 50,,,No,23
-Humboldt,2F-R3,Proposition 50,,,Yes,111
-Humboldt,2F-R3,State Assembly,2,DEM,Jim Wood,103
-Humboldt,2F-R3,U.S. House,2,REP,Dale K. Mensing,41
-Humboldt,2F-R3,U.S. House,2,DEM,Erin A. Schrode,10
-Humboldt,2F-R3,U.S. House,2,DEM,Jared W. Huffman,67
-Humboldt,2F-R3,U.S. House,2,IND,Matthew Robert Wookey,16
-Humboldt,2F-R3,U.S. Senate,,REP,Don Krampe,3
-Humboldt,2F-R3,U.S. Senate,,REP,Duf Sundheim,7
+Humboldt,2F-R3,President,,DEM,Hillary Clinton,54
+Humboldt,2F-R3,President,,GRN,Jill Stein,1
+Humboldt,2F-R3,President,,REP,John R. Kasich,5
+Humboldt,2F-R3,President,,DEM,Keith Judd,2
+Humboldt,2F-R3,President,,AIP,Robert Ornelas,1
+Humboldt,2F-R3,President,,REP,Ted Cruz,23
+Humboldt,2F-R3,President,,DEM,Willie Wilson,2
+Humboldt,2F-R3,Proposition 50,,,No,68
+Humboldt,2F-R3,Proposition 50,,,Yes,278
+Humboldt,2F-R3,State Assembly,2,DEM,Jim Wood,235
+Humboldt,2F-R3,U.S. House,2,REP,Dale K. Mensing,120
+Humboldt,2F-R3,U.S. House,2,DEM,Erin A. Schrode,20
+Humboldt,2F-R3,U.S. House,2,DEM,Jared W. Huffman,184
+Humboldt,2F-R3,U.S. House,2,IND,Matthew Robert Wookey,27
+Humboldt,2F-R3,U.S. Senate,,IND,Clive Grey,4
+Humboldt,2F-R3,U.S. Senate,,IND,Don J. Grundmann,3
+Humboldt,2F-R3,U.S. Senate,,REP,Don Krampe,11
+Humboldt,2F-R3,U.S. Senate,,REP,Duf Sundheim,17
 Humboldt,2F-R3,U.S. Senate,,IND,Eleanor García,1
-Humboldt,2F-R3,U.S. Senate,,LIB,Gail K. Lightfoot,4
+Humboldt,2F-R3,U.S. Senate,,LIB,Gail K. Lightfoot,10
 Humboldt,2F-R3,U.S. Senate,,IND,Gar Myers,1
-Humboldt,2F-R3,U.S. Senate,,REP,Greg Conlon,3
-Humboldt,2F-R3,U.S. Senate,,REP,Jarrell Williamson,4
-Humboldt,2F-R3,U.S. Senate,,REP,Jerry J. Laws,13
-Humboldt,2F-R3,U.S. Senate,,DEM,Kamala D. Harris,36
+Humboldt,2F-R3,U.S. Senate,,REP,George C. Yang,5
+Humboldt,2F-R3,U.S. Senate,,REP,Greg Conlon,9
+Humboldt,2F-R3,U.S. Senate,,REP,Jarrell Williamson,10
+Humboldt,2F-R3,U.S. Senate,,IND,Jason Hanania,1
+Humboldt,2F-R3,U.S. Senate,,IND,Jason Kraus,2
+Humboldt,2F-R3,U.S. Senate,,REP,Jerry J. Laws,28
+Humboldt,2F-R3,U.S. Senate,,PAF,John Thompson Parker,1
+Humboldt,2F-R3,U.S. Senate,,DEM,Kamala D. Harris,94
 Humboldt,2F-R3,U.S. Senate,,REP,Karen Roseberry,4
 Humboldt,2F-R3,U.S. Senate,,IND,Ling Ling Shi,3
-Humboldt,2F-R3,U.S. Senate,,DEM,Loretta L. Sanchez,18
-Humboldt,2F-R3,U.S. Senate,,IND,Mike Beitiks,2
-Humboldt,2F-R3,U.S. Senate,,GRN,Pamela Elizondo,6
-Humboldt,2F-R3,U.S. Senate,,IND,Paul Merritt,1
-Humboldt,2F-R3,U.S. Senate,,REP,Phil Wyman,9
-Humboldt,2F-R3,U.S. Senate,,REP,Ron Unz,2
-Humboldt,2F-R3,U.S. Senate,,DEM,Steve Stokes,4
-Humboldt,2F-R3,U.S. Senate,,REP,Thomas G. Del Beccaro,4
+Humboldt,2F-R3,U.S. Senate,,DEM,Loretta L. Sanchez,46
+Humboldt,2F-R3,U.S. Senate,,DEM,Massie Munroe,2
+Humboldt,2F-R3,U.S. Senate,,IND,Mike Beitiks,4
+Humboldt,2F-R3,U.S. Senate,,GRN,Pamela Elizondo,8
+Humboldt,2F-R3,U.S. Senate,,IND,Paul Merritt,2
+Humboldt,2F-R3,U.S. Senate,,REP,Phil Wyman,38
+Humboldt,2F-R3,U.S. Senate,,REP,Ron Unz,4
+Humboldt,2F-R3,U.S. Senate,,IND,Scott A. Vineberg,1
+Humboldt,2F-R3,U.S. Senate,,DEM,Steve Stokes,6
+Humboldt,2F-R3,U.S. Senate,,REP,Thomas G. Del Beccaro,9
 Humboldt,2F-R3,U.S. Senate,,IND,Tim Gildersleeve,1
-Humboldt,2F-R3,U.S. Senate,,REP,Tom Palzer,3
-Humboldt,2F-R3,U.S. Senate,,REP,Von Hougo,1
-Humboldt,2F-R3_A,President,,AIP,Alan Spears,1
-Humboldt,2F-R3_A,President,,REP,Ben Carson,4
-Humboldt,2F-R3_A,President,,DEM,Bernie Sanders,46
-Humboldt,2F-R3_A,President,,REP,Donald Trump,85
-Humboldt,2F-R3_A,President,,DEM,Hillary Clinton,39
-Humboldt,2F-R3_A,President,,GRN,Jill Stein,1
-Humboldt,2F-R3_A,President,,REP,John R. Kasich,5
-Humboldt,2F-R3_A,President,,DEM,Keith Judd,1
-Humboldt,2F-R3_A,President,,AIP,Robert Ornelas,1
-Humboldt,2F-R3_A,President,,REP,Ted Cruz,18
-Humboldt,2F-R3_A,President,,DEM,Willie Wilson,1
-Humboldt,2F-R3_A,Proposition 50,,,No,45
-Humboldt,2F-R3_A,Proposition 50,,,Yes,167
-Humboldt,2F-R3_A,State Assembly,2,DEM,Jim Wood,132
-Humboldt,2F-R3_A,U.S. House,2,REP,Dale K. Mensing,79
-Humboldt,2F-R3_A,U.S. House,2,DEM,Erin A. Schrode,10
-Humboldt,2F-R3_A,U.S. House,2,DEM,Jared W. Huffman,117
-Humboldt,2F-R3_A,U.S. House,2,IND,Matthew Robert Wookey,11
-Humboldt,2F-R3_A,U.S. Senate,,IND,Clive Grey,4
-Humboldt,2F-R3_A,U.S. Senate,,IND,Don J. Grundmann,3
-Humboldt,2F-R3_A,U.S. Senate,,REP,Don Krampe,8
-Humboldt,2F-R3_A,U.S. Senate,,REP,Duf Sundheim,10
-Humboldt,2F-R3_A,U.S. Senate,,LIB,Gail K. Lightfoot,6
-Humboldt,2F-R3_A,U.S. Senate,,REP,George C. Yang,5
-Humboldt,2F-R3_A,U.S. Senate,,REP,Greg Conlon,6
-Humboldt,2F-R3_A,U.S. Senate,,REP,Jarrell Williamson,6
-Humboldt,2F-R3_A,U.S. Senate,,IND,Jason Hanania,1
-Humboldt,2F-R3_A,U.S. Senate,,IND,Jason Kraus,2
-Humboldt,2F-R3_A,U.S. Senate,,REP,Jerry J. Laws,15
-Humboldt,2F-R3_A,U.S. Senate,,PAF,John Thompson Parker,1
-Humboldt,2F-R3_A,U.S. Senate,,DEM,Kamala D. Harris,58
-Humboldt,2F-R3_A,U.S. Senate,,DEM,Loretta L. Sanchez,28
-Humboldt,2F-R3_A,U.S. Senate,,DEM,Massie Munroe,2
-Humboldt,2F-R3_A,U.S. Senate,,IND,Mike Beitiks,2
-Humboldt,2F-R3_A,U.S. Senate,,GRN,Pamela Elizondo,2
-Humboldt,2F-R3_A,U.S. Senate,,IND,Paul Merritt,1
-Humboldt,2F-R3_A,U.S. Senate,,REP,Phil Wyman,29
-Humboldt,2F-R3_A,U.S. Senate,,REP,Ron Unz,2
-Humboldt,2F-R3_A,U.S. Senate,,IND,Scott A. Vineberg,1
-Humboldt,2F-R3_A,U.S. Senate,,DEM,Steve Stokes,2
-Humboldt,2F-R3_A,U.S. Senate,,REP,Thomas G. Del Beccaro,5
-Humboldt,2F-R3_A,U.S. Senate,,REP,Tom Palzer,3
-Humboldt,2F-R3_A,U.S. Senate,,REP,Von Hougo,3
-Humboldt,2F-R4,President,,REP,Ben Carson,7
-Humboldt,2F-R4,President,,DEM,Bernie Sanders,66
-Humboldt,2F-R4,President,,REP,Donald Trump,29
-Humboldt,2F-R4,President,,DEM,Hillary Clinton,31
+Humboldt,2F-R3,U.S. Senate,,REP,Tom Palzer,6
+Humboldt,2F-R3,U.S. Senate,,REP,Von Hougo,4
+Humboldt,2F-R4,President,,AIP,Alan Spears,1
+Humboldt,2F-R4,President,,REP,Ben Carson,16
+Humboldt,2F-R4,President,,DEM,Bernie Sanders,121
+Humboldt,2F-R4,President,,REP,Donald Trump,101
+Humboldt,2F-R4,President,,LIB,Gary Johnson,1
+Humboldt,2F-R4,President,,DEM,Hillary Clinton,77
 Humboldt,2F-R4,President,,AIP,J.R. Myers,1
+Humboldt,2F-R4,President,,GRN,Jill Stein,1
 Humboldt,2F-R4,President,,REP,Jim Gilmore,2
-Humboldt,2F-R4,President,,REP,John R. Kasich,3
-Humboldt,2F-R4,President,,REP,Ted Cruz,5
-Humboldt,2F-R4,Proposition 50,,,No,28
-Humboldt,2F-R4,Proposition 50,,,Yes,125
-Humboldt,2F-R4,State Assembly,2,DEM,Jim Wood,116
-Humboldt,2F-R4,U.S. House,2,REP,Dale K. Mensing,36
-Humboldt,2F-R4,U.S. House,2,DEM,Erin A. Schrode,14
-Humboldt,2F-R4,U.S. House,2,DEM,Jared W. Huffman,74
-Humboldt,2F-R4,U.S. House,2,IND,Matthew Robert Wookey,28
-Humboldt,2F-R4,U.S. Senate,,IND,Don J. Grundmann,2
-Humboldt,2F-R4,U.S. Senate,,REP,Don Krampe,2
-Humboldt,2F-R4,U.S. Senate,,REP,Duf Sundheim,3
+Humboldt,2F-R4,President,,LIB,John McAfee,2
+Humboldt,2F-R4,President,,REP,John R. Kasich,10
+Humboldt,2F-R4,President,,DEM,Michael Steinberg,2
+Humboldt,2F-R4,President,,REP,Ted Cruz,16
+Humboldt,2F-R4,President,,DEM,Willie Wilson,1
+Humboldt,2F-R4,Proposition 50,,,No,72
+Humboldt,2F-R4,Proposition 50,,,Yes,302
+Humboldt,2F-R4,State Assembly,2,DEM,Jim Wood,271
+Humboldt,2F-R4,U.S. House,2,REP,Dale K. Mensing,105
+Humboldt,2F-R4,U.S. House,2,DEM,Erin A. Schrode,25
+Humboldt,2F-R4,U.S. House,2,DEM,Jared W. Huffman,198
+Humboldt,2F-R4,U.S. House,2,IND,Matthew Robert Wookey,46
+Humboldt,2F-R4,U.S. Senate,,IND,Clive Grey,1
+Humboldt,2F-R4,U.S. Senate,,IND,Don J. Grundmann,3
+Humboldt,2F-R4,U.S. Senate,,REP,Don Krampe,5
+Humboldt,2F-R4,U.S. Senate,,REP,Duf Sundheim,27
+Humboldt,2F-R4,U.S. Senate,,IND,Eleanor García,2
 Humboldt,2F-R4,U.S. Senate,,DEM,Emory Rodgers,3
-Humboldt,2F-R4,U.S. Senate,,LIB,Gail K. Lightfoot,7
+Humboldt,2F-R4,U.S. Senate,,LIB,Gail K. Lightfoot,18
 Humboldt,2F-R4,U.S. Senate,,IND,Gar Myers,1
-Humboldt,2F-R4,U.S. Senate,,REP,George C. Yang,1
-Humboldt,2F-R4,U.S. Senate,,REP,Greg Conlon,7
-Humboldt,2F-R4,U.S. Senate,,REP,Jarrell Williamson,3
-Humboldt,2F-R4,U.S. Senate,,IND,Jason Kraus,1
-Humboldt,2F-R4,U.S. Senate,,REP,Jerry J. Laws,12
-Humboldt,2F-R4,U.S. Senate,,DEM,Kamala D. Harris,40
-Humboldt,2F-R4,U.S. Senate,,REP,Karen Roseberry,3
-Humboldt,2F-R4,U.S. Senate,,DEM,Loretta L. Sanchez,25
-Humboldt,2F-R4,U.S. Senate,,DEM,Massie Munroe,1
-Humboldt,2F-R4,U.S. Senate,,GRN,Pamela Elizondo,3
+Humboldt,2F-R4,U.S. Senate,,REP,George C. Yang,2
+Humboldt,2F-R4,U.S. Senate,,REP,Greg Conlon,18
+Humboldt,2F-R4,U.S. Senate,,REP,Jarrell Williamson,9
+Humboldt,2F-R4,U.S. Senate,,IND,Jason Hanania,2
+Humboldt,2F-R4,U.S. Senate,,IND,Jason Kraus,4
+Humboldt,2F-R4,U.S. Senate,,REP,Jerry J. Laws,23
+Humboldt,2F-R4,U.S. Senate,,PAF,John Thompson Parker,1
+Humboldt,2F-R4,U.S. Senate,,DEM,Kamala D. Harris,101
+Humboldt,2F-R4,U.S. Senate,,REP,Karen Roseberry,7
+Humboldt,2F-R4,U.S. Senate,,DEM,Loretta L. Sanchez,52
+Humboldt,2F-R4,U.S. Senate,,LIB,Mark Matthew Herd,1
+Humboldt,2F-R4,U.S. Senate,,DEM,Massie Munroe,3
+Humboldt,2F-R4,U.S. Senate,,IND,Mike Beitiks,2
+Humboldt,2F-R4,U.S. Senate,,GRN,Pamela Elizondo,7
 Humboldt,2F-R4,U.S. Senate,,IND,Paul Merritt,1
-Humboldt,2F-R4,U.S. Senate,,REP,Phil Wyman,11
-Humboldt,2F-R4,U.S. Senate,,DEM,President Cristina Grappo,1
+Humboldt,2F-R4,U.S. Senate,,REP,Phil Wyman,35
+Humboldt,2F-R4,U.S. Senate,,DEM,President Cristina Grappo,2
 Humboldt,2F-R4,U.S. Senate,,REP,Ron Unz,1
 Humboldt,2F-R4,U.S. Senate,,IND,Scott A. Vineberg,1
-Humboldt,2F-R4,U.S. Senate,,DEM,Steve Stokes,12
-Humboldt,2F-R4,U.S. Senate,,REP,Thomas G. Del Beccaro,2
-Humboldt,2F-R4,U.S. Senate,,REP,Tom Palzer,1
-Humboldt,2F-R4,U.S. Senate,,REP,Von Hougo,1
-Humboldt,2F-R4_A,President,,AIP,Alan Spears,1
-Humboldt,2F-R4_A,President,,REP,Ben Carson,9
-Humboldt,2F-R4_A,President,,DEM,Bernie Sanders,55
-Humboldt,2F-R4_A,President,,REP,Donald Trump,72
-Humboldt,2F-R4_A,President,,LIB,Gary Johnson,1
-Humboldt,2F-R4_A,President,,DEM,Hillary Clinton,46
-Humboldt,2F-R4_A,President,,GRN,Jill Stein,1
-Humboldt,2F-R4_A,President,,LIB,John McAfee,2
-Humboldt,2F-R4_A,President,,REP,John R. Kasich,7
-Humboldt,2F-R4_A,President,,DEM,Michael Steinberg,2
-Humboldt,2F-R4_A,President,,REP,Ted Cruz,11
-Humboldt,2F-R4_A,President,,DEM,Willie Wilson,1
-Humboldt,2F-R4_A,Proposition 50,,,No,44
-Humboldt,2F-R4_A,Proposition 50,,,Yes,177
-Humboldt,2F-R4_A,State Assembly,2,DEM,Jim Wood,155
-Humboldt,2F-R4_A,U.S. House,2,REP,Dale K. Mensing,69
-Humboldt,2F-R4_A,U.S. House,2,DEM,Erin A. Schrode,11
-Humboldt,2F-R4_A,U.S. House,2,DEM,Jared W. Huffman,124
-Humboldt,2F-R4_A,U.S. House,2,IND,Matthew Robert Wookey,18
-Humboldt,2F-R4_A,U.S. Senate,,IND,Clive Grey,1
-Humboldt,2F-R4_A,U.S. Senate,,IND,Don J. Grundmann,1
-Humboldt,2F-R4_A,U.S. Senate,,REP,Don Krampe,3
-Humboldt,2F-R4_A,U.S. Senate,,REP,Duf Sundheim,24
-Humboldt,2F-R4_A,U.S. Senate,,IND,Eleanor García,2
-Humboldt,2F-R4_A,U.S. Senate,,LIB,Gail K. Lightfoot,11
-Humboldt,2F-R4_A,U.S. Senate,,REP,George C. Yang,1
-Humboldt,2F-R4_A,U.S. Senate,,REP,Greg Conlon,11
-Humboldt,2F-R4_A,U.S. Senate,,REP,Jarrell Williamson,6
-Humboldt,2F-R4_A,U.S. Senate,,IND,Jason Hanania,2
-Humboldt,2F-R4_A,U.S. Senate,,IND,Jason Kraus,3
-Humboldt,2F-R4_A,U.S. Senate,,REP,Jerry J. Laws,11
-Humboldt,2F-R4_A,U.S. Senate,,PAF,John Thompson Parker,1
-Humboldt,2F-R4_A,U.S. Senate,,DEM,Kamala D. Harris,61
-Humboldt,2F-R4_A,U.S. Senate,,REP,Karen Roseberry,4
-Humboldt,2F-R4_A,U.S. Senate,,DEM,Loretta L. Sanchez,27
-Humboldt,2F-R4_A,U.S. Senate,,LIB,Mark Matthew Herd,1
-Humboldt,2F-R4_A,U.S. Senate,,DEM,Massie Munroe,2
-Humboldt,2F-R4_A,U.S. Senate,,IND,Mike Beitiks,2
-Humboldt,2F-R4_A,U.S. Senate,,GRN,Pamela Elizondo,4
-Humboldt,2F-R4_A,U.S. Senate,,REP,Phil Wyman,24
-Humboldt,2F-R4_A,U.S. Senate,,DEM,President Cristina Grappo,1
-Humboldt,2F-R4_A,U.S. Senate,,DEM,Steve Stokes,2
-Humboldt,2F-R4_A,U.S. Senate,,REP,Thomas G. Del Beccaro,8
-Humboldt,2F-R4_A,U.S. Senate,,IND,Tim Gildersleeve,3
-Humboldt,2F-R4_A,U.S. Senate,,REP,Tom Palzer,3
-Humboldt,2F-R4_A,U.S. Senate,,REP,Von Hougo,1
+Humboldt,2F-R4,U.S. Senate,,DEM,Steve Stokes,14
+Humboldt,2F-R4,U.S. Senate,,REP,Thomas G. Del Beccaro,10
+Humboldt,2F-R4,U.S. Senate,,IND,Tim Gildersleeve,3
+Humboldt,2F-R4,U.S. Senate,,REP,Tom Palzer,4
+Humboldt,2F-R4,U.S. Senate,,REP,Von Hougo,2
 Humboldt,2HV-1,President,,AIP,Alan Spears,1
-Humboldt,2HV-1,President,,REP,Ben Carson,5
-Humboldt,2HV-1,President,,DEM,Bernie Sanders,47
-Humboldt,2HV-1,President,,REP,Donald Trump,49
-Humboldt,2HV-1,President,,DEM,Hillary Clinton,26
-Humboldt,2HV-1,President,,REP,John R. Kasich,2
-Humboldt,2HV-1,President,,REP,Ted Cruz,11
+Humboldt,2HV-1,President,,REP,Ben Carson,11
+Humboldt,2HV-1,President,,DEM,Bernie Sanders,120
+Humboldt,2HV-1,President,,REP,Donald Trump,144
+Humboldt,2HV-1,President,,LIB,Gary Johnson,1
+Humboldt,2HV-1,President,,DEM,Hillary Clinton,78
+Humboldt,2HV-1,President,,REP,Jim Gilmore,1
+Humboldt,2HV-1,President,,REP,John R. Kasich,7
+Humboldt,2HV-1,President,,DEM,Keith Judd,1
+Humboldt,2HV-1,President,,DEM,Roque De La Fuente,1
+Humboldt,2HV-1,President,,REP,Ted Cruz,30
 Humboldt,2HV-1,President,,AIP,Thomas Hoefling,1
 Humboldt,2HV-1,President,,DEM,Willie Wilson,1
-Humboldt,2HV-1,Proposition 50,,,No,24
-Humboldt,2HV-1,Proposition 50,,,Yes,110
-Humboldt,2HV-1,State Assembly,2,DEM,Jim Wood,96
-Humboldt,2HV-1,U.S. House,2,REP,Dale K. Mensing,51
-Humboldt,2HV-1,U.S. House,2,DEM,Erin A. Schrode,13
-Humboldt,2HV-1,U.S. House,2,DEM,Jared W. Huffman,68
-Humboldt,2HV-1,U.S. House,2,IND,Matthew Robert Wookey,9
-Humboldt,2HV-1,U.S. Senate,,IND,Clive Grey,1
+Humboldt,2HV-1,Proposition 50,,,No,76
+Humboldt,2HV-1,Proposition 50,,,Yes,306
+Humboldt,2HV-1,State Assembly,2,DEM,Jim Wood,277
+Humboldt,2HV-1,U.S. House,2,REP,Dale K. Mensing,139
+Humboldt,2HV-1,U.S. House,2,DEM,Erin A. Schrode,26
+Humboldt,2HV-1,U.S. House,2,DEM,Jared W. Huffman,217
+Humboldt,2HV-1,U.S. House,2,IND,Matthew Robert Wookey,20
+Humboldt,2HV-1,U.S. Senate,,IND,Clive Grey,6
 Humboldt,2HV-1,U.S. Senate,,IND,Don J. Grundmann,1
 Humboldt,2HV-1,U.S. Senate,,REP,Don Krampe,1
-Humboldt,2HV-1,U.S. Senate,,REP,Duf Sundheim,4
-Humboldt,2HV-1,U.S. Senate,,IND,Eleanor García,2
+Humboldt,2HV-1,U.S. Senate,,REP,Duf Sundheim,27
+Humboldt,2HV-1,U.S. Senate,,IND,Eleanor García,3
 Humboldt,2HV-1,U.S. Senate,,DEM,Emory Rodgers,1
-Humboldt,2HV-1,U.S. Senate,,LIB,Gail K. Lightfoot,4
-Humboldt,2HV-1,U.S. Senate,,REP,George C. Yang,2
-Humboldt,2HV-1,U.S. Senate,,REP,Greg Conlon,11
+Humboldt,2HV-1,U.S. Senate,,LIB,Gail K. Lightfoot,10
+Humboldt,2HV-1,U.S. Senate,,REP,George C. Yang,3
+Humboldt,2HV-1,U.S. Senate,,REP,Greg Conlon,22
 Humboldt,2HV-1,U.S. Senate,,DEM,Herbert G. Peters,2
-Humboldt,2HV-1,U.S. Senate,,REP,Jarrell Williamson,3
-Humboldt,2HV-1,U.S. Senate,,IND,Jason Kraus,1
-Humboldt,2HV-1,U.S. Senate,,REP,Jerry J. Laws,16
-Humboldt,2HV-1,U.S. Senate,,DEM,Kamala D. Harris,36
-Humboldt,2HV-1,U.S. Senate,,REP,Karen Roseberry,4
-Humboldt,2HV-1,U.S. Senate,,DEM,Loretta L. Sanchez,18
+Humboldt,2HV-1,U.S. Senate,,REP,Jarrell Williamson,6
+Humboldt,2HV-1,U.S. Senate,,IND,Jason Kraus,3
+Humboldt,2HV-1,U.S. Senate,,REP,Jerry J. Laws,27
+Humboldt,2HV-1,U.S. Senate,,DEM,Kamala D. Harris,115
+Humboldt,2HV-1,U.S. Senate,,REP,Karen Roseberry,8
+Humboldt,2HV-1,U.S. Senate,,DEM,Loretta L. Sanchez,50
+Humboldt,2HV-1,U.S. Senate,,LIB,Mark Matthew Herd,2
 Humboldt,2HV-1,U.S. Senate,,DEM,Massie Munroe,1
 Humboldt,2HV-1,U.S. Senate,,IND,Mike Beitiks,3
-Humboldt,2HV-1,U.S. Senate,,GRN,Pamela Elizondo,3
-Humboldt,2HV-1,U.S. Senate,,REP,Phil Wyman,14
+Humboldt,2HV-1,U.S. Senate,,GRN,Pamela Elizondo,8
+Humboldt,2HV-1,U.S. Senate,,REP,Phil Wyman,50
 Humboldt,2HV-1,U.S. Senate,,DEM,President Cristina Grappo,2
-Humboldt,2HV-1,U.S. Senate,,DEM,Steve Stokes,7
-Humboldt,2HV-1,U.S. Senate,,REP,Thomas G. Del Beccaro,6
+Humboldt,2HV-1,U.S. Senate,,REP,Ron Unz,3
+Humboldt,2HV-1,U.S. Senate,,DEM,Steve Stokes,9
+Humboldt,2HV-1,U.S. Senate,,REP,Thomas G. Del Beccaro,24
 Humboldt,2HV-1,U.S. Senate,,IND,Tim Gildersleeve,1
-Humboldt,2HV-1,U.S. Senate,,REP,Tom Palzer,1
-Humboldt,2HV-1_A,President,,REP,Ben Carson,6
-Humboldt,2HV-1_A,President,,DEM,Bernie Sanders,73
-Humboldt,2HV-1_A,President,,REP,Donald Trump,95
-Humboldt,2HV-1_A,President,,LIB,Gary Johnson,1
-Humboldt,2HV-1_A,President,,DEM,Hillary Clinton,52
-Humboldt,2HV-1_A,President,,REP,Jim Gilmore,1
-Humboldt,2HV-1_A,President,,REP,John R. Kasich,5
-Humboldt,2HV-1_A,President,,DEM,Keith Judd,1
-Humboldt,2HV-1_A,President,,DEM,Roque De La Fuente,1
-Humboldt,2HV-1_A,President,,REP,Ted Cruz,19
-Humboldt,2HV-1_A,Proposition 50,,,No,52
-Humboldt,2HV-1_A,Proposition 50,,,Yes,196
-Humboldt,2HV-1_A,State Assembly,2,DEM,Jim Wood,181
-Humboldt,2HV-1_A,U.S. House,2,REP,Dale K. Mensing,88
-Humboldt,2HV-1_A,U.S. House,2,DEM,Erin A. Schrode,13
-Humboldt,2HV-1_A,U.S. House,2,DEM,Jared W. Huffman,149
-Humboldt,2HV-1_A,U.S. House,2,IND,Matthew Robert Wookey,11
-Humboldt,2HV-1_A,U.S. Senate,,IND,Clive Grey,5
-Humboldt,2HV-1_A,U.S. Senate,,REP,Duf Sundheim,23
-Humboldt,2HV-1_A,U.S. Senate,,IND,Eleanor García,1
-Humboldt,2HV-1_A,U.S. Senate,,LIB,Gail K. Lightfoot,6
-Humboldt,2HV-1_A,U.S. Senate,,REP,George C. Yang,1
-Humboldt,2HV-1_A,U.S. Senate,,REP,Greg Conlon,11
-Humboldt,2HV-1_A,U.S. Senate,,REP,Jarrell Williamson,3
-Humboldt,2HV-1_A,U.S. Senate,,IND,Jason Kraus,2
-Humboldt,2HV-1_A,U.S. Senate,,REP,Jerry J. Laws,11
-Humboldt,2HV-1_A,U.S. Senate,,DEM,Kamala D. Harris,79
-Humboldt,2HV-1_A,U.S. Senate,,REP,Karen Roseberry,4
-Humboldt,2HV-1_A,U.S. Senate,,DEM,Loretta L. Sanchez,32
-Humboldt,2HV-1_A,U.S. Senate,,LIB,Mark Matthew Herd,2
-Humboldt,2HV-1_A,U.S. Senate,,GRN,Pamela Elizondo,5
-Humboldt,2HV-1_A,U.S. Senate,,REP,Phil Wyman,36
-Humboldt,2HV-1_A,U.S. Senate,,REP,Ron Unz,3
-Humboldt,2HV-1_A,U.S. Senate,,DEM,Steve Stokes,2
-Humboldt,2HV-1_A,U.S. Senate,,REP,Thomas G. Del Beccaro,18
-Humboldt,2HV-1_A,U.S. Senate,,REP,Tom Palzer,5
-Humboldt,2HV-1_A,U.S. Senate,,REP,Von Hougo,5
+Humboldt,2HV-1,U.S. Senate,,REP,Tom Palzer,6
+Humboldt,2HV-1,U.S. Senate,,REP,Von Hougo,5
 Humboldt,2MR,President,,DEM,Bernie Sanders,10
 Humboldt,2MR,President,,REP,Donald Trump,7
 Humboldt,2MR,President,,DEM,Hillary Clinton,1
@@ -2369,237 +1496,138 @@ Humboldt,2MR,U.S. Senate,,REP,Jerry J. Laws,1
 Humboldt,2MR,U.S. Senate,,DEM,Kamala D. Harris,6
 Humboldt,2MR,U.S. Senate,,GRN,Pamela Elizondo,1
 Humboldt,2R--1,President,,AIP,Alan Spears,1
-Humboldt,2R--1,President,,AIP,Arthur Harris,1
-Humboldt,2R--1,President,,REP,Ben Carson,3
-Humboldt,2R--1,President,,DEM,Bernie Sanders,50
-Humboldt,2R--1,President,,REP,Donald Trump,31
-Humboldt,2R--1,President,,DEM,Hillary Clinton,24
+Humboldt,2R--1,President,,AIP,Arthur Harris,2
+Humboldt,2R--1,President,,REP,Ben Carson,6
+Humboldt,2R--1,President,,DEM,Bernie Sanders,107
+Humboldt,2R--1,President,,REP,Donald Trump,78
+Humboldt,2R--1,President,,DEM,Hillary Clinton,58
 Humboldt,2R--1,President,,AIP,James Hedges,1
-Humboldt,2R--1,President,,REP,John R. Kasich,2
+Humboldt,2R--1,President,,REP,John R. Kasich,4
 Humboldt,2R--1,President,,DEM,Keith Judd,2
 Humboldt,2R--1,President,,DEM,Michael Steinberg,1
 Humboldt,2R--1,President,,LIB,Rhett White Feather Smith,1
-Humboldt,2R--1,President,,AIP,Robert Ornelas,2
-Humboldt,2R--1,President,,REP,Ted Cruz,7
+Humboldt,2R--1,President,,AIP,Robert Ornelas,3
+Humboldt,2R--1,President,,REP,Ted Cruz,14
 Humboldt,2R--1,President,,AIP,Thomas Hoefling,1
-Humboldt,2R--1,Proposition 50,,,No,27
-Humboldt,2R--1,Proposition 50,,,Yes,98
-Humboldt,2R--1,State Assembly,2,DEM,Jim Wood,100
-Humboldt,2R--1,U.S. House,2,REP,Dale K. Mensing,35
-Humboldt,2R--1,U.S. House,2,DEM,Erin A. Schrode,18
-Humboldt,2R--1,U.S. House,2,DEM,Jared W. Huffman,57
-Humboldt,2R--1,U.S. House,2,IND,Matthew Robert Wookey,22
-Humboldt,2R--1,U.S. Senate,,IND,Clive Grey,1
-Humboldt,2R--1,U.S. Senate,,IND,Don J. Grundmann,3
-Humboldt,2R--1,U.S. Senate,,REP,Don Krampe,2
-Humboldt,2R--1,U.S. Senate,,REP,Duf Sundheim,8
+Humboldt,2R--1,Proposition 50,,,No,52
+Humboldt,2R--1,Proposition 50,,,Yes,234
+Humboldt,2R--1,State Assembly,2,DEM,Jim Wood,230
+Humboldt,2R--1,U.S. House,2,REP,Dale K. Mensing,85
+Humboldt,2R--1,U.S. House,2,DEM,Erin A. Schrode,32
+Humboldt,2R--1,U.S. House,2,DEM,Jared W. Huffman,149
+Humboldt,2R--1,U.S. House,2,IND,Matthew Robert Wookey,36
+Humboldt,2R--1,U.S. Senate,,IND,Clive Grey,2
+Humboldt,2R--1,U.S. Senate,,IND,Don J. Grundmann,5
+Humboldt,2R--1,U.S. Senate,,REP,Don Krampe,5
+Humboldt,2R--1,U.S. Senate,,REP,Duf Sundheim,20
 Humboldt,2R--1,U.S. Senate,,IND,Eleanor García,2
-Humboldt,2R--1,U.S. Senate,,DEM,Emory Rodgers,1
-Humboldt,2R--1,U.S. Senate,,LIB,Gail K. Lightfoot,7
-Humboldt,2R--1,U.S. Senate,,REP,George C. Yang,1
-Humboldt,2R--1,U.S. Senate,,REP,Greg Conlon,7
-Humboldt,2R--1,U.S. Senate,,IND,Jason Hanania,1
-Humboldt,2R--1,U.S. Senate,,REP,Jerry J. Laws,9
-Humboldt,2R--1,U.S. Senate,,DEM,Kamala D. Harris,32
-Humboldt,2R--1,U.S. Senate,,REP,Karen Roseberry,3
-Humboldt,2R--1,U.S. Senate,,IND,Ling Ling Shi,1
-Humboldt,2R--1,U.S. Senate,,DEM,Loretta L. Sanchez,16
-Humboldt,2R--1,U.S. Senate,,LIB,Mark Matthew Herd,1
-Humboldt,2R--1,U.S. Senate,,DEM,Massie Munroe,1
+Humboldt,2R--1,U.S. Senate,,DEM,Emory Rodgers,3
+Humboldt,2R--1,U.S. Senate,,LIB,Gail K. Lightfoot,14
+Humboldt,2R--1,U.S. Senate,,REP,George C. Yang,2
+Humboldt,2R--1,U.S. Senate,,REP,Greg Conlon,16
+Humboldt,2R--1,U.S. Senate,,REP,Jarrell Williamson,2
+Humboldt,2R--1,U.S. Senate,,IND,Jason Hanania,2
+Humboldt,2R--1,U.S. Senate,,IND,Jason Kraus,2
+Humboldt,2R--1,U.S. Senate,,REP,Jerry J. Laws,15
+Humboldt,2R--1,U.S. Senate,,PAF,John Thompson Parker,1
+Humboldt,2R--1,U.S. Senate,,DEM,Kamala D. Harris,74
+Humboldt,2R--1,U.S. Senate,,REP,Karen Roseberry,7
+Humboldt,2R--1,U.S. Senate,,IND,Ling Ling Shi,2
+Humboldt,2R--1,U.S. Senate,,DEM,Loretta L. Sanchez,41
+Humboldt,2R--1,U.S. Senate,,LIB,Mark Matthew Herd,2
+Humboldt,2R--1,U.S. Senate,,DEM,Massie Munroe,6
 Humboldt,2R--1,U.S. Senate,,IND,Mike Beitiks,1
-Humboldt,2R--1,U.S. Senate,,GRN,Pamela Elizondo,4
+Humboldt,2R--1,U.S. Senate,,GRN,Pamela Elizondo,5
 Humboldt,2R--1,U.S. Senate,,IND,Paul Merritt,3
-Humboldt,2R--1,U.S. Senate,,REP,Phil Wyman,16
+Humboldt,2R--1,U.S. Senate,,REP,Phil Wyman,33
 Humboldt,2R--1,U.S. Senate,,REP,Ron Unz,1
-Humboldt,2R--1,U.S. Senate,,DEM,Steve Stokes,8
-Humboldt,2R--1,U.S. Senate,,REP,Thomas G. Del Beccaro,1
+Humboldt,2R--1,U.S. Senate,,DEM,Steve Stokes,17
+Humboldt,2R--1,U.S. Senate,,REP,Thomas G. Del Beccaro,3
 Humboldt,2R--1,U.S. Senate,,IND,Tim Gildersleeve,1
-Humboldt,2R--1,U.S. Senate,,REP,Von Hougo,1
-Humboldt,2R--1_A,President,,AIP,Arthur Harris,1
-Humboldt,2R--1_A,President,,REP,Ben Carson,3
-Humboldt,2R--1_A,President,,DEM,Bernie Sanders,57
-Humboldt,2R--1_A,President,,REP,Donald Trump,47
-Humboldt,2R--1_A,President,,DEM,Hillary Clinton,34
-Humboldt,2R--1_A,President,,REP,John R. Kasich,2
-Humboldt,2R--1_A,President,,AIP,Robert Ornelas,1
-Humboldt,2R--1_A,President,,REP,Ted Cruz,7
-Humboldt,2R--1_A,Proposition 50,,,No,25
-Humboldt,2R--1_A,Proposition 50,,,Yes,136
-Humboldt,2R--1_A,State Assembly,2,DEM,Jim Wood,130
-Humboldt,2R--1_A,U.S. House,2,REP,Dale K. Mensing,50
-Humboldt,2R--1_A,U.S. House,2,DEM,Erin A. Schrode,14
-Humboldt,2R--1_A,U.S. House,2,DEM,Jared W. Huffman,92
-Humboldt,2R--1_A,U.S. House,2,IND,Matthew Robert Wookey,14
-Humboldt,2R--1_A,U.S. Senate,,IND,Clive Grey,1
-Humboldt,2R--1_A,U.S. Senate,,IND,Don J. Grundmann,2
-Humboldt,2R--1_A,U.S. Senate,,REP,Don Krampe,3
-Humboldt,2R--1_A,U.S. Senate,,REP,Duf Sundheim,12
-Humboldt,2R--1_A,U.S. Senate,,DEM,Emory Rodgers,2
-Humboldt,2R--1_A,U.S. Senate,,LIB,Gail K. Lightfoot,7
-Humboldt,2R--1_A,U.S. Senate,,REP,George C. Yang,1
-Humboldt,2R--1_A,U.S. Senate,,REP,Greg Conlon,9
-Humboldt,2R--1_A,U.S. Senate,,REP,Jarrell Williamson,2
-Humboldt,2R--1_A,U.S. Senate,,IND,Jason Hanania,1
-Humboldt,2R--1_A,U.S. Senate,,IND,Jason Kraus,2
-Humboldt,2R--1_A,U.S. Senate,,REP,Jerry J. Laws,6
-Humboldt,2R--1_A,U.S. Senate,,PAF,John Thompson Parker,1
-Humboldt,2R--1_A,U.S. Senate,,DEM,Kamala D. Harris,42
-Humboldt,2R--1_A,U.S. Senate,,REP,Karen Roseberry,4
-Humboldt,2R--1_A,U.S. Senate,,IND,Ling Ling Shi,1
-Humboldt,2R--1_A,U.S. Senate,,DEM,Loretta L. Sanchez,25
-Humboldt,2R--1_A,U.S. Senate,,LIB,Mark Matthew Herd,1
-Humboldt,2R--1_A,U.S. Senate,,DEM,Massie Munroe,5
-Humboldt,2R--1_A,U.S. Senate,,GRN,Pamela Elizondo,1
-Humboldt,2R--1_A,U.S. Senate,,REP,Phil Wyman,17
-Humboldt,2R--1_A,U.S. Senate,,DEM,Steve Stokes,9
-Humboldt,2R--1_A,U.S. Senate,,REP,Thomas G. Del Beccaro,2
-Humboldt,2R--1_A,U.S. Senate,,REP,Tom Palzer,1
-Humboldt,2R--1_A,U.S. Senate,,REP,Von Hougo,1
-Humboldt,2R--2,President,,AIP,Alan Spears,1
-Humboldt,2R--2,President,,REP,Ben Carson,5
-Humboldt,2R--2,President,,DEM,Bernie Sanders,40
-Humboldt,2R--2,President,,GRN,Darryl Cherney,1
-Humboldt,2R--2,President,,REP,Donald Trump,47
-Humboldt,2R--2,President,,LIB,Gary Johnson,2
-Humboldt,2R--2,President,,DEM,Hillary Clinton,28
-Humboldt,2R--2,President,,REP,Jim Gilmore,1
-Humboldt,2R--2,President,,REP,John R. Kasich,5
-Humboldt,2R--2,President,,REP,Ted Cruz,7
-Humboldt,2R--2,Proposition 50,,,No,21
-Humboldt,2R--2,Proposition 50,,,Yes,102
-Humboldt,2R--2,State Assembly,2,DEM,Jim Wood,91
-Humboldt,2R--2,U.S. House,2,REP,Dale K. Mensing,50
-Humboldt,2R--2,U.S. House,2,DEM,Erin A. Schrode,9
-Humboldt,2R--2,U.S. House,2,DEM,Jared W. Huffman,62
-Humboldt,2R--2,U.S. House,2,IND,Matthew Robert Wookey,18
-Humboldt,2R--2,U.S. Senate,,IND,Don J. Grundmann,2
-Humboldt,2R--2,U.S. Senate,,REP,Duf Sundheim,13
-Humboldt,2R--2,U.S. Senate,,LIB,Gail K. Lightfoot,9
-Humboldt,2R--2,U.S. Senate,,REP,George C. Yang,1
-Humboldt,2R--2,U.S. Senate,,REP,Greg Conlon,6
-Humboldt,2R--2,U.S. Senate,,REP,Jarrell Williamson,1
-Humboldt,2R--2,U.S. Senate,,REP,Jerry J. Laws,19
-Humboldt,2R--2,U.S. Senate,,DEM,Kamala D. Harris,26
-Humboldt,2R--2,U.S. Senate,,REP,Karen Roseberry,2
-Humboldt,2R--2,U.S. Senate,,IND,Ling Ling Shi,2
-Humboldt,2R--2,U.S. Senate,,DEM,Loretta L. Sanchez,20
-Humboldt,2R--2,U.S. Senate,,DEM,Massie Munroe,2
-Humboldt,2R--2,U.S. Senate,,IND,Mike Beitiks,1
-Humboldt,2R--2,U.S. Senate,,GRN,Pamela Elizondo,4
-Humboldt,2R--2,U.S. Senate,,REP,Phil Wyman,16
-Humboldt,2R--2,U.S. Senate,,REP,Ron Unz,2
+Humboldt,2R--1,U.S. Senate,,REP,Tom Palzer,1
+Humboldt,2R--1,U.S. Senate,,REP,Von Hougo,2
+Humboldt,2R--2,President,,AIP,Alan Spears,2
+Humboldt,2R--2,President,,REP,Ben Carson,10
+Humboldt,2R--2,President,,DEM,Bernie Sanders,89
+Humboldt,2R--2,President,,GRN,Darryl Cherney,2
+Humboldt,2R--2,President,,REP,Donald Trump,126
+Humboldt,2R--2,President,,LIB,Gary Johnson,3
+Humboldt,2R--2,President,,DEM,Hillary Clinton,57
+Humboldt,2R--2,President,,AIP,James Hedges,1
+Humboldt,2R--2,President,,REP,Jim Gilmore,3
+Humboldt,2R--2,President,,REP,John R. Kasich,15
+Humboldt,2R--2,President,,REP,Ted Cruz,12
+Humboldt,2R--2,President,,AIP,Wiley Drake,1
+Humboldt,2R--2,Proposition 50,,,No,60
+Humboldt,2R--2,Proposition 50,,,Yes,269
+Humboldt,2R--2,State Assembly,2,DEM,Jim Wood,234
+Humboldt,2R--2,U.S. House,2,REP,Dale K. Mensing,114
+Humboldt,2R--2,U.S. House,2,DEM,Erin A. Schrode,16
+Humboldt,2R--2,U.S. House,2,DEM,Jared W. Huffman,168
+Humboldt,2R--2,U.S. House,2,IND,Matthew Robert Wookey,43
+Humboldt,2R--2,U.S. Senate,,IND,Clive Grey,1
+Humboldt,2R--2,U.S. Senate,,IND,Don J. Grundmann,3
+Humboldt,2R--2,U.S. Senate,,REP,Don Krampe,3
+Humboldt,2R--2,U.S. Senate,,REP,Duf Sundheim,22
+Humboldt,2R--2,U.S. Senate,,LIB,Gail K. Lightfoot,18
+Humboldt,2R--2,U.S. Senate,,REP,George C. Yang,5
+Humboldt,2R--2,U.S. Senate,,REP,Greg Conlon,26
+Humboldt,2R--2,U.S. Senate,,DEM,Herbert G. Peters,1
+Humboldt,2R--2,U.S. Senate,,REP,Jarrell Williamson,4
+Humboldt,2R--2,U.S. Senate,,IND,Jason Hanania,4
+Humboldt,2R--2,U.S. Senate,,IND,Jason Kraus,3
+Humboldt,2R--2,U.S. Senate,,REP,Jerry J. Laws,35
+Humboldt,2R--2,U.S. Senate,,DEM,Kamala D. Harris,64
+Humboldt,2R--2,U.S. Senate,,REP,Karen Roseberry,7
+Humboldt,2R--2,U.S. Senate,,IND,Ling Ling Shi,3
+Humboldt,2R--2,U.S. Senate,,DEM,Loretta L. Sanchez,48
+Humboldt,2R--2,U.S. Senate,,LIB,Mark Matthew Herd,2
+Humboldt,2R--2,U.S. Senate,,DEM,Massie Munroe,5
+Humboldt,2R--2,U.S. Senate,,IND,Mike Beitiks,3
+Humboldt,2R--2,U.S. Senate,,GRN,Pamela Elizondo,7
+Humboldt,2R--2,U.S. Senate,,IND,Paul Merritt,3
+Humboldt,2R--2,U.S. Senate,,REP,Phil Wyman,36
+Humboldt,2R--2,U.S. Senate,,REP,Ron Unz,3
 Humboldt,2R--2,U.S. Senate,,IND,Scott A. Vineberg,1
-Humboldt,2R--2,U.S. Senate,,DEM,Steve Stokes,4
-Humboldt,2R--2,U.S. Senate,,REP,Thomas G. Del Beccaro,2
-Humboldt,2R--2,U.S. Senate,,REP,Tom Palzer,2
-Humboldt,2R--2,U.S. Senate,,REP,Von Hougo,3
-Humboldt,2R--2_A,President,,AIP,Alan Spears,1
-Humboldt,2R--2_A,President,,REP,Ben Carson,5
-Humboldt,2R--2_A,President,,DEM,Bernie Sanders,49
-Humboldt,2R--2_A,President,,GRN,Darryl Cherney,1
-Humboldt,2R--2_A,President,,REP,Donald Trump,79
-Humboldt,2R--2_A,President,,LIB,Gary Johnson,1
-Humboldt,2R--2_A,President,,DEM,Hillary Clinton,29
-Humboldt,2R--2_A,President,,AIP,James Hedges,1
-Humboldt,2R--2_A,President,,REP,Jim Gilmore,2
-Humboldt,2R--2_A,President,,REP,John R. Kasich,10
-Humboldt,2R--2_A,President,,REP,Ted Cruz,5
-Humboldt,2R--2_A,President,,AIP,Wiley Drake,1
-Humboldt,2R--2_A,Proposition 50,,,No,39
-Humboldt,2R--2_A,Proposition 50,,,Yes,167
-Humboldt,2R--2_A,State Assembly,2,DEM,Jim Wood,143
-Humboldt,2R--2_A,U.S. House,2,REP,Dale K. Mensing,64
-Humboldt,2R--2_A,U.S. House,2,DEM,Erin A. Schrode,7
-Humboldt,2R--2_A,U.S. House,2,DEM,Jared W. Huffman,106
-Humboldt,2R--2_A,U.S. House,2,IND,Matthew Robert Wookey,25
-Humboldt,2R--2_A,U.S. Senate,,IND,Clive Grey,1
-Humboldt,2R--2_A,U.S. Senate,,IND,Don J. Grundmann,1
-Humboldt,2R--2_A,U.S. Senate,,REP,Don Krampe,3
-Humboldt,2R--2_A,U.S. Senate,,REP,Duf Sundheim,9
-Humboldt,2R--2_A,U.S. Senate,,LIB,Gail K. Lightfoot,9
-Humboldt,2R--2_A,U.S. Senate,,REP,George C. Yang,4
-Humboldt,2R--2_A,U.S. Senate,,REP,Greg Conlon,20
-Humboldt,2R--2_A,U.S. Senate,,DEM,Herbert G. Peters,1
-Humboldt,2R--2_A,U.S. Senate,,REP,Jarrell Williamson,3
-Humboldt,2R--2_A,U.S. Senate,,IND,Jason Hanania,4
-Humboldt,2R--2_A,U.S. Senate,,IND,Jason Kraus,3
-Humboldt,2R--2_A,U.S. Senate,,REP,Jerry J. Laws,16
-Humboldt,2R--2_A,U.S. Senate,,DEM,Kamala D. Harris,38
-Humboldt,2R--2_A,U.S. Senate,,REP,Karen Roseberry,5
-Humboldt,2R--2_A,U.S. Senate,,IND,Ling Ling Shi,1
-Humboldt,2R--2_A,U.S. Senate,,DEM,Loretta L. Sanchez,28
-Humboldt,2R--2_A,U.S. Senate,,LIB,Mark Matthew Herd,2
-Humboldt,2R--2_A,U.S. Senate,,DEM,Massie Munroe,3
-Humboldt,2R--2_A,U.S. Senate,,IND,Mike Beitiks,2
-Humboldt,2R--2_A,U.S. Senate,,GRN,Pamela Elizondo,3
-Humboldt,2R--2_A,U.S. Senate,,IND,Paul Merritt,3
-Humboldt,2R--2_A,U.S. Senate,,REP,Phil Wyman,20
-Humboldt,2R--2_A,U.S. Senate,,REP,Ron Unz,1
-Humboldt,2R--2_A,U.S. Senate,,DEM,Steve Stokes,3
-Humboldt,2R--2_A,U.S. Senate,,REP,Thomas G. Del Beccaro,4
-Humboldt,2R--2_A,U.S. Senate,,REP,Tom Palzer,1
-Humboldt,2R--2_A,U.S. Senate,,REP,Von Hougo,3
-Humboldt,2RV-1,President,,REP,Ben Carson,1
-Humboldt,2RV-1,President,,DEM,Bernie Sanders,17
-Humboldt,2RV-1,President,,REP,Donald Trump,14
-Humboldt,2RV-1,President,,DEM,Hillary Clinton,15
+Humboldt,2R--2,U.S. Senate,,DEM,Steve Stokes,7
+Humboldt,2R--2,U.S. Senate,,REP,Thomas G. Del Beccaro,6
+Humboldt,2R--2,U.S. Senate,,REP,Tom Palzer,3
+Humboldt,2R--2,U.S. Senate,,REP,Von Hougo,6
+Humboldt,2RV-1,President,,REP,Ben Carson,6
+Humboldt,2RV-1,President,,DEM,Bernie Sanders,39
+Humboldt,2RV-1,President,,REP,Donald Trump,50
+Humboldt,2RV-1,President,,DEM,Hillary Clinton,36
 Humboldt,2RV-1,President,,AIP,J.R. Myers,1
-Humboldt,2RV-1,President,,REP,John R. Kasich,2
-Humboldt,2RV-1,President,,REP,Ted Cruz,2
-Humboldt,2RV-1,Proposition 50,,,No,9
-Humboldt,2RV-1,Proposition 50,,,Yes,43
-Humboldt,2RV-1,State Assembly,2,DEM,Jim Wood,36
-Humboldt,2RV-1,U.S. House,2,REP,Dale K. Mensing,15
-Humboldt,2RV-1,U.S. House,2,DEM,Erin A. Schrode,6
-Humboldt,2RV-1,U.S. House,2,DEM,Jared W. Huffman,28
-Humboldt,2RV-1,U.S. House,2,IND,Matthew Robert Wookey,7
-Humboldt,2RV-1,U.S. Senate,,IND,Don J. Grundmann,1
-Humboldt,2RV-1,U.S. Senate,,REP,Don Krampe,4
-Humboldt,2RV-1,U.S. Senate,,REP,Duf Sundheim,6
-Humboldt,2RV-1,U.S. Senate,,LIB,Gail K. Lightfoot,3
-Humboldt,2RV-1,U.S. Senate,,REP,Greg Conlon,3
+Humboldt,2RV-1,President,,REP,John R. Kasich,4
+Humboldt,2RV-1,President,,DEM,Keith Judd,1
+Humboldt,2RV-1,President,,DEM,Roque De La Fuente,1
+Humboldt,2RV-1,President,,REP,Ted Cruz,3
+Humboldt,2RV-1,Proposition 50,,,No,23
+Humboldt,2RV-1,Proposition 50,,,Yes,122
+Humboldt,2RV-1,State Assembly,2,DEM,Jim Wood,92
+Humboldt,2RV-1,U.S. House,2,REP,Dale K. Mensing,46
+Humboldt,2RV-1,U.S. House,2,DEM,Erin A. Schrode,7
+Humboldt,2RV-1,U.S. House,2,DEM,Jared W. Huffman,83
+Humboldt,2RV-1,U.S. House,2,IND,Matthew Robert Wookey,13
+Humboldt,2RV-1,U.S. Senate,,IND,Don J. Grundmann,2
+Humboldt,2RV-1,U.S. Senate,,REP,Don Krampe,5
+Humboldt,2RV-1,U.S. Senate,,REP,Duf Sundheim,14
+Humboldt,2RV-1,U.S. Senate,,LIB,Gail K. Lightfoot,5
+Humboldt,2RV-1,U.S. Senate,,REP,Greg Conlon,11
+Humboldt,2RV-1,U.S. Senate,,REP,Jarrell Williamson,3
 Humboldt,2RV-1,U.S. Senate,,IND,Jason Hanania,1
-Humboldt,2RV-1,U.S. Senate,,REP,Jerry J. Laws,2
-Humboldt,2RV-1,U.S. Senate,,DEM,Kamala D. Harris,18
-Humboldt,2RV-1,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Humboldt,2RV-1,U.S. Senate,,REP,Jerry J. Laws,3
+Humboldt,2RV-1,U.S. Senate,,DEM,Kamala D. Harris,50
+Humboldt,2RV-1,U.S. Senate,,DEM,Loretta L. Sanchez,13
 Humboldt,2RV-1,U.S. Senate,,LIB,Mark Matthew Herd,1
-Humboldt,2RV-1,U.S. Senate,,GRN,Pamela Elizondo,4
-Humboldt,2RV-1,U.S. Senate,,REP,Phil Wyman,3
+Humboldt,2RV-1,U.S. Senate,,GRN,Pamela Elizondo,6
+Humboldt,2RV-1,U.S. Senate,,IND,Paul Merritt,1
+Humboldt,2RV-1,U.S. Senate,,REP,Phil Wyman,21
 Humboldt,2RV-1,U.S. Senate,,DEM,President Cristina Grappo,1
-Humboldt,2RV-1,U.S. Senate,,REP,Ron Unz,1
-Humboldt,2RV-1,U.S. Senate,,DEM,Steve Stokes,2
-Humboldt,2RV-1,U.S. Senate,,REP,Tom Palzer,1
-Humboldt,2RV-1_A,President,,REP,Ben Carson,5
-Humboldt,2RV-1_A,President,,DEM,Bernie Sanders,22
-Humboldt,2RV-1_A,President,,REP,Donald Trump,36
-Humboldt,2RV-1_A,President,,DEM,Hillary Clinton,21
-Humboldt,2RV-1_A,President,,REP,John R. Kasich,2
-Humboldt,2RV-1_A,President,,DEM,Keith Judd,1
-Humboldt,2RV-1_A,President,,DEM,Roque De La Fuente,1
-Humboldt,2RV-1_A,President,,REP,Ted Cruz,1
-Humboldt,2RV-1_A,Proposition 50,,,No,14
-Humboldt,2RV-1_A,Proposition 50,,,Yes,79
-Humboldt,2RV-1_A,State Assembly,2,DEM,Jim Wood,56
-Humboldt,2RV-1_A,U.S. House,2,REP,Dale K. Mensing,31
-Humboldt,2RV-1_A,U.S. House,2,DEM,Erin A. Schrode,1
-Humboldt,2RV-1_A,U.S. House,2,DEM,Jared W. Huffman,55
-Humboldt,2RV-1_A,U.S. House,2,IND,Matthew Robert Wookey,6
-Humboldt,2RV-1_A,U.S. Senate,,IND,Don J. Grundmann,1
-Humboldt,2RV-1_A,U.S. Senate,,REP,Don Krampe,1
-Humboldt,2RV-1_A,U.S. Senate,,REP,Duf Sundheim,8
-Humboldt,2RV-1_A,U.S. Senate,,LIB,Gail K. Lightfoot,2
-Humboldt,2RV-1_A,U.S. Senate,,REP,Greg Conlon,8
-Humboldt,2RV-1_A,U.S. Senate,,REP,Jarrell Williamson,3
-Humboldt,2RV-1_A,U.S. Senate,,REP,Jerry J. Laws,1
-Humboldt,2RV-1_A,U.S. Senate,,DEM,Kamala D. Harris,32
-Humboldt,2RV-1_A,U.S. Senate,,DEM,Loretta L. Sanchez,10
-Humboldt,2RV-1_A,U.S. Senate,,GRN,Pamela Elizondo,2
-Humboldt,2RV-1_A,U.S. Senate,,IND,Paul Merritt,1
-Humboldt,2RV-1_A,U.S. Senate,,REP,Phil Wyman,18
-Humboldt,2RV-1_A,U.S. Senate,,REP,Ron Unz,2
-Humboldt,2RV-1_A,U.S. Senate,,DEM,Steve Stokes,1
-Humboldt,2RV-1_A,U.S. Senate,,REP,Thomas G. Del Beccaro,1
-Humboldt,2RV-1_A,U.S. Senate,,REP,Tom Palzer,1
+Humboldt,2RV-1,U.S. Senate,,REP,Ron Unz,3
+Humboldt,2RV-1,U.S. Senate,,DEM,Steve Stokes,3
+Humboldt,2RV-1,U.S. Senate,,REP,Thomas G. Del Beccaro,1
+Humboldt,2RV-1,U.S. Senate,,REP,Tom Palzer,2
 Humboldt,2SH-1,President,,DEM,Bernie Sanders,91
 Humboldt,2SH-1,President,,REP,Donald Trump,2
 Humboldt,2SH-1,President,,DEM,Hillary Clinton,16
@@ -2682,170 +1710,112 @@ Humboldt,2SH-3,U.S. Senate,,DEM,President Cristina Grappo,1
 Humboldt,2SH-3,U.S. Senate,,REP,Ron Unz,1
 Humboldt,2SH-3,U.S. Senate,,REP,Thomas G. Del Beccaro,1
 Humboldt,2SH-3,U.S. Senate,,REP,Tom Palzer,3
-Humboldt,2SH-4,President,,DEM,Bernie Sanders,116
-Humboldt,2SH-4,President,,GRN,Darryl Cherney,2
-Humboldt,2SH-4,President,,REP,Donald Trump,6
-Humboldt,2SH-4,President,,DEM,Hillary Clinton,21
-Humboldt,2SH-4,President,,REP,John R. Kasich,1
-Humboldt,2SH-4,Proposition 50,,,No,32
-Humboldt,2SH-4,Proposition 50,,,Yes,90
-Humboldt,2SH-4,State Assembly,2,DEM,Jim Wood,116
-Humboldt,2SH-4,U.S. House,2,REP,Dale K. Mensing,12
-Humboldt,2SH-4,U.S. House,2,DEM,Erin A. Schrode,26
-Humboldt,2SH-4,U.S. House,2,DEM,Jared W. Huffman,93
-Humboldt,2SH-4,U.S. House,2,IND,Matthew Robert Wookey,8
-Humboldt,2SH-4,U.S. Senate,,LIB,Gail K. Lightfoot,7
+Humboldt,2SH-4,President,,AIP,Alan Spears,1
+Humboldt,2SH-4,President,,REP,Ben Carson,1
+Humboldt,2SH-4,President,,DEM,Bernie Sanders,264
+Humboldt,2SH-4,President,,GRN,Darryl Cherney,5
+Humboldt,2SH-4,President,,REP,Donald Trump,38
+Humboldt,2SH-4,President,,DEM,Hillary Clinton,70
+Humboldt,2SH-4,President,,REP,John R. Kasich,7
+Humboldt,2SH-4,President,,DEM,Michael Steinberg,1
+Humboldt,2SH-4,President,,REP,Ted Cruz,2
+Humboldt,2SH-4,Proposition 50,,,No,71
+Humboldt,2SH-4,Proposition 50,,,Yes,292
+Humboldt,2SH-4,State Assembly,2,DEM,Jim Wood,317
+Humboldt,2SH-4,U.S. House,2,REP,Dale K. Mensing,52
+Humboldt,2SH-4,U.S. House,2,DEM,Erin A. Schrode,46
+Humboldt,2SH-4,U.S. House,2,DEM,Jared W. Huffman,280
+Humboldt,2SH-4,U.S. House,2,IND,Matthew Robert Wookey,20
+Humboldt,2SH-4,U.S. Senate,,IND,Clive Grey,2
+Humboldt,2SH-4,U.S. Senate,,IND,Don J. Grundmann,1
+Humboldt,2SH-4,U.S. Senate,,REP,Duf Sundheim,10
+Humboldt,2SH-4,U.S. Senate,,IND,Eleanor García,1
+Humboldt,2SH-4,U.S. Senate,,DEM,Emory Rodgers,2
+Humboldt,2SH-4,U.S. Senate,,LIB,Gail K. Lightfoot,14
+Humboldt,2SH-4,U.S. Senate,,REP,George C. Yang,1
+Humboldt,2SH-4,U.S. Senate,,REP,Greg Conlon,4
+Humboldt,2SH-4,U.S. Senate,,REP,Jarrell Williamson,4
 Humboldt,2SH-4,U.S. Senate,,IND,Jason Kraus,1
-Humboldt,2SH-4,U.S. Senate,,REP,Jerry J. Laws,2
-Humboldt,2SH-4,U.S. Senate,,DEM,Kamala D. Harris,64
+Humboldt,2SH-4,U.S. Senate,,REP,Jerry J. Laws,9
+Humboldt,2SH-4,U.S. Senate,,DEM,Kamala D. Harris,180
 Humboldt,2SH-4,U.S. Senate,,REP,Karen Roseberry,2
 Humboldt,2SH-4,U.S. Senate,,IND,Ling Ling Shi,1
-Humboldt,2SH-4,U.S. Senate,,DEM,Loretta L. Sanchez,24
+Humboldt,2SH-4,U.S. Senate,,DEM,Loretta L. Sanchez,52
 Humboldt,2SH-4,U.S. Senate,,LIB,Mark Matthew Herd,1
-Humboldt,2SH-4,U.S. Senate,,DEM,Massie Munroe,4
-Humboldt,2SH-4,U.S. Senate,,IND,Mike Beitiks,4
-Humboldt,2SH-4,U.S. Senate,,GRN,Pamela Elizondo,13
-Humboldt,2SH-4,U.S. Senate,,REP,Phil Wyman,4
+Humboldt,2SH-4,U.S. Senate,,DEM,Massie Munroe,8
+Humboldt,2SH-4,U.S. Senate,,IND,Mike Beitiks,5
+Humboldt,2SH-4,U.S. Senate,,GRN,Pamela Elizondo,32
+Humboldt,2SH-4,U.S. Senate,,REP,Phil Wyman,13
 Humboldt,2SH-4,U.S. Senate,,DEM,President Cristina Grappo,2
-Humboldt,2SH-4,U.S. Senate,,DEM,Steve Stokes,3
-Humboldt,2SH-4,U.S. Senate,,REP,Thomas G. Del Beccaro,1
-Humboldt,2SH-4,U.S. Senate,,REP,Von Hougo,1
-Humboldt,2SH-4_A,President,,AIP,Alan Spears,1
-Humboldt,2SH-4_A,President,,REP,Ben Carson,1
-Humboldt,2SH-4_A,President,,DEM,Bernie Sanders,148
-Humboldt,2SH-4_A,President,,GRN,Darryl Cherney,3
-Humboldt,2SH-4_A,President,,REP,Donald Trump,32
-Humboldt,2SH-4_A,President,,DEM,Hillary Clinton,49
-Humboldt,2SH-4_A,President,,REP,John R. Kasich,6
-Humboldt,2SH-4_A,President,,DEM,Michael Steinberg,1
-Humboldt,2SH-4_A,President,,REP,Ted Cruz,2
-Humboldt,2SH-4_A,Proposition 50,,,No,39
-Humboldt,2SH-4_A,Proposition 50,,,Yes,202
-Humboldt,2SH-4_A,State Assembly,2,DEM,Jim Wood,201
-Humboldt,2SH-4_A,U.S. House,2,REP,Dale K. Mensing,40
-Humboldt,2SH-4_A,U.S. House,2,DEM,Erin A. Schrode,20
-Humboldt,2SH-4_A,U.S. House,2,DEM,Jared W. Huffman,187
-Humboldt,2SH-4_A,U.S. House,2,IND,Matthew Robert Wookey,12
-Humboldt,2SH-4_A,U.S. Senate,,IND,Clive Grey,2
-Humboldt,2SH-4_A,U.S. Senate,,IND,Don J. Grundmann,1
-Humboldt,2SH-4_A,U.S. Senate,,REP,Duf Sundheim,10
-Humboldt,2SH-4_A,U.S. Senate,,IND,Eleanor García,1
-Humboldt,2SH-4_A,U.S. Senate,,DEM,Emory Rodgers,2
-Humboldt,2SH-4_A,U.S. Senate,,LIB,Gail K. Lightfoot,7
-Humboldt,2SH-4_A,U.S. Senate,,REP,George C. Yang,1
-Humboldt,2SH-4_A,U.S. Senate,,REP,Greg Conlon,4
-Humboldt,2SH-4_A,U.S. Senate,,REP,Jarrell Williamson,4
-Humboldt,2SH-4_A,U.S. Senate,,REP,Jerry J. Laws,7
-Humboldt,2SH-4_A,U.S. Senate,,DEM,Kamala D. Harris,116
-Humboldt,2SH-4_A,U.S. Senate,,DEM,Loretta L. Sanchez,28
-Humboldt,2SH-4_A,U.S. Senate,,DEM,Massie Munroe,4
-Humboldt,2SH-4_A,U.S. Senate,,IND,Mike Beitiks,1
-Humboldt,2SH-4_A,U.S. Senate,,GRN,Pamela Elizondo,19
-Humboldt,2SH-4_A,U.S. Senate,,REP,Phil Wyman,9
-Humboldt,2SH-4_A,U.S. Senate,,REP,Ron Unz,2
-Humboldt,2SH-4_A,U.S. Senate,,DEM,Steve Stokes,12
-Humboldt,2SH-4_A,U.S. Senate,,REP,Thomas G. Del Beccaro,4
-Humboldt,2SH-4_A,U.S. Senate,,REP,Tom Palzer,2
-Humboldt,2SH-4_A,U.S. Senate,,REP,Von Hougo,3
-Humboldt,2SH-5,President,,REP,Ben Carson,3
-Humboldt,2SH-5,President,,DEM,Bernie Sanders,156
-Humboldt,2SH-5,President,,REP,Donald Trump,11
+Humboldt,2SH-4,U.S. Senate,,REP,Ron Unz,2
+Humboldt,2SH-4,U.S. Senate,,DEM,Steve Stokes,15
+Humboldt,2SH-4,U.S. Senate,,REP,Thomas G. Del Beccaro,5
+Humboldt,2SH-4,U.S. Senate,,REP,Tom Palzer,2
+Humboldt,2SH-4,U.S. Senate,,REP,Von Hougo,4
+Humboldt,2SH-5,President,,REP,Ben Carson,6
+Humboldt,2SH-5,President,,DEM,Bernie Sanders,307
+Humboldt,2SH-5,President,,REP,Donald Trump,62
 Humboldt,2SH-5,President,,PAF,Gloria Estela La Riva,1
-Humboldt,2SH-5,President,,DEM,Hillary Clinton,28
+Humboldt,2SH-5,President,,DEM,Hillary Clinton,86
 Humboldt,2SH-5,President,,AIP,James Hedges,1
-Humboldt,2SH-5,President,,GRN,Jill Stein,1
-Humboldt,2SH-5,President,,REP,John R. Kasich,3
+Humboldt,2SH-5,President,,GRN,Jill Stein,3
+Humboldt,2SH-5,President,,REP,John R. Kasich,6
 Humboldt,2SH-5,President,,DEM,Roque De La Fuente,1
-Humboldt,2SH-5,President,,REP,Ted Cruz,1
-Humboldt,2SH-5,Proposition 50,,,No,42
-Humboldt,2SH-5,Proposition 50,,,Yes,132
-Humboldt,2SH-5,State Assembly,2,DEM,Jim Wood,153
-Humboldt,2SH-5,U.S. House,2,REP,Dale K. Mensing,28
-Humboldt,2SH-5,U.S. House,2,DEM,Erin A. Schrode,34
-Humboldt,2SH-5,U.S. House,2,DEM,Jared W. Huffman,117
-Humboldt,2SH-5,U.S. House,2,IND,Matthew Robert Wookey,17
-Humboldt,2SH-5,U.S. Senate,,IND,Clive Grey,1
-Humboldt,2SH-5,U.S. Senate,,REP,Duf Sundheim,1
+Humboldt,2SH-5,President,,REP,Ted Cruz,4
+Humboldt,2SH-5,President,,AIP,Thomas Hoefling,1
+Humboldt,2SH-5,President,,DEM,Willie Wilson,3
+Humboldt,2SH-5,Proposition 50,,,No,103
+Humboldt,2SH-5,Proposition 50,,,Yes,357
+Humboldt,2SH-5,State Assembly,2,DEM,Jim Wood,388
+Humboldt,2SH-5,U.S. House,2,REP,Dale K. Mensing,92
+Humboldt,2SH-5,U.S. House,2,DEM,Erin A. Schrode,65
+Humboldt,2SH-5,U.S. House,2,DEM,Jared W. Huffman,311
+Humboldt,2SH-5,U.S. House,2,IND,Matthew Robert Wookey,31
+Humboldt,2SH-5,U.S. Senate,,IND,Clive Grey,3
+Humboldt,2SH-5,U.S. Senate,,REP,Don Krampe,1
+Humboldt,2SH-5,U.S. Senate,,REP,Duf Sundheim,10
 Humboldt,2SH-5,U.S. Senate,,IND,Eleanor García,1
 Humboldt,2SH-5,U.S. Senate,,DEM,Emory Rodgers,1
-Humboldt,2SH-5,U.S. Senate,,LIB,Gail K. Lightfoot,9
-Humboldt,2SH-5,U.S. Senate,,REP,George C. Yang,2
-Humboldt,2SH-5,U.S. Senate,,REP,Jarrell Williamson,1
-Humboldt,2SH-5,U.S. Senate,,IND,Jason Kraus,2
-Humboldt,2SH-5,U.S. Senate,,REP,Jerry J. Laws,4
-Humboldt,2SH-5,U.S. Senate,,DEM,Kamala D. Harris,91
+Humboldt,2SH-5,U.S. Senate,,LIB,Gail K. Lightfoot,14
+Humboldt,2SH-5,U.S. Senate,,REP,George C. Yang,4
+Humboldt,2SH-5,U.S. Senate,,REP,Greg Conlon,8
+Humboldt,2SH-5,U.S. Senate,,REP,Jarrell Williamson,3
+Humboldt,2SH-5,U.S. Senate,,IND,Jason Kraus,3
+Humboldt,2SH-5,U.S. Senate,,REP,Jerry J. Laws,16
+Humboldt,2SH-5,U.S. Senate,,PAF,John Thompson Parker,3
+Humboldt,2SH-5,U.S. Senate,,DEM,Kamala D. Harris,206
 Humboldt,2SH-5,U.S. Senate,,REP,Karen Roseberry,1
-Humboldt,2SH-5,U.S. Senate,,IND,Ling Ling Shi,4
-Humboldt,2SH-5,U.S. Senate,,DEM,Loretta L. Sanchez,24
-Humboldt,2SH-5,U.S. Senate,,LIB,Mark Matthew Herd,1
-Humboldt,2SH-5,U.S. Senate,,DEM,Massie Munroe,8
-Humboldt,2SH-5,U.S. Senate,,IND,Mike Beitiks,2
-Humboldt,2SH-5,U.S. Senate,,GRN,Pamela Elizondo,15
-Humboldt,2SH-5,U.S. Senate,,REP,Phil Wyman,2
+Humboldt,2SH-5,U.S. Senate,,IND,Ling Ling Shi,7
+Humboldt,2SH-5,U.S. Senate,,DEM,Loretta L. Sanchez,77
+Humboldt,2SH-5,U.S. Senate,,LIB,Mark Matthew Herd,3
+Humboldt,2SH-5,U.S. Senate,,DEM,Massie Munroe,9
+Humboldt,2SH-5,U.S. Senate,,IND,Mike Beitiks,3
+Humboldt,2SH-5,U.S. Senate,,GRN,Pamela Elizondo,32
+Humboldt,2SH-5,U.S. Senate,,IND,Paul Merritt,2
+Humboldt,2SH-5,U.S. Senate,,REP,Phil Wyman,26
 Humboldt,2SH-5,U.S. Senate,,DEM,President Cristina Grappo,2
 Humboldt,2SH-5,U.S. Senate,,REP,Ron Unz,1
-Humboldt,2SH-5,U.S. Senate,,DEM,Steve Stokes,15
-Humboldt,2SH-5,U.S. Senate,,REP,Von Hougo,1
-Humboldt,2SH-5_A,President,,REP,Ben Carson,3
-Humboldt,2SH-5_A,President,,DEM,Bernie Sanders,151
-Humboldt,2SH-5_A,President,,REP,Donald Trump,51
-Humboldt,2SH-5_A,President,,DEM,Hillary Clinton,58
-Humboldt,2SH-5_A,President,,GRN,Jill Stein,2
-Humboldt,2SH-5_A,President,,REP,John R. Kasich,3
-Humboldt,2SH-5_A,President,,REP,Ted Cruz,3
-Humboldt,2SH-5_A,President,,AIP,Thomas Hoefling,1
-Humboldt,2SH-5_A,President,,DEM,Willie Wilson,3
-Humboldt,2SH-5_A,Proposition 50,,,No,61
-Humboldt,2SH-5_A,Proposition 50,,,Yes,225
-Humboldt,2SH-5_A,State Assembly,2,DEM,Jim Wood,235
-Humboldt,2SH-5_A,U.S. House,2,REP,Dale K. Mensing,64
-Humboldt,2SH-5_A,U.S. House,2,DEM,Erin A. Schrode,31
-Humboldt,2SH-5_A,U.S. House,2,DEM,Jared W. Huffman,194
-Humboldt,2SH-5_A,U.S. House,2,IND,Matthew Robert Wookey,14
-Humboldt,2SH-5_A,U.S. Senate,,IND,Clive Grey,2
-Humboldt,2SH-5_A,U.S. Senate,,REP,Don Krampe,1
-Humboldt,2SH-5_A,U.S. Senate,,REP,Duf Sundheim,9
-Humboldt,2SH-5_A,U.S. Senate,,LIB,Gail K. Lightfoot,5
-Humboldt,2SH-5_A,U.S. Senate,,REP,George C. Yang,2
-Humboldt,2SH-5_A,U.S. Senate,,REP,Greg Conlon,8
-Humboldt,2SH-5_A,U.S. Senate,,REP,Jarrell Williamson,2
-Humboldt,2SH-5_A,U.S. Senate,,IND,Jason Kraus,1
-Humboldt,2SH-5_A,U.S. Senate,,REP,Jerry J. Laws,12
-Humboldt,2SH-5_A,U.S. Senate,,PAF,John Thompson Parker,3
-Humboldt,2SH-5_A,U.S. Senate,,DEM,Kamala D. Harris,115
-Humboldt,2SH-5_A,U.S. Senate,,IND,Ling Ling Shi,3
-Humboldt,2SH-5_A,U.S. Senate,,DEM,Loretta L. Sanchez,53
-Humboldt,2SH-5_A,U.S. Senate,,LIB,Mark Matthew Herd,2
-Humboldt,2SH-5_A,U.S. Senate,,DEM,Massie Munroe,1
-Humboldt,2SH-5_A,U.S. Senate,,IND,Mike Beitiks,1
-Humboldt,2SH-5_A,U.S. Senate,,GRN,Pamela Elizondo,17
-Humboldt,2SH-5_A,U.S. Senate,,IND,Paul Merritt,2
-Humboldt,2SH-5_A,U.S. Senate,,REP,Phil Wyman,24
-Humboldt,2SH-5_A,U.S. Senate,,DEM,Steve Stokes,11
-Humboldt,2SH-5_A,U.S. Senate,,REP,Thomas G. Del Beccaro,2
-Humboldt,2SH-5_A,U.S. Senate,,REP,Von Hougo,6
+Humboldt,2SH-5,U.S. Senate,,DEM,Steve Stokes,26
+Humboldt,2SH-5,U.S. Senate,,REP,Thomas G. Del Beccaro,2
+Humboldt,2SH-5,U.S. Senate,,REP,Von Hougo,7
 Humboldt,2SH-7,President,,DEM,Bernie Sanders,34
 Humboldt,2SH-7,President,,GRN,Darryl Cherney,1
-Humboldt,2SH-7,President,,REP,Donald Trump,1
+Humboldt,2SH-7,President,,REP,Donald Trump,2
 Humboldt,2SH-7,President,,DEM,Hillary Clinton,1
-Humboldt,2SH-7,Proposition 50,,,No,7
+Humboldt,2SH-7,Proposition 50,,,No,8
 Humboldt,2SH-7,Proposition 50,,,Yes,22
 Humboldt,2SH-7,State Assembly,2,DEM,Jim Wood,26
-Humboldt,2SH-7,U.S. House,2,REP,Dale K. Mensing,5
+Humboldt,2SH-7,U.S. House,2,REP,Dale K. Mensing,6
 Humboldt,2SH-7,U.S. House,2,DEM,Erin A. Schrode,12
 Humboldt,2SH-7,U.S. House,2,DEM,Jared W. Huffman,22
 Humboldt,2SH-7,U.S. House,2,IND,Matthew Robert Wookey,1
 Humboldt,2SH-7,U.S. Senate,,IND,Clive Grey,1
-Humboldt,2SH-7,U.S. Senate,,REP,Duf Sundheim,2
+Humboldt,2SH-7,U.S. Senate,,REP,Duf Sundheim,3
 Humboldt,2SH-7,U.S. Senate,,DEM,Kamala D. Harris,18
 Humboldt,2SH-7,U.S. Senate,,IND,Ling Ling Shi,1
 Humboldt,2SH-7,U.S. Senate,,DEM,Loretta L. Sanchez,8
 Humboldt,2SH-7,U.S. Senate,,GRN,Pamela Elizondo,4
 Humboldt,2SH-7,U.S. Senate,,DEM,Steve Stokes,3
-Humboldt,2SH-7_A,President,,REP,Donald Trump,1
-Humboldt,2SH-7_A,Proposition 50,,,No,1
-Humboldt,2SH-7_A,U.S. House,2,REP,Dale K. Mensing,1
-Humboldt,2SH-7_A,U.S. Senate,,REP,Duf Sundheim,1
 Humboldt,2SH-8,President,,AIP,Alan Spears,1
 Humboldt,2SH-8,President,,DEM,Bernie Sanders,33
 Humboldt,2SH-8,President,,GRN,Darryl Cherney,8
@@ -2975,163 +1945,102 @@ Humboldt,2SHR2,U.S. Senate,,REP,Ron Unz,1
 Humboldt,2SHR2,U.S. Senate,,DEM,Steve Stokes,6
 Humboldt,2SHR2,U.S. Senate,,REP,Thomas G. Del Beccaro,3
 Humboldt,2SHR2,U.S. Senate,,REP,Tom Palzer,2
-Humboldt,2SHS4,President,,DEM,Bernie Sanders,127
-Humboldt,2SHS4,President,,GRN,Darryl Cherney,4
-Humboldt,2SHS4,President,,REP,Donald Trump,11
-Humboldt,2SHS4,President,,LIB,Gary Johnson,1
-Humboldt,2SHS4,President,,DEM,Hillary Clinton,15
-Humboldt,2SHS4,President,,GRN,Jill Stein,2
-Humboldt,2SHS4,President,,DEM,Michael Steinberg,1
+Humboldt,2SHS4,President,,AIP,Alan Spears,2
+Humboldt,2SHS4,President,,REP,Ben Carson,2
+Humboldt,2SHS4,President,,DEM,Bernie Sanders,242
+Humboldt,2SHS4,President,,GRN,Darryl Cherney,5
+Humboldt,2SHS4,President,,REP,Donald Trump,33
+Humboldt,2SHS4,President,,LIB,Gary Johnson,2
+Humboldt,2SHS4,President,,DEM,Hillary Clinton,40
+Humboldt,2SHS4,President,,AIP,J.R. Myers,1
+Humboldt,2SHS4,President,,GRN,Jill Stein,4
+Humboldt,2SHS4,President,,REP,John R. Kasich,1
+Humboldt,2SHS4,President,,DEM,Michael Steinberg,3
 Humboldt,2SHS4,President,,PAF,Monica Moorehead,1
-Humboldt,2SHS4,Proposition 50,,,No,36
-Humboldt,2SHS4,Proposition 50,,,Yes,111
-Humboldt,2SHS4,State Assembly,2,DEM,Jim Wood,127
-Humboldt,2SHS4,U.S. House,2,REP,Dale K. Mensing,30
-Humboldt,2SHS4,U.S. House,2,DEM,Erin A. Schrode,29
-Humboldt,2SHS4,U.S. House,2,DEM,Jared W. Huffman,75
-Humboldt,2SHS4,U.S. House,2,IND,Matthew Robert Wookey,25
-Humboldt,2SHS4,U.S. Senate,,REP,Don Krampe,1
-Humboldt,2SHS4,U.S. Senate,,REP,Duf Sundheim,2
-Humboldt,2SHS4,U.S. Senate,,LIB,Gail K. Lightfoot,4
+Humboldt,2SHS4,President,,REP,Ted Cruz,1
+Humboldt,2SHS4,Proposition 50,,,No,71
+Humboldt,2SHS4,Proposition 50,,,Yes,238
+Humboldt,2SHS4,State Assembly,2,DEM,Jim Wood,251
+Humboldt,2SHS4,U.S. House,2,REP,Dale K. Mensing,61
+Humboldt,2SHS4,U.S. House,2,DEM,Erin A. Schrode,61
+Humboldt,2SHS4,U.S. House,2,DEM,Jared W. Huffman,177
+Humboldt,2SHS4,U.S. House,2,IND,Matthew Robert Wookey,33
+Humboldt,2SHS4,U.S. Senate,,IND,Clive Grey,2
+Humboldt,2SHS4,U.S. Senate,,REP,Don Krampe,2
+Humboldt,2SHS4,U.S. Senate,,REP,Duf Sundheim,8
+Humboldt,2SHS4,U.S. Senate,,IND,Eleanor García,1
+Humboldt,2SHS4,U.S. Senate,,LIB,Gail K. Lightfoot,11
 Humboldt,2SHS4,U.S. Senate,,IND,Gar Myers,1
 Humboldt,2SHS4,U.S. Senate,,REP,George C. Yang,2
-Humboldt,2SHS4,U.S. Senate,,REP,Greg Conlon,1
+Humboldt,2SHS4,U.S. Senate,,REP,Greg Conlon,4
 Humboldt,2SHS4,U.S. Senate,,DEM,Herbert G. Peters,1
+Humboldt,2SHS4,U.S. Senate,,REP,Jarrell Williamson,3
 Humboldt,2SHS4,U.S. Senate,,IND,Jason Hanania,1
 Humboldt,2SHS4,U.S. Senate,,IND,Jason Kraus,1
-Humboldt,2SHS4,U.S. Senate,,REP,Jerry J. Laws,5
+Humboldt,2SHS4,U.S. Senate,,REP,Jerry J. Laws,11
 Humboldt,2SHS4,U.S. Senate,,PAF,John Thompson Parker,3
-Humboldt,2SHS4,U.S. Senate,,DEM,Kamala D. Harris,50
+Humboldt,2SHS4,U.S. Senate,,DEM,Kamala D. Harris,127
 Humboldt,2SHS4,U.S. Senate,,REP,Karen Roseberry,3
 Humboldt,2SHS4,U.S. Senate,,IND,Ling Ling Shi,2
-Humboldt,2SHS4,U.S. Senate,,DEM,Loretta L. Sanchez,19
+Humboldt,2SHS4,U.S. Senate,,DEM,Loretta L. Sanchez,45
 Humboldt,2SHS4,U.S. Senate,,LIB,Mark Matthew Herd,1
-Humboldt,2SHS4,U.S. Senate,,DEM,Massie Munroe,6
-Humboldt,2SHS4,U.S. Senate,,IND,Mike Beitiks,3
-Humboldt,2SHS4,U.S. Senate,,GRN,Pamela Elizondo,24
-Humboldt,2SHS4,U.S. Senate,,REP,Phil Wyman,3
-Humboldt,2SHS4,U.S. Senate,,DEM,Steve Stokes,16
+Humboldt,2SHS4,U.S. Senate,,DEM,Massie Munroe,10
+Humboldt,2SHS4,U.S. Senate,,IND,Mike Beitiks,6
+Humboldt,2SHS4,U.S. Senate,,GRN,Pamela Elizondo,41
+Humboldt,2SHS4,U.S. Senate,,IND,Paul Merritt,3
+Humboldt,2SHS4,U.S. Senate,,REP,Phil Wyman,9
+Humboldt,2SHS4,U.S. Senate,,DEM,Steve Stokes,24
+Humboldt,2SHS4,U.S. Senate,,REP,Thomas G. Del Beccaro,3
 Humboldt,2SHS4,U.S. Senate,,REP,Von Hougo,1
-Humboldt,2SHS4_A,President,,AIP,Alan Spears,2
-Humboldt,2SHS4_A,President,,REP,Ben Carson,2
-Humboldt,2SHS4_A,President,,DEM,Bernie Sanders,115
-Humboldt,2SHS4_A,President,,GRN,Darryl Cherney,1
-Humboldt,2SHS4_A,President,,REP,Donald Trump,22
-Humboldt,2SHS4_A,President,,LIB,Gary Johnson,1
-Humboldt,2SHS4_A,President,,DEM,Hillary Clinton,25
-Humboldt,2SHS4_A,President,,AIP,J.R. Myers,1
-Humboldt,2SHS4_A,President,,GRN,Jill Stein,2
-Humboldt,2SHS4_A,President,,REP,John R. Kasich,1
-Humboldt,2SHS4_A,President,,DEM,Michael Steinberg,2
-Humboldt,2SHS4_A,President,,REP,Ted Cruz,1
-Humboldt,2SHS4_A,Proposition 50,,,No,35
-Humboldt,2SHS4_A,Proposition 50,,,Yes,127
-Humboldt,2SHS4_A,State Assembly,2,DEM,Jim Wood,124
-Humboldt,2SHS4_A,U.S. House,2,REP,Dale K. Mensing,31
-Humboldt,2SHS4_A,U.S. House,2,DEM,Erin A. Schrode,32
-Humboldt,2SHS4_A,U.S. House,2,DEM,Jared W. Huffman,102
-Humboldt,2SHS4_A,U.S. House,2,IND,Matthew Robert Wookey,8
-Humboldt,2SHS4_A,U.S. Senate,,IND,Clive Grey,2
-Humboldt,2SHS4_A,U.S. Senate,,REP,Don Krampe,1
-Humboldt,2SHS4_A,U.S. Senate,,REP,Duf Sundheim,6
-Humboldt,2SHS4_A,U.S. Senate,,IND,Eleanor García,1
-Humboldt,2SHS4_A,U.S. Senate,,LIB,Gail K. Lightfoot,7
-Humboldt,2SHS4_A,U.S. Senate,,REP,Greg Conlon,3
-Humboldt,2SHS4_A,U.S. Senate,,REP,Jarrell Williamson,3
-Humboldt,2SHS4_A,U.S. Senate,,REP,Jerry J. Laws,6
-Humboldt,2SHS4_A,U.S. Senate,,DEM,Kamala D. Harris,77
-Humboldt,2SHS4_A,U.S. Senate,,DEM,Loretta L. Sanchez,26
-Humboldt,2SHS4_A,U.S. Senate,,DEM,Massie Munroe,4
-Humboldt,2SHS4_A,U.S. Senate,,IND,Mike Beitiks,3
-Humboldt,2SHS4_A,U.S. Senate,,GRN,Pamela Elizondo,17
-Humboldt,2SHS4_A,U.S. Senate,,IND,Paul Merritt,3
-Humboldt,2SHS4_A,U.S. Senate,,REP,Phil Wyman,6
-Humboldt,2SHS4_A,U.S. Senate,,DEM,Steve Stokes,8
-Humboldt,2SHS4_A,U.S. Senate,,REP,Thomas G. Del Beccaro,3
+Humboldt,2SHS7,President,,AIP,Arthur Harris,1
 Humboldt,2SHS7,President,,REP,Ben Carson,1
-Humboldt,2SHS7,President,,DEM,Bernie Sanders,266
-Humboldt,2SHS7,President,,GRN,Darryl Cherney,5
-Humboldt,2SHS7,President,,REP,Donald Trump,17
-Humboldt,2SHS7,President,,DEM,Hillary Clinton,40
-Humboldt,2SHS7,President,,GRN,Jill Stein,2
-Humboldt,2SHS7,President,,REP,John R. Kasich,2
+Humboldt,2SHS7,President,,DEM,Bernie Sanders,468
+Humboldt,2SHS7,President,,GRN,Darryl Cherney,8
+Humboldt,2SHS7,President,,REP,Donald Trump,58
+Humboldt,2SHS7,President,,DEM,Hillary Clinton,87
+Humboldt,2SHS7,President,,GRN,Jill Stein,4
+Humboldt,2SHS7,President,,REP,John R. Kasich,4
 Humboldt,2SHS7,President,,DEM,Michael Steinberg,1
-Humboldt,2SHS7,President,,REP,Ted Cruz,1
-Humboldt,2SHS7,Proposition 50,,,No,55
-Humboldt,2SHS7,Proposition 50,,,Yes,200
-Humboldt,2SHS7,State Assembly,2,DEM,Jim Wood,240
-Humboldt,2SHS7,U.S. House,2,REP,Dale K. Mensing,60
-Humboldt,2SHS7,U.S. House,2,DEM,Erin A. Schrode,43
-Humboldt,2SHS7,U.S. House,2,DEM,Jared W. Huffman,183
-Humboldt,2SHS7,U.S. House,2,IND,Matthew Robert Wookey,22
-Humboldt,2SHS7,U.S. Senate,,IND,Clive Grey,1
+Humboldt,2SHS7,President,,REP,Ted Cruz,3
+Humboldt,2SHS7,President,,DEM,Willie Wilson,1
+Humboldt,2SHS7,Proposition 50,,,No,119
+Humboldt,2SHS7,Proposition 50,,,Yes,403
+Humboldt,2SHS7,State Assembly,2,DEM,Jim Wood,449
+Humboldt,2SHS7,U.S. House,2,REP,Dale K. Mensing,122
+Humboldt,2SHS7,U.S. House,2,DEM,Erin A. Schrode,93
+Humboldt,2SHS7,U.S. House,2,DEM,Jared W. Huffman,350
+Humboldt,2SHS7,U.S. House,2,IND,Matthew Robert Wookey,42
+Humboldt,2SHS7,U.S. Senate,,IND,Clive Grey,2
 Humboldt,2SHS7,U.S. Senate,,IND,Don J. Grundmann,1
-Humboldt,2SHS7,U.S. Senate,,REP,Don Krampe,1
-Humboldt,2SHS7,U.S. Senate,,REP,Duf Sundheim,5
+Humboldt,2SHS7,U.S. Senate,,REP,Don Krampe,4
+Humboldt,2SHS7,U.S. Senate,,REP,Duf Sundheim,16
 Humboldt,2SHS7,U.S. Senate,,IND,Eleanor García,1
 Humboldt,2SHS7,U.S. Senate,,DEM,Emory Rodgers,1
-Humboldt,2SHS7,U.S. Senate,,LIB,Gail K. Lightfoot,22
-Humboldt,2SHS7,U.S. Senate,,REP,George C. Yang,3
-Humboldt,2SHS7,U.S. Senate,,REP,Greg Conlon,2
+Humboldt,2SHS7,U.S. Senate,,LIB,Gail K. Lightfoot,33
+Humboldt,2SHS7,U.S. Senate,,IND,Gar Myers,1
+Humboldt,2SHS7,U.S. Senate,,REP,George C. Yang,4
+Humboldt,2SHS7,U.S. Senate,,REP,Greg Conlon,5
 Humboldt,2SHS7,U.S. Senate,,DEM,Herbert G. Peters,1
 Humboldt,2SHS7,U.S. Senate,,IND,Jason Hanania,1
-Humboldt,2SHS7,U.S. Senate,,IND,Jason Kraus,1
-Humboldt,2SHS7,U.S. Senate,,REP,Jerry J. Laws,8
-Humboldt,2SHS7,U.S. Senate,,PAF,John Thompson Parker,2
-Humboldt,2SHS7,U.S. Senate,,DEM,Kamala D. Harris,130
-Humboldt,2SHS7,U.S. Senate,,REP,Karen Roseberry,3
-Humboldt,2SHS7,U.S. Senate,,IND,Ling Ling Shi,1
-Humboldt,2SHS7,U.S. Senate,,DEM,Loretta L. Sanchez,39
-Humboldt,2SHS7,U.S. Senate,,LIB,Mark Matthew Herd,2
-Humboldt,2SHS7,U.S. Senate,,DEM,Massie Munroe,6
-Humboldt,2SHS7,U.S. Senate,,IND,Mike Beitiks,3
-Humboldt,2SHS7,U.S. Senate,,GRN,Pamela Elizondo,35
-Humboldt,2SHS7,U.S. Senate,,REP,Phil Wyman,6
+Humboldt,2SHS7,U.S. Senate,,IND,Jason Kraus,2
+Humboldt,2SHS7,U.S. Senate,,REP,Jerry J. Laws,20
+Humboldt,2SHS7,U.S. Senate,,PAF,John Thompson Parker,3
+Humboldt,2SHS7,U.S. Senate,,DEM,Kamala D. Harris,257
+Humboldt,2SHS7,U.S. Senate,,REP,Karen Roseberry,4
+Humboldt,2SHS7,U.S. Senate,,IND,Ling Ling Shi,2
+Humboldt,2SHS7,U.S. Senate,,DEM,Loretta L. Sanchez,89
+Humboldt,2SHS7,U.S. Senate,,LIB,Mark Matthew Herd,3
+Humboldt,2SHS7,U.S. Senate,,DEM,Massie Munroe,20
+Humboldt,2SHS7,U.S. Senate,,IND,Mike Beitiks,5
+Humboldt,2SHS7,U.S. Senate,,GRN,Pamela Elizondo,60
+Humboldt,2SHS7,U.S. Senate,,IND,Paul Merritt,2
+Humboldt,2SHS7,U.S. Senate,,REP,Phil Wyman,19
 Humboldt,2SHS7,U.S. Senate,,DEM,President Cristina Grappo,1
-Humboldt,2SHS7,U.S. Senate,,REP,Ron Unz,2
-Humboldt,2SHS7,U.S. Senate,,DEM,Steve Stokes,15
-Humboldt,2SHS7,U.S. Senate,,REP,Thomas G. Del Beccaro,1
-Humboldt,2SHS7_A,President,,AIP,Arthur Harris,1
-Humboldt,2SHS7_A,President,,DEM,Bernie Sanders,202
-Humboldt,2SHS7_A,President,,GRN,Darryl Cherney,3
-Humboldt,2SHS7_A,President,,REP,Donald Trump,41
-Humboldt,2SHS7_A,President,,DEM,Hillary Clinton,47
-Humboldt,2SHS7_A,President,,GRN,Jill Stein,2
-Humboldt,2SHS7_A,President,,REP,John R. Kasich,2
-Humboldt,2SHS7_A,President,,REP,Ted Cruz,2
-Humboldt,2SHS7_A,President,,DEM,Willie Wilson,1
-Humboldt,2SHS7_A,Proposition 50,,,No,64
-Humboldt,2SHS7_A,Proposition 50,,,Yes,203
-Humboldt,2SHS7_A,State Assembly,2,DEM,Jim Wood,209
-Humboldt,2SHS7_A,U.S. House,2,REP,Dale K. Mensing,62
-Humboldt,2SHS7_A,U.S. House,2,DEM,Erin A. Schrode,50
-Humboldt,2SHS7_A,U.S. House,2,DEM,Jared W. Huffman,167
-Humboldt,2SHS7_A,U.S. House,2,IND,Matthew Robert Wookey,20
-Humboldt,2SHS7_A,U.S. Senate,,IND,Clive Grey,1
-Humboldt,2SHS7_A,U.S. Senate,,REP,Don Krampe,3
-Humboldt,2SHS7_A,U.S. Senate,,REP,Duf Sundheim,11
-Humboldt,2SHS7_A,U.S. Senate,,LIB,Gail K. Lightfoot,11
-Humboldt,2SHS7_A,U.S. Senate,,IND,Gar Myers,1
-Humboldt,2SHS7_A,U.S. Senate,,REP,George C. Yang,1
-Humboldt,2SHS7_A,U.S. Senate,,REP,Greg Conlon,3
-Humboldt,2SHS7_A,U.S. Senate,,IND,Jason Kraus,1
-Humboldt,2SHS7_A,U.S. Senate,,REP,Jerry J. Laws,12
-Humboldt,2SHS7_A,U.S. Senate,,PAF,John Thompson Parker,1
-Humboldt,2SHS7_A,U.S. Senate,,DEM,Kamala D. Harris,127
-Humboldt,2SHS7_A,U.S. Senate,,REP,Karen Roseberry,1
-Humboldt,2SHS7_A,U.S. Senate,,IND,Ling Ling Shi,1
-Humboldt,2SHS7_A,U.S. Senate,,DEM,Loretta L. Sanchez,50
-Humboldt,2SHS7_A,U.S. Senate,,LIB,Mark Matthew Herd,1
-Humboldt,2SHS7_A,U.S. Senate,,DEM,Massie Munroe,14
-Humboldt,2SHS7_A,U.S. Senate,,IND,Mike Beitiks,2
-Humboldt,2SHS7_A,U.S. Senate,,GRN,Pamela Elizondo,25
-Humboldt,2SHS7_A,U.S. Senate,,IND,Paul Merritt,2
-Humboldt,2SHS7_A,U.S. Senate,,REP,Phil Wyman,13
-Humboldt,2SHS7_A,U.S. Senate,,REP,Ron Unz,1
-Humboldt,2SHS7_A,U.S. Senate,,DEM,Steve Stokes,11
-Humboldt,2SHS7_A,U.S. Senate,,REP,Thomas G. Del Beccaro,5
-Humboldt,2SHS7_A,U.S. Senate,,REP,Tom Palzer,1
-Humboldt,2SHS7_A,U.S. Senate,,REP,Von Hougo,1
+Humboldt,2SHS7,U.S. Senate,,REP,Ron Unz,3
+Humboldt,2SHS7,U.S. Senate,,DEM,Steve Stokes,26
+Humboldt,2SHS7,U.S. Senate,,REP,Thomas G. Del Beccaro,6
+Humboldt,2SHS7,U.S. Senate,,REP,Tom Palzer,1
+Humboldt,2SHS7,U.S. Senate,,REP,Von Hougo,1
 Humboldt,2SHVF,President,,DEM,Bernie Sanders,56
 Humboldt,2SHVF,President,,REP,Donald Trump,9
 Humboldt,2SHVF,President,,DEM,Hillary Clinton,15
@@ -3155,880 +2064,544 @@ Humboldt,2SHVF,U.S. Senate,,REP,Phil Wyman,4
 Humboldt,2SHVF,U.S. Senate,,DEM,Steve Stokes,3
 Humboldt,2SHVF,U.S. Senate,,IND,Tim Gildersleeve,1
 Humboldt,2SHVF,U.S. Senate,,REP,Von Hougo,1
-Humboldt,3A--1,President,,DEM,Bernie Sanders,249
+Humboldt,3A--1,President,,REP,Ben Carson,1
+Humboldt,3A--1,President,,DEM,Bernie Sanders,467
 Humboldt,3A--1,President,,GRN,Darryl Cherney,1
-Humboldt,3A--1,President,,REP,Donald Trump,6
-Humboldt,3A--1,President,,DEM,Hillary Clinton,49
-Humboldt,3A--1,President,,GRN,Jill Stein,2
+Humboldt,3A--1,President,,REP,Donald Trump,21
+Humboldt,3A--1,President,,DEM,Hillary Clinton,101
+Humboldt,3A--1,President,,GRN,Jill Stein,7
+Humboldt,3A--1,President,,REP,Jim Gilmore,1
 Humboldt,3A--1,President,,LIB,John McAfee,1
-Humboldt,3A--1,Proposition 50,,,No,47
-Humboldt,3A--1,Proposition 50,,,Yes,207
-Humboldt,3A--1,State Assembly,2,DEM,Jim Wood,242
-Humboldt,3A--1,U.S. House,2,REP,Dale K. Mensing,5
-Humboldt,3A--1,U.S. House,2,DEM,Erin A. Schrode,37
-Humboldt,3A--1,U.S. House,2,DEM,Jared W. Huffman,187
-Humboldt,3A--1,U.S. House,2,IND,Matthew Robert Wookey,47
+Humboldt,3A--1,President,,REP,John R. Kasich,1
+Humboldt,3A--1,President,,PAF,Monica Moorehead,1
+Humboldt,3A--1,President,,DEM,Willie Wilson,1
+Humboldt,3A--1,Proposition 50,,,No,109
+Humboldt,3A--1,Proposition 50,,,Yes,410
+Humboldt,3A--1,State Assembly,2,DEM,Jim Wood,478
+Humboldt,3A--1,U.S. House,2,REP,Dale K. Mensing,19
+Humboldt,3A--1,U.S. House,2,DEM,Erin A. Schrode,103
+Humboldt,3A--1,U.S. House,2,DEM,Jared W. Huffman,369
+Humboldt,3A--1,U.S. House,2,IND,Matthew Robert Wookey,70
 Humboldt,3A--1,U.S. Senate,,IND,Clive Grey,1
-Humboldt,3A--1,U.S. Senate,,REP,Duf Sundheim,2
+Humboldt,3A--1,U.S. Senate,,IND,Don J. Grundmann,2
+Humboldt,3A--1,U.S. Senate,,REP,Don Krampe,1
+Humboldt,3A--1,U.S. Senate,,REP,Duf Sundheim,6
 Humboldt,3A--1,U.S. Senate,,IND,Eleanor García,1
 Humboldt,3A--1,U.S. Senate,,DEM,Emory Rodgers,1
-Humboldt,3A--1,U.S. Senate,,LIB,Gail K. Lightfoot,11
+Humboldt,3A--1,U.S. Senate,,LIB,Gail K. Lightfoot,16
 Humboldt,3A--1,U.S. Senate,,REP,Greg Conlon,2
-Humboldt,3A--1,U.S. Senate,,IND,Jason Hanania,2
-Humboldt,3A--1,U.S. Senate,,REP,Jerry J. Laws,1
-Humboldt,3A--1,U.S. Senate,,PAF,John Thompson Parker,1
-Humboldt,3A--1,U.S. Senate,,DEM,Kamala D. Harris,125
-Humboldt,3A--1,U.S. Senate,,DEM,Loretta L. Sanchez,64
-Humboldt,3A--1,U.S. Senate,,LIB,Mark Matthew Herd,4
-Humboldt,3A--1,U.S. Senate,,DEM,Massie Munroe,7
-Humboldt,3A--1,U.S. Senate,,IND,Mike Beitiks,4
-Humboldt,3A--1,U.S. Senate,,GRN,Pamela Elizondo,30
-Humboldt,3A--1,U.S. Senate,,IND,Paul Merritt,1
-Humboldt,3A--1,U.S. Senate,,REP,Phil Wyman,1
+Humboldt,3A--1,U.S. Senate,,REP,Jarrell Williamson,3
+Humboldt,3A--1,U.S. Senate,,IND,Jason Hanania,5
+Humboldt,3A--1,U.S. Senate,,IND,Jason Kraus,1
+Humboldt,3A--1,U.S. Senate,,REP,Jerry J. Laws,2
+Humboldt,3A--1,U.S. Senate,,PAF,John Thompson Parker,4
+Humboldt,3A--1,U.S. Senate,,DEM,Kamala D. Harris,267
+Humboldt,3A--1,U.S. Senate,,DEM,Loretta L. Sanchez,122
+Humboldt,3A--1,U.S. Senate,,LIB,Mark Matthew Herd,6
+Humboldt,3A--1,U.S. Senate,,DEM,Massie Munroe,17
+Humboldt,3A--1,U.S. Senate,,IND,Mike Beitiks,7
+Humboldt,3A--1,U.S. Senate,,GRN,Pamela Elizondo,51
+Humboldt,3A--1,U.S. Senate,,IND,Paul Merritt,3
+Humboldt,3A--1,U.S. Senate,,REP,Phil Wyman,4
+Humboldt,3A--1,U.S. Senate,,DEM,President Cristina Grappo,3
 Humboldt,3A--1,U.S. Senate,,REP,Ron Unz,1
-Humboldt,3A--1,U.S. Senate,,DEM,Steve Stokes,16
+Humboldt,3A--1,U.S. Senate,,DEM,Steve Stokes,33
+Humboldt,3A--1,U.S. Senate,,REP,Thomas G. Del Beccaro,6
 Humboldt,3A--1,U.S. Senate,,REP,Von Hougo,1
-Humboldt,3A--1_A,President,,REP,Ben Carson,1
-Humboldt,3A--1_A,President,,DEM,Bernie Sanders,218
-Humboldt,3A--1_A,President,,REP,Donald Trump,15
-Humboldt,3A--1_A,President,,DEM,Hillary Clinton,52
-Humboldt,3A--1_A,President,,GRN,Jill Stein,5
-Humboldt,3A--1_A,President,,REP,Jim Gilmore,1
-Humboldt,3A--1_A,President,,REP,John R. Kasich,1
-Humboldt,3A--1_A,President,,PAF,Monica Moorehead,1
-Humboldt,3A--1_A,President,,DEM,Willie Wilson,1
-Humboldt,3A--1_A,Proposition 50,,,No,62
-Humboldt,3A--1_A,Proposition 50,,,Yes,203
-Humboldt,3A--1_A,State Assembly,2,DEM,Jim Wood,236
-Humboldt,3A--1_A,U.S. House,2,REP,Dale K. Mensing,14
-Humboldt,3A--1_A,U.S. House,2,DEM,Erin A. Schrode,66
-Humboldt,3A--1_A,U.S. House,2,DEM,Jared W. Huffman,182
-Humboldt,3A--1_A,U.S. House,2,IND,Matthew Robert Wookey,23
-Humboldt,3A--1_A,U.S. Senate,,IND,Don J. Grundmann,2
-Humboldt,3A--1_A,U.S. Senate,,REP,Don Krampe,1
-Humboldt,3A--1_A,U.S. Senate,,REP,Duf Sundheim,4
-Humboldt,3A--1_A,U.S. Senate,,LIB,Gail K. Lightfoot,5
-Humboldt,3A--1_A,U.S. Senate,,REP,Jarrell Williamson,3
-Humboldt,3A--1_A,U.S. Senate,,IND,Jason Hanania,3
-Humboldt,3A--1_A,U.S. Senate,,IND,Jason Kraus,1
-Humboldt,3A--1_A,U.S. Senate,,REP,Jerry J. Laws,1
-Humboldt,3A--1_A,U.S. Senate,,PAF,John Thompson Parker,3
-Humboldt,3A--1_A,U.S. Senate,,DEM,Kamala D. Harris,142
-Humboldt,3A--1_A,U.S. Senate,,DEM,Loretta L. Sanchez,58
-Humboldt,3A--1_A,U.S. Senate,,LIB,Mark Matthew Herd,2
-Humboldt,3A--1_A,U.S. Senate,,DEM,Massie Munroe,10
-Humboldt,3A--1_A,U.S. Senate,,IND,Mike Beitiks,3
-Humboldt,3A--1_A,U.S. Senate,,GRN,Pamela Elizondo,21
-Humboldt,3A--1_A,U.S. Senate,,IND,Paul Merritt,2
-Humboldt,3A--1_A,U.S. Senate,,REP,Phil Wyman,3
-Humboldt,3A--1_A,U.S. Senate,,DEM,President Cristina Grappo,3
-Humboldt,3A--1_A,U.S. Senate,,DEM,Steve Stokes,17
-Humboldt,3A--1_A,U.S. Senate,,REP,Thomas G. Del Beccaro,6
 Humboldt,3A--2,President,,REP,Ben Carson,2
-Humboldt,3A--2,President,,DEM,Bernie Sanders,207
+Humboldt,3A--2,President,,DEM,Bernie Sanders,278
 Humboldt,3A--2,President,,GRN,Darryl Cherney,3
-Humboldt,3A--2,President,,REP,Donald Trump,16
-Humboldt,3A--2,President,,DEM,Hillary Clinton,57
-Humboldt,3A--2,President,,GRN,Jill Stein,5
-Humboldt,3A--2,President,,REP,John R. Kasich,8
-Humboldt,3A--2,President,,REP,Ted Cruz,3
-Humboldt,3A--2,Proposition 50,,,No,52
-Humboldt,3A--2,Proposition 50,,,Yes,190
-Humboldt,3A--2,State Assembly,2,DEM,Jim Wood,219
-Humboldt,3A--2,U.S. House,2,REP,Dale K. Mensing,23
-Humboldt,3A--2,U.S. House,2,DEM,Erin A. Schrode,41
-Humboldt,3A--2,U.S. House,2,DEM,Jared W. Huffman,187
-Humboldt,3A--2,U.S. House,2,IND,Matthew Robert Wookey,27
+Humboldt,3A--2,President,,REP,Donald Trump,22
+Humboldt,3A--2,President,,DEM,Hillary Clinton,84
+Humboldt,3A--2,President,,GRN,Jill Stein,6
+Humboldt,3A--2,President,,REP,John R. Kasich,11
+Humboldt,3A--2,President,,REP,Ted Cruz,4
+Humboldt,3A--2,Proposition 50,,,No,79
+Humboldt,3A--2,Proposition 50,,,Yes,262
+Humboldt,3A--2,State Assembly,2,DEM,Jim Wood,313
+Humboldt,3A--2,U.S. House,2,REP,Dale K. Mensing,29
+Humboldt,3A--2,U.S. House,2,DEM,Erin A. Schrode,55
+Humboldt,3A--2,U.S. House,2,DEM,Jared W. Huffman,264
+Humboldt,3A--2,U.S. House,2,IND,Matthew Robert Wookey,39
 Humboldt,3A--2,U.S. Senate,,IND,Clive Grey,1
 Humboldt,3A--2,U.S. Senate,,IND,Don J. Grundmann,1
 Humboldt,3A--2,U.S. Senate,,REP,Don Krampe,2
-Humboldt,3A--2,U.S. Senate,,REP,Duf Sundheim,3
+Humboldt,3A--2,U.S. Senate,,REP,Duf Sundheim,4
 Humboldt,3A--2,U.S. Senate,,IND,Eleanor García,1
 Humboldt,3A--2,U.S. Senate,,DEM,Emory Rodgers,1
-Humboldt,3A--2,U.S. Senate,,LIB,Gail K. Lightfoot,8
+Humboldt,3A--2,U.S. Senate,,LIB,Gail K. Lightfoot,10
 Humboldt,3A--2,U.S. Senate,,REP,George C. Yang,3
-Humboldt,3A--2,U.S. Senate,,REP,Greg Conlon,5
+Humboldt,3A--2,U.S. Senate,,REP,Greg Conlon,6
 Humboldt,3A--2,U.S. Senate,,IND,Jason Hanania,1
 Humboldt,3A--2,U.S. Senate,,IND,Jason Kraus,1
 Humboldt,3A--2,U.S. Senate,,REP,Jerry J. Laws,1
-Humboldt,3A--2,U.S. Senate,,DEM,Kamala D. Harris,134
+Humboldt,3A--2,U.S. Senate,,PAF,John Thompson Parker,1
+Humboldt,3A--2,U.S. Senate,,DEM,Kamala D. Harris,201
 Humboldt,3A--2,U.S. Senate,,REP,Karen Roseberry,2
-Humboldt,3A--2,U.S. Senate,,IND,Ling Ling Shi,1
-Humboldt,3A--2,U.S. Senate,,DEM,Loretta L. Sanchez,50
+Humboldt,3A--2,U.S. Senate,,IND,Ling Ling Shi,2
+Humboldt,3A--2,U.S. Senate,,DEM,Loretta L. Sanchez,63
 Humboldt,3A--2,U.S. Senate,,LIB,Mark Matthew Herd,2
-Humboldt,3A--2,U.S. Senate,,DEM,Massie Munroe,8
+Humboldt,3A--2,U.S. Senate,,DEM,Massie Munroe,11
 Humboldt,3A--2,U.S. Senate,,IND,Mike Beitiks,4
-Humboldt,3A--2,U.S. Senate,,GRN,Pamela Elizondo,11
-Humboldt,3A--2,U.S. Senate,,REP,Phil Wyman,7
-Humboldt,3A--2,U.S. Senate,,REP,Ron Unz,1
+Humboldt,3A--2,U.S. Senate,,GRN,Pamela Elizondo,20
+Humboldt,3A--2,U.S. Senate,,REP,Phil Wyman,10
+Humboldt,3A--2,U.S. Senate,,REP,Ron Unz,2
 Humboldt,3A--2,U.S. Senate,,IND,Scott A. Vineberg,2
-Humboldt,3A--2,U.S. Senate,,DEM,Steve Stokes,19
+Humboldt,3A--2,U.S. Senate,,DEM,Steve Stokes,24
 Humboldt,3A--2,U.S. Senate,,REP,Thomas G. Del Beccaro,5
 Humboldt,3A--2,U.S. Senate,,IND,Tim Gildersleeve,1
-Humboldt,3A--2,U.S. Senate,,REP,Von Hougo,3
-Humboldt,3A--2_A,President,,DEM,Bernie Sanders,71
-Humboldt,3A--2_A,President,,REP,Donald Trump,6
-Humboldt,3A--2_A,President,,DEM,Hillary Clinton,27
-Humboldt,3A--2_A,President,,GRN,Jill Stein,1
-Humboldt,3A--2_A,President,,REP,John R. Kasich,3
-Humboldt,3A--2_A,President,,REP,Ted Cruz,1
-Humboldt,3A--2_A,Proposition 50,,,No,27
-Humboldt,3A--2_A,Proposition 50,,,Yes,72
-Humboldt,3A--2_A,State Assembly,2,DEM,Jim Wood,94
-Humboldt,3A--2_A,U.S. House,2,REP,Dale K. Mensing,6
-Humboldt,3A--2_A,U.S. House,2,DEM,Erin A. Schrode,14
-Humboldt,3A--2_A,U.S. House,2,DEM,Jared W. Huffman,77
-Humboldt,3A--2_A,U.S. House,2,IND,Matthew Robert Wookey,12
-Humboldt,3A--2_A,U.S. Senate,,REP,Duf Sundheim,1
-Humboldt,3A--2_A,U.S. Senate,,LIB,Gail K. Lightfoot,2
-Humboldt,3A--2_A,U.S. Senate,,REP,Greg Conlon,1
-Humboldt,3A--2_A,U.S. Senate,,PAF,John Thompson Parker,1
-Humboldt,3A--2_A,U.S. Senate,,DEM,Kamala D. Harris,67
-Humboldt,3A--2_A,U.S. Senate,,IND,Ling Ling Shi,1
-Humboldt,3A--2_A,U.S. Senate,,DEM,Loretta L. Sanchez,13
-Humboldt,3A--2_A,U.S. Senate,,DEM,Massie Munroe,3
-Humboldt,3A--2_A,U.S. Senate,,GRN,Pamela Elizondo,9
-Humboldt,3A--2_A,U.S. Senate,,REP,Phil Wyman,3
-Humboldt,3A--2_A,U.S. Senate,,REP,Ron Unz,1
-Humboldt,3A--2_A,U.S. Senate,,DEM,Steve Stokes,5
-Humboldt,3A--2_A,U.S. Senate,,REP,Von Hougo,1
+Humboldt,3A--2,U.S. Senate,,REP,Von Hougo,4
 Humboldt,3A--3,President,,REP,Ben Carson,1
-Humboldt,3A--3,President,,DEM,Bernie Sanders,108
+Humboldt,3A--3,President,,DEM,Bernie Sanders,265
 Humboldt,3A--3,President,,GRN,Darryl Cherney,1
-Humboldt,3A--3,President,,REP,Donald Trump,4
-Humboldt,3A--3,President,,DEM,Hillary Clinton,31
-Humboldt,3A--3,President,,GRN,Jill Stein,2
-Humboldt,3A--3,Proposition 50,,,No,29
-Humboldt,3A--3,Proposition 50,,,Yes,102
-Humboldt,3A--3,State Assembly,2,DEM,Jim Wood,124
-Humboldt,3A--3,U.S. House,2,REP,Dale K. Mensing,6
-Humboldt,3A--3,U.S. House,2,DEM,Erin A. Schrode,21
-Humboldt,3A--3,U.S. House,2,DEM,Jared W. Huffman,103
-Humboldt,3A--3,U.S. House,2,IND,Matthew Robert Wookey,15
-Humboldt,3A--3,U.S. Senate,,IND,Clive Grey,1
+Humboldt,3A--3,President,,REP,Donald Trump,11
+Humboldt,3A--3,President,,DEM,Hillary Clinton,70
+Humboldt,3A--3,President,,GRN,Jill Stein,5
+Humboldt,3A--3,President,,REP,John R. Kasich,4
+Humboldt,3A--3,President,,DEM,Michael Steinberg,1
+Humboldt,3A--3,President,,REP,Ted Cruz,1
+Humboldt,3A--3,President,,DEM,Willie Wilson,1
+Humboldt,3A--3,Proposition 50,,,No,70
+Humboldt,3A--3,Proposition 50,,,Yes,254
+Humboldt,3A--3,State Assembly,2,DEM,Jim Wood,296
+Humboldt,3A--3,U.S. House,2,REP,Dale K. Mensing,17
+Humboldt,3A--3,U.S. House,2,DEM,Erin A. Schrode,61
+Humboldt,3A--3,U.S. House,2,DEM,Jared W. Huffman,241
+Humboldt,3A--3,U.S. House,2,IND,Matthew Robert Wookey,34
+Humboldt,3A--3,U.S. Senate,,IND,Clive Grey,2
 Humboldt,3A--3,U.S. Senate,,REP,Don Krampe,2
-Humboldt,3A--3,U.S. Senate,,REP,Duf Sundheim,3
-Humboldt,3A--3,U.S. Senate,,IND,Eleanor García,1
+Humboldt,3A--3,U.S. Senate,,REP,Duf Sundheim,7
+Humboldt,3A--3,U.S. Senate,,IND,Eleanor García,2
 Humboldt,3A--3,U.S. Senate,,DEM,Emory Rodgers,1
-Humboldt,3A--3,U.S. Senate,,LIB,Gail K. Lightfoot,4
-Humboldt,3A--3,U.S. Senate,,IND,Jason Hanania,1
-Humboldt,3A--3,U.S. Senate,,DEM,Kamala D. Harris,69
+Humboldt,3A--3,U.S. Senate,,LIB,Gail K. Lightfoot,9
+Humboldt,3A--3,U.S. Senate,,REP,Greg Conlon,2
+Humboldt,3A--3,U.S. Senate,,DEM,Herbert G. Peters,1
+Humboldt,3A--3,U.S. Senate,,IND,Jason Hanania,2
+Humboldt,3A--3,U.S. Senate,,REP,Jerry J. Laws,2
+Humboldt,3A--3,U.S. Senate,,DEM,Kamala D. Harris,176
 Humboldt,3A--3,U.S. Senate,,IND,Ling Ling Shi,1
-Humboldt,3A--3,U.S. Senate,,DEM,Loretta L. Sanchez,34
+Humboldt,3A--3,U.S. Senate,,DEM,Loretta L. Sanchez,73
 Humboldt,3A--3,U.S. Senate,,LIB,Mark Matthew Herd,2
-Humboldt,3A--3,U.S. Senate,,IND,Mike Beitiks,2
-Humboldt,3A--3,U.S. Senate,,GRN,Pamela Elizondo,11
-Humboldt,3A--3,U.S. Senate,,IND,Paul Merritt,1
+Humboldt,3A--3,U.S. Senate,,DEM,Massie Munroe,7
+Humboldt,3A--3,U.S. Senate,,IND,Mike Beitiks,6
+Humboldt,3A--3,U.S. Senate,,GRN,Pamela Elizondo,26
+Humboldt,3A--3,U.S. Senate,,IND,Paul Merritt,4
+Humboldt,3A--3,U.S. Senate,,REP,Phil Wyman,1
 Humboldt,3A--3,U.S. Senate,,REP,Ron Unz,1
-Humboldt,3A--3,U.S. Senate,,DEM,Steve Stokes,11
-Humboldt,3A--3_A,President,,DEM,Bernie Sanders,157
-Humboldt,3A--3_A,President,,REP,Donald Trump,7
-Humboldt,3A--3_A,President,,DEM,Hillary Clinton,39
-Humboldt,3A--3_A,President,,GRN,Jill Stein,3
-Humboldt,3A--3_A,President,,REP,John R. Kasich,4
-Humboldt,3A--3_A,President,,DEM,Michael Steinberg,1
-Humboldt,3A--3_A,President,,REP,Ted Cruz,1
-Humboldt,3A--3_A,President,,DEM,Willie Wilson,1
-Humboldt,3A--3_A,Proposition 50,,,No,41
-Humboldt,3A--3_A,Proposition 50,,,Yes,152
-Humboldt,3A--3_A,State Assembly,2,DEM,Jim Wood,172
-Humboldt,3A--3_A,U.S. House,2,REP,Dale K. Mensing,11
-Humboldt,3A--3_A,U.S. House,2,DEM,Erin A. Schrode,40
-Humboldt,3A--3_A,U.S. House,2,DEM,Jared W. Huffman,138
-Humboldt,3A--3_A,U.S. House,2,IND,Matthew Robert Wookey,19
-Humboldt,3A--3_A,U.S. Senate,,IND,Clive Grey,1
-Humboldt,3A--3_A,U.S. Senate,,REP,Duf Sundheim,4
-Humboldt,3A--3_A,U.S. Senate,,IND,Eleanor García,1
-Humboldt,3A--3_A,U.S. Senate,,LIB,Gail K. Lightfoot,5
-Humboldt,3A--3_A,U.S. Senate,,REP,Greg Conlon,2
-Humboldt,3A--3_A,U.S. Senate,,DEM,Herbert G. Peters,1
-Humboldt,3A--3_A,U.S. Senate,,IND,Jason Hanania,1
-Humboldt,3A--3_A,U.S. Senate,,REP,Jerry J. Laws,2
-Humboldt,3A--3_A,U.S. Senate,,DEM,Kamala D. Harris,107
-Humboldt,3A--3_A,U.S. Senate,,DEM,Loretta L. Sanchez,39
-Humboldt,3A--3_A,U.S. Senate,,DEM,Massie Munroe,7
-Humboldt,3A--3_A,U.S. Senate,,IND,Mike Beitiks,4
-Humboldt,3A--3_A,U.S. Senate,,GRN,Pamela Elizondo,15
-Humboldt,3A--3_A,U.S. Senate,,IND,Paul Merritt,3
-Humboldt,3A--3_A,U.S. Senate,,REP,Phil Wyman,1
-Humboldt,3A--3_A,U.S. Senate,,DEM,Steve Stokes,11
-Humboldt,3A--7,President,,REP,Ben Carson,1
-Humboldt,3A--7,President,,DEM,Bernie Sanders,149
-Humboldt,3A--7,President,,REP,Donald Trump,7
+Humboldt,3A--3,U.S. Senate,,DEM,Steve Stokes,22
+Humboldt,3A--7,President,,REP,Ben Carson,3
+Humboldt,3A--7,President,,DEM,Bernie Sanders,277
+Humboldt,3A--7,President,,GRN,Darryl Cherney,1
+Humboldt,3A--7,President,,REP,Donald Trump,20
 Humboldt,3A--7,President,,LIB,Gary Johnson,2
-Humboldt,3A--7,President,,DEM,Hillary Clinton,25
-Humboldt,3A--7,President,,GRN,Jill Stein,1
-Humboldt,3A--7,President,,REP,John R. Kasich,2
+Humboldt,3A--7,President,,DEM,Hillary Clinton,71
+Humboldt,3A--7,President,,GRN,Jill Stein,2
+Humboldt,3A--7,President,,REP,John R. Kasich,3
 Humboldt,3A--7,President,,PAF,Lynn S. Kahn,1
-Humboldt,3A--7,President,,REP,Ted Cruz,3
-Humboldt,3A--7,Proposition 50,,,No,32
-Humboldt,3A--7,Proposition 50,,,Yes,122
-Humboldt,3A--7,State Assembly,2,DEM,Jim Wood,137
-Humboldt,3A--7,U.S. House,2,REP,Dale K. Mensing,12
-Humboldt,3A--7,U.S. House,2,DEM,Erin A. Schrode,33
-Humboldt,3A--7,U.S. House,2,DEM,Jared W. Huffman,113
-Humboldt,3A--7,U.S. House,2,IND,Matthew Robert Wookey,13
-Humboldt,3A--7,U.S. Senate,,IND,Clive Grey,1
-Humboldt,3A--7,U.S. Senate,,REP,Duf Sundheim,3
-Humboldt,3A--7,U.S. Senate,,DEM,Emory Rodgers,1
-Humboldt,3A--7,U.S. Senate,,LIB,Gail K. Lightfoot,6
+Humboldt,3A--7,President,,AIP,Robert Ornelas,1
+Humboldt,3A--7,President,,REP,Ted Cruz,7
+Humboldt,3A--7,Proposition 50,,,No,64
+Humboldt,3A--7,Proposition 50,,,Yes,263
+Humboldt,3A--7,State Assembly,2,DEM,Jim Wood,289
+Humboldt,3A--7,U.S. House,2,REP,Dale K. Mensing,29
+Humboldt,3A--7,U.S. House,2,DEM,Erin A. Schrode,65
+Humboldt,3A--7,U.S. House,2,DEM,Jared W. Huffman,240
+Humboldt,3A--7,U.S. House,2,IND,Matthew Robert Wookey,25
+Humboldt,3A--7,U.S. Senate,,IND,Clive Grey,3
+Humboldt,3A--7,U.S. Senate,,IND,Don J. Grundmann,1
+Humboldt,3A--7,U.S. Senate,,REP,Don Krampe,2
+Humboldt,3A--7,U.S. Senate,,REP,Duf Sundheim,6
+Humboldt,3A--7,U.S. Senate,,DEM,Emory Rodgers,2
+Humboldt,3A--7,U.S. Senate,,LIB,Gail K. Lightfoot,8
 Humboldt,3A--7,U.S. Senate,,REP,George C. Yang,1
-Humboldt,3A--7,U.S. Senate,,REP,Greg Conlon,2
+Humboldt,3A--7,U.S. Senate,,REP,Greg Conlon,3
 Humboldt,3A--7,U.S. Senate,,REP,Jarrell Williamson,1
-Humboldt,3A--7,U.S. Senate,,REP,Jerry J. Laws,1
-Humboldt,3A--7,U.S. Senate,,PAF,John Thompson Parker,3
-Humboldt,3A--7,U.S. Senate,,DEM,Kamala D. Harris,79
+Humboldt,3A--7,U.S. Senate,,REP,Jerry J. Laws,2
+Humboldt,3A--7,U.S. Senate,,PAF,John Thompson Parker,6
+Humboldt,3A--7,U.S. Senate,,DEM,Kamala D. Harris,167
+Humboldt,3A--7,U.S. Senate,,REP,Karen Roseberry,1
 Humboldt,3A--7,U.S. Senate,,IND,Ling Ling Shi,2
-Humboldt,3A--7,U.S. Senate,,DEM,Loretta L. Sanchez,34
+Humboldt,3A--7,U.S. Senate,,DEM,Loretta L. Sanchez,71
 Humboldt,3A--7,U.S. Senate,,LIB,Mark Matthew Herd,2
-Humboldt,3A--7,U.S. Senate,,DEM,Massie Munroe,4
-Humboldt,3A--7,U.S. Senate,,IND,Mike Beitiks,1
-Humboldt,3A--7,U.S. Senate,,GRN,Pamela Elizondo,14
+Humboldt,3A--7,U.S. Senate,,DEM,Massie Munroe,13
+Humboldt,3A--7,U.S. Senate,,IND,Mike Beitiks,4
+Humboldt,3A--7,U.S. Senate,,GRN,Pamela Elizondo,29
 Humboldt,3A--7,U.S. Senate,,IND,Paul Merritt,1
-Humboldt,3A--7,U.S. Senate,,REP,Phil Wyman,1
+Humboldt,3A--7,U.S. Senate,,REP,Phil Wyman,5
 Humboldt,3A--7,U.S. Senate,,DEM,President Cristina Grappo,1
-Humboldt,3A--7,U.S. Senate,,DEM,Steve Stokes,9
+Humboldt,3A--7,U.S. Senate,,DEM,Steve Stokes,16
 Humboldt,3A--7,U.S. Senate,,REP,Thomas G. Del Beccaro,1
+Humboldt,3A--7,U.S. Senate,,REP,Tom Palzer,3
 Humboldt,3A--7,U.S. Senate,,REP,Von Hougo,1
-Humboldt,3A--7_A,President,,REP,Ben Carson,2
-Humboldt,3A--7_A,President,,DEM,Bernie Sanders,128
-Humboldt,3A--7_A,President,,GRN,Darryl Cherney,1
-Humboldt,3A--7_A,President,,REP,Donald Trump,13
-Humboldt,3A--7_A,President,,DEM,Hillary Clinton,46
-Humboldt,3A--7_A,President,,GRN,Jill Stein,1
-Humboldt,3A--7_A,President,,REP,John R. Kasich,1
-Humboldt,3A--7_A,President,,AIP,Robert Ornelas,1
-Humboldt,3A--7_A,President,,REP,Ted Cruz,4
-Humboldt,3A--7_A,Proposition 50,,,No,32
-Humboldt,3A--7_A,Proposition 50,,,Yes,141
-Humboldt,3A--7_A,State Assembly,2,DEM,Jim Wood,152
-Humboldt,3A--7_A,U.S. House,2,REP,Dale K. Mensing,17
-Humboldt,3A--7_A,U.S. House,2,DEM,Erin A. Schrode,32
-Humboldt,3A--7_A,U.S. House,2,DEM,Jared W. Huffman,127
-Humboldt,3A--7_A,U.S. House,2,IND,Matthew Robert Wookey,12
-Humboldt,3A--7_A,U.S. Senate,,IND,Clive Grey,2
-Humboldt,3A--7_A,U.S. Senate,,IND,Don J. Grundmann,1
-Humboldt,3A--7_A,U.S. Senate,,REP,Don Krampe,2
-Humboldt,3A--7_A,U.S. Senate,,REP,Duf Sundheim,3
-Humboldt,3A--7_A,U.S. Senate,,DEM,Emory Rodgers,1
-Humboldt,3A--7_A,U.S. Senate,,LIB,Gail K. Lightfoot,2
-Humboldt,3A--7_A,U.S. Senate,,REP,Greg Conlon,1
-Humboldt,3A--7_A,U.S. Senate,,REP,Jerry J. Laws,1
-Humboldt,3A--7_A,U.S. Senate,,PAF,John Thompson Parker,3
-Humboldt,3A--7_A,U.S. Senate,,DEM,Kamala D. Harris,88
-Humboldt,3A--7_A,U.S. Senate,,REP,Karen Roseberry,1
-Humboldt,3A--7_A,U.S. Senate,,DEM,Loretta L. Sanchez,37
-Humboldt,3A--7_A,U.S. Senate,,DEM,Massie Munroe,9
-Humboldt,3A--7_A,U.S. Senate,,IND,Mike Beitiks,3
-Humboldt,3A--7_A,U.S. Senate,,GRN,Pamela Elizondo,15
-Humboldt,3A--7_A,U.S. Senate,,REP,Phil Wyman,4
-Humboldt,3A--7_A,U.S. Senate,,DEM,Steve Stokes,7
-Humboldt,3A--7_A,U.S. Senate,,REP,Tom Palzer,3
-Humboldt,3A--9,President,,DEM,Bernie Sanders,221
+Humboldt,3A--9,President,,REP,Ben Carson,1
+Humboldt,3A--9,President,,DEM,Bernie Sanders,389
 Humboldt,3A--9,President,,GRN,Darryl Cherney,3
-Humboldt,3A--9,President,,REP,Donald Trump,6
-Humboldt,3A--9,President,,DEM,Hillary Clinton,27
-Humboldt,3A--9,President,,GRN,Jill Stein,2
+Humboldt,3A--9,President,,REP,Donald Trump,18
+Humboldt,3A--9,President,,DEM,Hillary Clinton,88
+Humboldt,3A--9,President,,GRN,Jill Stein,4
 Humboldt,3A--9,President,,REP,Jim Gilmore,1
-Humboldt,3A--9,President,,REP,John R. Kasich,2
-Humboldt,3A--9,President,,REP,Ted Cruz,3
-Humboldt,3A--9,Proposition 50,,,No,41
-Humboldt,3A--9,Proposition 50,,,Yes,192
-Humboldt,3A--9,State Assembly,2,DEM,Jim Wood,217
-Humboldt,3A--9,U.S. House,2,REP,Dale K. Mensing,9
-Humboldt,3A--9,U.S. House,2,DEM,Erin A. Schrode,41
-Humboldt,3A--9,U.S. House,2,DEM,Jared W. Huffman,167
-Humboldt,3A--9,U.S. House,2,IND,Matthew Robert Wookey,32
+Humboldt,3A--9,President,,REP,John R. Kasich,4
+Humboldt,3A--9,President,,DEM,Keith Judd,1
+Humboldt,3A--9,President,,GRN,Sedinam Moyowasifsa-Curry,1
+Humboldt,3A--9,President,,REP,Ted Cruz,7
+Humboldt,3A--9,President,,AIP,Wiley Drake,1
+Humboldt,3A--9,President,,DEM,Willie Wilson,1
+Humboldt,3A--9,Proposition 50,,,No,85
+Humboldt,3A--9,Proposition 50,,,Yes,380
+Humboldt,3A--9,State Assembly,2,DEM,Jim Wood,402
+Humboldt,3A--9,U.S. House,2,REP,Dale K. Mensing,25
+Humboldt,3A--9,U.S. House,2,DEM,Erin A. Schrode,79
+Humboldt,3A--9,U.S. House,2,DEM,Jared W. Huffman,336
+Humboldt,3A--9,U.S. House,2,IND,Matthew Robert Wookey,48
 Humboldt,3A--9,U.S. Senate,,IND,Clive Grey,5
-Humboldt,3A--9,U.S. Senate,,REP,Don Krampe,1
-Humboldt,3A--9,U.S. Senate,,REP,Duf Sundheim,1
+Humboldt,3A--9,U.S. Senate,,REP,Don Krampe,2
+Humboldt,3A--9,U.S. Senate,,REP,Duf Sundheim,7
 Humboldt,3A--9,U.S. Senate,,IND,Eleanor García,4
-Humboldt,3A--9,U.S. Senate,,DEM,Emory Rodgers,1
-Humboldt,3A--9,U.S. Senate,,LIB,Gail K. Lightfoot,11
-Humboldt,3A--9,U.S. Senate,,REP,George C. Yang,1
+Humboldt,3A--9,U.S. Senate,,DEM,Emory Rodgers,2
+Humboldt,3A--9,U.S. Senate,,LIB,Gail K. Lightfoot,20
+Humboldt,3A--9,U.S. Senate,,REP,George C. Yang,2
+Humboldt,3A--9,U.S. Senate,,REP,Greg Conlon,1
+Humboldt,3A--9,U.S. Senate,,IND,Jason Hanania,1
 Humboldt,3A--9,U.S. Senate,,IND,Jason Kraus,2
-Humboldt,3A--9,U.S. Senate,,REP,Jerry J. Laws,4
-Humboldt,3A--9,U.S. Senate,,DEM,Kamala D. Harris,108
-Humboldt,3A--9,U.S. Senate,,IND,Ling Ling Shi,3
-Humboldt,3A--9,U.S. Senate,,DEM,Loretta L. Sanchez,47
-Humboldt,3A--9,U.S. Senate,,LIB,Mark Matthew Herd,3
-Humboldt,3A--9,U.S. Senate,,DEM,Massie Munroe,17
-Humboldt,3A--9,U.S. Senate,,GRN,Pamela Elizondo,24
-Humboldt,3A--9,U.S. Senate,,REP,Phil Wyman,1
-Humboldt,3A--9,U.S. Senate,,DEM,Steve Stokes,15
-Humboldt,3A--9,U.S. Senate,,REP,Thomas G. Del Beccaro,2
-Humboldt,3A--9,U.S. Senate,,REP,Tom Palzer,1
-Humboldt,3A--9,U.S. Senate,,REP,Von Hougo,1
-Humboldt,3A--9_A,President,,REP,Ben Carson,1
-Humboldt,3A--9_A,President,,DEM,Bernie Sanders,168
-Humboldt,3A--9_A,President,,REP,Donald Trump,12
-Humboldt,3A--9_A,President,,DEM,Hillary Clinton,61
-Humboldt,3A--9_A,President,,GRN,Jill Stein,2
-Humboldt,3A--9_A,President,,REP,John R. Kasich,2
-Humboldt,3A--9_A,President,,DEM,Keith Judd,1
-Humboldt,3A--9_A,President,,GRN,Sedinam Moyowasifsa-Curry,1
-Humboldt,3A--9_A,President,,REP,Ted Cruz,4
-Humboldt,3A--9_A,President,,AIP,Wiley Drake,1
-Humboldt,3A--9_A,President,,DEM,Willie Wilson,1
-Humboldt,3A--9_A,Proposition 50,,,No,44
-Humboldt,3A--9_A,Proposition 50,,,Yes,188
-Humboldt,3A--9_A,State Assembly,2,DEM,Jim Wood,185
-Humboldt,3A--9_A,U.S. House,2,REP,Dale K. Mensing,16
-Humboldt,3A--9_A,U.S. House,2,DEM,Erin A. Schrode,38
-Humboldt,3A--9_A,U.S. House,2,DEM,Jared W. Huffman,169
-Humboldt,3A--9_A,U.S. House,2,IND,Matthew Robert Wookey,16
-Humboldt,3A--9_A,U.S. Senate,,REP,Don Krampe,1
-Humboldt,3A--9_A,U.S. Senate,,REP,Duf Sundheim,6
-Humboldt,3A--9_A,U.S. Senate,,DEM,Emory Rodgers,1
-Humboldt,3A--9_A,U.S. Senate,,LIB,Gail K. Lightfoot,9
-Humboldt,3A--9_A,U.S. Senate,,REP,George C. Yang,1
-Humboldt,3A--9_A,U.S. Senate,,REP,Greg Conlon,1
-Humboldt,3A--9_A,U.S. Senate,,IND,Jason Hanania,1
-Humboldt,3A--9_A,U.S. Senate,,REP,Jerry J. Laws,4
-Humboldt,3A--9_A,U.S. Senate,,DEM,Kamala D. Harris,116
-Humboldt,3A--9_A,U.S. Senate,,REP,Karen Roseberry,1
-Humboldt,3A--9_A,U.S. Senate,,IND,Ling Ling Shi,1
-Humboldt,3A--9_A,U.S. Senate,,DEM,Loretta L. Sanchez,46
-Humboldt,3A--9_A,U.S. Senate,,LIB,Mark Matthew Herd,1
-Humboldt,3A--9_A,U.S. Senate,,DEM,Massie Munroe,7
-Humboldt,3A--9_A,U.S. Senate,,IND,Mike Beitiks,1
-Humboldt,3A--9_A,U.S. Senate,,GRN,Pamela Elizondo,18
-Humboldt,3A--9_A,U.S. Senate,,REP,Phil Wyman,2
-Humboldt,3A--9_A,U.S. Senate,,DEM,President Cristina Grappo,2
-Humboldt,3A--9_A,U.S. Senate,,IND,Scott A. Vineberg,1
-Humboldt,3A--9_A,U.S. Senate,,DEM,Steve Stokes,11
-Humboldt,3A--9_A,U.S. Senate,,REP,Thomas G. Del Beccaro,6
-Humboldt,3A--9_A,U.S. Senate,,REP,Tom Palzer,1
-Humboldt,3A--9_A,U.S. Senate,,REP,Von Hougo,1
-Humboldt,3A-10,President,,DEM,Bernie Sanders,267
-Humboldt,3A-10,President,,GRN,Darryl Cherney,1
-Humboldt,3A-10,President,,REP,Donald Trump,13
+Humboldt,3A--9,U.S. Senate,,REP,Jerry J. Laws,8
+Humboldt,3A--9,U.S. Senate,,DEM,Kamala D. Harris,224
+Humboldt,3A--9,U.S. Senate,,REP,Karen Roseberry,1
+Humboldt,3A--9,U.S. Senate,,IND,Ling Ling Shi,4
+Humboldt,3A--9,U.S. Senate,,DEM,Loretta L. Sanchez,93
+Humboldt,3A--9,U.S. Senate,,LIB,Mark Matthew Herd,4
+Humboldt,3A--9,U.S. Senate,,DEM,Massie Munroe,24
+Humboldt,3A--9,U.S. Senate,,IND,Mike Beitiks,1
+Humboldt,3A--9,U.S. Senate,,GRN,Pamela Elizondo,42
+Humboldt,3A--9,U.S. Senate,,REP,Phil Wyman,3
+Humboldt,3A--9,U.S. Senate,,DEM,President Cristina Grappo,2
+Humboldt,3A--9,U.S. Senate,,IND,Scott A. Vineberg,1
+Humboldt,3A--9,U.S. Senate,,DEM,Steve Stokes,26
+Humboldt,3A--9,U.S. Senate,,REP,Thomas G. Del Beccaro,8
+Humboldt,3A--9,U.S. Senate,,REP,Tom Palzer,2
+Humboldt,3A--9,U.S. Senate,,REP,Von Hougo,2
+Humboldt,3A-10,President,,DEM,Bernie Sanders,449
+Humboldt,3A-10,President,,GRN,Darryl Cherney,2
+Humboldt,3A-10,President,,REP,Donald Trump,27
 Humboldt,3A-10,President,,LIB,Gary Johnson,2
-Humboldt,3A-10,President,,DEM,Hillary Clinton,38
+Humboldt,3A-10,President,,PAF,Gloria Estela La Riva,1
+Humboldt,3A-10,President,,DEM,Henry Hewes,1
+Humboldt,3A-10,President,,DEM,Hillary Clinton,85
 Humboldt,3A-10,President,,AIP,James Hedges,1
-Humboldt,3A-10,President,,REP,Ted Cruz,2
-Humboldt,3A-10,Proposition 50,,,No,62
-Humboldt,3A-10,Proposition 50,,,Yes,215
-Humboldt,3A-10,State Assembly,2,DEM,Jim Wood,259
-Humboldt,3A-10,U.S. House,2,REP,Dale K. Mensing,11
-Humboldt,3A-10,U.S. House,2,DEM,Erin A. Schrode,54
-Humboldt,3A-10,U.S. House,2,DEM,Jared W. Huffman,196
-Humboldt,3A-10,U.S. House,2,IND,Matthew Robert Wookey,33
+Humboldt,3A-10,President,,GRN,Jill Stein,1
+Humboldt,3A-10,President,,REP,John R. Kasich,3
+Humboldt,3A-10,President,,DEM,Michael Steinberg,1
+Humboldt,3A-10,President,,REP,Ted Cruz,3
+Humboldt,3A-10,President,,DEM,Willie Wilson,1
+Humboldt,3A-10,Proposition 50,,,No,105
+Humboldt,3A-10,Proposition 50,,,Yes,394
+Humboldt,3A-10,State Assembly,2,DEM,Jim Wood,470
+Humboldt,3A-10,U.S. House,2,REP,Dale K. Mensing,33
+Humboldt,3A-10,U.S. House,2,DEM,Erin A. Schrode,102
+Humboldt,3A-10,U.S. House,2,DEM,Jared W. Huffman,348
+Humboldt,3A-10,U.S. House,2,IND,Matthew Robert Wookey,58
+Humboldt,3A-10,U.S. Senate,,IND,Clive Grey,1
 Humboldt,3A-10,U.S. Senate,,REP,Don Krampe,1
-Humboldt,3A-10,U.S. Senate,,REP,Duf Sundheim,1
-Humboldt,3A-10,U.S. Senate,,IND,Eleanor García,1
-Humboldt,3A-10,U.S. Senate,,LIB,Gail K. Lightfoot,7
-Humboldt,3A-10,U.S. Senate,,REP,Jarrell Williamson,2
+Humboldt,3A-10,U.S. Senate,,REP,Duf Sundheim,7
+Humboldt,3A-10,U.S. Senate,,IND,Eleanor García,2
+Humboldt,3A-10,U.S. Senate,,DEM,Emory Rodgers,3
+Humboldt,3A-10,U.S. Senate,,LIB,Gail K. Lightfoot,17
+Humboldt,3A-10,U.S. Senate,,REP,George C. Yang,2
+Humboldt,3A-10,U.S. Senate,,REP,Greg Conlon,2
+Humboldt,3A-10,U.S. Senate,,REP,Jarrell Williamson,3
+Humboldt,3A-10,U.S. Senate,,IND,Jason Hanania,1
 Humboldt,3A-10,U.S. Senate,,IND,Jason Kraus,1
-Humboldt,3A-10,U.S. Senate,,REP,Jerry J. Laws,5
-Humboldt,3A-10,U.S. Senate,,DEM,Kamala D. Harris,106
-Humboldt,3A-10,U.S. Senate,,REP,Karen Roseberry,2
-Humboldt,3A-10,U.S. Senate,,IND,Ling Ling Shi,5
-Humboldt,3A-10,U.S. Senate,,DEM,Loretta L. Sanchez,73
+Humboldt,3A-10,U.S. Senate,,REP,Jerry J. Laws,9
+Humboldt,3A-10,U.S. Senate,,PAF,John Thompson Parker,1
+Humboldt,3A-10,U.S. Senate,,DEM,Kamala D. Harris,202
+Humboldt,3A-10,U.S. Senate,,REP,Karen Roseberry,4
+Humboldt,3A-10,U.S. Senate,,IND,Ling Ling Shi,7
+Humboldt,3A-10,U.S. Senate,,DEM,Loretta L. Sanchez,132
 Humboldt,3A-10,U.S. Senate,,LIB,Mark Matthew Herd,3
-Humboldt,3A-10,U.S. Senate,,DEM,Massie Munroe,13
-Humboldt,3A-10,U.S. Senate,,IND,Mike Beitiks,5
-Humboldt,3A-10,U.S. Senate,,GRN,Pamela Elizondo,24
-Humboldt,3A-10,U.S. Senate,,REP,Phil Wyman,6
+Humboldt,3A-10,U.S. Senate,,DEM,Massie Munroe,18
+Humboldt,3A-10,U.S. Senate,,IND,Mike Beitiks,7
+Humboldt,3A-10,U.S. Senate,,GRN,Pamela Elizondo,40
+Humboldt,3A-10,U.S. Senate,,IND,Paul Merritt,2
+Humboldt,3A-10,U.S. Senate,,REP,Phil Wyman,7
+Humboldt,3A-10,U.S. Senate,,DEM,President Cristina Grappo,1
 Humboldt,3A-10,U.S. Senate,,REP,Ron Unz,1
 Humboldt,3A-10,U.S. Senate,,IND,Scott A. Vineberg,1
-Humboldt,3A-10,U.S. Senate,,DEM,Steve Stokes,24
-Humboldt,3A-10,U.S. Senate,,REP,Thomas G. Del Beccaro,2
-Humboldt,3A-10_A,President,,DEM,Bernie Sanders,182
-Humboldt,3A-10_A,President,,GRN,Darryl Cherney,1
-Humboldt,3A-10_A,President,,REP,Donald Trump,14
-Humboldt,3A-10_A,President,,PAF,Gloria Estela La Riva,1
-Humboldt,3A-10_A,President,,DEM,Henry Hewes,1
-Humboldt,3A-10_A,President,,DEM,Hillary Clinton,47
-Humboldt,3A-10_A,President,,GRN,Jill Stein,1
-Humboldt,3A-10_A,President,,REP,John R. Kasich,3
-Humboldt,3A-10_A,President,,DEM,Michael Steinberg,1
-Humboldt,3A-10_A,President,,REP,Ted Cruz,1
-Humboldt,3A-10_A,President,,DEM,Willie Wilson,1
-Humboldt,3A-10_A,Proposition 50,,,No,43
-Humboldt,3A-10_A,Proposition 50,,,Yes,179
-Humboldt,3A-10_A,State Assembly,2,DEM,Jim Wood,211
-Humboldt,3A-10_A,U.S. House,2,REP,Dale K. Mensing,22
-Humboldt,3A-10_A,U.S. House,2,DEM,Erin A. Schrode,48
-Humboldt,3A-10_A,U.S. House,2,DEM,Jared W. Huffman,152
-Humboldt,3A-10_A,U.S. House,2,IND,Matthew Robert Wookey,25
-Humboldt,3A-10_A,U.S. Senate,,IND,Clive Grey,1
-Humboldt,3A-10_A,U.S. Senate,,REP,Duf Sundheim,6
-Humboldt,3A-10_A,U.S. Senate,,IND,Eleanor García,1
-Humboldt,3A-10_A,U.S. Senate,,DEM,Emory Rodgers,3
-Humboldt,3A-10_A,U.S. Senate,,LIB,Gail K. Lightfoot,10
-Humboldt,3A-10_A,U.S. Senate,,REP,George C. Yang,2
-Humboldt,3A-10_A,U.S. Senate,,REP,Greg Conlon,2
-Humboldt,3A-10_A,U.S. Senate,,REP,Jarrell Williamson,1
-Humboldt,3A-10_A,U.S. Senate,,IND,Jason Hanania,1
-Humboldt,3A-10_A,U.S. Senate,,REP,Jerry J. Laws,4
-Humboldt,3A-10_A,U.S. Senate,,PAF,John Thompson Parker,1
-Humboldt,3A-10_A,U.S. Senate,,DEM,Kamala D. Harris,96
-Humboldt,3A-10_A,U.S. Senate,,REP,Karen Roseberry,2
-Humboldt,3A-10_A,U.S. Senate,,IND,Ling Ling Shi,2
-Humboldt,3A-10_A,U.S. Senate,,DEM,Loretta L. Sanchez,59
-Humboldt,3A-10_A,U.S. Senate,,DEM,Massie Munroe,5
-Humboldt,3A-10_A,U.S. Senate,,IND,Mike Beitiks,2
-Humboldt,3A-10_A,U.S. Senate,,GRN,Pamela Elizondo,16
-Humboldt,3A-10_A,U.S. Senate,,IND,Paul Merritt,2
-Humboldt,3A-10_A,U.S. Senate,,REP,Phil Wyman,1
-Humboldt,3A-10_A,U.S. Senate,,DEM,President Cristina Grappo,1
-Humboldt,3A-10_A,U.S. Senate,,DEM,Steve Stokes,19
-Humboldt,3A-10_A,U.S. Senate,,REP,Thomas G. Del Beccaro,6
-Humboldt,3A-10_A,U.S. Senate,,REP,Tom Palzer,1
-Humboldt,3A-10_A,U.S. Senate,,REP,Von Hougo,1
-Humboldt,3A-11,President,,DEM,Bernie Sanders,246
+Humboldt,3A-10,U.S. Senate,,DEM,Steve Stokes,43
+Humboldt,3A-10,U.S. Senate,,REP,Thomas G. Del Beccaro,8
+Humboldt,3A-10,U.S. Senate,,REP,Tom Palzer,1
+Humboldt,3A-10,U.S. Senate,,REP,Von Hougo,1
+Humboldt,3A-11,President,,AIP,Alan Spears,1
+Humboldt,3A-11,President,,DEM,Bernie Sanders,433
 Humboldt,3A-11,President,,GRN,Darryl Cherney,1
-Humboldt,3A-11,President,,REP,Donald Trump,5
-Humboldt,3A-11,President,,LIB,Gary Johnson,3
-Humboldt,3A-11,President,,DEM,Hillary Clinton,42
+Humboldt,3A-11,President,,REP,Donald Trump,24
+Humboldt,3A-11,President,,LIB,Gary Johnson,6
+Humboldt,3A-11,President,,DEM,Hillary Clinton,82
+Humboldt,3A-11,President,,GRN,Jill Stein,1
 Humboldt,3A-11,President,,LIB,John McAfee,1
 Humboldt,3A-11,President,,AIP,Robert Ornelas,1
-Humboldt,3A-11,President,,AIP,Wiley Drake,1
-Humboldt,3A-11,Proposition 50,,,No,61
-Humboldt,3A-11,Proposition 50,,,Yes,187
-Humboldt,3A-11,State Assembly,2,DEM,Jim Wood,230
-Humboldt,3A-11,U.S. House,2,REP,Dale K. Mensing,7
-Humboldt,3A-11,U.S. House,2,DEM,Erin A. Schrode,63
-Humboldt,3A-11,U.S. House,2,DEM,Jared W. Huffman,167
-Humboldt,3A-11,U.S. House,2,IND,Matthew Robert Wookey,36
+Humboldt,3A-11,President,,REP,Ted Cruz,1
+Humboldt,3A-11,President,,AIP,Wiley Drake,2
+Humboldt,3A-11,Proposition 50,,,No,108
+Humboldt,3A-11,Proposition 50,,,Yes,370
+Humboldt,3A-11,State Assembly,2,DEM,Jim Wood,445
+Humboldt,3A-11,U.S. House,2,REP,Dale K. Mensing,22
+Humboldt,3A-11,U.S. House,2,DEM,Erin A. Schrode,100
+Humboldt,3A-11,U.S. House,2,DEM,Jared W. Huffman,338
+Humboldt,3A-11,U.S. House,2,IND,Matthew Robert Wookey,59
 Humboldt,3A-11,U.S. Senate,,IND,Clive Grey,1
-Humboldt,3A-11,U.S. Senate,,IND,Eleanor García,1
-Humboldt,3A-11,U.S. Senate,,DEM,Emory Rodgers,4
-Humboldt,3A-11,U.S. Senate,,LIB,Gail K. Lightfoot,12
-Humboldt,3A-11,U.S. Senate,,IND,Jason Hanania,1
+Humboldt,3A-11,U.S. Senate,,REP,Don Krampe,1
+Humboldt,3A-11,U.S. Senate,,REP,Duf Sundheim,2
+Humboldt,3A-11,U.S. Senate,,IND,Eleanor García,2
+Humboldt,3A-11,U.S. Senate,,DEM,Emory Rodgers,6
+Humboldt,3A-11,U.S. Senate,,LIB,Gail K. Lightfoot,15
+Humboldt,3A-11,U.S. Senate,,REP,Greg Conlon,4
+Humboldt,3A-11,U.S. Senate,,REP,Jarrell Williamson,1
+Humboldt,3A-11,U.S. Senate,,IND,Jason Hanania,2
 Humboldt,3A-11,U.S. Senate,,IND,Jason Kraus,1
-Humboldt,3A-11,U.S. Senate,,DEM,Kamala D. Harris,111
-Humboldt,3A-11,U.S. Senate,,IND,Ling Ling Shi,6
-Humboldt,3A-11,U.S. Senate,,DEM,Loretta L. Sanchez,51
-Humboldt,3A-11,U.S. Senate,,LIB,Mark Matthew Herd,3
-Humboldt,3A-11,U.S. Senate,,DEM,Massie Munroe,10
-Humboldt,3A-11,U.S. Senate,,IND,Mike Beitiks,4
-Humboldt,3A-11,U.S. Senate,,GRN,Pamela Elizondo,27
-Humboldt,3A-11,U.S. Senate,,REP,Phil Wyman,2
+Humboldt,3A-11,U.S. Senate,,REP,Jerry J. Laws,1
+Humboldt,3A-11,U.S. Senate,,PAF,John Thompson Parker,1
+Humboldt,3A-11,U.S. Senate,,DEM,Kamala D. Harris,219
+Humboldt,3A-11,U.S. Senate,,REP,Karen Roseberry,2
+Humboldt,3A-11,U.S. Senate,,IND,Ling Ling Shi,7
+Humboldt,3A-11,U.S. Senate,,DEM,Loretta L. Sanchez,104
+Humboldt,3A-11,U.S. Senate,,LIB,Mark Matthew Herd,4
+Humboldt,3A-11,U.S. Senate,,DEM,Massie Munroe,17
+Humboldt,3A-11,U.S. Senate,,IND,Mike Beitiks,8
+Humboldt,3A-11,U.S. Senate,,GRN,Pamela Elizondo,54
+Humboldt,3A-11,U.S. Senate,,IND,Paul Merritt,1
+Humboldt,3A-11,U.S. Senate,,REP,Phil Wyman,6
 Humboldt,3A-11,U.S. Senate,,DEM,President Cristina Grappo,1
+Humboldt,3A-11,U.S. Senate,,REP,Ron Unz,3
 Humboldt,3A-11,U.S. Senate,,IND,Scott A. Vineberg,2
-Humboldt,3A-11,U.S. Senate,,DEM,Steve Stokes,20
-Humboldt,3A-11,U.S. Senate,,REP,Thomas G. Del Beccaro,4
+Humboldt,3A-11,U.S. Senate,,DEM,Steve Stokes,30
+Humboldt,3A-11,U.S. Senate,,REP,Thomas G. Del Beccaro,5
 Humboldt,3A-11,U.S. Senate,,REP,Tom Palzer,2
-Humboldt,3A-11,U.S. Senate,,REP,Von Hougo,2
-Humboldt,3A-11_A,President,,AIP,Alan Spears,1
-Humboldt,3A-11_A,President,,DEM,Bernie Sanders,187
-Humboldt,3A-11_A,President,,REP,Donald Trump,19
-Humboldt,3A-11_A,President,,LIB,Gary Johnson,3
-Humboldt,3A-11_A,President,,DEM,Hillary Clinton,40
-Humboldt,3A-11_A,President,,GRN,Jill Stein,1
-Humboldt,3A-11_A,President,,REP,Ted Cruz,1
-Humboldt,3A-11_A,President,,AIP,Wiley Drake,1
-Humboldt,3A-11_A,Proposition 50,,,No,47
-Humboldt,3A-11_A,Proposition 50,,,Yes,183
-Humboldt,3A-11_A,State Assembly,2,DEM,Jim Wood,215
-Humboldt,3A-11_A,U.S. House,2,REP,Dale K. Mensing,15
-Humboldt,3A-11_A,U.S. House,2,DEM,Erin A. Schrode,37
-Humboldt,3A-11_A,U.S. House,2,DEM,Jared W. Huffman,171
-Humboldt,3A-11_A,U.S. House,2,IND,Matthew Robert Wookey,23
-Humboldt,3A-11_A,U.S. Senate,,REP,Don Krampe,1
-Humboldt,3A-11_A,U.S. Senate,,REP,Duf Sundheim,2
-Humboldt,3A-11_A,U.S. Senate,,IND,Eleanor García,1
-Humboldt,3A-11_A,U.S. Senate,,DEM,Emory Rodgers,2
-Humboldt,3A-11_A,U.S. Senate,,LIB,Gail K. Lightfoot,3
-Humboldt,3A-11_A,U.S. Senate,,REP,Greg Conlon,4
-Humboldt,3A-11_A,U.S. Senate,,REP,Jarrell Williamson,1
-Humboldt,3A-11_A,U.S. Senate,,IND,Jason Hanania,1
-Humboldt,3A-11_A,U.S. Senate,,REP,Jerry J. Laws,1
-Humboldt,3A-11_A,U.S. Senate,,PAF,John Thompson Parker,1
-Humboldt,3A-11_A,U.S. Senate,,DEM,Kamala D. Harris,108
-Humboldt,3A-11_A,U.S. Senate,,REP,Karen Roseberry,2
-Humboldt,3A-11_A,U.S. Senate,,IND,Ling Ling Shi,1
-Humboldt,3A-11_A,U.S. Senate,,DEM,Loretta L. Sanchez,53
-Humboldt,3A-11_A,U.S. Senate,,LIB,Mark Matthew Herd,1
-Humboldt,3A-11_A,U.S. Senate,,DEM,Massie Munroe,7
-Humboldt,3A-11_A,U.S. Senate,,IND,Mike Beitiks,4
-Humboldt,3A-11_A,U.S. Senate,,GRN,Pamela Elizondo,27
-Humboldt,3A-11_A,U.S. Senate,,IND,Paul Merritt,1
-Humboldt,3A-11_A,U.S. Senate,,REP,Phil Wyman,4
-Humboldt,3A-11_A,U.S. Senate,,REP,Ron Unz,3
-Humboldt,3A-11_A,U.S. Senate,,DEM,Steve Stokes,10
-Humboldt,3A-11_A,U.S. Senate,,REP,Thomas G. Del Beccaro,1
-Humboldt,3A-11_A,U.S. Senate,,REP,Von Hougo,3
-Humboldt,3A-12,President,,DEM,Bernie Sanders,86
-Humboldt,3A-12,President,,REP,Donald Trump,4
-Humboldt,3A-12,President,,DEM,Hillary Clinton,12
-Humboldt,3A-12,President,,REP,John R. Kasich,2
-Humboldt,3A-12,President,,REP,Ted Cruz,1
-Humboldt,3A-12,Proposition 50,,,No,12
-Humboldt,3A-12,Proposition 50,,,Yes,82
-Humboldt,3A-12,State Assembly,2,DEM,Jim Wood,83
-Humboldt,3A-12,U.S. House,2,REP,Dale K. Mensing,4
-Humboldt,3A-12,U.S. House,2,DEM,Erin A. Schrode,20
-Humboldt,3A-12,U.S. House,2,DEM,Jared W. Huffman,68
-Humboldt,3A-12,U.S. House,2,IND,Matthew Robert Wookey,8
+Humboldt,3A-11,U.S. Senate,,REP,Von Hougo,5
+Humboldt,3A-12,President,,REP,Ben Carson,1
+Humboldt,3A-12,President,,DEM,Bernie Sanders,155
+Humboldt,3A-12,President,,REP,Donald Trump,10
+Humboldt,3A-12,President,,DEM,Hillary Clinton,44
+Humboldt,3A-12,President,,GRN,Jill Stein,2
+Humboldt,3A-12,President,,REP,John R. Kasich,3
+Humboldt,3A-12,President,,REP,Ted Cruz,2
+Humboldt,3A-12,Proposition 50,,,No,29
+Humboldt,3A-12,Proposition 50,,,Yes,171
+Humboldt,3A-12,State Assembly,2,DEM,Jim Wood,185
+Humboldt,3A-12,U.S. House,2,REP,Dale K. Mensing,8
+Humboldt,3A-12,U.S. House,2,DEM,Erin A. Schrode,37
+Humboldt,3A-12,U.S. House,2,DEM,Jared W. Huffman,152
+Humboldt,3A-12,U.S. House,2,IND,Matthew Robert Wookey,16
 Humboldt,3A-12,U.S. Senate,,IND,Clive Grey,1
 Humboldt,3A-12,U.S. Senate,,REP,Don Krampe,2
-Humboldt,3A-12,U.S. Senate,,LIB,Gail K. Lightfoot,2
+Humboldt,3A-12,U.S. Senate,,REP,Duf Sundheim,2
+Humboldt,3A-12,U.S. Senate,,LIB,Gail K. Lightfoot,6
+Humboldt,3A-12,U.S. Senate,,REP,George C. Yang,1
 Humboldt,3A-12,U.S. Senate,,REP,Greg Conlon,2
-Humboldt,3A-12,U.S. Senate,,REP,Jerry J. Laws,1
-Humboldt,3A-12,U.S. Senate,,DEM,Kamala D. Harris,47
-Humboldt,3A-12,U.S. Senate,,DEM,Loretta L. Sanchez,24
-Humboldt,3A-12,U.S. Senate,,LIB,Mark Matthew Herd,1
+Humboldt,3A-12,U.S. Senate,,REP,Jarrell Williamson,2
+Humboldt,3A-12,U.S. Senate,,IND,Jason Hanania,1
+Humboldt,3A-12,U.S. Senate,,IND,Jason Kraus,1
+Humboldt,3A-12,U.S. Senate,,REP,Jerry J. Laws,2
+Humboldt,3A-12,U.S. Senate,,DEM,Kamala D. Harris,107
+Humboldt,3A-12,U.S. Senate,,IND,Ling Ling Shi,1
+Humboldt,3A-12,U.S. Senate,,DEM,Loretta L. Sanchez,39
+Humboldt,3A-12,U.S. Senate,,LIB,Mark Matthew Herd,2
+Humboldt,3A-12,U.S. Senate,,DEM,Massie Munroe,9
 Humboldt,3A-12,U.S. Senate,,IND,Mike Beitiks,1
-Humboldt,3A-12,U.S. Senate,,GRN,Pamela Elizondo,9
+Humboldt,3A-12,U.S. Senate,,GRN,Pamela Elizondo,18
 Humboldt,3A-12,U.S. Senate,,IND,Paul Merritt,1
-Humboldt,3A-12,U.S. Senate,,DEM,Steve Stokes,3
-Humboldt,3A-12_A,President,,REP,Ben Carson,1
-Humboldt,3A-12_A,President,,DEM,Bernie Sanders,69
-Humboldt,3A-12_A,President,,REP,Donald Trump,6
-Humboldt,3A-12_A,President,,DEM,Hillary Clinton,32
-Humboldt,3A-12_A,President,,GRN,Jill Stein,2
-Humboldt,3A-12_A,President,,REP,John R. Kasich,1
-Humboldt,3A-12_A,President,,REP,Ted Cruz,1
-Humboldt,3A-12_A,Proposition 50,,,No,17
-Humboldt,3A-12_A,Proposition 50,,,Yes,89
-Humboldt,3A-12_A,State Assembly,2,DEM,Jim Wood,102
-Humboldt,3A-12_A,U.S. House,2,REP,Dale K. Mensing,4
-Humboldt,3A-12_A,U.S. House,2,DEM,Erin A. Schrode,17
-Humboldt,3A-12_A,U.S. House,2,DEM,Jared W. Huffman,84
-Humboldt,3A-12_A,U.S. House,2,IND,Matthew Robert Wookey,8
-Humboldt,3A-12_A,U.S. Senate,,REP,Duf Sundheim,2
-Humboldt,3A-12_A,U.S. Senate,,LIB,Gail K. Lightfoot,4
-Humboldt,3A-12_A,U.S. Senate,,REP,George C. Yang,1
-Humboldt,3A-12_A,U.S. Senate,,REP,Jarrell Williamson,2
-Humboldt,3A-12_A,U.S. Senate,,IND,Jason Hanania,1
-Humboldt,3A-12_A,U.S. Senate,,IND,Jason Kraus,1
-Humboldt,3A-12_A,U.S. Senate,,REP,Jerry J. Laws,1
-Humboldt,3A-12_A,U.S. Senate,,DEM,Kamala D. Harris,60
-Humboldt,3A-12_A,U.S. Senate,,IND,Ling Ling Shi,1
-Humboldt,3A-12_A,U.S. Senate,,DEM,Loretta L. Sanchez,15
-Humboldt,3A-12_A,U.S. Senate,,LIB,Mark Matthew Herd,1
-Humboldt,3A-12_A,U.S. Senate,,DEM,Massie Munroe,9
-Humboldt,3A-12_A,U.S. Senate,,GRN,Pamela Elizondo,9
-Humboldt,3A-12_A,U.S. Senate,,REP,Phil Wyman,1
-Humboldt,3A-12_A,U.S. Senate,,REP,Ron Unz,1
-Humboldt,3A-12_A,U.S. Senate,,DEM,Steve Stokes,2
-Humboldt,3A-13,President,,REP,Ben Carson,2
-Humboldt,3A-13,President,,DEM,Bernie Sanders,209
-Humboldt,3A-13,President,,REP,Donald Trump,5
-Humboldt,3A-13,President,,DEM,Hillary Clinton,43
-Humboldt,3A-13,President,,GRN,Jill Stein,2
-Humboldt,3A-13,President,,REP,John R. Kasich,2
+Humboldt,3A-12,U.S. Senate,,REP,Phil Wyman,1
+Humboldt,3A-12,U.S. Senate,,REP,Ron Unz,1
+Humboldt,3A-12,U.S. Senate,,DEM,Steve Stokes,5
+Humboldt,3A-13,President,,REP,Ben Carson,5
+Humboldt,3A-13,President,,DEM,Bernie Sanders,417
+Humboldt,3A-13,President,,REP,Donald Trump,26
+Humboldt,3A-13,President,,LIB,Gary Johnson,1
+Humboldt,3A-13,President,,DEM,Henry Hewes,1
+Humboldt,3A-13,President,,DEM,Hillary Clinton,128
+Humboldt,3A-13,President,,GRN,Jill Stein,7
+Humboldt,3A-13,President,,LIB,John McAfee,1
+Humboldt,3A-13,President,,REP,John R. Kasich,9
 Humboldt,3A-13,President,,DEM,Keith Judd,1
-Humboldt,3A-13,President,,REP,Ted Cruz,2
+Humboldt,3A-13,President,,REP,Ted Cruz,3
 Humboldt,3A-13,President,,GRN,William Kreml,1
-Humboldt,3A-13,Proposition 50,,,No,50
-Humboldt,3A-13,Proposition 50,,,Yes,184
-Humboldt,3A-13,State Assembly,2,DEM,Jim Wood,197
-Humboldt,3A-13,U.S. House,2,REP,Dale K. Mensing,13
-Humboldt,3A-13,U.S. House,2,DEM,Erin A. Schrode,64
-Humboldt,3A-13,U.S. House,2,DEM,Jared W. Huffman,141
-Humboldt,3A-13,U.S. House,2,IND,Matthew Robert Wookey,26
+Humboldt,3A-13,President,,DEM,Willie Wilson,1
+Humboldt,3A-13,Proposition 50,,,No,107
+Humboldt,3A-13,Proposition 50,,,Yes,442
+Humboldt,3A-13,State Assembly,2,DEM,Jim Wood,459
+Humboldt,3A-13,U.S. House,2,REP,Dale K. Mensing,44
+Humboldt,3A-13,U.S. House,2,DEM,Erin A. Schrode,123
+Humboldt,3A-13,U.S. House,2,DEM,Jared W. Huffman,345
+Humboldt,3A-13,U.S. House,2,IND,Matthew Robert Wookey,52
+Humboldt,3A-13,U.S. Senate,,IND,Clive Grey,2
 Humboldt,3A-13,U.S. Senate,,REP,Don Krampe,1
-Humboldt,3A-13,U.S. Senate,,REP,Duf Sundheim,3
-Humboldt,3A-13,U.S. Senate,,IND,Eleanor García,4
-Humboldt,3A-13,U.S. Senate,,DEM,Emory Rodgers,1
-Humboldt,3A-13,U.S. Senate,,LIB,Gail K. Lightfoot,12
-Humboldt,3A-13,U.S. Senate,,REP,George C. Yang,1
+Humboldt,3A-13,U.S. Senate,,REP,Duf Sundheim,12
+Humboldt,3A-13,U.S. Senate,,IND,Eleanor García,8
+Humboldt,3A-13,U.S. Senate,,DEM,Emory Rodgers,5
+Humboldt,3A-13,U.S. Senate,,LIB,Gail K. Lightfoot,20
+Humboldt,3A-13,U.S. Senate,,REP,George C. Yang,2
+Humboldt,3A-13,U.S. Senate,,REP,Greg Conlon,11
 Humboldt,3A-13,U.S. Senate,,DEM,Herbert G. Peters,1
+Humboldt,3A-13,U.S. Senate,,REP,Jarrell Williamson,3
 Humboldt,3A-13,U.S. Senate,,IND,Jason Hanania,2
 Humboldt,3A-13,U.S. Senate,,IND,Jason Kraus,2
-Humboldt,3A-13,U.S. Senate,,REP,Jerry J. Laws,6
-Humboldt,3A-13,U.S. Senate,,DEM,Kamala D. Harris,100
-Humboldt,3A-13,U.S. Senate,,IND,Ling Ling Shi,5
-Humboldt,3A-13,U.S. Senate,,DEM,Loretta L. Sanchez,41
-Humboldt,3A-13,U.S. Senate,,LIB,Mark Matthew Herd,3
-Humboldt,3A-13,U.S. Senate,,DEM,Massie Munroe,7
-Humboldt,3A-13,U.S. Senate,,IND,Mike Beitiks,2
-Humboldt,3A-13,U.S. Senate,,GRN,Pamela Elizondo,28
-Humboldt,3A-13,U.S. Senate,,REP,Phil Wyman,1
-Humboldt,3A-13,U.S. Senate,,REP,Ron Unz,2
-Humboldt,3A-13,U.S. Senate,,IND,Scott A. Vineberg,1
-Humboldt,3A-13,U.S. Senate,,DEM,Steve Stokes,18
+Humboldt,3A-13,U.S. Senate,,REP,Jerry J. Laws,9
+Humboldt,3A-13,U.S. Senate,,PAF,John Thompson Parker,1
+Humboldt,3A-13,U.S. Senate,,DEM,Kamala D. Harris,263
+Humboldt,3A-13,U.S. Senate,,IND,Ling Ling Shi,8
+Humboldt,3A-13,U.S. Senate,,DEM,Loretta L. Sanchez,90
+Humboldt,3A-13,U.S. Senate,,LIB,Mark Matthew Herd,5
+Humboldt,3A-13,U.S. Senate,,DEM,Massie Munroe,13
+Humboldt,3A-13,U.S. Senate,,IND,Mike Beitiks,7
+Humboldt,3A-13,U.S. Senate,,GRN,Pamela Elizondo,54
+Humboldt,3A-13,U.S. Senate,,IND,Paul Merritt,2
+Humboldt,3A-13,U.S. Senate,,REP,Phil Wyman,11
+Humboldt,3A-13,U.S. Senate,,DEM,President Cristina Grappo,2
+Humboldt,3A-13,U.S. Senate,,REP,Ron Unz,3
+Humboldt,3A-13,U.S. Senate,,IND,Scott A. Vineberg,2
+Humboldt,3A-13,U.S. Senate,,DEM,Steve Stokes,27
+Humboldt,3A-13,U.S. Senate,,REP,Thomas G. Del Beccaro,2
 Humboldt,3A-13,U.S. Senate,,REP,Tom Palzer,1
-Humboldt,3A-13,U.S. Senate,,REP,Von Hougo,1
-Humboldt,3A-13_A,President,,REP,Ben Carson,3
-Humboldt,3A-13_A,President,,DEM,Bernie Sanders,208
-Humboldt,3A-13_A,President,,REP,Donald Trump,21
-Humboldt,3A-13_A,President,,LIB,Gary Johnson,1
-Humboldt,3A-13_A,President,,DEM,Henry Hewes,1
-Humboldt,3A-13_A,President,,DEM,Hillary Clinton,85
-Humboldt,3A-13_A,President,,GRN,Jill Stein,5
-Humboldt,3A-13_A,President,,LIB,John McAfee,1
-Humboldt,3A-13_A,President,,REP,John R. Kasich,7
-Humboldt,3A-13_A,President,,REP,Ted Cruz,1
-Humboldt,3A-13_A,President,,DEM,Willie Wilson,1
-Humboldt,3A-13_A,Proposition 50,,,No,57
-Humboldt,3A-13_A,Proposition 50,,,Yes,258
-Humboldt,3A-13_A,State Assembly,2,DEM,Jim Wood,262
-Humboldt,3A-13_A,U.S. House,2,REP,Dale K. Mensing,31
-Humboldt,3A-13_A,U.S. House,2,DEM,Erin A. Schrode,59
-Humboldt,3A-13_A,U.S. House,2,DEM,Jared W. Huffman,204
-Humboldt,3A-13_A,U.S. House,2,IND,Matthew Robert Wookey,26
-Humboldt,3A-13_A,U.S. Senate,,IND,Clive Grey,2
-Humboldt,3A-13_A,U.S. Senate,,REP,Duf Sundheim,9
-Humboldt,3A-13_A,U.S. Senate,,IND,Eleanor García,4
-Humboldt,3A-13_A,U.S. Senate,,DEM,Emory Rodgers,4
-Humboldt,3A-13_A,U.S. Senate,,LIB,Gail K. Lightfoot,8
-Humboldt,3A-13_A,U.S. Senate,,REP,George C. Yang,1
-Humboldt,3A-13_A,U.S. Senate,,REP,Greg Conlon,11
-Humboldt,3A-13_A,U.S. Senate,,REP,Jarrell Williamson,3
-Humboldt,3A-13_A,U.S. Senate,,REP,Jerry J. Laws,3
-Humboldt,3A-13_A,U.S. Senate,,PAF,John Thompson Parker,1
-Humboldt,3A-13_A,U.S. Senate,,DEM,Kamala D. Harris,163
-Humboldt,3A-13_A,U.S. Senate,,IND,Ling Ling Shi,3
-Humboldt,3A-13_A,U.S. Senate,,DEM,Loretta L. Sanchez,49
-Humboldt,3A-13_A,U.S. Senate,,LIB,Mark Matthew Herd,2
-Humboldt,3A-13_A,U.S. Senate,,DEM,Massie Munroe,6
-Humboldt,3A-13_A,U.S. Senate,,IND,Mike Beitiks,5
-Humboldt,3A-13_A,U.S. Senate,,GRN,Pamela Elizondo,26
-Humboldt,3A-13_A,U.S. Senate,,IND,Paul Merritt,2
-Humboldt,3A-13_A,U.S. Senate,,REP,Phil Wyman,10
-Humboldt,3A-13_A,U.S. Senate,,DEM,President Cristina Grappo,2
-Humboldt,3A-13_A,U.S. Senate,,REP,Ron Unz,1
-Humboldt,3A-13_A,U.S. Senate,,IND,Scott A. Vineberg,1
-Humboldt,3A-13_A,U.S. Senate,,DEM,Steve Stokes,9
-Humboldt,3A-13_A,U.S. Senate,,REP,Thomas G. Del Beccaro,2
-Humboldt,3A-13_A,U.S. Senate,,REP,Von Hougo,2
+Humboldt,3A-13,U.S. Senate,,REP,Von Hougo,3
 Humboldt,3A-J1,President,,REP,Ben Carson,4
-Humboldt,3A-J1,President,,DEM,Bernie Sanders,157
-Humboldt,3A-J1,President,,REP,Donald Trump,6
+Humboldt,3A-J1,President,,DEM,Bernie Sanders,281
+Humboldt,3A-J1,President,,REP,Donald Trump,30
 Humboldt,3A-J1,President,,LIB,Gary Johnson,1
-Humboldt,3A-J1,President,,DEM,Hillary Clinton,62
-Humboldt,3A-J1,President,,GRN,Jill Stein,1
-Humboldt,3A-J1,President,,REP,Ted Cruz,3
-Humboldt,3A-J1,Proposition 50,,,No,36
-Humboldt,3A-J1,Proposition 50,,,Yes,159
-Humboldt,3A-J1,State Assembly,2,DEM,Jim Wood,180
-Humboldt,3A-J1,U.S. House,2,REP,Dale K. Mensing,9
-Humboldt,3A-J1,U.S. House,2,DEM,Erin A. Schrode,25
-Humboldt,3A-J1,U.S. House,2,DEM,Jared W. Huffman,161
-Humboldt,3A-J1,U.S. House,2,IND,Matthew Robert Wookey,16
+Humboldt,3A-J1,President,,DEM,Hillary Clinton,134
+Humboldt,3A-J1,President,,GRN,Jill Stein,2
+Humboldt,3A-J1,President,,REP,John R. Kasich,6
+Humboldt,3A-J1,President,,DEM,Keith Judd,1
+Humboldt,3A-J1,President,,DEM,Michael Steinberg,1
+Humboldt,3A-J1,President,,REP,Ted Cruz,7
+Humboldt,3A-J1,Proposition 50,,,No,83
+Humboldt,3A-J1,Proposition 50,,,Yes,335
+Humboldt,3A-J1,State Assembly,2,DEM,Jim Wood,381
+Humboldt,3A-J1,U.S. House,2,REP,Dale K. Mensing,30
+Humboldt,3A-J1,U.S. House,2,DEM,Erin A. Schrode,52
+Humboldt,3A-J1,U.S. House,2,DEM,Jared W. Huffman,353
+Humboldt,3A-J1,U.S. House,2,IND,Matthew Robert Wookey,20
 Humboldt,3A-J1,U.S. Senate,,IND,Clive Grey,1
-Humboldt,3A-J1,U.S. Senate,,REP,Don Krampe,2
-Humboldt,3A-J1,U.S. Senate,,REP,Duf Sundheim,1
-Humboldt,3A-J1,U.S. Senate,,IND,Eleanor García,1
-Humboldt,3A-J1,U.S. Senate,,LIB,Gail K. Lightfoot,6
-Humboldt,3A-J1,U.S. Senate,,REP,Greg Conlon,1
-Humboldt,3A-J1,U.S. Senate,,IND,Jason Hanania,1
-Humboldt,3A-J1,U.S. Senate,,REP,Jerry J. Laws,1
-Humboldt,3A-J1,U.S. Senate,,DEM,Kamala D. Harris,108
+Humboldt,3A-J1,U.S. Senate,,REP,Don Krampe,3
+Humboldt,3A-J1,U.S. Senate,,REP,Duf Sundheim,4
+Humboldt,3A-J1,U.S. Senate,,IND,Eleanor García,2
+Humboldt,3A-J1,U.S. Senate,,DEM,Emory Rodgers,1
+Humboldt,3A-J1,U.S. Senate,,LIB,Gail K. Lightfoot,8
+Humboldt,3A-J1,U.S. Senate,,REP,Greg Conlon,8
+Humboldt,3A-J1,U.S. Senate,,DEM,Herbert G. Peters,1
+Humboldt,3A-J1,U.S. Senate,,IND,Jason Hanania,4
+Humboldt,3A-J1,U.S. Senate,,REP,Jerry J. Laws,3
+Humboldt,3A-J1,U.S. Senate,,PAF,John Thompson Parker,2
+Humboldt,3A-J1,U.S. Senate,,DEM,Kamala D. Harris,241
 Humboldt,3A-J1,U.S. Senate,,REP,Karen Roseberry,4
 Humboldt,3A-J1,U.S. Senate,,IND,Ling Ling Shi,2
-Humboldt,3A-J1,U.S. Senate,,DEM,Loretta L. Sanchez,42
-Humboldt,3A-J1,U.S. Senate,,LIB,Mark Matthew Herd,4
-Humboldt,3A-J1,U.S. Senate,,DEM,Massie Munroe,3
+Humboldt,3A-J1,U.S. Senate,,DEM,Loretta L. Sanchez,89
+Humboldt,3A-J1,U.S. Senate,,LIB,Mark Matthew Herd,6
+Humboldt,3A-J1,U.S. Senate,,DEM,Massie Munroe,6
 Humboldt,3A-J1,U.S. Senate,,IND,Mike Beitiks,2
-Humboldt,3A-J1,U.S. Senate,,GRN,Pamela Elizondo,17
-Humboldt,3A-J1,U.S. Senate,,REP,Phil Wyman,3
-Humboldt,3A-J1,U.S. Senate,,DEM,President Cristina Grappo,1
-Humboldt,3A-J1,U.S. Senate,,REP,Ron Unz,1
-Humboldt,3A-J1,U.S. Senate,,DEM,Steve Stokes,12
-Humboldt,3A-J1_A,President,,DEM,Bernie Sanders,124
-Humboldt,3A-J1_A,President,,REP,Donald Trump,24
-Humboldt,3A-J1_A,President,,DEM,Hillary Clinton,72
-Humboldt,3A-J1_A,President,,GRN,Jill Stein,1
-Humboldt,3A-J1_A,President,,REP,John R. Kasich,6
-Humboldt,3A-J1_A,President,,DEM,Keith Judd,1
-Humboldt,3A-J1_A,President,,DEM,Michael Steinberg,1
-Humboldt,3A-J1_A,President,,REP,Ted Cruz,4
-Humboldt,3A-J1_A,Proposition 50,,,No,47
-Humboldt,3A-J1_A,Proposition 50,,,Yes,176
-Humboldt,3A-J1_A,State Assembly,2,DEM,Jim Wood,201
-Humboldt,3A-J1_A,U.S. House,2,REP,Dale K. Mensing,21
-Humboldt,3A-J1_A,U.S. House,2,DEM,Erin A. Schrode,27
-Humboldt,3A-J1_A,U.S. House,2,DEM,Jared W. Huffman,192
-Humboldt,3A-J1_A,U.S. House,2,IND,Matthew Robert Wookey,4
-Humboldt,3A-J1_A,U.S. Senate,,REP,Don Krampe,1
-Humboldt,3A-J1_A,U.S. Senate,,REP,Duf Sundheim,3
-Humboldt,3A-J1_A,U.S. Senate,,IND,Eleanor García,1
-Humboldt,3A-J1_A,U.S. Senate,,DEM,Emory Rodgers,1
-Humboldt,3A-J1_A,U.S. Senate,,LIB,Gail K. Lightfoot,2
-Humboldt,3A-J1_A,U.S. Senate,,REP,Greg Conlon,7
-Humboldt,3A-J1_A,U.S. Senate,,DEM,Herbert G. Peters,1
-Humboldt,3A-J1_A,U.S. Senate,,IND,Jason Hanania,3
-Humboldt,3A-J1_A,U.S. Senate,,REP,Jerry J. Laws,2
-Humboldt,3A-J1_A,U.S. Senate,,PAF,John Thompson Parker,2
-Humboldt,3A-J1_A,U.S. Senate,,DEM,Kamala D. Harris,133
-Humboldt,3A-J1_A,U.S. Senate,,DEM,Loretta L. Sanchez,47
-Humboldt,3A-J1_A,U.S. Senate,,LIB,Mark Matthew Herd,2
-Humboldt,3A-J1_A,U.S. Senate,,DEM,Massie Munroe,3
-Humboldt,3A-J1_A,U.S. Senate,,GRN,Pamela Elizondo,9
-Humboldt,3A-J1_A,U.S. Senate,,REP,Phil Wyman,6
-Humboldt,3A-J1_A,U.S. Senate,,DEM,President Cristina Grappo,1
-Humboldt,3A-J1_A,U.S. Senate,,REP,Ron Unz,2
-Humboldt,3A-J1_A,U.S. Senate,,DEM,Steve Stokes,8
-Humboldt,3A-J1_A,U.S. Senate,,REP,Thomas G. Del Beccaro,4
-Humboldt,3A-P2,President,,REP,Ben Carson,4
-Humboldt,3A-P2,President,,DEM,Bernie Sanders,183
-Humboldt,3A-P2,President,,GRN,Darryl Cherney,1
-Humboldt,3A-P2,President,,REP,Donald Trump,17
+Humboldt,3A-J1,U.S. Senate,,GRN,Pamela Elizondo,26
+Humboldt,3A-J1,U.S. Senate,,REP,Phil Wyman,9
+Humboldt,3A-J1,U.S. Senate,,DEM,President Cristina Grappo,2
+Humboldt,3A-J1,U.S. Senate,,REP,Ron Unz,3
+Humboldt,3A-J1,U.S. Senate,,DEM,Steve Stokes,20
+Humboldt,3A-J1,U.S. Senate,,REP,Thomas G. Del Beccaro,4
+Humboldt,3A-P2,President,,REP,Ben Carson,7
+Humboldt,3A-P2,President,,DEM,Bernie Sanders,355
+Humboldt,3A-P2,President,,GRN,Darryl Cherney,3
+Humboldt,3A-P2,President,,REP,Donald Trump,51
 Humboldt,3A-P2,President,,LIB,Gary Johnson,1
 Humboldt,3A-P2,President,,DEM,Henry Hewes,1
-Humboldt,3A-P2,President,,DEM,Hillary Clinton,48
+Humboldt,3A-P2,President,,DEM,Hillary Clinton,110
 Humboldt,3A-P2,President,,AIP,J.R. Myers,1
-Humboldt,3A-P2,President,,GRN,Jill Stein,3
-Humboldt,3A-P2,President,,REP,John R. Kasich,4
-Humboldt,3A-P2,President,,REP,Ted Cruz,4
-Humboldt,3A-P2,Proposition 50,,,No,55
-Humboldt,3A-P2,Proposition 50,,,Yes,176
-Humboldt,3A-P2,State Assembly,2,DEM,Jim Wood,215
-Humboldt,3A-P2,U.S. House,2,REP,Dale K. Mensing,27
-Humboldt,3A-P2,U.S. House,2,DEM,Erin A. Schrode,41
-Humboldt,3A-P2,U.S. House,2,DEM,Jared W. Huffman,165
-Humboldt,3A-P2,U.S. House,2,IND,Matthew Robert Wookey,29
-Humboldt,3A-P2,U.S. Senate,,REP,Don Krampe,1
-Humboldt,3A-P2,U.S. Senate,,REP,Duf Sundheim,8
+Humboldt,3A-P2,President,,GRN,Jill Stein,5
+Humboldt,3A-P2,President,,REP,John R. Kasich,5
+Humboldt,3A-P2,President,,REP,Ted Cruz,10
+Humboldt,3A-P2,President,,GRN,William Kreml,1
+Humboldt,3A-P2,President,,DEM,Willie Wilson,1
+Humboldt,3A-P2,Proposition 50,,,No,88
+Humboldt,3A-P2,Proposition 50,,,Yes,392
+Humboldt,3A-P2,State Assembly,2,DEM,Jim Wood,429
+Humboldt,3A-P2,U.S. House,2,REP,Dale K. Mensing,53
+Humboldt,3A-P2,U.S. House,2,DEM,Erin A. Schrode,87
+Humboldt,3A-P2,U.S. House,2,DEM,Jared W. Huffman,344
+Humboldt,3A-P2,U.S. House,2,IND,Matthew Robert Wookey,43
+Humboldt,3A-P2,U.S. Senate,,REP,Don Krampe,4
+Humboldt,3A-P2,U.S. Senate,,REP,Duf Sundheim,12
 Humboldt,3A-P2,U.S. Senate,,IND,Eleanor García,3
-Humboldt,3A-P2,U.S. Senate,,DEM,Emory Rodgers,1
-Humboldt,3A-P2,U.S. Senate,,LIB,Gail K. Lightfoot,9
-Humboldt,3A-P2,U.S. Senate,,REP,George C. Yang,2
-Humboldt,3A-P2,U.S. Senate,,REP,Greg Conlon,6
+Humboldt,3A-P2,U.S. Senate,,DEM,Emory Rodgers,2
+Humboldt,3A-P2,U.S. Senate,,LIB,Gail K. Lightfoot,12
+Humboldt,3A-P2,U.S. Senate,,REP,George C. Yang,3
+Humboldt,3A-P2,U.S. Senate,,REP,Greg Conlon,15
 Humboldt,3A-P2,U.S. Senate,,DEM,Herbert G. Peters,1
-Humboldt,3A-P2,U.S. Senate,,IND,Jason Hanania,3
-Humboldt,3A-P2,U.S. Senate,,REP,Jerry J. Laws,6
+Humboldt,3A-P2,U.S. Senate,,REP,Jarrell Williamson,1
+Humboldt,3A-P2,U.S. Senate,,IND,Jason Hanania,7
+Humboldt,3A-P2,U.S. Senate,,IND,Jason Kraus,1
+Humboldt,3A-P2,U.S. Senate,,REP,Jerry J. Laws,11
 Humboldt,3A-P2,U.S. Senate,,PAF,John Thompson Parker,3
-Humboldt,3A-P2,U.S. Senate,,DEM,Kamala D. Harris,90
+Humboldt,3A-P2,U.S. Senate,,DEM,Kamala D. Harris,197
 Humboldt,3A-P2,U.S. Senate,,REP,Karen Roseberry,3
-Humboldt,3A-P2,U.S. Senate,,DEM,Loretta L. Sanchez,38
-Humboldt,3A-P2,U.S. Senate,,LIB,Mark Matthew Herd,3
-Humboldt,3A-P2,U.S. Senate,,DEM,Massie Munroe,6
-Humboldt,3A-P2,U.S. Senate,,IND,Mike Beitiks,5
-Humboldt,3A-P2,U.S. Senate,,GRN,Pamela Elizondo,27
-Humboldt,3A-P2,U.S. Senate,,REP,Phil Wyman,7
-Humboldt,3A-P2,U.S. Senate,,DEM,President Cristina Grappo,1
-Humboldt,3A-P2,U.S. Senate,,REP,Ron Unz,1
+Humboldt,3A-P2,U.S. Senate,,DEM,Loretta L. Sanchez,84
+Humboldt,3A-P2,U.S. Senate,,LIB,Mark Matthew Herd,5
+Humboldt,3A-P2,U.S. Senate,,DEM,Massie Munroe,16
+Humboldt,3A-P2,U.S. Senate,,IND,Mike Beitiks,8
+Humboldt,3A-P2,U.S. Senate,,GRN,Pamela Elizondo,47
+Humboldt,3A-P2,U.S. Senate,,IND,Paul Merritt,1
+Humboldt,3A-P2,U.S. Senate,,REP,Phil Wyman,20
+Humboldt,3A-P2,U.S. Senate,,DEM,President Cristina Grappo,2
+Humboldt,3A-P2,U.S. Senate,,REP,Ron Unz,3
 Humboldt,3A-P2,U.S. Senate,,IND,Scott A. Vineberg,1
-Humboldt,3A-P2,U.S. Senate,,DEM,Steve Stokes,17
-Humboldt,3A-P2,U.S. Senate,,REP,Thomas G. Del Beccaro,5
+Humboldt,3A-P2,U.S. Senate,,DEM,Steve Stokes,38
+Humboldt,3A-P2,U.S. Senate,,REP,Thomas G. Del Beccaro,7
 Humboldt,3A-P2,U.S. Senate,,REP,Tom Palzer,1
-Humboldt,3A-P2,U.S. Senate,,REP,Von Hougo,2
-Humboldt,3A-P2_A,President,,REP,Ben Carson,3
-Humboldt,3A-P2_A,President,,DEM,Bernie Sanders,172
-Humboldt,3A-P2_A,President,,GRN,Darryl Cherney,2
-Humboldt,3A-P2_A,President,,REP,Donald Trump,34
-Humboldt,3A-P2_A,President,,DEM,Hillary Clinton,62
-Humboldt,3A-P2_A,President,,GRN,Jill Stein,2
-Humboldt,3A-P2_A,President,,REP,John R. Kasich,1
-Humboldt,3A-P2_A,President,,REP,Ted Cruz,6
-Humboldt,3A-P2_A,President,,GRN,William Kreml,1
-Humboldt,3A-P2_A,President,,DEM,Willie Wilson,1
-Humboldt,3A-P2_A,Proposition 50,,,No,33
-Humboldt,3A-P2_A,Proposition 50,,,Yes,216
-Humboldt,3A-P2_A,State Assembly,2,DEM,Jim Wood,214
-Humboldt,3A-P2_A,U.S. House,2,REP,Dale K. Mensing,26
-Humboldt,3A-P2_A,U.S. House,2,DEM,Erin A. Schrode,46
-Humboldt,3A-P2_A,U.S. House,2,DEM,Jared W. Huffman,179
-Humboldt,3A-P2_A,U.S. House,2,IND,Matthew Robert Wookey,14
-Humboldt,3A-P2_A,U.S. Senate,,REP,Don Krampe,3
-Humboldt,3A-P2_A,U.S. Senate,,REP,Duf Sundheim,4
-Humboldt,3A-P2_A,U.S. Senate,,DEM,Emory Rodgers,1
-Humboldt,3A-P2_A,U.S. Senate,,LIB,Gail K. Lightfoot,3
-Humboldt,3A-P2_A,U.S. Senate,,REP,George C. Yang,1
-Humboldt,3A-P2_A,U.S. Senate,,REP,Greg Conlon,9
-Humboldt,3A-P2_A,U.S. Senate,,REP,Jarrell Williamson,1
-Humboldt,3A-P2_A,U.S. Senate,,IND,Jason Hanania,4
-Humboldt,3A-P2_A,U.S. Senate,,IND,Jason Kraus,1
-Humboldt,3A-P2_A,U.S. Senate,,REP,Jerry J. Laws,5
-Humboldt,3A-P2_A,U.S. Senate,,DEM,Kamala D. Harris,107
-Humboldt,3A-P2_A,U.S. Senate,,DEM,Loretta L. Sanchez,46
-Humboldt,3A-P2_A,U.S. Senate,,LIB,Mark Matthew Herd,2
-Humboldt,3A-P2_A,U.S. Senate,,DEM,Massie Munroe,10
-Humboldt,3A-P2_A,U.S. Senate,,IND,Mike Beitiks,3
-Humboldt,3A-P2_A,U.S. Senate,,GRN,Pamela Elizondo,20
-Humboldt,3A-P2_A,U.S. Senate,,IND,Paul Merritt,1
-Humboldt,3A-P2_A,U.S. Senate,,REP,Phil Wyman,13
-Humboldt,3A-P2_A,U.S. Senate,,DEM,President Cristina Grappo,1
-Humboldt,3A-P2_A,U.S. Senate,,REP,Ron Unz,2
-Humboldt,3A-P2_A,U.S. Senate,,DEM,Steve Stokes,21
-Humboldt,3A-P2_A,U.S. Senate,,REP,Thomas G. Del Beccaro,2
-Humboldt,3A-P2_A,U.S. Senate,,REP,Von Hougo,4
-Humboldt,3A-P4,President,,REP,Ben Carson,3
-Humboldt,3A-P4,President,,DEM,Bernie Sanders,191
+Humboldt,3A-P2,U.S. Senate,,REP,Von Hougo,6
+Humboldt,3A-P4,President,,REP,Ben Carson,5
+Humboldt,3A-P4,President,,DEM,Bernie Sanders,357
 Humboldt,3A-P4,President,,GRN,Darryl Cherney,2
-Humboldt,3A-P4,President,,REP,Donald Trump,17
+Humboldt,3A-P4,President,,REP,Donald Trump,59
 Humboldt,3A-P4,President,,LIB,Gary Johnson,2
-Humboldt,3A-P4,President,,DEM,Hillary Clinton,25
-Humboldt,3A-P4,President,,GRN,Jill Stein,1
-Humboldt,3A-P4,President,,REP,Ted Cruz,3
-Humboldt,3A-P4,Proposition 50,,,No,45
-Humboldt,3A-P4,Proposition 50,,,Yes,162
-Humboldt,3A-P4,State Assembly,2,DEM,Jim Wood,190
-Humboldt,3A-P4,U.S. House,2,REP,Dale K. Mensing,24
-Humboldt,3A-P4,U.S. House,2,DEM,Erin A. Schrode,48
-Humboldt,3A-P4,U.S. House,2,DEM,Jared W. Huffman,130
-Humboldt,3A-P4,U.S. House,2,IND,Matthew Robert Wookey,24
-Humboldt,3A-P4,U.S. Senate,,IND,Clive Grey,1
+Humboldt,3A-P4,President,,DEM,Hillary Clinton,90
+Humboldt,3A-P4,President,,GRN,Jill Stein,2
+Humboldt,3A-P4,President,,REP,Jim Gilmore,1
+Humboldt,3A-P4,President,,REP,John R. Kasich,4
+Humboldt,3A-P4,President,,DEM,Keith Judd,1
+Humboldt,3A-P4,President,,REP,Ted Cruz,7
+Humboldt,3A-P4,President,,DEM,Willie Wilson,1
+Humboldt,3A-P4,Proposition 50,,,No,102
+Humboldt,3A-P4,Proposition 50,,,Yes,374
+Humboldt,3A-P4,State Assembly,2,DEM,Jim Wood,413
+Humboldt,3A-P4,U.S. House,2,REP,Dale K. Mensing,60
+Humboldt,3A-P4,U.S. House,2,DEM,Erin A. Schrode,92
+Humboldt,3A-P4,U.S. House,2,DEM,Jared W. Huffman,309
+Humboldt,3A-P4,U.S. House,2,IND,Matthew Robert Wookey,46
+Humboldt,3A-P4,U.S. Senate,,IND,Clive Grey,3
 Humboldt,3A-P4,U.S. Senate,,IND,Don J. Grundmann,1
 Humboldt,3A-P4,U.S. Senate,,REP,Don Krampe,1
-Humboldt,3A-P4,U.S. Senate,,REP,Duf Sundheim,4
-Humboldt,3A-P4,U.S. Senate,,DEM,Emory Rodgers,1
-Humboldt,3A-P4,U.S. Senate,,LIB,Gail K. Lightfoot,10
-Humboldt,3A-P4,U.S. Senate,,IND,Gar Myers,1
-Humboldt,3A-P4,U.S. Senate,,REP,Greg Conlon,3
-Humboldt,3A-P4,U.S. Senate,,REP,Jarrell Williamson,1
-Humboldt,3A-P4,U.S. Senate,,IND,Jason Hanania,3
-Humboldt,3A-P4,U.S. Senate,,IND,Jason Kraus,1
-Humboldt,3A-P4,U.S. Senate,,REP,Jerry J. Laws,7
-Humboldt,3A-P4,U.S. Senate,,PAF,John Thompson Parker,1
-Humboldt,3A-P4,U.S. Senate,,DEM,Kamala D. Harris,82
-Humboldt,3A-P4,U.S. Senate,,REP,Karen Roseberry,1
-Humboldt,3A-P4,U.S. Senate,,IND,Ling Ling Shi,1
-Humboldt,3A-P4,U.S. Senate,,DEM,Loretta L. Sanchez,45
-Humboldt,3A-P4,U.S. Senate,,LIB,Mark Matthew Herd,1
-Humboldt,3A-P4,U.S. Senate,,DEM,Massie Munroe,6
-Humboldt,3A-P4,U.S. Senate,,IND,Mike Beitiks,3
-Humboldt,3A-P4,U.S. Senate,,GRN,Pamela Elizondo,15
+Humboldt,3A-P4,U.S. Senate,,REP,Duf Sundheim,13
+Humboldt,3A-P4,U.S. Senate,,DEM,Emory Rodgers,3
+Humboldt,3A-P4,U.S. Senate,,LIB,Gail K. Lightfoot,20
+Humboldt,3A-P4,U.S. Senate,,IND,Gar Myers,2
+Humboldt,3A-P4,U.S. Senate,,REP,George C. Yang,5
+Humboldt,3A-P4,U.S. Senate,,REP,Greg Conlon,10
+Humboldt,3A-P4,U.S. Senate,,DEM,Herbert G. Peters,1
+Humboldt,3A-P4,U.S. Senate,,REP,Jarrell Williamson,2
+Humboldt,3A-P4,U.S. Senate,,IND,Jason Hanania,5
+Humboldt,3A-P4,U.S. Senate,,IND,Jason Kraus,3
+Humboldt,3A-P4,U.S. Senate,,REP,Jerry J. Laws,16
+Humboldt,3A-P4,U.S. Senate,,PAF,John Thompson Parker,2
+Humboldt,3A-P4,U.S. Senate,,DEM,Kamala D. Harris,198
+Humboldt,3A-P4,U.S. Senate,,REP,Karen Roseberry,9
+Humboldt,3A-P4,U.S. Senate,,IND,Ling Ling Shi,4
+Humboldt,3A-P4,U.S. Senate,,DEM,Loretta L. Sanchez,96
+Humboldt,3A-P4,U.S. Senate,,LIB,Mark Matthew Herd,5
+Humboldt,3A-P4,U.S. Senate,,DEM,Massie Munroe,9
+Humboldt,3A-P4,U.S. Senate,,IND,Mike Beitiks,5
+Humboldt,3A-P4,U.S. Senate,,GRN,Pamela Elizondo,28
 Humboldt,3A-P4,U.S. Senate,,IND,Paul Merritt,1
-Humboldt,3A-P4,U.S. Senate,,REP,Phil Wyman,8
-Humboldt,3A-P4,U.S. Senate,,DEM,President Cristina Grappo,1
-Humboldt,3A-P4,U.S. Senate,,REP,Ron Unz,1
-Humboldt,3A-P4,U.S. Senate,,DEM,Steve Stokes,14
-Humboldt,3A-P4,U.S. Senate,,REP,Thomas G. Del Beccaro,1
-Humboldt,3A-P4,U.S. Senate,,REP,Tom Palzer,1
+Humboldt,3A-P4,U.S. Senate,,REP,Phil Wyman,17
+Humboldt,3A-P4,U.S. Senate,,DEM,President Cristina Grappo,4
+Humboldt,3A-P4,U.S. Senate,,REP,Ron Unz,2
+Humboldt,3A-P4,U.S. Senate,,IND,Scott A. Vineberg,1
+Humboldt,3A-P4,U.S. Senate,,DEM,Steve Stokes,25
+Humboldt,3A-P4,U.S. Senate,,REP,Thomas G. Del Beccaro,5
+Humboldt,3A-P4,U.S. Senate,,REP,Tom Palzer,5
 Humboldt,3A-P4,U.S. Senate,,REP,Von Hougo,4
-Humboldt,3A-P4_A,President,,REP,Ben Carson,2
-Humboldt,3A-P4_A,President,,DEM,Bernie Sanders,166
-Humboldt,3A-P4_A,President,,REP,Donald Trump,42
-Humboldt,3A-P4_A,President,,DEM,Hillary Clinton,65
-Humboldt,3A-P4_A,President,,GRN,Jill Stein,1
-Humboldt,3A-P4_A,President,,REP,Jim Gilmore,1
-Humboldt,3A-P4_A,President,,REP,John R. Kasich,4
-Humboldt,3A-P4_A,President,,DEM,Keith Judd,1
-Humboldt,3A-P4_A,President,,REP,Ted Cruz,4
-Humboldt,3A-P4_A,President,,DEM,Willie Wilson,1
-Humboldt,3A-P4_A,Proposition 50,,,No,57
-Humboldt,3A-P4_A,Proposition 50,,,Yes,212
-Humboldt,3A-P4_A,State Assembly,2,DEM,Jim Wood,223
-Humboldt,3A-P4_A,U.S. House,2,REP,Dale K. Mensing,36
-Humboldt,3A-P4_A,U.S. House,2,DEM,Erin A. Schrode,44
-Humboldt,3A-P4_A,U.S. House,2,DEM,Jared W. Huffman,179
-Humboldt,3A-P4_A,U.S. House,2,IND,Matthew Robert Wookey,22
-Humboldt,3A-P4_A,U.S. Senate,,IND,Clive Grey,2
-Humboldt,3A-P4_A,U.S. Senate,,REP,Duf Sundheim,9
-Humboldt,3A-P4_A,U.S. Senate,,DEM,Emory Rodgers,2
-Humboldt,3A-P4_A,U.S. Senate,,LIB,Gail K. Lightfoot,10
-Humboldt,3A-P4_A,U.S. Senate,,IND,Gar Myers,1
-Humboldt,3A-P4_A,U.S. Senate,,REP,George C. Yang,5
-Humboldt,3A-P4_A,U.S. Senate,,REP,Greg Conlon,7
-Humboldt,3A-P4_A,U.S. Senate,,DEM,Herbert G. Peters,1
-Humboldt,3A-P4_A,U.S. Senate,,REP,Jarrell Williamson,1
-Humboldt,3A-P4_A,U.S. Senate,,IND,Jason Hanania,2
-Humboldt,3A-P4_A,U.S. Senate,,IND,Jason Kraus,2
-Humboldt,3A-P4_A,U.S. Senate,,REP,Jerry J. Laws,9
-Humboldt,3A-P4_A,U.S. Senate,,PAF,John Thompson Parker,1
-Humboldt,3A-P4_A,U.S. Senate,,DEM,Kamala D. Harris,116
-Humboldt,3A-P4_A,U.S. Senate,,REP,Karen Roseberry,8
-Humboldt,3A-P4_A,U.S. Senate,,IND,Ling Ling Shi,3
-Humboldt,3A-P4_A,U.S. Senate,,DEM,Loretta L. Sanchez,51
-Humboldt,3A-P4_A,U.S. Senate,,LIB,Mark Matthew Herd,4
-Humboldt,3A-P4_A,U.S. Senate,,DEM,Massie Munroe,3
-Humboldt,3A-P4_A,U.S. Senate,,IND,Mike Beitiks,2
-Humboldt,3A-P4_A,U.S. Senate,,GRN,Pamela Elizondo,13
-Humboldt,3A-P4_A,U.S. Senate,,REP,Phil Wyman,9
-Humboldt,3A-P4_A,U.S. Senate,,DEM,President Cristina Grappo,3
-Humboldt,3A-P4_A,U.S. Senate,,REP,Ron Unz,1
-Humboldt,3A-P4_A,U.S. Senate,,IND,Scott A. Vineberg,1
-Humboldt,3A-P4_A,U.S. Senate,,DEM,Steve Stokes,11
-Humboldt,3A-P4_A,U.S. Senate,,REP,Thomas G. Del Beccaro,4
-Humboldt,3A-P4_A,U.S. Senate,,REP,Tom Palzer,4
 Humboldt,3AS-1,President,,REP,Ben Carson,1
 Humboldt,3AS-1,President,,DEM,Bernie Sanders,47
 Humboldt,3AS-1,President,,REP,Donald Trump,17
@@ -4086,478 +2659,287 @@ Humboldt,3AS-9,U.S. Senate,,GRN,Pamela Elizondo,3
 Humboldt,3AS-9,U.S. Senate,,REP,Phil Wyman,7
 Humboldt,3AS-9,U.S. Senate,,DEM,Steve Stokes,3
 Humboldt,3AS-9,U.S. Senate,,REP,Thomas G. Del Beccaro,2
-Humboldt,3B--1,President,,REP,Ben Carson,2
-Humboldt,3B--1,President,,DEM,Bernie Sanders,176
-Humboldt,3B--1,President,,GRN,Darryl Cherney,1
-Humboldt,3B--1,President,,REP,Donald Trump,19
-Humboldt,3B--1,President,,DEM,Hillary Clinton,48
-Humboldt,3B--1,President,,GRN,Jill Stein,3
-Humboldt,3B--1,President,,REP,John R. Kasich,1
-Humboldt,3B--1,President,,REP,Ted Cruz,5
-Humboldt,3B--1,Proposition 50,,,No,33
-Humboldt,3B--1,Proposition 50,,,Yes,181
-Humboldt,3B--1,State Assembly,2,DEM,Jim Wood,193
-Humboldt,3B--1,U.S. House,2,REP,Dale K. Mensing,21
-Humboldt,3B--1,U.S. House,2,DEM,Erin A. Schrode,33
-Humboldt,3B--1,U.S. House,2,DEM,Jared W. Huffman,166
-Humboldt,3B--1,U.S. House,2,IND,Matthew Robert Wookey,21
-Humboldt,3B--1,U.S. Senate,,IND,Clive Grey,1
-Humboldt,3B--1,U.S. Senate,,REP,Don Krampe,2
-Humboldt,3B--1,U.S. Senate,,REP,Duf Sundheim,8
+Humboldt,3B--1,President,,REP,Ben Carson,6
+Humboldt,3B--1,President,,DEM,Bernie Sanders,284
+Humboldt,3B--1,President,,GRN,Darryl Cherney,3
+Humboldt,3B--1,President,,REP,Donald Trump,49
+Humboldt,3B--1,President,,DEM,Hillary Clinton,88
+Humboldt,3B--1,President,,GRN,Jill Stein,4
+Humboldt,3B--1,President,,REP,Jim Gilmore,1
+Humboldt,3B--1,President,,REP,John R. Kasich,7
+Humboldt,3B--1,President,,DEM,Keith Judd,1
+Humboldt,3B--1,President,,LIB,Rhett White Feather Smith,1
+Humboldt,3B--1,President,,AIP,Robert Ornelas,2
+Humboldt,3B--1,President,,REP,Ted Cruz,13
+Humboldt,3B--1,President,,DEM,Willie Wilson,1
+Humboldt,3B--1,Proposition 50,,,No,69
+Humboldt,3B--1,Proposition 50,,,Yes,347
+Humboldt,3B--1,State Assembly,2,DEM,Jim Wood,353
+Humboldt,3B--1,U.S. House,2,REP,Dale K. Mensing,63
+Humboldt,3B--1,U.S. House,2,DEM,Erin A. Schrode,54
+Humboldt,3B--1,U.S. House,2,DEM,Jared W. Huffman,300
+Humboldt,3B--1,U.S. House,2,IND,Matthew Robert Wookey,34
+Humboldt,3B--1,U.S. Senate,,IND,Clive Grey,2
+Humboldt,3B--1,U.S. Senate,,REP,Don Krampe,3
+Humboldt,3B--1,U.S. Senate,,REP,Duf Sundheim,18
 Humboldt,3B--1,U.S. Senate,,IND,Eleanor García,1
-Humboldt,3B--1,U.S. Senate,,LIB,Gail K. Lightfoot,10
-Humboldt,3B--1,U.S. Senate,,IND,Gar Myers,1
-Humboldt,3B--1,U.S. Senate,,REP,George C. Yang,1
-Humboldt,3B--1,U.S. Senate,,REP,Greg Conlon,1
-Humboldt,3B--1,U.S. Senate,,REP,Jerry J. Laws,5
-Humboldt,3B--1,U.S. Senate,,DEM,Kamala D. Harris,106
-Humboldt,3B--1,U.S. Senate,,REP,Karen Roseberry,1
+Humboldt,3B--1,U.S. Senate,,LIB,Gail K. Lightfoot,22
+Humboldt,3B--1,U.S. Senate,,IND,Gar Myers,2
+Humboldt,3B--1,U.S. Senate,,REP,George C. Yang,2
+Humboldt,3B--1,U.S. Senate,,REP,Greg Conlon,14
+Humboldt,3B--1,U.S. Senate,,REP,Jarrell Williamson,1
+Humboldt,3B--1,U.S. Senate,,REP,Jerry J. Laws,12
+Humboldt,3B--1,U.S. Senate,,PAF,John Thompson Parker,2
+Humboldt,3B--1,U.S. Senate,,DEM,Kamala D. Harris,185
+Humboldt,3B--1,U.S. Senate,,REP,Karen Roseberry,3
 Humboldt,3B--1,U.S. Senate,,IND,Ling Ling Shi,2
-Humboldt,3B--1,U.S. Senate,,DEM,Loretta L. Sanchez,48
-Humboldt,3B--1,U.S. Senate,,DEM,Massie Munroe,6
-Humboldt,3B--1,U.S. Senate,,IND,Mike Beitiks,4
-Humboldt,3B--1,U.S. Senate,,GRN,Pamela Elizondo,13
-Humboldt,3B--1,U.S. Senate,,IND,Paul Merritt,1
-Humboldt,3B--1,U.S. Senate,,REP,Phil Wyman,6
+Humboldt,3B--1,U.S. Senate,,DEM,Loretta L. Sanchez,82
+Humboldt,3B--1,U.S. Senate,,LIB,Mark Matthew Herd,1
+Humboldt,3B--1,U.S. Senate,,DEM,Massie Munroe,8
+Humboldt,3B--1,U.S. Senate,,IND,Mike Beitiks,10
+Humboldt,3B--1,U.S. Senate,,GRN,Pamela Elizondo,20
+Humboldt,3B--1,U.S. Senate,,IND,Paul Merritt,2
+Humboldt,3B--1,U.S. Senate,,REP,Phil Wyman,17
 Humboldt,3B--1,U.S. Senate,,DEM,President Cristina Grappo,1
 Humboldt,3B--1,U.S. Senate,,REP,Ron Unz,1
-Humboldt,3B--1,U.S. Senate,,DEM,Steve Stokes,14
-Humboldt,3B--1,U.S. Senate,,REP,Thomas G. Del Beccaro,1
-Humboldt,3B--1,U.S. Senate,,REP,Tom Palzer,1
-Humboldt,3B--1,U.S. Senate,,REP,Von Hougo,1
-Humboldt,3B--1_A,President,,REP,Ben Carson,4
-Humboldt,3B--1_A,President,,DEM,Bernie Sanders,108
-Humboldt,3B--1_A,President,,GRN,Darryl Cherney,2
-Humboldt,3B--1_A,President,,REP,Donald Trump,30
-Humboldt,3B--1_A,President,,DEM,Hillary Clinton,40
-Humboldt,3B--1_A,President,,GRN,Jill Stein,1
-Humboldt,3B--1_A,President,,REP,Jim Gilmore,1
-Humboldt,3B--1_A,President,,REP,John R. Kasich,6
-Humboldt,3B--1_A,President,,DEM,Keith Judd,1
-Humboldt,3B--1_A,President,,LIB,Rhett White Feather Smith,1
-Humboldt,3B--1_A,President,,AIP,Robert Ornelas,2
-Humboldt,3B--1_A,President,,REP,Ted Cruz,8
-Humboldt,3B--1_A,President,,DEM,Willie Wilson,1
-Humboldt,3B--1_A,Proposition 50,,,No,36
-Humboldt,3B--1_A,Proposition 50,,,Yes,166
-Humboldt,3B--1_A,State Assembly,2,DEM,Jim Wood,160
-Humboldt,3B--1_A,U.S. House,2,REP,Dale K. Mensing,42
-Humboldt,3B--1_A,U.S. House,2,DEM,Erin A. Schrode,21
-Humboldt,3B--1_A,U.S. House,2,DEM,Jared W. Huffman,134
-Humboldt,3B--1_A,U.S. House,2,IND,Matthew Robert Wookey,13
-Humboldt,3B--1_A,U.S. Senate,,IND,Clive Grey,1
-Humboldt,3B--1_A,U.S. Senate,,REP,Don Krampe,1
-Humboldt,3B--1_A,U.S. Senate,,REP,Duf Sundheim,10
-Humboldt,3B--1_A,U.S. Senate,,LIB,Gail K. Lightfoot,12
-Humboldt,3B--1_A,U.S. Senate,,IND,Gar Myers,1
-Humboldt,3B--1_A,U.S. Senate,,REP,George C. Yang,1
-Humboldt,3B--1_A,U.S. Senate,,REP,Greg Conlon,13
-Humboldt,3B--1_A,U.S. Senate,,REP,Jarrell Williamson,1
-Humboldt,3B--1_A,U.S. Senate,,REP,Jerry J. Laws,7
-Humboldt,3B--1_A,U.S. Senate,,PAF,John Thompson Parker,2
-Humboldt,3B--1_A,U.S. Senate,,DEM,Kamala D. Harris,79
-Humboldt,3B--1_A,U.S. Senate,,REP,Karen Roseberry,2
-Humboldt,3B--1_A,U.S. Senate,,DEM,Loretta L. Sanchez,34
-Humboldt,3B--1_A,U.S. Senate,,LIB,Mark Matthew Herd,1
-Humboldt,3B--1_A,U.S. Senate,,DEM,Massie Munroe,2
-Humboldt,3B--1_A,U.S. Senate,,IND,Mike Beitiks,6
-Humboldt,3B--1_A,U.S. Senate,,GRN,Pamela Elizondo,7
-Humboldt,3B--1_A,U.S. Senate,,IND,Paul Merritt,1
-Humboldt,3B--1_A,U.S. Senate,,REP,Phil Wyman,11
-Humboldt,3B--1_A,U.S. Senate,,DEM,Steve Stokes,8
-Humboldt,3B--1_A,U.S. Senate,,REP,Thomas G. Del Beccaro,1
-Humboldt,3B--1_A,U.S. Senate,,REP,Tom Palzer,1
-Humboldt,3B--1_A,U.S. Senate,,REP,Von Hougo,4
-Humboldt,3ES-6,President,,AIP,Alan Spears,1
-Humboldt,3ES-6,President,,REP,Ben Carson,1
-Humboldt,3ES-6,President,,DEM,Bernie Sanders,53
+Humboldt,3B--1,U.S. Senate,,DEM,Steve Stokes,22
+Humboldt,3B--1,U.S. Senate,,REP,Thomas G. Del Beccaro,2
+Humboldt,3B--1,U.S. Senate,,REP,Tom Palzer,2
+Humboldt,3B--1,U.S. Senate,,REP,Von Hougo,5
+Humboldt,3ES-6,President,,AIP,Alan Spears,2
+Humboldt,3ES-6,President,,REP,Ben Carson,4
+Humboldt,3ES-6,President,,DEM,Bernie Sanders,121
 Humboldt,3ES-6,President,,GRN,Darryl Cherney,1
-Humboldt,3ES-6,President,,REP,Donald Trump,27
-Humboldt,3ES-6,President,,DEM,Hillary Clinton,22
+Humboldt,3ES-6,President,,REP,Donald Trump,77
+Humboldt,3ES-6,President,,LIB,Gary Johnson,2
+Humboldt,3ES-6,President,,DEM,Hillary Clinton,69
 Humboldt,3ES-6,President,,REP,Jim Gilmore,1
-Humboldt,3ES-6,President,,REP,John R. Kasich,3
+Humboldt,3ES-6,President,,REP,John R. Kasich,16
 Humboldt,3ES-6,President,,PAF,Lynn S. Kahn,1
-Humboldt,3ES-6,President,,GRN,Sedinam Moyowasifsa-Curry,1
-Humboldt,3ES-6,President,,REP,Ted Cruz,2
-Humboldt,3ES-6,Proposition 50,,,No,24
-Humboldt,3ES-6,Proposition 50,,,Yes,75
-Humboldt,3ES-6,State Assembly,2,DEM,Jim Wood,74
-Humboldt,3ES-6,U.S. House,2,REP,Dale K. Mensing,23
-Humboldt,3ES-6,U.S. House,2,DEM,Erin A. Schrode,12
-Humboldt,3ES-6,U.S. House,2,DEM,Jared W. Huffman,59
-Humboldt,3ES-6,U.S. House,2,IND,Matthew Robert Wookey,8
+Humboldt,3ES-6,President,,GRN,Sedinam Moyowasifsa-Curry,2
+Humboldt,3ES-6,President,,REP,Ted Cruz,7
+Humboldt,3ES-6,President,,DEM,Willie Wilson,1
+Humboldt,3ES-6,Proposition 50,,,No,71
+Humboldt,3ES-6,Proposition 50,,,Yes,212
+Humboldt,3ES-6,State Assembly,2,DEM,Jim Wood,218
+Humboldt,3ES-6,U.S. House,2,REP,Dale K. Mensing,74
+Humboldt,3ES-6,U.S. House,2,DEM,Erin A. Schrode,18
+Humboldt,3ES-6,U.S. House,2,DEM,Jared W. Huffman,183
+Humboldt,3ES-6,U.S. House,2,IND,Matthew Robert Wookey,27
 Humboldt,3ES-6,U.S. Senate,,IND,Clive Grey,1
 Humboldt,3ES-6,U.S. Senate,,IND,Don J. Grundmann,2
-Humboldt,3ES-6,U.S. Senate,,REP,Duf Sundheim,3
-Humboldt,3ES-6,U.S. Senate,,LIB,Gail K. Lightfoot,4
-Humboldt,3ES-6,U.S. Senate,,REP,George C. Yang,2
-Humboldt,3ES-6,U.S. Senate,,REP,Greg Conlon,4
+Humboldt,3ES-6,U.S. Senate,,REP,Duf Sundheim,21
+Humboldt,3ES-6,U.S. Senate,,IND,Eleanor García,1
+Humboldt,3ES-6,U.S. Senate,,LIB,Gail K. Lightfoot,14
+Humboldt,3ES-6,U.S. Senate,,REP,George C. Yang,6
+Humboldt,3ES-6,U.S. Senate,,REP,Greg Conlon,17
 Humboldt,3ES-6,U.S. Senate,,DEM,Herbert G. Peters,1
+Humboldt,3ES-6,U.S. Senate,,REP,Jarrell Williamson,2
 Humboldt,3ES-6,U.S. Senate,,IND,Jason Hanania,1
-Humboldt,3ES-6,U.S. Senate,,REP,Jerry J. Laws,4
-Humboldt,3ES-6,U.S. Senate,,DEM,Kamala D. Harris,32
+Humboldt,3ES-6,U.S. Senate,,REP,Jerry J. Laws,11
+Humboldt,3ES-6,U.S. Senate,,DEM,Kamala D. Harris,112
+Humboldt,3ES-6,U.S. Senate,,REP,Karen Roseberry,1
 Humboldt,3ES-6,U.S. Senate,,IND,Ling Ling Shi,1
-Humboldt,3ES-6,U.S. Senate,,DEM,Loretta L. Sanchez,16
-Humboldt,3ES-6,U.S. Senate,,DEM,Massie Munroe,2
-Humboldt,3ES-6,U.S. Senate,,GRN,Pamela Elizondo,3
-Humboldt,3ES-6,U.S. Senate,,REP,Phil Wyman,7
-Humboldt,3ES-6,U.S. Senate,,REP,Ron Unz,2
-Humboldt,3ES-6,U.S. Senate,,IND,Scott A. Vineberg,3
-Humboldt,3ES-6,U.S. Senate,,DEM,Steve Stokes,5
-Humboldt,3ES-6,U.S. Senate,,REP,Thomas G. Del Beccaro,5
-Humboldt,3ES-6,U.S. Senate,,REP,Von Hougo,3
-Humboldt,3ES-6_A,President,,AIP,Alan Spears,1
-Humboldt,3ES-6_A,President,,REP,Ben Carson,3
-Humboldt,3ES-6_A,President,,DEM,Bernie Sanders,68
-Humboldt,3ES-6_A,President,,REP,Donald Trump,50
-Humboldt,3ES-6_A,President,,LIB,Gary Johnson,2
-Humboldt,3ES-6_A,President,,DEM,Hillary Clinton,47
-Humboldt,3ES-6_A,President,,REP,John R. Kasich,13
-Humboldt,3ES-6_A,President,,GRN,Sedinam Moyowasifsa-Curry,1
-Humboldt,3ES-6_A,President,,REP,Ted Cruz,5
-Humboldt,3ES-6_A,President,,DEM,Willie Wilson,1
-Humboldt,3ES-6_A,Proposition 50,,,No,47
-Humboldt,3ES-6_A,Proposition 50,,,Yes,137
-Humboldt,3ES-6_A,State Assembly,2,DEM,Jim Wood,144
-Humboldt,3ES-6_A,U.S. House,2,REP,Dale K. Mensing,51
-Humboldt,3ES-6_A,U.S. House,2,DEM,Erin A. Schrode,6
-Humboldt,3ES-6_A,U.S. House,2,DEM,Jared W. Huffman,124
-Humboldt,3ES-6_A,U.S. House,2,IND,Matthew Robert Wookey,19
-Humboldt,3ES-6_A,U.S. Senate,,REP,Duf Sundheim,18
-Humboldt,3ES-6_A,U.S. Senate,,IND,Eleanor García,1
-Humboldt,3ES-6_A,U.S. Senate,,LIB,Gail K. Lightfoot,10
-Humboldt,3ES-6_A,U.S. Senate,,REP,George C. Yang,4
-Humboldt,3ES-6_A,U.S. Senate,,REP,Greg Conlon,13
-Humboldt,3ES-6_A,U.S. Senate,,REP,Jarrell Williamson,2
-Humboldt,3ES-6_A,U.S. Senate,,REP,Jerry J. Laws,7
-Humboldt,3ES-6_A,U.S. Senate,,DEM,Kamala D. Harris,80
-Humboldt,3ES-6_A,U.S. Senate,,REP,Karen Roseberry,1
-Humboldt,3ES-6_A,U.S. Senate,,DEM,Loretta L. Sanchez,17
-Humboldt,3ES-6_A,U.S. Senate,,DEM,Massie Munroe,1
-Humboldt,3ES-6_A,U.S. Senate,,IND,Mike Beitiks,1
-Humboldt,3ES-6_A,U.S. Senate,,GRN,Pamela Elizondo,1
-Humboldt,3ES-6_A,U.S. Senate,,REP,Phil Wyman,12
-Humboldt,3ES-6_A,U.S. Senate,,DEM,President Cristina Grappo,1
-Humboldt,3ES-6_A,U.S. Senate,,REP,Ron Unz,1
-Humboldt,3ES-6_A,U.S. Senate,,IND,Scott A. Vineberg,1
-Humboldt,3ES-6_A,U.S. Senate,,DEM,Steve Stokes,8
-Humboldt,3ES-6_A,U.S. Senate,,REP,Thomas G. Del Beccaro,8
-Humboldt,3ES-6_A,U.S. Senate,,REP,Tom Palzer,2
-Humboldt,3ES-6_A,U.S. Senate,,REP,Von Hougo,1
-Humboldt,3FW,President,,REP,Ben Carson,1
-Humboldt,3FW,President,,DEM,Bernie Sanders,147
-Humboldt,3FW,President,,GRN,Darryl Cherney,1
-Humboldt,3FW,President,,REP,Donald Trump,23
-Humboldt,3FW,President,,DEM,Henry Hewes,1
-Humboldt,3FW,President,,DEM,Hillary Clinton,56
-Humboldt,3FW,President,,GRN,Jill Stein,1
-Humboldt,3FW,President,,REP,John R. Kasich,1
+Humboldt,3ES-6,U.S. Senate,,DEM,Loretta L. Sanchez,33
+Humboldt,3ES-6,U.S. Senate,,DEM,Massie Munroe,3
+Humboldt,3ES-6,U.S. Senate,,IND,Mike Beitiks,1
+Humboldt,3ES-6,U.S. Senate,,GRN,Pamela Elizondo,4
+Humboldt,3ES-6,U.S. Senate,,REP,Phil Wyman,19
+Humboldt,3ES-6,U.S. Senate,,DEM,President Cristina Grappo,1
+Humboldt,3ES-6,U.S. Senate,,REP,Ron Unz,3
+Humboldt,3ES-6,U.S. Senate,,IND,Scott A. Vineberg,4
+Humboldt,3ES-6,U.S. Senate,,DEM,Steve Stokes,13
+Humboldt,3ES-6,U.S. Senate,,REP,Thomas G. Del Beccaro,13
+Humboldt,3ES-6,U.S. Senate,,REP,Tom Palzer,2
+Humboldt,3ES-6,U.S. Senate,,REP,Von Hougo,4
+Humboldt,3FW,President,,REP,Ben Carson,6
+Humboldt,3FW,President,,DEM,Bernie Sanders,279
+Humboldt,3FW,President,,GRN,Darryl Cherney,3
+Humboldt,3FW,President,,REP,Donald Trump,88
+Humboldt,3FW,President,,LIB,Gary Johnson,1
+Humboldt,3FW,President,,DEM,Henry Hewes,2
+Humboldt,3FW,President,,DEM,Hillary Clinton,132
+Humboldt,3FW,President,,AIP,James Hedges,1
+Humboldt,3FW,President,,GRN,Jill Stein,3
+Humboldt,3FW,President,,REP,Jim Gilmore,1
+Humboldt,3FW,President,,REP,John R. Kasich,11
 Humboldt,3FW,President,,GRN,Sedinam Moyowasifsa-Curry,1
-Humboldt,3FW,President,,REP,Ted Cruz,3
-Humboldt,3FW,Proposition 50,,,No,29
-Humboldt,3FW,Proposition 50,,,Yes,179
-Humboldt,3FW,State Assembly,2,DEM,Jim Wood,176
-Humboldt,3FW,U.S. House,2,REP,Dale K. Mensing,29
-Humboldt,3FW,U.S. House,2,DEM,Erin A. Schrode,28
-Humboldt,3FW,U.S. House,2,DEM,Jared W. Huffman,154
-Humboldt,3FW,U.S. House,2,IND,Matthew Robert Wookey,15
-Humboldt,3FW,U.S. Senate,,IND,Clive Grey,2
-Humboldt,3FW,U.S. Senate,,REP,Duf Sundheim,8
-Humboldt,3FW,U.S. Senate,,LIB,Gail K. Lightfoot,10
-Humboldt,3FW,U.S. Senate,,REP,George C. Yang,1
-Humboldt,3FW,U.S. Senate,,REP,Greg Conlon,5
+Humboldt,3FW,President,,REP,Ted Cruz,10
+Humboldt,3FW,Proposition 50,,,No,86
+Humboldt,3FW,Proposition 50,,,Yes,428
+Humboldt,3FW,State Assembly,2,DEM,Jim Wood,418
+Humboldt,3FW,U.S. House,2,REP,Dale K. Mensing,88
+Humboldt,3FW,U.S. House,2,DEM,Erin A. Schrode,50
+Humboldt,3FW,U.S. House,2,DEM,Jared W. Huffman,369
+Humboldt,3FW,U.S. House,2,IND,Matthew Robert Wookey,38
+Humboldt,3FW,U.S. Senate,,IND,Clive Grey,5
+Humboldt,3FW,U.S. Senate,,REP,Don Krampe,1
+Humboldt,3FW,U.S. Senate,,REP,Duf Sundheim,16
+Humboldt,3FW,U.S. Senate,,DEM,Emory Rodgers,3
+Humboldt,3FW,U.S. Senate,,LIB,Gail K. Lightfoot,18
+Humboldt,3FW,U.S. Senate,,REP,George C. Yang,3
+Humboldt,3FW,U.S. Senate,,REP,Greg Conlon,17
 Humboldt,3FW,U.S. Senate,,DEM,Herbert G. Peters,1
-Humboldt,3FW,U.S. Senate,,IND,Jason Kraus,1
-Humboldt,3FW,U.S. Senate,,REP,Jerry J. Laws,6
-Humboldt,3FW,U.S. Senate,,DEM,Kamala D. Harris,91
-Humboldt,3FW,U.S. Senate,,REP,Karen Roseberry,1
+Humboldt,3FW,U.S. Senate,,REP,Jarrell Williamson,4
+Humboldt,3FW,U.S. Senate,,IND,Jason Kraus,2
+Humboldt,3FW,U.S. Senate,,REP,Jerry J. Laws,14
+Humboldt,3FW,U.S. Senate,,DEM,Kamala D. Harris,229
+Humboldt,3FW,U.S. Senate,,REP,Karen Roseberry,3
 Humboldt,3FW,U.S. Senate,,IND,Ling Ling Shi,2
-Humboldt,3FW,U.S. Senate,,DEM,Loretta L. Sanchez,46
-Humboldt,3FW,U.S. Senate,,LIB,Mark Matthew Herd,1
-Humboldt,3FW,U.S. Senate,,DEM,Massie Munroe,2
-Humboldt,3FW,U.S. Senate,,IND,Mike Beitiks,2
-Humboldt,3FW,U.S. Senate,,GRN,Pamela Elizondo,18
-Humboldt,3FW,U.S. Senate,,IND,Paul Merritt,1
-Humboldt,3FW,U.S. Senate,,REP,Phil Wyman,7
+Humboldt,3FW,U.S. Senate,,DEM,Loretta L. Sanchez,95
+Humboldt,3FW,U.S. Senate,,LIB,Mark Matthew Herd,2
+Humboldt,3FW,U.S. Senate,,DEM,Massie Munroe,3
+Humboldt,3FW,U.S. Senate,,IND,Mike Beitiks,5
+Humboldt,3FW,U.S. Senate,,GRN,Pamela Elizondo,34
+Humboldt,3FW,U.S. Senate,,IND,Paul Merritt,2
+Humboldt,3FW,U.S. Senate,,REP,Phil Wyman,25
 Humboldt,3FW,U.S. Senate,,DEM,President Cristina Grappo,1
-Humboldt,3FW,U.S. Senate,,DEM,Steve Stokes,9
-Humboldt,3FW,U.S. Senate,,REP,Thomas G. Del Beccaro,2
-Humboldt,3FW,U.S. Senate,,REP,Von Hougo,1
-Humboldt,3FWS,President,,REP,Ben Carson,6
-Humboldt,3FWS,President,,DEM,Bernie Sanders,109
-Humboldt,3FWS,President,,GRN,Darryl Cherney,1
-Humboldt,3FWS,President,,REP,Donald Trump,31
+Humboldt,3FW,U.S. Senate,,REP,Ron Unz,1
+Humboldt,3FW,U.S. Senate,,IND,Scott A. Vineberg,1
+Humboldt,3FW,U.S. Senate,,DEM,Steve Stokes,22
+Humboldt,3FW,U.S. Senate,,REP,Thomas G. Del Beccaro,17
+Humboldt,3FW,U.S. Senate,,IND,Tim Gildersleeve,2
+Humboldt,3FW,U.S. Senate,,REP,Von Hougo,5
+Humboldt,3FWS,President,,REP,Ben Carson,10
+Humboldt,3FWS,President,,DEM,Bernie Sanders,224
+Humboldt,3FWS,President,,GRN,Darryl Cherney,2
+Humboldt,3FWS,President,,REP,Donald Trump,105
 Humboldt,3FWS,President,,LIB,Gary Johnson,1
-Humboldt,3FWS,President,,DEM,Hillary Clinton,56
-Humboldt,3FWS,President,,GRN,Jill Stein,2
-Humboldt,3FWS,President,,REP,John R. Kasich,3
-Humboldt,3FWS,President,,DEM,Keith Judd,1
-Humboldt,3FWS,President,,REP,Ted Cruz,7
-Humboldt,3FWS,President,,DEM,Willie Wilson,1
-Humboldt,3FWS,Proposition 50,,,No,44
-Humboldt,3FWS,Proposition 50,,,Yes,158
-Humboldt,3FWS,State Assembly,2,DEM,Jim Wood,177
-Humboldt,3FWS,U.S. House,2,REP,Dale K. Mensing,37
-Humboldt,3FWS,U.S. House,2,DEM,Erin A. Schrode,17
-Humboldt,3FWS,U.S. House,2,DEM,Jared W. Huffman,154
-Humboldt,3FWS,U.S. House,2,IND,Matthew Robert Wookey,14
-Humboldt,3FWS,U.S. Senate,,IND,Clive Grey,1
-Humboldt,3FWS,U.S. Senate,,REP,Don Krampe,3
-Humboldt,3FWS,U.S. Senate,,REP,Duf Sundheim,7
+Humboldt,3FWS,President,,DEM,Henry Hewes,2
+Humboldt,3FWS,President,,DEM,Hillary Clinton,131
+Humboldt,3FWS,President,,GRN,Jill Stein,4
+Humboldt,3FWS,President,,REP,John R. Kasich,7
+Humboldt,3FWS,President,,DEM,Keith Judd,2
+Humboldt,3FWS,President,,DEM,Michael Steinberg,4
+Humboldt,3FWS,President,,REP,Ted Cruz,15
+Humboldt,3FWS,President,,DEM,Willie Wilson,2
+Humboldt,3FWS,Proposition 50,,,No,85
+Humboldt,3FWS,Proposition 50,,,Yes,391
+Humboldt,3FWS,State Assembly,2,DEM,Jim Wood,382
+Humboldt,3FWS,U.S. House,2,REP,Dale K. Mensing,100
+Humboldt,3FWS,U.S. House,2,DEM,Erin A. Schrode,38
+Humboldt,3FWS,U.S. House,2,DEM,Jared W. Huffman,343
+Humboldt,3FWS,U.S. House,2,IND,Matthew Robert Wookey,26
+Humboldt,3FWS,U.S. Senate,,IND,Clive Grey,2
+Humboldt,3FWS,U.S. Senate,,IND,Don J. Grundmann,1
+Humboldt,3FWS,U.S. Senate,,REP,Don Krampe,9
+Humboldt,3FWS,U.S. Senate,,REP,Duf Sundheim,30
 Humboldt,3FWS,U.S. Senate,,IND,Eleanor García,1
-Humboldt,3FWS,U.S. Senate,,LIB,Gail K. Lightfoot,5
+Humboldt,3FWS,U.S. Senate,,DEM,Emory Rodgers,3
+Humboldt,3FWS,U.S. Senate,,LIB,Gail K. Lightfoot,8
 Humboldt,3FWS,U.S. Senate,,IND,Gar Myers,1
-Humboldt,3FWS,U.S. Senate,,REP,Greg Conlon,4
-Humboldt,3FWS,U.S. Senate,,REP,Jarrell Williamson,1
-Humboldt,3FWS,U.S. Senate,,REP,Jerry J. Laws,11
+Humboldt,3FWS,U.S. Senate,,REP,George C. Yang,1
+Humboldt,3FWS,U.S. Senate,,REP,Greg Conlon,21
+Humboldt,3FWS,U.S. Senate,,REP,Jarrell Williamson,3
+Humboldt,3FWS,U.S. Senate,,IND,Jason Kraus,1
+Humboldt,3FWS,U.S. Senate,,REP,Jerry J. Laws,17
 Humboldt,3FWS,U.S. Senate,,PAF,John Thompson Parker,2
-Humboldt,3FWS,U.S. Senate,,DEM,Kamala D. Harris,85
-Humboldt,3FWS,U.S. Senate,,REP,Karen Roseberry,1
-Humboldt,3FWS,U.S. Senate,,IND,Ling Ling Shi,1
-Humboldt,3FWS,U.S. Senate,,DEM,Loretta L. Sanchez,38
-Humboldt,3FWS,U.S. Senate,,LIB,Mark Matthew Herd,2
-Humboldt,3FWS,U.S. Senate,,DEM,Massie Munroe,2
+Humboldt,3FWS,U.S. Senate,,DEM,Kamala D. Harris,193
+Humboldt,3FWS,U.S. Senate,,REP,Karen Roseberry,2
+Humboldt,3FWS,U.S. Senate,,IND,Ling Ling Shi,2
+Humboldt,3FWS,U.S. Senate,,DEM,Loretta L. Sanchez,80
+Humboldt,3FWS,U.S. Senate,,LIB,Mark Matthew Herd,5
+Humboldt,3FWS,U.S. Senate,,DEM,Massie Munroe,4
 Humboldt,3FWS,U.S. Senate,,IND,Mike Beitiks,1
-Humboldt,3FWS,U.S. Senate,,GRN,Pamela Elizondo,13
-Humboldt,3FWS,U.S. Senate,,REP,Phil Wyman,13
-Humboldt,3FWS,U.S. Senate,,REP,Ron Unz,3
+Humboldt,3FWS,U.S. Senate,,GRN,Pamela Elizondo,19
+Humboldt,3FWS,U.S. Senate,,REP,Phil Wyman,30
+Humboldt,3FWS,U.S. Senate,,DEM,President Cristina Grappo,1
+Humboldt,3FWS,U.S. Senate,,REP,Ron Unz,5
 Humboldt,3FWS,U.S. Senate,,IND,Scott A. Vineberg,1
-Humboldt,3FWS,U.S. Senate,,DEM,Steve Stokes,12
+Humboldt,3FWS,U.S. Senate,,DEM,Steve Stokes,26
+Humboldt,3FWS,U.S. Senate,,REP,Thomas G. Del Beccaro,8
 Humboldt,3FWS,U.S. Senate,,IND,Tim Gildersleeve,1
-Humboldt,3FWS,U.S. Senate,,REP,Tom Palzer,1
-Humboldt,3FWS,U.S. Senate,,REP,Von Hougo,5
-Humboldt,3FWS_A,President,,REP,Ben Carson,4
-Humboldt,3FWS_A,President,,DEM,Bernie Sanders,115
-Humboldt,3FWS_A,President,,GRN,Darryl Cherney,1
-Humboldt,3FWS_A,President,,REP,Donald Trump,74
-Humboldt,3FWS_A,President,,DEM,Henry Hewes,2
-Humboldt,3FWS_A,President,,DEM,Hillary Clinton,75
-Humboldt,3FWS_A,President,,GRN,Jill Stein,2
-Humboldt,3FWS_A,President,,REP,John R. Kasich,4
-Humboldt,3FWS_A,President,,DEM,Keith Judd,1
-Humboldt,3FWS_A,President,,DEM,Michael Steinberg,4
-Humboldt,3FWS_A,President,,REP,Ted Cruz,8
-Humboldt,3FWS_A,President,,DEM,Willie Wilson,1
-Humboldt,3FWS_A,Proposition 50,,,No,41
-Humboldt,3FWS_A,Proposition 50,,,Yes,233
-Humboldt,3FWS_A,State Assembly,2,DEM,Jim Wood,205
-Humboldt,3FWS_A,U.S. House,2,REP,Dale K. Mensing,63
-Humboldt,3FWS_A,U.S. House,2,DEM,Erin A. Schrode,21
-Humboldt,3FWS_A,U.S. House,2,DEM,Jared W. Huffman,189
-Humboldt,3FWS_A,U.S. House,2,IND,Matthew Robert Wookey,12
-Humboldt,3FWS_A,U.S. Senate,,IND,Clive Grey,1
-Humboldt,3FWS_A,U.S. Senate,,IND,Don J. Grundmann,1
-Humboldt,3FWS_A,U.S. Senate,,REP,Don Krampe,6
-Humboldt,3FWS_A,U.S. Senate,,REP,Duf Sundheim,23
-Humboldt,3FWS_A,U.S. Senate,,DEM,Emory Rodgers,3
-Humboldt,3FWS_A,U.S. Senate,,LIB,Gail K. Lightfoot,3
-Humboldt,3FWS_A,U.S. Senate,,REP,George C. Yang,1
-Humboldt,3FWS_A,U.S. Senate,,REP,Greg Conlon,17
-Humboldt,3FWS_A,U.S. Senate,,REP,Jarrell Williamson,2
-Humboldt,3FWS_A,U.S. Senate,,IND,Jason Kraus,1
-Humboldt,3FWS_A,U.S. Senate,,REP,Jerry J. Laws,6
-Humboldt,3FWS_A,U.S. Senate,,DEM,Kamala D. Harris,108
-Humboldt,3FWS_A,U.S. Senate,,REP,Karen Roseberry,1
-Humboldt,3FWS_A,U.S. Senate,,IND,Ling Ling Shi,1
-Humboldt,3FWS_A,U.S. Senate,,DEM,Loretta L. Sanchez,42
-Humboldt,3FWS_A,U.S. Senate,,LIB,Mark Matthew Herd,3
-Humboldt,3FWS_A,U.S. Senate,,DEM,Massie Munroe,2
-Humboldt,3FWS_A,U.S. Senate,,GRN,Pamela Elizondo,6
-Humboldt,3FWS_A,U.S. Senate,,REP,Phil Wyman,17
-Humboldt,3FWS_A,U.S. Senate,,DEM,President Cristina Grappo,1
-Humboldt,3FWS_A,U.S. Senate,,REP,Ron Unz,2
-Humboldt,3FWS_A,U.S. Senate,,DEM,Steve Stokes,14
-Humboldt,3FWS_A,U.S. Senate,,REP,Thomas G. Del Beccaro,8
-Humboldt,3FWS_A,U.S. Senate,,REP,Tom Palzer,2
-Humboldt,3FWS_A,U.S. Senate,,REP,Von Hougo,1
-Humboldt,3FW_A,President,,REP,Ben Carson,5
-Humboldt,3FW_A,President,,DEM,Bernie Sanders,132
-Humboldt,3FW_A,President,,GRN,Darryl Cherney,2
-Humboldt,3FW_A,President,,REP,Donald Trump,65
-Humboldt,3FW_A,President,,LIB,Gary Johnson,1
-Humboldt,3FW_A,President,,DEM,Henry Hewes,1
-Humboldt,3FW_A,President,,DEM,Hillary Clinton,76
-Humboldt,3FW_A,President,,AIP,James Hedges,1
-Humboldt,3FW_A,President,,GRN,Jill Stein,2
-Humboldt,3FW_A,President,,REP,Jim Gilmore,1
-Humboldt,3FW_A,President,,REP,John R. Kasich,10
-Humboldt,3FW_A,President,,REP,Ted Cruz,7
-Humboldt,3FW_A,Proposition 50,,,No,57
-Humboldt,3FW_A,Proposition 50,,,Yes,249
-Humboldt,3FW_A,State Assembly,2,DEM,Jim Wood,242
-Humboldt,3FW_A,U.S. House,2,REP,Dale K. Mensing,59
-Humboldt,3FW_A,U.S. House,2,DEM,Erin A. Schrode,22
-Humboldt,3FW_A,U.S. House,2,DEM,Jared W. Huffman,215
-Humboldt,3FW_A,U.S. House,2,IND,Matthew Robert Wookey,23
-Humboldt,3FW_A,U.S. Senate,,IND,Clive Grey,3
-Humboldt,3FW_A,U.S. Senate,,REP,Don Krampe,1
-Humboldt,3FW_A,U.S. Senate,,REP,Duf Sundheim,8
-Humboldt,3FW_A,U.S. Senate,,DEM,Emory Rodgers,3
-Humboldt,3FW_A,U.S. Senate,,LIB,Gail K. Lightfoot,8
-Humboldt,3FW_A,U.S. Senate,,REP,George C. Yang,2
-Humboldt,3FW_A,U.S. Senate,,REP,Greg Conlon,12
-Humboldt,3FW_A,U.S. Senate,,REP,Jarrell Williamson,4
-Humboldt,3FW_A,U.S. Senate,,IND,Jason Kraus,1
-Humboldt,3FW_A,U.S. Senate,,REP,Jerry J. Laws,8
-Humboldt,3FW_A,U.S. Senate,,DEM,Kamala D. Harris,138
-Humboldt,3FW_A,U.S. Senate,,REP,Karen Roseberry,2
-Humboldt,3FW_A,U.S. Senate,,DEM,Loretta L. Sanchez,49
-Humboldt,3FW_A,U.S. Senate,,LIB,Mark Matthew Herd,1
-Humboldt,3FW_A,U.S. Senate,,DEM,Massie Munroe,1
-Humboldt,3FW_A,U.S. Senate,,IND,Mike Beitiks,3
-Humboldt,3FW_A,U.S. Senate,,GRN,Pamela Elizondo,16
-Humboldt,3FW_A,U.S. Senate,,IND,Paul Merritt,1
-Humboldt,3FW_A,U.S. Senate,,REP,Phil Wyman,18
-Humboldt,3FW_A,U.S. Senate,,REP,Ron Unz,1
-Humboldt,3FW_A,U.S. Senate,,IND,Scott A. Vineberg,1
-Humboldt,3FW_A,U.S. Senate,,DEM,Steve Stokes,13
-Humboldt,3FW_A,U.S. Senate,,REP,Thomas G. Del Beccaro,15
-Humboldt,3FW_A,U.S. Senate,,IND,Tim Gildersleeve,2
-Humboldt,3FW_A,U.S. Senate,,REP,Von Hougo,4
-Humboldt,3JCFR,President,,REP,Ben Carson,2
-Humboldt,3JCFR,President,,DEM,Bernie Sanders,107
+Humboldt,3FWS,U.S. Senate,,REP,Tom Palzer,3
+Humboldt,3FWS,U.S. Senate,,REP,Von Hougo,6
+Humboldt,3JCFR,President,,REP,Ben Carson,5
+Humboldt,3JCFR,President,,DEM,Bernie Sanders,199
 Humboldt,3JCFR,President,,GRN,Darryl Cherney,1
-Humboldt,3JCFR,President,,REP,Donald Trump,12
-Humboldt,3JCFR,President,,DEM,Hillary Clinton,38
-Humboldt,3JCFR,President,,GRN,Jill Stein,5
-Humboldt,3JCFR,President,,REP,John R. Kasich,3
+Humboldt,3JCFR,President,,REP,Donald Trump,46
+Humboldt,3JCFR,President,,DEM,Hillary Clinton,100
+Humboldt,3JCFR,President,,GRN,Jill Stein,8
+Humboldt,3JCFR,President,,REP,Jim Gilmore,1
+Humboldt,3JCFR,President,,REP,John R. Kasich,13
 Humboldt,3JCFR,President,,LIB,Marc Feldman,1
-Humboldt,3JCFR,President,,REP,Ted Cruz,2
-Humboldt,3JCFR,Proposition 50,,,No,29
-Humboldt,3JCFR,Proposition 50,,,Yes,127
-Humboldt,3JCFR,State Assembly,2,DEM,Jim Wood,138
-Humboldt,3JCFR,U.S. House,2,REP,Dale K. Mensing,15
-Humboldt,3JCFR,U.S. House,2,DEM,Erin A. Schrode,20
-Humboldt,3JCFR,U.S. House,2,DEM,Jared W. Huffman,125
-Humboldt,3JCFR,U.S. House,2,IND,Matthew Robert Wookey,9
+Humboldt,3JCFR,President,,REP,Ted Cruz,5
+Humboldt,3JCFR,Proposition 50,,,No,69
+Humboldt,3JCFR,Proposition 50,,,Yes,289
+Humboldt,3JCFR,State Assembly,2,DEM,Jim Wood,298
+Humboldt,3JCFR,U.S. House,2,REP,Dale K. Mensing,44
+Humboldt,3JCFR,U.S. House,2,DEM,Erin A. Schrode,32
+Humboldt,3JCFR,U.S. House,2,DEM,Jared W. Huffman,280
+Humboldt,3JCFR,U.S. House,2,IND,Matthew Robert Wookey,22
 Humboldt,3JCFR,U.S. Senate,,IND,Clive Grey,5
 Humboldt,3JCFR,U.S. Senate,,IND,Don J. Grundmann,1
-Humboldt,3JCFR,U.S. Senate,,REP,Duf Sundheim,6
-Humboldt,3JCFR,U.S. Senate,,LIB,Gail K. Lightfoot,3
-Humboldt,3JCFR,U.S. Senate,,REP,Greg Conlon,6
+Humboldt,3JCFR,U.S. Senate,,REP,Don Krampe,1
+Humboldt,3JCFR,U.S. Senate,,REP,Duf Sundheim,14
+Humboldt,3JCFR,U.S. Senate,,IND,Eleanor García,1
+Humboldt,3JCFR,U.S. Senate,,LIB,Gail K. Lightfoot,7
+Humboldt,3JCFR,U.S. Senate,,REP,George C. Yang,4
+Humboldt,3JCFR,U.S. Senate,,REP,Greg Conlon,13
 Humboldt,3JCFR,U.S. Senate,,REP,Jarrell Williamson,2
-Humboldt,3JCFR,U.S. Senate,,REP,Jerry J. Laws,4
-Humboldt,3JCFR,U.S. Senate,,DEM,Kamala D. Harris,74
-Humboldt,3JCFR,U.S. Senate,,DEM,Loretta L. Sanchez,35
-Humboldt,3JCFR,U.S. Senate,,DEM,Massie Munroe,2
+Humboldt,3JCFR,U.S. Senate,,IND,Jason Hanania,2
+Humboldt,3JCFR,U.S. Senate,,REP,Jerry J. Laws,7
+Humboldt,3JCFR,U.S. Senate,,PAF,John Thompson Parker,1
+Humboldt,3JCFR,U.S. Senate,,DEM,Kamala D. Harris,192
+Humboldt,3JCFR,U.S. Senate,,REP,Karen Roseberry,1
+Humboldt,3JCFR,U.S. Senate,,DEM,Loretta L. Sanchez,58
+Humboldt,3JCFR,U.S. Senate,,LIB,Mark Matthew Herd,2
+Humboldt,3JCFR,U.S. Senate,,DEM,Massie Munroe,3
 Humboldt,3JCFR,U.S. Senate,,IND,Mike Beitiks,2
-Humboldt,3JCFR,U.S. Senate,,GRN,Pamela Elizondo,9
-Humboldt,3JCFR,U.S. Senate,,REP,Phil Wyman,2
+Humboldt,3JCFR,U.S. Senate,,GRN,Pamela Elizondo,18
+Humboldt,3JCFR,U.S. Senate,,IND,Paul Merritt,1
+Humboldt,3JCFR,U.S. Senate,,REP,Phil Wyman,11
 Humboldt,3JCFR,U.S. Senate,,DEM,President Cristina Grappo,1
-Humboldt,3JCFR,U.S. Senate,,REP,Ron Unz,1
-Humboldt,3JCFR,U.S. Senate,,DEM,Steve Stokes,8
+Humboldt,3JCFR,U.S. Senate,,REP,Ron Unz,2
+Humboldt,3JCFR,U.S. Senate,,DEM,Steve Stokes,11
+Humboldt,3JCFR,U.S. Senate,,REP,Thomas G. Del Beccaro,5
 Humboldt,3JCFR,U.S. Senate,,REP,Von Hougo,1
-Humboldt,3JCFR_A,President,,REP,Ben Carson,3
-Humboldt,3JCFR_A,President,,DEM,Bernie Sanders,92
-Humboldt,3JCFR_A,President,,REP,Donald Trump,34
-Humboldt,3JCFR_A,President,,DEM,Hillary Clinton,62
-Humboldt,3JCFR_A,President,,GRN,Jill Stein,3
-Humboldt,3JCFR_A,President,,REP,Jim Gilmore,1
-Humboldt,3JCFR_A,President,,REP,John R. Kasich,10
-Humboldt,3JCFR_A,President,,REP,Ted Cruz,3
-Humboldt,3JCFR_A,Proposition 50,,,No,40
-Humboldt,3JCFR_A,Proposition 50,,,Yes,162
-Humboldt,3JCFR_A,State Assembly,2,DEM,Jim Wood,160
-Humboldt,3JCFR_A,U.S. House,2,REP,Dale K. Mensing,29
-Humboldt,3JCFR_A,U.S. House,2,DEM,Erin A. Schrode,12
-Humboldt,3JCFR_A,U.S. House,2,DEM,Jared W. Huffman,155
-Humboldt,3JCFR_A,U.S. House,2,IND,Matthew Robert Wookey,13
-Humboldt,3JCFR_A,U.S. Senate,,REP,Don Krampe,1
-Humboldt,3JCFR_A,U.S. Senate,,REP,Duf Sundheim,8
-Humboldt,3JCFR_A,U.S. Senate,,IND,Eleanor García,1
-Humboldt,3JCFR_A,U.S. Senate,,LIB,Gail K. Lightfoot,4
-Humboldt,3JCFR_A,U.S. Senate,,REP,George C. Yang,4
-Humboldt,3JCFR_A,U.S. Senate,,REP,Greg Conlon,7
-Humboldt,3JCFR_A,U.S. Senate,,IND,Jason Hanania,2
-Humboldt,3JCFR_A,U.S. Senate,,REP,Jerry J. Laws,3
-Humboldt,3JCFR_A,U.S. Senate,,PAF,John Thompson Parker,1
-Humboldt,3JCFR_A,U.S. Senate,,DEM,Kamala D. Harris,118
-Humboldt,3JCFR_A,U.S. Senate,,REP,Karen Roseberry,1
-Humboldt,3JCFR_A,U.S. Senate,,DEM,Loretta L. Sanchez,23
-Humboldt,3JCFR_A,U.S. Senate,,LIB,Mark Matthew Herd,2
-Humboldt,3JCFR_A,U.S. Senate,,DEM,Massie Munroe,1
-Humboldt,3JCFR_A,U.S. Senate,,GRN,Pamela Elizondo,9
-Humboldt,3JCFR_A,U.S. Senate,,IND,Paul Merritt,1
-Humboldt,3JCFR_A,U.S. Senate,,REP,Phil Wyman,9
-Humboldt,3JCFR_A,U.S. Senate,,REP,Ron Unz,1
-Humboldt,3JCFR_A,U.S. Senate,,DEM,Steve Stokes,3
-Humboldt,3JCFR_A,U.S. Senate,,REP,Thomas G. Del Beccaro,5
-Humboldt,3JCWR,President,,REP,Ben Carson,1
-Humboldt,3JCWR,President,,DEM,Bernie Sanders,101
-Humboldt,3JCWR,President,,REP,Donald Trump,7
-Humboldt,3JCWR,President,,DEM,Hillary Clinton,54
-Humboldt,3JCWR,President,,GRN,Jill Stein,3
+Humboldt,3JCWR,President,,REP,Ben Carson,7
+Humboldt,3JCWR,President,,DEM,Bernie Sanders,217
+Humboldt,3JCWR,President,,GRN,Darryl Cherney,1
+Humboldt,3JCWR,President,,REP,Donald Trump,49
+Humboldt,3JCWR,President,,LIB,Gary Johnson,1
+Humboldt,3JCWR,President,,DEM,Hillary Clinton,130
+Humboldt,3JCWR,President,,GRN,Jill Stein,6
 Humboldt,3JCWR,President,,REP,Jim Gilmore,1
 Humboldt,3JCWR,President,,LIB,John Hale,1
-Humboldt,3JCWR,President,,REP,John R. Kasich,6
-Humboldt,3JCWR,President,,REP,Ted Cruz,3
-Humboldt,3JCWR,President,,DEM,Willie Wilson,2
-Humboldt,3JCWR,Proposition 50,,,No,37
-Humboldt,3JCWR,Proposition 50,,,Yes,119
-Humboldt,3JCWR,State Assembly,2,DEM,Jim Wood,133
-Humboldt,3JCWR,U.S. House,2,REP,Dale K. Mensing,18
-Humboldt,3JCWR,U.S. House,2,DEM,Erin A. Schrode,31
-Humboldt,3JCWR,U.S. House,2,DEM,Jared W. Huffman,119
-Humboldt,3JCWR,U.S. House,2,IND,Matthew Robert Wookey,11
+Humboldt,3JCWR,President,,REP,John R. Kasich,9
+Humboldt,3JCWR,President,,DEM,Keith Judd,1
+Humboldt,3JCWR,President,,REP,Ted Cruz,8
+Humboldt,3JCWR,President,,DEM,Willie Wilson,3
+Humboldt,3JCWR,Proposition 50,,,No,83
+Humboldt,3JCWR,Proposition 50,,,Yes,323
+Humboldt,3JCWR,State Assembly,2,DEM,Jim Wood,336
+Humboldt,3JCWR,U.S. House,2,REP,Dale K. Mensing,59
+Humboldt,3JCWR,U.S. House,2,DEM,Erin A. Schrode,52
+Humboldt,3JCWR,U.S. House,2,DEM,Jared W. Huffman,309
+Humboldt,3JCWR,U.S. House,2,IND,Matthew Robert Wookey,25
 Humboldt,3JCWR,U.S. Senate,,IND,Clive Grey,1
-Humboldt,3JCWR,U.S. Senate,,REP,Duf Sundheim,5
-Humboldt,3JCWR,U.S. Senate,,LIB,Gail K. Lightfoot,4
-Humboldt,3JCWR,U.S. Senate,,REP,Greg Conlon,2
-Humboldt,3JCWR,U.S. Senate,,IND,Jason Kraus,2
-Humboldt,3JCWR,U.S. Senate,,REP,Jerry J. Laws,4
-Humboldt,3JCWR,U.S. Senate,,DEM,Kamala D. Harris,78
-Humboldt,3JCWR,U.S. Senate,,REP,Karen Roseberry,1
+Humboldt,3JCWR,U.S. Senate,,REP,Duf Sundheim,18
+Humboldt,3JCWR,U.S. Senate,,LIB,Gail K. Lightfoot,6
+Humboldt,3JCWR,U.S. Senate,,REP,George C. Yang,3
+Humboldt,3JCWR,U.S. Senate,,REP,Greg Conlon,14
+Humboldt,3JCWR,U.S. Senate,,DEM,Herbert G. Peters,1
+Humboldt,3JCWR,U.S. Senate,,REP,Jarrell Williamson,2
+Humboldt,3JCWR,U.S. Senate,,IND,Jason Hanania,1
+Humboldt,3JCWR,U.S. Senate,,IND,Jason Kraus,3
+Humboldt,3JCWR,U.S. Senate,,REP,Jerry J. Laws,7
+Humboldt,3JCWR,U.S. Senate,,DEM,Kamala D. Harris,207
+Humboldt,3JCWR,U.S. Senate,,REP,Karen Roseberry,4
 Humboldt,3JCWR,U.S. Senate,,IND,Ling Ling Shi,3
-Humboldt,3JCWR,U.S. Senate,,DEM,Loretta L. Sanchez,28
+Humboldt,3JCWR,U.S. Senate,,DEM,Loretta L. Sanchez,71
 Humboldt,3JCWR,U.S. Senate,,LIB,Mark Matthew Herd,1
-Humboldt,3JCWR,U.S. Senate,,DEM,Massie Munroe,3
-Humboldt,3JCWR,U.S. Senate,,GRN,Pamela Elizondo,10
+Humboldt,3JCWR,U.S. Senate,,DEM,Massie Munroe,5
+Humboldt,3JCWR,U.S. Senate,,IND,Mike Beitiks,2
+Humboldt,3JCWR,U.S. Senate,,GRN,Pamela Elizondo,16
 Humboldt,3JCWR,U.S. Senate,,IND,Paul Merritt,1
-Humboldt,3JCWR,U.S. Senate,,REP,Phil Wyman,4
-Humboldt,3JCWR,U.S. Senate,,REP,Ron Unz,2
+Humboldt,3JCWR,U.S. Senate,,REP,Phil Wyman,17
+Humboldt,3JCWR,U.S. Senate,,REP,Ron Unz,4
 Humboldt,3JCWR,U.S. Senate,,IND,Scott A. Vineberg,1
-Humboldt,3JCWR,U.S. Senate,,DEM,Steve Stokes,12
-Humboldt,3JCWR,U.S. Senate,,REP,Thomas G. Del Beccaro,4
-Humboldt,3JCWR,U.S. Senate,,REP,Von Hougo,1
-Humboldt,3JCWR_A,President,,REP,Ben Carson,6
-Humboldt,3JCWR_A,President,,DEM,Bernie Sanders,116
-Humboldt,3JCWR_A,President,,GRN,Darryl Cherney,1
-Humboldt,3JCWR_A,President,,REP,Donald Trump,42
-Humboldt,3JCWR_A,President,,LIB,Gary Johnson,1
-Humboldt,3JCWR_A,President,,DEM,Hillary Clinton,76
-Humboldt,3JCWR_A,President,,GRN,Jill Stein,3
-Humboldt,3JCWR_A,President,,REP,John R. Kasich,3
-Humboldt,3JCWR_A,President,,DEM,Keith Judd,1
-Humboldt,3JCWR_A,President,,REP,Ted Cruz,5
-Humboldt,3JCWR_A,President,,DEM,Willie Wilson,1
-Humboldt,3JCWR_A,Proposition 50,,,No,46
-Humboldt,3JCWR_A,Proposition 50,,,Yes,204
-Humboldt,3JCWR_A,State Assembly,2,DEM,Jim Wood,203
-Humboldt,3JCWR_A,U.S. House,2,REP,Dale K. Mensing,41
-Humboldt,3JCWR_A,U.S. House,2,DEM,Erin A. Schrode,21
-Humboldt,3JCWR_A,U.S. House,2,DEM,Jared W. Huffman,190
-Humboldt,3JCWR_A,U.S. House,2,IND,Matthew Robert Wookey,14
-Humboldt,3JCWR_A,U.S. Senate,,REP,Duf Sundheim,13
-Humboldt,3JCWR_A,U.S. Senate,,LIB,Gail K. Lightfoot,2
-Humboldt,3JCWR_A,U.S. Senate,,REP,George C. Yang,3
-Humboldt,3JCWR_A,U.S. Senate,,REP,Greg Conlon,12
-Humboldt,3JCWR_A,U.S. Senate,,DEM,Herbert G. Peters,1
-Humboldt,3JCWR_A,U.S. Senate,,REP,Jarrell Williamson,2
-Humboldt,3JCWR_A,U.S. Senate,,IND,Jason Hanania,1
-Humboldt,3JCWR_A,U.S. Senate,,IND,Jason Kraus,1
-Humboldt,3JCWR_A,U.S. Senate,,REP,Jerry J. Laws,3
-Humboldt,3JCWR_A,U.S. Senate,,DEM,Kamala D. Harris,129
-Humboldt,3JCWR_A,U.S. Senate,,REP,Karen Roseberry,3
-Humboldt,3JCWR_A,U.S. Senate,,DEM,Loretta L. Sanchez,43
-Humboldt,3JCWR_A,U.S. Senate,,DEM,Massie Munroe,2
-Humboldt,3JCWR_A,U.S. Senate,,IND,Mike Beitiks,2
-Humboldt,3JCWR_A,U.S. Senate,,GRN,Pamela Elizondo,6
-Humboldt,3JCWR_A,U.S. Senate,,REP,Phil Wyman,13
-Humboldt,3JCWR_A,U.S. Senate,,REP,Ron Unz,2
-Humboldt,3JCWR_A,U.S. Senate,,DEM,Steve Stokes,8
-Humboldt,3JCWR_A,U.S. Senate,,REP,Thomas G. Del Beccaro,6
-Humboldt,3JCWR_A,U.S. Senate,,REP,Tom Palzer,1
-Humboldt,3JCWR_A,U.S. Senate,,REP,Von Hougo,1
+Humboldt,3JCWR,U.S. Senate,,DEM,Steve Stokes,20
+Humboldt,3JCWR,U.S. Senate,,REP,Thomas G. Del Beccaro,10
+Humboldt,3JCWR,U.S. Senate,,REP,Tom Palzer,1
+Humboldt,3JCWR,U.S. Senate,,REP,Von Hougo,2
 Humboldt,3KL,President,,REP,Ben Carson,1
 Humboldt,3KL,President,,DEM,Bernie Sanders,13
 Humboldt,3KL,President,,REP,Donald Trump,6
@@ -4610,1484 +2992,906 @@ Humboldt,3KL-1,U.S. Senate,,REP,Phil Wyman,17
 Humboldt,3KL-1,U.S. Senate,,DEM,Steve Stokes,5
 Humboldt,3KL-1,U.S. Senate,,REP,Thomas G. Del Beccaro,2
 Humboldt,3KL-1,U.S. Senate,,REP,Von Hougo,2
+Humboldt,3MA-1,President,,AIP,Alan Spears,2
+Humboldt,3MA-1,President,,AIP,Arthur Harris,1
 Humboldt,3MA-1,President,,REP,Ben Carson,1
-Humboldt,3MA-1,President,,DEM,Bernie Sanders,103
-Humboldt,3MA-1,President,,GRN,Darryl Cherney,1
-Humboldt,3MA-1,President,,REP,Donald Trump,7
+Humboldt,3MA-1,President,,DEM,Bernie Sanders,192
+Humboldt,3MA-1,President,,GRN,Darryl Cherney,2
+Humboldt,3MA-1,President,,REP,Donald Trump,23
 Humboldt,3MA-1,President,,PAF,Gloria Estela La Riva,1
-Humboldt,3MA-1,President,,DEM,Hillary Clinton,30
+Humboldt,3MA-1,President,,DEM,Hillary Clinton,56
 Humboldt,3MA-1,President,,GRN,Jill Stein,2
 Humboldt,3MA-1,President,,REP,John R. Kasich,1
-Humboldt,3MA-1,President,,REP,Ted Cruz,2
-Humboldt,3MA-1,Proposition 50,,,No,30
-Humboldt,3MA-1,Proposition 50,,,Yes,103
-Humboldt,3MA-1,State Assembly,2,DEM,Jim Wood,112
-Humboldt,3MA-1,U.S. House,2,REP,Dale K. Mensing,8
-Humboldt,3MA-1,U.S. House,2,DEM,Erin A. Schrode,25
-Humboldt,3MA-1,U.S. House,2,DEM,Jared W. Huffman,92
-Humboldt,3MA-1,U.S. House,2,IND,Matthew Robert Wookey,15
-Humboldt,3MA-1,U.S. Senate,,REP,Don Krampe,1
-Humboldt,3MA-1,U.S. Senate,,LIB,Gail K. Lightfoot,8
+Humboldt,3MA-1,President,,AIP,Robert Ornelas,1
+Humboldt,3MA-1,President,,REP,Ted Cruz,4
+Humboldt,3MA-1,Proposition 50,,,No,59
+Humboldt,3MA-1,Proposition 50,,,Yes,198
+Humboldt,3MA-1,State Assembly,2,DEM,Jim Wood,227
+Humboldt,3MA-1,U.S. House,2,REP,Dale K. Mensing,26
+Humboldt,3MA-1,U.S. House,2,DEM,Erin A. Schrode,38
+Humboldt,3MA-1,U.S. House,2,DEM,Jared W. Huffman,189
+Humboldt,3MA-1,U.S. House,2,IND,Matthew Robert Wookey,24
+Humboldt,3MA-1,U.S. Senate,,IND,Clive Grey,1
+Humboldt,3MA-1,U.S. Senate,,REP,Don Krampe,2
+Humboldt,3MA-1,U.S. Senate,,REP,Duf Sundheim,3
+Humboldt,3MA-1,U.S. Senate,,LIB,Gail K. Lightfoot,14
 Humboldt,3MA-1,U.S. Senate,,REP,George C. Yang,1
+Humboldt,3MA-1,U.S. Senate,,DEM,Herbert G. Peters,1
 Humboldt,3MA-1,U.S. Senate,,REP,Jarrell Williamson,1
-Humboldt,3MA-1,U.S. Senate,,REP,Jerry J. Laws,1
+Humboldt,3MA-1,U.S. Senate,,IND,Jason Kraus,2
+Humboldt,3MA-1,U.S. Senate,,REP,Jerry J. Laws,8
 Humboldt,3MA-1,U.S. Senate,,PAF,John Thompson Parker,1
-Humboldt,3MA-1,U.S. Senate,,DEM,Kamala D. Harris,60
+Humboldt,3MA-1,U.S. Senate,,DEM,Kamala D. Harris,132
+Humboldt,3MA-1,U.S. Senate,,REP,Karen Roseberry,1
 Humboldt,3MA-1,U.S. Senate,,IND,Ling Ling Shi,2
-Humboldt,3MA-1,U.S. Senate,,DEM,Loretta L. Sanchez,26
+Humboldt,3MA-1,U.S. Senate,,DEM,Loretta L. Sanchez,48
 Humboldt,3MA-1,U.S. Senate,,LIB,Mark Matthew Herd,1
-Humboldt,3MA-1,U.S. Senate,,DEM,Massie Munroe,5
-Humboldt,3MA-1,U.S. Senate,,IND,Mike Beitiks,4
-Humboldt,3MA-1,U.S. Senate,,GRN,Pamela Elizondo,19
-Humboldt,3MA-1,U.S. Senate,,REP,Phil Wyman,5
-Humboldt,3MA-1,U.S. Senate,,DEM,Steve Stokes,10
-Humboldt,3MA-1_A,President,,AIP,Alan Spears,2
-Humboldt,3MA-1_A,President,,AIP,Arthur Harris,1
-Humboldt,3MA-1_A,President,,DEM,Bernie Sanders,89
-Humboldt,3MA-1_A,President,,GRN,Darryl Cherney,1
-Humboldt,3MA-1_A,President,,REP,Donald Trump,16
-Humboldt,3MA-1_A,President,,DEM,Hillary Clinton,26
-Humboldt,3MA-1_A,President,,AIP,Robert Ornelas,1
-Humboldt,3MA-1_A,President,,REP,Ted Cruz,2
-Humboldt,3MA-1_A,Proposition 50,,,No,29
-Humboldt,3MA-1_A,Proposition 50,,,Yes,95
-Humboldt,3MA-1_A,State Assembly,2,DEM,Jim Wood,115
-Humboldt,3MA-1_A,U.S. House,2,REP,Dale K. Mensing,18
-Humboldt,3MA-1_A,U.S. House,2,DEM,Erin A. Schrode,13
-Humboldt,3MA-1_A,U.S. House,2,DEM,Jared W. Huffman,97
-Humboldt,3MA-1_A,U.S. House,2,IND,Matthew Robert Wookey,9
-Humboldt,3MA-1_A,U.S. Senate,,IND,Clive Grey,1
-Humboldt,3MA-1_A,U.S. Senate,,REP,Don Krampe,1
-Humboldt,3MA-1_A,U.S. Senate,,REP,Duf Sundheim,3
-Humboldt,3MA-1_A,U.S. Senate,,LIB,Gail K. Lightfoot,6
-Humboldt,3MA-1_A,U.S. Senate,,DEM,Herbert G. Peters,1
-Humboldt,3MA-1_A,U.S. Senate,,IND,Jason Kraus,2
-Humboldt,3MA-1_A,U.S. Senate,,REP,Jerry J. Laws,7
-Humboldt,3MA-1_A,U.S. Senate,,DEM,Kamala D. Harris,72
-Humboldt,3MA-1_A,U.S. Senate,,REP,Karen Roseberry,1
-Humboldt,3MA-1_A,U.S. Senate,,DEM,Loretta L. Sanchez,22
-Humboldt,3MA-1_A,U.S. Senate,,DEM,Massie Munroe,2
-Humboldt,3MA-1_A,U.S. Senate,,IND,Mike Beitiks,1
-Humboldt,3MA-1_A,U.S. Senate,,GRN,Pamela Elizondo,3
-Humboldt,3MA-1_A,U.S. Senate,,REP,Phil Wyman,5
-Humboldt,3MA-1_A,U.S. Senate,,REP,Ron Unz,1
-Humboldt,3MA-1_A,U.S. Senate,,DEM,Steve Stokes,5
-Humboldt,3MA-1_A,U.S. Senate,,REP,Tom Palzer,2
-Humboldt,3PA-1,President,,REP,Ben Carson,1
-Humboldt,3PA-1,President,,DEM,Bernie Sanders,106
+Humboldt,3MA-1,U.S. Senate,,DEM,Massie Munroe,7
+Humboldt,3MA-1,U.S. Senate,,IND,Mike Beitiks,5
+Humboldt,3MA-1,U.S. Senate,,GRN,Pamela Elizondo,22
+Humboldt,3MA-1,U.S. Senate,,REP,Phil Wyman,10
+Humboldt,3MA-1,U.S. Senate,,REP,Ron Unz,1
+Humboldt,3MA-1,U.S. Senate,,DEM,Steve Stokes,15
+Humboldt,3MA-1,U.S. Senate,,REP,Tom Palzer,2
+Humboldt,3PA-1,President,,AIP,Arthur Harris,1
+Humboldt,3PA-1,President,,REP,Ben Carson,2
+Humboldt,3PA-1,President,,DEM,Bernie Sanders,230
 Humboldt,3PA-1,President,,GRN,Darryl Cherney,1
-Humboldt,3PA-1,President,,REP,Donald Trump,20
+Humboldt,3PA-1,President,,REP,Donald Trump,58
 Humboldt,3PA-1,President,,LIB,Gary Johnson,1
-Humboldt,3PA-1,President,,DEM,Hillary Clinton,45
+Humboldt,3PA-1,President,,DEM,Hillary Clinton,96
+Humboldt,3PA-1,President,,AIP,J.R. Myers,1
 Humboldt,3PA-1,President,,GRN,Jill Stein,1
-Humboldt,3PA-1,President,,REP,John R. Kasich,9
+Humboldt,3PA-1,President,,REP,John R. Kasich,24
 Humboldt,3PA-1,President,,LIB,Marc Feldman,1
-Humboldt,3PA-1,President,,REP,Ted Cruz,2
-Humboldt,3PA-1,Proposition 50,,,No,34
-Humboldt,3PA-1,Proposition 50,,,Yes,134
-Humboldt,3PA-1,State Assembly,2,DEM,Jim Wood,149
-Humboldt,3PA-1,U.S. House,2,REP,Dale K. Mensing,25
-Humboldt,3PA-1,U.S. House,2,DEM,Erin A. Schrode,18
-Humboldt,3PA-1,U.S. House,2,DEM,Jared W. Huffman,119
-Humboldt,3PA-1,U.S. House,2,IND,Matthew Robert Wookey,18
-Humboldt,3PA-1,U.S. Senate,,IND,Clive Grey,1
-Humboldt,3PA-1,U.S. Senate,,IND,Don J. Grundmann,1
-Humboldt,3PA-1,U.S. Senate,,REP,Don Krampe,4
-Humboldt,3PA-1,U.S. Senate,,REP,Duf Sundheim,2
+Humboldt,3PA-1,President,,REP,Ted Cruz,8
+Humboldt,3PA-1,Proposition 50,,,No,79
+Humboldt,3PA-1,Proposition 50,,,Yes,319
+Humboldt,3PA-1,State Assembly,2,DEM,Jim Wood,330
+Humboldt,3PA-1,U.S. House,2,REP,Dale K. Mensing,70
+Humboldt,3PA-1,U.S. House,2,DEM,Erin A. Schrode,36
+Humboldt,3PA-1,U.S. House,2,DEM,Jared W. Huffman,283
+Humboldt,3PA-1,U.S. House,2,IND,Matthew Robert Wookey,31
+Humboldt,3PA-1,U.S. Senate,,IND,Clive Grey,2
+Humboldt,3PA-1,U.S. Senate,,IND,Don J. Grundmann,2
+Humboldt,3PA-1,U.S. Senate,,REP,Don Krampe,5
+Humboldt,3PA-1,U.S. Senate,,REP,Duf Sundheim,17
 Humboldt,3PA-1,U.S. Senate,,DEM,Emory Rodgers,1
-Humboldt,3PA-1,U.S. Senate,,LIB,Gail K. Lightfoot,9
+Humboldt,3PA-1,U.S. Senate,,LIB,Gail K. Lightfoot,13
 Humboldt,3PA-1,U.S. Senate,,IND,Gar Myers,1
-Humboldt,3PA-1,U.S. Senate,,REP,George C. Yang,3
-Humboldt,3PA-1,U.S. Senate,,REP,Greg Conlon,4
+Humboldt,3PA-1,U.S. Senate,,REP,George C. Yang,4
+Humboldt,3PA-1,U.S. Senate,,REP,Greg Conlon,13
+Humboldt,3PA-1,U.S. Senate,,REP,Jarrell Williamson,1
+Humboldt,3PA-1,U.S. Senate,,IND,Jason Hanania,1
 Humboldt,3PA-1,U.S. Senate,,IND,Jason Kraus,1
-Humboldt,3PA-1,U.S. Senate,,REP,Jerry J. Laws,5
+Humboldt,3PA-1,U.S. Senate,,REP,Jerry J. Laws,14
 Humboldt,3PA-1,U.S. Senate,,PAF,John Thompson Parker,1
-Humboldt,3PA-1,U.S. Senate,,DEM,Kamala D. Harris,71
-Humboldt,3PA-1,U.S. Senate,,REP,Karen Roseberry,1
-Humboldt,3PA-1,U.S. Senate,,DEM,Loretta L. Sanchez,29
-Humboldt,3PA-1,U.S. Senate,,DEM,Massie Munroe,3
-Humboldt,3PA-1,U.S. Senate,,IND,Mike Beitiks,2
-Humboldt,3PA-1,U.S. Senate,,GRN,Pamela Elizondo,11
-Humboldt,3PA-1,U.S. Senate,,REP,Phil Wyman,7
+Humboldt,3PA-1,U.S. Senate,,DEM,Kamala D. Harris,165
+Humboldt,3PA-1,U.S. Senate,,REP,Karen Roseberry,2
+Humboldt,3PA-1,U.S. Senate,,IND,Ling Ling Shi,2
+Humboldt,3PA-1,U.S. Senate,,DEM,Loretta L. Sanchez,75
+Humboldt,3PA-1,U.S. Senate,,DEM,Massie Munroe,9
+Humboldt,3PA-1,U.S. Senate,,IND,Mike Beitiks,4
+Humboldt,3PA-1,U.S. Senate,,GRN,Pamela Elizondo,19
+Humboldt,3PA-1,U.S. Senate,,REP,Phil Wyman,29
 Humboldt,3PA-1,U.S. Senate,,IND,Scott A. Vineberg,1
-Humboldt,3PA-1,U.S. Senate,,DEM,Steve Stokes,14
-Humboldt,3PA-1,U.S. Senate,,REP,Thomas G. Del Beccaro,1
+Humboldt,3PA-1,U.S. Senate,,DEM,Steve Stokes,23
+Humboldt,3PA-1,U.S. Senate,,REP,Thomas G. Del Beccaro,6
 Humboldt,3PA-1,U.S. Senate,,IND,Tim Gildersleeve,1
-Humboldt,3PA-1,U.S. Senate,,REP,Tom Palzer,1
-Humboldt,3PA-1,U.S. Senate,,REP,Von Hougo,1
-Humboldt,3PA-1_A,President,,AIP,Arthur Harris,1
-Humboldt,3PA-1_A,President,,REP,Ben Carson,1
-Humboldt,3PA-1_A,President,,DEM,Bernie Sanders,124
-Humboldt,3PA-1_A,President,,REP,Donald Trump,38
-Humboldt,3PA-1_A,President,,DEM,Hillary Clinton,51
-Humboldt,3PA-1_A,President,,AIP,J.R. Myers,1
-Humboldt,3PA-1_A,President,,REP,John R. Kasich,15
-Humboldt,3PA-1_A,President,,REP,Ted Cruz,6
-Humboldt,3PA-1_A,Proposition 50,,,No,45
-Humboldt,3PA-1_A,Proposition 50,,,Yes,185
-Humboldt,3PA-1_A,State Assembly,2,DEM,Jim Wood,181
-Humboldt,3PA-1_A,U.S. House,2,REP,Dale K. Mensing,45
-Humboldt,3PA-1_A,U.S. House,2,DEM,Erin A. Schrode,18
-Humboldt,3PA-1_A,U.S. House,2,DEM,Jared W. Huffman,164
-Humboldt,3PA-1_A,U.S. House,2,IND,Matthew Robert Wookey,13
-Humboldt,3PA-1_A,U.S. Senate,,IND,Clive Grey,1
-Humboldt,3PA-1_A,U.S. Senate,,IND,Don J. Grundmann,1
-Humboldt,3PA-1_A,U.S. Senate,,REP,Don Krampe,1
-Humboldt,3PA-1_A,U.S. Senate,,REP,Duf Sundheim,15
-Humboldt,3PA-1_A,U.S. Senate,,LIB,Gail K. Lightfoot,4
-Humboldt,3PA-1_A,U.S. Senate,,REP,George C. Yang,1
-Humboldt,3PA-1_A,U.S. Senate,,REP,Greg Conlon,9
-Humboldt,3PA-1_A,U.S. Senate,,REP,Jarrell Williamson,1
-Humboldt,3PA-1_A,U.S. Senate,,IND,Jason Hanania,1
-Humboldt,3PA-1_A,U.S. Senate,,REP,Jerry J. Laws,9
-Humboldt,3PA-1_A,U.S. Senate,,DEM,Kamala D. Harris,94
-Humboldt,3PA-1_A,U.S. Senate,,REP,Karen Roseberry,1
-Humboldt,3PA-1_A,U.S. Senate,,IND,Ling Ling Shi,2
-Humboldt,3PA-1_A,U.S. Senate,,DEM,Loretta L. Sanchez,46
-Humboldt,3PA-1_A,U.S. Senate,,DEM,Massie Munroe,6
-Humboldt,3PA-1_A,U.S. Senate,,IND,Mike Beitiks,2
-Humboldt,3PA-1_A,U.S. Senate,,GRN,Pamela Elizondo,8
-Humboldt,3PA-1_A,U.S. Senate,,REP,Phil Wyman,22
-Humboldt,3PA-1_A,U.S. Senate,,DEM,Steve Stokes,9
-Humboldt,3PA-1_A,U.S. Senate,,REP,Thomas G. Del Beccaro,5
-Humboldt,3PA-1_A,U.S. Senate,,REP,Tom Palzer,1
-Humboldt,3PA-1_A,U.S. Senate,,REP,Von Hougo,5
+Humboldt,3PA-1,U.S. Senate,,REP,Tom Palzer,2
+Humboldt,3PA-1,U.S. Senate,,REP,Von Hougo,6
 Humboldt,4E-11,President,,REP,Ben Carson,2
-Humboldt,4E-11,President,,DEM,Bernie Sanders,130
-Humboldt,4E-11,President,,REP,Donald Trump,6
-Humboldt,4E-11,President,,DEM,Hillary Clinton,36
+Humboldt,4E-11,President,,DEM,Bernie Sanders,220
+Humboldt,4E-11,President,,GRN,Darryl Cherney,3
+Humboldt,4E-11,President,,REP,Donald Trump,30
+Humboldt,4E-11,President,,PAF,Gloria Estela La Riva,1
+Humboldt,4E-11,President,,DEM,Hillary Clinton,65
 Humboldt,4E-11,President,,LIB,"Jack Robinson, Jr.",1
-Humboldt,4E-11,President,,GRN,Jill Stein,1
+Humboldt,4E-11,President,,AIP,James Hedges,1
+Humboldt,4E-11,President,,GRN,Jill Stein,3
+Humboldt,4E-11,President,,REP,Jim Gilmore,1
 Humboldt,4E-11,President,,REP,John R. Kasich,2
-Humboldt,4E-11,President,,REP,Ted Cruz,2
-Humboldt,4E-11,President,,DEM,Willie Wilson,1
-Humboldt,4E-11,Proposition 50,,,No,37
-Humboldt,4E-11,Proposition 50,,,Yes,121
-Humboldt,4E-11,State Assembly,2,DEM,Jim Wood,140
-Humboldt,4E-11,U.S. House,2,REP,Dale K. Mensing,14
-Humboldt,4E-11,U.S. House,2,DEM,Erin A. Schrode,36
-Humboldt,4E-11,U.S. House,2,DEM,Jared W. Huffman,93
-Humboldt,4E-11,U.S. House,2,IND,Matthew Robert Wookey,25
+Humboldt,4E-11,President,,LIB,Rhett White Feather Smith,1
+Humboldt,4E-11,President,,AIP,Robert Ornelas,1
+Humboldt,4E-11,President,,DEM,Roque De La Fuente,1
+Humboldt,4E-11,President,,REP,Ted Cruz,3
+Humboldt,4E-11,President,,DEM,Willie Wilson,2
+Humboldt,4E-11,Proposition 50,,,No,70
+Humboldt,4E-11,Proposition 50,,,Yes,239
+Humboldt,4E-11,State Assembly,2,DEM,Jim Wood,260
+Humboldt,4E-11,U.S. House,2,REP,Dale K. Mensing,32
+Humboldt,4E-11,U.S. House,2,DEM,Erin A. Schrode,59
+Humboldt,4E-11,U.S. House,2,DEM,Jared W. Huffman,186
+Humboldt,4E-11,U.S. House,2,IND,Matthew Robert Wookey,43
 Humboldt,4E-11,U.S. Senate,,IND,Clive Grey,2
-Humboldt,4E-11,U.S. Senate,,REP,Duf Sundheim,3
-Humboldt,4E-11,U.S. Senate,,IND,Eleanor García,2
-Humboldt,4E-11,U.S. Senate,,LIB,Gail K. Lightfoot,8
+Humboldt,4E-11,U.S. Senate,,REP,Don Krampe,1
+Humboldt,4E-11,U.S. Senate,,REP,Duf Sundheim,13
+Humboldt,4E-11,U.S. Senate,,IND,Eleanor García,3
+Humboldt,4E-11,U.S. Senate,,DEM,Emory Rodgers,1
+Humboldt,4E-11,U.S. Senate,,LIB,Gail K. Lightfoot,14
 Humboldt,4E-11,U.S. Senate,,IND,Gar Myers,1
-Humboldt,4E-11,U.S. Senate,,REP,Greg Conlon,1
+Humboldt,4E-11,U.S. Senate,,REP,Greg Conlon,4
 Humboldt,4E-11,U.S. Senate,,DEM,Herbert G. Peters,1
-Humboldt,4E-11,U.S. Senate,,REP,Jarrell Williamson,3
-Humboldt,4E-11,U.S. Senate,,REP,Jerry J. Laws,3
-Humboldt,4E-11,U.S. Senate,,DEM,Kamala D. Harris,58
+Humboldt,4E-11,U.S. Senate,,REP,Jarrell Williamson,5
+Humboldt,4E-11,U.S. Senate,,IND,Jason Kraus,1
+Humboldt,4E-11,U.S. Senate,,REP,Jerry J. Laws,7
+Humboldt,4E-11,U.S. Senate,,DEM,Kamala D. Harris,125
 Humboldt,4E-11,U.S. Senate,,REP,Karen Roseberry,1
-Humboldt,4E-11,U.S. Senate,,IND,Ling Ling Shi,7
-Humboldt,4E-11,U.S. Senate,,DEM,Loretta L. Sanchez,33
+Humboldt,4E-11,U.S. Senate,,IND,Ling Ling Shi,8
+Humboldt,4E-11,U.S. Senate,,DEM,Loretta L. Sanchez,61
 Humboldt,4E-11,U.S. Senate,,LIB,Mark Matthew Herd,2
-Humboldt,4E-11,U.S. Senate,,DEM,Massie Munroe,7
-Humboldt,4E-11,U.S. Senate,,IND,Mike Beitiks,2
-Humboldt,4E-11,U.S. Senate,,GRN,Pamela Elizondo,13
-Humboldt,4E-11,U.S. Senate,,REP,Phil Wyman,1
-Humboldt,4E-11,U.S. Senate,,DEM,President Cristina Grappo,2
-Humboldt,4E-11,U.S. Senate,,REP,Ron Unz,1
+Humboldt,4E-11,U.S. Senate,,DEM,Massie Munroe,12
+Humboldt,4E-11,U.S. Senate,,IND,Mike Beitiks,4
+Humboldt,4E-11,U.S. Senate,,GRN,Pamela Elizondo,20
+Humboldt,4E-11,U.S. Senate,,IND,Paul Merritt,1
+Humboldt,4E-11,U.S. Senate,,REP,Phil Wyman,6
+Humboldt,4E-11,U.S. Senate,,DEM,President Cristina Grappo,3
+Humboldt,4E-11,U.S. Senate,,REP,Ron Unz,3
 Humboldt,4E-11,U.S. Senate,,IND,Scott A. Vineberg,2
-Humboldt,4E-11,U.S. Senate,,DEM,Steve Stokes,12
-Humboldt,4E-11,U.S. Senate,,REP,Thomas G. Del Beccaro,3
-Humboldt,4E-11,U.S. Senate,,REP,Von Hougo,1
-Humboldt,4E-11_A,President,,DEM,Bernie Sanders,90
-Humboldt,4E-11_A,President,,GRN,Darryl Cherney,3
-Humboldt,4E-11_A,President,,REP,Donald Trump,24
-Humboldt,4E-11_A,President,,PAF,Gloria Estela La Riva,1
-Humboldt,4E-11_A,President,,DEM,Hillary Clinton,29
-Humboldt,4E-11_A,President,,AIP,James Hedges,1
-Humboldt,4E-11_A,President,,GRN,Jill Stein,2
-Humboldt,4E-11_A,President,,REP,Jim Gilmore,1
-Humboldt,4E-11_A,President,,LIB,Rhett White Feather Smith,1
-Humboldt,4E-11_A,President,,AIP,Robert Ornelas,1
-Humboldt,4E-11_A,President,,DEM,Roque De La Fuente,1
-Humboldt,4E-11_A,President,,REP,Ted Cruz,1
-Humboldt,4E-11_A,President,,DEM,Willie Wilson,1
-Humboldt,4E-11_A,Proposition 50,,,No,33
-Humboldt,4E-11_A,Proposition 50,,,Yes,118
-Humboldt,4E-11_A,State Assembly,2,DEM,Jim Wood,120
-Humboldt,4E-11_A,U.S. House,2,REP,Dale K. Mensing,18
-Humboldt,4E-11_A,U.S. House,2,DEM,Erin A. Schrode,23
-Humboldt,4E-11_A,U.S. House,2,DEM,Jared W. Huffman,93
-Humboldt,4E-11_A,U.S. House,2,IND,Matthew Robert Wookey,18
-Humboldt,4E-11_A,U.S. Senate,,REP,Don Krampe,1
-Humboldt,4E-11_A,U.S. Senate,,REP,Duf Sundheim,10
-Humboldt,4E-11_A,U.S. Senate,,IND,Eleanor García,1
-Humboldt,4E-11_A,U.S. Senate,,DEM,Emory Rodgers,1
-Humboldt,4E-11_A,U.S. Senate,,LIB,Gail K. Lightfoot,6
-Humboldt,4E-11_A,U.S. Senate,,REP,Greg Conlon,3
-Humboldt,4E-11_A,U.S. Senate,,REP,Jarrell Williamson,2
-Humboldt,4E-11_A,U.S. Senate,,IND,Jason Kraus,1
-Humboldt,4E-11_A,U.S. Senate,,REP,Jerry J. Laws,4
-Humboldt,4E-11_A,U.S. Senate,,DEM,Kamala D. Harris,67
-Humboldt,4E-11_A,U.S. Senate,,IND,Ling Ling Shi,1
-Humboldt,4E-11_A,U.S. Senate,,DEM,Loretta L. Sanchez,28
-Humboldt,4E-11_A,U.S. Senate,,DEM,Massie Munroe,5
-Humboldt,4E-11_A,U.S. Senate,,IND,Mike Beitiks,2
-Humboldt,4E-11_A,U.S. Senate,,GRN,Pamela Elizondo,7
-Humboldt,4E-11_A,U.S. Senate,,IND,Paul Merritt,1
-Humboldt,4E-11_A,U.S. Senate,,REP,Phil Wyman,5
-Humboldt,4E-11_A,U.S. Senate,,DEM,President Cristina Grappo,1
-Humboldt,4E-11_A,U.S. Senate,,REP,Ron Unz,2
-Humboldt,4E-11_A,U.S. Senate,,DEM,Steve Stokes,5
-Humboldt,4E-11_A,U.S. Senate,,REP,Thomas G. Del Beccaro,2
-Humboldt,4E-11_A,U.S. Senate,,REP,Von Hougo,3
+Humboldt,4E-11,U.S. Senate,,DEM,Steve Stokes,17
+Humboldt,4E-11,U.S. Senate,,REP,Thomas G. Del Beccaro,5
+Humboldt,4E-11,U.S. Senate,,REP,Von Hougo,4
+Humboldt,4E-12,President,,AIP,Alan Spears,1
 Humboldt,4E-12,President,,REP,Ben Carson,2
-Humboldt,4E-12,President,,DEM,Bernie Sanders,113
-Humboldt,4E-12,President,,REP,Donald Trump,9
-Humboldt,4E-12,President,,DEM,Hillary Clinton,26
+Humboldt,4E-12,President,,DEM,Bernie Sanders,193
+Humboldt,4E-12,President,,REP,Donald Trump,32
+Humboldt,4E-12,President,,DEM,Henry Hewes,1
+Humboldt,4E-12,President,,DEM,Hillary Clinton,49
+Humboldt,4E-12,President,,GRN,Jill Stein,2
 Humboldt,4E-12,President,,REP,John R. Kasich,3
-Humboldt,4E-12,President,,REP,Ted Cruz,1
-Humboldt,4E-12,Proposition 50,,,No,30
-Humboldt,4E-12,Proposition 50,,,Yes,108
-Humboldt,4E-12,State Assembly,2,DEM,Jim Wood,106
-Humboldt,4E-12,U.S. House,2,REP,Dale K. Mensing,19
-Humboldt,4E-12,U.S. House,2,DEM,Erin A. Schrode,20
-Humboldt,4E-12,U.S. House,2,DEM,Jared W. Huffman,80
-Humboldt,4E-12,U.S. House,2,IND,Matthew Robert Wookey,20
-Humboldt,4E-12,U.S. Senate,,REP,Duf Sundheim,3
+Humboldt,4E-12,President,,REP,Ted Cruz,5
+Humboldt,4E-12,President,,DEM,Willie Wilson,1
+Humboldt,4E-12,Proposition 50,,,No,57
+Humboldt,4E-12,Proposition 50,,,Yes,211
+Humboldt,4E-12,State Assembly,2,DEM,Jim Wood,205
+Humboldt,4E-12,U.S. House,2,REP,Dale K. Mensing,44
+Humboldt,4E-12,U.S. House,2,DEM,Erin A. Schrode,42
+Humboldt,4E-12,U.S. House,2,DEM,Jared W. Huffman,150
+Humboldt,4E-12,U.S. House,2,IND,Matthew Robert Wookey,33
+Humboldt,4E-12,U.S. Senate,,REP,Don Krampe,2
+Humboldt,4E-12,U.S. Senate,,REP,Duf Sundheim,8
 Humboldt,4E-12,U.S. Senate,,IND,Eleanor García,1
-Humboldt,4E-12,U.S. Senate,,LIB,Gail K. Lightfoot,11
-Humboldt,4E-12,U.S. Senate,,IND,Gar Myers,1
+Humboldt,4E-12,U.S. Senate,,DEM,Emory Rodgers,1
+Humboldt,4E-12,U.S. Senate,,LIB,Gail K. Lightfoot,21
+Humboldt,4E-12,U.S. Senate,,IND,Gar Myers,3
 Humboldt,4E-12,U.S. Senate,,REP,George C. Yang,3
-Humboldt,4E-12,U.S. Senate,,REP,Greg Conlon,1
+Humboldt,4E-12,U.S. Senate,,REP,Greg Conlon,5
+Humboldt,4E-12,U.S. Senate,,REP,Jarrell Williamson,4
 Humboldt,4E-12,U.S. Senate,,IND,Jason Kraus,1
-Humboldt,4E-12,U.S. Senate,,REP,Jerry J. Laws,4
-Humboldt,4E-12,U.S. Senate,,DEM,Kamala D. Harris,45
-Humboldt,4E-12,U.S. Senate,,REP,Karen Roseberry,2
+Humboldt,4E-12,U.S. Senate,,REP,Jerry J. Laws,9
+Humboldt,4E-12,U.S. Senate,,DEM,Kamala D. Harris,79
+Humboldt,4E-12,U.S. Senate,,REP,Karen Roseberry,4
 Humboldt,4E-12,U.S. Senate,,IND,Ling Ling Shi,1
-Humboldt,4E-12,U.S. Senate,,DEM,Loretta L. Sanchez,35
-Humboldt,4E-12,U.S. Senate,,DEM,Massie Munroe,5
-Humboldt,4E-12,U.S. Senate,,IND,Mike Beitiks,3
-Humboldt,4E-12,U.S. Senate,,GRN,Pamela Elizondo,6
-Humboldt,4E-12,U.S. Senate,,REP,Phil Wyman,2
-Humboldt,4E-12,U.S. Senate,,DEM,President Cristina Grappo,1
-Humboldt,4E-12,U.S. Senate,,REP,Ron Unz,1
-Humboldt,4E-12,U.S. Senate,,DEM,Steve Stokes,11
+Humboldt,4E-12,U.S. Senate,,DEM,Loretta L. Sanchez,57
+Humboldt,4E-12,U.S. Senate,,LIB,Mark Matthew Herd,2
+Humboldt,4E-12,U.S. Senate,,DEM,Massie Munroe,6
+Humboldt,4E-12,U.S. Senate,,IND,Mike Beitiks,6
+Humboldt,4E-12,U.S. Senate,,GRN,Pamela Elizondo,14
+Humboldt,4E-12,U.S. Senate,,IND,Paul Merritt,1
+Humboldt,4E-12,U.S. Senate,,REP,Phil Wyman,6
+Humboldt,4E-12,U.S. Senate,,DEM,President Cristina Grappo,2
+Humboldt,4E-12,U.S. Senate,,REP,Ron Unz,2
+Humboldt,4E-12,U.S. Senate,,DEM,Steve Stokes,18
 Humboldt,4E-12,U.S. Senate,,REP,Thomas G. Del Beccaro,1
-Humboldt,4E-12,U.S. Senate,,REP,Tom Palzer,1
-Humboldt,4E-12,U.S. Senate,,REP,Von Hougo,1
-Humboldt,4E-12_A,President,,AIP,Alan Spears,1
-Humboldt,4E-12_A,President,,DEM,Bernie Sanders,80
-Humboldt,4E-12_A,President,,REP,Donald Trump,23
-Humboldt,4E-12_A,President,,DEM,Henry Hewes,1
-Humboldt,4E-12_A,President,,DEM,Hillary Clinton,23
-Humboldt,4E-12_A,President,,GRN,Jill Stein,2
-Humboldt,4E-12_A,President,,REP,Ted Cruz,4
-Humboldt,4E-12_A,President,,DEM,Willie Wilson,1
-Humboldt,4E-12_A,Proposition 50,,,No,27
-Humboldt,4E-12_A,Proposition 50,,,Yes,103
-Humboldt,4E-12_A,State Assembly,2,DEM,Jim Wood,99
-Humboldt,4E-12_A,U.S. House,2,REP,Dale K. Mensing,25
-Humboldt,4E-12_A,U.S. House,2,DEM,Erin A. Schrode,22
-Humboldt,4E-12_A,U.S. House,2,DEM,Jared W. Huffman,70
-Humboldt,4E-12_A,U.S. House,2,IND,Matthew Robert Wookey,13
-Humboldt,4E-12_A,U.S. Senate,,REP,Don Krampe,2
-Humboldt,4E-12_A,U.S. Senate,,REP,Duf Sundheim,5
-Humboldt,4E-12_A,U.S. Senate,,DEM,Emory Rodgers,1
-Humboldt,4E-12_A,U.S. Senate,,LIB,Gail K. Lightfoot,10
-Humboldt,4E-12_A,U.S. Senate,,IND,Gar Myers,2
-Humboldt,4E-12_A,U.S. Senate,,REP,Greg Conlon,4
-Humboldt,4E-12_A,U.S. Senate,,REP,Jarrell Williamson,4
-Humboldt,4E-12_A,U.S. Senate,,REP,Jerry J. Laws,5
-Humboldt,4E-12_A,U.S. Senate,,DEM,Kamala D. Harris,34
-Humboldt,4E-12_A,U.S. Senate,,REP,Karen Roseberry,2
-Humboldt,4E-12_A,U.S. Senate,,DEM,Loretta L. Sanchez,22
-Humboldt,4E-12_A,U.S. Senate,,LIB,Mark Matthew Herd,2
-Humboldt,4E-12_A,U.S. Senate,,DEM,Massie Munroe,1
-Humboldt,4E-12_A,U.S. Senate,,IND,Mike Beitiks,3
-Humboldt,4E-12_A,U.S. Senate,,GRN,Pamela Elizondo,8
-Humboldt,4E-12_A,U.S. Senate,,IND,Paul Merritt,1
-Humboldt,4E-12_A,U.S. Senate,,REP,Phil Wyman,4
-Humboldt,4E-12_A,U.S. Senate,,DEM,President Cristina Grappo,1
-Humboldt,4E-12_A,U.S. Senate,,REP,Ron Unz,1
-Humboldt,4E-12_A,U.S. Senate,,DEM,Steve Stokes,7
-Humboldt,4E-12_A,U.S. Senate,,IND,Tim Gildersleeve,2
-Humboldt,4E-12_A,U.S. Senate,,REP,Tom Palzer,1
-Humboldt,4E-12_A,U.S. Senate,,REP,Von Hougo,4
-Humboldt,4E-13,President,,DEM,Bernie Sanders,177
+Humboldt,4E-12,U.S. Senate,,IND,Tim Gildersleeve,2
+Humboldt,4E-12,U.S. Senate,,REP,Tom Palzer,2
+Humboldt,4E-12,U.S. Senate,,REP,Von Hougo,5
+Humboldt,4E-13,President,,AIP,Alan Spears,1
+Humboldt,4E-13,President,,REP,Ben Carson,2
+Humboldt,4E-13,President,,DEM,Bernie Sanders,374
 Humboldt,4E-13,President,,GRN,Darryl Cherney,1
-Humboldt,4E-13,President,,REP,Donald Trump,19
-Humboldt,4E-13,President,,LIB,Gary Johnson,2
-Humboldt,4E-13,President,,DEM,Hillary Clinton,39
+Humboldt,4E-13,President,,REP,Donald Trump,49
+Humboldt,4E-13,President,,LIB,Gary Johnson,3
+Humboldt,4E-13,President,,DEM,Hillary Clinton,112
 Humboldt,4E-13,President,,GRN,Jill Stein,3
-Humboldt,4E-13,President,,REP,John R. Kasich,3
+Humboldt,4E-13,President,,REP,John R. Kasich,6
+Humboldt,4E-13,President,,DEM,Keith Judd,1
+Humboldt,4E-13,President,,DEM,Michael Steinberg,2
+Humboldt,4E-13,President,,LIB,Rhett White Feather Smith,1
+Humboldt,4E-13,President,,AIP,Robert Ornelas,1
 Humboldt,4E-13,President,,DEM,Roque De La Fuente,1
-Humboldt,4E-13,President,,REP,Ted Cruz,3
-Humboldt,4E-13,Proposition 50,,,No,38
-Humboldt,4E-13,Proposition 50,,,Yes,177
-Humboldt,4E-13,State Assembly,2,DEM,Jim Wood,191
-Humboldt,4E-13,U.S. House,2,REP,Dale K. Mensing,20
-Humboldt,4E-13,U.S. House,2,DEM,Erin A. Schrode,32
-Humboldt,4E-13,U.S. House,2,DEM,Jared W. Huffman,147
-Humboldt,4E-13,U.S. House,2,IND,Matthew Robert Wookey,25
-Humboldt,4E-13,U.S. Senate,,IND,Clive Grey,1
+Humboldt,4E-13,President,,REP,Ted Cruz,9
+Humboldt,4E-13,President,,DEM,Willie Wilson,3
+Humboldt,4E-13,Proposition 50,,,No,95
+Humboldt,4E-13,Proposition 50,,,Yes,421
+Humboldt,4E-13,State Assembly,2,DEM,Jim Wood,448
+Humboldt,4E-13,U.S. House,2,REP,Dale K. Mensing,48
+Humboldt,4E-13,U.S. House,2,DEM,Erin A. Schrode,80
+Humboldt,4E-13,U.S. House,2,DEM,Jared W. Huffman,352
+Humboldt,4E-13,U.S. House,2,IND,Matthew Robert Wookey,59
+Humboldt,4E-13,U.S. Senate,,IND,Clive Grey,4
 Humboldt,4E-13,U.S. Senate,,IND,Don J. Grundmann,1
-Humboldt,4E-13,U.S. Senate,,REP,Duf Sundheim,6
+Humboldt,4E-13,U.S. Senate,,REP,Don Krampe,3
+Humboldt,4E-13,U.S. Senate,,REP,Duf Sundheim,16
 Humboldt,4E-13,U.S. Senate,,IND,Eleanor García,2
-Humboldt,4E-13,U.S. Senate,,LIB,Gail K. Lightfoot,11
-Humboldt,4E-13,U.S. Senate,,REP,Greg Conlon,5
-Humboldt,4E-13,U.S. Senate,,IND,Jason Hanania,4
-Humboldt,4E-13,U.S. Senate,,REP,Jerry J. Laws,6
-Humboldt,4E-13,U.S. Senate,,PAF,John Thompson Parker,2
-Humboldt,4E-13,U.S. Senate,,DEM,Kamala D. Harris,78
+Humboldt,4E-13,U.S. Senate,,LIB,Gail K. Lightfoot,24
+Humboldt,4E-13,U.S. Senate,,REP,Greg Conlon,13
+Humboldt,4E-13,U.S. Senate,,DEM,Herbert G. Peters,1
+Humboldt,4E-13,U.S. Senate,,REP,Jarrell Williamson,4
+Humboldt,4E-13,U.S. Senate,,IND,Jason Hanania,5
+Humboldt,4E-13,U.S. Senate,,IND,Jason Kraus,1
+Humboldt,4E-13,U.S. Senate,,REP,Jerry J. Laws,11
+Humboldt,4E-13,U.S. Senate,,PAF,John Thompson Parker,4
+Humboldt,4E-13,U.S. Senate,,DEM,Kamala D. Harris,188
 Humboldt,4E-13,U.S. Senate,,REP,Karen Roseberry,5
-Humboldt,4E-13,U.S. Senate,,DEM,Loretta L. Sanchez,40
-Humboldt,4E-13,U.S. Senate,,LIB,Mark Matthew Herd,4
-Humboldt,4E-13,U.S. Senate,,DEM,Massie Munroe,2
-Humboldt,4E-13,U.S. Senate,,GRN,Pamela Elizondo,22
-Humboldt,4E-13,U.S. Senate,,IND,Paul Merritt,2
-Humboldt,4E-13,U.S. Senate,,REP,Phil Wyman,3
-Humboldt,4E-13,U.S. Senate,,REP,Ron Unz,1
-Humboldt,4E-13,U.S. Senate,,IND,Scott A. Vineberg,1
-Humboldt,4E-13,U.S. Senate,,DEM,Steve Stokes,24
-Humboldt,4E-13,U.S. Senate,,REP,Thomas G. Del Beccaro,2
+Humboldt,4E-13,U.S. Senate,,DEM,Loretta L. Sanchez,116
+Humboldt,4E-13,U.S. Senate,,LIB,Mark Matthew Herd,6
+Humboldt,4E-13,U.S. Senate,,DEM,Massie Munroe,10
+Humboldt,4E-13,U.S. Senate,,IND,Mike Beitiks,2
+Humboldt,4E-13,U.S. Senate,,GRN,Pamela Elizondo,43
+Humboldt,4E-13,U.S. Senate,,IND,Paul Merritt,3
+Humboldt,4E-13,U.S. Senate,,REP,Phil Wyman,14
+Humboldt,4E-13,U.S. Senate,,DEM,President Cristina Grappo,2
+Humboldt,4E-13,U.S. Senate,,REP,Ron Unz,8
+Humboldt,4E-13,U.S. Senate,,IND,Scott A. Vineberg,2
+Humboldt,4E-13,U.S. Senate,,DEM,Steve Stokes,40
+Humboldt,4E-13,U.S. Senate,,REP,Thomas G. Del Beccaro,3
 Humboldt,4E-13,U.S. Senate,,REP,Tom Palzer,1
-Humboldt,4E-13,U.S. Senate,,REP,Von Hougo,2
-Humboldt,4E-13_A,President,,AIP,Alan Spears,1
-Humboldt,4E-13_A,President,,REP,Ben Carson,2
-Humboldt,4E-13_A,President,,DEM,Bernie Sanders,197
-Humboldt,4E-13_A,President,,REP,Donald Trump,30
-Humboldt,4E-13_A,President,,LIB,Gary Johnson,1
-Humboldt,4E-13_A,President,,DEM,Hillary Clinton,73
-Humboldt,4E-13_A,President,,REP,John R. Kasich,3
-Humboldt,4E-13_A,President,,DEM,Keith Judd,1
-Humboldt,4E-13_A,President,,DEM,Michael Steinberg,2
-Humboldt,4E-13_A,President,,LIB,Rhett White Feather Smith,1
-Humboldt,4E-13_A,President,,AIP,Robert Ornelas,1
-Humboldt,4E-13_A,President,,REP,Ted Cruz,6
-Humboldt,4E-13_A,President,,DEM,Willie Wilson,3
-Humboldt,4E-13_A,Proposition 50,,,No,57
-Humboldt,4E-13_A,Proposition 50,,,Yes,244
-Humboldt,4E-13_A,State Assembly,2,DEM,Jim Wood,257
-Humboldt,4E-13_A,U.S. House,2,REP,Dale K. Mensing,28
-Humboldt,4E-13_A,U.S. House,2,DEM,Erin A. Schrode,48
-Humboldt,4E-13_A,U.S. House,2,DEM,Jared W. Huffman,205
-Humboldt,4E-13_A,U.S. House,2,IND,Matthew Robert Wookey,34
-Humboldt,4E-13_A,U.S. Senate,,IND,Clive Grey,3
-Humboldt,4E-13_A,U.S. Senate,,REP,Don Krampe,3
-Humboldt,4E-13_A,U.S. Senate,,REP,Duf Sundheim,10
-Humboldt,4E-13_A,U.S. Senate,,LIB,Gail K. Lightfoot,13
-Humboldt,4E-13_A,U.S. Senate,,REP,Greg Conlon,8
-Humboldt,4E-13_A,U.S. Senate,,DEM,Herbert G. Peters,1
-Humboldt,4E-13_A,U.S. Senate,,REP,Jarrell Williamson,4
-Humboldt,4E-13_A,U.S. Senate,,IND,Jason Hanania,1
-Humboldt,4E-13_A,U.S. Senate,,IND,Jason Kraus,1
-Humboldt,4E-13_A,U.S. Senate,,REP,Jerry J. Laws,5
-Humboldt,4E-13_A,U.S. Senate,,PAF,John Thompson Parker,2
-Humboldt,4E-13_A,U.S. Senate,,DEM,Kamala D. Harris,110
-Humboldt,4E-13_A,U.S. Senate,,DEM,Loretta L. Sanchez,76
-Humboldt,4E-13_A,U.S. Senate,,LIB,Mark Matthew Herd,2
-Humboldt,4E-13_A,U.S. Senate,,DEM,Massie Munroe,8
-Humboldt,4E-13_A,U.S. Senate,,IND,Mike Beitiks,2
-Humboldt,4E-13_A,U.S. Senate,,GRN,Pamela Elizondo,21
-Humboldt,4E-13_A,U.S. Senate,,IND,Paul Merritt,1
-Humboldt,4E-13_A,U.S. Senate,,REP,Phil Wyman,11
-Humboldt,4E-13_A,U.S. Senate,,DEM,President Cristina Grappo,2
-Humboldt,4E-13_A,U.S. Senate,,REP,Ron Unz,7
-Humboldt,4E-13_A,U.S. Senate,,IND,Scott A. Vineberg,1
-Humboldt,4E-13_A,U.S. Senate,,DEM,Steve Stokes,16
-Humboldt,4E-13_A,U.S. Senate,,REP,Thomas G. Del Beccaro,1
-Humboldt,4E-13_A,U.S. Senate,,REP,Von Hougo,4
-Humboldt,4E-14,President,,REP,Ben Carson,1
-Humboldt,4E-14,President,,DEM,Bernie Sanders,131
-Humboldt,4E-14,President,,REP,Donald Trump,15
-Humboldt,4E-14,President,,DEM,Hillary Clinton,24
+Humboldt,4E-13,U.S. Senate,,REP,Von Hougo,6
+Humboldt,4E-14,President,,REP,Ben Carson,6
+Humboldt,4E-14,President,,DEM,Bernie Sanders,250
+Humboldt,4E-14,President,,REP,Donald Trump,70
+Humboldt,4E-14,President,,LIB,Gary Johnson,3
+Humboldt,4E-14,President,,DEM,Hillary Clinton,86
 Humboldt,4E-14,President,,AIP,James Hedges,1
 Humboldt,4E-14,President,,GRN,Jill Stein,1
-Humboldt,4E-14,President,,REP,John R. Kasich,2
+Humboldt,4E-14,President,,REP,Jim Gilmore,2
+Humboldt,4E-14,President,,REP,John R. Kasich,4
+Humboldt,4E-14,President,,LIB,Joy Waymire,1
+Humboldt,4E-14,President,,DEM,Michael Steinberg,1
+Humboldt,4E-14,President,,PAF,Monica Moorehead,1
 Humboldt,4E-14,President,,AIP,Robert Ornelas,1
-Humboldt,4E-14,President,,REP,Ted Cruz,3
-Humboldt,4E-14,Proposition 50,,,No,29
-Humboldt,4E-14,Proposition 50,,,Yes,136
-Humboldt,4E-14,State Assembly,2,DEM,Jim Wood,140
-Humboldt,4E-14,U.S. House,2,REP,Dale K. Mensing,22
-Humboldt,4E-14,U.S. House,2,DEM,Erin A. Schrode,32
-Humboldt,4E-14,U.S. House,2,DEM,Jared W. Huffman,95
-Humboldt,4E-14,U.S. House,2,IND,Matthew Robert Wookey,22
+Humboldt,4E-14,President,,REP,Ted Cruz,6
+Humboldt,4E-14,President,,AIP,Thomas Hoefling,1
+Humboldt,4E-14,Proposition 50,,,No,85
+Humboldt,4E-14,Proposition 50,,,Yes,338
+Humboldt,4E-14,State Assembly,2,DEM,Jim Wood,343
+Humboldt,4E-14,U.S. House,2,REP,Dale K. Mensing,74
+Humboldt,4E-14,U.S. House,2,DEM,Erin A. Schrode,53
+Humboldt,4E-14,U.S. House,2,DEM,Jared W. Huffman,266
+Humboldt,4E-14,U.S. House,2,IND,Matthew Robert Wookey,42
 Humboldt,4E-14,U.S. Senate,,IND,Clive Grey,1
-Humboldt,4E-14,U.S. Senate,,REP,Don Krampe,1
-Humboldt,4E-14,U.S. Senate,,REP,Duf Sundheim,5
-Humboldt,4E-14,U.S. Senate,,IND,Eleanor García,1
-Humboldt,4E-14,U.S. Senate,,LIB,Gail K. Lightfoot,12
-Humboldt,4E-14,U.S. Senate,,REP,Greg Conlon,2
+Humboldt,4E-14,U.S. Senate,,IND,Don J. Grundmann,1
+Humboldt,4E-14,U.S. Senate,,REP,Don Krampe,3
+Humboldt,4E-14,U.S. Senate,,REP,Duf Sundheim,22
+Humboldt,4E-14,U.S. Senate,,IND,Eleanor García,2
+Humboldt,4E-14,U.S. Senate,,DEM,Emory Rodgers,2
+Humboldt,4E-14,U.S. Senate,,LIB,Gail K. Lightfoot,23
+Humboldt,4E-14,U.S. Senate,,IND,Gar Myers,1
+Humboldt,4E-14,U.S. Senate,,REP,George C. Yang,1
+Humboldt,4E-14,U.S. Senate,,REP,Greg Conlon,11
 Humboldt,4E-14,U.S. Senate,,DEM,Herbert G. Peters,1
-Humboldt,4E-14,U.S. Senate,,REP,Jarrell Williamson,1
-Humboldt,4E-14,U.S. Senate,,REP,Jerry J. Laws,11
+Humboldt,4E-14,U.S. Senate,,REP,Jarrell Williamson,4
+Humboldt,4E-14,U.S. Senate,,REP,Jerry J. Laws,23
 Humboldt,4E-14,U.S. Senate,,PAF,John Thompson Parker,3
-Humboldt,4E-14,U.S. Senate,,DEM,Kamala D. Harris,45
-Humboldt,4E-14,U.S. Senate,,REP,Karen Roseberry,4
-Humboldt,4E-14,U.S. Senate,,IND,Ling Ling Shi,1
-Humboldt,4E-14,U.S. Senate,,DEM,Loretta L. Sanchez,41
-Humboldt,4E-14,U.S. Senate,,LIB,Mark Matthew Herd,1
-Humboldt,4E-14,U.S. Senate,,DEM,Massie Munroe,4
-Humboldt,4E-14,U.S. Senate,,IND,Mike Beitiks,5
-Humboldt,4E-14,U.S. Senate,,GRN,Pamela Elizondo,7
-Humboldt,4E-14,U.S. Senate,,REP,Phil Wyman,1
-Humboldt,4E-14,U.S. Senate,,DEM,President Cristina Grappo,1
+Humboldt,4E-14,U.S. Senate,,DEM,Kamala D. Harris,146
+Humboldt,4E-14,U.S. Senate,,REP,Karen Roseberry,7
+Humboldt,4E-14,U.S. Senate,,IND,Ling Ling Shi,4
+Humboldt,4E-14,U.S. Senate,,DEM,Loretta L. Sanchez,77
+Humboldt,4E-14,U.S. Senate,,LIB,Mark Matthew Herd,4
+Humboldt,4E-14,U.S. Senate,,DEM,Massie Munroe,6
+Humboldt,4E-14,U.S. Senate,,IND,Mike Beitiks,6
+Humboldt,4E-14,U.S. Senate,,GRN,Pamela Elizondo,15
+Humboldt,4E-14,U.S. Senate,,IND,Paul Merritt,1
+Humboldt,4E-14,U.S. Senate,,REP,Phil Wyman,16
+Humboldt,4E-14,U.S. Senate,,DEM,President Cristina Grappo,3
 Humboldt,4E-14,U.S. Senate,,IND,Scott A. Vineberg,1
-Humboldt,4E-14,U.S. Senate,,DEM,Steve Stokes,11
-Humboldt,4E-14,U.S. Senate,,REP,Thomas G. Del Beccaro,3
-Humboldt,4E-14,U.S. Senate,,REP,Von Hougo,2
-Humboldt,4E-14_A,President,,REP,Ben Carson,5
-Humboldt,4E-14_A,President,,DEM,Bernie Sanders,119
-Humboldt,4E-14_A,President,,REP,Donald Trump,55
-Humboldt,4E-14_A,President,,LIB,Gary Johnson,3
-Humboldt,4E-14_A,President,,DEM,Hillary Clinton,62
-Humboldt,4E-14_A,President,,REP,Jim Gilmore,2
-Humboldt,4E-14_A,President,,REP,John R. Kasich,2
-Humboldt,4E-14_A,President,,LIB,Joy Waymire,1
-Humboldt,4E-14_A,President,,DEM,Michael Steinberg,1
-Humboldt,4E-14_A,President,,PAF,Monica Moorehead,1
-Humboldt,4E-14_A,President,,REP,Ted Cruz,3
-Humboldt,4E-14_A,President,,AIP,Thomas Hoefling,1
-Humboldt,4E-14_A,Proposition 50,,,No,56
-Humboldt,4E-14_A,Proposition 50,,,Yes,202
-Humboldt,4E-14_A,State Assembly,2,DEM,Jim Wood,203
-Humboldt,4E-14_A,U.S. House,2,REP,Dale K. Mensing,52
-Humboldt,4E-14_A,U.S. House,2,DEM,Erin A. Schrode,21
-Humboldt,4E-14_A,U.S. House,2,DEM,Jared W. Huffman,171
-Humboldt,4E-14_A,U.S. House,2,IND,Matthew Robert Wookey,20
-Humboldt,4E-14_A,U.S. Senate,,IND,Don J. Grundmann,1
-Humboldt,4E-14_A,U.S. Senate,,REP,Don Krampe,2
-Humboldt,4E-14_A,U.S. Senate,,REP,Duf Sundheim,17
-Humboldt,4E-14_A,U.S. Senate,,IND,Eleanor García,1
-Humboldt,4E-14_A,U.S. Senate,,DEM,Emory Rodgers,2
-Humboldt,4E-14_A,U.S. Senate,,LIB,Gail K. Lightfoot,11
-Humboldt,4E-14_A,U.S. Senate,,IND,Gar Myers,1
-Humboldt,4E-14_A,U.S. Senate,,REP,George C. Yang,1
-Humboldt,4E-14_A,U.S. Senate,,REP,Greg Conlon,9
-Humboldt,4E-14_A,U.S. Senate,,REP,Jarrell Williamson,3
-Humboldt,4E-14_A,U.S. Senate,,REP,Jerry J. Laws,12
-Humboldt,4E-14_A,U.S. Senate,,DEM,Kamala D. Harris,101
-Humboldt,4E-14_A,U.S. Senate,,REP,Karen Roseberry,3
-Humboldt,4E-14_A,U.S. Senate,,IND,Ling Ling Shi,3
-Humboldt,4E-14_A,U.S. Senate,,DEM,Loretta L. Sanchez,36
-Humboldt,4E-14_A,U.S. Senate,,LIB,Mark Matthew Herd,3
-Humboldt,4E-14_A,U.S. Senate,,DEM,Massie Munroe,2
-Humboldt,4E-14_A,U.S. Senate,,IND,Mike Beitiks,1
-Humboldt,4E-14_A,U.S. Senate,,GRN,Pamela Elizondo,8
-Humboldt,4E-14_A,U.S. Senate,,IND,Paul Merritt,1
-Humboldt,4E-14_A,U.S. Senate,,REP,Phil Wyman,15
-Humboldt,4E-14_A,U.S. Senate,,DEM,President Cristina Grappo,2
-Humboldt,4E-14_A,U.S. Senate,,DEM,Steve Stokes,8
-Humboldt,4E-14_A,U.S. Senate,,REP,Thomas G. Del Beccaro,6
-Humboldt,4E-14_A,U.S. Senate,,REP,Tom Palzer,3
-Humboldt,4E-14_A,U.S. Senate,,REP,Von Hougo,6
-Humboldt,4E-21,President,,REP,Ben Carson,1
-Humboldt,4E-21,President,,DEM,Bernie Sanders,96
+Humboldt,4E-14,U.S. Senate,,DEM,Steve Stokes,19
+Humboldt,4E-14,U.S. Senate,,REP,Thomas G. Del Beccaro,9
+Humboldt,4E-14,U.S. Senate,,REP,Tom Palzer,3
+Humboldt,4E-14,U.S. Senate,,REP,Von Hougo,8
+Humboldt,4E-21,President,,REP,Ben Carson,3
+Humboldt,4E-21,President,,DEM,Bernie Sanders,201
+Humboldt,4E-21,President,,LIB,Cecil Ince,1
 Humboldt,4E-21,President,,GRN,Darryl Cherney,1
-Humboldt,4E-21,President,,REP,Donald Trump,9
-Humboldt,4E-21,President,,DEM,Hillary Clinton,30
+Humboldt,4E-21,President,,REP,Donald Trump,32
+Humboldt,4E-21,President,,DEM,Henry Hewes,1
+Humboldt,4E-21,President,,DEM,Hillary Clinton,58
+Humboldt,4E-21,President,,AIP,James Hedges,1
 Humboldt,4E-21,President,,GRN,Jill Stein,3
-Humboldt,4E-21,President,,REP,John R. Kasich,1
+Humboldt,4E-21,President,,REP,Jim Gilmore,1
+Humboldt,4E-21,President,,REP,John R. Kasich,3
 Humboldt,4E-21,President,,PAF,Monica Moorehead,1
-Humboldt,4E-21,President,,REP,Ted Cruz,1
-Humboldt,4E-21,Proposition 50,,,No,33
-Humboldt,4E-21,Proposition 50,,,Yes,108
-Humboldt,4E-21,State Assembly,2,DEM,Jim Wood,118
-Humboldt,4E-21,U.S. House,2,REP,Dale K. Mensing,17
-Humboldt,4E-21,U.S. House,2,DEM,Erin A. Schrode,24
-Humboldt,4E-21,U.S. House,2,DEM,Jared W. Huffman,78
-Humboldt,4E-21,U.S. House,2,IND,Matthew Robert Wookey,21
-Humboldt,4E-21,U.S. Senate,,REP,Duf Sundheim,4
+Humboldt,4E-21,President,,REP,Ted Cruz,2
+Humboldt,4E-21,Proposition 50,,,No,74
+Humboldt,4E-21,Proposition 50,,,Yes,216
+Humboldt,4E-21,State Assembly,2,DEM,Jim Wood,236
+Humboldt,4E-21,U.S. House,2,REP,Dale K. Mensing,37
+Humboldt,4E-21,U.S. House,2,DEM,Erin A. Schrode,47
+Humboldt,4E-21,U.S. House,2,DEM,Jared W. Huffman,173
+Humboldt,4E-21,U.S. House,2,IND,Matthew Robert Wookey,34
+Humboldt,4E-21,U.S. Senate,,IND,Clive Grey,1
+Humboldt,4E-21,U.S. Senate,,REP,Don Krampe,2
+Humboldt,4E-21,U.S. Senate,,REP,Duf Sundheim,6
 Humboldt,4E-21,U.S. Senate,,IND,Eleanor García,1
-Humboldt,4E-21,U.S. Senate,,DEM,Emory Rodgers,1
-Humboldt,4E-21,U.S. Senate,,LIB,Gail K. Lightfoot,5
-Humboldt,4E-21,U.S. Senate,,REP,Greg Conlon,1
+Humboldt,4E-21,U.S. Senate,,DEM,Emory Rodgers,4
+Humboldt,4E-21,U.S. Senate,,LIB,Gail K. Lightfoot,10
+Humboldt,4E-21,U.S. Senate,,REP,Greg Conlon,4
 Humboldt,4E-21,U.S. Senate,,REP,Jarrell Williamson,1
-Humboldt,4E-21,U.S. Senate,,IND,Jason Hanania,1
+Humboldt,4E-21,U.S. Senate,,IND,Jason Hanania,2
 Humboldt,4E-21,U.S. Senate,,IND,Jason Kraus,1
-Humboldt,4E-21,U.S. Senate,,REP,Jerry J. Laws,5
-Humboldt,4E-21,U.S. Senate,,DEM,Kamala D. Harris,48
+Humboldt,4E-21,U.S. Senate,,REP,Jerry J. Laws,9
+Humboldt,4E-21,U.S. Senate,,PAF,John Thompson Parker,2
+Humboldt,4E-21,U.S. Senate,,DEM,Kamala D. Harris,104
 Humboldt,4E-21,U.S. Senate,,REP,Karen Roseberry,4
 Humboldt,4E-21,U.S. Senate,,IND,Ling Ling Shi,3
-Humboldt,4E-21,U.S. Senate,,DEM,Loretta L. Sanchez,23
-Humboldt,4E-21,U.S. Senate,,DEM,Massie Munroe,4
-Humboldt,4E-21,U.S. Senate,,IND,Mike Beitiks,4
-Humboldt,4E-21,U.S. Senate,,GRN,Pamela Elizondo,10
-Humboldt,4E-21,U.S. Senate,,REP,Phil Wyman,5
-Humboldt,4E-21,U.S. Senate,,REP,Ron Unz,3
+Humboldt,4E-21,U.S. Senate,,DEM,Loretta L. Sanchez,56
+Humboldt,4E-21,U.S. Senate,,DEM,Massie Munroe,5
+Humboldt,4E-21,U.S. Senate,,IND,Mike Beitiks,6
+Humboldt,4E-21,U.S. Senate,,GRN,Pamela Elizondo,16
+Humboldt,4E-21,U.S. Senate,,REP,Phil Wyman,7
+Humboldt,4E-21,U.S. Senate,,REP,Ron Unz,6
 Humboldt,4E-21,U.S. Senate,,IND,Scott A. Vineberg,1
-Humboldt,4E-21,U.S. Senate,,DEM,Steve Stokes,14
+Humboldt,4E-21,U.S. Senate,,DEM,Steve Stokes,29
+Humboldt,4E-21,U.S. Senate,,REP,Thomas G. Del Beccaro,2
 Humboldt,4E-21,U.S. Senate,,IND,Tim Gildersleeve,2
-Humboldt,4E-21_A,President,,REP,Ben Carson,2
-Humboldt,4E-21_A,President,,DEM,Bernie Sanders,105
-Humboldt,4E-21_A,President,,LIB,Cecil Ince,1
-Humboldt,4E-21_A,President,,REP,Donald Trump,23
-Humboldt,4E-21_A,President,,DEM,Henry Hewes,1
-Humboldt,4E-21_A,President,,DEM,Hillary Clinton,28
-Humboldt,4E-21_A,President,,AIP,James Hedges,1
-Humboldt,4E-21_A,President,,REP,Jim Gilmore,1
-Humboldt,4E-21_A,President,,REP,John R. Kasich,2
-Humboldt,4E-21_A,President,,REP,Ted Cruz,1
-Humboldt,4E-21_A,Proposition 50,,,No,41
-Humboldt,4E-21_A,Proposition 50,,,Yes,108
-Humboldt,4E-21_A,State Assembly,2,DEM,Jim Wood,118
-Humboldt,4E-21_A,U.S. House,2,REP,Dale K. Mensing,20
-Humboldt,4E-21_A,U.S. House,2,DEM,Erin A. Schrode,23
-Humboldt,4E-21_A,U.S. House,2,DEM,Jared W. Huffman,95
-Humboldt,4E-21_A,U.S. House,2,IND,Matthew Robert Wookey,13
-Humboldt,4E-21_A,U.S. Senate,,IND,Clive Grey,1
-Humboldt,4E-21_A,U.S. Senate,,REP,Don Krampe,2
-Humboldt,4E-21_A,U.S. Senate,,REP,Duf Sundheim,2
-Humboldt,4E-21_A,U.S. Senate,,DEM,Emory Rodgers,3
-Humboldt,4E-21_A,U.S. Senate,,LIB,Gail K. Lightfoot,5
-Humboldt,4E-21_A,U.S. Senate,,REP,Greg Conlon,3
-Humboldt,4E-21_A,U.S. Senate,,IND,Jason Hanania,1
-Humboldt,4E-21_A,U.S. Senate,,REP,Jerry J. Laws,4
-Humboldt,4E-21_A,U.S. Senate,,PAF,John Thompson Parker,2
-Humboldt,4E-21_A,U.S. Senate,,DEM,Kamala D. Harris,56
-Humboldt,4E-21_A,U.S. Senate,,DEM,Loretta L. Sanchez,33
-Humboldt,4E-21_A,U.S. Senate,,DEM,Massie Munroe,1
-Humboldt,4E-21_A,U.S. Senate,,IND,Mike Beitiks,2
-Humboldt,4E-21_A,U.S. Senate,,GRN,Pamela Elizondo,6
-Humboldt,4E-21_A,U.S. Senate,,REP,Phil Wyman,2
-Humboldt,4E-21_A,U.S. Senate,,REP,Ron Unz,3
-Humboldt,4E-21_A,U.S. Senate,,DEM,Steve Stokes,15
-Humboldt,4E-21_A,U.S. Senate,,REP,Thomas G. Del Beccaro,2
-Humboldt,4E-21_A,U.S. Senate,,REP,Tom Palzer,3
-Humboldt,4E-21_A,U.S. Senate,,REP,Von Hougo,1
-Humboldt,4E-22,President,,REP,Ben Carson,1
-Humboldt,4E-22,President,,DEM,Bernie Sanders,92
-Humboldt,4E-22,President,,REP,Donald Trump,21
-Humboldt,4E-22,President,,DEM,Hillary Clinton,26
-Humboldt,4E-22,President,,GRN,Jill Stein,3
-Humboldt,4E-22,President,,REP,John R. Kasich,1
-Humboldt,4E-22,President,,REP,Ted Cruz,6
-Humboldt,4E-22,Proposition 50,,,No,25
-Humboldt,4E-22,Proposition 50,,,Yes,111
-Humboldt,4E-22,State Assembly,2,DEM,Jim Wood,116
-Humboldt,4E-22,U.S. House,2,REP,Dale K. Mensing,20
-Humboldt,4E-22,U.S. House,2,DEM,Erin A. Schrode,22
-Humboldt,4E-22,U.S. House,2,DEM,Jared W. Huffman,84
-Humboldt,4E-22,U.S. House,2,IND,Matthew Robert Wookey,20
+Humboldt,4E-21,U.S. Senate,,REP,Tom Palzer,3
+Humboldt,4E-21,U.S. Senate,,REP,Von Hougo,1
+Humboldt,4E-22,President,,REP,Ben Carson,4
+Humboldt,4E-22,President,,DEM,Bernie Sanders,178
+Humboldt,4E-22,President,,REP,Donald Trump,53
+Humboldt,4E-22,President,,LIB,Gary Johnson,1
+Humboldt,4E-22,President,,DEM,Hillary Clinton,84
+Humboldt,4E-22,President,,GRN,Jill Stein,4
+Humboldt,4E-22,President,,REP,John R. Kasich,4
+Humboldt,4E-22,President,,DEM,Michael Steinberg,2
+Humboldt,4E-22,President,,REP,Ted Cruz,15
+Humboldt,4E-22,President,,AIP,Thomas Hoefling,1
+Humboldt,4E-22,Proposition 50,,,No,60
+Humboldt,4E-22,Proposition 50,,,Yes,265
+Humboldt,4E-22,State Assembly,2,DEM,Jim Wood,273
+Humboldt,4E-22,U.S. House,2,REP,Dale K. Mensing,58
+Humboldt,4E-22,U.S. House,2,DEM,Erin A. Schrode,41
+Humboldt,4E-22,U.S. House,2,DEM,Jared W. Huffman,213
+Humboldt,4E-22,U.S. House,2,IND,Matthew Robert Wookey,34
 Humboldt,4E-22,U.S. Senate,,IND,Clive Grey,1
-Humboldt,4E-22,U.S. Senate,,REP,Duf Sundheim,4
+Humboldt,4E-22,U.S. Senate,,REP,Don Krampe,2
+Humboldt,4E-22,U.S. Senate,,REP,Duf Sundheim,18
 Humboldt,4E-22,U.S. Senate,,IND,Eleanor García,1
-Humboldt,4E-22,U.S. Senate,,DEM,Emory Rodgers,1
-Humboldt,4E-22,U.S. Senate,,LIB,Gail K. Lightfoot,4
-Humboldt,4E-22,U.S. Senate,,REP,Greg Conlon,9
-Humboldt,4E-22,U.S. Senate,,IND,Jason Hanania,2
-Humboldt,4E-22,U.S. Senate,,IND,Jason Kraus,1
-Humboldt,4E-22,U.S. Senate,,REP,Jerry J. Laws,7
-Humboldt,4E-22,U.S. Senate,,DEM,Kamala D. Harris,52
+Humboldt,4E-22,U.S. Senate,,DEM,Emory Rodgers,2
+Humboldt,4E-22,U.S. Senate,,LIB,Gail K. Lightfoot,11
+Humboldt,4E-22,U.S. Senate,,REP,George C. Yang,2
+Humboldt,4E-22,U.S. Senate,,REP,Greg Conlon,13
+Humboldt,4E-22,U.S. Senate,,REP,Jarrell Williamson,1
+Humboldt,4E-22,U.S. Senate,,IND,Jason Hanania,5
+Humboldt,4E-22,U.S. Senate,,IND,Jason Kraus,2
+Humboldt,4E-22,U.S. Senate,,REP,Jerry J. Laws,10
+Humboldt,4E-22,U.S. Senate,,PAF,John Thompson Parker,3
+Humboldt,4E-22,U.S. Senate,,DEM,Kamala D. Harris,133
+Humboldt,4E-22,U.S. Senate,,REP,Karen Roseberry,3
 Humboldt,4E-22,U.S. Senate,,IND,Ling Ling Shi,2
-Humboldt,4E-22,U.S. Senate,,DEM,Loretta L. Sanchez,18
-Humboldt,4E-22,U.S. Senate,,LIB,Mark Matthew Herd,2
-Humboldt,4E-22,U.S. Senate,,DEM,Massie Munroe,1
+Humboldt,4E-22,U.S. Senate,,DEM,Loretta L. Sanchez,51
+Humboldt,4E-22,U.S. Senate,,LIB,Mark Matthew Herd,4
+Humboldt,4E-22,U.S. Senate,,DEM,Massie Munroe,3
 Humboldt,4E-22,U.S. Senate,,IND,Mike Beitiks,1
-Humboldt,4E-22,U.S. Senate,,GRN,Pamela Elizondo,9
-Humboldt,4E-22,U.S. Senate,,REP,Phil Wyman,6
+Humboldt,4E-22,U.S. Senate,,GRN,Pamela Elizondo,20
+Humboldt,4E-22,U.S. Senate,,REP,Phil Wyman,21
 Humboldt,4E-22,U.S. Senate,,DEM,President Cristina Grappo,1
+Humboldt,4E-22,U.S. Senate,,REP,Ron Unz,1
 Humboldt,4E-22,U.S. Senate,,IND,Scott A. Vineberg,1
-Humboldt,4E-22,U.S. Senate,,DEM,Steve Stokes,12
-Humboldt,4E-22,U.S. Senate,,REP,Tom Palzer,1
-Humboldt,4E-22,U.S. Senate,,REP,Von Hougo,2
-Humboldt,4E-22_A,President,,REP,Ben Carson,3
-Humboldt,4E-22_A,President,,DEM,Bernie Sanders,86
-Humboldt,4E-22_A,President,,REP,Donald Trump,32
-Humboldt,4E-22_A,President,,LIB,Gary Johnson,1
-Humboldt,4E-22_A,President,,DEM,Hillary Clinton,58
-Humboldt,4E-22_A,President,,GRN,Jill Stein,1
-Humboldt,4E-22_A,President,,REP,John R. Kasich,3
-Humboldt,4E-22_A,President,,DEM,Michael Steinberg,2
-Humboldt,4E-22_A,President,,REP,Ted Cruz,9
-Humboldt,4E-22_A,President,,AIP,Thomas Hoefling,1
-Humboldt,4E-22_A,Proposition 50,,,No,35
-Humboldt,4E-22_A,Proposition 50,,,Yes,154
-Humboldt,4E-22_A,State Assembly,2,DEM,Jim Wood,157
-Humboldt,4E-22_A,U.S. House,2,REP,Dale K. Mensing,38
-Humboldt,4E-22_A,U.S. House,2,DEM,Erin A. Schrode,19
-Humboldt,4E-22_A,U.S. House,2,DEM,Jared W. Huffman,129
-Humboldt,4E-22_A,U.S. House,2,IND,Matthew Robert Wookey,14
-Humboldt,4E-22_A,U.S. Senate,,REP,Don Krampe,2
-Humboldt,4E-22_A,U.S. Senate,,REP,Duf Sundheim,14
-Humboldt,4E-22_A,U.S. Senate,,DEM,Emory Rodgers,1
-Humboldt,4E-22_A,U.S. Senate,,LIB,Gail K. Lightfoot,7
-Humboldt,4E-22_A,U.S. Senate,,REP,George C. Yang,2
-Humboldt,4E-22_A,U.S. Senate,,REP,Greg Conlon,4
-Humboldt,4E-22_A,U.S. Senate,,REP,Jarrell Williamson,1
-Humboldt,4E-22_A,U.S. Senate,,IND,Jason Hanania,3
-Humboldt,4E-22_A,U.S. Senate,,IND,Jason Kraus,1
-Humboldt,4E-22_A,U.S. Senate,,REP,Jerry J. Laws,3
-Humboldt,4E-22_A,U.S. Senate,,PAF,John Thompson Parker,3
-Humboldt,4E-22_A,U.S. Senate,,DEM,Kamala D. Harris,81
-Humboldt,4E-22_A,U.S. Senate,,REP,Karen Roseberry,3
-Humboldt,4E-22_A,U.S. Senate,,DEM,Loretta L. Sanchez,33
-Humboldt,4E-22_A,U.S. Senate,,LIB,Mark Matthew Herd,2
-Humboldt,4E-22_A,U.S. Senate,,DEM,Massie Munroe,2
-Humboldt,4E-22_A,U.S. Senate,,GRN,Pamela Elizondo,11
-Humboldt,4E-22_A,U.S. Senate,,REP,Phil Wyman,15
-Humboldt,4E-22_A,U.S. Senate,,REP,Ron Unz,1
-Humboldt,4E-22_A,U.S. Senate,,DEM,Steve Stokes,6
-Humboldt,4E-22_A,U.S. Senate,,REP,Thomas G. Del Beccaro,2
-Humboldt,4E-22_A,U.S. Senate,,REP,Tom Palzer,2
-Humboldt,4E-22_A,U.S. Senate,,REP,Von Hougo,2
-Humboldt,4E-23,President,,AIP,Alan Spears,1
-Humboldt,4E-23,President,,REP,Ben Carson,3
-Humboldt,4E-23,President,,DEM,Bernie Sanders,154
+Humboldt,4E-22,U.S. Senate,,DEM,Steve Stokes,18
+Humboldt,4E-22,U.S. Senate,,REP,Thomas G. Del Beccaro,2
+Humboldt,4E-22,U.S. Senate,,REP,Tom Palzer,3
+Humboldt,4E-22,U.S. Senate,,REP,Von Hougo,4
+Humboldt,4E-23,President,,AIP,Alan Spears,3
+Humboldt,4E-23,President,,REP,Ben Carson,5
+Humboldt,4E-23,President,,DEM,Bernie Sanders,321
 Humboldt,4E-23,President,,GRN,Darryl Cherney,3
-Humboldt,4E-23,President,,REP,Donald Trump,30
+Humboldt,4E-23,President,,REP,Donald Trump,96
 Humboldt,4E-23,President,,PAF,Gloria Estela La Riva,1
-Humboldt,4E-23,President,,DEM,Hillary Clinton,53
-Humboldt,4E-23,President,,GRN,Jill Stein,1
-Humboldt,4E-23,President,,REP,John R. Kasich,4
+Humboldt,4E-23,President,,DEM,Hillary Clinton,136
+Humboldt,4E-23,President,,GRN,Jill Stein,3
+Humboldt,4E-23,President,,REP,Jim Gilmore,1
+Humboldt,4E-23,President,,REP,John R. Kasich,6
 Humboldt,4E-23,President,,DEM,Keith Judd,1
+Humboldt,4E-23,President,,DEM,Michael Steinberg,2
 Humboldt,4E-23,President,,LIB,Rhett White Feather Smith,1
-Humboldt,4E-23,President,,REP,Ted Cruz,17
+Humboldt,4E-23,President,,REP,Ted Cruz,31
 Humboldt,4E-23,President,,AIP,Thomas Hoefling,1
-Humboldt,4E-23,Proposition 50,,,No,79
-Humboldt,4E-23,Proposition 50,,,Yes,185
-Humboldt,4E-23,State Assembly,2,DEM,Jim Wood,209
-Humboldt,4E-23,U.S. House,2,REP,Dale K. Mensing,42
-Humboldt,4E-23,U.S. House,2,DEM,Erin A. Schrode,28
-Humboldt,4E-23,U.S. House,2,DEM,Jared W. Huffman,180
-Humboldt,4E-23,U.S. House,2,IND,Matthew Robert Wookey,26
-Humboldt,4E-23,U.S. Senate,,IND,Clive Grey,1
-Humboldt,4E-23,U.S. Senate,,REP,Don Krampe,7
-Humboldt,4E-23,U.S. Senate,,REP,Duf Sundheim,11
+Humboldt,4E-23,President,,DEM,Willie Wilson,1
+Humboldt,4E-23,Proposition 50,,,No,136
+Humboldt,4E-23,Proposition 50,,,Yes,441
+Humboldt,4E-23,State Assembly,2,DEM,Jim Wood,473
+Humboldt,4E-23,U.S. House,2,REP,Dale K. Mensing,106
+Humboldt,4E-23,U.S. House,2,DEM,Erin A. Schrode,58
+Humboldt,4E-23,U.S. House,2,DEM,Jared W. Huffman,403
+Humboldt,4E-23,U.S. House,2,IND,Matthew Robert Wookey,47
+Humboldt,4E-23,U.S. Senate,,IND,Clive Grey,4
+Humboldt,4E-23,U.S. Senate,,IND,Don J. Grundmann,2
+Humboldt,4E-23,U.S. Senate,,REP,Don Krampe,11
+Humboldt,4E-23,U.S. Senate,,REP,Duf Sundheim,25
 Humboldt,4E-23,U.S. Senate,,IND,Eleanor García,1
-Humboldt,4E-23,U.S. Senate,,LIB,Gail K. Lightfoot,15
+Humboldt,4E-23,U.S. Senate,,DEM,Emory Rodgers,1
+Humboldt,4E-23,U.S. Senate,,LIB,Gail K. Lightfoot,25
 Humboldt,4E-23,U.S. Senate,,IND,Gar Myers,1
 Humboldt,4E-23,U.S. Senate,,REP,George C. Yang,2
-Humboldt,4E-23,U.S. Senate,,REP,Greg Conlon,6
-Humboldt,4E-23,U.S. Senate,,REP,Jarrell Williamson,1
-Humboldt,4E-23,U.S. Senate,,IND,Jason Hanania,1
-Humboldt,4E-23,U.S. Senate,,REP,Jerry J. Laws,5
-Humboldt,4E-23,U.S. Senate,,DEM,Kamala D. Harris,112
-Humboldt,4E-23,U.S. Senate,,REP,Karen Roseberry,4
-Humboldt,4E-23,U.S. Senate,,IND,Ling Ling Shi,1
-Humboldt,4E-23,U.S. Senate,,DEM,Loretta L. Sanchez,44
-Humboldt,4E-23,U.S. Senate,,LIB,Mark Matthew Herd,4
-Humboldt,4E-23,U.S. Senate,,DEM,Massie Munroe,4
-Humboldt,4E-23,U.S. Senate,,IND,Mike Beitiks,3
-Humboldt,4E-23,U.S. Senate,,GRN,Pamela Elizondo,17
-Humboldt,4E-23,U.S. Senate,,REP,Phil Wyman,10
+Humboldt,4E-23,U.S. Senate,,REP,Greg Conlon,21
+Humboldt,4E-23,U.S. Senate,,REP,Jarrell Williamson,2
+Humboldt,4E-23,U.S. Senate,,IND,Jason Hanania,2
+Humboldt,4E-23,U.S. Senate,,IND,Jason Kraus,5
+Humboldt,4E-23,U.S. Senate,,REP,Jerry J. Laws,16
+Humboldt,4E-23,U.S. Senate,,DEM,Kamala D. Harris,256
+Humboldt,4E-23,U.S. Senate,,REP,Karen Roseberry,9
+Humboldt,4E-23,U.S. Senate,,IND,Ling Ling Shi,2
+Humboldt,4E-23,U.S. Senate,,DEM,Loretta L. Sanchez,92
+Humboldt,4E-23,U.S. Senate,,LIB,Mark Matthew Herd,6
+Humboldt,4E-23,U.S. Senate,,DEM,Massie Munroe,6
+Humboldt,4E-23,U.S. Senate,,IND,Mike Beitiks,5
+Humboldt,4E-23,U.S. Senate,,GRN,Pamela Elizondo,24
+Humboldt,4E-23,U.S. Senate,,REP,Phil Wyman,34
+Humboldt,4E-23,U.S. Senate,,REP,Ron Unz,1
 Humboldt,4E-23,U.S. Senate,,IND,Scott A. Vineberg,1
-Humboldt,4E-23,U.S. Senate,,DEM,Steve Stokes,11
-Humboldt,4E-23,U.S. Senate,,REP,Thomas G. Del Beccaro,3
+Humboldt,4E-23,U.S. Senate,,DEM,Steve Stokes,27
+Humboldt,4E-23,U.S. Senate,,REP,Thomas G. Del Beccaro,10
 Humboldt,4E-23,U.S. Senate,,IND,Tim Gildersleeve,2
-Humboldt,4E-23,U.S. Senate,,REP,Von Hougo,2
-Humboldt,4E-23_A,President,,AIP,Alan Spears,2
-Humboldt,4E-23_A,President,,REP,Ben Carson,2
-Humboldt,4E-23_A,President,,DEM,Bernie Sanders,167
-Humboldt,4E-23_A,President,,REP,Donald Trump,66
-Humboldt,4E-23_A,President,,DEM,Hillary Clinton,83
-Humboldt,4E-23_A,President,,GRN,Jill Stein,2
-Humboldt,4E-23_A,President,,REP,Jim Gilmore,1
-Humboldt,4E-23_A,President,,REP,John R. Kasich,2
-Humboldt,4E-23_A,President,,DEM,Michael Steinberg,2
-Humboldt,4E-23_A,President,,REP,Ted Cruz,14
-Humboldt,4E-23_A,President,,DEM,Willie Wilson,1
-Humboldt,4E-23_A,Proposition 50,,,No,57
-Humboldt,4E-23_A,Proposition 50,,,Yes,256
-Humboldt,4E-23_A,State Assembly,2,DEM,Jim Wood,264
-Humboldt,4E-23_A,U.S. House,2,REP,Dale K. Mensing,64
-Humboldt,4E-23_A,U.S. House,2,DEM,Erin A. Schrode,30
-Humboldt,4E-23_A,U.S. House,2,DEM,Jared W. Huffman,223
-Humboldt,4E-23_A,U.S. House,2,IND,Matthew Robert Wookey,21
-Humboldt,4E-23_A,U.S. Senate,,IND,Clive Grey,3
-Humboldt,4E-23_A,U.S. Senate,,IND,Don J. Grundmann,2
-Humboldt,4E-23_A,U.S. Senate,,REP,Don Krampe,4
-Humboldt,4E-23_A,U.S. Senate,,REP,Duf Sundheim,14
-Humboldt,4E-23_A,U.S. Senate,,DEM,Emory Rodgers,1
-Humboldt,4E-23_A,U.S. Senate,,LIB,Gail K. Lightfoot,10
-Humboldt,4E-23_A,U.S. Senate,,REP,Greg Conlon,15
-Humboldt,4E-23_A,U.S. Senate,,REP,Jarrell Williamson,1
-Humboldt,4E-23_A,U.S. Senate,,IND,Jason Hanania,1
-Humboldt,4E-23_A,U.S. Senate,,IND,Jason Kraus,5
-Humboldt,4E-23_A,U.S. Senate,,REP,Jerry J. Laws,11
-Humboldt,4E-23_A,U.S. Senate,,DEM,Kamala D. Harris,144
-Humboldt,4E-23_A,U.S. Senate,,REP,Karen Roseberry,5
-Humboldt,4E-23_A,U.S. Senate,,IND,Ling Ling Shi,1
-Humboldt,4E-23_A,U.S. Senate,,DEM,Loretta L. Sanchez,48
-Humboldt,4E-23_A,U.S. Senate,,LIB,Mark Matthew Herd,2
-Humboldt,4E-23_A,U.S. Senate,,DEM,Massie Munroe,2
-Humboldt,4E-23_A,U.S. Senate,,IND,Mike Beitiks,2
-Humboldt,4E-23_A,U.S. Senate,,GRN,Pamela Elizondo,7
-Humboldt,4E-23_A,U.S. Senate,,REP,Phil Wyman,24
-Humboldt,4E-23_A,U.S. Senate,,REP,Ron Unz,1
-Humboldt,4E-23_A,U.S. Senate,,DEM,Steve Stokes,16
-Humboldt,4E-23_A,U.S. Senate,,REP,Thomas G. Del Beccaro,7
-Humboldt,4E-23_A,U.S. Senate,,REP,Tom Palzer,7
-Humboldt,4E-23_A,U.S. Senate,,REP,Von Hougo,2
-Humboldt,4E-25,President,,REP,Ben Carson,5
-Humboldt,4E-25,President,,DEM,Bernie Sanders,71
-Humboldt,4E-25,President,,REP,Donald Trump,42
+Humboldt,4E-23,U.S. Senate,,REP,Tom Palzer,7
+Humboldt,4E-23,U.S. Senate,,REP,Von Hougo,4
+Humboldt,4E-25,President,,AIP,Arthur Harris,1
+Humboldt,4E-25,President,,REP,Ben Carson,13
+Humboldt,4E-25,President,,DEM,Bernie Sanders,163
+Humboldt,4E-25,President,,REP,Donald Trump,108
 Humboldt,4E-25,President,,LIB,Gary Johnson,1
-Humboldt,4E-25,President,,DEM,Hillary Clinton,41
+Humboldt,4E-25,President,,DEM,Hillary Clinton,118
+Humboldt,4E-25,President,,AIP,James Hedges,1
 Humboldt,4E-25,President,,GRN,Jill Stein,1
 Humboldt,4E-25,President,,LIB,John Hale,1
-Humboldt,4E-25,President,,REP,John R. Kasich,4
-Humboldt,4E-25,President,,REP,Ted Cruz,8
-Humboldt,4E-25,Proposition 50,,,No,28
-Humboldt,4E-25,Proposition 50,,,Yes,132
-Humboldt,4E-25,State Assembly,2,DEM,Jim Wood,122
-Humboldt,4E-25,U.S. House,2,REP,Dale K. Mensing,47
-Humboldt,4E-25,U.S. House,2,DEM,Erin A. Schrode,17
-Humboldt,4E-25,U.S. House,2,DEM,Jared W. Huffman,95
-Humboldt,4E-25,U.S. House,2,IND,Matthew Robert Wookey,13
-Humboldt,4E-25,U.S. Senate,,REP,Duf Sundheim,13
-Humboldt,4E-25,U.S. Senate,,LIB,Gail K. Lightfoot,5
+Humboldt,4E-25,President,,REP,John R. Kasich,16
+Humboldt,4E-25,President,,DEM,Keith Judd,1
+Humboldt,4E-25,President,,DEM,Michael Steinberg,2
+Humboldt,4E-25,President,,REP,Ted Cruz,20
+Humboldt,4E-25,President,,AIP,Wiley Drake,1
+Humboldt,4E-25,Proposition 50,,,No,74
+Humboldt,4E-25,Proposition 50,,,Yes,358
+Humboldt,4E-25,State Assembly,2,DEM,Jim Wood,317
+Humboldt,4E-25,U.S. House,2,REP,Dale K. Mensing,104
+Humboldt,4E-25,U.S. House,2,DEM,Erin A. Schrode,28
+Humboldt,4E-25,U.S. House,2,DEM,Jared W. Huffman,281
+Humboldt,4E-25,U.S. House,2,IND,Matthew Robert Wookey,34
+Humboldt,4E-25,U.S. Senate,,IND,Clive Grey,1
+Humboldt,4E-25,U.S. Senate,,REP,Don Krampe,4
+Humboldt,4E-25,U.S. Senate,,REP,Duf Sundheim,25
+Humboldt,4E-25,U.S. Senate,,IND,Eleanor García,1
+Humboldt,4E-25,U.S. Senate,,LIB,Gail K. Lightfoot,14
 Humboldt,4E-25,U.S. Senate,,IND,Gar Myers,1
 Humboldt,4E-25,U.S. Senate,,REP,George C. Yang,1
-Humboldt,4E-25,U.S. Senate,,REP,Greg Conlon,9
-Humboldt,4E-25,U.S. Senate,,REP,Jarrell Williamson,3
-Humboldt,4E-25,U.S. Senate,,REP,Jerry J. Laws,7
-Humboldt,4E-25,U.S. Senate,,PAF,John Thompson Parker,1
-Humboldt,4E-25,U.S. Senate,,DEM,Kamala D. Harris,60
-Humboldt,4E-25,U.S. Senate,,IND,Ling Ling Shi,2
-Humboldt,4E-25,U.S. Senate,,DEM,Loretta L. Sanchez,26
-Humboldt,4E-25,U.S. Senate,,DEM,Massie Munroe,1
-Humboldt,4E-25,U.S. Senate,,IND,Mike Beitiks,1
-Humboldt,4E-25,U.S. Senate,,GRN,Pamela Elizondo,7
-Humboldt,4E-25,U.S. Senate,,REP,Phil Wyman,15
+Humboldt,4E-25,U.S. Senate,,REP,Greg Conlon,25
+Humboldt,4E-25,U.S. Senate,,REP,Jarrell Williamson,4
+Humboldt,4E-25,U.S. Senate,,IND,Jason Hanania,2
+Humboldt,4E-25,U.S. Senate,,IND,Jason Kraus,3
+Humboldt,4E-25,U.S. Senate,,REP,Jerry J. Laws,18
+Humboldt,4E-25,U.S. Senate,,PAF,John Thompson Parker,2
+Humboldt,4E-25,U.S. Senate,,DEM,Kamala D. Harris,157
+Humboldt,4E-25,U.S. Senate,,REP,Karen Roseberry,2
+Humboldt,4E-25,U.S. Senate,,IND,Ling Ling Shi,4
+Humboldt,4E-25,U.S. Senate,,DEM,Loretta L. Sanchez,64
+Humboldt,4E-25,U.S. Senate,,LIB,Mark Matthew Herd,1
+Humboldt,4E-25,U.S. Senate,,DEM,Massie Munroe,2
+Humboldt,4E-25,U.S. Senate,,IND,Mike Beitiks,3
+Humboldt,4E-25,U.S. Senate,,GRN,Pamela Elizondo,17
+Humboldt,4E-25,U.S. Senate,,IND,Paul Merritt,1
+Humboldt,4E-25,U.S. Senate,,REP,Phil Wyman,42
 Humboldt,4E-25,U.S. Senate,,DEM,President Cristina Grappo,4
-Humboldt,4E-25,U.S. Senate,,REP,Ron Unz,4
+Humboldt,4E-25,U.S. Senate,,REP,Ron Unz,10
 Humboldt,4E-25,U.S. Senate,,IND,Scott A. Vineberg,1
-Humboldt,4E-25,U.S. Senate,,DEM,Steve Stokes,6
-Humboldt,4E-25,U.S. Senate,,REP,Thomas G. Del Beccaro,2
-Humboldt,4E-25,U.S. Senate,,REP,Tom Palzer,1
-Humboldt,4E-25,U.S. Senate,,REP,Von Hougo,2
-Humboldt,4E-25_A,President,,AIP,Arthur Harris,1
-Humboldt,4E-25_A,President,,REP,Ben Carson,8
-Humboldt,4E-25_A,President,,DEM,Bernie Sanders,92
-Humboldt,4E-25_A,President,,REP,Donald Trump,66
-Humboldt,4E-25_A,President,,DEM,Hillary Clinton,77
-Humboldt,4E-25_A,President,,AIP,James Hedges,1
-Humboldt,4E-25_A,President,,REP,John R. Kasich,12
-Humboldt,4E-25_A,President,,DEM,Keith Judd,1
-Humboldt,4E-25_A,President,,DEM,Michael Steinberg,2
-Humboldt,4E-25_A,President,,REP,Ted Cruz,12
-Humboldt,4E-25_A,President,,AIP,Wiley Drake,1
-Humboldt,4E-25_A,Proposition 50,,,No,46
-Humboldt,4E-25_A,Proposition 50,,,Yes,226
-Humboldt,4E-25_A,State Assembly,2,DEM,Jim Wood,195
-Humboldt,4E-25_A,U.S. House,2,REP,Dale K. Mensing,57
-Humboldt,4E-25_A,U.S. House,2,DEM,Erin A. Schrode,11
-Humboldt,4E-25_A,U.S. House,2,DEM,Jared W. Huffman,186
-Humboldt,4E-25_A,U.S. House,2,IND,Matthew Robert Wookey,21
-Humboldt,4E-25_A,U.S. Senate,,IND,Clive Grey,1
-Humboldt,4E-25_A,U.S. Senate,,REP,Don Krampe,4
-Humboldt,4E-25_A,U.S. Senate,,REP,Duf Sundheim,12
-Humboldt,4E-25_A,U.S. Senate,,IND,Eleanor García,1
-Humboldt,4E-25_A,U.S. Senate,,LIB,Gail K. Lightfoot,9
-Humboldt,4E-25_A,U.S. Senate,,REP,Greg Conlon,16
-Humboldt,4E-25_A,U.S. Senate,,REP,Jarrell Williamson,1
-Humboldt,4E-25_A,U.S. Senate,,IND,Jason Hanania,2
-Humboldt,4E-25_A,U.S. Senate,,IND,Jason Kraus,3
-Humboldt,4E-25_A,U.S. Senate,,REP,Jerry J. Laws,11
-Humboldt,4E-25_A,U.S. Senate,,PAF,John Thompson Parker,1
-Humboldt,4E-25_A,U.S. Senate,,DEM,Kamala D. Harris,97
-Humboldt,4E-25_A,U.S. Senate,,REP,Karen Roseberry,2
-Humboldt,4E-25_A,U.S. Senate,,IND,Ling Ling Shi,2
-Humboldt,4E-25_A,U.S. Senate,,DEM,Loretta L. Sanchez,38
-Humboldt,4E-25_A,U.S. Senate,,LIB,Mark Matthew Herd,1
-Humboldt,4E-25_A,U.S. Senate,,DEM,Massie Munroe,1
-Humboldt,4E-25_A,U.S. Senate,,IND,Mike Beitiks,2
-Humboldt,4E-25_A,U.S. Senate,,GRN,Pamela Elizondo,10
-Humboldt,4E-25_A,U.S. Senate,,IND,Paul Merritt,1
-Humboldt,4E-25_A,U.S. Senate,,REP,Phil Wyman,27
-Humboldt,4E-25_A,U.S. Senate,,REP,Ron Unz,6
-Humboldt,4E-25_A,U.S. Senate,,DEM,Steve Stokes,6
-Humboldt,4E-25_A,U.S. Senate,,REP,Thomas G. Del Beccaro,8
-Humboldt,4E-25_A,U.S. Senate,,REP,Tom Palzer,1
-Humboldt,4E-25_A,U.S. Senate,,REP,Von Hougo,4
-Humboldt,4E-32,President,,REP,Ben Carson,2
-Humboldt,4E-32,President,,DEM,Bernie Sanders,93
-Humboldt,4E-32,President,,REP,Donald Trump,14
-Humboldt,4E-32,President,,DEM,Hillary Clinton,25
+Humboldt,4E-25,U.S. Senate,,DEM,Steve Stokes,12
+Humboldt,4E-25,U.S. Senate,,REP,Thomas G. Del Beccaro,10
+Humboldt,4E-25,U.S. Senate,,REP,Tom Palzer,2
+Humboldt,4E-25,U.S. Senate,,REP,Von Hougo,6
+Humboldt,4E-32,President,,REP,Ben Carson,4
+Humboldt,4E-32,President,,DEM,Bernie Sanders,182
+Humboldt,4E-32,President,,GRN,Darryl Cherney,1
+Humboldt,4E-32,President,,REP,Donald Trump,26
+Humboldt,4E-32,President,,DEM,Hillary Clinton,61
 Humboldt,4E-32,President,,AIP,James Hedges,1
-Humboldt,4E-32,President,,GRN,Jill Stein,1
+Humboldt,4E-32,President,,GRN,Jill Stein,3
+Humboldt,4E-32,President,,REP,Jim Gilmore,1
+Humboldt,4E-32,President,,REP,John R. Kasich,1
 Humboldt,4E-32,President,,LIB,Marc Feldman,1
-Humboldt,4E-32,President,,REP,Ted Cruz,1
-Humboldt,4E-32,Proposition 50,,,No,34
-Humboldt,4E-32,Proposition 50,,,Yes,89
-Humboldt,4E-32,State Assembly,2,DEM,Jim Wood,108
-Humboldt,4E-32,U.S. House,2,REP,Dale K. Mensing,17
-Humboldt,4E-32,U.S. House,2,DEM,Erin A. Schrode,22
-Humboldt,4E-32,U.S. House,2,DEM,Jared W. Huffman,85
-Humboldt,4E-32,U.S. House,2,IND,Matthew Robert Wookey,7
-Humboldt,4E-32,U.S. Senate,,REP,Don Krampe,1
-Humboldt,4E-32,U.S. Senate,,REP,Duf Sundheim,3
-Humboldt,4E-32,U.S. Senate,,LIB,Gail K. Lightfoot,9
-Humboldt,4E-32,U.S. Senate,,REP,Greg Conlon,4
-Humboldt,4E-32,U.S. Senate,,REP,Jerry J. Laws,5
-Humboldt,4E-32,U.S. Senate,,DEM,Kamala D. Harris,54
-Humboldt,4E-32,U.S. Senate,,REP,Karen Roseberry,1
-Humboldt,4E-32,U.S. Senate,,DEM,Loretta L. Sanchez,21
-Humboldt,4E-32,U.S. Senate,,DEM,Massie Munroe,5
-Humboldt,4E-32,U.S. Senate,,GRN,Pamela Elizondo,8
-Humboldt,4E-32,U.S. Senate,,REP,Phil Wyman,2
+Humboldt,4E-32,President,,REP,Ted Cruz,5
+Humboldt,4E-32,Proposition 50,,,No,56
+Humboldt,4E-32,Proposition 50,,,Yes,210
+Humboldt,4E-32,State Assembly,2,DEM,Jim Wood,226
+Humboldt,4E-32,U.S. House,2,REP,Dale K. Mensing,30
+Humboldt,4E-32,U.S. House,2,DEM,Erin A. Schrode,41
+Humboldt,4E-32,U.S. House,2,DEM,Jared W. Huffman,186
+Humboldt,4E-32,U.S. House,2,IND,Matthew Robert Wookey,19
+Humboldt,4E-32,U.S. Senate,,IND,Don J. Grundmann,1
+Humboldt,4E-32,U.S. Senate,,REP,Don Krampe,2
+Humboldt,4E-32,U.S. Senate,,REP,Duf Sundheim,6
+Humboldt,4E-32,U.S. Senate,,LIB,Gail K. Lightfoot,12
+Humboldt,4E-32,U.S. Senate,,REP,George C. Yang,2
+Humboldt,4E-32,U.S. Senate,,REP,Greg Conlon,6
+Humboldt,4E-32,U.S. Senate,,REP,Jerry J. Laws,8
+Humboldt,4E-32,U.S. Senate,,DEM,Kamala D. Harris,117
+Humboldt,4E-32,U.S. Senate,,REP,Karen Roseberry,2
+Humboldt,4E-32,U.S. Senate,,DEM,Loretta L. Sanchez,60
+Humboldt,4E-32,U.S. Senate,,LIB,Mark Matthew Herd,2
+Humboldt,4E-32,U.S. Senate,,DEM,Massie Munroe,7
+Humboldt,4E-32,U.S. Senate,,IND,Mike Beitiks,3
+Humboldt,4E-32,U.S. Senate,,GRN,Pamela Elizondo,18
+Humboldt,4E-32,U.S. Senate,,IND,Paul Merritt,1
+Humboldt,4E-32,U.S. Senate,,REP,Phil Wyman,5
 Humboldt,4E-32,U.S. Senate,,DEM,President Cristina Grappo,2
 Humboldt,4E-32,U.S. Senate,,REP,Ron Unz,3
-Humboldt,4E-32,U.S. Senate,,DEM,Steve Stokes,11
-Humboldt,4E-32,U.S. Senate,,REP,Thomas G. Del Beccaro,1
-Humboldt,4E-32,U.S. Senate,,REP,Tom Palzer,1
-Humboldt,4E-32_A,President,,REP,Ben Carson,2
-Humboldt,4E-32_A,President,,DEM,Bernie Sanders,89
-Humboldt,4E-32_A,President,,GRN,Darryl Cherney,1
-Humboldt,4E-32_A,President,,REP,Donald Trump,12
-Humboldt,4E-32_A,President,,DEM,Hillary Clinton,36
-Humboldt,4E-32_A,President,,GRN,Jill Stein,2
-Humboldt,4E-32_A,President,,REP,Jim Gilmore,1
-Humboldt,4E-32_A,President,,REP,John R. Kasich,1
-Humboldt,4E-32_A,President,,REP,Ted Cruz,4
-Humboldt,4E-32_A,Proposition 50,,,No,22
-Humboldt,4E-32_A,Proposition 50,,,Yes,121
-Humboldt,4E-32_A,State Assembly,2,DEM,Jim Wood,118
-Humboldt,4E-32_A,U.S. House,2,REP,Dale K. Mensing,13
-Humboldt,4E-32_A,U.S. House,2,DEM,Erin A. Schrode,19
-Humboldt,4E-32_A,U.S. House,2,DEM,Jared W. Huffman,101
-Humboldt,4E-32_A,U.S. House,2,IND,Matthew Robert Wookey,12
-Humboldt,4E-32_A,U.S. Senate,,IND,Don J. Grundmann,1
-Humboldt,4E-32_A,U.S. Senate,,REP,Don Krampe,1
-Humboldt,4E-32_A,U.S. Senate,,REP,Duf Sundheim,3
-Humboldt,4E-32_A,U.S. Senate,,LIB,Gail K. Lightfoot,3
-Humboldt,4E-32_A,U.S. Senate,,REP,George C. Yang,2
-Humboldt,4E-32_A,U.S. Senate,,REP,Greg Conlon,2
-Humboldt,4E-32_A,U.S. Senate,,REP,Jerry J. Laws,3
-Humboldt,4E-32_A,U.S. Senate,,DEM,Kamala D. Harris,63
-Humboldt,4E-32_A,U.S. Senate,,REP,Karen Roseberry,1
-Humboldt,4E-32_A,U.S. Senate,,DEM,Loretta L. Sanchez,39
-Humboldt,4E-32_A,U.S. Senate,,LIB,Mark Matthew Herd,2
-Humboldt,4E-32_A,U.S. Senate,,DEM,Massie Munroe,2
-Humboldt,4E-32_A,U.S. Senate,,IND,Mike Beitiks,3
-Humboldt,4E-32_A,U.S. Senate,,GRN,Pamela Elizondo,10
-Humboldt,4E-32_A,U.S. Senate,,IND,Paul Merritt,1
-Humboldt,4E-32_A,U.S. Senate,,REP,Phil Wyman,3
-Humboldt,4E-32_A,U.S. Senate,,DEM,Steve Stokes,4
-Humboldt,4E-32_A,U.S. Senate,,REP,Thomas G. Del Beccaro,1
-Humboldt,4E-32_A,U.S. Senate,,REP,Tom Palzer,2
-Humboldt,4E-32_A,U.S. Senate,,REP,Von Hougo,3
-Humboldt,4E-33,President,,REP,Ben Carson,1
-Humboldt,4E-33,President,,DEM,Bernie Sanders,106
-Humboldt,4E-33,President,,REP,Donald Trump,12
-Humboldt,4E-33,President,,LIB,Gary Johnson,1
-Humboldt,4E-33,President,,DEM,Hillary Clinton,23
-Humboldt,4E-33,President,,GRN,Jill Stein,3
-Humboldt,4E-33,President,,REP,John R. Kasich,4
+Humboldt,4E-32,U.S. Senate,,DEM,Steve Stokes,15
+Humboldt,4E-32,U.S. Senate,,REP,Thomas G. Del Beccaro,2
+Humboldt,4E-32,U.S. Senate,,REP,Tom Palzer,3
+Humboldt,4E-32,U.S. Senate,,REP,Von Hougo,3
+Humboldt,4E-33,President,,REP,Ben Carson,2
+Humboldt,4E-33,President,,DEM,Bernie Sanders,202
+Humboldt,4E-33,President,,REP,Donald Trump,39
+Humboldt,4E-33,President,,LIB,Gary Johnson,3
+Humboldt,4E-33,President,,DEM,Hillary Clinton,73
+Humboldt,4E-33,President,,GRN,Jill Stein,4
+Humboldt,4E-33,President,,REP,Jim Gilmore,4
+Humboldt,4E-33,President,,REP,John R. Kasich,7
 Humboldt,4E-33,President,,DEM,Michael Steinberg,1
-Humboldt,4E-33,President,,REP,Ted Cruz,2
-Humboldt,4E-33,Proposition 50,,,No,30
-Humboldt,4E-33,Proposition 50,,,Yes,106
-Humboldt,4E-33,State Assembly,2,DEM,Jim Wood,126
-Humboldt,4E-33,U.S. House,2,REP,Dale K. Mensing,15
-Humboldt,4E-33,U.S. House,2,DEM,Erin A. Schrode,22
-Humboldt,4E-33,U.S. House,2,DEM,Jared W. Huffman,87
-Humboldt,4E-33,U.S. House,2,IND,Matthew Robert Wookey,19
-Humboldt,4E-33,U.S. Senate,,IND,Clive Grey,1
-Humboldt,4E-33,U.S. Senate,,REP,Duf Sundheim,4
-Humboldt,4E-33,U.S. Senate,,DEM,Emory Rodgers,1
-Humboldt,4E-33,U.S. Senate,,LIB,Gail K. Lightfoot,6
+Humboldt,4E-33,President,,AIP,Robert Ornelas,1
+Humboldt,4E-33,President,,REP,Ted Cruz,7
+Humboldt,4E-33,Proposition 50,,,No,68
+Humboldt,4E-33,Proposition 50,,,Yes,247
+Humboldt,4E-33,State Assembly,2,DEM,Jim Wood,273
+Humboldt,4E-33,U.S. House,2,REP,Dale K. Mensing,50
+Humboldt,4E-33,U.S. House,2,DEM,Erin A. Schrode,39
+Humboldt,4E-33,U.S. House,2,DEM,Jared W. Huffman,212
+Humboldt,4E-33,U.S. House,2,IND,Matthew Robert Wookey,35
+Humboldt,4E-33,U.S. Senate,,IND,Clive Grey,3
+Humboldt,4E-33,U.S. Senate,,IND,Don J. Grundmann,1
+Humboldt,4E-33,U.S. Senate,,REP,Don Krampe,1
+Humboldt,4E-33,U.S. Senate,,REP,Duf Sundheim,11
+Humboldt,4E-33,U.S. Senate,,DEM,Emory Rodgers,3
+Humboldt,4E-33,U.S. Senate,,LIB,Gail K. Lightfoot,13
 Humboldt,4E-33,U.S. Senate,,IND,Gar Myers,1
-Humboldt,4E-33,U.S. Senate,,REP,Greg Conlon,4
-Humboldt,4E-33,U.S. Senate,,DEM,Herbert G. Peters,1
-Humboldt,4E-33,U.S. Senate,,REP,Jarrell Williamson,2
+Humboldt,4E-33,U.S. Senate,,REP,George C. Yang,1
+Humboldt,4E-33,U.S. Senate,,REP,Greg Conlon,15
+Humboldt,4E-33,U.S. Senate,,DEM,Herbert G. Peters,2
+Humboldt,4E-33,U.S. Senate,,REP,Jarrell Williamson,6
 Humboldt,4E-33,U.S. Senate,,IND,Jason Kraus,1
-Humboldt,4E-33,U.S. Senate,,REP,Jerry J. Laws,8
-Humboldt,4E-33,U.S. Senate,,DEM,Kamala D. Harris,43
-Humboldt,4E-33,U.S. Senate,,DEM,Loretta L. Sanchez,29
+Humboldt,4E-33,U.S. Senate,,REP,Jerry J. Laws,15
+Humboldt,4E-33,U.S. Senate,,PAF,John Thompson Parker,1
+Humboldt,4E-33,U.S. Senate,,DEM,Kamala D. Harris,122
+Humboldt,4E-33,U.S. Senate,,DEM,Loretta L. Sanchez,64
 Humboldt,4E-33,U.S. Senate,,LIB,Mark Matthew Herd,2
-Humboldt,4E-33,U.S. Senate,,DEM,Massie Munroe,7
+Humboldt,4E-33,U.S. Senate,,DEM,Massie Munroe,12
 Humboldt,4E-33,U.S. Senate,,IND,Mike Beitiks,5
-Humboldt,4E-33,U.S. Senate,,GRN,Pamela Elizondo,15
-Humboldt,4E-33,U.S. Senate,,REP,Phil Wyman,1
+Humboldt,4E-33,U.S. Senate,,GRN,Pamela Elizondo,24
+Humboldt,4E-33,U.S. Senate,,REP,Phil Wyman,8
 Humboldt,4E-33,U.S. Senate,,DEM,President Cristina Grappo,1
 Humboldt,4E-33,U.S. Senate,,REP,Ron Unz,1
-Humboldt,4E-33,U.S. Senate,,IND,Scott A. Vineberg,1
-Humboldt,4E-33,U.S. Senate,,DEM,Steve Stokes,10
-Humboldt,4E-33,U.S. Senate,,REP,Tom Palzer,1
-Humboldt,4E-33,U.S. Senate,,REP,Von Hougo,1
-Humboldt,4E-33_A,President,,REP,Ben Carson,1
-Humboldt,4E-33_A,President,,DEM,Bernie Sanders,96
-Humboldt,4E-33_A,President,,REP,Donald Trump,27
-Humboldt,4E-33_A,President,,LIB,Gary Johnson,2
-Humboldt,4E-33_A,President,,DEM,Hillary Clinton,50
-Humboldt,4E-33_A,President,,GRN,Jill Stein,1
-Humboldt,4E-33_A,President,,REP,Jim Gilmore,4
-Humboldt,4E-33_A,President,,REP,John R. Kasich,3
-Humboldt,4E-33_A,President,,AIP,Robert Ornelas,1
-Humboldt,4E-33_A,President,,REP,Ted Cruz,5
-Humboldt,4E-33_A,Proposition 50,,,No,38
-Humboldt,4E-33_A,Proposition 50,,,Yes,141
-Humboldt,4E-33_A,State Assembly,2,DEM,Jim Wood,147
-Humboldt,4E-33_A,U.S. House,2,REP,Dale K. Mensing,35
-Humboldt,4E-33_A,U.S. House,2,DEM,Erin A. Schrode,17
-Humboldt,4E-33_A,U.S. House,2,DEM,Jared W. Huffman,125
-Humboldt,4E-33_A,U.S. House,2,IND,Matthew Robert Wookey,16
-Humboldt,4E-33_A,U.S. Senate,,IND,Clive Grey,2
-Humboldt,4E-33_A,U.S. Senate,,IND,Don J. Grundmann,1
-Humboldt,4E-33_A,U.S. Senate,,REP,Don Krampe,1
-Humboldt,4E-33_A,U.S. Senate,,REP,Duf Sundheim,7
-Humboldt,4E-33_A,U.S. Senate,,DEM,Emory Rodgers,2
-Humboldt,4E-33_A,U.S. Senate,,LIB,Gail K. Lightfoot,7
-Humboldt,4E-33_A,U.S. Senate,,REP,George C. Yang,1
-Humboldt,4E-33_A,U.S. Senate,,REP,Greg Conlon,11
-Humboldt,4E-33_A,U.S. Senate,,DEM,Herbert G. Peters,1
-Humboldt,4E-33_A,U.S. Senate,,REP,Jarrell Williamson,4
-Humboldt,4E-33_A,U.S. Senate,,REP,Jerry J. Laws,7
-Humboldt,4E-33_A,U.S. Senate,,PAF,John Thompson Parker,1
-Humboldt,4E-33_A,U.S. Senate,,DEM,Kamala D. Harris,79
-Humboldt,4E-33_A,U.S. Senate,,DEM,Loretta L. Sanchez,35
-Humboldt,4E-33_A,U.S. Senate,,DEM,Massie Munroe,5
-Humboldt,4E-33_A,U.S. Senate,,GRN,Pamela Elizondo,9
-Humboldt,4E-33_A,U.S. Senate,,REP,Phil Wyman,7
-Humboldt,4E-33_A,U.S. Senate,,IND,Scott A. Vineberg,2
-Humboldt,4E-33_A,U.S. Senate,,DEM,Steve Stokes,3
-Humboldt,4E-33_A,U.S. Senate,,REP,Thomas G. Del Beccaro,2
-Humboldt,4E-33_A,U.S. Senate,,IND,Tim Gildersleeve,1
-Humboldt,4E-33_A,U.S. Senate,,REP,Tom Palzer,1
-Humboldt,4E-33_A,U.S. Senate,,REP,Von Hougo,1
-Humboldt,4E-34,President,,REP,Ben Carson,1
-Humboldt,4E-34,President,,DEM,Bernie Sanders,90
-Humboldt,4E-34,President,,REP,Donald Trump,16
-Humboldt,4E-34,President,,DEM,Hillary Clinton,36
+Humboldt,4E-33,U.S. Senate,,IND,Scott A. Vineberg,3
+Humboldt,4E-33,U.S. Senate,,DEM,Steve Stokes,13
+Humboldt,4E-33,U.S. Senate,,REP,Thomas G. Del Beccaro,2
+Humboldt,4E-33,U.S. Senate,,IND,Tim Gildersleeve,1
+Humboldt,4E-33,U.S. Senate,,REP,Tom Palzer,2
+Humboldt,4E-33,U.S. Senate,,REP,Von Hougo,2
+Humboldt,4E-34,President,,REP,Ben Carson,2
+Humboldt,4E-34,President,,DEM,Bernie Sanders,207
+Humboldt,4E-34,President,,REP,Donald Trump,74
+Humboldt,4E-34,President,,LIB,Gary Johnson,1
+Humboldt,4E-34,President,,DEM,Hillary Clinton,90
 Humboldt,4E-34,President,,GRN,Jill Stein,2
+Humboldt,4E-34,President,,REP,Jim Gilmore,1
+Humboldt,4E-34,President,,REP,John R. Kasich,4
 Humboldt,4E-34,President,,LIB,Joy Waymire,1
-Humboldt,4E-34,President,,REP,Ted Cruz,2
-Humboldt,4E-34,Proposition 50,,,No,27
-Humboldt,4E-34,Proposition 50,,,Yes,114
-Humboldt,4E-34,State Assembly,2,DEM,Jim Wood,126
-Humboldt,4E-34,U.S. House,2,REP,Dale K. Mensing,18
-Humboldt,4E-34,U.S. House,2,DEM,Erin A. Schrode,17
-Humboldt,4E-34,U.S. House,2,DEM,Jared W. Huffman,103
-Humboldt,4E-34,U.S. House,2,IND,Matthew Robert Wookey,12
+Humboldt,4E-34,President,,DEM,Keith Judd,1
+Humboldt,4E-34,President,,LIB,Marc Feldman,1
+Humboldt,4E-34,President,,REP,Ted Cruz,5
+Humboldt,4E-34,President,,AIP,Thomas Hoefling,1
+Humboldt,4E-34,President,,DEM,Willie Wilson,1
+Humboldt,4E-34,Proposition 50,,,No,73
+Humboldt,4E-34,Proposition 50,,,Yes,314
+Humboldt,4E-34,State Assembly,2,DEM,Jim Wood,312
+Humboldt,4E-34,U.S. House,2,REP,Dale K. Mensing,74
+Humboldt,4E-34,U.S. House,2,DEM,Erin A. Schrode,47
+Humboldt,4E-34,U.S. House,2,DEM,Jared W. Huffman,260
+Humboldt,4E-34,U.S. House,2,IND,Matthew Robert Wookey,25
 Humboldt,4E-34,U.S. Senate,,IND,Clive Grey,2
-Humboldt,4E-34,U.S. Senate,,REP,Don Krampe,1
-Humboldt,4E-34,U.S. Senate,,REP,Duf Sundheim,5
-Humboldt,4E-34,U.S. Senate,,LIB,Gail K. Lightfoot,3
-Humboldt,4E-34,U.S. Senate,,REP,George C. Yang,1
-Humboldt,4E-34,U.S. Senate,,REP,Greg Conlon,3
+Humboldt,4E-34,U.S. Senate,,REP,Don Krampe,2
+Humboldt,4E-34,U.S. Senate,,REP,Duf Sundheim,25
+Humboldt,4E-34,U.S. Senate,,DEM,Emory Rodgers,1
+Humboldt,4E-34,U.S. Senate,,LIB,Gail K. Lightfoot,11
+Humboldt,4E-34,U.S. Senate,,REP,George C. Yang,2
+Humboldt,4E-34,U.S. Senate,,REP,Greg Conlon,16
 Humboldt,4E-34,U.S. Senate,,DEM,Herbert G. Peters,1
-Humboldt,4E-34,U.S. Senate,,REP,Jarrell Williamson,1
+Humboldt,4E-34,U.S. Senate,,REP,Jarrell Williamson,3
 Humboldt,4E-34,U.S. Senate,,IND,Jason Hanania,1
-Humboldt,4E-34,U.S. Senate,,REP,Jerry J. Laws,5
-Humboldt,4E-34,U.S. Senate,,DEM,Kamala D. Harris,57
+Humboldt,4E-34,U.S. Senate,,REP,Jerry J. Laws,17
+Humboldt,4E-34,U.S. Senate,,PAF,John Thompson Parker,1
+Humboldt,4E-34,U.S. Senate,,DEM,Kamala D. Harris,157
+Humboldt,4E-34,U.S. Senate,,REP,Karen Roseberry,1
 Humboldt,4E-34,U.S. Senate,,IND,Ling Ling Shi,2
-Humboldt,4E-34,U.S. Senate,,DEM,Loretta L. Sanchez,36
-Humboldt,4E-34,U.S. Senate,,LIB,Mark Matthew Herd,1
-Humboldt,4E-34,U.S. Senate,,IND,Mike Beitiks,1
-Humboldt,4E-34,U.S. Senate,,GRN,Pamela Elizondo,12
-Humboldt,4E-34,U.S. Senate,,REP,Phil Wyman,3
+Humboldt,4E-34,U.S. Senate,,DEM,Loretta L. Sanchez,72
+Humboldt,4E-34,U.S. Senate,,LIB,Mark Matthew Herd,6
+Humboldt,4E-34,U.S. Senate,,DEM,Massie Munroe,4
+Humboldt,4E-34,U.S. Senate,,IND,Mike Beitiks,6
+Humboldt,4E-34,U.S. Senate,,GRN,Pamela Elizondo,19
+Humboldt,4E-34,U.S. Senate,,IND,Paul Merritt,1
+Humboldt,4E-34,U.S. Senate,,REP,Phil Wyman,15
+Humboldt,4E-34,U.S. Senate,,REP,Ron Unz,2
 Humboldt,4E-34,U.S. Senate,,IND,Scott A. Vineberg,1
-Humboldt,4E-34,U.S. Senate,,DEM,Steve Stokes,11
-Humboldt,4E-34,U.S. Senate,,REP,Thomas G. Del Beccaro,2
-Humboldt,4E-34,U.S. Senate,,REP,Tom Palzer,3
-Humboldt,4E-34_A,President,,REP,Ben Carson,1
-Humboldt,4E-34_A,President,,DEM,Bernie Sanders,117
-Humboldt,4E-34_A,President,,REP,Donald Trump,58
-Humboldt,4E-34_A,President,,LIB,Gary Johnson,1
-Humboldt,4E-34_A,President,,DEM,Hillary Clinton,54
-Humboldt,4E-34_A,President,,REP,Jim Gilmore,1
-Humboldt,4E-34_A,President,,REP,John R. Kasich,4
-Humboldt,4E-34_A,President,,DEM,Keith Judd,1
-Humboldt,4E-34_A,President,,LIB,Marc Feldman,1
-Humboldt,4E-34_A,President,,REP,Ted Cruz,3
-Humboldt,4E-34_A,President,,AIP,Thomas Hoefling,1
-Humboldt,4E-34_A,President,,DEM,Willie Wilson,1
-Humboldt,4E-34_A,Proposition 50,,,No,46
-Humboldt,4E-34_A,Proposition 50,,,Yes,200
-Humboldt,4E-34_A,State Assembly,2,DEM,Jim Wood,186
-Humboldt,4E-34_A,U.S. House,2,REP,Dale K. Mensing,56
-Humboldt,4E-34_A,U.S. House,2,DEM,Erin A. Schrode,30
-Humboldt,4E-34_A,U.S. House,2,DEM,Jared W. Huffman,157
-Humboldt,4E-34_A,U.S. House,2,IND,Matthew Robert Wookey,13
-Humboldt,4E-34_A,U.S. Senate,,REP,Don Krampe,1
-Humboldt,4E-34_A,U.S. Senate,,REP,Duf Sundheim,20
-Humboldt,4E-34_A,U.S. Senate,,DEM,Emory Rodgers,1
-Humboldt,4E-34_A,U.S. Senate,,LIB,Gail K. Lightfoot,8
-Humboldt,4E-34_A,U.S. Senate,,REP,George C. Yang,1
-Humboldt,4E-34_A,U.S. Senate,,REP,Greg Conlon,13
-Humboldt,4E-34_A,U.S. Senate,,REP,Jarrell Williamson,2
-Humboldt,4E-34_A,U.S. Senate,,REP,Jerry J. Laws,12
-Humboldt,4E-34_A,U.S. Senate,,PAF,John Thompson Parker,1
-Humboldt,4E-34_A,U.S. Senate,,DEM,Kamala D. Harris,100
-Humboldt,4E-34_A,U.S. Senate,,REP,Karen Roseberry,1
-Humboldt,4E-34_A,U.S. Senate,,DEM,Loretta L. Sanchez,36
-Humboldt,4E-34_A,U.S. Senate,,LIB,Mark Matthew Herd,5
-Humboldt,4E-34_A,U.S. Senate,,DEM,Massie Munroe,4
-Humboldt,4E-34_A,U.S. Senate,,IND,Mike Beitiks,5
-Humboldt,4E-34_A,U.S. Senate,,GRN,Pamela Elizondo,7
-Humboldt,4E-34_A,U.S. Senate,,IND,Paul Merritt,1
-Humboldt,4E-34_A,U.S. Senate,,REP,Phil Wyman,12
-Humboldt,4E-34_A,U.S. Senate,,REP,Ron Unz,2
-Humboldt,4E-34_A,U.S. Senate,,DEM,Steve Stokes,11
-Humboldt,4E-34_A,U.S. Senate,,REP,Thomas G. Del Beccaro,2
-Humboldt,4E-34_A,U.S. Senate,,REP,Tom Palzer,4
-Humboldt,4E-34_A,U.S. Senate,,REP,Von Hougo,2
-Humboldt,4E-51,President,,REP,Ben Carson,1
-Humboldt,4E-51,President,,DEM,Bernie Sanders,78
-Humboldt,4E-51,President,,REP,Donald Trump,21
-Humboldt,4E-51,President,,LIB,Gary Johnson,1
-Humboldt,4E-51,President,,DEM,Hillary Clinton,25
+Humboldt,4E-34,U.S. Senate,,DEM,Steve Stokes,22
+Humboldt,4E-34,U.S. Senate,,REP,Thomas G. Del Beccaro,4
+Humboldt,4E-34,U.S. Senate,,REP,Tom Palzer,7
+Humboldt,4E-34,U.S. Senate,,REP,Von Hougo,2
+Humboldt,4E-51,President,,REP,Ben Carson,3
+Humboldt,4E-51,President,,DEM,Bernie Sanders,174
+Humboldt,4E-51,President,,REP,Donald Trump,51
+Humboldt,4E-51,President,,LIB,Gary Johnson,2
+Humboldt,4E-51,President,,DEM,Hillary Clinton,68
 Humboldt,4E-51,President,,GRN,Jill Stein,1
 Humboldt,4E-51,President,,REP,Jim Gilmore,1
-Humboldt,4E-51,President,,REP,John R. Kasich,1
+Humboldt,4E-51,President,,REP,John R. Kasich,6
 Humboldt,4E-51,President,,PAF,Lynn S. Kahn,1
-Humboldt,4E-51,President,,REP,Ted Cruz,4
-Humboldt,4E-51,Proposition 50,,,No,29
-Humboldt,4E-51,Proposition 50,,,Yes,94
-Humboldt,4E-51,State Assembly,2,DEM,Jim Wood,101
-Humboldt,4E-51,U.S. House,2,REP,Dale K. Mensing,21
-Humboldt,4E-51,U.S. House,2,DEM,Erin A. Schrode,11
-Humboldt,4E-51,U.S. House,2,DEM,Jared W. Huffman,89
-Humboldt,4E-51,U.S. House,2,IND,Matthew Robert Wookey,5
-Humboldt,4E-51,U.S. Senate,,IND,Clive Grey,1
-Humboldt,4E-51,U.S. Senate,,REP,Duf Sundheim,5
-Humboldt,4E-51,U.S. Senate,,LIB,Gail K. Lightfoot,3
-Humboldt,4E-51,U.S. Senate,,REP,Greg Conlon,5
-Humboldt,4E-51,U.S. Senate,,IND,Jason Kraus,2
+Humboldt,4E-51,President,,REP,Ted Cruz,7
+Humboldt,4E-51,Proposition 50,,,No,60
+Humboldt,4E-51,Proposition 50,,,Yes,232
+Humboldt,4E-51,State Assembly,2,DEM,Jim Wood,241
+Humboldt,4E-51,U.S. House,2,REP,Dale K. Mensing,44
+Humboldt,4E-51,U.S. House,2,DEM,Erin A. Schrode,26
+Humboldt,4E-51,U.S. House,2,DEM,Jared W. Huffman,216
+Humboldt,4E-51,U.S. House,2,IND,Matthew Robert Wookey,16
+Humboldt,4E-51,U.S. Senate,,IND,Clive Grey,2
+Humboldt,4E-51,U.S. Senate,,REP,Don Krampe,1
+Humboldt,4E-51,U.S. Senate,,REP,Duf Sundheim,18
+Humboldt,4E-51,U.S. Senate,,DEM,Emory Rodgers,1
+Humboldt,4E-51,U.S. Senate,,LIB,Gail K. Lightfoot,11
+Humboldt,4E-51,U.S. Senate,,REP,Greg Conlon,11
+Humboldt,4E-51,U.S. Senate,,REP,Jarrell Williamson,1
+Humboldt,4E-51,U.S. Senate,,IND,Jason Hanania,1
+Humboldt,4E-51,U.S. Senate,,IND,Jason Kraus,3
 Humboldt,4E-51,U.S. Senate,,REP,Jerry J. Laws,4
 Humboldt,4E-51,U.S. Senate,,PAF,John Thompson Parker,1
-Humboldt,4E-51,U.S. Senate,,DEM,Kamala D. Harris,41
-Humboldt,4E-51,U.S. Senate,,REP,Karen Roseberry,1
-Humboldt,4E-51,U.S. Senate,,IND,Ling Ling Shi,1
-Humboldt,4E-51,U.S. Senate,,DEM,Loretta L. Sanchez,30
-Humboldt,4E-51,U.S. Senate,,DEM,Massie Munroe,3
-Humboldt,4E-51,U.S. Senate,,IND,Mike Beitiks,4
-Humboldt,4E-51,U.S. Senate,,GRN,Pamela Elizondo,7
-Humboldt,4E-51,U.S. Senate,,REP,Phil Wyman,1
+Humboldt,4E-51,U.S. Senate,,DEM,Kamala D. Harris,130
+Humboldt,4E-51,U.S. Senate,,REP,Karen Roseberry,3
+Humboldt,4E-51,U.S. Senate,,IND,Ling Ling Shi,2
+Humboldt,4E-51,U.S. Senate,,DEM,Loretta L. Sanchez,50
+Humboldt,4E-51,U.S. Senate,,DEM,Massie Munroe,7
+Humboldt,4E-51,U.S. Senate,,IND,Mike Beitiks,7
+Humboldt,4E-51,U.S. Senate,,GRN,Pamela Elizondo,8
+Humboldt,4E-51,U.S. Senate,,REP,Phil Wyman,9
+Humboldt,4E-51,U.S. Senate,,REP,Ron Unz,2
 Humboldt,4E-51,U.S. Senate,,IND,Scott A. Vineberg,1
-Humboldt,4E-51,U.S. Senate,,DEM,Steve Stokes,13
-Humboldt,4E-51,U.S. Senate,,REP,Thomas G. Del Beccaro,4
-Humboldt,4E-51,U.S. Senate,,REP,Tom Palzer,3
-Humboldt,4E-51,U.S. Senate,,REP,Von Hougo,3
-Humboldt,4E-51_A,President,,REP,Ben Carson,2
-Humboldt,4E-51_A,President,,DEM,Bernie Sanders,96
-Humboldt,4E-51_A,President,,REP,Donald Trump,30
-Humboldt,4E-51_A,President,,LIB,Gary Johnson,1
-Humboldt,4E-51_A,President,,DEM,Hillary Clinton,43
-Humboldt,4E-51_A,President,,REP,John R. Kasich,5
-Humboldt,4E-51_A,President,,REP,Ted Cruz,3
-Humboldt,4E-51_A,Proposition 50,,,No,31
-Humboldt,4E-51_A,Proposition 50,,,Yes,138
-Humboldt,4E-51_A,State Assembly,2,DEM,Jim Wood,140
-Humboldt,4E-51_A,U.S. House,2,REP,Dale K. Mensing,23
-Humboldt,4E-51_A,U.S. House,2,DEM,Erin A. Schrode,15
-Humboldt,4E-51_A,U.S. House,2,DEM,Jared W. Huffman,127
-Humboldt,4E-51_A,U.S. House,2,IND,Matthew Robert Wookey,11
-Humboldt,4E-51_A,U.S. Senate,,IND,Clive Grey,1
-Humboldt,4E-51_A,U.S. Senate,,REP,Don Krampe,1
-Humboldt,4E-51_A,U.S. Senate,,REP,Duf Sundheim,13
-Humboldt,4E-51_A,U.S. Senate,,DEM,Emory Rodgers,1
-Humboldt,4E-51_A,U.S. Senate,,LIB,Gail K. Lightfoot,8
-Humboldt,4E-51_A,U.S. Senate,,REP,Greg Conlon,6
-Humboldt,4E-51_A,U.S. Senate,,REP,Jarrell Williamson,1
-Humboldt,4E-51_A,U.S. Senate,,IND,Jason Hanania,1
-Humboldt,4E-51_A,U.S. Senate,,IND,Jason Kraus,1
-Humboldt,4E-51_A,U.S. Senate,,DEM,Kamala D. Harris,89
-Humboldt,4E-51_A,U.S. Senate,,REP,Karen Roseberry,2
-Humboldt,4E-51_A,U.S. Senate,,IND,Ling Ling Shi,1
-Humboldt,4E-51_A,U.S. Senate,,DEM,Loretta L. Sanchez,20
-Humboldt,4E-51_A,U.S. Senate,,DEM,Massie Munroe,4
-Humboldt,4E-51_A,U.S. Senate,,IND,Mike Beitiks,3
-Humboldt,4E-51_A,U.S. Senate,,GRN,Pamela Elizondo,1
-Humboldt,4E-51_A,U.S. Senate,,REP,Phil Wyman,8
-Humboldt,4E-51_A,U.S. Senate,,REP,Ron Unz,2
-Humboldt,4E-51_A,U.S. Senate,,DEM,Steve Stokes,2
-Humboldt,4E-51_A,U.S. Senate,,REP,Thomas G. Del Beccaro,5
-Humboldt,4E-51_A,U.S. Senate,,REP,Tom Palzer,2
-Humboldt,4E-51_A,U.S. Senate,,REP,Von Hougo,2
-Humboldt,4E-52,President,,DEM,Bernie Sanders,43
-Humboldt,4E-52,President,,REP,Donald Trump,8
-Humboldt,4E-52,President,,DEM,Hillary Clinton,18
-Humboldt,4E-52,President,,REP,John R. Kasich,2
-Humboldt,4E-52,President,,REP,Ted Cruz,2
-Humboldt,4E-52,President,,DEM,Willie Wilson,1
-Humboldt,4E-52,Proposition 50,,,No,20
-Humboldt,4E-52,Proposition 50,,,Yes,56
-Humboldt,4E-52,State Assembly,2,DEM,Jim Wood,60
-Humboldt,4E-52,U.S. House,2,REP,Dale K. Mensing,11
-Humboldt,4E-52,U.S. House,2,DEM,Erin A. Schrode,14
-Humboldt,4E-52,U.S. House,2,DEM,Jared W. Huffman,45
-Humboldt,4E-52,U.S. House,2,IND,Matthew Robert Wookey,6
-Humboldt,4E-52,U.S. Senate,,REP,Don Krampe,1
-Humboldt,4E-52,U.S. Senate,,REP,Duf Sundheim,2
+Humboldt,4E-51,U.S. Senate,,DEM,Steve Stokes,15
+Humboldt,4E-51,U.S. Senate,,REP,Thomas G. Del Beccaro,9
+Humboldt,4E-51,U.S. Senate,,REP,Tom Palzer,5
+Humboldt,4E-51,U.S. Senate,,REP,Von Hougo,5
+Humboldt,4E-52,President,,REP,Ben Carson,1
+Humboldt,4E-52,President,,DEM,Bernie Sanders,89
+Humboldt,4E-52,President,,REP,Donald Trump,32
+Humboldt,4E-52,President,,LIB,Gary Johnson,1
+Humboldt,4E-52,President,,DEM,Henry Hewes,1
+Humboldt,4E-52,President,,DEM,Hillary Clinton,46
+Humboldt,4E-52,President,,REP,Jim Gilmore,1
+Humboldt,4E-52,President,,REP,John R. Kasich,5
+Humboldt,4E-52,President,,DEM,Michael Steinberg,1
+Humboldt,4E-52,President,,REP,Ted Cruz,5
+Humboldt,4E-52,President,,DEM,Willie Wilson,5
+Humboldt,4E-52,Proposition 50,,,No,40
+Humboldt,4E-52,Proposition 50,,,Yes,159
+Humboldt,4E-52,State Assembly,2,DEM,Jim Wood,159
+Humboldt,4E-52,U.S. House,2,REP,Dale K. Mensing,36
+Humboldt,4E-52,U.S. House,2,DEM,Erin A. Schrode,26
+Humboldt,4E-52,U.S. House,2,DEM,Jared W. Huffman,131
+Humboldt,4E-52,U.S. House,2,IND,Matthew Robert Wookey,8
+Humboldt,4E-52,U.S. Senate,,IND,Clive Grey,3
+Humboldt,4E-52,U.S. Senate,,IND,Don J. Grundmann,1
+Humboldt,4E-52,U.S. Senate,,REP,Don Krampe,5
+Humboldt,4E-52,U.S. Senate,,REP,Duf Sundheim,6
 Humboldt,4E-52,U.S. Senate,,DEM,Emory Rodgers,1
-Humboldt,4E-52,U.S. Senate,,LIB,Gail K. Lightfoot,2
-Humboldt,4E-52,U.S. Senate,,REP,Greg Conlon,1
+Humboldt,4E-52,U.S. Senate,,LIB,Gail K. Lightfoot,6
+Humboldt,4E-52,U.S. Senate,,REP,George C. Yang,1
+Humboldt,4E-52,U.S. Senate,,REP,Greg Conlon,4
 Humboldt,4E-52,U.S. Senate,,DEM,Herbert G. Peters,1
-Humboldt,4E-52,U.S. Senate,,REP,Jarrell Williamson,1
-Humboldt,4E-52,U.S. Senate,,IND,Jason Hanania,2
+Humboldt,4E-52,U.S. Senate,,REP,Jarrell Williamson,2
+Humboldt,4E-52,U.S. Senate,,IND,Jason Hanania,3
 Humboldt,4E-52,U.S. Senate,,IND,Jason Kraus,1
-Humboldt,4E-52,U.S. Senate,,REP,Jerry J. Laws,1
-Humboldt,4E-52,U.S. Senate,,DEM,Kamala D. Harris,19
+Humboldt,4E-52,U.S. Senate,,REP,Jerry J. Laws,6
+Humboldt,4E-52,U.S. Senate,,DEM,Kamala D. Harris,58
+Humboldt,4E-52,U.S. Senate,,REP,Karen Roseberry,1
 Humboldt,4E-52,U.S. Senate,,IND,Ling Ling Shi,1
-Humboldt,4E-52,U.S. Senate,,DEM,Loretta L. Sanchez,14
-Humboldt,4E-52,U.S. Senate,,DEM,Massie Munroe,1
+Humboldt,4E-52,U.S. Senate,,DEM,Loretta L. Sanchez,45
+Humboldt,4E-52,U.S. Senate,,LIB,Mark Matthew Herd,1
+Humboldt,4E-52,U.S. Senate,,DEM,Massie Munroe,4
 Humboldt,4E-52,U.S. Senate,,IND,Mike Beitiks,3
-Humboldt,4E-52,U.S. Senate,,GRN,Pamela Elizondo,7
-Humboldt,4E-52,U.S. Senate,,IND,Paul Merritt,1
-Humboldt,4E-52,U.S. Senate,,REP,Phil Wyman,4
+Humboldt,4E-52,U.S. Senate,,GRN,Pamela Elizondo,11
+Humboldt,4E-52,U.S. Senate,,IND,Paul Merritt,3
+Humboldt,4E-52,U.S. Senate,,REP,Phil Wyman,9
 Humboldt,4E-52,U.S. Senate,,DEM,President Cristina Grappo,1
-Humboldt,4E-52,U.S. Senate,,IND,Scott A. Vineberg,1
-Humboldt,4E-52,U.S. Senate,,DEM,Steve Stokes,7
-Humboldt,4E-52,U.S. Senate,,REP,Thomas G. Del Beccaro,2
-Humboldt,4E-52,U.S. Senate,,REP,Von Hougo,1
-Humboldt,4E-52_A,President,,REP,Ben Carson,1
-Humboldt,4E-52_A,President,,DEM,Bernie Sanders,46
-Humboldt,4E-52_A,President,,REP,Donald Trump,24
-Humboldt,4E-52_A,President,,LIB,Gary Johnson,1
-Humboldt,4E-52_A,President,,DEM,Henry Hewes,1
-Humboldt,4E-52_A,President,,DEM,Hillary Clinton,28
-Humboldt,4E-52_A,President,,REP,Jim Gilmore,1
-Humboldt,4E-52_A,President,,REP,John R. Kasich,3
-Humboldt,4E-52_A,President,,DEM,Michael Steinberg,1
-Humboldt,4E-52_A,President,,REP,Ted Cruz,3
-Humboldt,4E-52_A,President,,DEM,Willie Wilson,4
-Humboldt,4E-52_A,Proposition 50,,,No,20
-Humboldt,4E-52_A,Proposition 50,,,Yes,103
-Humboldt,4E-52_A,State Assembly,2,DEM,Jim Wood,99
-Humboldt,4E-52_A,U.S. House,2,REP,Dale K. Mensing,25
-Humboldt,4E-52_A,U.S. House,2,DEM,Erin A. Schrode,12
-Humboldt,4E-52_A,U.S. House,2,DEM,Jared W. Huffman,86
-Humboldt,4E-52_A,U.S. House,2,IND,Matthew Robert Wookey,2
-Humboldt,4E-52_A,U.S. Senate,,IND,Clive Grey,3
-Humboldt,4E-52_A,U.S. Senate,,IND,Don J. Grundmann,1
-Humboldt,4E-52_A,U.S. Senate,,REP,Don Krampe,4
-Humboldt,4E-52_A,U.S. Senate,,REP,Duf Sundheim,4
-Humboldt,4E-52_A,U.S. Senate,,LIB,Gail K. Lightfoot,4
-Humboldt,4E-52_A,U.S. Senate,,REP,George C. Yang,1
-Humboldt,4E-52_A,U.S. Senate,,REP,Greg Conlon,3
-Humboldt,4E-52_A,U.S. Senate,,REP,Jarrell Williamson,1
-Humboldt,4E-52_A,U.S. Senate,,IND,Jason Hanania,1
-Humboldt,4E-52_A,U.S. Senate,,REP,Jerry J. Laws,5
-Humboldt,4E-52_A,U.S. Senate,,DEM,Kamala D. Harris,39
-Humboldt,4E-52_A,U.S. Senate,,REP,Karen Roseberry,1
-Humboldt,4E-52_A,U.S. Senate,,DEM,Loretta L. Sanchez,31
-Humboldt,4E-52_A,U.S. Senate,,LIB,Mark Matthew Herd,1
-Humboldt,4E-52_A,U.S. Senate,,DEM,Massie Munroe,3
-Humboldt,4E-52_A,U.S. Senate,,GRN,Pamela Elizondo,4
-Humboldt,4E-52_A,U.S. Senate,,IND,Paul Merritt,2
-Humboldt,4E-52_A,U.S. Senate,,REP,Phil Wyman,5
-Humboldt,4E-52_A,U.S. Senate,,IND,Scott A. Vineberg,1
-Humboldt,4E-52_A,U.S. Senate,,DEM,Steve Stokes,4
-Humboldt,4E-52_A,U.S. Senate,,REP,Thomas G. Del Beccaro,1
-Humboldt,4E-52_A,U.S. Senate,,REP,Tom Palzer,2
-Humboldt,4E-52_A,U.S. Senate,,REP,Von Hougo,3
-Humboldt,4E-54,President,,REP,Ben Carson,3
-Humboldt,4E-54,President,,DEM,Bernie Sanders,119
-Humboldt,4E-54,President,,GRN,Darryl Cherney,1
-Humboldt,4E-54,President,,REP,Donald Trump,28
-Humboldt,4E-54,President,,DEM,Hillary Clinton,46
+Humboldt,4E-52,U.S. Senate,,IND,Scott A. Vineberg,2
+Humboldt,4E-52,U.S. Senate,,DEM,Steve Stokes,11
+Humboldt,4E-52,U.S. Senate,,REP,Thomas G. Del Beccaro,3
+Humboldt,4E-52,U.S. Senate,,REP,Tom Palzer,2
+Humboldt,4E-52,U.S. Senate,,REP,Von Hougo,4
+Humboldt,4E-54,President,,LIB,Austin Petersen,1
+Humboldt,4E-54,President,,REP,Ben Carson,5
+Humboldt,4E-54,President,,DEM,Bernie Sanders,226
+Humboldt,4E-54,President,,GRN,Darryl Cherney,2
+Humboldt,4E-54,President,,REP,Donald Trump,95
+Humboldt,4E-54,President,,LIB,Gary Johnson,1
+Humboldt,4E-54,President,,DEM,Hillary Clinton,113
 Humboldt,4E-54,President,,LIB,"Jack Robinson, Jr.",1
-Humboldt,4E-54,President,,REP,John R. Kasich,4
-Humboldt,4E-54,President,,DEM,Michael Steinberg,2
-Humboldt,4E-54,President,,REP,Ted Cruz,6
-Humboldt,4E-54,Proposition 50,,,No,50
-Humboldt,4E-54,Proposition 50,,,Yes,149
-Humboldt,4E-54,State Assembly,2,DEM,Jim Wood,162
-Humboldt,4E-54,U.S. House,2,REP,Dale K. Mensing,36
-Humboldt,4E-54,U.S. House,2,DEM,Erin A. Schrode,26
-Humboldt,4E-54,U.S. House,2,DEM,Jared W. Huffman,121
-Humboldt,4E-54,U.S. House,2,IND,Matthew Robert Wookey,20
+Humboldt,4E-54,President,,REP,Jim Gilmore,1
+Humboldt,4E-54,President,,REP,John R. Kasich,11
+Humboldt,4E-54,President,,DEM,Keith Judd,1
+Humboldt,4E-54,President,,DEM,Michael Steinberg,3
+Humboldt,4E-54,President,,REP,Ted Cruz,15
+Humboldt,4E-54,President,,AIP,Thomas Hoefling,1
+Humboldt,4E-54,Proposition 50,,,No,97
+Humboldt,4E-54,Proposition 50,,,Yes,362
+Humboldt,4E-54,State Assembly,2,DEM,Jim Wood,376
+Humboldt,4E-54,U.S. House,2,REP,Dale K. Mensing,97
+Humboldt,4E-54,U.S. House,2,DEM,Erin A. Schrode,51
+Humboldt,4E-54,U.S. House,2,DEM,Jared W. Huffman,289
+Humboldt,4E-54,U.S. House,2,IND,Matthew Robert Wookey,38
 Humboldt,4E-54,U.S. Senate,,IND,Clive Grey,1
-Humboldt,4E-54,U.S. Senate,,IND,Don J. Grundmann,1
-Humboldt,4E-54,U.S. Senate,,REP,Don Krampe,4
-Humboldt,4E-54,U.S. Senate,,REP,Duf Sundheim,9
-Humboldt,4E-54,U.S. Senate,,IND,Eleanor García,1
-Humboldt,4E-54,U.S. Senate,,LIB,Gail K. Lightfoot,9
-Humboldt,4E-54,U.S. Senate,,REP,George C. Yang,1
-Humboldt,4E-54,U.S. Senate,,REP,Greg Conlon,4
+Humboldt,4E-54,U.S. Senate,,IND,Don J. Grundmann,2
+Humboldt,4E-54,U.S. Senate,,REP,Don Krampe,8
+Humboldt,4E-54,U.S. Senate,,REP,Duf Sundheim,17
+Humboldt,4E-54,U.S. Senate,,IND,Eleanor García,2
+Humboldt,4E-54,U.S. Senate,,LIB,Gail K. Lightfoot,20
+Humboldt,4E-54,U.S. Senate,,REP,George C. Yang,5
+Humboldt,4E-54,U.S. Senate,,REP,Greg Conlon,15
 Humboldt,4E-54,U.S. Senate,,DEM,Herbert G. Peters,1
-Humboldt,4E-54,U.S. Senate,,REP,Jarrell Williamson,1
+Humboldt,4E-54,U.S. Senate,,REP,Jarrell Williamson,6
 Humboldt,4E-54,U.S. Senate,,IND,Jason Hanania,1
-Humboldt,4E-54,U.S. Senate,,IND,Jason Kraus,1
-Humboldt,4E-54,U.S. Senate,,REP,Jerry J. Laws,12
-Humboldt,4E-54,U.S. Senate,,PAF,John Thompson Parker,1
-Humboldt,4E-54,U.S. Senate,,DEM,Kamala D. Harris,73
-Humboldt,4E-54,U.S. Senate,,REP,Karen Roseberry,5
-Humboldt,4E-54,U.S. Senate,,DEM,Loretta L. Sanchez,38
+Humboldt,4E-54,U.S. Senate,,IND,Jason Kraus,3
+Humboldt,4E-54,U.S. Senate,,REP,Jerry J. Laws,16
+Humboldt,4E-54,U.S. Senate,,PAF,John Thompson Parker,2
+Humboldt,4E-54,U.S. Senate,,DEM,Kamala D. Harris,164
+Humboldt,4E-54,U.S. Senate,,REP,Karen Roseberry,8
+Humboldt,4E-54,U.S. Senate,,IND,Ling Ling Shi,4
+Humboldt,4E-54,U.S. Senate,,DEM,Loretta L. Sanchez,97
 Humboldt,4E-54,U.S. Senate,,LIB,Mark Matthew Herd,1
-Humboldt,4E-54,U.S. Senate,,DEM,Massie Munroe,6
-Humboldt,4E-54,U.S. Senate,,IND,Mike Beitiks,1
-Humboldt,4E-54,U.S. Senate,,GRN,Pamela Elizondo,5
+Humboldt,4E-54,U.S. Senate,,DEM,Massie Munroe,9
+Humboldt,4E-54,U.S. Senate,,IND,Mike Beitiks,2
+Humboldt,4E-54,U.S. Senate,,GRN,Pamela Elizondo,19
 Humboldt,4E-54,U.S. Senate,,IND,Paul Merritt,1
-Humboldt,4E-54,U.S. Senate,,REP,Phil Wyman,5
-Humboldt,4E-54,U.S. Senate,,DEM,President Cristina Grappo,1
+Humboldt,4E-54,U.S. Senate,,REP,Phil Wyman,21
+Humboldt,4E-54,U.S. Senate,,DEM,President Cristina Grappo,2
 Humboldt,4E-54,U.S. Senate,,REP,Ron Unz,1
-Humboldt,4E-54,U.S. Senate,,DEM,Steve Stokes,11
-Humboldt,4E-54,U.S. Senate,,REP,Thomas G. Del Beccaro,1
-Humboldt,4E-54,U.S. Senate,,REP,Tom Palzer,5
-Humboldt,4E-54,U.S. Senate,,REP,Von Hougo,3
-Humboldt,4E-54_A,President,,LIB,Austin Petersen,1
-Humboldt,4E-54_A,President,,REP,Ben Carson,2
-Humboldt,4E-54_A,President,,DEM,Bernie Sanders,107
-Humboldt,4E-54_A,President,,GRN,Darryl Cherney,1
-Humboldt,4E-54_A,President,,REP,Donald Trump,67
-Humboldt,4E-54_A,President,,LIB,Gary Johnson,1
-Humboldt,4E-54_A,President,,DEM,Hillary Clinton,67
-Humboldt,4E-54_A,President,,REP,Jim Gilmore,1
-Humboldt,4E-54_A,President,,REP,John R. Kasich,7
-Humboldt,4E-54_A,President,,DEM,Keith Judd,1
-Humboldt,4E-54_A,President,,DEM,Michael Steinberg,1
-Humboldt,4E-54_A,President,,REP,Ted Cruz,9
-Humboldt,4E-54_A,President,,AIP,Thomas Hoefling,1
-Humboldt,4E-54_A,Proposition 50,,,No,47
-Humboldt,4E-54_A,Proposition 50,,,Yes,213
-Humboldt,4E-54_A,State Assembly,2,DEM,Jim Wood,214
-Humboldt,4E-54_A,U.S. House,2,REP,Dale K. Mensing,61
-Humboldt,4E-54_A,U.S. House,2,DEM,Erin A. Schrode,25
-Humboldt,4E-54_A,U.S. House,2,DEM,Jared W. Huffman,168
-Humboldt,4E-54_A,U.S. House,2,IND,Matthew Robert Wookey,18
-Humboldt,4E-54_A,U.S. Senate,,IND,Don J. Grundmann,1
-Humboldt,4E-54_A,U.S. Senate,,REP,Don Krampe,4
-Humboldt,4E-54_A,U.S. Senate,,REP,Duf Sundheim,8
-Humboldt,4E-54_A,U.S. Senate,,IND,Eleanor García,1
-Humboldt,4E-54_A,U.S. Senate,,LIB,Gail K. Lightfoot,11
-Humboldt,4E-54_A,U.S. Senate,,REP,George C. Yang,4
-Humboldt,4E-54_A,U.S. Senate,,REP,Greg Conlon,11
-Humboldt,4E-54_A,U.S. Senate,,REP,Jarrell Williamson,5
-Humboldt,4E-54_A,U.S. Senate,,IND,Jason Kraus,2
-Humboldt,4E-54_A,U.S. Senate,,REP,Jerry J. Laws,4
-Humboldt,4E-54_A,U.S. Senate,,PAF,John Thompson Parker,1
-Humboldt,4E-54_A,U.S. Senate,,DEM,Kamala D. Harris,91
-Humboldt,4E-54_A,U.S. Senate,,REP,Karen Roseberry,3
-Humboldt,4E-54_A,U.S. Senate,,IND,Ling Ling Shi,4
-Humboldt,4E-54_A,U.S. Senate,,DEM,Loretta L. Sanchez,59
-Humboldt,4E-54_A,U.S. Senate,,DEM,Massie Munroe,3
-Humboldt,4E-54_A,U.S. Senate,,IND,Mike Beitiks,1
-Humboldt,4E-54_A,U.S. Senate,,GRN,Pamela Elizondo,14
-Humboldt,4E-54_A,U.S. Senate,,REP,Phil Wyman,16
-Humboldt,4E-54_A,U.S. Senate,,DEM,President Cristina Grappo,1
-Humboldt,4E-54_A,U.S. Senate,,DEM,Steve Stokes,7
-Humboldt,4E-54_A,U.S. Senate,,REP,Thomas G. Del Beccaro,2
-Humboldt,4E-54_A,U.S. Senate,,REP,Tom Palzer,6
-Humboldt,4E-54_A,U.S. Senate,,REP,Von Hougo,5
-Humboldt,4ES-4,President,,REP,Ben Carson,1
-Humboldt,4ES-4,President,,DEM,Bernie Sanders,85
-Humboldt,4ES-4,President,,REP,Donald Trump,31
-Humboldt,4ES-4,President,,LIB,Gary Johnson,1
-Humboldt,4ES-4,President,,DEM,Hillary Clinton,27
+Humboldt,4E-54,U.S. Senate,,DEM,Steve Stokes,18
+Humboldt,4E-54,U.S. Senate,,REP,Thomas G. Del Beccaro,3
+Humboldt,4E-54,U.S. Senate,,REP,Tom Palzer,11
+Humboldt,4E-54,U.S. Senate,,REP,Von Hougo,8
+Humboldt,4ES-4,President,,REP,Ben Carson,11
+Humboldt,4ES-4,President,,DEM,Bernie Sanders,165
+Humboldt,4ES-4,President,,GRN,Darryl Cherney,1
+Humboldt,4ES-4,President,,REP,Donald Trump,82
+Humboldt,4ES-4,President,,LIB,Gary Johnson,3
+Humboldt,4ES-4,President,,DEM,Hillary Clinton,79
+Humboldt,4ES-4,President,,AIP,James Hedges,1
 Humboldt,4ES-4,President,,GRN,Jill Stein,2
-Humboldt,4ES-4,President,,REP,John R. Kasich,2
-Humboldt,4ES-4,President,,REP,Ted Cruz,1
-Humboldt,4ES-4,Proposition 50,,,No,21
-Humboldt,4ES-4,Proposition 50,,,Yes,119
-Humboldt,4ES-4,State Assembly,2,DEM,Jim Wood,109
-Humboldt,4ES-4,U.S. House,2,REP,Dale K. Mensing,28
-Humboldt,4ES-4,U.S. House,2,DEM,Erin A. Schrode,18
-Humboldt,4ES-4,U.S. House,2,DEM,Jared W. Huffman,88
-Humboldt,4ES-4,U.S. House,2,IND,Matthew Robert Wookey,10
-Humboldt,4ES-4,U.S. Senate,,REP,Duf Sundheim,9
-Humboldt,4ES-4,U.S. Senate,,IND,Eleanor García,1
-Humboldt,4ES-4,U.S. Senate,,LIB,Gail K. Lightfoot,8
-Humboldt,4ES-4,U.S. Senate,,REP,Greg Conlon,11
-Humboldt,4ES-4,U.S. Senate,,REP,Jarrell Williamson,2
-Humboldt,4ES-4,U.S. Senate,,IND,Jason Kraus,1
-Humboldt,4ES-4,U.S. Senate,,REP,Jerry J. Laws,6
-Humboldt,4ES-4,U.S. Senate,,DEM,Kamala D. Harris,47
-Humboldt,4ES-4,U.S. Senate,,DEM,Loretta L. Sanchez,31
+Humboldt,4ES-4,President,,REP,John R. Kasich,8
+Humboldt,4ES-4,President,,REP,Ted Cruz,7
+Humboldt,4ES-4,Proposition 50,,,No,73
+Humboldt,4ES-4,Proposition 50,,,Yes,284
+Humboldt,4ES-4,State Assembly,2,DEM,Jim Wood,272
+Humboldt,4ES-4,U.S. House,2,REP,Dale K. Mensing,82
+Humboldt,4ES-4,U.S. House,2,DEM,Erin A. Schrode,40
+Humboldt,4ES-4,U.S. House,2,DEM,Jared W. Huffman,223
+Humboldt,4ES-4,U.S. House,2,IND,Matthew Robert Wookey,28
+Humboldt,4ES-4,U.S. Senate,,IND,Clive Grey,1
+Humboldt,4ES-4,U.S. Senate,,REP,Don Krampe,1
+Humboldt,4ES-4,U.S. Senate,,REP,Duf Sundheim,26
+Humboldt,4ES-4,U.S. Senate,,IND,Eleanor García,2
+Humboldt,4ES-4,U.S. Senate,,LIB,Gail K. Lightfoot,16
+Humboldt,4ES-4,U.S. Senate,,REP,Greg Conlon,21
+Humboldt,4ES-4,U.S. Senate,,DEM,Herbert G. Peters,1
+Humboldt,4ES-4,U.S. Senate,,REP,Jarrell Williamson,8
+Humboldt,4ES-4,U.S. Senate,,IND,Jason Kraus,3
+Humboldt,4ES-4,U.S. Senate,,REP,Jerry J. Laws,18
+Humboldt,4ES-4,U.S. Senate,,DEM,Kamala D. Harris,126
+Humboldt,4ES-4,U.S. Senate,,REP,Karen Roseberry,1
+Humboldt,4ES-4,U.S. Senate,,IND,Ling Ling Shi,1
+Humboldt,4ES-4,U.S. Senate,,DEM,Loretta L. Sanchez,70
 Humboldt,4ES-4,U.S. Senate,,LIB,Mark Matthew Herd,3
-Humboldt,4ES-4,U.S. Senate,,DEM,Massie Munroe,1
-Humboldt,4ES-4,U.S. Senate,,IND,Mike Beitiks,1
-Humboldt,4ES-4,U.S. Senate,,GRN,Pamela Elizondo,7
-Humboldt,4ES-4,U.S. Senate,,REP,Phil Wyman,9
-Humboldt,4ES-4,U.S. Senate,,DEM,President Cristina Grappo,1
-Humboldt,4ES-4,U.S. Senate,,DEM,Steve Stokes,5
-Humboldt,4ES-4_A,President,,REP,Ben Carson,10
-Humboldt,4ES-4_A,President,,DEM,Bernie Sanders,80
-Humboldt,4ES-4_A,President,,GRN,Darryl Cherney,1
-Humboldt,4ES-4_A,President,,REP,Donald Trump,51
-Humboldt,4ES-4_A,President,,LIB,Gary Johnson,2
-Humboldt,4ES-4_A,President,,DEM,Hillary Clinton,52
-Humboldt,4ES-4_A,President,,AIP,James Hedges,1
-Humboldt,4ES-4_A,President,,REP,John R. Kasich,6
-Humboldt,4ES-4_A,President,,REP,Ted Cruz,6
-Humboldt,4ES-4_A,Proposition 50,,,No,52
-Humboldt,4ES-4_A,Proposition 50,,,Yes,165
-Humboldt,4ES-4_A,State Assembly,2,DEM,Jim Wood,163
-Humboldt,4ES-4_A,U.S. House,2,REP,Dale K. Mensing,54
-Humboldt,4ES-4_A,U.S. House,2,DEM,Erin A. Schrode,22
-Humboldt,4ES-4_A,U.S. House,2,DEM,Jared W. Huffman,135
-Humboldt,4ES-4_A,U.S. House,2,IND,Matthew Robert Wookey,18
-Humboldt,4ES-4_A,U.S. Senate,,IND,Clive Grey,1
-Humboldt,4ES-4_A,U.S. Senate,,REP,Don Krampe,1
-Humboldt,4ES-4_A,U.S. Senate,,REP,Duf Sundheim,17
-Humboldt,4ES-4_A,U.S. Senate,,IND,Eleanor García,1
-Humboldt,4ES-4_A,U.S. Senate,,LIB,Gail K. Lightfoot,8
-Humboldt,4ES-4_A,U.S. Senate,,REP,Greg Conlon,10
-Humboldt,4ES-4_A,U.S. Senate,,DEM,Herbert G. Peters,1
-Humboldt,4ES-4_A,U.S. Senate,,REP,Jarrell Williamson,6
-Humboldt,4ES-4_A,U.S. Senate,,IND,Jason Kraus,2
-Humboldt,4ES-4_A,U.S. Senate,,REP,Jerry J. Laws,12
-Humboldt,4ES-4_A,U.S. Senate,,DEM,Kamala D. Harris,79
-Humboldt,4ES-4_A,U.S. Senate,,REP,Karen Roseberry,1
-Humboldt,4ES-4_A,U.S. Senate,,IND,Ling Ling Shi,1
-Humboldt,4ES-4_A,U.S. Senate,,DEM,Loretta L. Sanchez,39
-Humboldt,4ES-4_A,U.S. Senate,,DEM,Massie Munroe,1
-Humboldt,4ES-4_A,U.S. Senate,,IND,Mike Beitiks,4
-Humboldt,4ES-4_A,U.S. Senate,,GRN,Pamela Elizondo,3
-Humboldt,4ES-4_A,U.S. Senate,,REP,Phil Wyman,14
-Humboldt,4ES-4_A,U.S. Senate,,DEM,President Cristina Grappo,1
-Humboldt,4ES-4_A,U.S. Senate,,DEM,Steve Stokes,7
-Humboldt,4ES-4_A,U.S. Senate,,REP,Thomas G. Del Beccaro,4
-Humboldt,4ES-4_A,U.S. Senate,,REP,Tom Palzer,6
-Humboldt,4ES-4_A,U.S. Senate,,REP,Von Hougo,1
-Humboldt,4ES-5,President,,REP,Ben Carson,3
-Humboldt,4ES-5,President,,DEM,Bernie Sanders,124
+Humboldt,4ES-4,U.S. Senate,,DEM,Massie Munroe,2
+Humboldt,4ES-4,U.S. Senate,,IND,Mike Beitiks,5
+Humboldt,4ES-4,U.S. Senate,,GRN,Pamela Elizondo,10
+Humboldt,4ES-4,U.S. Senate,,REP,Phil Wyman,23
+Humboldt,4ES-4,U.S. Senate,,DEM,President Cristina Grappo,2
+Humboldt,4ES-4,U.S. Senate,,DEM,Steve Stokes,12
+Humboldt,4ES-4,U.S. Senate,,REP,Thomas G. Del Beccaro,4
+Humboldt,4ES-4,U.S. Senate,,REP,Tom Palzer,6
+Humboldt,4ES-4,U.S. Senate,,REP,Von Hougo,1
+Humboldt,4ES-5,President,,AIP,Alan Spears,1
+Humboldt,4ES-5,President,,REP,Ben Carson,6
+Humboldt,4ES-5,President,,DEM,Bernie Sanders,254
+Humboldt,4ES-5,President,,LIB,Cecil Ince,1
 Humboldt,4ES-5,President,,GRN,Darryl Cherney,1
-Humboldt,4ES-5,President,,REP,Donald Trump,20
+Humboldt,4ES-5,President,,REP,Donald Trump,80
 Humboldt,4ES-5,President,,LIB,Gary Johnson,1
-Humboldt,4ES-5,President,,DEM,Hillary Clinton,52
-Humboldt,4ES-5,President,,GRN,Jill Stein,1
+Humboldt,4ES-5,President,,DEM,Hillary Clinton,105
+Humboldt,4ES-5,President,,GRN,Jill Stein,3
 Humboldt,4ES-5,President,,REP,Jim Gilmore,1
-Humboldt,4ES-5,President,,REP,John R. Kasich,4
+Humboldt,4ES-5,President,,REP,John R. Kasich,9
+Humboldt,4ES-5,President,,DEM,Keith Judd,2
 Humboldt,4ES-5,President,,GRN,Kent Mesplay,1
-Humboldt,4ES-5,President,,REP,Ted Cruz,7
-Humboldt,4ES-5,Proposition 50,,,No,48
-Humboldt,4ES-5,Proposition 50,,,Yes,148
-Humboldt,4ES-5,State Assembly,2,DEM,Jim Wood,160
-Humboldt,4ES-5,U.S. House,2,REP,Dale K. Mensing,29
-Humboldt,4ES-5,U.S. House,2,DEM,Erin A. Schrode,22
-Humboldt,4ES-5,U.S. House,2,DEM,Jared W. Huffman,123
-Humboldt,4ES-5,U.S. House,2,IND,Matthew Robert Wookey,32
-Humboldt,4ES-5,U.S. Senate,,IND,Clive Grey,4
-Humboldt,4ES-5,U.S. Senate,,REP,Duf Sundheim,10
+Humboldt,4ES-5,President,,DEM,Roque De La Fuente,1
+Humboldt,4ES-5,President,,REP,Ted Cruz,17
+Humboldt,4ES-5,President,,DEM,Willie Wilson,3
+Humboldt,4ES-5,Proposition 50,,,No,91
+Humboldt,4ES-5,Proposition 50,,,Yes,351
+Humboldt,4ES-5,State Assembly,2,DEM,Jim Wood,376
+Humboldt,4ES-5,U.S. House,2,REP,Dale K. Mensing,85
+Humboldt,4ES-5,U.S. House,2,DEM,Erin A. Schrode,40
+Humboldt,4ES-5,U.S. House,2,DEM,Jared W. Huffman,305
+Humboldt,4ES-5,U.S. House,2,IND,Matthew Robert Wookey,57
+Humboldt,4ES-5,U.S. Senate,,IND,Clive Grey,6
+Humboldt,4ES-5,U.S. Senate,,IND,Don J. Grundmann,2
+Humboldt,4ES-5,U.S. Senate,,REP,Don Krampe,2
+Humboldt,4ES-5,U.S. Senate,,REP,Duf Sundheim,24
 Humboldt,4ES-5,U.S. Senate,,IND,Eleanor García,5
-Humboldt,4ES-5,U.S. Senate,,LIB,Gail K. Lightfoot,6
-Humboldt,4ES-5,U.S. Senate,,REP,George C. Yang,1
-Humboldt,4ES-5,U.S. Senate,,REP,Greg Conlon,6
-Humboldt,4ES-5,U.S. Senate,,REP,Jarrell Williamson,2
+Humboldt,4ES-5,U.S. Senate,,DEM,Emory Rodgers,1
+Humboldt,4ES-5,U.S. Senate,,LIB,Gail K. Lightfoot,14
+Humboldt,4ES-5,U.S. Senate,,REP,George C. Yang,3
+Humboldt,4ES-5,U.S. Senate,,REP,Greg Conlon,32
+Humboldt,4ES-5,U.S. Senate,,REP,Jarrell Williamson,5
 Humboldt,4ES-5,U.S. Senate,,IND,Jason Hanania,3
-Humboldt,4ES-5,U.S. Senate,,REP,Jerry J. Laws,6
-Humboldt,4ES-5,U.S. Senate,,DEM,Kamala D. Harris,70
+Humboldt,4ES-5,U.S. Senate,,REP,Jerry J. Laws,15
+Humboldt,4ES-5,U.S. Senate,,PAF,John Thompson Parker,1
+Humboldt,4ES-5,U.S. Senate,,DEM,Kamala D. Harris,165
+Humboldt,4ES-5,U.S. Senate,,REP,Karen Roseberry,1
 Humboldt,4ES-5,U.S. Senate,,IND,Ling Ling Shi,3
-Humboldt,4ES-5,U.S. Senate,,DEM,Loretta L. Sanchez,39
+Humboldt,4ES-5,U.S. Senate,,DEM,Loretta L. Sanchez,89
 Humboldt,4ES-5,U.S. Senate,,LIB,Mark Matthew Herd,1
-Humboldt,4ES-5,U.S. Senate,,DEM,Massie Munroe,6
-Humboldt,4ES-5,U.S. Senate,,GRN,Pamela Elizondo,9
-Humboldt,4ES-5,U.S. Senate,,IND,Paul Merritt,1
-Humboldt,4ES-5,U.S. Senate,,REP,Phil Wyman,4
+Humboldt,4ES-5,U.S. Senate,,DEM,Massie Munroe,7
+Humboldt,4ES-5,U.S. Senate,,IND,Mike Beitiks,2
+Humboldt,4ES-5,U.S. Senate,,GRN,Pamela Elizondo,16
+Humboldt,4ES-5,U.S. Senate,,IND,Paul Merritt,3
+Humboldt,4ES-5,U.S. Senate,,REP,Phil Wyman,12
 Humboldt,4ES-5,U.S. Senate,,DEM,President Cristina Grappo,3
+Humboldt,4ES-5,U.S. Senate,,REP,Ron Unz,3
 Humboldt,4ES-5,U.S. Senate,,IND,Scott A. Vineberg,1
-Humboldt,4ES-5,U.S. Senate,,DEM,Steve Stokes,16
-Humboldt,4ES-5,U.S. Senate,,REP,Thomas G. Del Beccaro,2
-Humboldt,4ES-5,U.S. Senate,,REP,Tom Palzer,1
-Humboldt,4ES-5,U.S. Senate,,REP,Von Hougo,5
-Humboldt,4ES-5_A,President,,AIP,Alan Spears,1
-Humboldt,4ES-5_A,President,,REP,Ben Carson,3
-Humboldt,4ES-5_A,President,,DEM,Bernie Sanders,130
-Humboldt,4ES-5_A,President,,LIB,Cecil Ince,1
-Humboldt,4ES-5_A,President,,REP,Donald Trump,60
-Humboldt,4ES-5_A,President,,DEM,Hillary Clinton,53
-Humboldt,4ES-5_A,President,,GRN,Jill Stein,2
-Humboldt,4ES-5_A,President,,REP,John R. Kasich,5
-Humboldt,4ES-5_A,President,,DEM,Keith Judd,2
-Humboldt,4ES-5_A,President,,DEM,Roque De La Fuente,1
-Humboldt,4ES-5_A,President,,REP,Ted Cruz,10
-Humboldt,4ES-5_A,President,,DEM,Willie Wilson,3
-Humboldt,4ES-5_A,Proposition 50,,,No,43
-Humboldt,4ES-5_A,Proposition 50,,,Yes,203
-Humboldt,4ES-5_A,State Assembly,2,DEM,Jim Wood,216
-Humboldt,4ES-5_A,U.S. House,2,REP,Dale K. Mensing,56
-Humboldt,4ES-5_A,U.S. House,2,DEM,Erin A. Schrode,18
-Humboldt,4ES-5_A,U.S. House,2,DEM,Jared W. Huffman,182
-Humboldt,4ES-5_A,U.S. House,2,IND,Matthew Robert Wookey,25
-Humboldt,4ES-5_A,U.S. Senate,,IND,Clive Grey,2
-Humboldt,4ES-5_A,U.S. Senate,,IND,Don J. Grundmann,2
-Humboldt,4ES-5_A,U.S. Senate,,REP,Don Krampe,2
-Humboldt,4ES-5_A,U.S. Senate,,REP,Duf Sundheim,14
-Humboldt,4ES-5_A,U.S. Senate,,DEM,Emory Rodgers,1
-Humboldt,4ES-5_A,U.S. Senate,,LIB,Gail K. Lightfoot,8
-Humboldt,4ES-5_A,U.S. Senate,,REP,George C. Yang,2
-Humboldt,4ES-5_A,U.S. Senate,,REP,Greg Conlon,26
-Humboldt,4ES-5_A,U.S. Senate,,REP,Jarrell Williamson,3
-Humboldt,4ES-5_A,U.S. Senate,,REP,Jerry J. Laws,9
-Humboldt,4ES-5_A,U.S. Senate,,PAF,John Thompson Parker,1
-Humboldt,4ES-5_A,U.S. Senate,,DEM,Kamala D. Harris,95
-Humboldt,4ES-5_A,U.S. Senate,,REP,Karen Roseberry,1
-Humboldt,4ES-5_A,U.S. Senate,,DEM,Loretta L. Sanchez,50
-Humboldt,4ES-5_A,U.S. Senate,,DEM,Massie Munroe,1
-Humboldt,4ES-5_A,U.S. Senate,,IND,Mike Beitiks,2
-Humboldt,4ES-5_A,U.S. Senate,,GRN,Pamela Elizondo,7
-Humboldt,4ES-5_A,U.S. Senate,,IND,Paul Merritt,2
-Humboldt,4ES-5_A,U.S. Senate,,REP,Phil Wyman,8
-Humboldt,4ES-5_A,U.S. Senate,,REP,Ron Unz,3
-Humboldt,4ES-5_A,U.S. Senate,,DEM,Steve Stokes,16
-Humboldt,4ES-5_A,U.S. Senate,,REP,Thomas G. Del Beccaro,3
-Humboldt,4ES-5_A,U.S. Senate,,REP,Tom Palzer,5
-Humboldt,4ES-5_A,U.S. Senate,,REP,Von Hougo,3
-Humboldt,4ES-6,President,,REP,Ben Carson,1
-Humboldt,4ES-6,President,,DEM,Bernie Sanders,92
-Humboldt,4ES-6,President,,REP,Donald Trump,19
+Humboldt,4ES-5,U.S. Senate,,DEM,Steve Stokes,32
+Humboldt,4ES-5,U.S. Senate,,REP,Thomas G. Del Beccaro,5
+Humboldt,4ES-5,U.S. Senate,,REP,Tom Palzer,6
+Humboldt,4ES-5,U.S. Senate,,REP,Von Hougo,8
+Humboldt,4ES-6,President,,REP,Ben Carson,8
+Humboldt,4ES-6,President,,DEM,Bernie Sanders,191
+Humboldt,4ES-6,President,,REP,Donald Trump,83
 Humboldt,4ES-6,President,,LIB,Gary Johnson,2
-Humboldt,4ES-6,President,,DEM,Hillary Clinton,26
+Humboldt,4ES-6,President,,DEM,Hillary Clinton,86
+Humboldt,4ES-6,President,,AIP,James Hedges,1
 Humboldt,4ES-6,President,,GRN,Jill Stein,1
-Humboldt,4ES-6,President,,REP,John R. Kasich,4
-Humboldt,4ES-6,President,,REP,Ted Cruz,3
-Humboldt,4ES-6,Proposition 50,,,No,27
-Humboldt,4ES-6,Proposition 50,,,Yes,104
-Humboldt,4ES-6,State Assembly,2,DEM,Jim Wood,113
-Humboldt,4ES-6,U.S. House,2,REP,Dale K. Mensing,20
-Humboldt,4ES-6,U.S. House,2,DEM,Erin A. Schrode,15
-Humboldt,4ES-6,U.S. House,2,DEM,Jared W. Huffman,90
-Humboldt,4ES-6,U.S. House,2,IND,Matthew Robert Wookey,16
-Humboldt,4ES-6,U.S. Senate,,REP,Duf Sundheim,7
+Humboldt,4ES-6,President,,REP,Jim Gilmore,3
+Humboldt,4ES-6,President,,REP,John R. Kasich,11
+Humboldt,4ES-6,President,,DEM,Keith Judd,1
+Humboldt,4ES-6,President,,REP,Ted Cruz,13
+Humboldt,4ES-6,President,,DEM,Willie Wilson,1
+Humboldt,4ES-6,Proposition 50,,,No,76
+Humboldt,4ES-6,Proposition 50,,,Yes,315
+Humboldt,4ES-6,State Assembly,2,DEM,Jim Wood,300
+Humboldt,4ES-6,U.S. House,2,REP,Dale K. Mensing,72
+Humboldt,4ES-6,U.S. House,2,DEM,Erin A. Schrode,28
+Humboldt,4ES-6,U.S. House,2,DEM,Jared W. Huffman,254
+Humboldt,4ES-6,U.S. House,2,IND,Matthew Robert Wookey,42
+Humboldt,4ES-6,U.S. Senate,,IND,Clive Grey,4
+Humboldt,4ES-6,U.S. Senate,,REP,Duf Sundheim,14
 Humboldt,4ES-6,U.S. Senate,,DEM,Emory Rodgers,1
-Humboldt,4ES-6,U.S. Senate,,LIB,Gail K. Lightfoot,8
+Humboldt,4ES-6,U.S. Senate,,LIB,Gail K. Lightfoot,19
 Humboldt,4ES-6,U.S. Senate,,IND,Gar Myers,2
-Humboldt,4ES-6,U.S. Senate,,REP,George C. Yang,1
-Humboldt,4ES-6,U.S. Senate,,REP,Greg Conlon,5
-Humboldt,4ES-6,U.S. Senate,,IND,Jason Hanania,1
-Humboldt,4ES-6,U.S. Senate,,IND,Jason Kraus,1
-Humboldt,4ES-6,U.S. Senate,,REP,Jerry J. Laws,5
-Humboldt,4ES-6,U.S. Senate,,DEM,Kamala D. Harris,54
-Humboldt,4ES-6,U.S. Senate,,DEM,Loretta L. Sanchez,29
-Humboldt,4ES-6,U.S. Senate,,DEM,Massie Munroe,1
-Humboldt,4ES-6,U.S. Senate,,IND,Mike Beitiks,3
-Humboldt,4ES-6,U.S. Senate,,GRN,Pamela Elizondo,3
-Humboldt,4ES-6,U.S. Senate,,IND,Paul Merritt,1
-Humboldt,4ES-6,U.S. Senate,,REP,Phil Wyman,6
-Humboldt,4ES-6,U.S. Senate,,REP,Ron Unz,1
-Humboldt,4ES-6,U.S. Senate,,DEM,Steve Stokes,9
-Humboldt,4ES-6,U.S. Senate,,REP,Tom Palzer,1
-Humboldt,4ES-6,U.S. Senate,,REP,Von Hougo,1
-Humboldt,4ES-6_A,President,,REP,Ben Carson,7
-Humboldt,4ES-6_A,President,,DEM,Bernie Sanders,99
-Humboldt,4ES-6_A,President,,REP,Donald Trump,64
-Humboldt,4ES-6_A,President,,DEM,Hillary Clinton,60
-Humboldt,4ES-6_A,President,,AIP,James Hedges,1
-Humboldt,4ES-6_A,President,,REP,Jim Gilmore,3
-Humboldt,4ES-6_A,President,,REP,John R. Kasich,7
-Humboldt,4ES-6_A,President,,DEM,Keith Judd,1
-Humboldt,4ES-6_A,President,,REP,Ted Cruz,10
-Humboldt,4ES-6_A,President,,DEM,Willie Wilson,1
-Humboldt,4ES-6_A,Proposition 50,,,No,49
-Humboldt,4ES-6_A,Proposition 50,,,Yes,211
-Humboldt,4ES-6_A,State Assembly,2,DEM,Jim Wood,187
-Humboldt,4ES-6_A,U.S. House,2,REP,Dale K. Mensing,52
-Humboldt,4ES-6_A,U.S. House,2,DEM,Erin A. Schrode,13
-Humboldt,4ES-6_A,U.S. House,2,DEM,Jared W. Huffman,164
-Humboldt,4ES-6_A,U.S. House,2,IND,Matthew Robert Wookey,26
-Humboldt,4ES-6_A,U.S. Senate,,IND,Clive Grey,4
-Humboldt,4ES-6_A,U.S. Senate,,REP,Duf Sundheim,7
-Humboldt,4ES-6_A,U.S. Senate,,LIB,Gail K. Lightfoot,11
-Humboldt,4ES-6_A,U.S. Senate,,REP,George C. Yang,1
-Humboldt,4ES-6_A,U.S. Senate,,REP,Greg Conlon,21
-Humboldt,4ES-6_A,U.S. Senate,,DEM,Herbert G. Peters,2
-Humboldt,4ES-6_A,U.S. Senate,,IND,Jason Hanania,1
-Humboldt,4ES-6_A,U.S. Senate,,IND,Jason Kraus,7
-Humboldt,4ES-6_A,U.S. Senate,,REP,Jerry J. Laws,13
-Humboldt,4ES-6_A,U.S. Senate,,PAF,John Thompson Parker,1
-Humboldt,4ES-6_A,U.S. Senate,,DEM,Kamala D. Harris,91
-Humboldt,4ES-6_A,U.S. Senate,,REP,Karen Roseberry,2
-Humboldt,4ES-6_A,U.S. Senate,,DEM,Loretta L. Sanchez,45
-Humboldt,4ES-6_A,U.S. Senate,,LIB,Mark Matthew Herd,1
-Humboldt,4ES-6_A,U.S. Senate,,DEM,Massie Munroe,1
-Humboldt,4ES-6_A,U.S. Senate,,IND,Mike Beitiks,1
-Humboldt,4ES-6_A,U.S. Senate,,GRN,Pamela Elizondo,3
-Humboldt,4ES-6_A,U.S. Senate,,IND,Paul Merritt,2
-Humboldt,4ES-6_A,U.S. Senate,,REP,Phil Wyman,15
-Humboldt,4ES-6_A,U.S. Senate,,REP,Ron Unz,2
-Humboldt,4ES-6_A,U.S. Senate,,DEM,Steve Stokes,8
-Humboldt,4ES-6_A,U.S. Senate,,REP,Thomas G. Del Beccaro,7
-Humboldt,4ES-6_A,U.S. Senate,,REP,Tom Palzer,2
-Humboldt,4ES-6_A,U.S. Senate,,REP,Von Hougo,4
+Humboldt,4ES-6,U.S. Senate,,REP,George C. Yang,2
+Humboldt,4ES-6,U.S. Senate,,REP,Greg Conlon,26
+Humboldt,4ES-6,U.S. Senate,,DEM,Herbert G. Peters,2
+Humboldt,4ES-6,U.S. Senate,,IND,Jason Hanania,2
+Humboldt,4ES-6,U.S. Senate,,IND,Jason Kraus,8
+Humboldt,4ES-6,U.S. Senate,,REP,Jerry J. Laws,18
+Humboldt,4ES-6,U.S. Senate,,PAF,John Thompson Parker,1
+Humboldt,4ES-6,U.S. Senate,,DEM,Kamala D. Harris,145
+Humboldt,4ES-6,U.S. Senate,,REP,Karen Roseberry,2
+Humboldt,4ES-6,U.S. Senate,,DEM,Loretta L. Sanchez,74
+Humboldt,4ES-6,U.S. Senate,,LIB,Mark Matthew Herd,1
+Humboldt,4ES-6,U.S. Senate,,DEM,Massie Munroe,2
+Humboldt,4ES-6,U.S. Senate,,IND,Mike Beitiks,4
+Humboldt,4ES-6,U.S. Senate,,GRN,Pamela Elizondo,6
+Humboldt,4ES-6,U.S. Senate,,IND,Paul Merritt,3
+Humboldt,4ES-6,U.S. Senate,,REP,Phil Wyman,21
+Humboldt,4ES-6,U.S. Senate,,REP,Ron Unz,3
+Humboldt,4ES-6,U.S. Senate,,DEM,Steve Stokes,17
+Humboldt,4ES-6,U.S. Senate,,REP,Thomas G. Del Beccaro,7
+Humboldt,4ES-6,U.S. Senate,,REP,Tom Palzer,3
+Humboldt,4ES-6,U.S. Senate,,REP,Von Hougo,5
 Humboldt,4PEF,President,,REP,Ben Carson,1
 Humboldt,4PEF,President,,DEM,Bernie Sanders,50
 Humboldt,4PEF,President,,GRN,Darryl Cherney,1
@@ -6145,77 +3949,48 @@ Humboldt,5AS-4,U.S. Senate,,REP,Phil Wyman,1
 Humboldt,5AS-4,U.S. Senate,,DEM,Steve Stokes,1
 Humboldt,5AS-4,U.S. Senate,,REP,Tom Palzer,2
 Humboldt,5BL,President,,REP,Ben Carson,3
-Humboldt,5BL,President,,DEM,Bernie Sanders,113
-Humboldt,5BL,President,,REP,Donald Trump,35
-Humboldt,5BL,President,,LIB,Gary Johnson,2
-Humboldt,5BL,President,,DEM,Hillary Clinton,41
+Humboldt,5BL,President,,DEM,Bernie Sanders,140
+Humboldt,5BL,President,,REP,Donald Trump,57
+Humboldt,5BL,President,,LIB,Gary Johnson,3
+Humboldt,5BL,President,,DEM,Hillary Clinton,67
 Humboldt,5BL,President,,GRN,Jill Stein,1
-Humboldt,5BL,President,,REP,John R. Kasich,4
+Humboldt,5BL,President,,LIB,John McAfee,1
+Humboldt,5BL,President,,REP,John R. Kasich,5
 Humboldt,5BL,President,,GRN,Sedinam Moyowasifsa-Curry,1
-Humboldt,5BL,President,,REP,Ted Cruz,2
+Humboldt,5BL,President,,REP,Ted Cruz,3
+Humboldt,5BL,President,,AIP,Thomas Hoefling,1
 Humboldt,5BL,President,,GRN,William Kreml,1
-Humboldt,5BL,Proposition 50,,,No,36
-Humboldt,5BL,Proposition 50,,,Yes,147
-Humboldt,5BL,State Assembly,2,DEM,Jim Wood,156
-Humboldt,5BL,U.S. House,2,REP,Dale K. Mensing,42
-Humboldt,5BL,U.S. House,2,DEM,Erin A. Schrode,24
-Humboldt,5BL,U.S. House,2,DEM,Jared W. Huffman,121
-Humboldt,5BL,U.S. House,2,IND,Matthew Robert Wookey,17
+Humboldt,5BL,Proposition 50,,,No,48
+Humboldt,5BL,Proposition 50,,,Yes,212
+Humboldt,5BL,State Assembly,2,DEM,Jim Wood,209
+Humboldt,5BL,U.S. House,2,REP,Dale K. Mensing,63
+Humboldt,5BL,U.S. House,2,DEM,Erin A. Schrode,30
+Humboldt,5BL,U.S. House,2,DEM,Jared W. Huffman,171
+Humboldt,5BL,U.S. House,2,IND,Matthew Robert Wookey,20
 Humboldt,5BL,U.S. Senate,,IND,Clive Grey,1
-Humboldt,5BL,U.S. Senate,,REP,Duf Sundheim,11
-Humboldt,5BL,U.S. Senate,,LIB,Gail K. Lightfoot,7
-Humboldt,5BL,U.S. Senate,,REP,Greg Conlon,8
-Humboldt,5BL,U.S. Senate,,REP,Jarrell Williamson,1
+Humboldt,5BL,U.S. Senate,,REP,Don Krampe,1
+Humboldt,5BL,U.S. Senate,,REP,Duf Sundheim,15
+Humboldt,5BL,U.S. Senate,,LIB,Gail K. Lightfoot,9
+Humboldt,5BL,U.S. Senate,,REP,Greg Conlon,9
+Humboldt,5BL,U.S. Senate,,REP,Jarrell Williamson,2
 Humboldt,5BL,U.S. Senate,,IND,Jason Hanania,1
 Humboldt,5BL,U.S. Senate,,IND,Jason Kraus,1
-Humboldt,5BL,U.S. Senate,,REP,Jerry J. Laws,4
-Humboldt,5BL,U.S. Senate,,DEM,Kamala D. Harris,65
+Humboldt,5BL,U.S. Senate,,REP,Jerry J. Laws,6
+Humboldt,5BL,U.S. Senate,,DEM,Kamala D. Harris,98
 Humboldt,5BL,U.S. Senate,,REP,Karen Roseberry,1
 Humboldt,5BL,U.S. Senate,,IND,Ling Ling Shi,2
-Humboldt,5BL,U.S. Senate,,DEM,Loretta L. Sanchez,35
-Humboldt,5BL,U.S. Senate,,LIB,Mark Matthew Herd,1
-Humboldt,5BL,U.S. Senate,,DEM,Massie Munroe,2
-Humboldt,5BL,U.S. Senate,,IND,Mike Beitiks,4
+Humboldt,5BL,U.S. Senate,,DEM,Loretta L. Sanchez,48
+Humboldt,5BL,U.S. Senate,,LIB,Mark Matthew Herd,3
+Humboldt,5BL,U.S. Senate,,DEM,Massie Munroe,3
+Humboldt,5BL,U.S. Senate,,IND,Mike Beitiks,6
 Humboldt,5BL,U.S. Senate,,GRN,Pamela Elizondo,12
-Humboldt,5BL,U.S. Senate,,REP,Phil Wyman,14
-Humboldt,5BL,U.S. Senate,,REP,Ron Unz,1
+Humboldt,5BL,U.S. Senate,,REP,Phil Wyman,21
+Humboldt,5BL,U.S. Senate,,REP,Ron Unz,2
 Humboldt,5BL,U.S. Senate,,IND,Scott A. Vineberg,1
-Humboldt,5BL,U.S. Senate,,DEM,Steve Stokes,12
-Humboldt,5BL,U.S. Senate,,REP,Thomas G. Del Beccaro,2
-Humboldt,5BL,U.S. Senate,,REP,Tom Palzer,3
-Humboldt,5BL,U.S. Senate,,REP,Von Hougo,2
-Humboldt,5BL_A,President,,DEM,Bernie Sanders,27
-Humboldt,5BL_A,President,,REP,Donald Trump,22
-Humboldt,5BL_A,President,,LIB,Gary Johnson,1
-Humboldt,5BL_A,President,,DEM,Hillary Clinton,26
-Humboldt,5BL_A,President,,LIB,John McAfee,1
-Humboldt,5BL_A,President,,REP,John R. Kasich,1
-Humboldt,5BL_A,President,,REP,Ted Cruz,1
-Humboldt,5BL_A,President,,AIP,Thomas Hoefling,1
-Humboldt,5BL_A,Proposition 50,,,No,12
-Humboldt,5BL_A,Proposition 50,,,Yes,65
-Humboldt,5BL_A,State Assembly,2,DEM,Jim Wood,53
-Humboldt,5BL_A,U.S. House,2,REP,Dale K. Mensing,21
-Humboldt,5BL_A,U.S. House,2,DEM,Erin A. Schrode,6
-Humboldt,5BL_A,U.S. House,2,DEM,Jared W. Huffman,50
-Humboldt,5BL_A,U.S. House,2,IND,Matthew Robert Wookey,3
-Humboldt,5BL_A,U.S. Senate,,REP,Don Krampe,1
-Humboldt,5BL_A,U.S. Senate,,REP,Duf Sundheim,4
-Humboldt,5BL_A,U.S. Senate,,LIB,Gail K. Lightfoot,2
-Humboldt,5BL_A,U.S. Senate,,REP,Greg Conlon,1
-Humboldt,5BL_A,U.S. Senate,,REP,Jarrell Williamson,1
-Humboldt,5BL_A,U.S. Senate,,REP,Jerry J. Laws,2
-Humboldt,5BL_A,U.S. Senate,,DEM,Kamala D. Harris,33
-Humboldt,5BL_A,U.S. Senate,,DEM,Loretta L. Sanchez,13
-Humboldt,5BL_A,U.S. Senate,,LIB,Mark Matthew Herd,2
-Humboldt,5BL_A,U.S. Senate,,DEM,Massie Munroe,1
-Humboldt,5BL_A,U.S. Senate,,IND,Mike Beitiks,2
-Humboldt,5BL_A,U.S. Senate,,REP,Phil Wyman,7
-Humboldt,5BL_A,U.S. Senate,,REP,Ron Unz,1
-Humboldt,5BL_A,U.S. Senate,,DEM,Steve Stokes,2
-Humboldt,5BL_A,U.S. Senate,,REP,Thomas G. Del Beccaro,3
-Humboldt,5BL_A,U.S. Senate,,REP,Tom Palzer,2
-Humboldt,5BL_A,U.S. Senate,,REP,Von Hougo,4
+Humboldt,5BL,U.S. Senate,,DEM,Steve Stokes,14
+Humboldt,5BL,U.S. Senate,,REP,Thomas G. Del Beccaro,5
+Humboldt,5BL,U.S. Senate,,REP,Tom Palzer,5
+Humboldt,5BL,U.S. Senate,,REP,Von Hougo,6
 Humboldt,5BM,President,,REP,Ben Carson,1
 Humboldt,5BM,President,,DEM,Bernie Sanders,48
 Humboldt,5BM,President,,LIB,Cecil Ince,1
@@ -6253,89 +4028,59 @@ Humboldt,5BM,U.S. Senate,,DEM,Steve Stokes,4
 Humboldt,5BM,U.S. Senate,,REP,Thomas G. Del Beccaro,1
 Humboldt,5BM,U.S. Senate,,REP,Tom Palzer,1
 Humboldt,5BM,U.S. Senate,,REP,Von Hougo,2
-Humboldt,5FB,President,,REP,Ben Carson,1
-Humboldt,5FB,President,,DEM,Bernie Sanders,143
+Humboldt,5FB,President,,REP,Ben Carson,2
+Humboldt,5FB,President,,DEM,Bernie Sanders,192
 Humboldt,5FB,President,,GRN,Darryl Cherney,1
-Humboldt,5FB,President,,REP,Donald Trump,41
+Humboldt,5FB,President,,REP,Donald Trump,61
 Humboldt,5FB,President,,LIB,Gary Johnson,1
 Humboldt,5FB,President,,PAF,Gloria Estela La Riva,1
-Humboldt,5FB,President,,DEM,Hillary Clinton,64
+Humboldt,5FB,President,,DEM,Henry Hewes,1
+Humboldt,5FB,President,,DEM,Hillary Clinton,88
+Humboldt,5FB,President,,LIB,"Jack Robinson, Jr.",1
 Humboldt,5FB,President,,GRN,Jill Stein,2
-Humboldt,5FB,President,,REP,Jim Gilmore,1
+Humboldt,5FB,President,,REP,Jim Gilmore,2
 Humboldt,5FB,President,,LIB,John McAfee,1
-Humboldt,5FB,President,,REP,John R. Kasich,7
+Humboldt,5FB,President,,REP,John R. Kasich,11
 Humboldt,5FB,President,,DEM,Michael Steinberg,1
 Humboldt,5FB,President,,PAF,Monica Moorehead,1
 Humboldt,5FB,President,,AIP,Robert Ornelas,1
-Humboldt,5FB,President,,REP,Ted Cruz,9
-Humboldt,5FB,Proposition 50,,,No,60
-Humboldt,5FB,Proposition 50,,,Yes,204
-Humboldt,5FB,State Assembly,2,DEM,Jim Wood,223
-Humboldt,5FB,U.S. House,2,REP,Dale K. Mensing,48
-Humboldt,5FB,U.S. House,2,DEM,Erin A. Schrode,23
-Humboldt,5FB,U.S. House,2,DEM,Jared W. Huffman,193
-Humboldt,5FB,U.S. House,2,IND,Matthew Robert Wookey,17
-Humboldt,5FB,U.S. Senate,,REP,Don Krampe,2
-Humboldt,5FB,U.S. Senate,,REP,Duf Sundheim,8
+Humboldt,5FB,President,,REP,Ted Cruz,10
+Humboldt,5FB,Proposition 50,,,No,71
+Humboldt,5FB,Proposition 50,,,Yes,300
+Humboldt,5FB,State Assembly,2,DEM,Jim Wood,301
+Humboldt,5FB,U.S. House,2,REP,Dale K. Mensing,73
+Humboldt,5FB,U.S. House,2,DEM,Erin A. Schrode,26
+Humboldt,5FB,U.S. House,2,DEM,Jared W. Huffman,268
+Humboldt,5FB,U.S. House,2,IND,Matthew Robert Wookey,23
+Humboldt,5FB,U.S. Senate,,IND,Clive Grey,1
+Humboldt,5FB,U.S. Senate,,REP,Don Krampe,5
+Humboldt,5FB,U.S. Senate,,REP,Duf Sundheim,12
 Humboldt,5FB,U.S. Senate,,IND,Eleanor García,1
-Humboldt,5FB,U.S. Senate,,DEM,Emory Rodgers,2
-Humboldt,5FB,U.S. Senate,,LIB,Gail K. Lightfoot,2
+Humboldt,5FB,U.S. Senate,,DEM,Emory Rodgers,3
+Humboldt,5FB,U.S. Senate,,LIB,Gail K. Lightfoot,4
 Humboldt,5FB,U.S. Senate,,REP,George C. Yang,2
-Humboldt,5FB,U.S. Senate,,REP,Greg Conlon,5
+Humboldt,5FB,U.S. Senate,,REP,Greg Conlon,8
 Humboldt,5FB,U.S. Senate,,REP,Jarrell Williamson,1
 Humboldt,5FB,U.S. Senate,,IND,Jason Hanania,1
 Humboldt,5FB,U.S. Senate,,IND,Jason Kraus,4
-Humboldt,5FB,U.S. Senate,,REP,Jerry J. Laws,11
+Humboldt,5FB,U.S. Senate,,REP,Jerry J. Laws,15
 Humboldt,5FB,U.S. Senate,,PAF,John Thompson Parker,1
-Humboldt,5FB,U.S. Senate,,DEM,Kamala D. Harris,124
-Humboldt,5FB,U.S. Senate,,IND,Ling Ling Shi,1
-Humboldt,5FB,U.S. Senate,,DEM,Loretta L. Sanchez,37
+Humboldt,5FB,U.S. Senate,,DEM,Kamala D. Harris,168
+Humboldt,5FB,U.S. Senate,,REP,Karen Roseberry,1
+Humboldt,5FB,U.S. Senate,,IND,Ling Ling Shi,2
+Humboldt,5FB,U.S. Senate,,DEM,Loretta L. Sanchez,51
 Humboldt,5FB,U.S. Senate,,LIB,Mark Matthew Herd,1
-Humboldt,5FB,U.S. Senate,,DEM,Massie Munroe,4
-Humboldt,5FB,U.S. Senate,,IND,Mike Beitiks,2
-Humboldt,5FB,U.S. Senate,,GRN,Pamela Elizondo,17
-Humboldt,5FB,U.S. Senate,,REP,Phil Wyman,12
+Humboldt,5FB,U.S. Senate,,DEM,Massie Munroe,8
+Humboldt,5FB,U.S. Senate,,IND,Mike Beitiks,4
+Humboldt,5FB,U.S. Senate,,GRN,Pamela Elizondo,19
+Humboldt,5FB,U.S. Senate,,IND,Paul Merritt,2
+Humboldt,5FB,U.S. Senate,,REP,Phil Wyman,22
 Humboldt,5FB,U.S. Senate,,DEM,President Cristina Grappo,1
-Humboldt,5FB,U.S. Senate,,IND,Scott A. Vineberg,1
-Humboldt,5FB,U.S. Senate,,DEM,Steve Stokes,14
+Humboldt,5FB,U.S. Senate,,IND,Scott A. Vineberg,2
+Humboldt,5FB,U.S. Senate,,DEM,Steve Stokes,17
 Humboldt,5FB,U.S. Senate,,REP,Thomas G. Del Beccaro,14
-Humboldt,5FB,U.S. Senate,,REP,Tom Palzer,2
+Humboldt,5FB,U.S. Senate,,REP,Tom Palzer,3
 Humboldt,5FB,U.S. Senate,,REP,Von Hougo,5
-Humboldt,5FB_A,President,,REP,Ben Carson,1
-Humboldt,5FB_A,President,,DEM,Bernie Sanders,49
-Humboldt,5FB_A,President,,REP,Donald Trump,20
-Humboldt,5FB_A,President,,DEM,Henry Hewes,1
-Humboldt,5FB_A,President,,DEM,Hillary Clinton,24
-Humboldt,5FB_A,President,,LIB,"Jack Robinson, Jr.",1
-Humboldt,5FB_A,President,,REP,Jim Gilmore,1
-Humboldt,5FB_A,President,,REP,John R. Kasich,4
-Humboldt,5FB_A,President,,REP,Ted Cruz,1
-Humboldt,5FB_A,Proposition 50,,,No,11
-Humboldt,5FB_A,Proposition 50,,,Yes,96
-Humboldt,5FB_A,State Assembly,2,DEM,Jim Wood,78
-Humboldt,5FB_A,U.S. House,2,REP,Dale K. Mensing,25
-Humboldt,5FB_A,U.S. House,2,DEM,Erin A. Schrode,3
-Humboldt,5FB_A,U.S. House,2,DEM,Jared W. Huffman,75
-Humboldt,5FB_A,U.S. House,2,IND,Matthew Robert Wookey,6
-Humboldt,5FB_A,U.S. Senate,,IND,Clive Grey,1
-Humboldt,5FB_A,U.S. Senate,,REP,Don Krampe,3
-Humboldt,5FB_A,U.S. Senate,,REP,Duf Sundheim,4
-Humboldt,5FB_A,U.S. Senate,,DEM,Emory Rodgers,1
-Humboldt,5FB_A,U.S. Senate,,LIB,Gail K. Lightfoot,2
-Humboldt,5FB_A,U.S. Senate,,REP,Greg Conlon,3
-Humboldt,5FB_A,U.S. Senate,,REP,Jerry J. Laws,4
-Humboldt,5FB_A,U.S. Senate,,DEM,Kamala D. Harris,44
-Humboldt,5FB_A,U.S. Senate,,REP,Karen Roseberry,1
-Humboldt,5FB_A,U.S. Senate,,IND,Ling Ling Shi,1
-Humboldt,5FB_A,U.S. Senate,,DEM,Loretta L. Sanchez,14
-Humboldt,5FB_A,U.S. Senate,,DEM,Massie Munroe,4
-Humboldt,5FB_A,U.S. Senate,,IND,Mike Beitiks,2
-Humboldt,5FB_A,U.S. Senate,,GRN,Pamela Elizondo,2
-Humboldt,5FB_A,U.S. Senate,,IND,Paul Merritt,2
-Humboldt,5FB_A,U.S. Senate,,REP,Phil Wyman,10
-Humboldt,5FB_A,U.S. Senate,,IND,Scott A. Vineberg,1
-Humboldt,5FB_A,U.S. Senate,,DEM,Steve Stokes,3
-Humboldt,5FB_A,U.S. Senate,,REP,Tom Palzer,1
 Humboldt,5GP,President,,DEM,Bernie Sanders,32
 Humboldt,5GP,President,,REP,Donald Trump,16
 Humboldt,5GP,President,,DEM,Hillary Clinton,9
@@ -6361,45 +4106,32 @@ Humboldt,5GP,U.S. Senate,,IND,Paul Merritt,1
 Humboldt,5GP,U.S. Senate,,DEM,Steve Stokes,4
 Humboldt,5GP,U.S. Senate,,REP,Thomas G. Del Beccaro,3
 Humboldt,5GP,U.S. Senate,,REP,Tom Palzer,1
-Humboldt,5KT-1,President,,DEM,Bernie Sanders,13
+Humboldt,5KT-1,President,,DEM,Bernie Sanders,20
 Humboldt,5KT-1,President,,GRN,Darryl Cherney,1
-Humboldt,5KT-1,President,,REP,Donald Trump,3
-Humboldt,5KT-1,President,,DEM,Hillary Clinton,9
+Humboldt,5KT-1,President,,REP,Donald Trump,6
+Humboldt,5KT-1,President,,DEM,Hillary Clinton,13
+Humboldt,5KT-1,President,,GRN,Jill Stein,1
 Humboldt,5KT-1,President,,REP,John R. Kasich,2
-Humboldt,5KT-1,Proposition 50,,,No,7
-Humboldt,5KT-1,Proposition 50,,,Yes,16
-Humboldt,5KT-1,State Assembly,2,DEM,Jim Wood,24
-Humboldt,5KT-1,U.S. House,2,REP,Dale K. Mensing,1
-Humboldt,5KT-1,U.S. House,2,DEM,Erin A. Schrode,2
-Humboldt,5KT-1,U.S. House,2,DEM,Jared W. Huffman,20
+Humboldt,5KT-1,Proposition 50,,,No,13
+Humboldt,5KT-1,Proposition 50,,,Yes,27
+Humboldt,5KT-1,State Assembly,2,DEM,Jim Wood,38
+Humboldt,5KT-1,U.S. House,2,REP,Dale K. Mensing,5
+Humboldt,5KT-1,U.S. House,2,DEM,Erin A. Schrode,6
+Humboldt,5KT-1,U.S. House,2,DEM,Jared W. Huffman,28
 Humboldt,5KT-1,U.S. House,2,IND,Matthew Robert Wookey,4
+Humboldt,5KT-1,U.S. Senate,,IND,Clive Grey,2
 Humboldt,5KT-1,U.S. Senate,,REP,Don Krampe,1
 Humboldt,5KT-1,U.S. Senate,,LIB,Gail K. Lightfoot,1
 Humboldt,5KT-1,U.S. Senate,,REP,Jarrell Williamson,2
-Humboldt,5KT-1,U.S. Senate,,IND,Jason Kraus,1
-Humboldt,5KT-1,U.S. Senate,,DEM,Kamala D. Harris,16
-Humboldt,5KT-1,U.S. Senate,,DEM,Loretta L. Sanchez,3
+Humboldt,5KT-1,U.S. Senate,,IND,Jason Kraus,2
+Humboldt,5KT-1,U.S. Senate,,DEM,Kamala D. Harris,19
+Humboldt,5KT-1,U.S. Senate,,DEM,Loretta L. Sanchez,11
 Humboldt,5KT-1,U.S. Senate,,DEM,Massie Munroe,1
-Humboldt,5KT-1,U.S. Senate,,GRN,Pamela Elizondo,2
+Humboldt,5KT-1,U.S. Senate,,GRN,Pamela Elizondo,3
 Humboldt,5KT-1,U.S. Senate,,REP,Phil Wyman,1
-Humboldt,5KT-1_A,President,,DEM,Bernie Sanders,7
-Humboldt,5KT-1_A,President,,REP,Donald Trump,3
-Humboldt,5KT-1_A,President,,DEM,Hillary Clinton,4
-Humboldt,5KT-1_A,President,,GRN,Jill Stein,1
-Humboldt,5KT-1_A,Proposition 50,,,No,6
-Humboldt,5KT-1_A,Proposition 50,,,Yes,11
-Humboldt,5KT-1_A,State Assembly,2,DEM,Jim Wood,14
-Humboldt,5KT-1_A,U.S. House,2,REP,Dale K. Mensing,4
-Humboldt,5KT-1_A,U.S. House,2,DEM,Erin A. Schrode,4
-Humboldt,5KT-1_A,U.S. House,2,DEM,Jared W. Huffman,8
-Humboldt,5KT-1_A,U.S. Senate,,IND,Clive Grey,2
-Humboldt,5KT-1_A,U.S. Senate,,IND,Jason Kraus,1
-Humboldt,5KT-1_A,U.S. Senate,,DEM,Kamala D. Harris,3
-Humboldt,5KT-1_A,U.S. Senate,,DEM,Loretta L. Sanchez,8
-Humboldt,5KT-1_A,U.S. Senate,,GRN,Pamela Elizondo,1
-Humboldt,5KT-1_A,U.S. Senate,,DEM,President Cristina Grappo,1
-Humboldt,5KT-1_A,U.S. Senate,,DEM,Steve Stokes,1
-Humboldt,5KT-1_A,U.S. Senate,,REP,Tom Palzer,1
+Humboldt,5KT-1,U.S. Senate,,DEM,President Cristina Grappo,1
+Humboldt,5KT-1,U.S. Senate,,DEM,Steve Stokes,1
+Humboldt,5KT-1,U.S. Senate,,REP,Tom Palzer,1
 Humboldt,5KT-3,President,,REP,Ben Carson,5
 Humboldt,5KT-3,President,,DEM,Bernie Sanders,64
 Humboldt,5KT-3,President,,REP,Donald Trump,4
@@ -6433,166 +4165,106 @@ Humboldt,5KT-3,U.S. Senate,,REP,Phil Wyman,1
 Humboldt,5KT-3,U.S. Senate,,DEM,Steve Stokes,7
 Humboldt,5KT-3,U.S. Senate,,REP,Tom Palzer,3
 Humboldt,5KT-3,U.S. Senate,,REP,Von Hougo,1
-Humboldt,5KT-4,President,,REP,Ben Carson,1
-Humboldt,5KT-4,President,,DEM,Bernie Sanders,128
-Humboldt,5KT-4,President,,REP,Donald Trump,18
-Humboldt,5KT-4,President,,DEM,Hillary Clinton,50
+Humboldt,5KT-4,President,,REP,Ben Carson,4
+Humboldt,5KT-4,President,,DEM,Bernie Sanders,144
+Humboldt,5KT-4,President,,REP,Donald Trump,24
+Humboldt,5KT-4,President,,DEM,Hillary Clinton,62
 Humboldt,5KT-4,President,,GRN,Jill Stein,3
+Humboldt,5KT-4,President,,REP,John R. Kasich,1
 Humboldt,5KT-4,President,,DEM,Michael Steinberg,1
-Humboldt,5KT-4,President,,REP,Ted Cruz,3
+Humboldt,5KT-4,President,,REP,Ted Cruz,5
+Humboldt,5KT-4,President,,AIP,Wiley Drake,1
 Humboldt,5KT-4,President,,DEM,Willie Wilson,1
-Humboldt,5KT-4,Proposition 50,,,No,41
-Humboldt,5KT-4,Proposition 50,,,Yes,150
-Humboldt,5KT-4,State Assembly,2,DEM,Jim Wood,160
-Humboldt,5KT-4,U.S. House,2,REP,Dale K. Mensing,22
-Humboldt,5KT-4,U.S. House,2,DEM,Erin A. Schrode,24
-Humboldt,5KT-4,U.S. House,2,DEM,Jared W. Huffman,132
-Humboldt,5KT-4,U.S. House,2,IND,Matthew Robert Wookey,20
+Humboldt,5KT-4,Proposition 50,,,No,47
+Humboldt,5KT-4,Proposition 50,,,Yes,180
+Humboldt,5KT-4,State Assembly,2,DEM,Jim Wood,189
+Humboldt,5KT-4,U.S. House,2,REP,Dale K. Mensing,30
+Humboldt,5KT-4,U.S. House,2,DEM,Erin A. Schrode,27
+Humboldt,5KT-4,U.S. House,2,DEM,Jared W. Huffman,158
+Humboldt,5KT-4,U.S. House,2,IND,Matthew Robert Wookey,25
 Humboldt,5KT-4,U.S. Senate,,IND,Don J. Grundmann,1
 Humboldt,5KT-4,U.S. Senate,,REP,Don Krampe,3
+Humboldt,5KT-4,U.S. Senate,,REP,Duf Sundheim,4
 Humboldt,5KT-4,U.S. Senate,,DEM,Emory Rodgers,1
-Humboldt,5KT-4,U.S. Senate,,LIB,Gail K. Lightfoot,21
-Humboldt,5KT-4,U.S. Senate,,REP,Greg Conlon,7
+Humboldt,5KT-4,U.S. Senate,,LIB,Gail K. Lightfoot,22
+Humboldt,5KT-4,U.S. Senate,,IND,Gar Myers,1
+Humboldt,5KT-4,U.S. Senate,,REP,Greg Conlon,8
 Humboldt,5KT-4,U.S. Senate,,DEM,Herbert G. Peters,2
 Humboldt,5KT-4,U.S. Senate,,REP,Jarrell Williamson,2
 Humboldt,5KT-4,U.S. Senate,,IND,Jason Hanania,1
 Humboldt,5KT-4,U.S. Senate,,IND,Jason Kraus,1
 Humboldt,5KT-4,U.S. Senate,,REP,Jerry J. Laws,3
 Humboldt,5KT-4,U.S. Senate,,PAF,John Thompson Parker,1
-Humboldt,5KT-4,U.S. Senate,,DEM,Kamala D. Harris,56
-Humboldt,5KT-4,U.S. Senate,,DEM,Loretta L. Sanchez,61
+Humboldt,5KT-4,U.S. Senate,,DEM,Kamala D. Harris,68
+Humboldt,5KT-4,U.S. Senate,,DEM,Loretta L. Sanchez,72
 Humboldt,5KT-4,U.S. Senate,,LIB,Mark Matthew Herd,1
-Humboldt,5KT-4,U.S. Senate,,DEM,Massie Munroe,1
+Humboldt,5KT-4,U.S. Senate,,DEM,Massie Munroe,2
 Humboldt,5KT-4,U.S. Senate,,IND,Mike Beitiks,5
 Humboldt,5KT-4,U.S. Senate,,GRN,Pamela Elizondo,10
-Humboldt,5KT-4,U.S. Senate,,REP,Phil Wyman,4
+Humboldt,5KT-4,U.S. Senate,,REP,Phil Wyman,8
 Humboldt,5KT-4,U.S. Senate,,DEM,President Cristina Grappo,2
 Humboldt,5KT-4,U.S. Senate,,REP,Ron Unz,2
-Humboldt,5KT-4,U.S. Senate,,DEM,Steve Stokes,7
-Humboldt,5KT-4,U.S. Senate,,REP,Thomas G. Del Beccaro,2
+Humboldt,5KT-4,U.S. Senate,,DEM,Steve Stokes,8
+Humboldt,5KT-4,U.S. Senate,,REP,Thomas G. Del Beccaro,4
 Humboldt,5KT-4,U.S. Senate,,IND,Tim Gildersleeve,1
 Humboldt,5KT-4,U.S. Senate,,REP,Tom Palzer,3
 Humboldt,5KT-4,U.S. Senate,,REP,Von Hougo,3
-Humboldt,5KT-4_A,President,,REP,Ben Carson,3
-Humboldt,5KT-4_A,President,,DEM,Bernie Sanders,16
-Humboldt,5KT-4_A,President,,REP,Donald Trump,6
-Humboldt,5KT-4_A,President,,DEM,Hillary Clinton,12
-Humboldt,5KT-4_A,President,,REP,John R. Kasich,1
-Humboldt,5KT-4_A,President,,REP,Ted Cruz,2
-Humboldt,5KT-4_A,President,,AIP,Wiley Drake,1
-Humboldt,5KT-4_A,Proposition 50,,,No,6
-Humboldt,5KT-4_A,Proposition 50,,,Yes,30
-Humboldt,5KT-4_A,State Assembly,2,DEM,Jim Wood,29
-Humboldt,5KT-4_A,U.S. House,2,REP,Dale K. Mensing,8
-Humboldt,5KT-4_A,U.S. House,2,DEM,Erin A. Schrode,3
-Humboldt,5KT-4_A,U.S. House,2,DEM,Jared W. Huffman,26
-Humboldt,5KT-4_A,U.S. House,2,IND,Matthew Robert Wookey,5
-Humboldt,5KT-4_A,U.S. Senate,,REP,Duf Sundheim,4
-Humboldt,5KT-4_A,U.S. Senate,,LIB,Gail K. Lightfoot,1
-Humboldt,5KT-4_A,U.S. Senate,,IND,Gar Myers,1
-Humboldt,5KT-4_A,U.S. Senate,,REP,Greg Conlon,1
-Humboldt,5KT-4_A,U.S. Senate,,DEM,Kamala D. Harris,12
-Humboldt,5KT-4_A,U.S. Senate,,DEM,Loretta L. Sanchez,11
-Humboldt,5KT-4_A,U.S. Senate,,DEM,Massie Munroe,1
-Humboldt,5KT-4_A,U.S. Senate,,REP,Phil Wyman,4
-Humboldt,5KT-4_A,U.S. Senate,,DEM,Steve Stokes,1
-Humboldt,5KT-4_A,U.S. Senate,,REP,Thomas G. Del Beccaro,2
 Humboldt,5KT-6,President,,AIP,Alan Spears,1
 Humboldt,5KT-6,President,,AIP,Arthur Harris,1
-Humboldt,5KT-6,President,,REP,Ben Carson,9
-Humboldt,5KT-6,President,,DEM,Bernie Sanders,174
-Humboldt,5KT-6,President,,REP,Donald Trump,63
-Humboldt,5KT-6,President,,DEM,Hillary Clinton,61
-Humboldt,5KT-6,President,,GRN,Jill Stein,2
+Humboldt,5KT-6,President,,REP,Ben Carson,11
+Humboldt,5KT-6,President,,DEM,Bernie Sanders,238
+Humboldt,5KT-6,President,,REP,Donald Trump,143
+Humboldt,5KT-6,President,,DEM,Hillary Clinton,88
+Humboldt,5KT-6,President,,GRN,Jill Stein,3
 Humboldt,5KT-6,President,,LIB,John McAfee,1
-Humboldt,5KT-6,President,,REP,John R. Kasich,6
-Humboldt,5KT-6,President,,DEM,Michael Steinberg,1
-Humboldt,5KT-6,President,,REP,Ted Cruz,11
+Humboldt,5KT-6,President,,REP,John R. Kasich,14
+Humboldt,5KT-6,President,,DEM,Keith Judd,1
+Humboldt,5KT-6,President,,DEM,Michael Steinberg,2
+Humboldt,5KT-6,President,,REP,Ted Cruz,18
+Humboldt,5KT-6,President,,AIP,Wiley Drake,2
 Humboldt,5KT-6,President,,GRN,William Kreml,1
-Humboldt,5KT-6,President,,DEM,Willie Wilson,1
-Humboldt,5KT-6,Proposition 50,,,No,81
-Humboldt,5KT-6,Proposition 50,,,Yes,220
-Humboldt,5KT-6,State Assembly,2,DEM,Jim Wood,231
-Humboldt,5KT-6,U.S. House,2,REP,Dale K. Mensing,74
-Humboldt,5KT-6,U.S. House,2,DEM,Erin A. Schrode,37
-Humboldt,5KT-6,U.S. House,2,DEM,Jared W. Huffman,188
-Humboldt,5KT-6,U.S. House,2,IND,Matthew Robert Wookey,18
-Humboldt,5KT-6,U.S. Senate,,IND,Clive Grey,2
-Humboldt,5KT-6,U.S. Senate,,IND,Don J. Grundmann,2
-Humboldt,5KT-6,U.S. Senate,,REP,Don Krampe,4
-Humboldt,5KT-6,U.S. Senate,,REP,Duf Sundheim,11
+Humboldt,5KT-6,President,,DEM,Willie Wilson,2
+Humboldt,5KT-6,Proposition 50,,,No,115
+Humboldt,5KT-6,Proposition 50,,,Yes,400
+Humboldt,5KT-6,State Assembly,2,DEM,Jim Wood,370
+Humboldt,5KT-6,U.S. House,2,REP,Dale K. Mensing,151
+Humboldt,5KT-6,U.S. House,2,DEM,Erin A. Schrode,46
+Humboldt,5KT-6,U.S. House,2,DEM,Jared W. Huffman,297
+Humboldt,5KT-6,U.S. House,2,IND,Matthew Robert Wookey,31
+Humboldt,5KT-6,U.S. Senate,,IND,Clive Grey,8
+Humboldt,5KT-6,U.S. Senate,,IND,Don J. Grundmann,4
+Humboldt,5KT-6,U.S. Senate,,REP,Don Krampe,9
+Humboldt,5KT-6,U.S. Senate,,REP,Duf Sundheim,20
 Humboldt,5KT-6,U.S. Senate,,IND,Eleanor García,1
 Humboldt,5KT-6,U.S. Senate,,DEM,Emory Rodgers,2
-Humboldt,5KT-6,U.S. Senate,,LIB,Gail K. Lightfoot,12
-Humboldt,5KT-6,U.S. Senate,,IND,Gar Myers,1
-Humboldt,5KT-6,U.S. Senate,,REP,Greg Conlon,17
-Humboldt,5KT-6,U.S. Senate,,DEM,Herbert G. Peters,2
-Humboldt,5KT-6,U.S. Senate,,REP,Jarrell Williamson,1
-Humboldt,5KT-6,U.S. Senate,,IND,Jason Hanania,1
-Humboldt,5KT-6,U.S. Senate,,IND,Jason Kraus,5
-Humboldt,5KT-6,U.S. Senate,,REP,Jerry J. Laws,17
-Humboldt,5KT-6,U.S. Senate,,PAF,John Thompson Parker,3
-Humboldt,5KT-6,U.S. Senate,,DEM,Kamala D. Harris,88
-Humboldt,5KT-6,U.S. Senate,,REP,Karen Roseberry,8
+Humboldt,5KT-6,U.S. Senate,,LIB,Gail K. Lightfoot,16
+Humboldt,5KT-6,U.S. Senate,,IND,Gar Myers,4
+Humboldt,5KT-6,U.S. Senate,,REP,George C. Yang,7
+Humboldt,5KT-6,U.S. Senate,,REP,Greg Conlon,36
+Humboldt,5KT-6,U.S. Senate,,DEM,Herbert G. Peters,3
+Humboldt,5KT-6,U.S. Senate,,REP,Jarrell Williamson,4
+Humboldt,5KT-6,U.S. Senate,,IND,Jason Hanania,2
+Humboldt,5KT-6,U.S. Senate,,IND,Jason Kraus,7
+Humboldt,5KT-6,U.S. Senate,,REP,Jerry J. Laws,32
+Humboldt,5KT-6,U.S. Senate,,PAF,John Thompson Parker,4
+Humboldt,5KT-6,U.S. Senate,,DEM,Kamala D. Harris,129
+Humboldt,5KT-6,U.S. Senate,,REP,Karen Roseberry,10
 Humboldt,5KT-6,U.S. Senate,,IND,Ling Ling Shi,1
-Humboldt,5KT-6,U.S. Senate,,DEM,Loretta L. Sanchez,46
+Humboldt,5KT-6,U.S. Senate,,DEM,Loretta L. Sanchez,82
 Humboldt,5KT-6,U.S. Senate,,LIB,Mark Matthew Herd,1
-Humboldt,5KT-6,U.S. Senate,,DEM,Massie Munroe,1
-Humboldt,5KT-6,U.S. Senate,,IND,Mike Beitiks,2
-Humboldt,5KT-6,U.S. Senate,,GRN,Pamela Elizondo,19
-Humboldt,5KT-6,U.S. Senate,,IND,Paul Merritt,1
-Humboldt,5KT-6,U.S. Senate,,REP,Phil Wyman,22
+Humboldt,5KT-6,U.S. Senate,,DEM,Massie Munroe,5
+Humboldt,5KT-6,U.S. Senate,,IND,Mike Beitiks,3
+Humboldt,5KT-6,U.S. Senate,,GRN,Pamela Elizondo,28
+Humboldt,5KT-6,U.S. Senate,,IND,Paul Merritt,2
+Humboldt,5KT-6,U.S. Senate,,REP,Phil Wyman,41
 Humboldt,5KT-6,U.S. Senate,,DEM,President Cristina Grappo,1
+Humboldt,5KT-6,U.S. Senate,,REP,Ron Unz,1
 Humboldt,5KT-6,U.S. Senate,,IND,Scott A. Vineberg,2
-Humboldt,5KT-6,U.S. Senate,,DEM,Steve Stokes,23
-Humboldt,5KT-6,U.S. Senate,,REP,Thomas G. Del Beccaro,4
+Humboldt,5KT-6,U.S. Senate,,DEM,Steve Stokes,27
+Humboldt,5KT-6,U.S. Senate,,REP,Thomas G. Del Beccaro,6
+Humboldt,5KT-6,U.S. Senate,,IND,Tim Gildersleeve,1
 Humboldt,5KT-6,U.S. Senate,,REP,Tom Palzer,3
-Humboldt,5KT-6,U.S. Senate,,REP,Von Hougo,3
-Humboldt,5KT-6_A,President,,REP,Ben Carson,2
-Humboldt,5KT-6_A,President,,DEM,Bernie Sanders,64
-Humboldt,5KT-6_A,President,,REP,Donald Trump,80
-Humboldt,5KT-6_A,President,,DEM,Hillary Clinton,27
-Humboldt,5KT-6_A,President,,GRN,Jill Stein,1
-Humboldt,5KT-6_A,President,,REP,John R. Kasich,8
-Humboldt,5KT-6_A,President,,DEM,Keith Judd,1
-Humboldt,5KT-6_A,President,,DEM,Michael Steinberg,1
-Humboldt,5KT-6_A,President,,REP,Ted Cruz,7
-Humboldt,5KT-6_A,President,,AIP,Wiley Drake,2
-Humboldt,5KT-6_A,President,,DEM,Willie Wilson,1
-Humboldt,5KT-6_A,Proposition 50,,,No,34
-Humboldt,5KT-6_A,Proposition 50,,,Yes,180
-Humboldt,5KT-6_A,State Assembly,2,DEM,Jim Wood,139
-Humboldt,5KT-6_A,U.S. House,2,REP,Dale K. Mensing,77
-Humboldt,5KT-6_A,U.S. House,2,DEM,Erin A. Schrode,9
-Humboldt,5KT-6_A,U.S. House,2,DEM,Jared W. Huffman,109
-Humboldt,5KT-6_A,U.S. House,2,IND,Matthew Robert Wookey,13
-Humboldt,5KT-6_A,U.S. Senate,,IND,Clive Grey,6
-Humboldt,5KT-6_A,U.S. Senate,,IND,Don J. Grundmann,2
-Humboldt,5KT-6_A,U.S. Senate,,REP,Don Krampe,5
-Humboldt,5KT-6_A,U.S. Senate,,REP,Duf Sundheim,9
-Humboldt,5KT-6_A,U.S. Senate,,LIB,Gail K. Lightfoot,4
-Humboldt,5KT-6_A,U.S. Senate,,IND,Gar Myers,3
-Humboldt,5KT-6_A,U.S. Senate,,REP,George C. Yang,7
-Humboldt,5KT-6_A,U.S. Senate,,REP,Greg Conlon,19
-Humboldt,5KT-6_A,U.S. Senate,,DEM,Herbert G. Peters,1
-Humboldt,5KT-6_A,U.S. Senate,,REP,Jarrell Williamson,3
-Humboldt,5KT-6_A,U.S. Senate,,IND,Jason Hanania,1
-Humboldt,5KT-6_A,U.S. Senate,,IND,Jason Kraus,2
-Humboldt,5KT-6_A,U.S. Senate,,REP,Jerry J. Laws,15
-Humboldt,5KT-6_A,U.S. Senate,,PAF,John Thompson Parker,1
-Humboldt,5KT-6_A,U.S. Senate,,DEM,Kamala D. Harris,41
-Humboldt,5KT-6_A,U.S. Senate,,REP,Karen Roseberry,2
-Humboldt,5KT-6_A,U.S. Senate,,DEM,Loretta L. Sanchez,36
-Humboldt,5KT-6_A,U.S. Senate,,DEM,Massie Munroe,4
-Humboldt,5KT-6_A,U.S. Senate,,IND,Mike Beitiks,1
-Humboldt,5KT-6_A,U.S. Senate,,GRN,Pamela Elizondo,9
-Humboldt,5KT-6_A,U.S. Senate,,IND,Paul Merritt,1
-Humboldt,5KT-6_A,U.S. Senate,,REP,Phil Wyman,19
-Humboldt,5KT-6_A,U.S. Senate,,REP,Ron Unz,1
-Humboldt,5KT-6_A,U.S. Senate,,DEM,Steve Stokes,4
-Humboldt,5KT-6_A,U.S. Senate,,REP,Thomas G. Del Beccaro,2
-Humboldt,5KT-6_A,U.S. Senate,,IND,Tim Gildersleeve,1
-Humboldt,5KT-6_A,U.S. Senate,,REP,Von Hougo,2
+Humboldt,5KT-6,U.S. Senate,,REP,Von Hougo,5
 Humboldt,5KTS3,President,,REP,Ben Carson,2
 Humboldt,5KTS3,President,,DEM,Bernie Sanders,32
 Humboldt,5KTS3,President,,REP,Donald Trump,9
@@ -6642,863 +4314,406 @@ Humboldt,5MC,U.S. Senate,,REP,Jerry J. Laws,1
 Humboldt,5MC,U.S. Senate,,DEM,Kamala D. Harris,10
 Humboldt,5MC,U.S. Senate,,DEM,Loretta L. Sanchez,2
 Humboldt,5MC,U.S. Senate,,DEM,Massie Munroe,1
-Humboldt,5MK-1,President,,REP,Ben Carson,3
-Humboldt,5MK-1,President,,DEM,Bernie Sanders,182
+Humboldt,5MK-1,President,,AIP,Arthur Harris,1
+Humboldt,5MK-1,President,,REP,Ben Carson,4
+Humboldt,5MK-1,President,,DEM,Bernie Sanders,252
 Humboldt,5MK-1,President,,GRN,Darryl Cherney,1
-Humboldt,5MK-1,President,,REP,Donald Trump,50
+Humboldt,5MK-1,President,,REP,Donald Trump,73
 Humboldt,5MK-1,President,,LIB,Gary Johnson,1
-Humboldt,5MK-1,President,,DEM,Hillary Clinton,69
-Humboldt,5MK-1,President,,GRN,Jill Stein,5
-Humboldt,5MK-1,President,,REP,John R. Kasich,2
+Humboldt,5MK-1,President,,DEM,Hillary Clinton,128
+Humboldt,5MK-1,President,,AIP,James Hedges,1
+Humboldt,5MK-1,President,,GRN,Jill Stein,6
+Humboldt,5MK-1,President,,REP,Jim Gilmore,1
+Humboldt,5MK-1,President,,REP,John R. Kasich,7
 Humboldt,5MK-1,President,,LIB,Marc Feldman,1
-Humboldt,5MK-1,President,,DEM,Michael Steinberg,2
-Humboldt,5MK-1,President,,REP,Ted Cruz,9
-Humboldt,5MK-1,Proposition 50,,,No,51
-Humboldt,5MK-1,Proposition 50,,,Yes,252
-Humboldt,5MK-1,State Assembly,2,DEM,Jim Wood,250
-Humboldt,5MK-1,U.S. House,2,REP,Dale K. Mensing,59
-Humboldt,5MK-1,U.S. House,2,DEM,Erin A. Schrode,33
-Humboldt,5MK-1,U.S. House,2,DEM,Jared W. Huffman,204
-Humboldt,5MK-1,U.S. House,2,IND,Matthew Robert Wookey,24
-Humboldt,5MK-1,U.S. Senate,,REP,Duf Sundheim,8
-Humboldt,5MK-1,U.S. Senate,,IND,Eleanor García,1
-Humboldt,5MK-1,U.S. Senate,,LIB,Gail K. Lightfoot,19
+Humboldt,5MK-1,President,,DEM,Michael Steinberg,3
+Humboldt,5MK-1,President,,REP,Ted Cruz,12
+Humboldt,5MK-1,Proposition 50,,,No,83
+Humboldt,5MK-1,Proposition 50,,,Yes,379
+Humboldt,5MK-1,State Assembly,2,DEM,Jim Wood,382
+Humboldt,5MK-1,U.S. House,2,REP,Dale K. Mensing,89
+Humboldt,5MK-1,U.S. House,2,DEM,Erin A. Schrode,51
+Humboldt,5MK-1,U.S. House,2,DEM,Jared W. Huffman,317
+Humboldt,5MK-1,U.S. House,2,IND,Matthew Robert Wookey,33
+Humboldt,5MK-1,U.S. Senate,,IND,Clive Grey,1
+Humboldt,5MK-1,U.S. Senate,,REP,Duf Sundheim,17
+Humboldt,5MK-1,U.S. Senate,,IND,Eleanor García,3
+Humboldt,5MK-1,U.S. Senate,,LIB,Gail K. Lightfoot,23
 Humboldt,5MK-1,U.S. Senate,,REP,George C. Yang,3
-Humboldt,5MK-1,U.S. Senate,,REP,Greg Conlon,7
-Humboldt,5MK-1,U.S. Senate,,REP,Jarrell Williamson,3
-Humboldt,5MK-1,U.S. Senate,,IND,Jason Hanania,3
-Humboldt,5MK-1,U.S. Senate,,IND,Jason Kraus,2
-Humboldt,5MK-1,U.S. Senate,,REP,Jerry J. Laws,6
+Humboldt,5MK-1,U.S. Senate,,REP,Greg Conlon,12
+Humboldt,5MK-1,U.S. Senate,,REP,Jarrell Williamson,6
+Humboldt,5MK-1,U.S. Senate,,IND,Jason Hanania,5
+Humboldt,5MK-1,U.S. Senate,,IND,Jason Kraus,4
+Humboldt,5MK-1,U.S. Senate,,REP,Jerry J. Laws,12
 Humboldt,5MK-1,U.S. Senate,,PAF,John Thompson Parker,1
-Humboldt,5MK-1,U.S. Senate,,DEM,Kamala D. Harris,122
-Humboldt,5MK-1,U.S. Senate,,REP,Karen Roseberry,1
-Humboldt,5MK-1,U.S. Senate,,DEM,Loretta L. Sanchez,47
+Humboldt,5MK-1,U.S. Senate,,DEM,Kamala D. Harris,199
+Humboldt,5MK-1,U.S. Senate,,REP,Karen Roseberry,4
+Humboldt,5MK-1,U.S. Senate,,DEM,Loretta L. Sanchez,71
+Humboldt,5MK-1,U.S. Senate,,LIB,Mark Matthew Herd,1
 Humboldt,5MK-1,U.S. Senate,,DEM,Massie Munroe,5
 Humboldt,5MK-1,U.S. Senate,,IND,Mike Beitiks,3
-Humboldt,5MK-1,U.S. Senate,,GRN,Pamela Elizondo,23
-Humboldt,5MK-1,U.S. Senate,,REP,Phil Wyman,13
-Humboldt,5MK-1,U.S. Senate,,DEM,President Cristina Grappo,3
+Humboldt,5MK-1,U.S. Senate,,GRN,Pamela Elizondo,26
+Humboldt,5MK-1,U.S. Senate,,IND,Paul Merritt,1
+Humboldt,5MK-1,U.S. Senate,,REP,Phil Wyman,21
+Humboldt,5MK-1,U.S. Senate,,DEM,President Cristina Grappo,4
 Humboldt,5MK-1,U.S. Senate,,REP,Ron Unz,2
-Humboldt,5MK-1,U.S. Senate,,DEM,Steve Stokes,18
-Humboldt,5MK-1,U.S. Senate,,REP,Thomas G. Del Beccaro,15
+Humboldt,5MK-1,U.S. Senate,,DEM,Steve Stokes,24
+Humboldt,5MK-1,U.S. Senate,,REP,Thomas G. Del Beccaro,19
 Humboldt,5MK-1,U.S. Senate,,REP,Tom Palzer,6
 Humboldt,5MK-1,U.S. Senate,,REP,Von Hougo,5
-Humboldt,5MK-1_A,President,,AIP,Arthur Harris,1
-Humboldt,5MK-1_A,President,,REP,Ben Carson,1
-Humboldt,5MK-1_A,President,,DEM,Bernie Sanders,70
-Humboldt,5MK-1_A,President,,REP,Donald Trump,23
-Humboldt,5MK-1_A,President,,DEM,Hillary Clinton,59
-Humboldt,5MK-1_A,President,,AIP,James Hedges,1
-Humboldt,5MK-1_A,President,,GRN,Jill Stein,1
-Humboldt,5MK-1_A,President,,REP,Jim Gilmore,1
-Humboldt,5MK-1_A,President,,REP,John R. Kasich,5
-Humboldt,5MK-1_A,President,,DEM,Michael Steinberg,1
-Humboldt,5MK-1_A,President,,REP,Ted Cruz,3
-Humboldt,5MK-1_A,Proposition 50,,,No,32
-Humboldt,5MK-1_A,Proposition 50,,,Yes,127
-Humboldt,5MK-1_A,State Assembly,2,DEM,Jim Wood,132
-Humboldt,5MK-1_A,U.S. House,2,REP,Dale K. Mensing,30
-Humboldt,5MK-1_A,U.S. House,2,DEM,Erin A. Schrode,18
-Humboldt,5MK-1_A,U.S. House,2,DEM,Jared W. Huffman,113
-Humboldt,5MK-1_A,U.S. House,2,IND,Matthew Robert Wookey,9
-Humboldt,5MK-1_A,U.S. Senate,,IND,Clive Grey,1
-Humboldt,5MK-1_A,U.S. Senate,,REP,Duf Sundheim,9
-Humboldt,5MK-1_A,U.S. Senate,,IND,Eleanor García,2
-Humboldt,5MK-1_A,U.S. Senate,,LIB,Gail K. Lightfoot,4
-Humboldt,5MK-1_A,U.S. Senate,,REP,Greg Conlon,5
-Humboldt,5MK-1_A,U.S. Senate,,REP,Jarrell Williamson,3
-Humboldt,5MK-1_A,U.S. Senate,,IND,Jason Hanania,2
-Humboldt,5MK-1_A,U.S. Senate,,IND,Jason Kraus,2
-Humboldt,5MK-1_A,U.S. Senate,,REP,Jerry J. Laws,6
-Humboldt,5MK-1_A,U.S. Senate,,DEM,Kamala D. Harris,77
-Humboldt,5MK-1_A,U.S. Senate,,REP,Karen Roseberry,3
-Humboldt,5MK-1_A,U.S. Senate,,DEM,Loretta L. Sanchez,24
-Humboldt,5MK-1_A,U.S. Senate,,LIB,Mark Matthew Herd,1
-Humboldt,5MK-1_A,U.S. Senate,,GRN,Pamela Elizondo,3
-Humboldt,5MK-1_A,U.S. Senate,,IND,Paul Merritt,1
-Humboldt,5MK-1_A,U.S. Senate,,REP,Phil Wyman,8
-Humboldt,5MK-1_A,U.S. Senate,,DEM,President Cristina Grappo,1
-Humboldt,5MK-1_A,U.S. Senate,,DEM,Steve Stokes,6
-Humboldt,5MK-1_A,U.S. Senate,,REP,Thomas G. Del Beccaro,4
 Humboldt,5MK-2,President,,AIP,Alan Spears,2
-Humboldt,5MK-2,President,,REP,Ben Carson,9
-Humboldt,5MK-2,President,,DEM,Bernie Sanders,170
+Humboldt,5MK-2,President,,REP,Ben Carson,10
+Humboldt,5MK-2,President,,DEM,Bernie Sanders,224
 Humboldt,5MK-2,President,,GRN,Darryl Cherney,1
-Humboldt,5MK-2,President,,REP,Donald Trump,54
-Humboldt,5MK-2,President,,DEM,Henry Hewes,1
-Humboldt,5MK-2,President,,DEM,Hillary Clinton,77
-Humboldt,5MK-2,President,,GRN,Jill Stein,1
-Humboldt,5MK-2,President,,LIB,John McAfee,1
-Humboldt,5MK-2,President,,REP,John R. Kasich,7
-Humboldt,5MK-2,President,,REP,Ted Cruz,7
+Humboldt,5MK-2,President,,REP,Donald Trump,93
+Humboldt,5MK-2,President,,DEM,Henry Hewes,2
+Humboldt,5MK-2,President,,DEM,Hillary Clinton,111
+Humboldt,5MK-2,President,,GRN,Jill Stein,2
+Humboldt,5MK-2,President,,LIB,John McAfee,2
+Humboldt,5MK-2,President,,REP,John R. Kasich,19
+Humboldt,5MK-2,President,,DEM,Keith Judd,1
+Humboldt,5MK-2,President,,REP,Ted Cruz,10
 Humboldt,5MK-2,President,,DEM,Willie Wilson,1
-Humboldt,5MK-2,Proposition 50,,,No,65
-Humboldt,5MK-2,Proposition 50,,,Yes,247
-Humboldt,5MK-2,State Assembly,2,DEM,Jim Wood,237
-Humboldt,5MK-2,U.S. House,2,REP,Dale K. Mensing,67
-Humboldt,5MK-2,U.S. House,2,DEM,Erin A. Schrode,27
-Humboldt,5MK-2,U.S. House,2,DEM,Jared W. Huffman,207
-Humboldt,5MK-2,U.S. House,2,IND,Matthew Robert Wookey,22
+Humboldt,5MK-2,Proposition 50,,,No,90
+Humboldt,5MK-2,Proposition 50,,,Yes,368
+Humboldt,5MK-2,State Assembly,2,DEM,Jim Wood,342
+Humboldt,5MK-2,U.S. House,2,REP,Dale K. Mensing,106
+Humboldt,5MK-2,U.S. House,2,DEM,Erin A. Schrode,34
+Humboldt,5MK-2,U.S. House,2,DEM,Jared W. Huffman,303
+Humboldt,5MK-2,U.S. House,2,IND,Matthew Robert Wookey,29
 Humboldt,5MK-2,U.S. Senate,,IND,Don J. Grundmann,1
-Humboldt,5MK-2,U.S. Senate,,REP,Don Krampe,2
-Humboldt,5MK-2,U.S. Senate,,REP,Duf Sundheim,29
-Humboldt,5MK-2,U.S. Senate,,LIB,Gail K. Lightfoot,11
+Humboldt,5MK-2,U.S. Senate,,REP,Don Krampe,3
+Humboldt,5MK-2,U.S. Senate,,REP,Duf Sundheim,44
+Humboldt,5MK-2,U.S. Senate,,LIB,Gail K. Lightfoot,14
 Humboldt,5MK-2,U.S. Senate,,REP,George C. Yang,3
-Humboldt,5MK-2,U.S. Senate,,REP,Greg Conlon,18
+Humboldt,5MK-2,U.S. Senate,,REP,Greg Conlon,27
 Humboldt,5MK-2,U.S. Senate,,DEM,Herbert G. Peters,1
-Humboldt,5MK-2,U.S. Senate,,REP,Jarrell Williamson,2
+Humboldt,5MK-2,U.S. Senate,,REP,Jarrell Williamson,5
 Humboldt,5MK-2,U.S. Senate,,IND,Jason Hanania,1
-Humboldt,5MK-2,U.S. Senate,,REP,Jerry J. Laws,6
-Humboldt,5MK-2,U.S. Senate,,DEM,Kamala D. Harris,127
-Humboldt,5MK-2,U.S. Senate,,REP,Karen Roseberry,2
-Humboldt,5MK-2,U.S. Senate,,DEM,Loretta L. Sanchez,43
-Humboldt,5MK-2,U.S. Senate,,DEM,Massie Munroe,5
+Humboldt,5MK-2,U.S. Senate,,REP,Jerry J. Laws,11
+Humboldt,5MK-2,U.S. Senate,,PAF,John Thompson Parker,1
+Humboldt,5MK-2,U.S. Senate,,DEM,Kamala D. Harris,192
+Humboldt,5MK-2,U.S. Senate,,REP,Karen Roseberry,7
+Humboldt,5MK-2,U.S. Senate,,DEM,Loretta L. Sanchez,54
+Humboldt,5MK-2,U.S. Senate,,DEM,Massie Munroe,6
 Humboldt,5MK-2,U.S. Senate,,IND,Mike Beitiks,3
-Humboldt,5MK-2,U.S. Senate,,GRN,Pamela Elizondo,9
-Humboldt,5MK-2,U.S. Senate,,REP,Phil Wyman,17
+Humboldt,5MK-2,U.S. Senate,,GRN,Pamela Elizondo,14
+Humboldt,5MK-2,U.S. Senate,,REP,Phil Wyman,28
 Humboldt,5MK-2,U.S. Senate,,DEM,President Cristina Grappo,1
-Humboldt,5MK-2,U.S. Senate,,DEM,Steve Stokes,16
-Humboldt,5MK-2,U.S. Senate,,REP,Thomas G. Del Beccaro,9
+Humboldt,5MK-2,U.S. Senate,,REP,Ron Unz,2
+Humboldt,5MK-2,U.S. Senate,,IND,Scott A. Vineberg,1
+Humboldt,5MK-2,U.S. Senate,,DEM,Steve Stokes,20
+Humboldt,5MK-2,U.S. Senate,,REP,Thomas G. Del Beccaro,13
 Humboldt,5MK-2,U.S. Senate,,IND,Tim Gildersleeve,1
 Humboldt,5MK-2,U.S. Senate,,REP,Tom Palzer,3
 Humboldt,5MK-2,U.S. Senate,,REP,Von Hougo,4
-Humboldt,5MK-2_A,President,,REP,Ben Carson,1
-Humboldt,5MK-2_A,President,,DEM,Bernie Sanders,54
-Humboldt,5MK-2_A,President,,REP,Donald Trump,39
-Humboldt,5MK-2_A,President,,DEM,Henry Hewes,1
-Humboldt,5MK-2_A,President,,DEM,Hillary Clinton,34
-Humboldt,5MK-2_A,President,,GRN,Jill Stein,1
-Humboldt,5MK-2_A,President,,LIB,John McAfee,1
-Humboldt,5MK-2_A,President,,REP,John R. Kasich,12
-Humboldt,5MK-2_A,President,,DEM,Keith Judd,1
-Humboldt,5MK-2_A,President,,REP,Ted Cruz,3
-Humboldt,5MK-2_A,Proposition 50,,,No,25
-Humboldt,5MK-2_A,Proposition 50,,,Yes,121
-Humboldt,5MK-2_A,State Assembly,2,DEM,Jim Wood,105
-Humboldt,5MK-2_A,U.S. House,2,REP,Dale K. Mensing,39
-Humboldt,5MK-2_A,U.S. House,2,DEM,Erin A. Schrode,7
-Humboldt,5MK-2_A,U.S. House,2,DEM,Jared W. Huffman,96
-Humboldt,5MK-2_A,U.S. House,2,IND,Matthew Robert Wookey,7
-Humboldt,5MK-2_A,U.S. Senate,,REP,Don Krampe,1
-Humboldt,5MK-2_A,U.S. Senate,,REP,Duf Sundheim,15
-Humboldt,5MK-2_A,U.S. Senate,,LIB,Gail K. Lightfoot,3
-Humboldt,5MK-2_A,U.S. Senate,,REP,Greg Conlon,9
-Humboldt,5MK-2_A,U.S. Senate,,REP,Jarrell Williamson,3
-Humboldt,5MK-2_A,U.S. Senate,,REP,Jerry J. Laws,5
-Humboldt,5MK-2_A,U.S. Senate,,PAF,John Thompson Parker,1
-Humboldt,5MK-2_A,U.S. Senate,,DEM,Kamala D. Harris,65
-Humboldt,5MK-2_A,U.S. Senate,,REP,Karen Roseberry,5
-Humboldt,5MK-2_A,U.S. Senate,,DEM,Loretta L. Sanchez,11
-Humboldt,5MK-2_A,U.S. Senate,,DEM,Massie Munroe,1
-Humboldt,5MK-2_A,U.S. Senate,,GRN,Pamela Elizondo,5
-Humboldt,5MK-2_A,U.S. Senate,,REP,Phil Wyman,11
-Humboldt,5MK-2_A,U.S. Senate,,REP,Ron Unz,2
-Humboldt,5MK-2_A,U.S. Senate,,IND,Scott A. Vineberg,1
-Humboldt,5MK-2_A,U.S. Senate,,DEM,Steve Stokes,4
-Humboldt,5MK-2_A,U.S. Senate,,REP,Thomas G. Del Beccaro,4
+Humboldt,5MK-3,President,,AIP,Arthur Harris,1
 Humboldt,5MK-3,President,,REP,Ben Carson,4
-Humboldt,5MK-3,President,,DEM,Bernie Sanders,158
+Humboldt,5MK-3,President,,DEM,Bernie Sanders,207
 Humboldt,5MK-3,President,,GRN,Darryl Cherney,1
-Humboldt,5MK-3,President,,REP,Donald Trump,25
-Humboldt,5MK-3,President,,DEM,Hillary Clinton,49
-Humboldt,5MK-3,President,,AIP,James Hedges,1
-Humboldt,5MK-3,President,,GRN,Jill Stein,3
-Humboldt,5MK-3,President,,REP,John R. Kasich,5
+Humboldt,5MK-3,President,,REP,Donald Trump,54
+Humboldt,5MK-3,President,,DEM,Hillary Clinton,71
+Humboldt,5MK-3,President,,AIP,James Hedges,2
+Humboldt,5MK-3,President,,GRN,Jill Stein,5
+Humboldt,5MK-3,President,,REP,John R. Kasich,6
 Humboldt,5MK-3,President,,DEM,Keith Judd,1
-Humboldt,5MK-3,President,,REP,Ted Cruz,1
-Humboldt,5MK-3,Proposition 50,,,No,49
-Humboldt,5MK-3,Proposition 50,,,Yes,154
-Humboldt,5MK-3,State Assembly,2,DEM,Jim Wood,183
-Humboldt,5MK-3,U.S. House,2,REP,Dale K. Mensing,24
-Humboldt,5MK-3,U.S. House,2,DEM,Erin A. Schrode,37
-Humboldt,5MK-3,U.S. House,2,DEM,Jared W. Huffman,158
-Humboldt,5MK-3,U.S. House,2,IND,Matthew Robert Wookey,16
+Humboldt,5MK-3,President,,DEM,Michael Steinberg,1
+Humboldt,5MK-3,President,,REP,Ted Cruz,5
+Humboldt,5MK-3,Proposition 50,,,No,67
+Humboldt,5MK-3,Proposition 50,,,Yes,250
+Humboldt,5MK-3,State Assembly,2,DEM,Jim Wood,264
+Humboldt,5MK-3,U.S. House,2,REP,Dale K. Mensing,55
+Humboldt,5MK-3,U.S. House,2,DEM,Erin A. Schrode,53
+Humboldt,5MK-3,U.S. House,2,DEM,Jared W. Huffman,218
+Humboldt,5MK-3,U.S. House,2,IND,Matthew Robert Wookey,26
 Humboldt,5MK-3,U.S. Senate,,IND,Clive Grey,1
-Humboldt,5MK-3,U.S. Senate,,REP,Don Krampe,1
-Humboldt,5MK-3,U.S. Senate,,REP,Duf Sundheim,8
+Humboldt,5MK-3,U.S. Senate,,REP,Don Krampe,4
+Humboldt,5MK-3,U.S. Senate,,REP,Duf Sundheim,13
 Humboldt,5MK-3,U.S. Senate,,IND,Eleanor García,1
 Humboldt,5MK-3,U.S. Senate,,DEM,Emory Rodgers,2
-Humboldt,5MK-3,U.S. Senate,,LIB,Gail K. Lightfoot,6
-Humboldt,5MK-3,U.S. Senate,,REP,Greg Conlon,3
-Humboldt,5MK-3,U.S. Senate,,REP,Jarrell Williamson,3
-Humboldt,5MK-3,U.S. Senate,,REP,Jerry J. Laws,7
-Humboldt,5MK-3,U.S. Senate,,DEM,Kamala D. Harris,110
-Humboldt,5MK-3,U.S. Senate,,DEM,Loretta L. Sanchez,38
-Humboldt,5MK-3,U.S. Senate,,DEM,Massie Munroe,2
-Humboldt,5MK-3,U.S. Senate,,IND,Mike Beitiks,3
-Humboldt,5MK-3,U.S. Senate,,GRN,Pamela Elizondo,15
-Humboldt,5MK-3,U.S. Senate,,REP,Phil Wyman,6
-Humboldt,5MK-3,U.S. Senate,,DEM,Steve Stokes,17
+Humboldt,5MK-3,U.S. Senate,,LIB,Gail K. Lightfoot,13
+Humboldt,5MK-3,U.S. Senate,,REP,Greg Conlon,9
+Humboldt,5MK-3,U.S. Senate,,REP,Jarrell Williamson,7
+Humboldt,5MK-3,U.S. Senate,,IND,Jason Hanania,2
+Humboldt,5MK-3,U.S. Senate,,REP,Jerry J. Laws,11
+Humboldt,5MK-3,U.S. Senate,,DEM,Kamala D. Harris,146
+Humboldt,5MK-3,U.S. Senate,,DEM,Loretta L. Sanchez,58
+Humboldt,5MK-3,U.S. Senate,,LIB,Mark Matthew Herd,2
+Humboldt,5MK-3,U.S. Senate,,DEM,Massie Munroe,3
+Humboldt,5MK-3,U.S. Senate,,IND,Mike Beitiks,6
+Humboldt,5MK-3,U.S. Senate,,GRN,Pamela Elizondo,24
+Humboldt,5MK-3,U.S. Senate,,REP,Phil Wyman,14
+Humboldt,5MK-3,U.S. Senate,,DEM,President Cristina Grappo,2
+Humboldt,5MK-3,U.S. Senate,,REP,Ron Unz,1
+Humboldt,5MK-3,U.S. Senate,,DEM,Steve Stokes,19
+Humboldt,5MK-3,U.S. Senate,,REP,Thomas G. Del Beccaro,1
 Humboldt,5MK-3,U.S. Senate,,IND,Tim Gildersleeve,1
 Humboldt,5MK-3,U.S. Senate,,REP,Tom Palzer,1
-Humboldt,5MK-3_A,President,,AIP,Arthur Harris,1
-Humboldt,5MK-3_A,President,,DEM,Bernie Sanders,49
-Humboldt,5MK-3_A,President,,REP,Donald Trump,29
-Humboldt,5MK-3_A,President,,DEM,Hillary Clinton,22
-Humboldt,5MK-3_A,President,,AIP,James Hedges,1
-Humboldt,5MK-3_A,President,,GRN,Jill Stein,2
-Humboldt,5MK-3_A,President,,REP,John R. Kasich,1
-Humboldt,5MK-3_A,President,,DEM,Michael Steinberg,1
-Humboldt,5MK-3_A,President,,REP,Ted Cruz,4
-Humboldt,5MK-3_A,Proposition 50,,,No,18
-Humboldt,5MK-3_A,Proposition 50,,,Yes,96
-Humboldt,5MK-3_A,State Assembly,2,DEM,Jim Wood,81
-Humboldt,5MK-3_A,U.S. House,2,REP,Dale K. Mensing,31
-Humboldt,5MK-3_A,U.S. House,2,DEM,Erin A. Schrode,16
-Humboldt,5MK-3_A,U.S. House,2,DEM,Jared W. Huffman,60
-Humboldt,5MK-3_A,U.S. House,2,IND,Matthew Robert Wookey,10
-Humboldt,5MK-3_A,U.S. Senate,,REP,Don Krampe,3
-Humboldt,5MK-3_A,U.S. Senate,,REP,Duf Sundheim,5
-Humboldt,5MK-3_A,U.S. Senate,,LIB,Gail K. Lightfoot,7
-Humboldt,5MK-3_A,U.S. Senate,,REP,Greg Conlon,6
-Humboldt,5MK-3_A,U.S. Senate,,REP,Jarrell Williamson,4
-Humboldt,5MK-3_A,U.S. Senate,,IND,Jason Hanania,2
-Humboldt,5MK-3_A,U.S. Senate,,REP,Jerry J. Laws,4
-Humboldt,5MK-3_A,U.S. Senate,,DEM,Kamala D. Harris,36
-Humboldt,5MK-3_A,U.S. Senate,,DEM,Loretta L. Sanchez,20
-Humboldt,5MK-3_A,U.S. Senate,,LIB,Mark Matthew Herd,2
-Humboldt,5MK-3_A,U.S. Senate,,DEM,Massie Munroe,1
-Humboldt,5MK-3_A,U.S. Senate,,IND,Mike Beitiks,3
-Humboldt,5MK-3_A,U.S. Senate,,GRN,Pamela Elizondo,9
-Humboldt,5MK-3_A,U.S. Senate,,REP,Phil Wyman,8
-Humboldt,5MK-3_A,U.S. Senate,,DEM,President Cristina Grappo,2
-Humboldt,5MK-3_A,U.S. Senate,,REP,Ron Unz,1
-Humboldt,5MK-3_A,U.S. Senate,,DEM,Steve Stokes,2
-Humboldt,5MK-3_A,U.S. Senate,,REP,Thomas G. Del Beccaro,1
-Humboldt,5MK-4,President,,REP,Ben Carson,9
-Humboldt,5MK-4,President,,DEM,Bernie Sanders,192
-Humboldt,5MK-4,President,,REP,Donald Trump,48
-Humboldt,5MK-4,President,,DEM,Hillary Clinton,75
-Humboldt,5MK-4,President,,AIP,James Hedges,1
-Humboldt,5MK-4,President,,GRN,Jill Stein,1
+Humboldt,5MK-4,President,,AIP,Alan Spears,2
+Humboldt,5MK-4,President,,AIP,Arthur Harris,1
+Humboldt,5MK-4,President,,LIB,Austin Petersen,1
+Humboldt,5MK-4,President,,REP,Ben Carson,14
+Humboldt,5MK-4,President,,DEM,Bernie Sanders,419
+Humboldt,5MK-4,President,,GRN,Darryl Cherney,2
+Humboldt,5MK-4,President,,REP,Donald Trump,156
+Humboldt,5MK-4,President,,LIB,Gary Johnson,2
+Humboldt,5MK-4,President,,DEM,Hillary Clinton,195
+Humboldt,5MK-4,President,,AIP,James Hedges,2
+Humboldt,5MK-4,President,,GRN,Jill Stein,3
 Humboldt,5MK-4,President,,REP,Jim Gilmore,1
-Humboldt,5MK-4,President,,REP,John R. Kasich,4
+Humboldt,5MK-4,President,,REP,John R. Kasich,14
+Humboldt,5MK-4,President,,DEM,Michael Steinberg,1
+Humboldt,5MK-4,President,,AIP,Robert Ornelas,1
 Humboldt,5MK-4,President,,DEM,Roque De La Fuente,1
-Humboldt,5MK-4,President,,REP,Ted Cruz,8
-Humboldt,5MK-4,Proposition 50,,,No,70
-Humboldt,5MK-4,Proposition 50,,,Yes,231
-Humboldt,5MK-4,State Assembly,2,DEM,Jim Wood,258
-Humboldt,5MK-4,U.S. House,2,REP,Dale K. Mensing,57
-Humboldt,5MK-4,U.S. House,2,DEM,Erin A. Schrode,38
-Humboldt,5MK-4,U.S. House,2,DEM,Jared W. Huffman,209
-Humboldt,5MK-4,U.S. House,2,IND,Matthew Robert Wookey,25
-Humboldt,5MK-4,U.S. Senate,,REP,Don Krampe,5
-Humboldt,5MK-4,U.S. Senate,,REP,Duf Sundheim,20
-Humboldt,5MK-4,U.S. Senate,,IND,Eleanor García,1
-Humboldt,5MK-4,U.S. Senate,,DEM,Emory Rodgers,1
-Humboldt,5MK-4,U.S. Senate,,LIB,Gail K. Lightfoot,7
+Humboldt,5MK-4,President,,REP,Ted Cruz,28
+Humboldt,5MK-4,Proposition 50,,,No,153
+Humboldt,5MK-4,Proposition 50,,,Yes,633
+Humboldt,5MK-4,State Assembly,2,DEM,Jim Wood,640
+Humboldt,5MK-4,U.S. House,2,REP,Dale K. Mensing,164
+Humboldt,5MK-4,U.S. House,2,DEM,Erin A. Schrode,84
+Humboldt,5MK-4,U.S. House,2,DEM,Jared W. Huffman,531
+Humboldt,5MK-4,U.S. House,2,IND,Matthew Robert Wookey,53
+Humboldt,5MK-4,U.S. Senate,,IND,Clive Grey,2
+Humboldt,5MK-4,U.S. Senate,,REP,Don Krampe,12
+Humboldt,5MK-4,U.S. Senate,,REP,Duf Sundheim,53
+Humboldt,5MK-4,U.S. Senate,,IND,Eleanor García,2
+Humboldt,5MK-4,U.S. Senate,,DEM,Emory Rodgers,3
+Humboldt,5MK-4,U.S. Senate,,LIB,Gail K. Lightfoot,13
 Humboldt,5MK-4,U.S. Senate,,IND,Gar Myers,1
-Humboldt,5MK-4,U.S. Senate,,REP,Greg Conlon,8
-Humboldt,5MK-4,U.S. Senate,,REP,Jarrell Williamson,3
+Humboldt,5MK-4,U.S. Senate,,REP,George C. Yang,6
+Humboldt,5MK-4,U.S. Senate,,REP,Greg Conlon,24
+Humboldt,5MK-4,U.S. Senate,,REP,Jarrell Williamson,6
 Humboldt,5MK-4,U.S. Senate,,IND,Jason Hanania,1
-Humboldt,5MK-4,U.S. Senate,,IND,Jason Kraus,1
-Humboldt,5MK-4,U.S. Senate,,REP,Jerry J. Laws,13
-Humboldt,5MK-4,U.S. Senate,,DEM,Kamala D. Harris,119
-Humboldt,5MK-4,U.S. Senate,,REP,Karen Roseberry,4
-Humboldt,5MK-4,U.S. Senate,,IND,Ling Ling Shi,1
-Humboldt,5MK-4,U.S. Senate,,DEM,Loretta L. Sanchez,67
-Humboldt,5MK-4,U.S. Senate,,LIB,Mark Matthew Herd,3
-Humboldt,5MK-4,U.S. Senate,,DEM,Massie Munroe,5
-Humboldt,5MK-4,U.S. Senate,,IND,Mike Beitiks,3
-Humboldt,5MK-4,U.S. Senate,,GRN,Pamela Elizondo,9
-Humboldt,5MK-4,U.S. Senate,,REP,Phil Wyman,12
-Humboldt,5MK-4,U.S. Senate,,DEM,President Cristina Grappo,1
-Humboldt,5MK-4,U.S. Senate,,DEM,Steve Stokes,18
-Humboldt,5MK-4,U.S. Senate,,REP,Thomas G. Del Beccaro,8
-Humboldt,5MK-4,U.S. Senate,,REP,Tom Palzer,3
-Humboldt,5MK-4,U.S. Senate,,REP,Von Hougo,3
-Humboldt,5MK-4A,President,,AIP,Arthur Harris,1
-Humboldt,5MK-4A,President,,LIB,Austin Petersen,1
-Humboldt,5MK-4A,President,,REP,Ben Carson,2
-Humboldt,5MK-4A,President,,DEM,Bernie Sanders,124
-Humboldt,5MK-4A,President,,GRN,Darryl Cherney,1
-Humboldt,5MK-4A,President,,REP,Donald Trump,33
-Humboldt,5MK-4A,President,,LIB,Gary Johnson,1
-Humboldt,5MK-4A,President,,DEM,Hillary Clinton,41
-Humboldt,5MK-4A,President,,GRN,Jill Stein,1
-Humboldt,5MK-4A,President,,REP,Ted Cruz,3
-Humboldt,5MK-4A,Proposition 50,,,No,41
-Humboldt,5MK-4A,Proposition 50,,,Yes,158
-Humboldt,5MK-4A,State Assembly,2,DEM,Jim Wood,159
-Humboldt,5MK-4A,U.S. House,2,REP,Dale K. Mensing,34
-Humboldt,5MK-4A,U.S. House,2,DEM,Erin A. Schrode,32
-Humboldt,5MK-4A,U.S. House,2,DEM,Jared W. Huffman,125
-Humboldt,5MK-4A,U.S. House,2,IND,Matthew Robert Wookey,15
-Humboldt,5MK-4A,U.S. Senate,,REP,Don Krampe,3
-Humboldt,5MK-4A,U.S. Senate,,REP,Duf Sundheim,10
-Humboldt,5MK-4A,U.S. Senate,,DEM,Emory Rodgers,1
-Humboldt,5MK-4A,U.S. Senate,,LIB,Gail K. Lightfoot,3
-Humboldt,5MK-4A,U.S. Senate,,REP,George C. Yang,2
-Humboldt,5MK-4A,U.S. Senate,,REP,Greg Conlon,8
-Humboldt,5MK-4A,U.S. Senate,,IND,Jason Kraus,1
-Humboldt,5MK-4A,U.S. Senate,,REP,Jerry J. Laws,8
-Humboldt,5MK-4A,U.S. Senate,,PAF,John Thompson Parker,1
-Humboldt,5MK-4A,U.S. Senate,,DEM,Kamala D. Harris,63
-Humboldt,5MK-4A,U.S. Senate,,REP,Karen Roseberry,1
-Humboldt,5MK-4A,U.S. Senate,,DEM,Loretta L. Sanchez,46
-Humboldt,5MK-4A,U.S. Senate,,LIB,Mark Matthew Herd,2
-Humboldt,5MK-4A,U.S. Senate,,DEM,Massie Munroe,3
-Humboldt,5MK-4A,U.S. Senate,,IND,Mike Beitiks,3
-Humboldt,5MK-4A,U.S. Senate,,GRN,Pamela Elizondo,11
-Humboldt,5MK-4A,U.S. Senate,,IND,Paul Merritt,2
-Humboldt,5MK-4A,U.S. Senate,,REP,Phil Wyman,8
-Humboldt,5MK-4A,U.S. Senate,,DEM,President Cristina Grappo,3
-Humboldt,5MK-4A,U.S. Senate,,REP,Ron Unz,4
-Humboldt,5MK-4A,U.S. Senate,,IND,Scott A. Vineberg,2
-Humboldt,5MK-4A,U.S. Senate,,DEM,Steve Stokes,17
-Humboldt,5MK-4A,U.S. Senate,,REP,Thomas G. Del Beccaro,4
-Humboldt,5MK-4A_A,President,,AIP,Alan Spears,1
-Humboldt,5MK-4A_A,President,,REP,Ben Carson,1
-Humboldt,5MK-4A_A,President,,DEM,Bernie Sanders,46
-Humboldt,5MK-4A_A,President,,REP,Donald Trump,30
-Humboldt,5MK-4A_A,President,,DEM,Hillary Clinton,34
-Humboldt,5MK-4A_A,President,,REP,John R. Kasich,5
-Humboldt,5MK-4A_A,President,,AIP,Robert Ornelas,1
-Humboldt,5MK-4A_A,President,,REP,Ted Cruz,9
-Humboldt,5MK-4A_A,Proposition 50,,,No,25
-Humboldt,5MK-4A_A,Proposition 50,,,Yes,93
-Humboldt,5MK-4A_A,State Assembly,2,DEM,Jim Wood,88
-Humboldt,5MK-4A_A,U.S. House,2,REP,Dale K. Mensing,30
-Humboldt,5MK-4A_A,U.S. House,2,DEM,Erin A. Schrode,9
-Humboldt,5MK-4A_A,U.S. House,2,DEM,Jared W. Huffman,86
-Humboldt,5MK-4A_A,U.S. House,2,IND,Matthew Robert Wookey,5
-Humboldt,5MK-4A_A,U.S. Senate,,REP,Don Krampe,3
-Humboldt,5MK-4A_A,U.S. Senate,,REP,Duf Sundheim,7
-Humboldt,5MK-4A_A,U.S. Senate,,IND,Eleanor García,1
-Humboldt,5MK-4A_A,U.S. Senate,,REP,George C. Yang,1
-Humboldt,5MK-4A_A,U.S. Senate,,REP,Greg Conlon,3
-Humboldt,5MK-4A_A,U.S. Senate,,IND,Jason Kraus,1
-Humboldt,5MK-4A_A,U.S. Senate,,REP,Jerry J. Laws,7
-Humboldt,5MK-4A_A,U.S. Senate,,DEM,Kamala D. Harris,52
-Humboldt,5MK-4A_A,U.S. Senate,,IND,Ling Ling Shi,1
-Humboldt,5MK-4A_A,U.S. Senate,,DEM,Loretta L. Sanchez,17
-Humboldt,5MK-4A_A,U.S. Senate,,LIB,Mark Matthew Herd,1
-Humboldt,5MK-4A_A,U.S. Senate,,GRN,Pamela Elizondo,2
-Humboldt,5MK-4A_A,U.S. Senate,,IND,Paul Merritt,2
-Humboldt,5MK-4A_A,U.S. Senate,,REP,Phil Wyman,10
-Humboldt,5MK-4A_A,U.S. Senate,,DEM,Steve Stokes,2
-Humboldt,5MK-4A_A,U.S. Senate,,REP,Thomas G. Del Beccaro,4
-Humboldt,5MK-4A_A,U.S. Senate,,IND,Tim Gildersleeve,1
-Humboldt,5MK-4A_A,U.S. Senate,,REP,Von Hougo,3
-Humboldt,5MK-4_A,President,,AIP,Alan Spears,1
-Humboldt,5MK-4_A,President,,REP,Ben Carson,2
-Humboldt,5MK-4_A,President,,DEM,Bernie Sanders,57
-Humboldt,5MK-4_A,President,,GRN,Darryl Cherney,1
-Humboldt,5MK-4_A,President,,REP,Donald Trump,45
-Humboldt,5MK-4_A,President,,LIB,Gary Johnson,1
-Humboldt,5MK-4_A,President,,DEM,Hillary Clinton,45
-Humboldt,5MK-4_A,President,,AIP,James Hedges,1
-Humboldt,5MK-4_A,President,,GRN,Jill Stein,1
-Humboldt,5MK-4_A,President,,REP,John R. Kasich,5
-Humboldt,5MK-4_A,President,,DEM,Michael Steinberg,1
-Humboldt,5MK-4_A,President,,REP,Ted Cruz,8
-Humboldt,5MK-4_A,Proposition 50,,,No,17
-Humboldt,5MK-4_A,Proposition 50,,,Yes,151
-Humboldt,5MK-4_A,State Assembly,2,DEM,Jim Wood,135
-Humboldt,5MK-4_A,U.S. House,2,REP,Dale K. Mensing,43
-Humboldt,5MK-4_A,U.S. House,2,DEM,Erin A. Schrode,5
-Humboldt,5MK-4_A,U.S. House,2,DEM,Jared W. Huffman,111
-Humboldt,5MK-4_A,U.S. House,2,IND,Matthew Robert Wookey,8
-Humboldt,5MK-4_A,U.S. Senate,,IND,Clive Grey,2
-Humboldt,5MK-4_A,U.S. Senate,,REP,Don Krampe,1
-Humboldt,5MK-4_A,U.S. Senate,,REP,Duf Sundheim,16
-Humboldt,5MK-4_A,U.S. Senate,,DEM,Emory Rodgers,1
-Humboldt,5MK-4_A,U.S. Senate,,LIB,Gail K. Lightfoot,3
-Humboldt,5MK-4_A,U.S. Senate,,REP,George C. Yang,3
-Humboldt,5MK-4_A,U.S. Senate,,REP,Greg Conlon,5
-Humboldt,5MK-4_A,U.S. Senate,,REP,Jarrell Williamson,3
-Humboldt,5MK-4_A,U.S. Senate,,REP,Jerry J. Laws,5
-Humboldt,5MK-4_A,U.S. Senate,,PAF,John Thompson Parker,1
-Humboldt,5MK-4_A,U.S. Senate,,DEM,Kamala D. Harris,63
-Humboldt,5MK-4_A,U.S. Senate,,DEM,Loretta L. Sanchez,30
-Humboldt,5MK-4_A,U.S. Senate,,LIB,Mark Matthew Herd,2
-Humboldt,5MK-4_A,U.S. Senate,,GRN,Pamela Elizondo,7
-Humboldt,5MK-4_A,U.S. Senate,,REP,Phil Wyman,10
-Humboldt,5MK-4_A,U.S. Senate,,REP,Ron Unz,3
-Humboldt,5MK-4_A,U.S. Senate,,IND,Scott A. Vineberg,1
-Humboldt,5MK-4_A,U.S. Senate,,DEM,Steve Stokes,5
-Humboldt,5MK-4_A,U.S. Senate,,REP,Thomas G. Del Beccaro,1
-Humboldt,5MK-4_A,U.S. Senate,,REP,Tom Palzer,3
-Humboldt,5MK-4_A,U.S. Senate,,REP,Von Hougo,2
-Humboldt,5MK-5,President,,REP,Ben Carson,5
-Humboldt,5MK-5,President,,DEM,Bernie Sanders,159
-Humboldt,5MK-5,President,,REP,Donald Trump,41
-Humboldt,5MK-5,President,,LIB,Gary Johnson,1
-Humboldt,5MK-5,President,,DEM,Hillary Clinton,59
-Humboldt,5MK-5,President,,GRN,Jill Stein,3
-Humboldt,5MK-5,President,,REP,John R. Kasich,4
-Humboldt,5MK-5,President,,DEM,Keith Judd,1
-Humboldt,5MK-5,President,,AIP,Robert Ornelas,1
-Humboldt,5MK-5,President,,REP,Ted Cruz,14
-Humboldt,5MK-5,Proposition 50,,,No,51
-Humboldt,5MK-5,Proposition 50,,,Yes,217
-Humboldt,5MK-5,State Assembly,2,DEM,Jim Wood,216
-Humboldt,5MK-5,U.S. House,2,REP,Dale K. Mensing,47
-Humboldt,5MK-5,U.S. House,2,DEM,Erin A. Schrode,26
-Humboldt,5MK-5,U.S. House,2,DEM,Jared W. Huffman,191
-Humboldt,5MK-5,U.S. House,2,IND,Matthew Robert Wookey,18
-Humboldt,5MK-5,U.S. Senate,,IND,Clive Grey,1
-Humboldt,5MK-5,U.S. Senate,,IND,Don J. Grundmann,2
-Humboldt,5MK-5,U.S. Senate,,REP,Don Krampe,1
-Humboldt,5MK-5,U.S. Senate,,REP,Duf Sundheim,11
-Humboldt,5MK-5,U.S. Senate,,IND,Eleanor García,1
-Humboldt,5MK-5,U.S. Senate,,LIB,Gail K. Lightfoot,13
-Humboldt,5MK-5,U.S. Senate,,REP,George C. Yang,1
-Humboldt,5MK-5,U.S. Senate,,REP,Greg Conlon,9
-Humboldt,5MK-5,U.S. Senate,,REP,Jarrell Williamson,6
-Humboldt,5MK-5,U.S. Senate,,IND,Jason Hanania,2
-Humboldt,5MK-5,U.S. Senate,,IND,Jason Kraus,1
-Humboldt,5MK-5,U.S. Senate,,REP,Jerry J. Laws,6
-Humboldt,5MK-5,U.S. Senate,,PAF,John Thompson Parker,2
-Humboldt,5MK-5,U.S. Senate,,DEM,Kamala D. Harris,113
-Humboldt,5MK-5,U.S. Senate,,REP,Karen Roseberry,1
-Humboldt,5MK-5,U.S. Senate,,IND,Ling Ling Shi,1
-Humboldt,5MK-5,U.S. Senate,,DEM,Loretta L. Sanchez,54
-Humboldt,5MK-5,U.S. Senate,,LIB,Mark Matthew Herd,1
-Humboldt,5MK-5,U.S. Senate,,DEM,Massie Munroe,4
-Humboldt,5MK-5,U.S. Senate,,IND,Mike Beitiks,1
-Humboldt,5MK-5,U.S. Senate,,GRN,Pamela Elizondo,6
-Humboldt,5MK-5,U.S. Senate,,IND,Paul Merritt,2
-Humboldt,5MK-5,U.S. Senate,,REP,Phil Wyman,10
+Humboldt,5MK-4,U.S. Senate,,IND,Jason Kraus,3
+Humboldt,5MK-4,U.S. Senate,,REP,Jerry J. Laws,33
+Humboldt,5MK-4,U.S. Senate,,PAF,John Thompson Parker,2
+Humboldt,5MK-4,U.S. Senate,,DEM,Kamala D. Harris,297
+Humboldt,5MK-4,U.S. Senate,,REP,Karen Roseberry,5
+Humboldt,5MK-4,U.S. Senate,,IND,Ling Ling Shi,2
+Humboldt,5MK-4,U.S. Senate,,DEM,Loretta L. Sanchez,160
+Humboldt,5MK-4,U.S. Senate,,LIB,Mark Matthew Herd,8
+Humboldt,5MK-4,U.S. Senate,,DEM,Massie Munroe,8
+Humboldt,5MK-4,U.S. Senate,,IND,Mike Beitiks,6
+Humboldt,5MK-4,U.S. Senate,,GRN,Pamela Elizondo,29
+Humboldt,5MK-4,U.S. Senate,,IND,Paul Merritt,4
+Humboldt,5MK-4,U.S. Senate,,REP,Phil Wyman,40
+Humboldt,5MK-4,U.S. Senate,,DEM,President Cristina Grappo,4
+Humboldt,5MK-4,U.S. Senate,,REP,Ron Unz,7
+Humboldt,5MK-4,U.S. Senate,,IND,Scott A. Vineberg,3
+Humboldt,5MK-4,U.S. Senate,,DEM,Steve Stokes,42
+Humboldt,5MK-4,U.S. Senate,,REP,Thomas G. Del Beccaro,17
+Humboldt,5MK-4,U.S. Senate,,IND,Tim Gildersleeve,1
+Humboldt,5MK-4,U.S. Senate,,REP,Tom Palzer,6
+Humboldt,5MK-4,U.S. Senate,,REP,Von Hougo,8
+Humboldt,5MK-5,President,,AIP,Alan Spears,2
+Humboldt,5MK-5,President,,LIB,Austin Petersen,2
+Humboldt,5MK-5,President,,REP,Ben Carson,13
+Humboldt,5MK-5,President,,DEM,Bernie Sanders,461
+Humboldt,5MK-5,President,,REP,Donald Trump,158
+Humboldt,5MK-5,President,,LIB,Gary Johnson,3
+Humboldt,5MK-5,President,,DEM,Hillary Clinton,219
+Humboldt,5MK-5,President,,GRN,Jill Stein,6
+Humboldt,5MK-5,President,,LIB,John McAfee,1
+Humboldt,5MK-5,President,,REP,John R. Kasich,22
+Humboldt,5MK-5,President,,DEM,Keith Judd,2
+Humboldt,5MK-5,President,,AIP,Robert Ornelas,2
+Humboldt,5MK-5,President,,REP,Ted Cruz,30
+Humboldt,5MK-5,President,,AIP,Thomas Hoefling,1
+Humboldt,5MK-5,President,,AIP,Wiley Drake,1
+Humboldt,5MK-5,President,,DEM,Willie Wilson,1
+Humboldt,5MK-5,Proposition 50,,,No,173
+Humboldt,5MK-5,Proposition 50,,,Yes,706
+Humboldt,5MK-5,State Assembly,2,DEM,Jim Wood,685
+Humboldt,5MK-5,U.S. House,2,REP,Dale K. Mensing,174
+Humboldt,5MK-5,U.S. House,2,DEM,Erin A. Schrode,75
+Humboldt,5MK-5,U.S. House,2,DEM,Jared W. Huffman,597
+Humboldt,5MK-5,U.S. House,2,IND,Matthew Robert Wookey,53
+Humboldt,5MK-5,U.S. Senate,,IND,Clive Grey,4
+Humboldt,5MK-5,U.S. Senate,,IND,Don J. Grundmann,3
+Humboldt,5MK-5,U.S. Senate,,REP,Don Krampe,7
+Humboldt,5MK-5,U.S. Senate,,REP,Duf Sundheim,37
+Humboldt,5MK-5,U.S. Senate,,IND,Eleanor García,2
+Humboldt,5MK-5,U.S. Senate,,LIB,Gail K. Lightfoot,32
+Humboldt,5MK-5,U.S. Senate,,IND,Gar Myers,1
+Humboldt,5MK-5,U.S. Senate,,REP,George C. Yang,2
+Humboldt,5MK-5,U.S. Senate,,REP,Greg Conlon,37
+Humboldt,5MK-5,U.S. Senate,,DEM,Herbert G. Peters,2
+Humboldt,5MK-5,U.S. Senate,,REP,Jarrell Williamson,13
+Humboldt,5MK-5,U.S. Senate,,IND,Jason Hanania,4
+Humboldt,5MK-5,U.S. Senate,,IND,Jason Kraus,2
+Humboldt,5MK-5,U.S. Senate,,REP,Jerry J. Laws,35
+Humboldt,5MK-5,U.S. Senate,,PAF,John Thompson Parker,3
+Humboldt,5MK-5,U.S. Senate,,DEM,Kamala D. Harris,360
+Humboldt,5MK-5,U.S. Senate,,REP,Karen Roseberry,6
+Humboldt,5MK-5,U.S. Senate,,IND,Ling Ling Shi,2
+Humboldt,5MK-5,U.S. Senate,,DEM,Loretta L. Sanchez,150
+Humboldt,5MK-5,U.S. Senate,,LIB,Mark Matthew Herd,4
+Humboldt,5MK-5,U.S. Senate,,DEM,Massie Munroe,16
+Humboldt,5MK-5,U.S. Senate,,IND,Mike Beitiks,8
+Humboldt,5MK-5,U.S. Senate,,GRN,Pamela Elizondo,25
+Humboldt,5MK-5,U.S. Senate,,IND,Paul Merritt,5
+Humboldt,5MK-5,U.S. Senate,,REP,Phil Wyman,47
 Humboldt,5MK-5,U.S. Senate,,DEM,President Cristina Grappo,2
-Humboldt,5MK-5,U.S. Senate,,REP,Ron Unz,6
-Humboldt,5MK-5,U.S. Senate,,DEM,Steve Stokes,11
-Humboldt,5MK-5,U.S. Senate,,REP,Thomas G. Del Beccaro,2
-Humboldt,5MK-5,U.S. Senate,,IND,Tim Gildersleeve,1
-Humboldt,5MK-5,U.S. Senate,,REP,Tom Palzer,4
-Humboldt,5MK-5,U.S. Senate,,REP,Von Hougo,3
-Humboldt,5MK-5A,President,,AIP,Alan Spears,1
-Humboldt,5MK-5A,President,,LIB,Austin Petersen,2
-Humboldt,5MK-5A,President,,REP,Ben Carson,4
-Humboldt,5MK-5A,President,,DEM,Bernie Sanders,168
-Humboldt,5MK-5A,President,,REP,Donald Trump,55
-Humboldt,5MK-5A,President,,LIB,Gary Johnson,2
-Humboldt,5MK-5A,President,,DEM,Hillary Clinton,63
-Humboldt,5MK-5A,President,,GRN,Jill Stein,2
-Humboldt,5MK-5A,President,,REP,John R. Kasich,4
-Humboldt,5MK-5A,President,,REP,Ted Cruz,6
-Humboldt,5MK-5A,President,,AIP,Wiley Drake,1
-Humboldt,5MK-5A,Proposition 50,,,No,59
-Humboldt,5MK-5A,Proposition 50,,,Yes,230
-Humboldt,5MK-5A,State Assembly,2,DEM,Jim Wood,222
-Humboldt,5MK-5A,U.S. House,2,REP,Dale K. Mensing,63
-Humboldt,5MK-5A,U.S. House,2,DEM,Erin A. Schrode,33
-Humboldt,5MK-5A,U.S. House,2,DEM,Jared W. Huffman,175
-Humboldt,5MK-5A,U.S. House,2,IND,Matthew Robert Wookey,19
-Humboldt,5MK-5A,U.S. Senate,,IND,Don J. Grundmann,1
-Humboldt,5MK-5A,U.S. Senate,,REP,Don Krampe,4
-Humboldt,5MK-5A,U.S. Senate,,REP,Duf Sundheim,15
-Humboldt,5MK-5A,U.S. Senate,,IND,Eleanor García,1
-Humboldt,5MK-5A,U.S. Senate,,LIB,Gail K. Lightfoot,16
-Humboldt,5MK-5A,U.S. Senate,,IND,Gar Myers,1
-Humboldt,5MK-5A,U.S. Senate,,REP,Greg Conlon,4
-Humboldt,5MK-5A,U.S. Senate,,REP,Jarrell Williamson,3
-Humboldt,5MK-5A,U.S. Senate,,REP,Jerry J. Laws,15
-Humboldt,5MK-5A,U.S. Senate,,DEM,Kamala D. Harris,93
-Humboldt,5MK-5A,U.S. Senate,,REP,Karen Roseberry,4
-Humboldt,5MK-5A,U.S. Senate,,IND,Ling Ling Shi,1
-Humboldt,5MK-5A,U.S. Senate,,DEM,Loretta L. Sanchez,53
-Humboldt,5MK-5A,U.S. Senate,,LIB,Mark Matthew Herd,3
-Humboldt,5MK-5A,U.S. Senate,,DEM,Massie Munroe,8
-Humboldt,5MK-5A,U.S. Senate,,IND,Mike Beitiks,2
-Humboldt,5MK-5A,U.S. Senate,,GRN,Pamela Elizondo,13
-Humboldt,5MK-5A,U.S. Senate,,IND,Paul Merritt,1
-Humboldt,5MK-5A,U.S. Senate,,REP,Phil Wyman,22
-Humboldt,5MK-5A,U.S. Senate,,REP,Ron Unz,1
-Humboldt,5MK-5A,U.S. Senate,,DEM,Steve Stokes,15
-Humboldt,5MK-5A,U.S. Senate,,REP,Thomas G. Del Beccaro,6
-Humboldt,5MK-5A,U.S. Senate,,IND,Tim Gildersleeve,1
-Humboldt,5MK-5A,U.S. Senate,,REP,Tom Palzer,1
-Humboldt,5MK-5A,U.S. Senate,,REP,Von Hougo,2
-Humboldt,5MK-5A_A,President,,DEM,Bernie Sanders,66
-Humboldt,5MK-5A_A,President,,REP,Donald Trump,19
-Humboldt,5MK-5A_A,President,,DEM,Hillary Clinton,30
-Humboldt,5MK-5A_A,President,,REP,John R. Kasich,2
-Humboldt,5MK-5A_A,President,,DEM,Keith Judd,1
-Humboldt,5MK-5A_A,President,,REP,Ted Cruz,3
-Humboldt,5MK-5A_A,President,,AIP,Thomas Hoefling,1
-Humboldt,5MK-5A_A,Proposition 50,,,No,28
-Humboldt,5MK-5A_A,Proposition 50,,,Yes,94
-Humboldt,5MK-5A_A,State Assembly,2,DEM,Jim Wood,93
-Humboldt,5MK-5A_A,U.S. House,2,REP,Dale K. Mensing,19
-Humboldt,5MK-5A_A,U.S. House,2,DEM,Erin A. Schrode,9
-Humboldt,5MK-5A_A,U.S. House,2,DEM,Jared W. Huffman,89
-Humboldt,5MK-5A_A,U.S. House,2,IND,Matthew Robert Wookey,4
-Humboldt,5MK-5A_A,U.S. Senate,,IND,Clive Grey,1
-Humboldt,5MK-5A_A,U.S. Senate,,REP,Duf Sundheim,4
-Humboldt,5MK-5A_A,U.S. Senate,,REP,Greg Conlon,6
-Humboldt,5MK-5A_A,U.S. Senate,,DEM,Herbert G. Peters,2
-Humboldt,5MK-5A_A,U.S. Senate,,IND,Jason Hanania,2
-Humboldt,5MK-5A_A,U.S. Senate,,IND,Jason Kraus,1
-Humboldt,5MK-5A_A,U.S. Senate,,REP,Jerry J. Laws,2
-Humboldt,5MK-5A_A,U.S. Senate,,DEM,Kamala D. Harris,61
-Humboldt,5MK-5A_A,U.S. Senate,,DEM,Loretta L. Sanchez,16
-Humboldt,5MK-5A_A,U.S. Senate,,DEM,Massie Munroe,2
-Humboldt,5MK-5A_A,U.S. Senate,,IND,Mike Beitiks,2
-Humboldt,5MK-5A_A,U.S. Senate,,GRN,Pamela Elizondo,4
-Humboldt,5MK-5A_A,U.S. Senate,,IND,Paul Merritt,2
-Humboldt,5MK-5A_A,U.S. Senate,,REP,Phil Wyman,7
-Humboldt,5MK-5A_A,U.S. Senate,,IND,Scott A. Vineberg,1
-Humboldt,5MK-5A_A,U.S. Senate,,DEM,Steve Stokes,3
-Humboldt,5MK-5A_A,U.S. Senate,,REP,Thomas G. Del Beccaro,3
-Humboldt,5MK-5A_A,U.S. Senate,,REP,Von Hougo,2
-Humboldt,5MK-5_A,President,,AIP,Alan Spears,1
-Humboldt,5MK-5_A,President,,REP,Ben Carson,4
-Humboldt,5MK-5_A,President,,DEM,Bernie Sanders,68
-Humboldt,5MK-5_A,President,,REP,Donald Trump,43
-Humboldt,5MK-5_A,President,,DEM,Hillary Clinton,67
-Humboldt,5MK-5_A,President,,GRN,Jill Stein,1
-Humboldt,5MK-5_A,President,,LIB,John McAfee,1
-Humboldt,5MK-5_A,President,,REP,John R. Kasich,12
-Humboldt,5MK-5_A,President,,AIP,Robert Ornelas,1
-Humboldt,5MK-5_A,President,,REP,Ted Cruz,7
-Humboldt,5MK-5_A,President,,DEM,Willie Wilson,1
-Humboldt,5MK-5_A,Proposition 50,,,No,35
-Humboldt,5MK-5_A,Proposition 50,,,Yes,165
-Humboldt,5MK-5_A,State Assembly,2,DEM,Jim Wood,154
-Humboldt,5MK-5_A,U.S. House,2,REP,Dale K. Mensing,45
-Humboldt,5MK-5_A,U.S. House,2,DEM,Erin A. Schrode,7
-Humboldt,5MK-5_A,U.S. House,2,DEM,Jared W. Huffman,142
-Humboldt,5MK-5_A,U.S. House,2,IND,Matthew Robert Wookey,12
-Humboldt,5MK-5_A,U.S. Senate,,IND,Clive Grey,2
-Humboldt,5MK-5_A,U.S. Senate,,REP,Don Krampe,2
-Humboldt,5MK-5_A,U.S. Senate,,REP,Duf Sundheim,7
-Humboldt,5MK-5_A,U.S. Senate,,LIB,Gail K. Lightfoot,3
-Humboldt,5MK-5_A,U.S. Senate,,REP,George C. Yang,1
-Humboldt,5MK-5_A,U.S. Senate,,REP,Greg Conlon,18
-Humboldt,5MK-5_A,U.S. Senate,,REP,Jarrell Williamson,4
-Humboldt,5MK-5_A,U.S. Senate,,REP,Jerry J. Laws,12
-Humboldt,5MK-5_A,U.S. Senate,,PAF,John Thompson Parker,1
-Humboldt,5MK-5_A,U.S. Senate,,DEM,Kamala D. Harris,93
-Humboldt,5MK-5_A,U.S. Senate,,REP,Karen Roseberry,1
-Humboldt,5MK-5_A,U.S. Senate,,DEM,Loretta L. Sanchez,27
-Humboldt,5MK-5_A,U.S. Senate,,DEM,Massie Munroe,2
-Humboldt,5MK-5_A,U.S. Senate,,IND,Mike Beitiks,3
-Humboldt,5MK-5_A,U.S. Senate,,GRN,Pamela Elizondo,2
-Humboldt,5MK-5_A,U.S. Senate,,REP,Phil Wyman,8
-Humboldt,5MK-5_A,U.S. Senate,,REP,Ron Unz,2
-Humboldt,5MK-5_A,U.S. Senate,,DEM,Steve Stokes,4
-Humboldt,5MK-5_A,U.S. Senate,,REP,Thomas G. Del Beccaro,3
-Humboldt,5MK-5_A,U.S. Senate,,IND,Tim Gildersleeve,2
-Humboldt,5MK-5_A,U.S. Senate,,REP,Tom Palzer,2
-Humboldt,5MK-5_A,U.S. Senate,,REP,Von Hougo,5
-Humboldt,5MK-6,President,,REP,Ben Carson,1
-Humboldt,5MK-6,President,,DEM,Bernie Sanders,152
-Humboldt,5MK-6,President,,REP,Donald Trump,31
-Humboldt,5MK-6,President,,DEM,Hillary Clinton,40
+Humboldt,5MK-5,U.S. Senate,,REP,Ron Unz,9
+Humboldt,5MK-5,U.S. Senate,,IND,Scott A. Vineberg,1
+Humboldt,5MK-5,U.S. Senate,,DEM,Steve Stokes,33
+Humboldt,5MK-5,U.S. Senate,,REP,Thomas G. Del Beccaro,14
+Humboldt,5MK-5,U.S. Senate,,IND,Tim Gildersleeve,4
+Humboldt,5MK-5,U.S. Senate,,REP,Tom Palzer,7
+Humboldt,5MK-5,U.S. Senate,,REP,Von Hougo,12
+Humboldt,5MK-6,President,,REP,Ben Carson,6
+Humboldt,5MK-6,President,,DEM,Bernie Sanders,380
+Humboldt,5MK-6,President,,GRN,Darryl Cherney,1
+Humboldt,5MK-6,President,,REP,Donald Trump,108
+Humboldt,5MK-6,President,,DEM,Hillary Clinton,119
 Humboldt,5MK-6,President,,AIP,James Hedges,1
+Humboldt,5MK-6,President,,GRN,Jill Stein,3
 Humboldt,5MK-6,President,,REP,Jim Gilmore,1
-Humboldt,5MK-6,President,,REP,John R. Kasich,2
-Humboldt,5MK-6,President,,AIP,Robert Ornelas,1
-Humboldt,5MK-6,President,,REP,Ted Cruz,8
-Humboldt,5MK-6,Proposition 50,,,No,47
-Humboldt,5MK-6,Proposition 50,,,Yes,163
-Humboldt,5MK-6,State Assembly,2,DEM,Jim Wood,178
-Humboldt,5MK-6,U.S. House,2,REP,Dale K. Mensing,33
-Humboldt,5MK-6,U.S. House,2,DEM,Erin A. Schrode,29
-Humboldt,5MK-6,U.S. House,2,DEM,Jared W. Huffman,130
-Humboldt,5MK-6,U.S. House,2,IND,Matthew Robert Wookey,31
-Humboldt,5MK-6,U.S. Senate,,IND,Clive Grey,1
-Humboldt,5MK-6,U.S. Senate,,REP,Don Krampe,4
-Humboldt,5MK-6,U.S. Senate,,REP,Duf Sundheim,10
-Humboldt,5MK-6,U.S. Senate,,IND,Eleanor García,2
-Humboldt,5MK-6,U.S. Senate,,DEM,Emory Rodgers,2
-Humboldt,5MK-6,U.S. Senate,,LIB,Gail K. Lightfoot,9
+Humboldt,5MK-6,President,,REP,John R. Kasich,12
+Humboldt,5MK-6,President,,DEM,Keith Judd,3
+Humboldt,5MK-6,President,,DEM,Michael Steinberg,2
+Humboldt,5MK-6,President,,AIP,Robert Ornelas,2
+Humboldt,5MK-6,President,,REP,Ted Cruz,28
+Humboldt,5MK-6,President,,DEM,Willie Wilson,2
+Humboldt,5MK-6,Proposition 50,,,No,143
+Humboldt,5MK-6,Proposition 50,,,Yes,500
+Humboldt,5MK-6,State Assembly,2,DEM,Jim Wood,514
+Humboldt,5MK-6,U.S. House,2,REP,Dale K. Mensing,119
+Humboldt,5MK-6,U.S. House,2,DEM,Erin A. Schrode,78
+Humboldt,5MK-6,U.S. House,2,DEM,Jared W. Huffman,403
+Humboldt,5MK-6,U.S. House,2,IND,Matthew Robert Wookey,66
+Humboldt,5MK-6,U.S. Senate,,IND,Clive Grey,2
+Humboldt,5MK-6,U.S. Senate,,REP,Don Krampe,8
+Humboldt,5MK-6,U.S. Senate,,REP,Duf Sundheim,39
+Humboldt,5MK-6,U.S. Senate,,IND,Eleanor García,3
+Humboldt,5MK-6,U.S. Senate,,DEM,Emory Rodgers,3
+Humboldt,5MK-6,U.S. Senate,,LIB,Gail K. Lightfoot,30
 Humboldt,5MK-6,U.S. Senate,,IND,Gar Myers,1
-Humboldt,5MK-6,U.S. Senate,,REP,Greg Conlon,7
-Humboldt,5MK-6,U.S. Senate,,REP,Jarrell Williamson,2
-Humboldt,5MK-6,U.S. Senate,,IND,Jason Hanania,1
-Humboldt,5MK-6,U.S. Senate,,IND,Jason Kraus,1
-Humboldt,5MK-6,U.S. Senate,,REP,Jerry J. Laws,3
-Humboldt,5MK-6,U.S. Senate,,PAF,John Thompson Parker,1
-Humboldt,5MK-6,U.S. Senate,,DEM,Kamala D. Harris,72
-Humboldt,5MK-6,U.S. Senate,,REP,Karen Roseberry,1
-Humboldt,5MK-6,U.S. Senate,,IND,Ling Ling Shi,3
-Humboldt,5MK-6,U.S. Senate,,DEM,Loretta L. Sanchez,38
-Humboldt,5MK-6,U.S. Senate,,LIB,Mark Matthew Herd,1
-Humboldt,5MK-6,U.S. Senate,,DEM,Massie Munroe,12
-Humboldt,5MK-6,U.S. Senate,,IND,Mike Beitiks,3
-Humboldt,5MK-6,U.S. Senate,,GRN,Pamela Elizondo,16
-Humboldt,5MK-6,U.S. Senate,,REP,Phil Wyman,18
-Humboldt,5MK-6,U.S. Senate,,REP,Ron Unz,1
+Humboldt,5MK-6,U.S. Senate,,REP,George C. Yang,2
+Humboldt,5MK-6,U.S. Senate,,REP,Greg Conlon,20
+Humboldt,5MK-6,U.S. Senate,,DEM,Herbert G. Peters,1
+Humboldt,5MK-6,U.S. Senate,,REP,Jarrell Williamson,6
+Humboldt,5MK-6,U.S. Senate,,IND,Jason Hanania,4
+Humboldt,5MK-6,U.S. Senate,,IND,Jason Kraus,5
+Humboldt,5MK-6,U.S. Senate,,REP,Jerry J. Laws,21
+Humboldt,5MK-6,U.S. Senate,,PAF,John Thompson Parker,2
+Humboldt,5MK-6,U.S. Senate,,DEM,Kamala D. Harris,217
+Humboldt,5MK-6,U.S. Senate,,REP,Karen Roseberry,8
+Humboldt,5MK-6,U.S. Senate,,IND,Ling Ling Shi,9
+Humboldt,5MK-6,U.S. Senate,,DEM,Loretta L. Sanchez,123
+Humboldt,5MK-6,U.S. Senate,,LIB,Mark Matthew Herd,2
+Humboldt,5MK-6,U.S. Senate,,DEM,Massie Munroe,18
+Humboldt,5MK-6,U.S. Senate,,IND,Mike Beitiks,6
+Humboldt,5MK-6,U.S. Senate,,GRN,Pamela Elizondo,30
+Humboldt,5MK-6,U.S. Senate,,REP,Phil Wyman,42
+Humboldt,5MK-6,U.S. Senate,,REP,Ron Unz,2
 Humboldt,5MK-6,U.S. Senate,,IND,Scott A. Vineberg,2
-Humboldt,5MK-6,U.S. Senate,,DEM,Steve Stokes,14
-Humboldt,5MK-6,U.S. Senate,,REP,Thomas G. Del Beccaro,2
-Humboldt,5MK-6,U.S. Senate,,REP,Tom Palzer,1
-Humboldt,5MK-6,U.S. Senate,,REP,Von Hougo,2
-Humboldt,5MK-6A,President,,REP,Ben Carson,4
-Humboldt,5MK-6A,President,,DEM,Bernie Sanders,123
-Humboldt,5MK-6A,President,,REP,Donald Trump,29
-Humboldt,5MK-6A,President,,DEM,Hillary Clinton,28
-Humboldt,5MK-6A,President,,GRN,Jill Stein,2
-Humboldt,5MK-6A,President,,REP,John R. Kasich,3
-Humboldt,5MK-6A,President,,REP,Ted Cruz,9
-Humboldt,5MK-6A,President,,DEM,Willie Wilson,1
-Humboldt,5MK-6A,Proposition 50,,,No,51
-Humboldt,5MK-6A,Proposition 50,,,Yes,145
-Humboldt,5MK-6A,State Assembly,2,DEM,Jim Wood,156
-Humboldt,5MK-6A,U.S. House,2,REP,Dale K. Mensing,33
-Humboldt,5MK-6A,U.S. House,2,DEM,Erin A. Schrode,33
-Humboldt,5MK-6A,U.S. House,2,DEM,Jared W. Huffman,121
-Humboldt,5MK-6A,U.S. House,2,IND,Matthew Robert Wookey,19
-Humboldt,5MK-6A,U.S. Senate,,REP,Don Krampe,1
-Humboldt,5MK-6A,U.S. Senate,,REP,Duf Sundheim,14
-Humboldt,5MK-6A,U.S. Senate,,DEM,Emory Rodgers,1
-Humboldt,5MK-6A,U.S. Senate,,LIB,Gail K. Lightfoot,11
-Humboldt,5MK-6A,U.S. Senate,,REP,George C. Yang,2
-Humboldt,5MK-6A,U.S. Senate,,REP,Greg Conlon,1
-Humboldt,5MK-6A,U.S. Senate,,DEM,Herbert G. Peters,1
-Humboldt,5MK-6A,U.S. Senate,,REP,Jarrell Williamson,1
-Humboldt,5MK-6A,U.S. Senate,,IND,Jason Hanania,2
-Humboldt,5MK-6A,U.S. Senate,,IND,Jason Kraus,3
-Humboldt,5MK-6A,U.S. Senate,,REP,Jerry J. Laws,11
-Humboldt,5MK-6A,U.S. Senate,,PAF,John Thompson Parker,1
-Humboldt,5MK-6A,U.S. Senate,,DEM,Kamala D. Harris,62
-Humboldt,5MK-6A,U.S. Senate,,REP,Karen Roseberry,3
-Humboldt,5MK-6A,U.S. Senate,,IND,Ling Ling Shi,1
-Humboldt,5MK-6A,U.S. Senate,,DEM,Loretta L. Sanchez,36
-Humboldt,5MK-6A,U.S. Senate,,LIB,Mark Matthew Herd,1
-Humboldt,5MK-6A,U.S. Senate,,DEM,Massie Munroe,5
-Humboldt,5MK-6A,U.S. Senate,,IND,Mike Beitiks,2
-Humboldt,5MK-6A,U.S. Senate,,GRN,Pamela Elizondo,12
-Humboldt,5MK-6A,U.S. Senate,,REP,Phil Wyman,7
-Humboldt,5MK-6A,U.S. Senate,,DEM,Steve Stokes,16
-Humboldt,5MK-6A,U.S. Senate,,REP,Tom Palzer,1
-Humboldt,5MK-6A,U.S. Senate,,REP,Von Hougo,2
-Humboldt,5MK-6A_A,President,,DEM,Bernie Sanders,42
-Humboldt,5MK-6A_A,President,,REP,Donald Trump,18
-Humboldt,5MK-6A_A,President,,DEM,Hillary Clinton,17
-Humboldt,5MK-6A_A,President,,GRN,Jill Stein,1
-Humboldt,5MK-6A_A,President,,REP,John R. Kasich,1
-Humboldt,5MK-6A_A,President,,DEM,Michael Steinberg,1
-Humboldt,5MK-6A_A,President,,AIP,Robert Ornelas,1
-Humboldt,5MK-6A_A,President,,REP,Ted Cruz,5
-Humboldt,5MK-6A_A,Proposition 50,,,No,16
-Humboldt,5MK-6A_A,Proposition 50,,,Yes,64
-Humboldt,5MK-6A_A,State Assembly,2,DEM,Jim Wood,58
-Humboldt,5MK-6A_A,U.S. House,2,REP,Dale K. Mensing,19
-Humboldt,5MK-6A_A,U.S. House,2,DEM,Erin A. Schrode,4
-Humboldt,5MK-6A_A,U.S. House,2,DEM,Jared W. Huffman,55
-Humboldt,5MK-6A_A,U.S. House,2,IND,Matthew Robert Wookey,4
-Humboldt,5MK-6A_A,U.S. Senate,,IND,Clive Grey,1
-Humboldt,5MK-6A_A,U.S. Senate,,REP,Don Krampe,3
-Humboldt,5MK-6A_A,U.S. Senate,,REP,Duf Sundheim,3
-Humboldt,5MK-6A_A,U.S. Senate,,LIB,Gail K. Lightfoot,2
-Humboldt,5MK-6A_A,U.S. Senate,,REP,Greg Conlon,5
-Humboldt,5MK-6A_A,U.S. Senate,,IND,Jason Hanania,1
-Humboldt,5MK-6A_A,U.S. Senate,,IND,Jason Kraus,1
-Humboldt,5MK-6A_A,U.S. Senate,,REP,Jerry J. Laws,1
-Humboldt,5MK-6A_A,U.S. Senate,,DEM,Kamala D. Harris,32
-Humboldt,5MK-6A_A,U.S. Senate,,REP,Karen Roseberry,1
-Humboldt,5MK-6A_A,U.S. Senate,,IND,Ling Ling Shi,1
-Humboldt,5MK-6A_A,U.S. Senate,,DEM,Loretta L. Sanchez,18
-Humboldt,5MK-6A_A,U.S. Senate,,IND,Mike Beitiks,1
-Humboldt,5MK-6A_A,U.S. Senate,,REP,Phil Wyman,6
-Humboldt,5MK-6A_A,U.S. Senate,,DEM,Steve Stokes,1
-Humboldt,5MK-6A_A,U.S. Senate,,REP,Von Hougo,2
-Humboldt,5MK-6_A,President,,REP,Ben Carson,1
-Humboldt,5MK-6_A,President,,DEM,Bernie Sanders,63
-Humboldt,5MK-6_A,President,,GRN,Darryl Cherney,1
-Humboldt,5MK-6_A,President,,REP,Donald Trump,30
-Humboldt,5MK-6_A,President,,DEM,Hillary Clinton,34
-Humboldt,5MK-6_A,President,,REP,John R. Kasich,6
-Humboldt,5MK-6_A,President,,DEM,Keith Judd,3
-Humboldt,5MK-6_A,President,,DEM,Michael Steinberg,1
-Humboldt,5MK-6_A,President,,REP,Ted Cruz,6
-Humboldt,5MK-6_A,President,,DEM,Willie Wilson,1
-Humboldt,5MK-6_A,Proposition 50,,,No,29
-Humboldt,5MK-6_A,Proposition 50,,,Yes,128
-Humboldt,5MK-6_A,State Assembly,2,DEM,Jim Wood,122
-Humboldt,5MK-6_A,U.S. House,2,REP,Dale K. Mensing,34
-Humboldt,5MK-6_A,U.S. House,2,DEM,Erin A. Schrode,12
-Humboldt,5MK-6_A,U.S. House,2,DEM,Jared W. Huffman,97
-Humboldt,5MK-6_A,U.S. House,2,IND,Matthew Robert Wookey,12
-Humboldt,5MK-6_A,U.S. Senate,,REP,Duf Sundheim,12
-Humboldt,5MK-6_A,U.S. Senate,,IND,Eleanor García,1
-Humboldt,5MK-6_A,U.S. Senate,,LIB,Gail K. Lightfoot,8
-Humboldt,5MK-6_A,U.S. Senate,,REP,Greg Conlon,7
-Humboldt,5MK-6_A,U.S. Senate,,REP,Jarrell Williamson,3
-Humboldt,5MK-6_A,U.S. Senate,,REP,Jerry J. Laws,6
-Humboldt,5MK-6_A,U.S. Senate,,DEM,Kamala D. Harris,51
-Humboldt,5MK-6_A,U.S. Senate,,REP,Karen Roseberry,3
-Humboldt,5MK-6_A,U.S. Senate,,IND,Ling Ling Shi,4
-Humboldt,5MK-6_A,U.S. Senate,,DEM,Loretta L. Sanchez,31
-Humboldt,5MK-6_A,U.S. Senate,,DEM,Massie Munroe,1
-Humboldt,5MK-6_A,U.S. Senate,,GRN,Pamela Elizondo,2
-Humboldt,5MK-6_A,U.S. Senate,,REP,Phil Wyman,11
-Humboldt,5MK-6_A,U.S. Senate,,REP,Ron Unz,1
-Humboldt,5MK-6_A,U.S. Senate,,DEM,Steve Stokes,8
-Humboldt,5MK-6_A,U.S. Senate,,REP,Thomas G. Del Beccaro,1
-Humboldt,5MK-6_A,U.S. Senate,,REP,Tom Palzer,2
+Humboldt,5MK-6,U.S. Senate,,DEM,Steve Stokes,39
+Humboldt,5MK-6,U.S. Senate,,REP,Thomas G. Del Beccaro,3
+Humboldt,5MK-6,U.S. Senate,,REP,Tom Palzer,4
+Humboldt,5MK-6,U.S. Senate,,REP,Von Hougo,6
 Humboldt,5MK-7,President,,AIP,Arthur Harris,1
-Humboldt,5MK-7,President,,REP,Ben Carson,3
-Humboldt,5MK-7,President,,DEM,Bernie Sanders,103
-Humboldt,5MK-7,President,,REP,Donald Trump,44
+Humboldt,5MK-7,President,,REP,Ben Carson,5
+Humboldt,5MK-7,President,,DEM,Bernie Sanders,160
+Humboldt,5MK-7,President,,REP,Donald Trump,87
 Humboldt,5MK-7,President,,LIB,Gary Johnson,1
-Humboldt,5MK-7,President,,DEM,Hillary Clinton,74
-Humboldt,5MK-7,President,,GRN,Jill Stein,1
+Humboldt,5MK-7,President,,DEM,Henry Hewes,1
+Humboldt,5MK-7,President,,DEM,Hillary Clinton,109
+Humboldt,5MK-7,President,,GRN,Jill Stein,2
 Humboldt,5MK-7,President,,LIB,John Hale,1
-Humboldt,5MK-7,President,,REP,John R. Kasich,6
+Humboldt,5MK-7,President,,REP,John R. Kasich,10
 Humboldt,5MK-7,President,,LIB,Marc Feldman,1
-Humboldt,5MK-7,President,,REP,Ted Cruz,7
-Humboldt,5MK-7,Proposition 50,,,No,50
-Humboldt,5MK-7,Proposition 50,,,Yes,159
-Humboldt,5MK-7,State Assembly,2,DEM,Jim Wood,164
-Humboldt,5MK-7,U.S. House,2,REP,Dale K. Mensing,50
-Humboldt,5MK-7,U.S. House,2,DEM,Erin A. Schrode,20
-Humboldt,5MK-7,U.S. House,2,DEM,Jared W. Huffman,140
-Humboldt,5MK-7,U.S. House,2,IND,Matthew Robert Wookey,15
+Humboldt,5MK-7,President,,DEM,Roque De La Fuente,1
+Humboldt,5MK-7,President,,REP,Ted Cruz,13
+Humboldt,5MK-7,Proposition 50,,,No,77
+Humboldt,5MK-7,Proposition 50,,,Yes,285
+Humboldt,5MK-7,State Assembly,2,DEM,Jim Wood,289
+Humboldt,5MK-7,U.S. House,2,REP,Dale K. Mensing,88
+Humboldt,5MK-7,U.S. House,2,DEM,Erin A. Schrode,25
+Humboldt,5MK-7,U.S. House,2,DEM,Jared W. Huffman,251
+Humboldt,5MK-7,U.S. House,2,IND,Matthew Robert Wookey,22
 Humboldt,5MK-7,U.S. Senate,,IND,Clive Grey,2
 Humboldt,5MK-7,U.S. Senate,,IND,Don J. Grundmann,1
-Humboldt,5MK-7,U.S. Senate,,REP,Don Krampe,4
-Humboldt,5MK-7,U.S. Senate,,REP,Duf Sundheim,2
-Humboldt,5MK-7,U.S. Senate,,IND,Eleanor García,1
-Humboldt,5MK-7,U.S. Senate,,LIB,Gail K. Lightfoot,10
-Humboldt,5MK-7,U.S. Senate,,REP,George C. Yang,2
-Humboldt,5MK-7,U.S. Senate,,REP,Greg Conlon,12
-Humboldt,5MK-7,U.S. Senate,,REP,Jarrell Williamson,3
+Humboldt,5MK-7,U.S. Senate,,REP,Don Krampe,7
+Humboldt,5MK-7,U.S. Senate,,REP,Duf Sundheim,10
+Humboldt,5MK-7,U.S. Senate,,IND,Eleanor García,3
+Humboldt,5MK-7,U.S. Senate,,LIB,Gail K. Lightfoot,14
+Humboldt,5MK-7,U.S. Senate,,REP,George C. Yang,3
+Humboldt,5MK-7,U.S. Senate,,REP,Greg Conlon,20
+Humboldt,5MK-7,U.S. Senate,,REP,Jarrell Williamson,4
+Humboldt,5MK-7,U.S. Senate,,IND,Jason Hanania,1
 Humboldt,5MK-7,U.S. Senate,,IND,Jason Kraus,1
-Humboldt,5MK-7,U.S. Senate,,REP,Jerry J. Laws,13
+Humboldt,5MK-7,U.S. Senate,,REP,Jerry J. Laws,18
 Humboldt,5MK-7,U.S. Senate,,PAF,John Thompson Parker,1
-Humboldt,5MK-7,U.S. Senate,,DEM,Kamala D. Harris,89
-Humboldt,5MK-7,U.S. Senate,,REP,Karen Roseberry,1
-Humboldt,5MK-7,U.S. Senate,,IND,Ling Ling Shi,3
-Humboldt,5MK-7,U.S. Senate,,DEM,Loretta L. Sanchez,26
+Humboldt,5MK-7,U.S. Senate,,DEM,Kamala D. Harris,142
+Humboldt,5MK-7,U.S. Senate,,REP,Karen Roseberry,3
+Humboldt,5MK-7,U.S. Senate,,IND,Ling Ling Shi,6
+Humboldt,5MK-7,U.S. Senate,,DEM,Loretta L. Sanchez,54
 Humboldt,5MK-7,U.S. Senate,,LIB,Mark Matthew Herd,3
-Humboldt,5MK-7,U.S. Senate,,DEM,Massie Munroe,2
-Humboldt,5MK-7,U.S. Senate,,IND,Mike Beitiks,3
-Humboldt,5MK-7,U.S. Senate,,GRN,Pamela Elizondo,8
-Humboldt,5MK-7,U.S. Senate,,REP,Phil Wyman,8
+Humboldt,5MK-7,U.S. Senate,,DEM,Massie Munroe,4
+Humboldt,5MK-7,U.S. Senate,,IND,Mike Beitiks,5
+Humboldt,5MK-7,U.S. Senate,,GRN,Pamela Elizondo,17
+Humboldt,5MK-7,U.S. Senate,,IND,Paul Merritt,1
+Humboldt,5MK-7,U.S. Senate,,REP,Phil Wyman,18
 Humboldt,5MK-7,U.S. Senate,,DEM,President Cristina Grappo,1
-Humboldt,5MK-7,U.S. Senate,,REP,Ron Unz,5
-Humboldt,5MK-7,U.S. Senate,,DEM,Steve Stokes,9
-Humboldt,5MK-7,U.S. Senate,,REP,Thomas G. Del Beccaro,10
-Humboldt,5MK-7,U.S. Senate,,REP,Tom Palzer,1
+Humboldt,5MK-7,U.S. Senate,,REP,Ron Unz,9
+Humboldt,5MK-7,U.S. Senate,,DEM,Steve Stokes,15
+Humboldt,5MK-7,U.S. Senate,,REP,Thomas G. Del Beccaro,16
+Humboldt,5MK-7,U.S. Senate,,REP,Tom Palzer,3
 Humboldt,5MK-7,U.S. Senate,,REP,Von Hougo,2
-Humboldt,5MK-7_A,President,,REP,Ben Carson,2
-Humboldt,5MK-7_A,President,,DEM,Bernie Sanders,57
-Humboldt,5MK-7_A,President,,REP,Donald Trump,43
-Humboldt,5MK-7_A,President,,DEM,Henry Hewes,1
-Humboldt,5MK-7_A,President,,DEM,Hillary Clinton,35
-Humboldt,5MK-7_A,President,,GRN,Jill Stein,1
-Humboldt,5MK-7_A,President,,REP,John R. Kasich,4
-Humboldt,5MK-7_A,President,,DEM,Roque De La Fuente,1
-Humboldt,5MK-7_A,President,,REP,Ted Cruz,6
-Humboldt,5MK-7_A,Proposition 50,,,No,27
-Humboldt,5MK-7_A,Proposition 50,,,Yes,126
-Humboldt,5MK-7_A,State Assembly,2,DEM,Jim Wood,125
-Humboldt,5MK-7_A,U.S. House,2,REP,Dale K. Mensing,38
-Humboldt,5MK-7_A,U.S. House,2,DEM,Erin A. Schrode,5
-Humboldt,5MK-7_A,U.S. House,2,DEM,Jared W. Huffman,111
-Humboldt,5MK-7_A,U.S. House,2,IND,Matthew Robert Wookey,7
-Humboldt,5MK-7_A,U.S. Senate,,REP,Don Krampe,3
-Humboldt,5MK-7_A,U.S. Senate,,REP,Duf Sundheim,8
-Humboldt,5MK-7_A,U.S. Senate,,IND,Eleanor García,2
-Humboldt,5MK-7_A,U.S. Senate,,LIB,Gail K. Lightfoot,4
-Humboldt,5MK-7_A,U.S. Senate,,REP,George C. Yang,1
-Humboldt,5MK-7_A,U.S. Senate,,REP,Greg Conlon,8
-Humboldt,5MK-7_A,U.S. Senate,,REP,Jarrell Williamson,1
-Humboldt,5MK-7_A,U.S. Senate,,IND,Jason Hanania,1
-Humboldt,5MK-7_A,U.S. Senate,,REP,Jerry J. Laws,5
-Humboldt,5MK-7_A,U.S. Senate,,DEM,Kamala D. Harris,53
-Humboldt,5MK-7_A,U.S. Senate,,REP,Karen Roseberry,2
-Humboldt,5MK-7_A,U.S. Senate,,IND,Ling Ling Shi,3
-Humboldt,5MK-7_A,U.S. Senate,,DEM,Loretta L. Sanchez,28
-Humboldt,5MK-7_A,U.S. Senate,,DEM,Massie Munroe,2
-Humboldt,5MK-7_A,U.S. Senate,,IND,Mike Beitiks,2
-Humboldt,5MK-7_A,U.S. Senate,,GRN,Pamela Elizondo,9
-Humboldt,5MK-7_A,U.S. Senate,,IND,Paul Merritt,1
-Humboldt,5MK-7_A,U.S. Senate,,REP,Phil Wyman,10
-Humboldt,5MK-7_A,U.S. Senate,,REP,Ron Unz,4
-Humboldt,5MK-7_A,U.S. Senate,,DEM,Steve Stokes,6
-Humboldt,5MK-7_A,U.S. Senate,,REP,Thomas G. Del Beccaro,6
-Humboldt,5MK-7_A,U.S. Senate,,REP,Tom Palzer,2
-Humboldt,5MK-8,President,,AIP,Arthur Harris,1
-Humboldt,5MK-8,President,,REP,Ben Carson,7
-Humboldt,5MK-8,President,,DEM,Bernie Sanders,200
+Humboldt,5MK-8,President,,AIP,Arthur Harris,2
+Humboldt,5MK-8,President,,REP,Ben Carson,9
+Humboldt,5MK-8,President,,DEM,Bernie Sanders,256
 Humboldt,5MK-8,President,,LIB,Derrick M. Reid,1
-Humboldt,5MK-8,President,,REP,Donald Trump,40
+Humboldt,5MK-8,President,,REP,Donald Trump,59
 Humboldt,5MK-8,President,,LIB,Gary Johnson,3
 Humboldt,5MK-8,President,,DEM,Henry Hewes,1
-Humboldt,5MK-8,President,,DEM,Hillary Clinton,57
+Humboldt,5MK-8,President,,DEM,Hillary Clinton,100
 Humboldt,5MK-8,President,,AIP,James Hedges,1
 Humboldt,5MK-8,President,,GRN,Jill Stein,1
-Humboldt,5MK-8,President,,REP,John R. Kasich,4
+Humboldt,5MK-8,President,,REP,Jim Gilmore,2
+Humboldt,5MK-8,President,,REP,John R. Kasich,7
 Humboldt,5MK-8,President,,DEM,Keith Judd,1
-Humboldt,5MK-8,President,,REP,Ted Cruz,8
+Humboldt,5MK-8,President,,DEM,Michael Steinberg,1
+Humboldt,5MK-8,President,,REP,Ted Cruz,10
 Humboldt,5MK-8,President,,AIP,Thomas Hoefling,1
-Humboldt,5MK-8,Proposition 50,,,No,59
-Humboldt,5MK-8,Proposition 50,,,Yes,237
-Humboldt,5MK-8,State Assembly,2,DEM,Jim Wood,252
-Humboldt,5MK-8,U.S. House,2,REP,Dale K. Mensing,49
-Humboldt,5MK-8,U.S. House,2,DEM,Erin A. Schrode,16
-Humboldt,5MK-8,U.S. House,2,DEM,Jared W. Huffman,234
-Humboldt,5MK-8,U.S. House,2,IND,Matthew Robert Wookey,24
-Humboldt,5MK-8,U.S. Senate,,IND,Clive Grey,3
+Humboldt,5MK-8,Proposition 50,,,No,80
+Humboldt,5MK-8,Proposition 50,,,Yes,349
+Humboldt,5MK-8,State Assembly,2,DEM,Jim Wood,362
+Humboldt,5MK-8,U.S. House,2,REP,Dale K. Mensing,70
+Humboldt,5MK-8,U.S. House,2,DEM,Erin A. Schrode,24
+Humboldt,5MK-8,U.S. House,2,DEM,Jared W. Huffman,337
+Humboldt,5MK-8,U.S. House,2,IND,Matthew Robert Wookey,31
+Humboldt,5MK-8,U.S. Senate,,IND,Clive Grey,4
 Humboldt,5MK-8,U.S. Senate,,REP,Don Krampe,1
-Humboldt,5MK-8,U.S. Senate,,REP,Duf Sundheim,8
+Humboldt,5MK-8,U.S. Senate,,REP,Duf Sundheim,13
 Humboldt,5MK-8,U.S. Senate,,IND,Eleanor García,1
 Humboldt,5MK-8,U.S. Senate,,DEM,Emory Rodgers,1
-Humboldt,5MK-8,U.S. Senate,,LIB,Gail K. Lightfoot,10
-Humboldt,5MK-8,U.S. Senate,,REP,George C. Yang,1
-Humboldt,5MK-8,U.S. Senate,,REP,Greg Conlon,8
-Humboldt,5MK-8,U.S. Senate,,DEM,Herbert G. Peters,2
-Humboldt,5MK-8,U.S. Senate,,REP,Jarrell Williamson,4
+Humboldt,5MK-8,U.S. Senate,,LIB,Gail K. Lightfoot,15
+Humboldt,5MK-8,U.S. Senate,,REP,George C. Yang,2
+Humboldt,5MK-8,U.S. Senate,,REP,Greg Conlon,11
+Humboldt,5MK-8,U.S. Senate,,DEM,Herbert G. Peters,3
+Humboldt,5MK-8,U.S. Senate,,REP,Jarrell Williamson,5
 Humboldt,5MK-8,U.S. Senate,,IND,Jason Hanania,1
-Humboldt,5MK-8,U.S. Senate,,IND,Jason Kraus,2
-Humboldt,5MK-8,U.S. Senate,,REP,Jerry J. Laws,9
-Humboldt,5MK-8,U.S. Senate,,PAF,John Thompson Parker,1
-Humboldt,5MK-8,U.S. Senate,,DEM,Kamala D. Harris,138
+Humboldt,5MK-8,U.S. Senate,,IND,Jason Kraus,3
+Humboldt,5MK-8,U.S. Senate,,REP,Jerry J. Laws,11
+Humboldt,5MK-8,U.S. Senate,,PAF,John Thompson Parker,2
+Humboldt,5MK-8,U.S. Senate,,DEM,Kamala D. Harris,203
+Humboldt,5MK-8,U.S. Senate,,REP,Karen Roseberry,2
 Humboldt,5MK-8,U.S. Senate,,IND,Ling Ling Shi,1
-Humboldt,5MK-8,U.S. Senate,,DEM,Loretta L. Sanchez,48
-Humboldt,5MK-8,U.S. Senate,,DEM,Massie Munroe,6
-Humboldt,5MK-8,U.S. Senate,,IND,Mike Beitiks,2
+Humboldt,5MK-8,U.S. Senate,,DEM,Loretta L. Sanchez,69
+Humboldt,5MK-8,U.S. Senate,,LIB,Mark Matthew Herd,2
+Humboldt,5MK-8,U.S. Senate,,DEM,Massie Munroe,8
+Humboldt,5MK-8,U.S. Senate,,IND,Mike Beitiks,5
 Humboldt,5MK-8,U.S. Senate,,GRN,Pamela Elizondo,7
 Humboldt,5MK-8,U.S. Senate,,IND,Paul Merritt,4
-Humboldt,5MK-8,U.S. Senate,,REP,Phil Wyman,20
+Humboldt,5MK-8,U.S. Senate,,REP,Phil Wyman,28
 Humboldt,5MK-8,U.S. Senate,,DEM,President Cristina Grappo,1
 Humboldt,5MK-8,U.S. Senate,,REP,Ron Unz,1
-Humboldt,5MK-8,U.S. Senate,,DEM,Steve Stokes,16
-Humboldt,5MK-8,U.S. Senate,,REP,Thomas G. Del Beccaro,4
-Humboldt,5MK-8,U.S. Senate,,REP,Tom Palzer,2
-Humboldt,5MK-8,U.S. Senate,,REP,Von Hougo,1
-Humboldt,5MK-8_A,President,,AIP,Arthur Harris,1
-Humboldt,5MK-8_A,President,,REP,Ben Carson,2
-Humboldt,5MK-8_A,President,,DEM,Bernie Sanders,56
-Humboldt,5MK-8_A,President,,REP,Donald Trump,19
-Humboldt,5MK-8_A,President,,DEM,Hillary Clinton,43
-Humboldt,5MK-8_A,President,,REP,Jim Gilmore,2
-Humboldt,5MK-8_A,President,,REP,John R. Kasich,3
-Humboldt,5MK-8_A,President,,DEM,Michael Steinberg,1
-Humboldt,5MK-8_A,President,,REP,Ted Cruz,2
-Humboldt,5MK-8_A,Proposition 50,,,No,21
-Humboldt,5MK-8_A,Proposition 50,,,Yes,112
-Humboldt,5MK-8_A,State Assembly,2,DEM,Jim Wood,110
-Humboldt,5MK-8_A,U.S. House,2,REP,Dale K. Mensing,21
-Humboldt,5MK-8_A,U.S. House,2,DEM,Erin A. Schrode,8
-Humboldt,5MK-8_A,U.S. House,2,DEM,Jared W. Huffman,103
-Humboldt,5MK-8_A,U.S. House,2,IND,Matthew Robert Wookey,7
-Humboldt,5MK-8_A,U.S. Senate,,IND,Clive Grey,1
-Humboldt,5MK-8_A,U.S. Senate,,REP,Duf Sundheim,5
-Humboldt,5MK-8_A,U.S. Senate,,LIB,Gail K. Lightfoot,5
-Humboldt,5MK-8_A,U.S. Senate,,REP,George C. Yang,1
-Humboldt,5MK-8_A,U.S. Senate,,REP,Greg Conlon,3
-Humboldt,5MK-8_A,U.S. Senate,,DEM,Herbert G. Peters,1
-Humboldt,5MK-8_A,U.S. Senate,,REP,Jarrell Williamson,1
-Humboldt,5MK-8_A,U.S. Senate,,IND,Jason Kraus,1
-Humboldt,5MK-8_A,U.S. Senate,,REP,Jerry J. Laws,2
-Humboldt,5MK-8_A,U.S. Senate,,PAF,John Thompson Parker,1
-Humboldt,5MK-8_A,U.S. Senate,,DEM,Kamala D. Harris,65
-Humboldt,5MK-8_A,U.S. Senate,,REP,Karen Roseberry,2
-Humboldt,5MK-8_A,U.S. Senate,,DEM,Loretta L. Sanchez,21
-Humboldt,5MK-8_A,U.S. Senate,,LIB,Mark Matthew Herd,2
-Humboldt,5MK-8_A,U.S. Senate,,DEM,Massie Munroe,2
-Humboldt,5MK-8_A,U.S. Senate,,IND,Mike Beitiks,3
-Humboldt,5MK-8_A,U.S. Senate,,REP,Phil Wyman,8
-Humboldt,5MK-8_A,U.S. Senate,,DEM,Steve Stokes,6
-Humboldt,5MK-8_A,U.S. Senate,,REP,Thomas G. Del Beccaro,3
-Humboldt,5MK-8_A,U.S. Senate,,REP,Tom Palzer,2
-Humboldt,5MK-8_A,U.S. Senate,,REP,Von Hougo,3
+Humboldt,5MK-8,U.S. Senate,,DEM,Steve Stokes,22
+Humboldt,5MK-8,U.S. Senate,,REP,Thomas G. Del Beccaro,7
+Humboldt,5MK-8,U.S. Senate,,REP,Tom Palzer,4
+Humboldt,5MK-8,U.S. Senate,,REP,Von Hougo,4
 Humboldt,5OR,President,,REP,Ben Carson,1
 Humboldt,5OR,President,,DEM,Bernie Sanders,23
 Humboldt,5OR,President,,REP,Donald Trump,22
@@ -7560,208 +4775,127 @@ Humboldt,5PA-3,U.S. Senate,,REP,Phil Wyman,2
 Humboldt,5PA-3,U.S. Senate,,DEM,Steve Stokes,1
 Humboldt,5PA-3,U.S. Senate,,REP,Thomas G. Del Beccaro,2
 Humboldt,5PA-3,U.S. Senate,,REP,Von Hougo,1
-Humboldt,5T--1,President,,DEM,Bernie Sanders,55
+Humboldt,5T--1,President,,DEM,Bernie Sanders,77
 Humboldt,5T--1,President,,GRN,Darryl Cherney,1
-Humboldt,5T--1,President,,REP,Donald Trump,4
-Humboldt,5T--1,President,,DEM,Hillary Clinton,24
+Humboldt,5T--1,President,,REP,Donald Trump,12
+Humboldt,5T--1,President,,DEM,Hillary Clinton,49
 Humboldt,5T--1,President,,GRN,Jill Stein,1
-Humboldt,5T--1,President,,REP,John R. Kasich,2
-Humboldt,5T--1,Proposition 50,,,No,19
-Humboldt,5T--1,Proposition 50,,,Yes,60
-Humboldt,5T--1,State Assembly,2,DEM,Jim Wood,72
-Humboldt,5T--1,U.S. House,2,REP,Dale K. Mensing,5
-Humboldt,5T--1,U.S. House,2,DEM,Erin A. Schrode,13
-Humboldt,5T--1,U.S. House,2,DEM,Jared W. Huffman,60
-Humboldt,5T--1,U.S. House,2,IND,Matthew Robert Wookey,3
+Humboldt,5T--1,President,,REP,John R. Kasich,6
+Humboldt,5T--1,President,,DEM,Keith Judd,1
+Humboldt,5T--1,Proposition 50,,,No,30
+Humboldt,5T--1,Proposition 50,,,Yes,106
+Humboldt,5T--1,State Assembly,2,DEM,Jim Wood,121
+Humboldt,5T--1,U.S. House,2,REP,Dale K. Mensing,14
+Humboldt,5T--1,U.S. House,2,DEM,Erin A. Schrode,17
+Humboldt,5T--1,U.S. House,2,DEM,Jared W. Huffman,102
+Humboldt,5T--1,U.S. House,2,IND,Matthew Robert Wookey,6
+Humboldt,5T--1,U.S. Senate,,REP,Don Krampe,2
+Humboldt,5T--1,U.S. Senate,,REP,Duf Sundheim,1
 Humboldt,5T--1,U.S. Senate,,IND,Eleanor García,1
-Humboldt,5T--1,U.S. Senate,,LIB,Gail K. Lightfoot,4
-Humboldt,5T--1,U.S. Senate,,REP,Greg Conlon,2
-Humboldt,5T--1,U.S. Senate,,REP,Jarrell Williamson,1
-Humboldt,5T--1,U.S. Senate,,DEM,Kamala D. Harris,39
-Humboldt,5T--1,U.S. Senate,,DEM,Loretta L. Sanchez,18
+Humboldt,5T--1,U.S. Senate,,LIB,Gail K. Lightfoot,5
+Humboldt,5T--1,U.S. Senate,,REP,Greg Conlon,3
+Humboldt,5T--1,U.S. Senate,,REP,Jarrell Williamson,2
+Humboldt,5T--1,U.S. Senate,,IND,Jason Hanania,2
+Humboldt,5T--1,U.S. Senate,,IND,Jason Kraus,1
+Humboldt,5T--1,U.S. Senate,,DEM,Kamala D. Harris,72
+Humboldt,5T--1,U.S. Senate,,DEM,Loretta L. Sanchez,23
 Humboldt,5T--1,U.S. Senate,,DEM,Massie Munroe,3
-Humboldt,5T--1,U.S. Senate,,IND,Mike Beitiks,1
-Humboldt,5T--1,U.S. Senate,,GRN,Pamela Elizondo,4
-Humboldt,5T--1,U.S. Senate,,REP,Phil Wyman,1
-Humboldt,5T--1,U.S. Senate,,DEM,Steve Stokes,2
-Humboldt,5T--1,U.S. Senate,,REP,Thomas G. Del Beccaro,2
+Humboldt,5T--1,U.S. Senate,,IND,Mike Beitiks,4
+Humboldt,5T--1,U.S. Senate,,GRN,Pamela Elizondo,5
+Humboldt,5T--1,U.S. Senate,,REP,Phil Wyman,3
+Humboldt,5T--1,U.S. Senate,,DEM,Steve Stokes,5
+Humboldt,5T--1,U.S. Senate,,REP,Thomas G. Del Beccaro,4
 Humboldt,5T--1,U.S. Senate,,REP,Tom Palzer,2
 Humboldt,5T--1,U.S. Senate,,REP,Von Hougo,1
-Humboldt,5T--1_A,President,,DEM,Bernie Sanders,22
-Humboldt,5T--1_A,President,,REP,Donald Trump,8
-Humboldt,5T--1_A,President,,DEM,Hillary Clinton,25
-Humboldt,5T--1_A,President,,REP,John R. Kasich,4
-Humboldt,5T--1_A,President,,DEM,Keith Judd,1
-Humboldt,5T--1_A,Proposition 50,,,No,11
-Humboldt,5T--1_A,Proposition 50,,,Yes,46
-Humboldt,5T--1_A,State Assembly,2,DEM,Jim Wood,49
-Humboldt,5T--1_A,U.S. House,2,REP,Dale K. Mensing,9
-Humboldt,5T--1_A,U.S. House,2,DEM,Erin A. Schrode,4
-Humboldt,5T--1_A,U.S. House,2,DEM,Jared W. Huffman,42
-Humboldt,5T--1_A,U.S. House,2,IND,Matthew Robert Wookey,3
-Humboldt,5T--1_A,U.S. Senate,,REP,Don Krampe,2
-Humboldt,5T--1_A,U.S. Senate,,REP,Duf Sundheim,1
-Humboldt,5T--1_A,U.S. Senate,,LIB,Gail K. Lightfoot,1
-Humboldt,5T--1_A,U.S. Senate,,REP,Greg Conlon,1
-Humboldt,5T--1_A,U.S. Senate,,REP,Jarrell Williamson,1
-Humboldt,5T--1_A,U.S. Senate,,IND,Jason Hanania,2
-Humboldt,5T--1_A,U.S. Senate,,IND,Jason Kraus,1
-Humboldt,5T--1_A,U.S. Senate,,DEM,Kamala D. Harris,33
-Humboldt,5T--1_A,U.S. Senate,,DEM,Loretta L. Sanchez,5
-Humboldt,5T--1_A,U.S. Senate,,IND,Mike Beitiks,3
-Humboldt,5T--1_A,U.S. Senate,,GRN,Pamela Elizondo,1
-Humboldt,5T--1_A,U.S. Senate,,REP,Phil Wyman,2
-Humboldt,5T--1_A,U.S. Senate,,DEM,Steve Stokes,3
-Humboldt,5T--1_A,U.S. Senate,,REP,Thomas G. Del Beccaro,2
-Humboldt,5TU-1,President,,REP,Ben Carson,2
-Humboldt,5TU-1,President,,DEM,Bernie Sanders,195
+Humboldt,5TU-1,President,,REP,Ben Carson,4
+Humboldt,5TU-1,President,,DEM,Bernie Sanders,276
 Humboldt,5TU-1,President,,GRN,Darryl Cherney,1
-Humboldt,5TU-1,President,,REP,Donald Trump,22
+Humboldt,5TU-1,President,,REP,Donald Trump,43
 Humboldt,5TU-1,President,,LIB,Gary Johnson,2
-Humboldt,5TU-1,President,,DEM,Hillary Clinton,82
-Humboldt,5TU-1,President,,GRN,Jill Stein,3
+Humboldt,5TU-1,President,,DEM,Hillary Clinton,137
+Humboldt,5TU-1,President,,GRN,Jill Stein,5
+Humboldt,5TU-1,President,,REP,Jim Gilmore,2
 Humboldt,5TU-1,President,,LIB,John McAfee,1
-Humboldt,5TU-1,President,,REP,John R. Kasich,3
+Humboldt,5TU-1,President,,REP,John R. Kasich,9
 Humboldt,5TU-1,President,,DEM,Keith Judd,1
 Humboldt,5TU-1,President,,GRN,Kent Mesplay,1
-Humboldt,5TU-1,President,,REP,Ted Cruz,2
-Humboldt,5TU-1,Proposition 50,,,No,61
-Humboldt,5TU-1,Proposition 50,,,Yes,225
-Humboldt,5TU-1,State Assembly,2,DEM,Jim Wood,238
-Humboldt,5TU-1,U.S. House,2,REP,Dale K. Mensing,29
-Humboldt,5TU-1,U.S. House,2,DEM,Erin A. Schrode,27
-Humboldt,5TU-1,U.S. House,2,DEM,Jared W. Huffman,226
-Humboldt,5TU-1,U.S. House,2,IND,Matthew Robert Wookey,25
+Humboldt,5TU-1,President,,AIP,Robert Ornelas,1
+Humboldt,5TU-1,President,,REP,Ted Cruz,6
+Humboldt,5TU-1,Proposition 50,,,No,97
+Humboldt,5TU-1,Proposition 50,,,Yes,367
+Humboldt,5TU-1,State Assembly,2,DEM,Jim Wood,391
+Humboldt,5TU-1,U.S. House,2,REP,Dale K. Mensing,54
+Humboldt,5TU-1,U.S. House,2,DEM,Erin A. Schrode,41
+Humboldt,5TU-1,U.S. House,2,DEM,Jared W. Huffman,366
+Humboldt,5TU-1,U.S. House,2,IND,Matthew Robert Wookey,34
 Humboldt,5TU-1,U.S. Senate,,IND,Clive Grey,3
 Humboldt,5TU-1,U.S. Senate,,IND,Don J. Grundmann,1
-Humboldt,5TU-1,U.S. Senate,,REP,Don Krampe,2
-Humboldt,5TU-1,U.S. Senate,,REP,Duf Sundheim,9
-Humboldt,5TU-1,U.S. Senate,,IND,Eleanor García,1
+Humboldt,5TU-1,U.S. Senate,,REP,Don Krampe,3
+Humboldt,5TU-1,U.S. Senate,,REP,Duf Sundheim,24
+Humboldt,5TU-1,U.S. Senate,,IND,Eleanor García,2
 Humboldt,5TU-1,U.S. Senate,,DEM,Emory Rodgers,1
-Humboldt,5TU-1,U.S. Senate,,LIB,Gail K. Lightfoot,13
+Humboldt,5TU-1,U.S. Senate,,LIB,Gail K. Lightfoot,16
 Humboldt,5TU-1,U.S. Senate,,IND,Gar Myers,1
-Humboldt,5TU-1,U.S. Senate,,REP,George C. Yang,2
-Humboldt,5TU-1,U.S. Senate,,REP,Greg Conlon,4
+Humboldt,5TU-1,U.S. Senate,,REP,George C. Yang,3
+Humboldt,5TU-1,U.S. Senate,,REP,Greg Conlon,8
 Humboldt,5TU-1,U.S. Senate,,REP,Jarrell Williamson,2
-Humboldt,5TU-1,U.S. Senate,,REP,Jerry J. Laws,6
-Humboldt,5TU-1,U.S. Senate,,DEM,Kamala D. Harris,137
-Humboldt,5TU-1,U.S. Senate,,IND,Ling Ling Shi,2
-Humboldt,5TU-1,U.S. Senate,,DEM,Loretta L. Sanchez,47
-Humboldt,5TU-1,U.S. Senate,,DEM,Massie Munroe,6
+Humboldt,5TU-1,U.S. Senate,,REP,Jerry J. Laws,7
+Humboldt,5TU-1,U.S. Senate,,PAF,John Thompson Parker,1
+Humboldt,5TU-1,U.S. Senate,,DEM,Kamala D. Harris,234
+Humboldt,5TU-1,U.S. Senate,,IND,Ling Ling Shi,3
+Humboldt,5TU-1,U.S. Senate,,DEM,Loretta L. Sanchez,83
+Humboldt,5TU-1,U.S. Senate,,DEM,Massie Munroe,8
 Humboldt,5TU-1,U.S. Senate,,IND,Mike Beitiks,5
-Humboldt,5TU-1,U.S. Senate,,GRN,Pamela Elizondo,26
-Humboldt,5TU-1,U.S. Senate,,IND,Paul Merritt,1
-Humboldt,5TU-1,U.S. Senate,,REP,Phil Wyman,7
-Humboldt,5TU-1,U.S. Senate,,DEM,President Cristina Grappo,2
-Humboldt,5TU-1,U.S. Senate,,DEM,Steve Stokes,15
-Humboldt,5TU-1,U.S. Senate,,REP,Thomas G. Del Beccaro,5
-Humboldt,5TU-1,U.S. Senate,,REP,Von Hougo,3
-Humboldt,5TU-1_A,President,,REP,Ben Carson,2
-Humboldt,5TU-1_A,President,,DEM,Bernie Sanders,81
-Humboldt,5TU-1_A,President,,REP,Donald Trump,21
-Humboldt,5TU-1_A,President,,DEM,Hillary Clinton,55
-Humboldt,5TU-1_A,President,,GRN,Jill Stein,2
-Humboldt,5TU-1_A,President,,REP,Jim Gilmore,2
-Humboldt,5TU-1_A,President,,REP,John R. Kasich,6
-Humboldt,5TU-1_A,President,,AIP,Robert Ornelas,1
-Humboldt,5TU-1_A,President,,REP,Ted Cruz,4
-Humboldt,5TU-1_A,Proposition 50,,,No,36
-Humboldt,5TU-1_A,Proposition 50,,,Yes,142
-Humboldt,5TU-1_A,State Assembly,2,DEM,Jim Wood,153
-Humboldt,5TU-1_A,U.S. House,2,REP,Dale K. Mensing,25
-Humboldt,5TU-1_A,U.S. House,2,DEM,Erin A. Schrode,14
-Humboldt,5TU-1_A,U.S. House,2,DEM,Jared W. Huffman,140
-Humboldt,5TU-1_A,U.S. House,2,IND,Matthew Robert Wookey,9
-Humboldt,5TU-1_A,U.S. Senate,,REP,Don Krampe,1
-Humboldt,5TU-1_A,U.S. Senate,,REP,Duf Sundheim,15
-Humboldt,5TU-1_A,U.S. Senate,,IND,Eleanor García,1
-Humboldt,5TU-1_A,U.S. Senate,,LIB,Gail K. Lightfoot,3
-Humboldt,5TU-1_A,U.S. Senate,,REP,George C. Yang,1
-Humboldt,5TU-1_A,U.S. Senate,,REP,Greg Conlon,4
-Humboldt,5TU-1_A,U.S. Senate,,REP,Jerry J. Laws,1
-Humboldt,5TU-1_A,U.S. Senate,,PAF,John Thompson Parker,1
-Humboldt,5TU-1_A,U.S. Senate,,DEM,Kamala D. Harris,97
-Humboldt,5TU-1_A,U.S. Senate,,IND,Ling Ling Shi,1
-Humboldt,5TU-1_A,U.S. Senate,,DEM,Loretta L. Sanchez,36
-Humboldt,5TU-1_A,U.S. Senate,,DEM,Massie Munroe,2
-Humboldt,5TU-1_A,U.S. Senate,,GRN,Pamela Elizondo,3
-Humboldt,5TU-1_A,U.S. Senate,,IND,Paul Merritt,1
-Humboldt,5TU-1_A,U.S. Senate,,REP,Phil Wyman,8
-Humboldt,5TU-1_A,U.S. Senate,,DEM,President Cristina Grappo,1
-Humboldt,5TU-1_A,U.S. Senate,,REP,Ron Unz,1
-Humboldt,5TU-1_A,U.S. Senate,,DEM,Steve Stokes,2
-Humboldt,5TU-1_A,U.S. Senate,,REP,Thomas G. Del Beccaro,3
-Humboldt,5TU-1_A,U.S. Senate,,IND,Tim Gildersleeve,1
-Humboldt,5TU-1_A,U.S. Senate,,REP,Von Hougo,1
+Humboldt,5TU-1,U.S. Senate,,GRN,Pamela Elizondo,29
+Humboldt,5TU-1,U.S. Senate,,IND,Paul Merritt,2
+Humboldt,5TU-1,U.S. Senate,,REP,Phil Wyman,15
+Humboldt,5TU-1,U.S. Senate,,DEM,President Cristina Grappo,3
+Humboldt,5TU-1,U.S. Senate,,REP,Ron Unz,1
+Humboldt,5TU-1,U.S. Senate,,DEM,Steve Stokes,17
+Humboldt,5TU-1,U.S. Senate,,REP,Thomas G. Del Beccaro,8
+Humboldt,5TU-1,U.S. Senate,,IND,Tim Gildersleeve,1
+Humboldt,5TU-1,U.S. Senate,,REP,Von Hougo,4
 Humboldt,5TU-4,President,,REP,Ben Carson,1
-Humboldt,5TU-4,President,,DEM,Bernie Sanders,214
+Humboldt,5TU-4,President,,DEM,Bernie Sanders,279
 Humboldt,5TU-4,President,,GRN,Darryl Cherney,3
-Humboldt,5TU-4,President,,REP,Donald Trump,13
-Humboldt,5TU-4,President,,DEM,Hillary Clinton,87
-Humboldt,5TU-4,President,,GRN,Jill Stein,1
-Humboldt,5TU-4,President,,REP,John R. Kasich,3
+Humboldt,5TU-4,President,,REP,Donald Trump,32
+Humboldt,5TU-4,President,,DEM,Hillary Clinton,114
+Humboldt,5TU-4,President,,GRN,Jill Stein,3
+Humboldt,5TU-4,President,,REP,John R. Kasich,4
 Humboldt,5TU-4,President,,LIB,Joy Waymire,1
 Humboldt,5TU-4,President,,LIB,Marc Feldman,1
 Humboldt,5TU-4,President,,GRN,Sedinam Moyowasifsa-Curry,1
-Humboldt,5TU-4,President,,REP,Ted Cruz,2
+Humboldt,5TU-4,President,,REP,Ted Cruz,4
 Humboldt,5TU-4,President,,AIP,Wiley Drake,1
-Humboldt,5TU-4,Proposition 50,,,No,59
-Humboldt,5TU-4,Proposition 50,,,Yes,234
-Humboldt,5TU-4,State Assembly,2,DEM,Jim Wood,255
-Humboldt,5TU-4,U.S. House,2,REP,Dale K. Mensing,22
-Humboldt,5TU-4,U.S. House,2,DEM,Erin A. Schrode,38
-Humboldt,5TU-4,U.S. House,2,DEM,Jared W. Huffman,237
-Humboldt,5TU-4,U.S. House,2,IND,Matthew Robert Wookey,10
-Humboldt,5TU-4,U.S. Senate,,REP,Don Krampe,1
-Humboldt,5TU-4,U.S. Senate,,REP,Duf Sundheim,6
+Humboldt,5TU-4,Proposition 50,,,No,77
+Humboldt,5TU-4,Proposition 50,,,Yes,315
+Humboldt,5TU-4,State Assembly,2,DEM,Jim Wood,339
+Humboldt,5TU-4,U.S. House,2,REP,Dale K. Mensing,43
+Humboldt,5TU-4,U.S. House,2,DEM,Erin A. Schrode,46
+Humboldt,5TU-4,U.S. House,2,DEM,Jared W. Huffman,313
+Humboldt,5TU-4,U.S. House,2,IND,Matthew Robert Wookey,18
+Humboldt,5TU-4,U.S. Senate,,IND,Clive Grey,1
+Humboldt,5TU-4,U.S. Senate,,REP,Don Krampe,4
+Humboldt,5TU-4,U.S. Senate,,REP,Duf Sundheim,11
 Humboldt,5TU-4,U.S. Senate,,IND,Eleanor García,1
 Humboldt,5TU-4,U.S. Senate,,DEM,Emory Rodgers,1
 Humboldt,5TU-4,U.S. Senate,,LIB,Gail K. Lightfoot,11
-Humboldt,5TU-4,U.S. Senate,,REP,George C. Yang,1
-Humboldt,5TU-4,U.S. Senate,,REP,Greg Conlon,7
+Humboldt,5TU-4,U.S. Senate,,REP,George C. Yang,3
+Humboldt,5TU-4,U.S. Senate,,REP,Greg Conlon,10
 Humboldt,5TU-4,U.S. Senate,,DEM,Herbert G. Peters,1
-Humboldt,5TU-4,U.S. Senate,,REP,Jarrell Williamson,3
-Humboldt,5TU-4,U.S. Senate,,IND,Jason Hanania,2
+Humboldt,5TU-4,U.S. Senate,,REP,Jarrell Williamson,4
+Humboldt,5TU-4,U.S. Senate,,IND,Jason Hanania,3
 Humboldt,5TU-4,U.S. Senate,,REP,Jerry J. Laws,3
-Humboldt,5TU-4,U.S. Senate,,DEM,Kamala D. Harris,177
+Humboldt,5TU-4,U.S. Senate,,DEM,Kamala D. Harris,240
 Humboldt,5TU-4,U.S. Senate,,IND,Ling Ling Shi,1
-Humboldt,5TU-4,U.S. Senate,,DEM,Loretta L. Sanchez,51
-Humboldt,5TU-4,U.S. Senate,,DEM,Massie Munroe,7
-Humboldt,5TU-4,U.S. Senate,,IND,Mike Beitiks,1
-Humboldt,5TU-4,U.S. Senate,,GRN,Pamela Elizondo,23
-Humboldt,5TU-4,U.S. Senate,,REP,Phil Wyman,2
-Humboldt,5TU-4,U.S. Senate,,REP,Ron Unz,2
-Humboldt,5TU-4,U.S. Senate,,DEM,Steve Stokes,12
-Humboldt,5TU-4,U.S. Senate,,REP,Thomas G. Del Beccaro,3
+Humboldt,5TU-4,U.S. Senate,,DEM,Loretta L. Sanchez,67
+Humboldt,5TU-4,U.S. Senate,,LIB,Mark Matthew Herd,1
+Humboldt,5TU-4,U.S. Senate,,DEM,Massie Munroe,9
+Humboldt,5TU-4,U.S. Senate,,IND,Mike Beitiks,2
+Humboldt,5TU-4,U.S. Senate,,GRN,Pamela Elizondo,28
+Humboldt,5TU-4,U.S. Senate,,REP,Phil Wyman,7
+Humboldt,5TU-4,U.S. Senate,,REP,Ron Unz,3
+Humboldt,5TU-4,U.S. Senate,,DEM,Steve Stokes,13
+Humboldt,5TU-4,U.S. Senate,,REP,Thomas G. Del Beccaro,4
+Humboldt,5TU-4,U.S. Senate,,REP,Tom Palzer,2
 Humboldt,5TU-4,U.S. Senate,,REP,Von Hougo,1
-Humboldt,5TU-4_A,President,,DEM,Bernie Sanders,65
-Humboldt,5TU-4_A,President,,REP,Donald Trump,19
-Humboldt,5TU-4_A,President,,DEM,Hillary Clinton,27
-Humboldt,5TU-4_A,President,,GRN,Jill Stein,2
-Humboldt,5TU-4_A,President,,REP,John R. Kasich,1
-Humboldt,5TU-4_A,President,,REP,Ted Cruz,2
-Humboldt,5TU-4_A,Proposition 50,,,No,18
-Humboldt,5TU-4_A,Proposition 50,,,Yes,81
-Humboldt,5TU-4_A,State Assembly,2,DEM,Jim Wood,84
-Humboldt,5TU-4_A,U.S. House,2,REP,Dale K. Mensing,21
-Humboldt,5TU-4_A,U.S. House,2,DEM,Erin A. Schrode,8
-Humboldt,5TU-4_A,U.S. House,2,DEM,Jared W. Huffman,76
-Humboldt,5TU-4_A,U.S. House,2,IND,Matthew Robert Wookey,8
-Humboldt,5TU-4_A,U.S. Senate,,IND,Clive Grey,1
-Humboldt,5TU-4_A,U.S. Senate,,REP,Don Krampe,3
-Humboldt,5TU-4_A,U.S. Senate,,REP,Duf Sundheim,5
-Humboldt,5TU-4_A,U.S. Senate,,REP,George C. Yang,2
-Humboldt,5TU-4_A,U.S. Senate,,REP,Greg Conlon,3
-Humboldt,5TU-4_A,U.S. Senate,,REP,Jarrell Williamson,1
-Humboldt,5TU-4_A,U.S. Senate,,IND,Jason Hanania,1
-Humboldt,5TU-4_A,U.S. Senate,,DEM,Kamala D. Harris,63
-Humboldt,5TU-4_A,U.S. Senate,,DEM,Loretta L. Sanchez,16
-Humboldt,5TU-4_A,U.S. Senate,,LIB,Mark Matthew Herd,1
-Humboldt,5TU-4_A,U.S. Senate,,DEM,Massie Munroe,2
-Humboldt,5TU-4_A,U.S. Senate,,IND,Mike Beitiks,1
-Humboldt,5TU-4_A,U.S. Senate,,GRN,Pamela Elizondo,5
-Humboldt,5TU-4_A,U.S. Senate,,REP,Phil Wyman,5
-Humboldt,5TU-4_A,U.S. Senate,,REP,Ron Unz,1
-Humboldt,5TU-4_A,U.S. Senate,,DEM,Steve Stokes,1
-Humboldt,5TU-4_A,U.S. Senate,,REP,Thomas G. Del Beccaro,1
-Humboldt,5TU-4_A,U.S. Senate,,REP,Tom Palzer,2

--- a/src/swdb/swdb.py
+++ b/src/swdb/swdb.py
@@ -61,7 +61,9 @@ class SWDBResults(object):
 
         # All counties aside from Humboldt and Los Angeles have absentee
         # ballots for precincts coded with a trailing 'A'.
-        if self.county != 'Humboldt' and self.county != 'Los Angeles':
+        if self.county == 'Humboldt':
+            df.svprec = df.svprec.apply(lambda x: x.rstrip('_A'))
+        elif self.county != 'Los Angeles':
             df.svprec = df.svprec.apply(lambda x: x.rstrip('A'))
 
         result = pd.DataFrame(columns=fieldnames)


### PR DESCRIPTION
Most other counties have A appended to the precinct name to represent absentee ballots.  Humboldt often ends precincts with A already, so they use '_A'