### PR TITLE
Write-ins for Amador 2014 primary election.

### DIFF
--- a/2014/20140603__ca__primary__amador__precinct.csv
+++ b/2014/20140603__ca__primary__amador__precinct.csv
@@ -3462,3 +3462,4 @@ Amador,CP83,Treasurer,,DEM,John Chiang,11
 Amador,CP83,U.S. House,4,REP,"Arthur ""Art"" Moore",4
 Amador,CP83,U.S. House,4,IND,Jeffrey D. Gerlach,6
 Amador,CP83,U.S. House,4,REP,Tom McClintock,10
+Amador,Write-In,State Assembly,5,LIB,Patrick D. Hogan,5

--- a/src/swdb/writeins.py
+++ b/src/swdb/writeins.py
@@ -20,4 +20,15 @@ def alameda_p14(candidate_norm):
              'precinct': 'Write-In'} for
             c, v in cand_split if v != 0]
 
-WRITEINS = {'P14': {'Alameda': alameda_p14}}
+
+def amador_p14(_):
+    return [{'candidate': 'Patrick D. Hogan',
+             'county': 'Amador',
+             'office': 'State Assembly',
+             'district': '5',
+             'party': 'LIB',
+             'precinct': 'Write-In',
+             'votes': 5}]
+
+WRITEINS = {'P14': {'Alameda': alameda_p14,
+                    'Amador':  amador_p14}}


### PR DESCRIPTION
 - Fixes #102 
 - Manually entered since only available source is an [image PDF](http://www.co.amador.ca.us/home/showdocument?id=19064)