### PR TITLE
Fix 2014 Tuolumne primary tests.

### DIFF
--- a/2014/20140603__ca__primary__tuolumne__precinct.csv
+++ b/2014/20140603__ca__primary__tuolumne__precinct.csv
@@ -4059,3 +4059,4 @@ Tuolumne,999503,Treasurer,,DEM,John Chiang,81
 Tuolumne,999503,U.S. House,4,REP,"Arthur ""Art"" Moore",45
 Tuolumne,999503,U.S. House,4,IND,Jeffrey D. Gerlach,24
 Tuolumne,999503,U.S. House,4,REP,Tom McClintock,108
+Tuolumne,Unknown,State Assembly,5,LIB,Patrick D. Hogan,6


### PR DESCRIPTION
Fix 2014 Tuolumne primary tests by adding a few missing candidates.

This particular county election didn't have precinct-level records.