### PR TITLE
fix 2014 tests for Mono primary

### DIFF
--- a/2014/20140603__ca__primary__mono__precinct.csv
+++ b/2014/20140603__ca__primary__mono__precinct.csv
@@ -40,6 +40,10 @@ Mono,1,Lieutenant Governor,,DEM,Gavin Newsom,87
 Mono,1,Lieutenant Governor,,REP,George Yang,18
 Mono,1,Lieutenant Governor,,GRN,Jena F. Goodman,4
 Mono,1,Lieutenant Governor,,REP,Ron Nehring,96
+Mono,1,Proposition 41,,,Yes,144
+Mono,1,Proposition 41,,,No,106
+Mono,1,Proposition 42,,,Yes,140
+Mono,1,Proposition 42,,,No,103
 Mono,1,Secretary of State,,DEM,Alex Padilla,50
 Mono,1,Secretary of State,,NON,Dan Schnur,15
 Mono,1,Secretary of State,,GRN,David Curtis,1
@@ -102,6 +106,10 @@ Mono,10,Lieutenant Governor,,DEM,Gavin Newsom,139
 Mono,10,Lieutenant Governor,,REP,George Yang,24
 Mono,10,Lieutenant Governor,,GRN,Jena F. Goodman,6
 Mono,10,Lieutenant Governor,,REP,Ron Nehring,54
+Mono,10,Proposition 41,,,Yes,172
+Mono,10,Proposition 41,,,No,98
+Mono,10,Proposition 42,,,Yes,158
+Mono,10,Proposition 42,,,No,107
 Mono,10,Secretary of State,,DEM,Alex Padilla,60
 Mono,10,Secretary of State,,NON,Dan Schnur,19
 Mono,10,Secretary of State,,GRN,David Curtis,14
@@ -164,6 +172,10 @@ Mono,11,Lieutenant Governor,,DEM,Gavin Newsom,99
 Mono,11,Lieutenant Governor,,REP,George Yang,6
 Mono,11,Lieutenant Governor,,GRN,Jena F. Goodman,2
 Mono,11,Lieutenant Governor,,REP,Ron Nehring,28
+Mono,11,Proposition 41,,,Yes,116
+Mono,11,Proposition 41,,,No,52
+Mono,11,Proposition 42,,,Yes,104
+Mono,11,Proposition 42,,,No,58
 Mono,11,Secretary of State,,DEM,Alex Padilla,54
 Mono,11,Secretary of State,,NON,Dan Schnur,14
 Mono,11,Secretary of State,,GRN,David Curtis,9
@@ -226,6 +238,10 @@ Mono,12,Lieutenant Governor,,DEM,Gavin Newsom,140
 Mono,12,Lieutenant Governor,,REP,George Yang,15
 Mono,12,Lieutenant Governor,,GRN,Jena F. Goodman,17
 Mono,12,Lieutenant Governor,,REP,Ron Nehring,67
+Mono,12,Proposition 41,,,Yes,190
+Mono,12,Proposition 41,,,No,112
+Mono,12,Proposition 42,,,Yes,170
+Mono,12,Proposition 42,,,No,117
 Mono,12,Secretary of State,,DEM,Alex Padilla,55
 Mono,12,Secretary of State,,NON,Dan Schnur,7
 Mono,12,Secretary of State,,GRN,David Curtis,17
@@ -288,6 +304,10 @@ Mono,13,Lieutenant Governor,,DEM,Gavin Newsom,114
 Mono,13,Lieutenant Governor,,REP,George Yang,12
 Mono,13,Lieutenant Governor,,GRN,Jena F. Goodman,10
 Mono,13,Lieutenant Governor,,REP,Ron Nehring,54
+Mono,13,Proposition 41,,,Yes,139
+Mono,13,Proposition 41,,,No,106
+Mono,13,Proposition 42,,,Yes,117
+Mono,13,Proposition 42,,,No,114
 Mono,13,Secretary of State,,DEM,Alex Padilla,43
 Mono,13,Secretary of State,,NON,Dan Schnur,13
 Mono,13,Secretary of State,,GRN,David Curtis,14
@@ -350,6 +370,10 @@ Mono,2,Lieutenant Governor,,DEM,Gavin Newsom,15
 Mono,2,Lieutenant Governor,,REP,George Yang,5
 Mono,2,Lieutenant Governor,,GRN,Jena F. Goodman,3
 Mono,2,Lieutenant Governor,,REP,Ron Nehring,37
+Mono,2,Proposition 41,,,Yes,36
+Mono,2,Proposition 41,,,No,41
+Mono,2,Proposition 42,,,Yes,33
+Mono,2,Proposition 42,,,No,43
 Mono,2,Secretary of State,,DEM,Alex Padilla,12
 Mono,2,Secretary of State,,NON,Dan Schnur,0
 Mono,2,Secretary of State,,GRN,David Curtis,2
@@ -412,6 +436,10 @@ Mono,3,Lieutenant Governor,,DEM,Gavin Newsom,68
 Mono,3,Lieutenant Governor,,REP,George Yang,19
 Mono,3,Lieutenant Governor,,GRN,Jena F. Goodman,6
 Mono,3,Lieutenant Governor,,REP,Ron Nehring,109
+Mono,3,Proposition 41,,,Yes,142
+Mono,3,Proposition 41,,,No,118
+Mono,3,Proposition 42,,,Yes,100
+Mono,3,Proposition 42,,,No,160
 Mono,3,Secretary of State,,DEM,Alex Padilla,41
 Mono,3,Secretary of State,,NON,Dan Schnur,9
 Mono,3,Secretary of State,,GRN,David Curtis,7
