### PR TITLE
Fix test for 2014 Fresno primary

### DIFF
--- a/2014/20140603__ca__primary__fresno__precinct.csv
+++ b/2014/20140603__ca__primary__fresno__precinct.csv
@@ -669,6 +669,7 @@ Fresno,0000011,Secretary of State,,DEM,Leland Yee,40
 Fresno,0000011,Secretary of State,,REP,Pete Peterson,315
 Fresno,0000011,Secretary of State,,REP,Roy Allmond,108
 Fresno,0000011,State Assembly,31,DEM,Henry T. Perea,327
+Fresno,0000011,State Assembly,31,,Walter O. Villarreal,1
 Fresno,0000011,State Senate,12,REP,Anthony Cannella,599
 Fresno,0000011,State Senate,12,DEM,Shawn K. Bagley,118
 Fresno,0000011,Superintendent of Public Instruction,,NOP,Lydia A. Gutiérrez,109
@@ -980,6 +981,7 @@ Fresno,0000016,Secretary of State,,DEM,Leland Yee,41
 Fresno,0000016,Secretary of State,,REP,Pete Peterson,183
 Fresno,0000016,Secretary of State,,REP,Roy Allmond,85
 Fresno,0000016,State Assembly,31,DEM,Henry T. Perea,269
+Fresno,0000016,State Assembly,31,,Walter O. Villarreal,2
 Fresno,0000016,State Senate,12,REP,Anthony Cannella,339
 Fresno,0000016,State Senate,12,DEM,Shawn K. Bagley,126
 Fresno,0000016,Superintendent of Public Instruction,,NOP,Lydia A. Gutiérrez,70
@@ -1355,6 +1357,7 @@ Fresno,0000022,Secretary of State,,DEM,Leland Yee,27
 Fresno,0000022,Secretary of State,,REP,Pete Peterson,130
 Fresno,0000022,Secretary of State,,REP,Roy Allmond,49
 Fresno,0000022,State Assembly,31,DEM,Henry T. Perea,186
+Fresno,0000022,State Assembly,31,,Walter O. Villarreal,2
 Fresno,0000022,State Senate,12,REP,Anthony Cannella,237
 Fresno,0000022,State Senate,12,DEM,Shawn K. Bagley,85
 Fresno,0000022,Superintendent of Public Instruction,,NOP,Lydia A. Gutiérrez,74
@@ -1910,6 +1913,7 @@ Fresno,0000031,Secretary of State,,DEM,Leland Yee,8
 Fresno,0000031,Secretary of State,,REP,Pete Peterson,56
 Fresno,0000031,Secretary of State,,REP,Roy Allmond,11
 Fresno,0000031,State Assembly,31,DEM,Henry T. Perea,88
+Fresno,0000031,State Assembly,31,,Walter O. Villarreal,1
 Fresno,0000031,State Senate,12,REP,Anthony Cannella,90
 Fresno,0000031,State Senate,12,DEM,Shawn K. Bagley,46
 Fresno,0000031,Superintendent of Public Instruction,,NOP,Lydia A. Gutiérrez,48
@@ -2278,6 +2282,7 @@ Fresno,0000037,Secretary of State,,DEM,Leland Yee,20
 Fresno,0000037,Secretary of State,,REP,Pete Peterson,125
 Fresno,0000037,Secretary of State,,REP,Roy Allmond,54
 Fresno,0000037,State Assembly,31,DEM,Henry T. Perea,142
+Fresno,0000037,State Assembly,31,,Walter O. Villarreal,2
 Fresno,0000037,State Senate,12,REP,Anthony Cannella,255
 Fresno,0000037,State Senate,12,DEM,Shawn K. Bagley,54
 Fresno,0000037,Superintendent of Public Instruction,,NOP,Lydia A. Gutiérrez,32
@@ -2405,6 +2410,7 @@ Fresno,0000039,Secretary of State,,DEM,Leland Yee,35
 Fresno,0000039,Secretary of State,,REP,Pete Peterson,130
 Fresno,0000039,Secretary of State,,REP,Roy Allmond,49
 Fresno,0000039,State Assembly,31,DEM,Henry T. Perea,281
+Fresno,0000039,State Assembly,31,,Walter O. Villarreal,2
 Fresno,0000039,State Senate,12,REP,Anthony Cannella,256
 Fresno,0000039,State Senate,12,DEM,Shawn K. Bagley,144
 Fresno,0000039,Superintendent of Public Instruction,,NOP,Lydia A. Gutiérrez,133
