### PR TITLE
Fix 2014 Tehama primary tests

### DIFF
--- a/2014/20140603__ca__primary__tehama__precinct.csv
+++ b/2014/20140603__ca__primary__tehama__precinct.csv
@@ -1222,7 +1222,7 @@ Tehama,30270,Lieutenant Governor,,DEM,Gavin Newsom,85
 Tehama,30270,Lieutenant Governor,,REP,George Yang,25
 Tehama,30270,Lieutenant Governor,,GRN,Jena F. Goodman,4
 Tehama,30270,Lieutenant Governor,,REP,Ron Nehring,76
-Tehama,30270,Proposition 41,,,No,131
+Tehama,30270,Proposition 41,,,No,130
 Tehama,30270,Proposition 41,,,Yes,161
 Tehama,30270,Proposition 42,,,No,154
 Tehama,30270,Proposition 42,,,Yes,126
@@ -2931,3 +2931,4 @@ Tehama,53610,U.S. House,1,DEM,Dan Levine,5
 Tehama,53610,U.S. House,1,REP,Doug La Malfa,47
 Tehama,53610,U.S. House,1,REP,Gregory Cheadle,12
 Tehama,53610,U.S. House,1,DEM,Heidi Hall,32
+Tehama,Unknown,Governor,,DEM,Karen Jill Bernal,1


### PR DESCRIPTION
Fix 2014 Tehama primary tests by adding a missing candidate and fixing a revised vote count for Prop 21.

[Page 50 of this document](https://www.co.tehama.ca.us/images/images/Elections/Statewide_Primary_Election_June_3_2014.pdf) describes the revised vote count for Prop21 NO. I inferred from the YES/NO vote counts which precinct number (the document uses Tehama-based precinct names).