@@ -474,6 +502,10 @@ Mono,4,Lieutenant Governor,,DEM,Gavin Newsom,39
 Mono,4,Lieutenant Governor,,REP,George Yang,22
 Mono,4,Lieutenant Governor,,GRN,Jena F. Goodman,8
 Mono,4,Lieutenant Governor,,REP,Ron Nehring,51
+Mono,4,Proposition 41,,,Yes,83
+Mono,4,Proposition 41,,,No,76
+Mono,4,Proposition 42,,,Yes,68
+Mono,4,Proposition 42,,,No,85
 Mono,4,Secretary of State,,DEM,Alex Padilla,24
 Mono,4,Secretary of State,,NON,Dan Schnur,3
 Mono,4,Secretary of State,,GRN,David Curtis,14
@@ -536,6 +568,10 @@ Mono,5,Lieutenant Governor,,DEM,Gavin Newsom,75
 Mono,5,Lieutenant Governor,,REP,George Yang,14
 Mono,5,Lieutenant Governor,,GRN,Jena F. Goodman,7
 Mono,5,Lieutenant Governor,,REP,Ron Nehring,54
+Mono,5,Proposition 41,,,Yes,112
+Mono,5,Proposition 41,,,No,70
+Mono,5,Proposition 42,,,Yes,86
+Mono,5,Proposition 42,,,No,83
 Mono,5,Secretary of State,,DEM,Alex Padilla,29
 Mono,5,Secretary of State,,NON,Dan Schnur,12
 Mono,5,Secretary of State,,GRN,David Curtis,15
@@ -598,6 +634,10 @@ Mono,6,Lieutenant Governor,,DEM,Gavin Newsom,61
 Mono,6,Lieutenant Governor,,REP,George Yang,6
 Mono,6,Lieutenant Governor,,GRN,Jena F. Goodman,11
 Mono,6,Lieutenant Governor,,REP,Ron Nehring,45
+Mono,6,Proposition 41,,,Yes,74
+Mono,6,Proposition 41,,,No,61
+Mono,6,Proposition 42,,,Yes,62
+Mono,6,Proposition 42,,,No,77
 Mono,6,Secretary of State,,DEM,Alex Padilla,27
 Mono,6,Secretary of State,,NON,Dan Schnur,4
 Mono,6,Secretary of State,,GRN,David Curtis,11
@@ -660,6 +700,10 @@ Mono,7,Lieutenant Governor,,DEM,Gavin Newsom,148
 Mono,7,Lieutenant Governor,,REP,George Yang,20
 Mono,7,Lieutenant Governor,,GRN,Jena F. Goodman,8
 Mono,7,Lieutenant Governor,,REP,Ron Nehring,84
+Mono,7,Proposition 41,,,Yes,173
+Mono,7,Proposition 41,,,No,158
+Mono,7,Proposition 42,,,Yes,143
+Mono,7,Proposition 42,,,No,180
 Mono,7,Secretary of State,,DEM,Alex Padilla,76
 Mono,7,Secretary of State,,NON,Dan Schnur,16
 Mono,7,Secretary of State,,GRN,David Curtis,16
@@ -722,6 +766,10 @@ Mono,8,Lieutenant Governor,,DEM,Gavin Newsom,109
 Mono,8,Lieutenant Governor,,REP,George Yang,8
 Mono,8,Lieutenant Governor,,GRN,Jena F. Goodman,6
 Mono,8,Lieutenant Governor,,REP,Ron Nehring,47
+Mono,8,Proposition 41,,,Yes,145
+Mono,8,Proposition 41,,,No,86
+Mono,8,Proposition 42,,,Yes,108
+Mono,8,Proposition 42,,,No,107
 Mono,8,Secretary of State,,DEM,Alex Padilla,37
 Mono,8,Secretary of State,,NON,Dan Schnur,13
 Mono,8,Secretary of State,,GRN,David Curtis,10
@@ -784,6 +832,10 @@ Mono,9,Lieutenant Governor,,DEM,Gavin Newsom,153
 Mono,9,Lieutenant Governor,,REP,George Yang,24
 Mono,9,Lieutenant Governor,,GRN,Jena F. Goodman,9
 Mono,9,Lieutenant Governor,,REP,Ron Nehring,58
+Mono,9,Proposition 41,,,Yes,183
+Mono,9,Proposition 41,,,No,137
+Mono,9,Proposition 42,,,Yes,166
+Mono,9,Proposition 42,,,No,144
 Mono,9,Secretary of State,,DEM,Alex Padilla,74
 Mono,9,Secretary of State,,NON,Dan Schnur,12
 Mono,9,Secretary of State,,GRN,David Curtis,16
@@ -805,3 +857,5 @@ Mono,9,U.S. House,8,DEM,Bob Conaway,90
 Mono,9,U.S. House,8,DEM,Odessia D. Lee,44
 Mono,9,U.S. House,8,REP,Paul Cook,144
 Mono,9,U.S. House,8,REP,Paul Hannosh,28
+Mono,Unknown,Governor,,,Jimelle L. Walls,1
+Mono,Unknown,State Assembly,5,LIB,Patrick D. Hogan,17


### PR DESCRIPTION
fix 2014 tests for Mono primary by adding Proposition and write-in records.

**Note the last 2 lines are catch-all for the write-ins** which do not have official precinct-level data (not sure about implications of this in post-CSV processing). Please chime in if this is acceptable/unacceptable.