@@ -3200,6 +3206,7 @@ Fresno,0000052,Secretary of State,,DEM,Leland Yee,25
 Fresno,0000052,Secretary of State,,REP,Pete Peterson,95
 Fresno,0000052,Secretary of State,,REP,Roy Allmond,28
 Fresno,0000052,State Assembly,31,DEM,Henry T. Perea,190
+Fresno,0000052,State Assembly,31,,Walter O. Villarreal,2
 Fresno,0000052,State Senate,14,REP,Andy Vidak,169
 Fresno,0000052,State Senate,14,DEM,Luis Chavez,101
 Fresno,0000052,Superintendent of Public Instruction,,NOP,Lydia A. Gutiérrez,70
@@ -3262,6 +3269,7 @@ Fresno,0000053,Secretary of State,,DEM,Leland Yee,28
 Fresno,0000053,Secretary of State,,REP,Pete Peterson,53
 Fresno,0000053,Secretary of State,,REP,Roy Allmond,14
 Fresno,0000053,State Assembly,31,DEM,Henry T. Perea,167
+Fresno,0000053,State Assembly,31,,Walter O. Villarreal,10
 Fresno,0000053,State Senate,14,REP,Andy Vidak,101
 Fresno,0000053,State Senate,14,DEM,Luis Chavez,121
 Fresno,0000053,Superintendent of Public Instruction,,NOP,Lydia A. Gutiérrez,87
@@ -4845,6 +4853,7 @@ Fresno,0000079,Treasurer,,REP,Greg Conlon,69
 Fresno,0000079,Treasurer,,DEM,John Chiang,36
 Fresno,0000079,U.S. House,4,IND,Jeffrey D. Gerlach,22
 Fresno,0000079,U.S. House,4,REP,Tom McClintock,76
+Fresno,0000079,U.S. House,4,,"Arthur ""Art"" Moore",14
 Fresno,0000080,Attorney General,,REP,David King,14
 Fresno,0000080,Attorney General,,REP,John Haggerty,7
 Fresno,0000080,Attorney General,,LIB,Jonathan Jaech,2
@@ -4897,6 +4906,7 @@ Fresno,0000080,Treasurer,,REP,Greg Conlon,63
 Fresno,0000080,Treasurer,,DEM,John Chiang,24
 Fresno,0000080,U.S. House,4,IND,Jeffrey D. Gerlach,13
 Fresno,0000080,U.S. House,4,REP,Tom McClintock,62
+Fresno,0000080,U.S. House,4,,"Arthur ""Art"" Moore",13
 Fresno,0000081,Attorney General,,REP,David King,45
 Fresno,0000081,Attorney General,,REP,John Haggerty,27
 Fresno,0000081,Attorney General,,LIB,Jonathan Jaech,13
@@ -4957,6 +4967,7 @@ Fresno,0000081,Treasurer,,REP,Greg Conlon,216
 Fresno,0000081,Treasurer,,DEM,John Chiang,106
 Fresno,0000081,U.S. House,4,IND,Jeffrey D. Gerlach,51
 Fresno,0000081,U.S. House,4,REP,Tom McClintock,225
+Fresno,0000081,U.S. House,4,,"Arthur ""Art"" Moore",50
 Fresno,0000082,Attorney General,,REP,David King,58
 Fresno,0000082,Attorney General,,REP,John Haggerty,31
 Fresno,0000082,Attorney General,,LIB,Jonathan Jaech,4
@@ -5018,6 +5029,7 @@ Fresno,0000082,Treasurer,,REP,Greg Conlon,265
 Fresno,0000082,Treasurer,,DEM,John Chiang,145
 Fresno,0000082,U.S. House,4,IND,Jeffrey D. Gerlach,62
 Fresno,0000082,U.S. House,4,REP,Tom McClintock,287
+Fresno,0000079,U.S. House,4,,"Arthur ""Art"" Moore",65
 Fresno,0000083,Attorney General,,REP,David King,31
 Fresno,0000083,Attorney General,,REP,John Haggerty,30
 Fresno,0000083,Attorney General,,LIB,Jonathan Jaech,6
