### PR TITLE
Fix 2014 Riverside primary tests

### DIFF
--- a/2014/20140603__ca__primary__riverside__precinct.csv
+++ b/2014/20140603__ca__primary__riverside__precinct.csv
@@ -46873,3 +46873,11 @@ Riverside,59804,Treasurer,,DEM,John Chiang,39
 Riverside,59804,U.S. House,36,REP,Brian Nestande,15
 Riverside,59804,U.S. House,36,DEM,Raul Ruiz,50
 Riverside,59804,U.S. House,36,REP,Ray Haynes,12
+Riverside,Unknown,Governor,,IND,Nickolas Wildstar,2
+Riverside,Unknown,State Assembly,60,LIB,John Farr,34
+Riverside,Unknown,State Assembly,60,DEM,Ken Park,144
+Riverside,Unknown,State Assembly,60,DEM,Oliver Unaka,118
+Riverside,Unknown,State Assembly,67,DEM,Conrad Melton,58
+Riverside,Unknown,State Assembly,71,DEM,Howard L. Katz,11
+Riverside,Unknown,State Assembly,75,DEM,Nicholas Shestople,35
+Riverside,Unknown,U.S. House,42,REP,Floyd Harvey,8


### PR DESCRIPTION
Fix 2014 Riverside primary tests by adding a few missing candidates.

Precinct-level data not available from official county source, so I created precinct-level records with "Unknown" precinct id as catch-all. Candidate parties researched from other official documents.