### PR TITLE
Fix 2014 Tulare primary tests

### DIFF
--- a/2014/20140603__ca__primary__tulare__precinct.csv
+++ b/2014/20140603__ca__primary__tulare__precinct.csv
@@ -8333,3 +8333,6 @@ Tulare,599811,Treasurer,,GRN,Ellen H. Brown,26
 Tulare,599811,Treasurer,,REP,Greg Conlon,302
 Tulare,599811,Treasurer,,DEM,John Chiang,173
 Tulare,599811,U.S. House,23,REP,Kevin McCarthy,425
+Tulare,Unknown,State Senate,16,REP,Ruth Musser-Lopez,13
+Tulare,Unknown,U.S. House,23,REP,Gail K. Lightfoot,1
+Tulare,Unknown,U.S. House,23,REP,Raul Garcia,11


### PR DESCRIPTION
Fix 2014 Tulare primary tests by adding a few missing candidates.

This PR adds catchall records for each office+candidate as the precinct-level data is not available.