@@ -5077,6 +5089,7 @@ Fresno,0000083,Treasurer,,REP,Greg Conlon,193
 Fresno,0000083,Treasurer,,DEM,John Chiang,98
 Fresno,0000083,U.S. House,4,IND,Jeffrey D. Gerlach,48
 Fresno,0000083,U.S. House,4,REP,Tom McClintock,214
+Fresno,0000083,U.S. House,4,,"Arthur ""Art"" Moore",42
 Fresno,0000084,Attorney General,,REP,David King,45
 Fresno,0000084,Attorney General,,REP,John Haggerty,18
 Fresno,0000084,Attorney General,,LIB,Jonathan Jaech,6
@@ -5140,6 +5153,7 @@ Fresno,0000084,Treasurer,,REP,Greg Conlon,254
 Fresno,0000084,Treasurer,,DEM,John Chiang,117
 Fresno,0000084,U.S. House,4,IND,Jeffrey D. Gerlach,55
 Fresno,0000084,U.S. House,4,REP,Tom McClintock,264
+Fresno,0000084,U.S. House,4,,"Arthur ""Art"" Moore",59
 Fresno,0000085,Attorney General,,REP,David King,31
 Fresno,0000085,Attorney General,,REP,John Haggerty,21
 Fresno,0000085,Attorney General,,DEM,Kamala D. Harris,45
@@ -5199,6 +5213,7 @@ Fresno,0000085,Treasurer,,REP,Greg Conlon,129
 Fresno,0000085,Treasurer,,DEM,John Chiang,56
 Fresno,0000085,U.S. House,4,IND,Jeffrey D. Gerlach,21
 Fresno,0000085,U.S. House,4,REP,Tom McClintock,138
+Fresno,0000085,U.S. House,4,,"Arthur ""Art"" Moore",32
 Fresno,0000086,Attorney General,,REP,David King,26
 Fresno,0000086,Attorney General,,REP,John Haggerty,29
 Fresno,0000086,Attorney General,,LIB,Jonathan Jaech,5
@@ -5261,6 +5276,7 @@ Fresno,0000086,Treasurer,,REP,Greg Conlon,159
 Fresno,0000086,Treasurer,,DEM,John Chiang,93
 Fresno,0000086,U.S. House,4,IND,Jeffrey D. Gerlach,39
 Fresno,0000086,U.S. House,4,REP,Tom McClintock,177
+Fresno,0000086,U.S. House,4,,"Arthur ""Art"" Moore",46
 Fresno,0000087,Attorney General,,REP,David King,68
 Fresno,0000087,Attorney General,,REP,John Haggerty,49
 Fresno,0000087,Attorney General,,LIB,Jonathan Jaech,7
@@ -5320,6 +5336,7 @@ Fresno,0000087,Treasurer,,REP,Greg Conlon,335
 Fresno,0000087,Treasurer,,DEM,John Chiang,95
 Fresno,0000087,U.S. House,4,IND,Jeffrey D. Gerlach,43
 Fresno,0000087,U.S. House,4,REP,Tom McClintock,324
+Fresno,0000087,U.S. House,4,,"Arthur ""Art"" Moore",63
 Fresno,0000088,Attorney General,,REP,David King,69
 Fresno,0000088,Attorney General,,REP,John Haggerty,52
 Fresno,0000088,Attorney General,,LIB,Jonathan Jaech,6
@@ -5380,6 +5397,7 @@ Fresno,0000088,Treasurer,,REP,Greg Conlon,309
 Fresno,0000088,Treasurer,,DEM,John Chiang,138
 Fresno,0000088,U.S. House,4,IND,Jeffrey D. Gerlach,47
 Fresno,0000088,U.S. House,4,REP,Tom McClintock,347
+Fresno,0000088,U.S. House,4,,"Arthur ""Art"" Moore",61
 Fresno,0000089,Attorney General,,REP,David King,27
 Fresno,0000089,Attorney General,,REP,John Haggerty,19
 Fresno,0000089,Attorney General,,LIB,Jonathan Jaech,5
@@ -5441,6 +5459,7 @@ Fresno,0000089,Treasurer,,REP,Greg Conlon,133
 Fresno,0000089,Treasurer,,DEM,John Chiang,51
 Fresno,0000089,U.S. House,4,IND,Jeffrey D. Gerlach,17
 Fresno,0000089,U.S. House,4,REP,Tom McClintock,143
+Fresno,0000089,U.S. House,4,,"Arthur ""Art"" Moore",29
 Fresno,0000090,Attorney General,,REP,David King,22
 Fresno,0000090,Attorney General,,REP,John Haggerty,4
 Fresno,0000090,Attorney General,,LIB,Jonathan Jaech,4
