### PR TITLE
Write-ins for Calaveras 2014 primary election.

### DIFF
--- a/2014/20140603__ca__primary__calaveras__precinct.csv
+++ b/2014/20140603__ca__primary__calaveras__precinct.csv
@@ -1889,3 +1889,4 @@ Calaveras,570,Treasurer,,DEM,John Chiang,152
 Calaveras,570,U.S. House,4,REP,"Arthur ""Art"" Moore",65
 Calaveras,570,U.S. House,4,IND,Jeffrey D. Gerlach,70
 Calaveras,570,U.S. House,4,REP,Tom McClintock,230
+Calaveras,Write-In,State Assembly,5,LIB,Patrick D. Hogan,4

--- a/src/swdb/writeins.py
+++ b/src/swdb/writeins.py
@@ -30,5 +30,16 @@ def amador_p14(_):
              'precinct': 'Write-In',
              'votes': 5}]
 
-WRITEINS = {'P14': {'Alameda': alameda_p14,
-                    'Amador':  amador_p14}}
+
+def calaveras_p14(_):
+    return [{'candidate': 'Patrick D. Hogan',
+             'county': 'Calaveras',
+             'office': 'State Assembly',
+             'district': '5',
+             'party': 'LIB',
+             'precinct': 'Write-In',
+             'votes': 4}]
+
+WRITEINS = {'P14': {'Alameda':   alameda_p14,
+                    'Amador':    amador_p14,
+                    'Calaveras': calaveras_p14}}


### PR DESCRIPTION
 - Fixes #101 
 - Manual entry since no documents found at the county-level