@@ -15852,6 +15871,7 @@ Fresno,0000259,Secretary of State,,DEM,Leland Yee,29
 Fresno,0000259,Secretary of State,,REP,Pete Peterson,55
 Fresno,0000259,Secretary of State,,REP,Roy Allmond,14
 Fresno,0000259,State Assembly,31,DEM,Henry T. Perea,144
+Fresno,0000259,State Assembly,31,,Walter O. Villarreal,1
 Fresno,0000259,State Senate,8,DEM,Paulina Miranda,99
 Fresno,0000259,State Senate,8,REP,Tom Berryhill,100
 Fresno,0000259,Superintendent of Public Instruction,,NOP,Lydia A. Gutiérrez,51
@@ -20369,6 +20389,7 @@ Fresno,0000330,Secretary of State,,DEM,Leland Yee,65
 Fresno,0000330,Secretary of State,,REP,Pete Peterson,65
 Fresno,0000330,Secretary of State,,REP,Roy Allmond,18
 Fresno,0000330,State Assembly,31,DEM,Henry T. Perea,292
+Fresno,0000330,State Assembly,31,,Walter O. Villarreal,1
 Fresno,0000330,State Senate,8,DEM,Paulina Miranda,227
 Fresno,0000330,State Senate,8,REP,Tom Berryhill,153
 Fresno,0000330,Superintendent of Public Instruction,,NOP,Lydia A. Gutiérrez,100
@@ -23940,6 +23961,7 @@ Fresno,0001030,Superintendent of Public Instruction,,NOP,Marshall Tuck,5
 Fresno,0001030,Superintendent of Public Instruction,,NOP,Tom Torlakson,1
 Fresno,0001030,Treasurer,,REP,Greg Conlon,10
 Fresno,0001030,U.S. House,4,REP,Tom McClintock,6
+Fresno,0001030,U.S. House,4,,"Arthur ""Art"" Moore",4
 Fresno,0001031,Attorney General,,REP,David King,10
 Fresno,0001031,Attorney General,,REP,John Haggerty,10
 Fresno,0001031,Attorney General,,LIB,Jonathan Jaech,3
@@ -23993,6 +24015,7 @@ Fresno,0001031,Treasurer,,REP,Greg Conlon,44
 Fresno,0001031,Treasurer,,DEM,John Chiang,22
 Fresno,0001031,U.S. House,4,IND,Jeffrey D. Gerlach,9
 Fresno,0001031,U.S. House,4,REP,Tom McClintock,51
+Fresno,0001031,U.S. House,4,,"Arthur ""Art"" Moore",10
 Fresno,0001032,Attorney General,,REP,David King,7
 Fresno,0001032,Attorney General,,REP,John Haggerty,17
 Fresno,0001032,Attorney General,,LIB,Jonathan Jaech,2
@@ -24047,6 +24070,7 @@ Fresno,0001032,Treasurer,,REP,Greg Conlon,69
 Fresno,0001032,Treasurer,,DEM,John Chiang,16
 Fresno,0001032,U.S. House,4,IND,Jeffrey D. Gerlach,9
 Fresno,0001032,U.S. House,4,REP,Tom McClintock,70
+Fresno,0001032,U.S. House,4,,"Arthur ""Art"" Moore",15
 Fresno,0001034,Attorney General,,REP,David King,4
 Fresno,0001034,Attorney General,,DEM,Kamala D. Harris,7
 Fresno,0001034,Attorney General,,IND,Orly Taitz,1
@@ -24598,6 +24622,7 @@ Fresno,0001055,Treasurer,,REP,Greg Conlon,28
 Fresno,0001055,Treasurer,,DEM,John Chiang,11
 Fresno,0001055,U.S. House,4,IND,Jeffrey D. Gerlach,5
 Fresno,0001055,U.S. House,4,REP,Tom McClintock,32
+Fresno,0001055,U.S. House,4,,"Arthur ""Art"" Moore",6
 Fresno,0001057,Attorney General,,REP,John Haggerty,4
 Fresno,0001057,Board of Equalization,1,REP,George Runner,4
 Fresno,0001057,Controller,,REP,David Evans,4


### PR DESCRIPTION
Fix test for 2014 Fresno primary by manually adding rows for write-in candidates.