### PR TITLE
Fix tests 2014 madera primary

### DIFF
--- a/2014/20140603__ca__primary__madera__precinct.csv
+++ b/2014/20140603__ca__primary__madera__precinct.csv
@@ -4150,3 +4150,4 @@ Madera,5432,Superintendent of Public Instruction,,NOP,Tom Torlakson,2
 Madera,5432,Treasurer,,DEM,John Chiang,2
 Madera,5432,U.S. House,4,IND,Jeffrey D. Gerlach,1
 Madera,5432,U.S. House,4,REP,Tom McClintock,1
+Madera,Unknown,State Assembly,5,LIB,Patrick D. Hogan,18

--- a/2014/20140603__ca__primary__mono__precinct.csv
+++ b/2014/20140603__ca__primary__mono__precinct.csv
@@ -40,6 +40,10 @@ Mono,1,Lieutenant Governor,,DEM,Gavin Newsom,87
 Mono,1,Lieutenant Governor,,REP,George Yang,18
 Mono,1,Lieutenant Governor,,GRN,Jena F. Goodman,4
 Mono,1,Lieutenant Governor,,REP,Ron Nehring,96
+Mono,1,Proposition 41,,,Yes,144
+Mono,1,Proposition 41,,,No,106
+Mono,1,Proposition 42,,,Yes,140
+Mono,1,Proposition 42,,,No,103
 Mono,1,Secretary of State,,DEM,Alex Padilla,50
 Mono,1,Secretary of State,,NON,Dan Schnur,15
 Mono,1,Secretary of State,,GRN,David Curtis,1
@@ -102,6 +106,10 @@ Mono,10,Lieutenant Governor,,DEM,Gavin Newsom,139
 Mono,10,Lieutenant Governor,,REP,George Yang,24
 Mono,10,Lieutenant Governor,,GRN,Jena F. Goodman,6
 Mono,10,Lieutenant Governor,,REP,Ron Nehring,54
+Mono,10,Proposition 41,,,Yes,172
+Mono,10,Proposition 41,,,No,98
+Mono,10,Proposition 42,,,Yes,158
+Mono,10,Proposition 42,,,No,107
 Mono,10,Secretary of State,,DEM,Alex Padilla,60
 Mono,10,Secretary of State,,NON,Dan Schnur,19
 Mono,10,Secretary of State,,GRN,David Curtis,14
@@ -164,6 +172,10 @@ Mono,11,Lieutenant Governor,,DEM,Gavin Newsom,99
 Mono,11,Lieutenant Governor,,REP,George Yang,6
 Mono,11,Lieutenant Governor,,GRN,Jena F. Goodman,2
 Mono,11,Lieutenant Governor,,REP,Ron Nehring,28
+Mono,11,Proposition 41,,,Yes,116
+Mono,11,Proposition 41,,,No,52
+Mono,11,Proposition 42,,,Yes,104
+Mono,11,Proposition 42,,,No,58
 Mono,11,Secretary of State,,DEM,Alex Padilla,54
 Mono,11,Secretary of State,,NON,Dan Schnur,14
 Mono,11,Secretary of State,,GRN,David Curtis,9
@@ -226,6 +238,10 @@ Mono,12,Lieutenant Governor,,DEM,Gavin Newsom,140
 Mono,12,Lieutenant Governor,,REP,George Yang,15
 Mono,12,Lieutenant Governor,,GRN,Jena F. Goodman,17
 Mono,12,Lieutenant Governor,,REP,Ron Nehring,67
+Mono,12,Proposition 41,,,Yes,190
+Mono,12,Proposition 41,,,No,112
+Mono,12,Proposition 42,,,Yes,170
+Mono,12,Proposition 42,,,No,117
 Mono,12,Secretary of State,,DEM,Alex Padilla,55
 Mono,12,Secretary of State,,NON,Dan Schnur,7
 Mono,12,Secretary of State,,GRN,David Curtis,17
@@ -288,6 +304,10 @@ Mono,13,Lieutenant Governor,,DEM,Gavin Newsom,114
 Mono,13,Lieutenant Governor,,REP,George Yang,12
 Mono,13,Lieutenant Governor,,GRN,Jena F. Goodman,10
 Mono,13,Lieutenant Governor,,REP,Ron Nehring,54
+Mono,13,Proposition 41,,,Yes,139
+Mono,13,Proposition 41,,,No,106
+Mono,13,Proposition 42,,,Yes,117
+Mono,13,Proposition 42,,,No,114
 Mono,13,Secretary of State,,DEM,Alex Padilla,43
 Mono,13,Secretary of State,,NON,Dan Schnur,13
 Mono,13,Secretary of State,,GRN,David Curtis,14
@@ -350,6 +370,10 @@ Mono,2,Lieutenant Governor,,DEM,Gavin Newsom,15
 Mono,2,Lieutenant Governor,,REP,George Yang,5
 Mono,2,Lieutenant Governor,,GRN,Jena F. Goodman,3
 Mono,2,Lieutenant Governor,,REP,Ron Nehring,37
+Mono,2,Proposition 41,,,Yes,36
+Mono,2,Proposition 41,,,No,41
+Mono,2,Proposition 42,,,Yes,33
+Mono,2,Proposition 42,,,No,43
 Mono,2,Secretary of State,,DEM,Alex Padilla,12
 Mono,2,Secretary of State,,NON,Dan Schnur,0
 Mono,2,Secretary of State,,GRN,David Curtis,2
@@ -412,6 +436,10 @@ Mono,3,Lieutenant Governor,,DEM,Gavin Newsom,68
 Mono,3,Lieutenant Governor,,REP,George Yang,19
 Mono,3,Lieutenant Governor,,GRN,Jena F. Goodman,6
 Mono,3,Lieutenant Governor,,REP,Ron Nehring,109
+Mono,3,Proposition 41,,,Yes,142
+Mono,3,Proposition 41,,,No,118
+Mono,3,Proposition 42,,,Yes,100
+Mono,3,Proposition 42,,,No,160
 Mono,3,Secretary of State,,DEM,Alex Padilla,41
 Mono,3,Secretary of State,,NON,Dan Schnur,9
 Mono,3,Secretary of State,,GRN,David Curtis,7
@@ -474,6 +502,10 @@ Mono,4,Lieutenant Governor,,DEM,Gavin Newsom,39
 Mono,4,Lieutenant Governor,,REP,George Yang,22
 Mono,4,Lieutenant Governor,,GRN,Jena F. Goodman,8
 Mono,4,Lieutenant Governor,,REP,Ron Nehring,51
+Mono,4,Proposition 41,,,Yes,83
+Mono,4,Proposition 41,,,No,76
+Mono,4,Proposition 42,,,Yes,68
+Mono,4,Proposition 42,,,No,85
 Mono,4,Secretary of State,,DEM,Alex Padilla,24
 Mono,4,Secretary of State,,NON,Dan Schnur,3
 Mono,4,Secretary of State,,GRN,David Curtis,14
@@ -536,6 +568,10 @@ Mono,5,Lieutenant Governor,,DEM,Gavin Newsom,75
 Mono,5,Lieutenant Governor,,REP,George Yang,14
 Mono,5,Lieutenant Governor,,GRN,Jena F. Goodman,7
 Mono,5,Lieutenant Governor,,REP,Ron Nehring,54
+Mono,5,Proposition 41,,,Yes,112
+Mono,5,Proposition 41,,,No,70
+Mono,5,Proposition 42,,,Yes,86
+Mono,5,Proposition 42,,,No,83
 Mono,5,Secretary of State,,DEM,Alex Padilla,29
 Mono,5,Secretary of State,,NON,Dan Schnur,12
 Mono,5,Secretary of State,,GRN,David Curtis,15
@@ -598,6 +634,10 @@ Mono,6,Lieutenant Governor,,DEM,Gavin Newsom,61
 Mono,6,Lieutenant Governor,,REP,George Yang,6
 Mono,6,Lieutenant Governor,,GRN,Jena F. Goodman,11
 Mono,6,Lieutenant Governor,,REP,Ron Nehring,45
+Mono,6,Proposition 41,,,Yes,74
+Mono,6,Proposition 41,,,No,61
+Mono,6,Proposition 42,,,Yes,62
+Mono,6,Proposition 42,,,No,77
 Mono,6,Secretary of State,,DEM,Alex Padilla,27
 Mono,6,Secretary of State,,NON,Dan Schnur,4
 Mono,6,Secretary of State,,GRN,David Curtis,11
@@ -660,6 +700,10 @@ Mono,7,Lieutenant Governor,,DEM,Gavin Newsom,148
 Mono,7,Lieutenant Governor,,REP,George Yang,20
 Mono,7,Lieutenant Governor,,GRN,Jena F. Goodman,8
 Mono,7,Lieutenant Governor,,REP,Ron Nehring,84
+Mono,7,Proposition 41,,,Yes,173
+Mono,7,Proposition 41,,,No,158
+Mono,7,Proposition 42,,,Yes,143
+Mono,7,Proposition 42,,,No,180
 Mono,7,Secretary of State,,DEM,Alex Padilla,76
 Mono,7,Secretary of State,,NON,Dan Schnur,16
 Mono,7,Secretary of State,,GRN,David Curtis,16
@@ -722,6 +766,10 @@ Mono,8,Lieutenant Governor,,DEM,Gavin Newsom,109
 Mono,8,Lieutenant Governor,,REP,George Yang,8
 Mono,8,Lieutenant Governor,,GRN,Jena F. Goodman,6
 Mono,8,Lieutenant Governor,,REP,Ron Nehring,47
+Mono,8,Proposition 41,,,Yes,145
+Mono,8,Proposition 41,,,No,86
+Mono,8,Proposition 42,,,Yes,108
+Mono,8,Proposition 42,,,No,107
 Mono,8,Secretary of State,,DEM,Alex Padilla,37
 Mono,8,Secretary of State,,NON,Dan Schnur,13
 Mono,8,Secretary of State,,GRN,David Curtis,10
@@ -784,6 +832,10 @@ Mono,9,Lieutenant Governor,,DEM,Gavin Newsom,153
 Mono,9,Lieutenant Governor,,REP,George Yang,24
 Mono,9,Lieutenant Governor,,GRN,Jena F. Goodman,9
 Mono,9,Lieutenant Governor,,REP,Ron Nehring,58
+Mono,9,Proposition 41,,,Yes,183
+Mono,9,Proposition 41,,,No,137
+Mono,9,Proposition 42,,,Yes,166
+Mono,9,Proposition 42,,,No,144
 Mono,9,Secretary of State,,DEM,Alex Padilla,74
 Mono,9,Secretary of State,,NON,Dan Schnur,12
 Mono,9,Secretary of State,,GRN,David Curtis,16
@@ -805,3 +857,5 @@ Mono,9,U.S. House,8,DEM,Bob Conaway,90
 Mono,9,U.S. House,8,DEM,Odessia D. Lee,44
 Mono,9,U.S. House,8,REP,Paul Cook,144
 Mono,9,U.S. House,8,REP,Paul Hannosh,28
+Mono,Unknown,Governor,,,Jimelle L. Walls,1
+Mono,Unknown,State Assembly,5,LIB,Patrick D. Hogan,17

--- a/2020/20201103__ca__general__santa_clara__precinct.csv
+++ b/2020/20201103__ca__general__santa_clara__precinct.csv
@@ -1,0 +1,11153 @@
+county,precinct,office,district,party,candidate,votes,election_day,mail
+Santa Clara,0002001,Registered Voters,,,,9,,
+Santa Clara,0002002,Registered Voters,,,,2731,,
+Santa Clara,0002005,Registered Voters,,,,1751,,
+Santa Clara,0002006,Registered Voters,,,,81,,
+Santa Clara,0002009,Registered Voters,,,,4365,,
+Santa Clara,0002013,Registered Voters,,,,3559,,
+Santa Clara,0002014,Registered Voters,,,,3297,,
+Santa Clara,0002018,Registered Voters,,,,142,,
+Santa Clara,0002025,Registered Voters,,,,4073,,
+Santa Clara,0002043,Registered Voters,,,,3095,,
+Santa Clara,0002046,Registered Voters,,,,4236,,
+Santa Clara,0002057,Registered Voters,,,,3967,,
+Santa Clara,0002068,Registered Voters,,,,3755,,
+Santa Clara,0002098,Registered Voters,,,,4126,,
+Santa Clara,0002108,Registered Voters,,,,3462,,
+Santa Clara,0002125,Registered Voters,,,,366,,
+Santa Clara,0002274,Registered Voters,,,,276,,
+Santa Clara,0002275,Registered Voters,,,,1173,,
+Santa Clara,0002278,Registered Voters,,,,1128,,
+Santa Clara,0002281,Registered Voters,,,,6,,
+Santa Clara,0002282,Registered Voters,,,,1413,,
+Santa Clara,0002285,Registered Voters,,,,2532,,
+Santa Clara,0002301,Registered Voters,,,,3636,,
+Santa Clara,0002305,Registered Voters,,,,4846,,
+Santa Clara,0002309,Registered Voters,,,,1231,,
+Santa Clara,0002314,Registered Voters,,,,2828,,
+Santa Clara,0002317,Registered Voters,,,,2707,,
+Santa Clara,0002330,Registered Voters,,,,4245,,
+Santa Clara,0002338,Registered Voters,,,,167,,
+Santa Clara,0002351,Registered Voters,,,,2398,,
+Santa Clara,0002353,Registered Voters,,,,43,,
+Santa Clara,0002539,Registered Voters,,,,258,,
+Santa Clara,0002542,Registered Voters,,,,2081,,
+Santa Clara,0002545,Registered Voters,,,,2367,,
+Santa Clara,0002720,Registered Voters,,,,1633,,
+Santa Clara,0002721,Registered Voters,,,,1433,,
+Santa Clara,0002723,Registered Voters,,,,3283,,
+Santa Clara,0002724,Registered Voters,,,,2596,,
+Santa Clara,0002725,Registered Voters,,,,2504,,
+Santa Clara,0002726,Registered Voters,,,,1642,,
+Santa Clara,0002727,Registered Voters,,,,1809,,
+Santa Clara,0002729,Registered Voters,,,,1933,,
+Santa Clara,0002734,Registered Voters,,,,2730,,
+Santa Clara,0002740,Registered Voters,,,,3015,,
+Santa Clara,0002751,Registered Voters,,,,25,,
+Santa Clara,0002761,Registered Voters,,,,4,,
+Santa Clara,0002802,Registered Voters,,,,2580,,
+Santa Clara,0002808,Registered Voters,,,,107,,
+Santa Clara,0002810,Registered Voters,,,,24,,
+Santa Clara,0002811,Registered Voters,,,,37,,
+Santa Clara,0002812,Registered Voters,,,,303,,
+Santa Clara,0002813,Registered Voters,,,,255,,
+Santa Clara,0002816,Registered Voters,,,,25,,
+Santa Clara,0002825,Registered Voters,,,,30,,
+Santa Clara,0002870,Registered Voters,,,,133,,
+Santa Clara,0002951,Registered Voters,,,,323,,
+Santa Clara,0003001,Registered Voters,,,,3173,,
+Santa Clara,0003002,Registered Voters,,,,3009,,
+Santa Clara,0003005,Registered Voters,,,,57,,
+Santa Clara,0003008,Registered Voters,,,,38,,
+Santa Clara,0003010,Registered Voters,,,,2810,,
+Santa Clara,0003011,Registered Voters,,,,2533,,
+Santa Clara,0003012,Registered Voters,,,,134,,
+Santa Clara,0003013,Registered Voters,,,,3482,,
+Santa Clara,0003016,Registered Voters,,,,1009,,
+Santa Clara,0003017,Registered Voters,,,,793,,
+Santa Clara,0003018,Registered Voters,,,,423,,
+Santa Clara,0003019,Registered Voters,,,,3485,,
+Santa Clara,0003021,Registered Voters,,,,317,,
+Santa Clara,0003023,Registered Voters,,,,2854,,
+Santa Clara,0003026,Registered Voters,,,,2113,,
+Santa Clara,0003029,Registered Voters,,,,0,,
+Santa Clara,0003031,Registered Voters,,,,1,,
+Santa Clara,0003032,Registered Voters,,,,1642,,
+Santa Clara,0003034,Registered Voters,,,,3422,,
+Santa Clara,0003035,Registered Voters,,,,2557,,
+Santa Clara,0003039,Registered Voters,,,,1739,,
+Santa Clara,0003040,Registered Voters,,,,0,,
+Santa Clara,0003042,Registered Voters,,,,1879,,
+Santa Clara,0003043,Registered Voters,,,,3029,,
+Santa Clara,0003045,Registered Voters,,,,3911,,
+Santa Clara,0003047,Registered Voters,,,,1215,,
+Santa Clara,0003048,Registered Voters,,,,3686,,
+Santa Clara,0003051,Registered Voters,,,,2555,,
+Santa Clara,0003053,Registered Voters,,,,3027,,
+Santa Clara,0003061,Registered Voters,,,,101,,
+Santa Clara,0003079,Registered Voters,,,,668,,
+Santa Clara,0003080,Registered Voters,,,,1072,,
+Santa Clara,0003086,Registered Voters,,,,3417,,
+Santa Clara,0003087,Registered Voters,,,,1575,,
+Santa Clara,0003089,Registered Voters,,,,0,,
+Santa Clara,0003095,Registered Voters,,,,5,,
+Santa Clara,0003101,Registered Voters,,,,171,,
+Santa Clara,0003102,Registered Voters,,,,613,,
+Santa Clara,0003103,Registered Voters,,,,1401,,
+Santa Clara,0003116,Registered Voters,,,,925,,
+Santa Clara,0003117,Registered Voters,,,,1009,,
+Santa Clara,0003120,Registered Voters,,,,627,,
+Santa Clara,0003122,Registered Voters,,,,2549,,
+Santa Clara,0003156,Registered Voters,,,,178,,
+Santa Clara,0003402,Registered Voters,,,,3488,,
+Santa Clara,0003406,Registered Voters,,,,3417,,
+Santa Clara,0003407,Registered Voters,,,,3434,,
+Santa Clara,0003408,Registered Voters,,,,4039,,
+Santa Clara,0003409,Registered Voters,,,,4109,,
+Santa Clara,0003410,Registered Voters,,,,4179,,
+Santa Clara,0003417,Registered Voters,,,,3754,,
+Santa Clara,0003427,Registered Voters,,,,3240,,
+Santa Clara,0003434,Registered Voters,,,,2385,,
+Santa Clara,0003438,Registered Voters,,,,4335,,
+Santa Clara,0003445,Registered Voters,,,,4000,,
+Santa Clara,0003601,Registered Voters,,,,1493,,
+Santa Clara,0003602,Registered Voters,,,,2654,,
+Santa Clara,0003603,Registered Voters,,,,1443,,
+Santa Clara,0003604,Registered Voters,,,,3195,,
+Santa Clara,0003605,Registered Voters,,,,3612,,
+Santa Clara,0003606,Registered Voters,,,,2846,,
+Santa Clara,0003608,Registered Voters,,,,3234,,
+Santa Clara,0003609,Registered Voters,,,,4404,,
+Santa Clara,0003611,Registered Voters,,,,3101,,
+Santa Clara,0003614,Registered Voters,,,,1504,,
+Santa Clara,0003624,Registered Voters,,,,3889,,
+Santa Clara,0003635,Registered Voters,,,,0,,
+Santa Clara,0003652,Registered Voters,,,,1476,,
+Santa Clara,0003655,Registered Voters,,,,219,,
+Santa Clara,0003669,Registered Voters,,,,3,,
+Santa Clara,0003670,Registered Voters,,,,160,,
+Santa Clara,0003777,Registered Voters,,,,1745,,
+Santa Clara,0003779,Registered Voters,,,,146,,
+Santa Clara,0003782,Registered Voters,,,,421,,
+Santa Clara,0003783,Registered Voters,,,,423,,
+Santa Clara,0003801,Registered Voters,,,,1711,,
+Santa Clara,0003802,Registered Voters,,,,2793,,
+Santa Clara,0003803,Registered Voters,,,,2482,,
+Santa Clara,0003804,Registered Voters,,,,1112,,
+Santa Clara,0003810,Registered Voters,,,,2257,,
+Santa Clara,0003811,Registered Voters,,,,2865,,
+Santa Clara,0003814,Registered Voters,,,,2713,,
+Santa Clara,0003820,Registered Voters,,,,2323,,
+Santa Clara,0003821,Registered Voters,,,,1089,,
+Santa Clara,0003825,Registered Voters,,,,1427,,
+Santa Clara,0003828,Registered Voters,,,,1215,,
+Santa Clara,0003835,Registered Voters,,,,1393,,
+Santa Clara,0003840,Registered Voters,,,,2253,,
+Santa Clara,0003846,Registered Voters,,,,117,,
+Santa Clara,0003861,Registered Voters,,,,82,,
+Santa Clara,0004401,Registered Voters,,,,3560,,
+Santa Clara,0004402,Registered Voters,,,,4133,,
+Santa Clara,0004403,Registered Voters,,,,334,,
+Santa Clara,0004405,Registered Voters,,,,4385,,
+Santa Clara,0004407,Registered Voters,,,,3743,,
+Santa Clara,0004409,Registered Voters,,,,4845,,
+Santa Clara,0004411,Registered Voters,,,,2581,,
+Santa Clara,0004412,Registered Voters,,,,4345,,
+Santa Clara,0004414,Registered Voters,,,,4757,,
+Santa Clara,0004417,Registered Voters,,,,3982,,
+Santa Clara,0004665,Registered Voters,,,,38,,
+Santa Clara,0004666,Registered Voters,,,,7,,
+Santa Clara,0004671,Registered Voters,,,,1844,,
+Santa Clara,0004672,Registered Voters,,,,1031,,
+Santa Clara,0004674,Registered Voters,,,,1594,,
+Santa Clara,0004675,Registered Voters,,,,3153,,
+Santa Clara,0004685,Registered Voters,,,,1707,,
+Santa Clara,0004687,Registered Voters,,,,1777,,
+Santa Clara,0004688,Registered Voters,,,,3379,,
+Santa Clara,0004691,Registered Voters,,,,2285,,
+Santa Clara,0004696,Registered Voters,,,,1356,,
+Santa Clara,0004698,Registered Voters,,,,1201,,
+Santa Clara,0004699,Registered Voters,,,,1732,,
+Santa Clara,0004702,Registered Voters,,,,1089,,
+Santa Clara,0004715,Registered Voters,,,,641,,
+Santa Clara,0004733,Registered Voters,,,,51,,
+Santa Clara,0004801,Registered Voters,,,,1564,,
+Santa Clara,0004806,Registered Voters,,,,3037,,
+Santa Clara,0004811,Registered Voters,,,,1845,,
+Santa Clara,0004826,Registered Voters,,,,1603,,
+Santa Clara,0004827,Registered Voters,,,,3182,,
+Santa Clara,0004833,Registered Voters,,,,2168,,
+Santa Clara,0004851,Registered Voters,,,,1204,,
+Santa Clara,0004853,Registered Voters,,,,2222,,
+Santa Clara,0004858,Registered Voters,,,,3005,,
+Santa Clara,0004876,Registered Voters,,,,3740,,
+Santa Clara,0004881,Registered Voters,,,,4439,,
+Santa Clara,0004941,Registered Voters,,,,3088,,
+Santa Clara,0004942,Registered Voters,,,,2217,,
+Santa Clara,0004943,Registered Voters,,,,107,,
+Santa Clara,0004944,Registered Voters,,,,1139,,
+Santa Clara,0004945,Registered Voters,,,,1582,,
+Santa Clara,0004946,Registered Voters,,,,3484,,
+Santa Clara,0004949,Registered Voters,,,,2620,,
+Santa Clara,0004950,Registered Voters,,,,2320,,
+Santa Clara,0004954,Registered Voters,,,,2050,,
+Santa Clara,0004956,Registered Voters,,,,270,,
+Santa Clara,0004958,Registered Voters,,,,1699,,
+Santa Clara,0004965,Registered Voters,,,,3097,,
+Santa Clara,0004969,Registered Voters,,,,2417,,
+Santa Clara,0004971,Registered Voters,,,,944,,
+Santa Clara,0004973,Registered Voters,,,,2540,,
+Santa Clara,0004974,Registered Voters,,,,1119,,
+Santa Clara,0005449,Registered Voters,,,,148,,
+Santa Clara,0005451,Registered Voters,,,,17,,
+Santa Clara,0005454,Registered Voters,,,,9,,
+Santa Clara,0005455,Registered Voters,,,,0,,
+Santa Clara,0005456,Registered Voters,,,,4,,
+Santa Clara,0005458,Registered Voters,,,,2,,
+Santa Clara,0005502,Registered Voters,,,,464,,
+Santa Clara,0005503,Registered Voters,,,,400,,
+Santa Clara,0005505,Registered Voters,,,,374,,
+Santa Clara,0005507,Registered Voters,,,,1,,
+Santa Clara,0005556,Registered Voters,,,,1648,,
+Santa Clara,0005557,Registered Voters,,,,1052,,
+Santa Clara,0005567,Registered Voters,,,,616,,
+Santa Clara,0005742,Registered Voters,,,,18,,
+Santa Clara,0005743,Registered Voters,,,,587,,
+Santa Clara,0005745,Registered Voters,,,,493,,
+Santa Clara,0005747,Registered Voters,,,,988,,
+Santa Clara,0005748,Registered Voters,,,,1927,,
+Santa Clara,0005756,Registered Voters,,,,103,,
+Santa Clara,0005758,Registered Voters,,,,187,,
+Santa Clara,0005759,Registered Voters,,,,477,,
+Santa Clara,0005762,Registered Voters,,,,298,,
+Santa Clara,0005763,Registered Voters,,,,82,,
+Santa Clara,0005770,Registered Voters,,,,181,,
+Santa Clara,0005775,Registered Voters,,,,373,,
+Santa Clara,0005785,Registered Voters,,,,0,,
+Santa Clara,0005793,Registered Voters,,,,0,,
+Santa Clara,0005795,Registered Voters,,,,3,,
+Santa Clara,0005804,Registered Voters,,,,1276,,
+Santa Clara,0005810,Registered Voters,,,,415,,
+Santa Clara,0005811,Registered Voters,,,,327,,
+Santa Clara,0005813,Registered Voters,,,,60,,
+Santa Clara,0005814,Registered Voters,,,,263,,
+Santa Clara,0005854,Registered Voters,,,,2,,
+Santa Clara,0005879,Registered Voters,,,,25,,
+Santa Clara,0005886,Registered Voters,,,,22,,
+Santa Clara,0005888,Registered Voters,,,,0,,
+Santa Clara,0005894,Registered Voters,,,,258,,
+Santa Clara,0005896,Registered Voters,,,,4,,
+Santa Clara,0005901,Registered Voters,,,,1,,
+Santa Clara,0005902,Registered Voters,,,,496,,
+Santa Clara,0005903,Registered Voters,,,,679,,
+Santa Clara,0005906,Registered Voters,,,,472,,
+Santa Clara,0005907,Registered Voters,,,,9,,
+Santa Clara,0005911,Registered Voters,,,,2097,,
+Santa Clara,0005912,Registered Voters,,,,212,,
+Santa Clara,0005914,Registered Voters,,,,1243,,
+Santa Clara,0005915,Registered Voters,,,,1049,,
+Santa Clara,0005916,Registered Voters,,,,91,,
+Santa Clara,0005917,Registered Voters,,,,296,,
+Santa Clara,0005919,Registered Voters,,,,413,,
+Santa Clara,0005922,Registered Voters,,,,628,,
+Santa Clara,0005925,Registered Voters,,,,94,,
+Santa Clara,0005927,Registered Voters,,,,1,,
+Santa Clara,0005929,Registered Voters,,,,159,,
+Santa Clara,0005931,Registered Voters,,,,160,,
+Santa Clara,0005936,Registered Voters,,,,506,,
+Santa Clara,0005940,Registered Voters,,,,59,,
+Santa Clara,0005947,Registered Voters,,,,575,,
+Santa Clara,0005949,Registered Voters,,,,685,,
+Santa Clara,0005950,Registered Voters,,,,159,,
+Santa Clara,0005951,Registered Voters,,,,6,,
+Santa Clara,0005955,Registered Voters,,,,1347,,
+Santa Clara,0005956,Registered Voters,,,,1192,,
+Santa Clara,0005957,Registered Voters,,,,152,,
+Santa Clara,0005958,Registered Voters,,,,943,,
+Santa Clara,0005959,Registered Voters,,,,103,,
+Santa Clara,0005965,Registered Voters,,,,1280,,
+Santa Clara,0005966,Registered Voters,,,,241,,
+Santa Clara,0005975,Registered Voters,,,,57,,
+Santa Clara,0005988,Registered Voters,,,,2,,
+Santa Clara,0006023,Registered Voters,,,,18,,
+Santa Clara,0006028,Registered Voters,,,,73,,
+Santa Clara,0006031,Registered Voters,,,,35,,
+Santa Clara,0006035,Registered Voters,,,,0,,
+Santa Clara,0006036,Registered Voters,,,,0,,
+Santa Clara,0006048,Registered Voters,,,,24,,
+Santa Clara,0006401,Registered Voters,,,,1,,
+Santa Clara,0006402,Registered Voters,,,,100,,
+Santa Clara,0006404,Registered Voters,,,,2921,,
+Santa Clara,0006405,Registered Voters,,,,11,,
+Santa Clara,0006410,Registered Voters,,,,110,,
+Santa Clara,0006413,Registered Voters,,,,10,,
+Santa Clara,0006418,Registered Voters,,,,868,,
+Santa Clara,0006419,Registered Voters,,,,64,,
+Santa Clara,0006423,Registered Voters,,,,59,,
+Santa Clara,0006452,Registered Voters,,,,1297,,
+Santa Clara,0006454,Registered Voters,,,,301,,
+Santa Clara,0006455,Registered Voters,,,,3400,,
+Santa Clara,0006491,Registered Voters,,,,28,,
+Santa Clara,0006502,Registered Voters,,,,376,,
+Santa Clara,0006509,Registered Voters,,,,23,,
+Santa Clara,0006510,Registered Voters,,,,38,,
+Santa Clara,0006511,Registered Voters,,,,152,,
+Santa Clara,0006515,Registered Voters,,,,129,,
+Santa Clara,0006624,Registered Voters,,,,7,,
+Santa Clara,0006625,Registered Voters,,,,5,,
+Santa Clara,0006669,Registered Voters,,,,85,,
+Santa Clara,0006678,Registered Voters,,,,61,,
+Santa Clara,0007001,Registered Voters,,,,2136,,
+Santa Clara,0007005,Registered Voters,,,,2719,,
+Santa Clara,0007011,Registered Voters,,,,378,,
+Santa Clara,0007012,Registered Voters,,,,2078,,
+Santa Clara,0007014,Registered Voters,,,,2416,,
+Santa Clara,0007019,Registered Voters,,,,3976,,
+Santa Clara,0007025,Registered Voters,,,,3425,,
+Santa Clara,0007028,Registered Voters,,,,3142,,
+Santa Clara,0007032,Registered Voters,,,,4060,,
+Santa Clara,0007036,Registered Voters,,,,3701,,
+Santa Clara,0007038,Registered Voters,,,,321,,
+Santa Clara,0007041,Registered Voters,,,,3457,,
+Santa Clara,0007044,Registered Voters,,,,2098,,
+Santa Clara,0007046,Registered Voters,,,,3396,,
+Santa Clara,0007051,Registered Voters,,,,0,,
+Santa Clara,0007059,Registered Voters,,,,549,,
+Santa Clara,0007061,Registered Voters,,,,2225,,
+Santa Clara,0007062,Registered Voters,,,,2982,,
+Santa Clara,0007079,Registered Voters,,,,2131,,
+Santa Clara,0007081,Registered Voters,,,,1922,,
+Santa Clara,0007089,Registered Voters,,,,1362,,
+Santa Clara,0007201,Registered Voters,,,,489,,
+Santa Clara,0007202,Registered Voters,,,,1040,,
+Santa Clara,0007203,Registered Voters,,,,701,,
+Santa Clara,0007205,Registered Voters,,,,3320,,
+Santa Clara,0007214,Registered Voters,,,,2130,,
+Santa Clara,0007217,Registered Voters,,,,4044,,
+Santa Clara,0007219,Registered Voters,,,,1185,,
+Santa Clara,0007221,Registered Voters,,,,1804,,
+Santa Clara,0007224,Registered Voters,,,,1022,,
+Santa Clara,0007231,Registered Voters,,,,826,,
+Santa Clara,0007235,Registered Voters,,,,2681,,
+Santa Clara,0007237,Registered Voters,,,,2778,,
+Santa Clara,0007245,Registered Voters,,,,295,,
+Santa Clara,0007246,Registered Voters,,,,1654,,
+Santa Clara,0007248,Registered Voters,,,,2685,,
+Santa Clara,0007252,Registered Voters,,,,3672,,
+Santa Clara,0007255,Registered Voters,,,,3699,,
+Santa Clara,0007257,Registered Voters,,,,1653,,
+Santa Clara,0007261,Registered Voters,,,,2322,,
+Santa Clara,0007264,Registered Voters,,,,2647,,
+Santa Clara,0007271,Registered Voters,,,,3185,,
+Santa Clara,0007273,Registered Voters,,,,3592,,
+Santa Clara,0007282,Registered Voters,,,,2151,,
+Santa Clara,0007294,Registered Voters,,,,778,,
+Santa Clara,0007295,Registered Voters,,,,2045,,
+Santa Clara,0007298,Registered Voters,,,,1362,,
+Santa Clara,0007299,Registered Voters,,,,1137,,
+Santa Clara,0007306,Registered Voters,,,,0,,
+Santa Clara,0007401,Registered Voters,,,,0,,
+Santa Clara,0007402,Registered Voters,,,,660,,
+Santa Clara,0007403,Registered Voters,,,,1650,,
+Santa Clara,0007408,Registered Voters,,,,966,,
+Santa Clara,0007409,Registered Voters,,,,494,,
+Santa Clara,0007410,Registered Voters,,,,8,,
+Santa Clara,0007411,Registered Voters,,,,58,,
+Santa Clara,0007414,Registered Voters,,,,392,,
+Santa Clara,0007415,Registered Voters,,,,53,,
+Santa Clara,0007416,Registered Voters,,,,250,,
+Santa Clara,0007417,Registered Voters,,,,3477,,
+Santa Clara,0007418,Registered Voters,,,,2233,,
+Santa Clara,0007419,Registered Voters,,,,1353,,
+Santa Clara,0007430,Registered Voters,,,,3307,,
+Santa Clara,0007435,Registered Voters,,,,3152,,
+Santa Clara,0007436,Registered Voters,,,,4845,,
+Santa Clara,0007438,Registered Voters,,,,419,,
+Santa Clara,0007440,Registered Voters,,,,72,,
+Santa Clara,0007441,Registered Voters,,,,2350,,
+Santa Clara,0007442,Registered Voters,,,,356,,
+Santa Clara,0007447,Registered Voters,,,,3253,,
+Santa Clara,0007458,Registered Voters,,,,2928,,
+Santa Clara,0007459,Registered Voters,,,,3365,,
+Santa Clara,0007470,Registered Voters,,,,2646,,
+Santa Clara,0007471,Registered Voters,,,,4273,,
+Santa Clara,0007479,Registered Voters,,,,1875,,
+Santa Clara,0007483,Registered Voters,,,,3183,,
+Santa Clara,0007601,Registered Voters,,,,3927,,
+Santa Clara,0007606,Registered Voters,,,,4352,,
+Santa Clara,0007609,Registered Voters,,,,1044,,
+Santa Clara,0007615,Registered Voters,,,,1407,,
+Santa Clara,0007619,Registered Voters,,,,2469,,
+Santa Clara,0007620,Registered Voters,,,,3744,,
+Santa Clara,0007621,Registered Voters,,,,4374,,
+Santa Clara,0007624,Registered Voters,,,,3107,,
+Santa Clara,0007632,Registered Voters,,,,3674,,
+Santa Clara,0007634,Registered Voters,,,,2025,,
+Santa Clara,0007648,Registered Voters,,,,3583,,
+Santa Clara,0007654,Registered Voters,,,,4833,,
+Santa Clara,0007660,Registered Voters,,,,3885,,
+Santa Clara,0007666,Registered Voters,,,,3876,,
+Santa Clara,0007670,Registered Voters,,,,118,,
+Santa Clara,0007673,Registered Voters,,,,1,,
+Santa Clara,0007674,Registered Voters,,,,3,,
+Santa Clara,0007677,Registered Voters,,,,4292,,
+Santa Clara,0007680,Registered Voters,,,,2456,,
+Santa Clara,0007689,Registered Voters,,,,16,,
+Santa Clara,0007690,Registered Voters,,,,1264,,
+Santa Clara,0007801,Registered Voters,,,,881,,
+Santa Clara,0007802,Registered Voters,,,,458,,
+Santa Clara,0007803,Registered Voters,,,,1204,,
+Santa Clara,0007805,Registered Voters,,,,2246,,
+Santa Clara,0007810,Registered Voters,,,,309,,
+Santa Clara,0007811,Registered Voters,,,,230,,
+Santa Clara,0007812,Registered Voters,,,,1728,,
+Santa Clara,0007816,Registered Voters,,,,288,,
+Santa Clara,0007817,Registered Voters,,,,12,,
+Santa Clara,0007818,Registered Voters,,,,257,,
+Santa Clara,0007821,Registered Voters,,,,4767,,
+Santa Clara,0007826,Registered Voters,,,,4223,,
+Santa Clara,0007827,Registered Voters,,,,1536,,
+Santa Clara,0007832,Registered Voters,,,,2704,,
+Santa Clara,0007833,Registered Voters,,,,3385,,
+Santa Clara,0007843,Registered Voters,,,,5001,,
+Santa Clara,0007849,Registered Voters,,,,3380,,
+Santa Clara,0007850,Registered Voters,,,,2424,,
+Santa Clara,0007851,Registered Voters,,,,1426,,
+Santa Clara,0007861,Registered Voters,,,,2087,,
+Santa Clara,0007867,Registered Voters,,,,3759,,
+Santa Clara,0007874,Registered Voters,,,,507,,
+Santa Clara,0007880,Registered Voters,,,,5,,
+Santa Clara,0008001,Registered Voters,,,,273,,
+Santa Clara,0008002,Registered Voters,,,,465,,
+Santa Clara,0008003,Registered Voters,,,,2865,,
+Santa Clara,0008005,Registered Voters,,,,4023,,
+Santa Clara,0008007,Registered Voters,,,,761,,
+Santa Clara,0008011,Registered Voters,,,,492,,
+Santa Clara,0008012,Registered Voters,,,,16,,
+Santa Clara,0008013,Registered Voters,,,,109,,
+Santa Clara,0008016,Registered Voters,,,,4535,,
+Santa Clara,0008017,Registered Voters,,,,1925,,
+Santa Clara,0008022,Registered Voters,,,,969,,
+Santa Clara,0008023,Registered Voters,,,,970,,
+Santa Clara,0008026,Registered Voters,,,,1174,,
+Santa Clara,0008028,Registered Voters,,,,382,,
+Santa Clara,0008029,Registered Voters,,,,170,,
+Santa Clara,0008030,Registered Voters,,,,1148,,
+Santa Clara,0008033,Registered Voters,,,,282,,
+Santa Clara,0008034,Registered Voters,,,,290,,
+Santa Clara,0008038,Registered Voters,,,,4,,
+Santa Clara,0008040,Registered Voters,,,,630,,
+Santa Clara,0008047,Registered Voters,,,,2162,,
+Santa Clara,0008049,Registered Voters,,,,59,,
+Santa Clara,0008050,Registered Voters,,,,1860,,
+Santa Clara,0008053,Registered Voters,,,,2999,,
+Santa Clara,0008054,Registered Voters,,,,2428,,
+Santa Clara,0008055,Registered Voters,,,,339,,
+Santa Clara,0008062,Registered Voters,,,,3284,,
+Santa Clara,0008066,Registered Voters,,,,1063,,
+Santa Clara,0008067,Registered Voters,,,,3081,,
+Santa Clara,0008068,Registered Voters,,,,49,,
+Santa Clara,0008072,Registered Voters,,,,606,,
+Santa Clara,0008073,Registered Voters,,,,563,,
+Santa Clara,0008079,Registered Voters,,,,2822,,
+Santa Clara,0008082,Registered Voters,,,,2118,,
+Santa Clara,0008085,Registered Voters,,,,1419,,
+Santa Clara,0008089,Registered Voters,,,,2970,,
+Santa Clara,0008092,Registered Voters,,,,91,,
+Santa Clara,0008093,Registered Voters,,,,55,,
+Santa Clara,0008096,Registered Voters,,,,2762,,
+Santa Clara,0008101,Registered Voters,,,,1515,,
+Santa Clara,0008104,Registered Voters,,,,164,,
+Santa Clara,0008105,Registered Voters,,,,423,,
+Santa Clara,0008117,Registered Voters,,,,1915,,
+Santa Clara,0008122,Registered Voters,,,,2730,,
+Santa Clara,0008128,Registered Voters,,,,10,,
+Santa Clara,0008133,Registered Voters,,,,20,,
+Santa Clara,0008201,Registered Voters,,,,2933,,
+Santa Clara,0008203,Registered Voters,,,,3023,,
+Santa Clara,0008205,Registered Voters,,,,3725,,
+Santa Clara,0008208,Registered Voters,,,,3106,,
+Santa Clara,0008212,Registered Voters,,,,1552,,
+Santa Clara,0008214,Registered Voters,,,,602,,
+Santa Clara,0008227,Registered Voters,,,,4001,,
+Santa Clara,0008228,Registered Voters,,,,2382,,
+Santa Clara,0008230,Registered Voters,,,,3764,,
+Santa Clara,0008231,Registered Voters,,,,2526,,
+Santa Clara,0008232,Registered Voters,,,,4524,,
+Santa Clara,0008236,Registered Voters,,,,4911,,
+Santa Clara,0008246,Registered Voters,,,,2902,,
+Santa Clara,0008254,Registered Voters,,,,3016,,
+Santa Clara,0008262,Registered Voters,,,,2099,,
+Santa Clara,0008264,Registered Voters,,,,2143,,
+Santa Clara,0008401,Registered Voters,,,,2543,,
+Santa Clara,0008404,Registered Voters,,,,5049,,
+Santa Clara,0008408,Registered Voters,,,,1578,,
+Santa Clara,0008409,Registered Voters,,,,1567,,
+Santa Clara,0008414,Registered Voters,,,,469,,
+Santa Clara,0008418,Registered Voters,,,,538,,
+Santa Clara,0008421,Registered Voters,,,,49,,
+Santa Clara,0008423,Registered Voters,,,,2,,
+Santa Clara,0008430,Registered Voters,,,,3972,,
+Santa Clara,0008435,Registered Voters,,,,4237,,
+Santa Clara,0008438,Registered Voters,,,,4863,,
+Santa Clara,0008439,Registered Voters,,,,3957,,
+Santa Clara,0008445,Registered Voters,,,,2413,,
+Santa Clara,0008447,Registered Voters,,,,10,,
+Santa Clara,0008456,Registered Voters,,,,4489,,
+Santa Clara,0008457,Registered Voters,,,,4349,,
+Santa Clara,0008464,Registered Voters,,,,4207,,
+Santa Clara,0008470,Registered Voters,,,,4024,,
+Santa Clara,0008472,Registered Voters,,,,3480,,
+Santa Clara,0008486,Registered Voters,,,,4200,,
+Santa Clara,0008492,Registered Voters,,,,4467,,
+Santa Clara,0008502,Registered Voters,,,,258,,
+Santa Clara,0008601,Registered Voters,,,,586,,
+Santa Clara,0008603,Registered Voters,,,,2632,,
+Santa Clara,0008605,Registered Voters,,,,3541,,
+Santa Clara,0008609,Registered Voters,,,,0,,
+Santa Clara,0008610,Registered Voters,,,,1728,,
+Santa Clara,0008612,Registered Voters,,,,2526,,
+Santa Clara,0008615,Registered Voters,,,,2336,,
+Santa Clara,0008619,Registered Voters,,,,815,,
+Santa Clara,0008625,Registered Voters,,,,132,,
+Santa Clara,0008627,Registered Voters,,,,1434,,
+Santa Clara,0008629,Registered Voters,,,,2148,,
+Santa Clara,0008630,Registered Voters,,,,2906,,
+Santa Clara,0008631,Registered Voters,,,,1689,,
+Santa Clara,0008634,Registered Voters,,,,508,,
+Santa Clara,0008636,Registered Voters,,,,456,,
+Santa Clara,0008645,Registered Voters,,,,3394,,
+Santa Clara,0008648,Registered Voters,,,,3033,,
+Santa Clara,0008650,Registered Voters,,,,421,,
+Santa Clara,0008653,Registered Voters,,,,260,,
+Santa Clara,0008654,Registered Voters,,,,311,,
+Santa Clara,0008655,Registered Voters,,,,0,,
+Santa Clara,0008657,Registered Voters,,,,766,,
+Santa Clara,0008658,Registered Voters,,,,3874,,
+Santa Clara,0008670,Registered Voters,,,,2848,,
+Santa Clara,0008675,Registered Voters,,,,1559,,
+Santa Clara,0008676,Registered Voters,,,,3196,,
+Santa Clara,0008680,Registered Voters,,,,2189,,
+Santa Clara,0008683,Registered Voters,,,,3591,,
+Santa Clara,0008687,Registered Voters,,,,3452,,
+Santa Clara,0008697,Registered Voters,,,,3637,,
+Santa Clara,0008801,Registered Voters,,,,2428,,
+Santa Clara,0008805,Registered Voters,,,,1963,,
+Santa Clara,0008809,Registered Voters,,,,3399,,
+Santa Clara,0008812,Registered Voters,,,,2026,,
+Santa Clara,0008817,Registered Voters,,,,1041,,
+Santa Clara,0008820,Registered Voters,,,,2110,,
+Santa Clara,0008822,Registered Voters,,,,2375,,
+Santa Clara,0008828,Registered Voters,,,,803,,
+Santa Clara,0008829,Registered Voters,,,,721,,
+Santa Clara,0008832,Registered Voters,,,,2104,,
+Santa Clara,0008834,Registered Voters,,,,1266,,
+Santa Clara,0008838,Registered Voters,,,,300,,
+Santa Clara,0008839,Registered Voters,,,,3405,,
+Santa Clara,0008844,Registered Voters,,,,3471,,
+Santa Clara,0008848,Registered Voters,,,,1841,,
+Santa Clara,0008853,Registered Voters,,,,2363,,
+Santa Clara,0008857,Registered Voters,,,,1646,,
+Santa Clara,0008858,Registered Voters,,,,2376,,
+Santa Clara,0008862,Registered Voters,,,,2560,,
+Santa Clara,0008868,Registered Voters,,,,131,,
+Santa Clara,0008873,Registered Voters,,,,1045,,
+Santa Clara,0008874,Registered Voters,,,,21,,
+Santa Clara,0008879,Registered Voters,,,,3228,,
+Santa Clara,0008883,Registered Voters,,,,3404,,
+Santa Clara,0008885,Registered Voters,,,,3137,,
+Santa Clara,0008886,Registered Voters,,,,357,,
+Santa Clara,0008889,Registered Voters,,,,2680,,
+Santa Clara,0008898,Registered Voters,,,,2737,,
+Santa Clara,0008903,Registered Voters,,,,3460,,
+Santa Clara,0008915,Registered Voters,,,,19,,
+Santa Clara,0008916,Registered Voters,,,,15,,
+Santa Clara,0008920,Registered Voters,,,,2,,
+Santa Clara,0008923,Registered Voters,,,,4,,
+Santa Clara,0008924,Registered Voters,,,,17,,
+Santa Clara,0009001,Registered Voters,,,,3165,,
+Santa Clara,0009005,Registered Voters,,,,4703,,
+Santa Clara,0009051,Registered Voters,,,,1991,,
+Santa Clara,0009055,Registered Voters,,,,67,,
+Santa Clara,0009056,Registered Voters,,,,3199,,
+Santa Clara,0009059,Registered Voters,,,,2765,,
+Santa Clara,0009061,Registered Voters,,,,0,,
+Santa Clara,0009062,Registered Voters,,,,2525,,
+Santa Clara,0009101,Registered Voters,,,,3389,,
+Santa Clara,0009103,Registered Voters,,,,995,,
+Santa Clara,0009104,Registered Voters,,,,2986,,
+Santa Clara,0009109,Registered Voters,,,,1982,,
+Santa Clara,0009151,Registered Voters,,,,2951,,
+Santa Clara,0009157,Registered Voters,,,,3619,,
+Santa Clara,0009163,Registered Voters,,,,1454,,
+Santa Clara,0009166,Registered Voters,,,,1445,,
+Santa Clara,0009201,Registered Voters,,,,891,,
+Santa Clara,0009203,Registered Voters,,,,1773,,
+Santa Clara,0009208,Registered Voters,,,,1660,,
+Santa Clara,0009210,Registered Voters,,,,2215,,
+Santa Clara,0009219,Registered Voters,,,,231,,
+Santa Clara,0009220,Registered Voters,,,,2840,,
+Santa Clara,0009251,Registered Voters,,,,1343,,
+Santa Clara,0009252,Registered Voters,,,,2146,,
+Santa Clara,0009258,Registered Voters,,,,1901,,
+Santa Clara,0009262,Registered Voters,,,,267,,
+Santa Clara,0009264,Registered Voters,,,,1999,,
+Santa Clara,0009268,Registered Voters,,,,2037,,
+Santa Clara,0009275,Registered Voters,,,,2049,,
+Santa Clara,0009282,Registered Voters,,,,5,,
+Santa Clara,0002001,Ballots Cast,,,,81,,
+Santa Clara,0002002,Ballots Cast,,,,2410,,
+Santa Clara,0002005,Ballots Cast,,,,1588,,
+Santa Clara,0002006,Ballots Cast,,,,73,,
+Santa Clara,0002009,Ballots Cast,,,,3794,,
+Santa Clara,0002013,Ballots Cast,,,,3164,,
+Santa Clara,0002014,Ballots Cast,,,,2876,,
+Santa Clara,0002018,Ballots Cast,,,,118,,
+Santa Clara,0002025,Ballots Cast,,,,3621,,
+Santa Clara,0002043,Ballots Cast,,,,2814,,
+Santa Clara,0002046,Ballots Cast,,,,3751,,
+Santa Clara,0002057,Ballots Cast,,,,3510,,
+Santa Clara,0002068,Ballots Cast,,,,3394,,
+Santa Clara,0002098,Ballots Cast,,,,3618,,
+Santa Clara,0002108,Ballots Cast,,,,3105,,
+Santa Clara,0002125,Ballots Cast,,,,334,,
+Santa Clara,0002274,Ballots Cast,,,,247,,
+Santa Clara,0002275,Ballots Cast,,,,1086,,
+Santa Clara,0002278,Ballots Cast,,,,1014,,
+Santa Clara,0002281,Ballots Cast,,,,5,,
+Santa Clara,0002282,Ballots Cast,,,,1273,,
+Santa Clara,0002285,Ballots Cast,,,,2313,,
+Santa Clara,0002301,Ballots Cast,,,,3261,,
+Santa Clara,0002305,Ballots Cast,,,,4372,,
+Santa Clara,0002309,Ballots Cast,,,,1127,,
+Santa Clara,0002314,Ballots Cast,,,,2591,,
+Santa Clara,0002317,Ballots Cast,,,,2469,,
+Santa Clara,0002330,Ballots Cast,,,,3888,,
+Santa Clara,0002338,Ballots Cast,,,,147,,
+Santa Clara,0002351,Ballots Cast,,,,2194,,
+Santa Clara,0002353,Ballots Cast,,,,35,,
+Santa Clara,0002539,Ballots Cast,,,,147,,
+Santa Clara,0002542,Ballots Cast,,,,1541,,
+Santa Clara,0002545,Ballots Cast,,,,1975,,
+Santa Clara,0002720,Ballots Cast,,,,1501,,
+Santa Clara,0002721,Ballots Cast,,,,1290,,
+Santa Clara,0002723,Ballots Cast,,,,2971,,
+Santa Clara,0002724,Ballots Cast,,,,2330,,
+Santa Clara,0002725,Ballots Cast,,,,2218,,
+Santa Clara,0002726,Ballots Cast,,,,1431,,
+Santa Clara,0002727,Ballots Cast,,,,1667,,
+Santa Clara,0002729,Ballots Cast,,,,1767,,
+Santa Clara,0002734,Ballots Cast,,,,2374,,
+Santa Clara,0002740,Ballots Cast,,,,2659,,
+Santa Clara,0002751,Ballots Cast,,,,17,,
+Santa Clara,0002761,Ballots Cast,,,,4,,
+Santa Clara,0002802,Ballots Cast,,,,2375,,
+Santa Clara,0002808,Ballots Cast,,,,86,,
+Santa Clara,0002810,Ballots Cast,,,,21,,
+Santa Clara,0002811,Ballots Cast,,,,36,,
+Santa Clara,0002812,Ballots Cast,,,,269,,
+Santa Clara,0002813,Ballots Cast,,,,237,,
+Santa Clara,0002816,Ballots Cast,,,,23,,
+Santa Clara,0002825,Ballots Cast,,,,15,,
+Santa Clara,0002870,Ballots Cast,,,,121,,
+Santa Clara,0002951,Ballots Cast,,,,277,,
+Santa Clara,0003001,Ballots Cast,,,,2723,,
+Santa Clara,0003002,Ballots Cast,,,,2510,,
+Santa Clara,0003005,Ballots Cast,,,,54,,
+Santa Clara,0003008,Ballots Cast,,,,31,,
+Santa Clara,0003010,Ballots Cast,,,,2323,,
+Santa Clara,0003011,Ballots Cast,,,,2106,,
+Santa Clara,0003012,Ballots Cast,,,,118,,
+Santa Clara,0003013,Ballots Cast,,,,2880,,
+Santa Clara,0003016,Ballots Cast,,,,874,,
+Santa Clara,0003017,Ballots Cast,,,,635,,
+Santa Clara,0003018,Ballots Cast,,,,340,,
+Santa Clara,0003019,Ballots Cast,,,,2982,,
+Santa Clara,0003021,Ballots Cast,,,,270,,
+Santa Clara,0003023,Ballots Cast,,,,2472,,
+Santa Clara,0003026,Ballots Cast,,,,1777,,
+Santa Clara,0003029,Ballots Cast,,,,0,,
+Santa Clara,0003031,Ballots Cast,,,,0,,
+Santa Clara,0003032,Ballots Cast,,,,1475,,
+Santa Clara,0003034,Ballots Cast,,,,3074,,
+Santa Clara,0003035,Ballots Cast,,,,2189,,
+Santa Clara,0003039,Ballots Cast,,,,1556,,
+Santa Clara,0003040,Ballots Cast,,,,0,,
+Santa Clara,0003042,Ballots Cast,,,,1515,,
+Santa Clara,0003043,Ballots Cast,,,,2701,,
+Santa Clara,0003045,Ballots Cast,,,,3367,,
+Santa Clara,0003047,Ballots Cast,,,,1130,,
+Santa Clara,0003048,Ballots Cast,,,,3043,,
+Santa Clara,0003051,Ballots Cast,,,,2291,,
+Santa Clara,0003053,Ballots Cast,,,,2692,,
+Santa Clara,0003061,Ballots Cast,,,,86,,
+Santa Clara,0003079,Ballots Cast,,,,571,,
+Santa Clara,0003080,Ballots Cast,,,,981,,
+Santa Clara,0003086,Ballots Cast,,,,3126,,
+Santa Clara,0003087,Ballots Cast,,,,1230,,
+Santa Clara,0003089,Ballots Cast,,,,0,,
+Santa Clara,0003095,Ballots Cast,,,,2,,
+Santa Clara,0003101,Ballots Cast,,,,145,,
+Santa Clara,0003102,Ballots Cast,,,,531,,
+Santa Clara,0003103,Ballots Cast,,,,1237,,
+Santa Clara,0003116,Ballots Cast,,,,818,,
+Santa Clara,0003117,Ballots Cast,,,,858,,
+Santa Clara,0003120,Ballots Cast,,,,526,,
+Santa Clara,0003122,Ballots Cast,,,,2272,,
+Santa Clara,0003156,Ballots Cast,,,,136,,
+Santa Clara,0003402,Ballots Cast,,,,3036,,
+Santa Clara,0003406,Ballots Cast,,,,2840,,
+Santa Clara,0003407,Ballots Cast,,,,2978,,
+Santa Clara,0003408,Ballots Cast,,,,3592,,
+Santa Clara,0003409,Ballots Cast,,,,3552,,
+Santa Clara,0003410,Ballots Cast,,,,3676,,
+Santa Clara,0003417,Ballots Cast,,,,3279,,
+Santa Clara,0003427,Ballots Cast,,,,2832,,
+Santa Clara,0003434,Ballots Cast,,,,2211,,
+Santa Clara,0003438,Ballots Cast,,,,3937,,
+Santa Clara,0003445,Ballots Cast,,,,3531,,
+Santa Clara,0003601,Ballots Cast,,,,1335,,
+Santa Clara,0003602,Ballots Cast,,,,2364,,
+Santa Clara,0003603,Ballots Cast,,,,1285,,
+Santa Clara,0003604,Ballots Cast,,,,2784,,
+Santa Clara,0003605,Ballots Cast,,,,3128,,
+Santa Clara,0003606,Ballots Cast,,,,2556,,
+Santa Clara,0003608,Ballots Cast,,,,2804,,
+Santa Clara,0003609,Ballots Cast,,,,3893,,
+Santa Clara,0003611,Ballots Cast,,,,2752,,
+Santa Clara,0003614,Ballots Cast,,,,1333,,
+Santa Clara,0003624,Ballots Cast,,,,3413,,
+Santa Clara,0003635,Ballots Cast,,,,0,,
+Santa Clara,0003652,Ballots Cast,,,,1280,,
+Santa Clara,0003655,Ballots Cast,,,,201,,
+Santa Clara,0003669,Ballots Cast,,,,2,,
+Santa Clara,0003670,Ballots Cast,,,,126,,
+Santa Clara,0003777,Ballots Cast,,,,1613,,
+Santa Clara,0003779,Ballots Cast,,,,130,,
+Santa Clara,0003782,Ballots Cast,,,,371,,
+Santa Clara,0003783,Ballots Cast,,,,382,,
+Santa Clara,0003801,Ballots Cast,,,,1553,,
+Santa Clara,0003802,Ballots Cast,,,,2426,,
+Santa Clara,0003803,Ballots Cast,,,,2136,,
+Santa Clara,0003804,Ballots Cast,,,,1000,,
+Santa Clara,0003810,Ballots Cast,,,,1882,,
+Santa Clara,0003811,Ballots Cast,,,,2524,,
+Santa Clara,0003814,Ballots Cast,,,,2358,,
+Santa Clara,0003820,Ballots Cast,,,,2033,,
+Santa Clara,0003821,Ballots Cast,,,,892,,
+Santa Clara,0003825,Ballots Cast,,,,1266,,
+Santa Clara,0003828,Ballots Cast,,,,1100,,
+Santa Clara,0003835,Ballots Cast,,,,1272,,
+Santa Clara,0003840,Ballots Cast,,,,1997,,
+Santa Clara,0003846,Ballots Cast,,,,102,,
+Santa Clara,0003861,Ballots Cast,,,,66,,
+Santa Clara,0004401,Ballots Cast,,,,2972,,
+Santa Clara,0004402,Ballots Cast,,,,3356,,
+Santa Clara,0004403,Ballots Cast,,,,261,,
+Santa Clara,0004405,Ballots Cast,,,,3648,,
+Santa Clara,0004407,Ballots Cast,,,,3136,,
+Santa Clara,0004409,Ballots Cast,,,,4028,,
+Santa Clara,0004411,Ballots Cast,,,,2276,,
+Santa Clara,0004412,Ballots Cast,,,,3648,,
+Santa Clara,0004414,Ballots Cast,,,,4058,,
+Santa Clara,0004417,Ballots Cast,,,,3321,,
+Santa Clara,0004665,Ballots Cast,,,,31,,
+Santa Clara,0004666,Ballots Cast,,,,7,,
+Santa Clara,0004671,Ballots Cast,,,,1662,,
+Santa Clara,0004672,Ballots Cast,,,,922,,
+Santa Clara,0004674,Ballots Cast,,,,1450,,
+Santa Clara,0004675,Ballots Cast,,,,2852,,
+Santa Clara,0004685,Ballots Cast,,,,1518,,
+Santa Clara,0004687,Ballots Cast,,,,1624,,
+Santa Clara,0004688,Ballots Cast,,,,3025,,
+Santa Clara,0004691,Ballots Cast,,,,2013,,
+Santa Clara,0004696,Ballots Cast,,,,1208,,
+Santa Clara,0004698,Ballots Cast,,,,1075,,
+Santa Clara,0004699,Ballots Cast,,,,1559,,
+Santa Clara,0004702,Ballots Cast,,,,962,,
+Santa Clara,0004715,Ballots Cast,,,,511,,
+Santa Clara,0004733,Ballots Cast,,,,47,,
+Santa Clara,0004801,Ballots Cast,,,,1278,,
+Santa Clara,0004806,Ballots Cast,,,,2716,,
+Santa Clara,0004811,Ballots Cast,,,,1623,,
+Santa Clara,0004826,Ballots Cast,,,,1389,,
+Santa Clara,0004827,Ballots Cast,,,,2744,,
+Santa Clara,0004833,Ballots Cast,,,,1859,,
+Santa Clara,0004851,Ballots Cast,,,,1035,,
+Santa Clara,0004853,Ballots Cast,,,,1921,,
+Santa Clara,0004858,Ballots Cast,,,,2552,,
+Santa Clara,0004876,Ballots Cast,,,,3344,,
+Santa Clara,0004881,Ballots Cast,,,,4038,,
+Santa Clara,0004941,Ballots Cast,,,,2520,,
+Santa Clara,0004942,Ballots Cast,,,,1912,,
+Santa Clara,0004943,Ballots Cast,,,,92,,
+Santa Clara,0004944,Ballots Cast,,,,798,,
+Santa Clara,0004945,Ballots Cast,,,,1246,,
+Santa Clara,0004946,Ballots Cast,,,,2772,,
+Santa Clara,0004949,Ballots Cast,,,,2358,,
+Santa Clara,0004950,Ballots Cast,,,,2034,,
+Santa Clara,0004954,Ballots Cast,,,,1673,,
+Santa Clara,0004956,Ballots Cast,,,,209,,
+Santa Clara,0004958,Ballots Cast,,,,1249,,
+Santa Clara,0004965,Ballots Cast,,,,2701,,
+Santa Clara,0004969,Ballots Cast,,,,1950,,
+Santa Clara,0004971,Ballots Cast,,,,831,,
+Santa Clara,0004973,Ballots Cast,,,,2243,,
+Santa Clara,0004974,Ballots Cast,,,,925,,
+Santa Clara,0005449,Ballots Cast,,,,141,,
+Santa Clara,0005451,Ballots Cast,,,,15,,
+Santa Clara,0005454,Ballots Cast,,,,8,,
+Santa Clara,0005455,Ballots Cast,,,,0,,
+Santa Clara,0005456,Ballots Cast,,,,3,,
+Santa Clara,0005458,Ballots Cast,,,,0,,
+Santa Clara,0005502,Ballots Cast,,,,409,,
+Santa Clara,0005503,Ballots Cast,,,,302,,
+Santa Clara,0005505,Ballots Cast,,,,318,,
+Santa Clara,0005507,Ballots Cast,,,,0,,
+Santa Clara,0005556,Ballots Cast,,,,1319,,
+Santa Clara,0005557,Ballots Cast,,,,921,,
+Santa Clara,0005567,Ballots Cast,,,,512,,
+Santa Clara,0005742,Ballots Cast,,,,17,,
+Santa Clara,0005743,Ballots Cast,,,,527,,
+Santa Clara,0005745,Ballots Cast,,,,451,,
+Santa Clara,0005747,Ballots Cast,,,,912,,
+Santa Clara,0005748,Ballots Cast,,,,1742,,
+Santa Clara,0005756,Ballots Cast,,,,88,,
+Santa Clara,0005758,Ballots Cast,,,,171,,
+Santa Clara,0005759,Ballots Cast,,,,435,,
+Santa Clara,0005762,Ballots Cast,,,,266,,
+Santa Clara,0005763,Ballots Cast,,,,79,,
+Santa Clara,0005770,Ballots Cast,,,,165,,
+Santa Clara,0005775,Ballots Cast,,,,323,,
+Santa Clara,0005785,Ballots Cast,,,,0,,
+Santa Clara,0005793,Ballots Cast,,,,0,,
+Santa Clara,0005795,Ballots Cast,,,,2,,
+Santa Clara,0005804,Ballots Cast,,,,1134,,
+Santa Clara,0005810,Ballots Cast,,,,381,,
+Santa Clara,0005811,Ballots Cast,,,,290,,
+Santa Clara,0005813,Ballots Cast,,,,54,,
+Santa Clara,0005814,Ballots Cast,,,,231,,
+Santa Clara,0005854,Ballots Cast,,,,2,,
+Santa Clara,0005879,Ballots Cast,,,,23,,
+Santa Clara,0005886,Ballots Cast,,,,16,,
+Santa Clara,0005888,Ballots Cast,,,,0,,
+Santa Clara,0005894,Ballots Cast,,,,227,,
+Santa Clara,0005896,Ballots Cast,,,,3,,
+Santa Clara,0005901,Ballots Cast,,,,0,,
+Santa Clara,0005902,Ballots Cast,,,,457,,
+Santa Clara,0005903,Ballots Cast,,,,589,,
+Santa Clara,0005906,Ballots Cast,,,,403,,
+Santa Clara,0005907,Ballots Cast,,,,8,,
+Santa Clara,0005911,Ballots Cast,,,,1779,,
+Santa Clara,0005912,Ballots Cast,,,,160,,
+Santa Clara,0005914,Ballots Cast,,,,1108,,
+Santa Clara,0005915,Ballots Cast,,,,923,,
+Santa Clara,0005916,Ballots Cast,,,,81,,
+Santa Clara,0005917,Ballots Cast,,,,254,,
+Santa Clara,0005919,Ballots Cast,,,,349,,
+Santa Clara,0005922,Ballots Cast,,,,530,,
+Santa Clara,0005925,Ballots Cast,,,,81,,
+Santa Clara,0005927,Ballots Cast,,,,1,,
+Santa Clara,0005929,Ballots Cast,,,,135,,
+Santa Clara,0005931,Ballots Cast,,,,140,,
+Santa Clara,0005936,Ballots Cast,,,,426,,
+Santa Clara,0005940,Ballots Cast,,,,53,,
+Santa Clara,0005947,Ballots Cast,,,,505,,
+Santa Clara,0005949,Ballots Cast,,,,531,,
+Santa Clara,0005950,Ballots Cast,,,,137,,
+Santa Clara,0005951,Ballots Cast,,,,7,,
+Santa Clara,0005955,Ballots Cast,,,,1154,,
+Santa Clara,0005956,Ballots Cast,,,,1055,,
+Santa Clara,0005957,Ballots Cast,,,,125,,
+Santa Clara,0005958,Ballots Cast,,,,798,,
+Santa Clara,0005959,Ballots Cast,,,,81,,
+Santa Clara,0005965,Ballots Cast,,,,1086,,
+Santa Clara,0005966,Ballots Cast,,,,190,,
+Santa Clara,0005975,Ballots Cast,,,,36,,
+Santa Clara,0005988,Ballots Cast,,,,0,,
+Santa Clara,0006023,Ballots Cast,,,,13,,
+Santa Clara,0006028,Ballots Cast,,,,60,,
+Santa Clara,0006031,Ballots Cast,,,,28,,
+Santa Clara,0006035,Ballots Cast,,,,0,,
+Santa Clara,0006036,Ballots Cast,,,,0,,
+Santa Clara,0006048,Ballots Cast,,,,21,,
+Santa Clara,0006401,Ballots Cast,,,,0,,
+Santa Clara,0006402,Ballots Cast,,,,93,,
+Santa Clara,0006404,Ballots Cast,,,,2530,,
+Santa Clara,0006405,Ballots Cast,,,,10,,
+Santa Clara,0006410,Ballots Cast,,,,95,,
+Santa Clara,0006413,Ballots Cast,,,,9,,
+Santa Clara,0006418,Ballots Cast,,,,765,,
+Santa Clara,0006419,Ballots Cast,,,,59,,
+Santa Clara,0006423,Ballots Cast,,,,53,,
+Santa Clara,0006452,Ballots Cast,,,,945,,
+Santa Clara,0006454,Ballots Cast,,,,247,,
+Santa Clara,0006455,Ballots Cast,,,,2658,,
+Santa Clara,0006491,Ballots Cast,,,,24,,
+Santa Clara,0006502,Ballots Cast,,,,288,,
+Santa Clara,0006509,Ballots Cast,,,,15,,
+Santa Clara,0006510,Ballots Cast,,,,35,,
+Santa Clara,0006511,Ballots Cast,,,,130,,
+Santa Clara,0006515,Ballots Cast,,,,109,,
+Santa Clara,0006624,Ballots Cast,,,,7,,
+Santa Clara,0006625,Ballots Cast,,,,5,,
+Santa Clara,0006669,Ballots Cast,,,,77,,
+Santa Clara,0006678,Ballots Cast,,,,55,,
+Santa Clara,0007001,Ballots Cast,,,,1757,,
+Santa Clara,0007005,Ballots Cast,,,,2229,,
+Santa Clara,0007011,Ballots Cast,,,,321,,
+Santa Clara,0007012,Ballots Cast,,,,1817,,
+Santa Clara,0007014,Ballots Cast,,,,2116,,
+Santa Clara,0007019,Ballots Cast,,,,3318,,
+Santa Clara,0007025,Ballots Cast,,,,2790,,
+Santa Clara,0007028,Ballots Cast,,,,2697,,
+Santa Clara,0007032,Ballots Cast,,,,3580,,
+Santa Clara,0007036,Ballots Cast,,,,3293,,
+Santa Clara,0007038,Ballots Cast,,,,296,,
+Santa Clara,0007041,Ballots Cast,,,,2862,,
+Santa Clara,0007044,Ballots Cast,,,,1749,,
+Santa Clara,0007046,Ballots Cast,,,,2780,,
+Santa Clara,0007051,Ballots Cast,,,,0,,
+Santa Clara,0007059,Ballots Cast,,,,455,,
+Santa Clara,0007061,Ballots Cast,,,,1985,,
+Santa Clara,0007062,Ballots Cast,,,,2549,,
+Santa Clara,0007079,Ballots Cast,,,,1912,,
+Santa Clara,0007081,Ballots Cast,,,,1734,,
+Santa Clara,0007089,Ballots Cast,,,,1214,,
+Santa Clara,0007201,Ballots Cast,,,,420,,
+Santa Clara,0007202,Ballots Cast,,,,819,,
+Santa Clara,0007203,Ballots Cast,,,,532,,
+Santa Clara,0007205,Ballots Cast,,,,2612,,
+Santa Clara,0007214,Ballots Cast,,,,1769,,
+Santa Clara,0007217,Ballots Cast,,,,3089,,
+Santa Clara,0007219,Ballots Cast,,,,989,,
+Santa Clara,0007221,Ballots Cast,,,,1560,,
+Santa Clara,0007224,Ballots Cast,,,,831,,
+Santa Clara,0007231,Ballots Cast,,,,718,,
+Santa Clara,0007235,Ballots Cast,,,,2163,,
+Santa Clara,0007237,Ballots Cast,,,,2291,,
+Santa Clara,0007245,Ballots Cast,,,,263,,
+Santa Clara,0007246,Ballots Cast,,,,1373,,
+Santa Clara,0007248,Ballots Cast,,,,2306,,
+Santa Clara,0007252,Ballots Cast,,,,2930,,
+Santa Clara,0007255,Ballots Cast,,,,2974,,
+Santa Clara,0007257,Ballots Cast,,,,1443,,
+Santa Clara,0007261,Ballots Cast,,,,2021,,
+Santa Clara,0007264,Ballots Cast,,,,2257,,
+Santa Clara,0007271,Ballots Cast,,,,2782,,
+Santa Clara,0007273,Ballots Cast,,,,3216,,
+Santa Clara,0007282,Ballots Cast,,,,1840,,
+Santa Clara,0007294,Ballots Cast,,,,653,,
+Santa Clara,0007295,Ballots Cast,,,,1744,,
+Santa Clara,0007298,Ballots Cast,,,,1209,,
+Santa Clara,0007299,Ballots Cast,,,,970,,
+Santa Clara,0007306,Ballots Cast,,,,0,,
+Santa Clara,0007401,Ballots Cast,,,,1,,
+Santa Clara,0007402,Ballots Cast,,,,520,,
+Santa Clara,0007403,Ballots Cast,,,,1427,,
+Santa Clara,0007408,Ballots Cast,,,,783,,
+Santa Clara,0007409,Ballots Cast,,,,351,,
+Santa Clara,0007410,Ballots Cast,,,,6,,
+Santa Clara,0007411,Ballots Cast,,,,27,,
+Santa Clara,0007414,Ballots Cast,,,,338,,
+Santa Clara,0007415,Ballots Cast,,,,46,,
+Santa Clara,0007416,Ballots Cast,,,,170,,
+Santa Clara,0007417,Ballots Cast,,,,2948,,
+Santa Clara,0007418,Ballots Cast,,,,1698,,
+Santa Clara,0007419,Ballots Cast,,,,1165,,
+Santa Clara,0007430,Ballots Cast,,,,2579,,
+Santa Clara,0007435,Ballots Cast,,,,2394,,
+Santa Clara,0007436,Ballots Cast,,,,3724,,
+Santa Clara,0007438,Ballots Cast,,,,339,,
+Santa Clara,0007440,Ballots Cast,,,,48,,
+Santa Clara,0007441,Ballots Cast,,,,1858,,
+Santa Clara,0007442,Ballots Cast,,,,260,,
+Santa Clara,0007447,Ballots Cast,,,,2022,,
+Santa Clara,0007458,Ballots Cast,,,,1865,,
+Santa Clara,0007459,Ballots Cast,,,,2674,,
+Santa Clara,0007470,Ballots Cast,,,,2163,,
+Santa Clara,0007471,Ballots Cast,,,,3078,,
+Santa Clara,0007479,Ballots Cast,,,,1343,,
+Santa Clara,0007483,Ballots Cast,,,,2369,,
+Santa Clara,0007601,Ballots Cast,,,,3176,,
+Santa Clara,0007606,Ballots Cast,,,,3526,,
+Santa Clara,0007609,Ballots Cast,,,,817,,
+Santa Clara,0007615,Ballots Cast,,,,1076,,
+Santa Clara,0007619,Ballots Cast,,,,2036,,
+Santa Clara,0007620,Ballots Cast,,,,3150,,
+Santa Clara,0007621,Ballots Cast,,,,3654,,
+Santa Clara,0007624,Ballots Cast,,,,2620,,
+Santa Clara,0007632,Ballots Cast,,,,3104,,
+Santa Clara,0007634,Ballots Cast,,,,1768,,
+Santa Clara,0007648,Ballots Cast,,,,3006,,
+Santa Clara,0007654,Ballots Cast,,,,3937,,
+Santa Clara,0007660,Ballots Cast,,,,3179,,
+Santa Clara,0007666,Ballots Cast,,,,3344,,
+Santa Clara,0007670,Ballots Cast,,,,103,,
+Santa Clara,0007673,Ballots Cast,,,,0,,
+Santa Clara,0007674,Ballots Cast,,,,0,,
+Santa Clara,0007677,Ballots Cast,,,,3514,,
+Santa Clara,0007680,Ballots Cast,,,,2082,,
+Santa Clara,0007689,Ballots Cast,,,,13,,
+Santa Clara,0007690,Ballots Cast,,,,1019,,
+Santa Clara,0007801,Ballots Cast,,,,752,,
+Santa Clara,0007802,Ballots Cast,,,,375,,
+Santa Clara,0007803,Ballots Cast,,,,988,,
+Santa Clara,0007805,Ballots Cast,,,,1819,,
+Santa Clara,0007810,Ballots Cast,,,,245,,
+Santa Clara,0007811,Ballots Cast,,,,183,,
+Santa Clara,0007812,Ballots Cast,,,,1420,,
+Santa Clara,0007816,Ballots Cast,,,,244,,
+Santa Clara,0007817,Ballots Cast,,,,9,,
+Santa Clara,0007818,Ballots Cast,,,,225,,
+Santa Clara,0007821,Ballots Cast,,,,3550,,
+Santa Clara,0007826,Ballots Cast,,,,3091,,
+Santa Clara,0007827,Ballots Cast,,,,1126,,
+Santa Clara,0007832,Ballots Cast,,,,2011,,
+Santa Clara,0007833,Ballots Cast,,,,2533,,
+Santa Clara,0007843,Ballots Cast,,,,3707,,
+Santa Clara,0007849,Ballots Cast,,,,2503,,
+Santa Clara,0007850,Ballots Cast,,,,1830,,
+Santa Clara,0007851,Ballots Cast,,,,1198,,
+Santa Clara,0007861,Ballots Cast,,,,1578,,
+Santa Clara,0007867,Ballots Cast,,,,2862,,
+Santa Clara,0007874,Ballots Cast,,,,377,,
+Santa Clara,0007880,Ballots Cast,,,,7,,
+Santa Clara,0008001,Ballots Cast,,,,239,,
+Santa Clara,0008002,Ballots Cast,,,,378,,
+Santa Clara,0008003,Ballots Cast,,,,2535,,
+Santa Clara,0008005,Ballots Cast,,,,3558,,
+Santa Clara,0008007,Ballots Cast,,,,647,,
+Santa Clara,0008011,Ballots Cast,,,,437,,
+Santa Clara,0008012,Ballots Cast,,,,17,,
+Santa Clara,0008013,Ballots Cast,,,,84,,
+Santa Clara,0008016,Ballots Cast,,,,3837,,
+Santa Clara,0008017,Ballots Cast,,,,1598,,
+Santa Clara,0008022,Ballots Cast,,,,822,,
+Santa Clara,0008023,Ballots Cast,,,,827,,
+Santa Clara,0008026,Ballots Cast,,,,864,,
+Santa Clara,0008028,Ballots Cast,,,,296,,
+Santa Clara,0008029,Ballots Cast,,,,134,,
+Santa Clara,0008030,Ballots Cast,,,,945,,
+Santa Clara,0008033,Ballots Cast,,,,236,,
+Santa Clara,0008034,Ballots Cast,,,,205,,
+Santa Clara,0008038,Ballots Cast,,,,4,,
+Santa Clara,0008040,Ballots Cast,,,,515,,
+Santa Clara,0008047,Ballots Cast,,,,1882,,
+Santa Clara,0008049,Ballots Cast,,,,44,,
+Santa Clara,0008050,Ballots Cast,,,,1453,,
+Santa Clara,0008053,Ballots Cast,,,,2540,,
+Santa Clara,0008054,Ballots Cast,,,,2114,,
+Santa Clara,0008055,Ballots Cast,,,,278,,
+Santa Clara,0008062,Ballots Cast,,,,2627,,
+Santa Clara,0008066,Ballots Cast,,,,932,,
+Santa Clara,0008067,Ballots Cast,,,,2769,,
+Santa Clara,0008068,Ballots Cast,,,,41,,
+Santa Clara,0008072,Ballots Cast,,,,553,,
+Santa Clara,0008073,Ballots Cast,,,,462,,
+Santa Clara,0008079,Ballots Cast,,,,2560,,
+Santa Clara,0008082,Ballots Cast,,,,1892,,
+Santa Clara,0008085,Ballots Cast,,,,1271,,
+Santa Clara,0008089,Ballots Cast,,,,2681,,
+Santa Clara,0008092,Ballots Cast,,,,76,,
+Santa Clara,0008093,Ballots Cast,,,,50,,
+Santa Clara,0008096,Ballots Cast,,,,2516,,
+Santa Clara,0008101,Ballots Cast,,,,1195,,
+Santa Clara,0008104,Ballots Cast,,,,148,,
+Santa Clara,0008105,Ballots Cast,,,,399,,
+Santa Clara,0008117,Ballots Cast,,,,1755,,
+Santa Clara,0008122,Ballots Cast,,,,2257,,
+Santa Clara,0008128,Ballots Cast,,,,0,,
+Santa Clara,0008133,Ballots Cast,,,,15,,
+Santa Clara,0008201,Ballots Cast,,,,2279,,
+Santa Clara,0008203,Ballots Cast,,,,2206,,
+Santa Clara,0008205,Ballots Cast,,,,2828,,
+Santa Clara,0008208,Ballots Cast,,,,2224,,
+Santa Clara,0008212,Ballots Cast,,,,1141,,
+Santa Clara,0008214,Ballots Cast,,,,330,,
+Santa Clara,0008227,Ballots Cast,,,,2988,,
+Santa Clara,0008228,Ballots Cast,,,,2007,,
+Santa Clara,0008230,Ballots Cast,,,,3071,,
+Santa Clara,0008231,Ballots Cast,,,,1929,,
+Santa Clara,0008232,Ballots Cast,,,,3556,,
+Santa Clara,0008236,Ballots Cast,,,,3794,,
+Santa Clara,0008246,Ballots Cast,,,,2271,,
+Santa Clara,0008254,Ballots Cast,,,,2179,,
+Santa Clara,0008262,Ballots Cast,,,,1719,,
+Santa Clara,0008264,Ballots Cast,,,,1689,,
+Santa Clara,0008401,Ballots Cast,,,,1949,,
+Santa Clara,0008404,Ballots Cast,,,,3923,,
+Santa Clara,0008408,Ballots Cast,,,,1306,,
+Santa Clara,0008409,Ballots Cast,,,,1286,,
+Santa Clara,0008414,Ballots Cast,,,,404,,
+Santa Clara,0008418,Ballots Cast,,,,463,,
+Santa Clara,0008421,Ballots Cast,,,,44,,
+Santa Clara,0008423,Ballots Cast,,,,2,,
+Santa Clara,0008430,Ballots Cast,,,,3233,,
+Santa Clara,0008435,Ballots Cast,,,,3660,,
+Santa Clara,0008438,Ballots Cast,,,,3945,,
+Santa Clara,0008439,Ballots Cast,,,,3190,,
+Santa Clara,0008445,Ballots Cast,,,,2138,,
+Santa Clara,0008447,Ballots Cast,,,,9,,
+Santa Clara,0008456,Ballots Cast,,,,3895,,
+Santa Clara,0008457,Ballots Cast,,,,3806,,
+Santa Clara,0008464,Ballots Cast,,,,3491,,
+Santa Clara,0008470,Ballots Cast,,,,3600,,
+Santa Clara,0008472,Ballots Cast,,,,2990,,
+Santa Clara,0008486,Ballots Cast,,,,3743,,
+Santa Clara,0008492,Ballots Cast,,,,4069,,
+Santa Clara,0008502,Ballots Cast,,,,229,,
+Santa Clara,0008601,Ballots Cast,,,,502,,
+Santa Clara,0008603,Ballots Cast,,,,2347,,
+Santa Clara,0008605,Ballots Cast,,,,3076,,
+Santa Clara,0008609,Ballots Cast,,,,2,,
+Santa Clara,0008610,Ballots Cast,,,,1561,,
+Santa Clara,0008612,Ballots Cast,,,,2296,,
+Santa Clara,0008615,Ballots Cast,,,,2113,,
+Santa Clara,0008619,Ballots Cast,,,,720,,
+Santa Clara,0008625,Ballots Cast,,,,96,,
+Santa Clara,0008627,Ballots Cast,,,,1266,,
+Santa Clara,0008629,Ballots Cast,,,,1850,,
+Santa Clara,0008630,Ballots Cast,,,,2528,,
+Santa Clara,0008631,Ballots Cast,,,,1498,,
+Santa Clara,0008634,Ballots Cast,,,,402,,
+Santa Clara,0008636,Ballots Cast,,,,404,,
+Santa Clara,0008645,Ballots Cast,,,,3046,,
+Santa Clara,0008648,Ballots Cast,,,,2654,,
+Santa Clara,0008650,Ballots Cast,,,,374,,
+Santa Clara,0008653,Ballots Cast,,,,239,,
+Santa Clara,0008654,Ballots Cast,,,,271,,
+Santa Clara,0008655,Ballots Cast,,,,0,,
+Santa Clara,0008657,Ballots Cast,,,,655,,
+Santa Clara,0008658,Ballots Cast,,,,3374,,
+Santa Clara,0008670,Ballots Cast,,,,2203,,
+Santa Clara,0008675,Ballots Cast,,,,1328,,
+Santa Clara,0008676,Ballots Cast,,,,2640,,
+Santa Clara,0008680,Ballots Cast,,,,1981,,
+Santa Clara,0008683,Ballots Cast,,,,3226,,
+Santa Clara,0008687,Ballots Cast,,,,2989,,
+Santa Clara,0008697,Ballots Cast,,,,3133,,
+Santa Clara,0008801,Ballots Cast,,,,2008,,
+Santa Clara,0008805,Ballots Cast,,,,1688,,
+Santa Clara,0008809,Ballots Cast,,,,2746,,
+Santa Clara,0008812,Ballots Cast,,,,1555,,
+Santa Clara,0008817,Ballots Cast,,,,919,,
+Santa Clara,0008820,Ballots Cast,,,,1882,,
+Santa Clara,0008822,Ballots Cast,,,,1962,,
+Santa Clara,0008828,Ballots Cast,,,,689,,
+Santa Clara,0008829,Ballots Cast,,,,615,,
+Santa Clara,0008832,Ballots Cast,,,,1897,,
+Santa Clara,0008834,Ballots Cast,,,,1012,,
+Santa Clara,0008838,Ballots Cast,,,,258,,
+Santa Clara,0008839,Ballots Cast,,,,2771,,
+Santa Clara,0008844,Ballots Cast,,,,3006,,
+Santa Clara,0008848,Ballots Cast,,,,1573,,
+Santa Clara,0008853,Ballots Cast,,,,2040,,
+Santa Clara,0008857,Ballots Cast,,,,1517,,
+Santa Clara,0008858,Ballots Cast,,,,2167,,
+Santa Clara,0008862,Ballots Cast,,,,2262,,
+Santa Clara,0008868,Ballots Cast,,,,123,,
+Santa Clara,0008873,Ballots Cast,,,,936,,
+Santa Clara,0008874,Ballots Cast,,,,19,,
+Santa Clara,0008879,Ballots Cast,,,,2921,,
+Santa Clara,0008883,Ballots Cast,,,,3104,,
+Santa Clara,0008885,Ballots Cast,,,,2858,,
+Santa Clara,0008886,Ballots Cast,,,,330,,
+Santa Clara,0008889,Ballots Cast,,,,2458,,
+Santa Clara,0008898,Ballots Cast,,,,2497,,
+Santa Clara,0008903,Ballots Cast,,,,3108,,
+Santa Clara,0008915,Ballots Cast,,,,18,,
+Santa Clara,0008916,Ballots Cast,,,,15,,
+Santa Clara,0008920,Ballots Cast,,,,1,,
+Santa Clara,0008923,Ballots Cast,,,,3,,
+Santa Clara,0008924,Ballots Cast,,,,14,,
+Santa Clara,0009001,Ballots Cast,,,,2647,,
+Santa Clara,0009005,Ballots Cast,,,,4012,,
+Santa Clara,0009051,Ballots Cast,,,,1612,,
+Santa Clara,0009055,Ballots Cast,,,,60,,
+Santa Clara,0009056,Ballots Cast,,,,2685,,
+Santa Clara,0009059,Ballots Cast,,,,2241,,
+Santa Clara,0009061,Ballots Cast,,,,0,,
+Santa Clara,0009062,Ballots Cast,,,,2167,,
+Santa Clara,0009101,Ballots Cast,,,,2812,,
+Santa Clara,0009103,Ballots Cast,,,,826,,
+Santa Clara,0009104,Ballots Cast,,,,2552,,
+Santa Clara,0009109,Ballots Cast,,,,1639,,
+Santa Clara,0009151,Ballots Cast,,,,2453,,
+Santa Clara,0009157,Ballots Cast,,,,2978,,
+Santa Clara,0009163,Ballots Cast,,,,1269,,
+Santa Clara,0009166,Ballots Cast,,,,1267,,
+Santa Clara,0009201,Ballots Cast,,,,769,,
+Santa Clara,0009203,Ballots Cast,,,,1540,,
+Santa Clara,0009208,Ballots Cast,,,,1275,,
+Santa Clara,0009210,Ballots Cast,,,,1914,,
+Santa Clara,0009219,Ballots Cast,,,,188,,
+Santa Clara,0009220,Ballots Cast,,,,2400,,
+Santa Clara,0009251,Ballots Cast,,,,1223,,
+Santa Clara,0009252,Ballots Cast,,,,1842,,
+Santa Clara,0009258,Ballots Cast,,,,1623,,
+Santa Clara,0009262,Ballots Cast,,,,227,,
+Santa Clara,0009264,Ballots Cast,,,,1785,,
+Santa Clara,0009268,Ballots Cast,,,,1799,,
+Santa Clara,0009275,Ballots Cast,,,,1673,,
+Santa Clara,0009282,Ballots Cast,,,,8,,
+Santa Clara,0002001,President,,DEM,Joe Biden,37,31,6
+Santa Clara,0002002,President,,DEM,Joe Biden,2070,111,1959
+Santa Clara,0002005,President,,DEM,Joe Biden,1337,51,1286
+Santa Clara,0002006,President,,DEM,Joe Biden,55,1,54
+Santa Clara,0002009,President,,DEM,Joe Biden,3132,151,2981
+Santa Clara,0002013,President,,DEM,Joe Biden,2523,94,2429
+Santa Clara,0002014,President,,DEM,Joe Biden,2252,123,2129
+Santa Clara,0002018,President,,DEM,Joe Biden,60,4,56
+Santa Clara,0002025,President,,DEM,Joe Biden,3016,103,2913
+Santa Clara,0002043,President,,DEM,Joe Biden,2329,72,2257
+Santa Clara,0002046,President,,DEM,Joe Biden,3201,129,3072
+Santa Clara,0002057,President,,DEM,Joe Biden,3023,128,2895
+Santa Clara,0002068,President,,DEM,Joe Biden,2857,100,2757
+Santa Clara,0002098,President,,DEM,Joe Biden,2882,113,2769
+Santa Clara,0002108,President,,DEM,Joe Biden,2573,74,2499
+Santa Clara,0002125,President,,DEM,Joe Biden,257,4,253
+Santa Clara,0002274,President,,DEM,Joe Biden,175,2,173
+Santa Clara,0002275,President,,DEM,Joe Biden,742,24,718
+Santa Clara,0002278,President,,DEM,Joe Biden,722,38,684
+Santa Clara,0002281,President,,DEM,Joe Biden,5,0,5
+Santa Clara,0002282,President,,DEM,Joe Biden,930,33,897
+Santa Clara,0002285,President,,DEM,Joe Biden,1671,71,1600
+Santa Clara,0002301,President,,DEM,Joe Biden,2567,72,2495
+Santa Clara,0002305,President,,DEM,Joe Biden,3440,124,3316
+Santa Clara,0002309,President,,DEM,Joe Biden,877,17,860
+Santa Clara,0002314,President,,DEM,Joe Biden,2007,59,1948
+Santa Clara,0002317,President,,DEM,Joe Biden,1912,61,1851
+Santa Clara,0002330,President,,DEM,Joe Biden,3077,58,3019
+Santa Clara,0002338,President,,DEM,Joe Biden,119,4,115
+Santa Clara,0002351,President,,DEM,Joe Biden,1682,51,1631
+Santa Clara,0002353,President,,DEM,Joe Biden,24,3,21
+Santa Clara,0002539,President,,DEM,Joe Biden,131,6,125
+Santa Clara,0002542,President,,DEM,Joe Biden,1426,204,1222
+Santa Clara,0002545,President,,DEM,Joe Biden,1836,100,1736
+Santa Clara,0002720,President,,DEM,Joe Biden,1066,37,1029
+Santa Clara,0002721,President,,DEM,Joe Biden,874,22,852
+Santa Clara,0002723,President,,DEM,Joe Biden,2107,47,2060
+Santa Clara,0002724,President,,DEM,Joe Biden,1616,61,1555
+Santa Clara,0002725,President,,DEM,Joe Biden,1579,62,1517
+Santa Clara,0002726,President,,DEM,Joe Biden,965,40,925
+Santa Clara,0002727,President,,DEM,Joe Biden,1183,25,1158
+Santa Clara,0002729,President,,DEM,Joe Biden,1341,26,1315
+Santa Clara,0002734,President,,DEM,Joe Biden,1693,57,1636
+Santa Clara,0002740,President,,DEM,Joe Biden,1876,65,1811
+Santa Clara,0002751,President,,DEM,Joe Biden,13,0,13
+Santa Clara,0002761,President,,DEM,Joe Biden,4,0,4
+Santa Clara,0002802,President,,DEM,Joe Biden,1737,54,1683
+Santa Clara,0002808,President,,DEM,Joe Biden,67,2,65
+Santa Clara,0002810,President,,DEM,Joe Biden,19,0,19
+Santa Clara,0002811,President,,DEM,Joe Biden,24,0,24
+Santa Clara,0002812,President,,DEM,Joe Biden,196,5,191
+Santa Clara,0002813,President,,DEM,Joe Biden,146,3,143
+Santa Clara,0002816,President,,DEM,Joe Biden,19,0,19
+Santa Clara,0002825,President,,DEM,Joe Biden,14,0,14
+Santa Clara,0002870,President,,DEM,Joe Biden,91,3,88
+Santa Clara,0002951,President,,DEM,Joe Biden,183,12,171
+Santa Clara,0003001,President,,DEM,Joe Biden,1866,81,1785
+Santa Clara,0003002,President,,DEM,Joe Biden,1896,122,1774
+Santa Clara,0003005,President,,DEM,Joe Biden,40,1,39
+Santa Clara,0003008,President,,DEM,Joe Biden,21,0,21
+Santa Clara,0003010,President,,DEM,Joe Biden,1754,109,1645
+Santa Clara,0003011,President,,DEM,Joe Biden,1639,109,1530
+Santa Clara,0003012,President,,DEM,Joe Biden,89,2,87
+Santa Clara,0003013,President,,DEM,Joe Biden,2237,133,2104
+Santa Clara,0003016,President,,DEM,Joe Biden,703,25,678
+Santa Clara,0003017,President,,DEM,Joe Biden,490,32,458
+Santa Clara,0003018,President,,DEM,Joe Biden,261,23,238
+Santa Clara,0003019,President,,DEM,Joe Biden,2356,105,2251
+Santa Clara,0003021,President,,DEM,Joe Biden,210,11,199
+Santa Clara,0003023,President,,DEM,Joe Biden,1826,95,1731
+Santa Clara,0003026,President,,DEM,Joe Biden,1277,40,1237
+Santa Clara,0003029,President,,DEM,Joe Biden,0,0,0
+Santa Clara,0003031,President,,DEM,Joe Biden,0,0,0
+Santa Clara,0003032,President,,DEM,Joe Biden,1108,50,1058
+Santa Clara,0003034,President,,DEM,Joe Biden,2298,89,2209
+Santa Clara,0003035,President,,DEM,Joe Biden,1696,101,1595
+Santa Clara,0003039,President,,DEM,Joe Biden,1222,45,1177
+Santa Clara,0003040,President,,DEM,Joe Biden,0,0,0
+Santa Clara,0003042,President,,DEM,Joe Biden,1153,63,1090
+Santa Clara,0003043,President,,DEM,Joe Biden,2012,70,1942
+Santa Clara,0003045,President,,DEM,Joe Biden,2554,105,2449
+Santa Clara,0003047,President,,DEM,Joe Biden,870,26,844
+Santa Clara,0003048,President,,DEM,Joe Biden,2309,107,2202
+Santa Clara,0003051,President,,DEM,Joe Biden,1715,38,1677
+Santa Clara,0003053,President,,DEM,Joe Biden,1975,53,1922
+Santa Clara,0003061,President,,DEM,Joe Biden,71,8,63
+Santa Clara,0003079,President,,DEM,Joe Biden,412,13,399
+Santa Clara,0003080,President,,DEM,Joe Biden,788,30,758
+Santa Clara,0003086,President,,DEM,Joe Biden,2328,71,2257
+Santa Clara,0003087,President,,DEM,Joe Biden,868,64,804
+Santa Clara,0003089,President,,DEM,Joe Biden,0,0,0
+Santa Clara,0003095,President,,DEM,Joe Biden,2,0,2
+Santa Clara,0003101,President,,DEM,Joe Biden,108,5,103
+Santa Clara,0003102,President,,DEM,Joe Biden,392,25,367
+Santa Clara,0003103,President,,DEM,Joe Biden,956,55,901
+Santa Clara,0003116,President,,DEM,Joe Biden,609,20,589
+Santa Clara,0003117,President,,DEM,Joe Biden,652,25,627
+Santa Clara,0003120,President,,DEM,Joe Biden,413,25,388
+Santa Clara,0003122,President,,DEM,Joe Biden,1764,70,1694
+Santa Clara,0003156,President,,DEM,Joe Biden,101,2,99
+Santa Clara,0003402,President,,DEM,Joe Biden,2438,79,2359
+Santa Clara,0003406,President,,DEM,Joe Biden,2296,184,2112
+Santa Clara,0003407,President,,DEM,Joe Biden,2438,95,2343
+Santa Clara,0003408,President,,DEM,Joe Biden,2973,148,2825
+Santa Clara,0003409,President,,DEM,Joe Biden,2854,159,2695
+Santa Clara,0003410,President,,DEM,Joe Biden,2986,110,2876
+Santa Clara,0003417,President,,DEM,Joe Biden,2794,111,2683
+Santa Clara,0003427,President,,DEM,Joe Biden,2326,108,2218
+Santa Clara,0003434,President,,DEM,Joe Biden,1764,43,1721
+Santa Clara,0003438,President,,DEM,Joe Biden,3122,88,3034
+Santa Clara,0003445,President,,DEM,Joe Biden,2848,110,2738
+Santa Clara,0003601,President,,DEM,Joe Biden,1045,18,1027
+Santa Clara,0003602,President,,DEM,Joe Biden,1723,64,1659
+Santa Clara,0003603,President,,DEM,Joe Biden,939,26,913
+Santa Clara,0003604,President,,DEM,Joe Biden,2018,61,1957
+Santa Clara,0003605,President,,DEM,Joe Biden,2297,100,2197
+Santa Clara,0003606,President,,DEM,Joe Biden,1919,50,1869
+Santa Clara,0003608,President,,DEM,Joe Biden,2036,61,1975
+Santa Clara,0003609,President,,DEM,Joe Biden,2892,71,2821
+Santa Clara,0003611,President,,DEM,Joe Biden,2015,58,1957
+Santa Clara,0003614,President,,DEM,Joe Biden,887,26,861
+Santa Clara,0003624,President,,DEM,Joe Biden,2601,72,2529
+Santa Clara,0003635,President,,DEM,Joe Biden,0,0,0
+Santa Clara,0003652,President,,DEM,Joe Biden,903,60,843
+Santa Clara,0003655,President,,DEM,Joe Biden,131,7,124
+Santa Clara,0003669,President,,DEM,Joe Biden,2,0,2
+Santa Clara,0003670,President,,DEM,Joe Biden,101,6,95
+Santa Clara,0003777,President,,DEM,Joe Biden,1102,23,1079
+Santa Clara,0003779,President,,DEM,Joe Biden,72,2,70
+Santa Clara,0003782,President,,DEM,Joe Biden,231,8,223
+Santa Clara,0003783,President,,DEM,Joe Biden,248,4,244
+Santa Clara,0003801,President,,DEM,Joe Biden,1138,48,1090
+Santa Clara,0003802,President,,DEM,Joe Biden,1811,60,1751
+Santa Clara,0003803,President,,DEM,Joe Biden,1582,59,1523
+Santa Clara,0003804,President,,DEM,Joe Biden,726,34,692
+Santa Clara,0003810,President,,DEM,Joe Biden,1391,87,1304
+Santa Clara,0003811,President,,DEM,Joe Biden,1798,71,1727
+Santa Clara,0003814,President,,DEM,Joe Biden,1653,67,1586
+Santa Clara,0003820,President,,DEM,Joe Biden,1521,58,1463
+Santa Clara,0003821,President,,DEM,Joe Biden,665,24,641
+Santa Clara,0003825,President,,DEM,Joe Biden,939,37,902
+Santa Clara,0003828,President,,DEM,Joe Biden,774,13,761
+Santa Clara,0003835,President,,DEM,Joe Biden,888,21,867
+Santa Clara,0003840,President,,DEM,Joe Biden,1393,51,1342
+Santa Clara,0003846,President,,DEM,Joe Biden,72,1,71
+Santa Clara,0003861,President,,DEM,Joe Biden,52,1,51
+Santa Clara,0004401,President,,DEM,Joe Biden,1964,102,1862
+Santa Clara,0004402,President,,DEM,Joe Biden,2353,113,2240
+Santa Clara,0004403,President,,DEM,Joe Biden,194,25,169
+Santa Clara,0004405,President,,DEM,Joe Biden,2432,139,2293
+Santa Clara,0004407,President,,DEM,Joe Biden,2099,128,1971
+Santa Clara,0004409,President,,DEM,Joe Biden,2704,162,2542
+Santa Clara,0004411,President,,DEM,Joe Biden,1523,71,1452
+Santa Clara,0004412,President,,DEM,Joe Biden,2372,94,2278
+Santa Clara,0004414,President,,DEM,Joe Biden,2777,104,2673
+Santa Clara,0004417,President,,DEM,Joe Biden,2151,89,2062
+Santa Clara,0004665,President,,DEM,Joe Biden,20,0,20
+Santa Clara,0004666,President,,DEM,Joe Biden,4,0,4
+Santa Clara,0004671,President,,DEM,Joe Biden,1162,37,1125
+Santa Clara,0004672,President,,DEM,Joe Biden,594,16,578
+Santa Clara,0004674,President,,DEM,Joe Biden,1028,40,988
+Santa Clara,0004675,President,,DEM,Joe Biden,1959,88,1871
+Santa Clara,0004685,President,,DEM,Joe Biden,1022,25,997
+Santa Clara,0004687,President,,DEM,Joe Biden,1142,24,1118
+Santa Clara,0004688,President,,DEM,Joe Biden,2157,72,2085
+Santa Clara,0004691,President,,DEM,Joe Biden,1383,52,1331
+Santa Clara,0004696,President,,DEM,Joe Biden,875,9,866
+Santa Clara,0004698,President,,DEM,Joe Biden,807,18,789
+Santa Clara,0004699,President,,DEM,Joe Biden,1166,40,1126
+Santa Clara,0004702,President,,DEM,Joe Biden,701,22,679
+Santa Clara,0004715,President,,DEM,Joe Biden,347,9,338
+Santa Clara,0004733,President,,DEM,Joe Biden,29,2,27
+Santa Clara,0004801,President,,DEM,Joe Biden,873,59,814
+Santa Clara,0004806,President,,DEM,Joe Biden,1651,67,1584
+Santa Clara,0004811,President,,DEM,Joe Biden,971,48,923
+Santa Clara,0004826,President,,DEM,Joe Biden,876,42,834
+Santa Clara,0004827,President,,DEM,Joe Biden,1880,83,1797
+Santa Clara,0004833,President,,DEM,Joe Biden,1205,56,1149
+Santa Clara,0004851,President,,DEM,Joe Biden,644,24,620
+Santa Clara,0004853,President,,DEM,Joe Biden,1202,36,1166
+Santa Clara,0004858,President,,DEM,Joe Biden,1610,100,1510
+Santa Clara,0004876,President,,DEM,Joe Biden,2091,85,2006
+Santa Clara,0004881,President,,DEM,Joe Biden,2549,94,2455
+Santa Clara,0004941,President,,DEM,Joe Biden,1729,112,1617
+Santa Clara,0004942,President,,DEM,Joe Biden,1229,65,1164
+Santa Clara,0004943,President,,DEM,Joe Biden,71,5,66
+Santa Clara,0004944,President,,DEM,Joe Biden,597,77,520
+Santa Clara,0004945,President,,DEM,Joe Biden,876,83,793
+Santa Clara,0004946,President,,DEM,Joe Biden,1870,150,1720
+Santa Clara,0004949,President,,DEM,Joe Biden,1453,65,1388
+Santa Clara,0004950,President,,DEM,Joe Biden,1204,46,1158
+Santa Clara,0004954,President,,DEM,Joe Biden,1186,71,1115
+Santa Clara,0004956,President,,DEM,Joe Biden,151,13,138
+Santa Clara,0004958,President,,DEM,Joe Biden,975,93,882
+Santa Clara,0004965,President,,DEM,Joe Biden,1675,91,1584
+Santa Clara,0004969,President,,DEM,Joe Biden,1460,92,1368
+Santa Clara,0004971,President,,DEM,Joe Biden,555,18,537
+Santa Clara,0004973,President,,DEM,Joe Biden,1310,40,1270
+Santa Clara,0004974,President,,DEM,Joe Biden,692,52,640
+Santa Clara,0005449,President,,DEM,Joe Biden,77,3,74
+Santa Clara,0005451,President,,DEM,Joe Biden,12,0,12
+Santa Clara,0005454,President,,DEM,Joe Biden,5,1,4
+Santa Clara,0005455,President,,DEM,Joe Biden,0,0,0
+Santa Clara,0005456,President,,DEM,Joe Biden,3,0,3
+Santa Clara,0005458,President,,DEM,Joe Biden,0,0,0
+Santa Clara,0005502,President,,DEM,Joe Biden,262,13,249
+Santa Clara,0005503,President,,DEM,Joe Biden,226,20,206
+Santa Clara,0005505,President,,DEM,Joe Biden,193,8,185
+Santa Clara,0005507,President,,DEM,Joe Biden,0,0,0
+Santa Clara,0005556,President,,DEM,Joe Biden,1037,82,955
+Santa Clara,0005557,President,,DEM,Joe Biden,699,21,678
+Santa Clara,0005567,President,,DEM,Joe Biden,392,24,368
+Santa Clara,0005742,President,,DEM,Joe Biden,8,0,8
+Santa Clara,0005743,President,,DEM,Joe Biden,371,18,353
+Santa Clara,0005745,President,,DEM,Joe Biden,300,12,288
+Santa Clara,0005747,President,,DEM,Joe Biden,679,13,666
+Santa Clara,0005748,President,,DEM,Joe Biden,1246,96,1150
+Santa Clara,0005756,President,,DEM,Joe Biden,59,2,57
+Santa Clara,0005758,President,,DEM,Joe Biden,110,2,108
+Santa Clara,0005759,President,,DEM,Joe Biden,278,9,269
+Santa Clara,0005762,President,,DEM,Joe Biden,184,4,180
+Santa Clara,0005763,President,,DEM,Joe Biden,65,5,60
+Santa Clara,0005770,President,,DEM,Joe Biden,105,3,102
+Santa Clara,0005775,President,,DEM,Joe Biden,239,3,236
+Santa Clara,0005785,President,,DEM,Joe Biden,0,0,0
+Santa Clara,0005793,President,,DEM,Joe Biden,0,0,0
+Santa Clara,0005795,President,,DEM,Joe Biden,2,0,2
+Santa Clara,0005804,President,,DEM,Joe Biden,753,23,730
+Santa Clara,0005810,President,,DEM,Joe Biden,260,17,243
+Santa Clara,0005811,President,,DEM,Joe Biden,192,8,184
+Santa Clara,0005813,President,,DEM,Joe Biden,37,0,37
+Santa Clara,0005814,President,,DEM,Joe Biden,131,2,129
+Santa Clara,0005854,President,,DEM,Joe Biden,0,0,0
+Santa Clara,0005879,President,,DEM,Joe Biden,16,1,15
+Santa Clara,0005886,President,,DEM,Joe Biden,13,3,10
+Santa Clara,0005888,President,,DEM,Joe Biden,0,0,0
+Santa Clara,0005894,President,,DEM,Joe Biden,143,3,140
+Santa Clara,0005896,President,,DEM,Joe Biden,3,0,3
+Santa Clara,0005901,President,,DEM,Joe Biden,0,0,0
+Santa Clara,0005902,President,,DEM,Joe Biden,279,8,271
+Santa Clara,0005903,President,,DEM,Joe Biden,357,12,345
+Santa Clara,0005906,President,,DEM,Joe Biden,261,17,244
+Santa Clara,0005907,President,,DEM,Joe Biden,5,0,5
+Santa Clara,0005911,President,,DEM,Joe Biden,1042,71,971
+Santa Clara,0005912,President,,DEM,Joe Biden,101,3,98
+Santa Clara,0005914,President,,DEM,Joe Biden,616,21,595
+Santa Clara,0005915,President,,DEM,Joe Biden,507,13,494
+Santa Clara,0005916,President,,DEM,Joe Biden,38,2,36
+Santa Clara,0005917,President,,DEM,Joe Biden,137,3,134
+Santa Clara,0005919,President,,DEM,Joe Biden,190,9,181
+Santa Clara,0005922,President,,DEM,Joe Biden,285,18,267
+Santa Clara,0005925,President,,DEM,Joe Biden,35,0,35
+Santa Clara,0005927,President,,DEM,Joe Biden,1,0,1
+Santa Clara,0005929,President,,DEM,Joe Biden,63,8,55
+Santa Clara,0005931,President,,DEM,Joe Biden,81,3,78
+Santa Clara,0005936,President,,DEM,Joe Biden,270,18,252
+Santa Clara,0005940,President,,DEM,Joe Biden,31,3,28
+Santa Clara,0005947,President,,DEM,Joe Biden,230,3,227
+Santa Clara,0005949,President,,DEM,Joe Biden,329,20,309
+Santa Clara,0005950,President,,DEM,Joe Biden,84,6,78
+Santa Clara,0005951,President,,DEM,Joe Biden,7,0,7
+Santa Clara,0005955,President,,DEM,Joe Biden,606,25,581
+Santa Clara,0005956,President,,DEM,Joe Biden,577,14,563
+Santa Clara,0005957,President,,DEM,Joe Biden,57,2,55
+Santa Clara,0005958,President,,DEM,Joe Biden,442,24,418
+Santa Clara,0005959,President,,DEM,Joe Biden,26,0,26
+Santa Clara,0005965,President,,DEM,Joe Biden,637,38,599
+Santa Clara,0005966,President,,DEM,Joe Biden,111,2,109
+Santa Clara,0005975,President,,DEM,Joe Biden,28,0,28
+Santa Clara,0005988,President,,DEM,Joe Biden,0,0,0
+Santa Clara,0006023,President,,DEM,Joe Biden,10,0,10
+Santa Clara,0006028,President,,DEM,Joe Biden,18,0,18
+Santa Clara,0006031,President,,DEM,Joe Biden,16,1,15
+Santa Clara,0006035,President,,DEM,Joe Biden,0,0,0
+Santa Clara,0006036,President,,DEM,Joe Biden,0,0,0
+Santa Clara,0006048,President,,DEM,Joe Biden,16,0,16
+Santa Clara,0006401,President,,DEM,Joe Biden,0,0,0
+Santa Clara,0006402,President,,DEM,Joe Biden,49,1,48
+Santa Clara,0006404,President,,DEM,Joe Biden,1725,63,1662
+Santa Clara,0006405,President,,DEM,Joe Biden,4,0,4
+Santa Clara,0006410,President,,DEM,Joe Biden,60,3,57
+Santa Clara,0006413,President,,DEM,Joe Biden,7,0,7
+Santa Clara,0006418,President,,DEM,Joe Biden,501,22,479
+Santa Clara,0006419,President,,DEM,Joe Biden,21,0,21
+Santa Clara,0006423,President,,DEM,Joe Biden,26,1,25
+Santa Clara,0006452,President,,DEM,Joe Biden,710,59,651
+Santa Clara,0006454,President,,DEM,Joe Biden,161,3,158
+Santa Clara,0006455,President,,DEM,Joe Biden,1958,106,1852
+Santa Clara,0006491,President,,DEM,Joe Biden,20,0,20
+Santa Clara,0006502,President,,DEM,Joe Biden,211,14,197
+Santa Clara,0006509,President,,DEM,Joe Biden,6,2,4
+Santa Clara,0006510,President,,DEM,Joe Biden,28,1,27
+Santa Clara,0006511,President,,DEM,Joe Biden,77,2,75
+Santa Clara,0006515,President,,DEM,Joe Biden,65,1,64
+Santa Clara,0006624,President,,DEM,Joe Biden,6,0,6
+Santa Clara,0006625,President,,DEM,Joe Biden,5,0,5
+Santa Clara,0006669,President,,DEM,Joe Biden,53,0,53
+Santa Clara,0006678,President,,DEM,Joe Biden,42,0,42
+Santa Clara,0007001,President,,DEM,Joe Biden,1266,81,1185
+Santa Clara,0007005,President,,DEM,Joe Biden,1648,95,1553
+Santa Clara,0007011,President,,DEM,Joe Biden,272,21,251
+Santa Clara,0007012,President,,DEM,Joe Biden,1290,50,1240
+Santa Clara,0007014,President,,DEM,Joe Biden,1534,49,1485
+Santa Clara,0007019,President,,DEM,Joe Biden,2425,144,2281
+Santa Clara,0007025,President,,DEM,Joe Biden,2083,101,1982
+Santa Clara,0007028,President,,DEM,Joe Biden,1840,80,1760
+Santa Clara,0007032,President,,DEM,Joe Biden,2429,75,2354
+Santa Clara,0007036,President,,DEM,Joe Biden,2314,56,2258
+Santa Clara,0007038,President,,DEM,Joe Biden,216,7,209
+Santa Clara,0007041,President,,DEM,Joe Biden,2048,152,1896
+Santa Clara,0007044,President,,DEM,Joe Biden,1201,76,1125
+Santa Clara,0007046,President,,DEM,Joe Biden,2042,127,1915
+Santa Clara,0007051,President,,DEM,Joe Biden,0,0,0
+Santa Clara,0007059,President,,DEM,Joe Biden,318,17,301
+Santa Clara,0007061,President,,DEM,Joe Biden,1484,63,1421
+Santa Clara,0007062,President,,DEM,Joe Biden,1831,90,1741
+Santa Clara,0007079,President,,DEM,Joe Biden,1359,48,1311
+Santa Clara,0007081,President,,DEM,Joe Biden,1221,47,1174
+Santa Clara,0007089,President,,DEM,Joe Biden,825,18,807
+Santa Clara,0007201,President,,DEM,Joe Biden,259,17,242
+Santa Clara,0007202,President,,DEM,Joe Biden,473,31,442
+Santa Clara,0007203,President,,DEM,Joe Biden,334,28,306
+Santa Clara,0007205,President,,DEM,Joe Biden,1842,111,1731
+Santa Clara,0007214,President,,DEM,Joe Biden,1111,64,1047
+Santa Clara,0007217,President,,DEM,Joe Biden,2199,172,2027
+Santa Clara,0007219,President,,DEM,Joe Biden,683,24,659
+Santa Clara,0007221,President,,DEM,Joe Biden,1106,45,1061
+Santa Clara,0007224,President,,DEM,Joe Biden,526,28,498
+Santa Clara,0007231,President,,DEM,Joe Biden,470,27,443
+Santa Clara,0007235,President,,DEM,Joe Biden,1631,136,1495
+Santa Clara,0007237,President,,DEM,Joe Biden,1546,109,1437
+Santa Clara,0007245,President,,DEM,Joe Biden,161,3,158
+Santa Clara,0007246,President,,DEM,Joe Biden,963,30,933
+Santa Clara,0007248,President,,DEM,Joe Biden,1640,81,1559
+Santa Clara,0007252,President,,DEM,Joe Biden,2151,150,2001
+Santa Clara,0007255,President,,DEM,Joe Biden,1949,126,1823
+Santa Clara,0007257,President,,DEM,Joe Biden,1000,32,968
+Santa Clara,0007261,President,,DEM,Joe Biden,1377,85,1292
+Santa Clara,0007264,President,,DEM,Joe Biden,1553,91,1462
+Santa Clara,0007271,President,,DEM,Joe Biden,1935,88,1847
+Santa Clara,0007273,President,,DEM,Joe Biden,2219,103,2116
+Santa Clara,0007282,President,,DEM,Joe Biden,1260,60,1200
+Santa Clara,0007294,President,,DEM,Joe Biden,447,12,435
+Santa Clara,0007295,President,,DEM,Joe Biden,1189,49,1140
+Santa Clara,0007298,President,,DEM,Joe Biden,801,18,783
+Santa Clara,0007299,President,,DEM,Joe Biden,648,25,623
+Santa Clara,0007306,President,,DEM,Joe Biden,0,0,0
+Santa Clara,0007401,President,,DEM,Joe Biden,1,1,0
+Santa Clara,0007402,President,,DEM,Joe Biden,427,22,405
+Santa Clara,0007403,President,,DEM,Joe Biden,824,76,748
+Santa Clara,0007408,President,,DEM,Joe Biden,627,17,610
+Santa Clara,0007409,President,,DEM,Joe Biden,231,14,217
+Santa Clara,0007410,President,,DEM,Joe Biden,4,1,3
+Santa Clara,0007411,President,,DEM,Joe Biden,22,3,19
+Santa Clara,0007414,President,,DEM,Joe Biden,261,12,249
+Santa Clara,0007415,President,,DEM,Joe Biden,39,0,39
+Santa Clara,0007416,President,,DEM,Joe Biden,144,11,133
+Santa Clara,0007417,President,,DEM,Joe Biden,2442,129,2313
+Santa Clara,0007418,President,,DEM,Joe Biden,1314,72,1242
+Santa Clara,0007419,President,,DEM,Joe Biden,958,42,916
+Santa Clara,0007430,President,,DEM,Joe Biden,2077,166,1911
+Santa Clara,0007435,President,,DEM,Joe Biden,1911,131,1780
+Santa Clara,0007436,President,,DEM,Joe Biden,2852,179,2673
+Santa Clara,0007438,President,,DEM,Joe Biden,241,25,216
+Santa Clara,0007440,President,,DEM,Joe Biden,23,4,19
+Santa Clara,0007441,President,,DEM,Joe Biden,1022,63,959
+Santa Clara,0007442,President,,DEM,Joe Biden,193,20,173
+Santa Clara,0007447,President,,DEM,Joe Biden,1575,161,1414
+Santa Clara,0007458,President,,DEM,Joe Biden,1430,213,1217
+Santa Clara,0007459,President,,DEM,Joe Biden,2171,189,1982
+Santa Clara,0007470,President,,DEM,Joe Biden,1767,116,1651
+Santa Clara,0007471,President,,DEM,Joe Biden,2400,189,2211
+Santa Clara,0007479,President,,DEM,Joe Biden,957,74,883
+Santa Clara,0007483,President,,DEM,Joe Biden,1958,186,1772
+Santa Clara,0007601,President,,DEM,Joe Biden,2474,165,2309
+Santa Clara,0007606,President,,DEM,Joe Biden,2637,164,2473
+Santa Clara,0007609,President,,DEM,Joe Biden,645,67,578
+Santa Clara,0007615,President,,DEM,Joe Biden,725,61,664
+Santa Clara,0007619,President,,DEM,Joe Biden,1477,66,1411
+Santa Clara,0007620,President,,DEM,Joe Biden,2092,97,1995
+Santa Clara,0007621,President,,DEM,Joe Biden,2266,89,2177
+Santa Clara,0007624,President,,DEM,Joe Biden,1646,73,1573
+Santa Clara,0007632,President,,DEM,Joe Biden,1940,102,1838
+Santa Clara,0007634,President,,DEM,Joe Biden,1144,40,1104
+Santa Clara,0007648,President,,DEM,Joe Biden,2140,79,2061
+Santa Clara,0007654,President,,DEM,Joe Biden,2510,110,2400
+Santa Clara,0007660,President,,DEM,Joe Biden,2036,82,1954
+Santa Clara,0007666,President,,DEM,Joe Biden,2203,100,2103
+Santa Clara,0007670,President,,DEM,Joe Biden,68,0,68
+Santa Clara,0007673,President,,DEM,Joe Biden,0,0,0
+Santa Clara,0007674,President,,DEM,Joe Biden,0,0,0
+Santa Clara,0007677,President,,DEM,Joe Biden,2373,92,2281
+Santa Clara,0007680,President,,DEM,Joe Biden,1403,57,1346
+Santa Clara,0007689,President,,DEM,Joe Biden,10,0,10
+Santa Clara,0007690,President,,DEM,Joe Biden,699,28,671
+Santa Clara,0007801,President,,DEM,Joe Biden,504,23,481
+Santa Clara,0007802,President,,DEM,Joe Biden,268,11,257
+Santa Clara,0007803,President,,DEM,Joe Biden,678,22,656
+Santa Clara,0007805,President,,DEM,Joe Biden,1101,45,1056
+Santa Clara,0007810,President,,DEM,Joe Biden,162,5,157
+Santa Clara,0007811,President,,DEM,Joe Biden,133,11,122
+Santa Clara,0007812,President,,DEM,Joe Biden,946,42,904
+Santa Clara,0007816,President,,DEM,Joe Biden,186,21,165
+Santa Clara,0007817,President,,DEM,Joe Biden,7,0,7
+Santa Clara,0007818,President,,DEM,Joe Biden,150,5,145
+Santa Clara,0007821,President,,DEM,Joe Biden,2337,158,2179
+Santa Clara,0007826,President,,DEM,Joe Biden,2239,147,2092
+Santa Clara,0007827,President,,DEM,Joe Biden,879,74,805
+Santa Clara,0007832,President,,DEM,Joe Biden,1355,103,1252
+Santa Clara,0007833,President,,DEM,Joe Biden,1798,129,1669
+Santa Clara,0007843,President,,DEM,Joe Biden,2814,254,2560
+Santa Clara,0007849,President,,DEM,Joe Biden,1908,133,1775
+Santa Clara,0007850,President,,DEM,Joe Biden,1342,123,1219
+Santa Clara,0007851,President,,DEM,Joe Biden,779,32,747
+Santa Clara,0007861,President,,DEM,Joe Biden,1195,91,1104
+Santa Clara,0007867,President,,DEM,Joe Biden,2085,137,1948
+Santa Clara,0007874,President,,DEM,Joe Biden,282,13,269
+Santa Clara,0007880,President,,DEM,Joe Biden,3,1,2
+Santa Clara,0008001,President,,DEM,Joe Biden,184,8,176
+Santa Clara,0008002,President,,DEM,Joe Biden,302,14,288
+Santa Clara,0008003,President,,DEM,Joe Biden,1872,75,1797
+Santa Clara,0008005,President,,DEM,Joe Biden,2746,91,2655
+Santa Clara,0008007,President,,DEM,Joe Biden,523,37,486
+Santa Clara,0008011,President,,DEM,Joe Biden,311,8,303
+Santa Clara,0008012,President,,DEM,Joe Biden,10,0,10
+Santa Clara,0008013,President,,DEM,Joe Biden,66,3,63
+Santa Clara,0008016,President,,DEM,Joe Biden,3107,206,2901
+Santa Clara,0008017,President,,DEM,Joe Biden,1266,88,1178
+Santa Clara,0008022,President,,DEM,Joe Biden,742,49,693
+Santa Clara,0008023,President,,DEM,Joe Biden,628,26,602
+Santa Clara,0008026,President,,DEM,Joe Biden,643,63,580
+Santa Clara,0008028,President,,DEM,Joe Biden,240,18,222
+Santa Clara,0008029,President,,DEM,Joe Biden,98,4,94
+Santa Clara,0008030,President,,DEM,Joe Biden,659,40,619
+Santa Clara,0008033,President,,DEM,Joe Biden,162,6,156
+Santa Clara,0008034,President,,DEM,Joe Biden,176,14,162
+Santa Clara,0008038,President,,DEM,Joe Biden,4,0,4
+Santa Clara,0008040,President,,DEM,Joe Biden,422,30,392
+Santa Clara,0008047,President,,DEM,Joe Biden,1355,54,1301
+Santa Clara,0008049,President,,DEM,Joe Biden,35,1,34
+Santa Clara,0008050,President,,DEM,Joe Biden,1101,56,1045
+Santa Clara,0008053,President,,DEM,Joe Biden,1874,92,1782
+Santa Clara,0008054,President,,DEM,Joe Biden,1575,50,1525
+Santa Clara,0008055,President,,DEM,Joe Biden,218,12,206
+Santa Clara,0008062,President,,DEM,Joe Biden,2012,126,1886
+Santa Clara,0008066,President,,DEM,Joe Biden,714,45,669
+Santa Clara,0008067,President,,DEM,Joe Biden,2165,85,2080
+Santa Clara,0008068,President,,DEM,Joe Biden,30,2,28
+Santa Clara,0008072,President,,DEM,Joe Biden,448,21,427
+Santa Clara,0008073,President,,DEM,Joe Biden,368,25,343
+Santa Clara,0008079,President,,DEM,Joe Biden,1961,44,1917
+Santa Clara,0008082,President,,DEM,Joe Biden,1455,50,1405
+Santa Clara,0008085,President,,DEM,Joe Biden,866,17,849
+Santa Clara,0008089,President,,DEM,Joe Biden,2025,51,1974
+Santa Clara,0008092,President,,DEM,Joe Biden,50,2,48
+Santa Clara,0008093,President,,DEM,Joe Biden,28,0,28
+Santa Clara,0008096,President,,DEM,Joe Biden,1761,57,1704
+Santa Clara,0008101,President,,DEM,Joe Biden,850,67,783
+Santa Clara,0008104,President,,DEM,Joe Biden,110,3,107
+Santa Clara,0008105,President,,DEM,Joe Biden,277,5,272
+Santa Clara,0008117,President,,DEM,Joe Biden,1296,36,1260
+Santa Clara,0008122,President,,DEM,Joe Biden,1615,88,1527
+Santa Clara,0008128,President,,DEM,Joe Biden,0,0,0
+Santa Clara,0008133,President,,DEM,Joe Biden,9,0,9
+Santa Clara,0008201,President,,DEM,Joe Biden,1172,87,1085
+Santa Clara,0008203,President,,DEM,Joe Biden,1488,147,1341
+Santa Clara,0008205,President,,DEM,Joe Biden,1745,157,1588
+Santa Clara,0008208,President,,DEM,Joe Biden,1714,131,1583
+Santa Clara,0008212,President,,DEM,Joe Biden,886,92,794
+Santa Clara,0008214,President,,DEM,Joe Biden,178,20,158
+Santa Clara,0008227,President,,DEM,Joe Biden,1839,129,1710
+Santa Clara,0008228,President,,DEM,Joe Biden,1413,53,1360
+Santa Clara,0008230,President,,DEM,Joe Biden,2028,106,1922
+Santa Clara,0008231,President,,DEM,Joe Biden,1075,77,998
+Santa Clara,0008232,President,,DEM,Joe Biden,1968,111,1857
+Santa Clara,0008236,President,,DEM,Joe Biden,2206,123,2083
+Santa Clara,0008246,President,,DEM,Joe Biden,1553,109,1444
+Santa Clara,0008254,President,,DEM,Joe Biden,1536,135,1401
+Santa Clara,0008262,President,,DEM,Joe Biden,939,33,906
+Santa Clara,0008264,President,,DEM,Joe Biden,1032,49,983
+Santa Clara,0008401,President,,DEM,Joe Biden,1381,78,1303
+Santa Clara,0008404,President,,DEM,Joe Biden,2439,170,2269
+Santa Clara,0008408,President,,DEM,Joe Biden,858,49,809
+Santa Clara,0008409,President,,DEM,Joe Biden,884,32,852
+Santa Clara,0008414,President,,DEM,Joe Biden,279,14,265
+Santa Clara,0008418,President,,DEM,Joe Biden,296,6,290
+Santa Clara,0008421,President,,DEM,Joe Biden,26,0,26
+Santa Clara,0008423,President,,DEM,Joe Biden,2,1,1
+Santa Clara,0008430,President,,DEM,Joe Biden,2088,106,1982
+Santa Clara,0008435,President,,DEM,Joe Biden,2520,87,2433
+Santa Clara,0008438,President,,DEM,Joe Biden,2547,146,2401
+Santa Clara,0008439,President,,DEM,Joe Biden,2145,86,2059
+Santa Clara,0008445,President,,DEM,Joe Biden,1498,44,1454
+Santa Clara,0008447,President,,DEM,Joe Biden,9,0,9
+Santa Clara,0008456,President,,DEM,Joe Biden,2744,127,2617
+Santa Clara,0008457,President,,DEM,Joe Biden,2506,115,2391
+Santa Clara,0008464,President,,DEM,Joe Biden,2432,124,2308
+Santa Clara,0008470,President,,DEM,Joe Biden,2637,100,2537
+Santa Clara,0008472,President,,DEM,Joe Biden,1973,67,1906
+Santa Clara,0008486,President,,DEM,Joe Biden,2502,89,2413
+Santa Clara,0008492,President,,DEM,Joe Biden,2835,48,2787
+Santa Clara,0008502,President,,DEM,Joe Biden,170,4,166
+Santa Clara,0008601,President,,DEM,Joe Biden,360,21,339
+Santa Clara,0008603,President,,DEM,Joe Biden,1665,80,1585
+Santa Clara,0008605,President,,DEM,Joe Biden,2136,103,2033
+Santa Clara,0008609,President,,DEM,Joe Biden,0,0,0
+Santa Clara,0008610,President,,DEM,Joe Biden,1149,46,1103
+Santa Clara,0008612,President,,DEM,Joe Biden,1699,56,1643
+Santa Clara,0008615,President,,DEM,Joe Biden,1494,50,1444
+Santa Clara,0008619,President,,DEM,Joe Biden,545,16,529
+Santa Clara,0008625,President,,DEM,Joe Biden,77,4,73
+Santa Clara,0008627,President,,DEM,Joe Biden,954,40,914
+Santa Clara,0008629,President,,DEM,Joe Biden,1316,68,1248
+Santa Clara,0008630,President,,DEM,Joe Biden,1804,62,1742
+Santa Clara,0008631,President,,DEM,Joe Biden,1085,42,1043
+Santa Clara,0008634,President,,DEM,Joe Biden,305,19,286
+Santa Clara,0008636,President,,DEM,Joe Biden,218,6,212
+Santa Clara,0008645,President,,DEM,Joe Biden,2011,62,1949
+Santa Clara,0008648,President,,DEM,Joe Biden,1812,60,1752
+Santa Clara,0008650,President,,DEM,Joe Biden,251,7,244
+Santa Clara,0008653,President,,DEM,Joe Biden,161,6,155
+Santa Clara,0008654,President,,DEM,Joe Biden,183,8,175
+Santa Clara,0008655,President,,DEM,Joe Biden,0,0,0
+Santa Clara,0008657,President,,DEM,Joe Biden,461,9,452
+Santa Clara,0008658,President,,DEM,Joe Biden,2356,104,2252
+Santa Clara,0008670,President,,DEM,Joe Biden,1556,98,1458
+Santa Clara,0008675,President,,DEM,Joe Biden,916,71,845
+Santa Clara,0008676,President,,DEM,Joe Biden,1818,83,1735
+Santa Clara,0008680,President,,DEM,Joe Biden,1435,38,1397
+Santa Clara,0008683,President,,DEM,Joe Biden,2240,87,2153
+Santa Clara,0008687,President,,DEM,Joe Biden,2073,93,1980
+Santa Clara,0008697,President,,DEM,Joe Biden,2211,86,2125
+Santa Clara,0008801,President,,DEM,Joe Biden,1369,94,1275
+Santa Clara,0008805,President,,DEM,Joe Biden,1121,42,1079
+Santa Clara,0008809,President,,DEM,Joe Biden,1969,81,1888
+Santa Clara,0008812,President,,DEM,Joe Biden,1142,95,1047
+Santa Clara,0008817,President,,DEM,Joe Biden,642,31,611
+Santa Clara,0008820,President,,DEM,Joe Biden,1235,45,1190
+Santa Clara,0008822,President,,DEM,Joe Biden,1345,56,1289
+Santa Clara,0008828,President,,DEM,Joe Biden,479,23,456
+Santa Clara,0008829,President,,DEM,Joe Biden,438,21,417
+Santa Clara,0008832,President,,DEM,Joe Biden,1285,33,1252
+Santa Clara,0008834,President,,DEM,Joe Biden,715,54,661
+Santa Clara,0008838,President,,DEM,Joe Biden,187,11,176
+Santa Clara,0008839,President,,DEM,Joe Biden,1995,120,1875
+Santa Clara,0008844,President,,DEM,Joe Biden,2021,84,1937
+Santa Clara,0008848,President,,DEM,Joe Biden,1100,55,1045
+Santa Clara,0008853,President,,DEM,Joe Biden,1379,63,1316
+Santa Clara,0008857,President,,DEM,Joe Biden,1011,28,983
+Santa Clara,0008858,President,,DEM,Joe Biden,1469,46,1423
+Santa Clara,0008862,President,,DEM,Joe Biden,1487,47,1440
+Santa Clara,0008868,President,,DEM,Joe Biden,80,4,76
+Santa Clara,0008873,President,,DEM,Joe Biden,640,19,621
+Santa Clara,0008874,President,,DEM,Joe Biden,11,0,11
+Santa Clara,0008879,President,,DEM,Joe Biden,1974,53,1921
+Santa Clara,0008883,President,,DEM,Joe Biden,2034,80,1954
+Santa Clara,0008885,President,,DEM,Joe Biden,1977,66,1911
+Santa Clara,0008886,President,,DEM,Joe Biden,229,2,227
+Santa Clara,0008889,President,,DEM,Joe Biden,1569,42,1527
+Santa Clara,0008898,President,,DEM,Joe Biden,1735,56,1679
+Santa Clara,0008903,President,,DEM,Joe Biden,2199,54,2145
+Santa Clara,0008915,President,,DEM,Joe Biden,12,1,11
+Santa Clara,0008916,President,,DEM,Joe Biden,6,0,6
+Santa Clara,0008920,President,,DEM,Joe Biden,0,0,0
+Santa Clara,0008923,President,,DEM,Joe Biden,0,0,0
+Santa Clara,0008924,President,,DEM,Joe Biden,10,0,10
+Santa Clara,0009001,President,,DEM,Joe Biden,1942,121,1821
+Santa Clara,0009005,President,,DEM,Joe Biden,3033,207,2826
+Santa Clara,0009051,President,,DEM,Joe Biden,970,52,918
+Santa Clara,0009055,President,,DEM,Joe Biden,54,1,53
+Santa Clara,0009056,President,,DEM,Joe Biden,1988,113,1875
+Santa Clara,0009059,President,,DEM,Joe Biden,1623,118,1505
+Santa Clara,0009061,President,,DEM,Joe Biden,0,0,0
+Santa Clara,0009062,President,,DEM,Joe Biden,1575,59,1516
+Santa Clara,0009101,President,,DEM,Joe Biden,2041,86,1955
+Santa Clara,0009103,President,,DEM,Joe Biden,600,36,564
+Santa Clara,0009104,President,,DEM,Joe Biden,1866,69,1797
+Santa Clara,0009109,President,,DEM,Joe Biden,1224,70,1154
+Santa Clara,0009151,President,,DEM,Joe Biden,1731,87,1644
+Santa Clara,0009157,President,,DEM,Joe Biden,2158,110,2048
+Santa Clara,0009163,President,,DEM,Joe Biden,966,26,940
+Santa Clara,0009166,President,,DEM,Joe Biden,914,27,887
+Santa Clara,0009201,President,,DEM,Joe Biden,521,17,504
+Santa Clara,0009203,President,,DEM,Joe Biden,1145,44,1101
+Santa Clara,0009208,President,,DEM,Joe Biden,953,57,896
+Santa Clara,0009210,President,,DEM,Joe Biden,1403,50,1353
+Santa Clara,0009219,President,,DEM,Joe Biden,143,9,134
+Santa Clara,0009220,President,,DEM,Joe Biden,1855,87,1768
+Santa Clara,0009251,President,,DEM,Joe Biden,885,29,856
+Santa Clara,0009252,President,,DEM,Joe Biden,1367,49,1318
+Santa Clara,0009258,President,,DEM,Joe Biden,1172,75,1097
+Santa Clara,0009262,President,,DEM,Joe Biden,155,5,150
+Santa Clara,0009264,President,,DEM,Joe Biden,1346,30,1316
+Santa Clara,0009268,President,,DEM,Joe Biden,1289,40,1249
+Santa Clara,0009275,President,,DEM,Joe Biden,1272,70,1202
+Santa Clara,0009282,President,,DEM,Joe Biden,6,3,3
+Santa Clara,0002001,President,,REP,Donald Trump,42,40,2
+Santa Clara,0002002,President,,REP,Donald Trump,261,36,225
+Santa Clara,0002005,President,,REP,Donald Trump,193,27,166
+Santa Clara,0002006,President,,REP,Donald Trump,12,1,11
+Santa Clara,0002009,President,,REP,Donald Trump,514,75,439
+Santa Clara,0002013,President,,REP,Donald Trump,513,71,442
+Santa Clara,0002014,President,,REP,Donald Trump,503,92,411
+Santa Clara,0002018,President,,REP,Donald Trump,50,8,42
+Santa Clara,0002025,President,,REP,Donald Trump,491,47,444
+Santa Clara,0002043,President,,REP,Donald Trump,385,45,340
+Santa Clara,0002046,President,,REP,Donald Trump,423,68,355
+Santa Clara,0002057,President,,REP,Donald Trump,376,49,327
+Santa Clara,0002068,President,,REP,Donald Trump,422,36,386
+Santa Clara,0002098,President,,REP,Donald Trump,603,58,545
+Santa Clara,0002108,President,,REP,Donald Trump,421,62,359
+Santa Clara,0002125,President,,REP,Donald Trump,61,9,52
+Santa Clara,0002274,President,,REP,Donald Trump,59,4,55
+Santa Clara,0002275,President,,REP,Donald Trump,299,37,262
+Santa Clara,0002278,President,,REP,Donald Trump,224,30,194
+Santa Clara,0002281,President,,REP,Donald Trump,0,0,0
+Santa Clara,0002282,President,,REP,Donald Trump,285,33,252
+Santa Clara,0002285,President,,REP,Donald Trump,532,67,465
+Santa Clara,0002301,President,,REP,Donald Trump,582,52,530
+Santa Clara,0002305,President,,REP,Donald Trump,738,65,673
+Santa Clara,0002309,President,,REP,Donald Trump,211,25,186
+Santa Clara,0002314,President,,REP,Donald Trump,475,52,423
+Santa Clara,0002317,President,,REP,Donald Trump,461,55,406
+Santa Clara,0002330,President,,REP,Donald Trump,680,71,609
+Santa Clara,0002338,President,,REP,Donald Trump,26,3,23
+Santa Clara,0002351,President,,REP,Donald Trump,410,27,383
+Santa Clara,0002353,President,,REP,Donald Trump,11,3,8
+Santa Clara,0002539,President,,REP,Donald Trump,14,0,14
+Santa Clara,0002542,President,,REP,Donald Trump,57,15,42
+Santa Clara,0002545,President,,REP,Donald Trump,81,9,72
+Santa Clara,0002720,President,,REP,Donald Trump,377,33,344
+Santa Clara,0002721,President,,REP,Donald Trump,365,33,332
+Santa Clara,0002723,President,,REP,Donald Trump,736,71,665
+Santa Clara,0002724,President,,REP,Donald Trump,599,80,519
+Santa Clara,0002725,President,,REP,Donald Trump,552,61,491
+Santa Clara,0002726,President,,REP,Donald Trump,407,62,345
+Santa Clara,0002727,President,,REP,Donald Trump,411,42,369
+Santa Clara,0002729,President,,REP,Donald Trump,361,26,335
+Santa Clara,0002734,President,,REP,Donald Trump,580,65,515
+Santa Clara,0002740,President,,REP,Donald Trump,693,78,615
+Santa Clara,0002751,President,,REP,Donald Trump,4,0,4
+Santa Clara,0002761,President,,REP,Donald Trump,0,0,0
+Santa Clara,0002802,President,,REP,Donald Trump,508,52,456
+Santa Clara,0002808,President,,REP,Donald Trump,18,1,17
+Santa Clara,0002810,President,,REP,Donald Trump,1,0,1
+Santa Clara,0002811,President,,REP,Donald Trump,10,0,10
+Santa Clara,0002812,President,,REP,Donald Trump,64,10,54
+Santa Clara,0002813,President,,REP,Donald Trump,74,6,68
+Santa Clara,0002816,President,,REP,Donald Trump,3,0,3
+Santa Clara,0002825,President,,REP,Donald Trump,1,0,1
+Santa Clara,0002870,President,,REP,Donald Trump,29,3,26
+Santa Clara,0002951,President,,REP,Donald Trump,79,15,64
+Santa Clara,0003001,President,,REP,Donald Trump,761,102,659
+Santa Clara,0003002,President,,REP,Donald Trump,508,83,425
+Santa Clara,0003005,President,,REP,Donald Trump,12,3,9
+Santa Clara,0003008,President,,REP,Donald Trump,9,0,9
+Santa Clara,0003010,President,,REP,Donald Trump,488,60,428
+Santa Clara,0003011,President,,REP,Donald Trump,384,59,325
+Santa Clara,0003012,President,,REP,Donald Trump,24,5,19
+Santa Clara,0003013,President,,REP,Donald Trump,534,82,452
+Santa Clara,0003016,President,,REP,Donald Trump,135,14,121
+Santa Clara,0003017,President,,REP,Donald Trump,127,27,100
+Santa Clara,0003018,President,,REP,Donald Trump,72,5,67
+Santa Clara,0003019,President,,REP,Donald Trump,528,76,452
+Santa Clara,0003021,President,,REP,Donald Trump,52,6,46
+Santa Clara,0003023,President,,REP,Donald Trump,538,89,449
+Santa Clara,0003026,President,,REP,Donald Trump,425,50,375
+Santa Clara,0003029,President,,REP,Donald Trump,0,0,0
+Santa Clara,0003031,President,,REP,Donald Trump,0,0,0
+Santa Clara,0003032,President,,REP,Donald Trump,300,52,248
+Santa Clara,0003034,President,,REP,Donald Trump,667,86,581
+Santa Clara,0003035,President,,REP,Donald Trump,414,67,347
+Santa Clara,0003039,President,,REP,Donald Trump,268,23,245
+Santa Clara,0003040,President,,REP,Donald Trump,0,0,0
+Santa Clara,0003042,President,,REP,Donald Trump,316,45,271
+Santa Clara,0003043,President,,REP,Donald Trump,574,58,516
+Santa Clara,0003045,President,,REP,Donald Trump,682,87,595
+Santa Clara,0003047,President,,REP,Donald Trump,212,26,186
+Santa Clara,0003048,President,,REP,Donald Trump,614,88,526
+Santa Clara,0003051,President,,REP,Donald Trump,458,31,427
+Santa Clara,0003053,President,,REP,Donald Trump,611,63,548
+Santa Clara,0003061,President,,REP,Donald Trump,11,2,9
+Santa Clara,0003079,President,,REP,Donald Trump,142,15,127
+Santa Clara,0003080,President,,REP,Donald Trump,158,13,145
+Santa Clara,0003086,President,,REP,Donald Trump,656,65,591
+Santa Clara,0003087,President,,REP,Donald Trump,312,48,264
+Santa Clara,0003089,President,,REP,Donald Trump,0,0,0
+Santa Clara,0003095,President,,REP,Donald Trump,0,0,0
+Santa Clara,0003101,President,,REP,Donald Trump,32,5,27
+Santa Clara,0003102,President,,REP,Donald Trump,115,10,105
+Santa Clara,0003103,President,,REP,Donald Trump,231,31,200
+Santa Clara,0003116,President,,REP,Donald Trump,190,19,171
+Santa Clara,0003117,President,,REP,Donald Trump,179,23,156
+Santa Clara,0003120,President,,REP,Donald Trump,94,14,80
+Santa Clara,0003122,President,,REP,Donald Trump,431,55,376
+Santa Clara,0003156,President,,REP,Donald Trump,31,8,23
+Santa Clara,0003402,President,,REP,Donald Trump,476,80,396
+Santa Clara,0003406,President,,REP,Donald Trump,434,87,347
+Santa Clara,0003407,President,,REP,Donald Trump,429,59,370
+Santa Clara,0003408,President,,REP,Donald Trump,513,89,424
+Santa Clara,0003409,President,,REP,Donald Trump,578,103,475
+Santa Clara,0003410,President,,REP,Donald Trump,549,87,462
+Santa Clara,0003417,President,,REP,Donald Trump,378,54,324
+Santa Clara,0003427,President,,REP,Donald Trump,392,65,327
+Santa Clara,0003434,President,,REP,Donald Trump,355,37,318
+Santa Clara,0003438,President,,REP,Donald Trump,672,80,592
+Santa Clara,0003445,President,,REP,Donald Trump,561,84,477
+Santa Clara,0003601,President,,REP,Donald Trump,246,19,227
+Santa Clara,0003602,President,,REP,Donald Trump,547,54,493
+Santa Clara,0003603,President,,REP,Donald Trump,304,30,274
+Santa Clara,0003604,President,,REP,Donald Trump,636,63,573
+Santa Clara,0003605,President,,REP,Donald Trump,705,66,639
+Santa Clara,0003606,President,,REP,Donald Trump,559,50,509
+Santa Clara,0003608,President,,REP,Donald Trump,654,69,585
+Santa Clara,0003609,President,,REP,Donald Trump,855,87,768
+Santa Clara,0003611,President,,REP,Donald Trump,627,52,575
+Santa Clara,0003614,President,,REP,Donald Trump,377,51,326
+Santa Clara,0003624,President,,REP,Donald Trump,656,76,580
+Santa Clara,0003635,President,,REP,Donald Trump,0,0,0
+Santa Clara,0003652,President,,REP,Donald Trump,328,45,283
+Santa Clara,0003655,President,,REP,Donald Trump,54,7,47
+Santa Clara,0003669,President,,REP,Donald Trump,0,0,0
+Santa Clara,0003670,President,,REP,Donald Trump,19,1,18
+Santa Clara,0003777,President,,REP,Donald Trump,457,37,420
+Santa Clara,0003779,President,,REP,Donald Trump,50,1,49
+Santa Clara,0003782,President,,REP,Donald Trump,132,7,125
+Santa Clara,0003783,President,,REP,Donald Trump,115,6,109
+Santa Clara,0003801,President,,REP,Donald Trump,347,54,293
+Santa Clara,0003802,President,,REP,Donald Trump,500,63,437
+Santa Clara,0003803,President,,REP,Donald Trump,472,50,422
+Santa Clara,0003804,President,,REP,Donald Trump,244,46,198
+Santa Clara,0003810,President,,REP,Donald Trump,426,90,336
+Santa Clara,0003811,President,,REP,Donald Trump,661,91,570
+Santa Clara,0003814,President,,REP,Donald Trump,605,107,498
+Santa Clara,0003820,President,,REP,Donald Trump,438,72,366
+Santa Clara,0003821,President,,REP,Donald Trump,187,35,152
+Santa Clara,0003825,President,,REP,Donald Trump,272,59,213
+Santa Clara,0003828,President,,REP,Donald Trump,268,42,226
+Santa Clara,0003835,President,,REP,Donald Trump,334,28,306
+Santa Clara,0003840,President,,REP,Donald Trump,529,98,431
+Santa Clara,0003846,President,,REP,Donald Trump,26,2,24
+Santa Clara,0003861,President,,REP,Donald Trump,13,2,11
+Santa Clara,0004401,President,,REP,Donald Trump,920,153,767
+Santa Clara,0004402,President,,REP,Donald Trump,911,144,767
+Santa Clara,0004403,President,,REP,Donald Trump,59,11,48
+Santa Clara,0004405,President,,REP,Donald Trump,1119,164,955
+Santa Clara,0004407,President,,REP,Donald Trump,961,147,814
+Santa Clara,0004409,President,,REP,Donald Trump,1203,168,1035
+Santa Clara,0004411,President,,REP,Donald Trump,661,79,582
+Santa Clara,0004412,President,,REP,Donald Trump,1165,147,1018
+Santa Clara,0004414,President,,REP,Donald Trump,1158,137,1021
+Santa Clara,0004417,President,,REP,Donald Trump,1063,123,940
+Santa Clara,0004665,President,,REP,Donald Trump,10,0,10
+Santa Clara,0004666,President,,REP,Donald Trump,3,0,3
+Santa Clara,0004671,President,,REP,Donald Trump,425,56,369
+Santa Clara,0004672,President,,REP,Donald Trump,285,27,258
+Santa Clara,0004674,President,,REP,Donald Trump,359,45,314
+Santa Clara,0004675,President,,REP,Donald Trump,780,121,659
+Santa Clara,0004685,President,,REP,Donald Trump,424,36,388
+Santa Clara,0004687,President,,REP,Donald Trump,416,41,375
+Santa Clara,0004688,President,,REP,Donald Trump,707,59,648
+Santa Clara,0004691,President,,REP,Donald Trump,532,55,477
+Santa Clara,0004696,President,,REP,Donald Trump,296,33,263
+Santa Clara,0004698,President,,REP,Donald Trump,225,30,195
+Santa Clara,0004699,President,,REP,Donald Trump,330,22,308
+Santa Clara,0004702,President,,REP,Donald Trump,227,26,201
+Santa Clara,0004715,President,,REP,Donald Trump,138,12,126
+Santa Clara,0004733,President,,REP,Donald Trump,17,5,12
+Santa Clara,0004801,President,,REP,Donald Trump,356,62,294
+Santa Clara,0004806,President,,REP,Donald Trump,948,137,811
+Santa Clara,0004811,President,,REP,Donald Trump,591,66,525
+Santa Clara,0004826,President,,REP,Donald Trump,463,59,404
+Santa Clara,0004827,President,,REP,Donald Trump,758,97,661
+Santa Clara,0004833,President,,REP,Donald Trump,582,79,503
+Santa Clara,0004851,President,,REP,Donald Trump,346,54,292
+Santa Clara,0004853,President,,REP,Donald Trump,639,72,567
+Santa Clara,0004858,President,,REP,Donald Trump,826,144,682
+Santa Clara,0004876,President,,REP,Donald Trump,1118,135,983
+Santa Clara,0004881,President,,REP,Donald Trump,1330,144,1186
+Santa Clara,0004941,President,,REP,Donald Trump,718,89,629
+Santa Clara,0004942,President,,REP,Donald Trump,629,76,553
+Santa Clara,0004943,President,,REP,Donald Trump,19,3,16
+Santa Clara,0004944,President,,REP,Donald Trump,183,39,144
+Santa Clara,0004945,President,,REP,Donald Trump,330,51,279
+Santa Clara,0004946,President,,REP,Donald Trump,822,119,703
+Santa Clara,0004949,President,,REP,Donald Trump,814,110,704
+Santa Clara,0004950,President,,REP,Donald Trump,762,134,628
+Santa Clara,0004954,President,,REP,Donald Trump,438,55,383
+Santa Clara,0004956,President,,REP,Donald Trump,44,10,34
+Santa Clara,0004958,President,,REP,Donald Trump,226,46,180
+Santa Clara,0004965,President,,REP,Donald Trump,900,108,792
+Santa Clara,0004969,President,,REP,Donald Trump,426,54,372
+Santa Clara,0004971,President,,REP,Donald Trump,243,33,210
+Santa Clara,0004973,President,,REP,Donald Trump,845,109,736
+Santa Clara,0004974,President,,REP,Donald Trump,201,37,164
+Santa Clara,0005449,President,,REP,Donald Trump,60,4,56
+Santa Clara,0005451,President,,REP,Donald Trump,3,0,3
+Santa Clara,0005454,President,,REP,Donald Trump,3,0,3
+Santa Clara,0005455,President,,REP,Donald Trump,0,0,0
+Santa Clara,0005456,President,,REP,Donald Trump,0,0,0
+Santa Clara,0005458,President,,REP,Donald Trump,0,0,0
+Santa Clara,0005502,President,,REP,Donald Trump,136,14,122
+Santa Clara,0005503,President,,REP,Donald Trump,66,7,59
+Santa Clara,0005505,President,,REP,Donald Trump,111,8,103
+Santa Clara,0005507,President,,REP,Donald Trump,0,0,0
+Santa Clara,0005556,President,,REP,Donald Trump,218,45,173
+Santa Clara,0005557,President,,REP,Donald Trump,182,29,153
+Santa Clara,0005567,President,,REP,Donald Trump,99,18,81
+Santa Clara,0005742,President,,REP,Donald Trump,9,0,9
+Santa Clara,0005743,President,,REP,Donald Trump,126,20,106
+Santa Clara,0005745,President,,REP,Donald Trump,132,16,116
+Santa Clara,0005747,President,,REP,Donald Trump,202,18,184
+Santa Clara,0005748,President,,REP,Donald Trump,430,72,358
+Santa Clara,0005756,President,,REP,Donald Trump,21,1,20
+Santa Clara,0005758,President,,REP,Donald Trump,53,1,52
+Santa Clara,0005759,President,,REP,Donald Trump,135,14,121
+Santa Clara,0005762,President,,REP,Donald Trump,69,2,67
+Santa Clara,0005763,President,,REP,Donald Trump,12,2,10
+Santa Clara,0005770,President,,REP,Donald Trump,54,0,54
+Santa Clara,0005775,President,,REP,Donald Trump,70,6,64
+Santa Clara,0005785,President,,REP,Donald Trump,0,0,0
+Santa Clara,0005793,President,,REP,Donald Trump,0,0,0
+Santa Clara,0005795,President,,REP,Donald Trump,0,0,0
+Santa Clara,0005804,President,,REP,Donald Trump,343,39,304
+Santa Clara,0005810,President,,REP,Donald Trump,108,10,98
+Santa Clara,0005811,President,,REP,Donald Trump,81,6,75
+Santa Clara,0005813,President,,REP,Donald Trump,15,4,11
+Santa Clara,0005814,President,,REP,Donald Trump,88,14,74
+Santa Clara,0005854,President,,REP,Donald Trump,2,0,2
+Santa Clara,0005879,President,,REP,Donald Trump,6,2,4
+Santa Clara,0005886,President,,REP,Donald Trump,3,0,3
+Santa Clara,0005888,President,,REP,Donald Trump,0,0,0
+Santa Clara,0005894,President,,REP,Donald Trump,72,4,68
+Santa Clara,0005896,President,,REP,Donald Trump,0,0,0
+Santa Clara,0005901,President,,REP,Donald Trump,0,0,0
+Santa Clara,0005902,President,,REP,Donald Trump,157,14,143
+Santa Clara,0005903,President,,REP,Donald Trump,206,39,167
+Santa Clara,0005906,President,,REP,Donald Trump,126,17,109
+Santa Clara,0005907,President,,REP,Donald Trump,2,0,2
+Santa Clara,0005911,President,,REP,Donald Trump,672,110,562
+Santa Clara,0005912,President,,REP,Donald Trump,57,12,45
+Santa Clara,0005914,President,,REP,Donald Trump,443,61,382
+Santa Clara,0005915,President,,REP,Donald Trump,375,45,330
+Santa Clara,0005916,President,,REP,Donald Trump,37,4,33
+Santa Clara,0005917,President,,REP,Donald Trump,113,19,94
+Santa Clara,0005919,President,,REP,Donald Trump,139,19,120
+Santa Clara,0005922,President,,REP,Donald Trump,226,38,188
+Santa Clara,0005925,President,,REP,Donald Trump,44,2,42
+Santa Clara,0005927,President,,REP,Donald Trump,0,0,0
+Santa Clara,0005929,President,,REP,Donald Trump,66,7,59
+Santa Clara,0005931,President,,REP,Donald Trump,53,2,51
+Santa Clara,0005936,President,,REP,Donald Trump,141,16,125
+Santa Clara,0005940,President,,REP,Donald Trump,21,5,16
+Santa Clara,0005947,President,,REP,Donald Trump,249,18,231
+Santa Clara,0005949,President,,REP,Donald Trump,192,28,164
+Santa Clara,0005950,President,,REP,Donald Trump,51,8,43
+Santa Clara,0005951,President,,REP,Donald Trump,0,0,0
+Santa Clara,0005955,President,,REP,Donald Trump,514,76,438
+Santa Clara,0005956,President,,REP,Donald Trump,437,40,397
+Santa Clara,0005957,President,,REP,Donald Trump,63,6,57
+Santa Clara,0005958,President,,REP,Donald Trump,323,49,274
+Santa Clara,0005959,President,,REP,Donald Trump,54,3,51
+Santa Clara,0005965,President,,REP,Donald Trump,419,60,359
+Santa Clara,0005966,President,,REP,Donald Trump,71,10,61
+Santa Clara,0005975,President,,REP,Donald Trump,8,5,3
+Santa Clara,0005988,President,,REP,Donald Trump,0,0,0
+Santa Clara,0006023,President,,REP,Donald Trump,3,0,3
+Santa Clara,0006028,President,,REP,Donald Trump,41,1,40
+Santa Clara,0006031,President,,REP,Donald Trump,11,1,10
+Santa Clara,0006035,President,,REP,Donald Trump,0,0,0
+Santa Clara,0006036,President,,REP,Donald Trump,0,0,0
+Santa Clara,0006048,President,,REP,Donald Trump,5,0,5
+Santa Clara,0006401,President,,REP,Donald Trump,0,0,0
+Santa Clara,0006402,President,,REP,Donald Trump,43,1,42
+Santa Clara,0006404,President,,REP,Donald Trump,715,77,638
+Santa Clara,0006405,President,,REP,Donald Trump,6,0,6
+Santa Clara,0006410,President,,REP,Donald Trump,30,3,27
+Santa Clara,0006413,President,,REP,Donald Trump,2,0,2
+Santa Clara,0006418,President,,REP,Donald Trump,238,32,206
+Santa Clara,0006419,President,,REP,Donald Trump,36,5,31
+Santa Clara,0006423,President,,REP,Donald Trump,27,3,24
+Santa Clara,0006452,President,,REP,Donald Trump,205,41,164
+Santa Clara,0006454,President,,REP,Donald Trump,75,12,63
+Santa Clara,0006455,President,,REP,Donald Trump,633,95,538
+Santa Clara,0006491,President,,REP,Donald Trump,4,0,4
+Santa Clara,0006502,President,,REP,Donald Trump,68,10,58
+Santa Clara,0006509,President,,REP,Donald Trump,9,1,8
+Santa Clara,0006510,President,,REP,Donald Trump,6,1,5
+Santa Clara,0006511,President,,REP,Donald Trump,48,3,45
+Santa Clara,0006515,President,,REP,Donald Trump,41,7,34
+Santa Clara,0006624,President,,REP,Donald Trump,0,0,0
+Santa Clara,0006625,President,,REP,Donald Trump,0,0,0
+Santa Clara,0006669,President,,REP,Donald Trump,22,1,21
+Santa Clara,0006678,President,,REP,Donald Trump,12,1,11
+Santa Clara,0007001,President,,REP,Donald Trump,427,67,360
+Santa Clara,0007005,President,,REP,Donald Trump,501,70,431
+Santa Clara,0007011,President,,REP,Donald Trump,35,8,27
+Santa Clara,0007012,President,,REP,Donald Trump,462,54,408
+Santa Clara,0007014,President,,REP,Donald Trump,509,52,457
+Santa Clara,0007019,President,,REP,Donald Trump,771,106,665
+Santa Clara,0007025,President,,REP,Donald Trump,591,88,503
+Santa Clara,0007028,President,,REP,Donald Trump,729,88,641
+Santa Clara,0007032,President,,REP,Donald Trump,983,106,877
+Santa Clara,0007036,President,,REP,Donald Trump,846,70,776
+Santa Clara,0007038,President,,REP,Donald Trump,69,10,59
+Santa Clara,0007041,President,,REP,Donald Trump,706,115,591
+Santa Clara,0007044,President,,REP,Donald Trump,469,59,410
+Santa Clara,0007046,President,,REP,Donald Trump,636,77,559
+Santa Clara,0007051,President,,REP,Donald Trump,0,0,0
+Santa Clara,0007059,President,,REP,Donald Trump,117,24,93
+Santa Clara,0007061,President,,REP,Donald Trump,426,38,388
+Santa Clara,0007062,President,,REP,Donald Trump,602,80,522
+Santa Clara,0007079,President,,REP,Donald Trump,480,71,409
+Santa Clara,0007081,President,,REP,Donald Trump,432,49,383
+Santa Clara,0007089,President,,REP,Donald Trump,338,35,303
+Santa Clara,0007201,President,,REP,Donald Trump,149,4,145
+Santa Clara,0007202,President,,REP,Donald Trump,325,44,281
+Santa Clara,0007203,President,,REP,Donald Trump,183,25,158
+Santa Clara,0007205,President,,REP,Donald Trump,702,107,595
+Santa Clara,0007214,President,,REP,Donald Trump,601,93,508
+Santa Clara,0007217,President,,REP,Donald Trump,791,119,672
+Santa Clara,0007219,President,,REP,Donald Trump,273,29,244
+Santa Clara,0007221,President,,REP,Donald Trump,408,42,366
+Santa Clara,0007224,President,,REP,Donald Trump,287,48,239
+Santa Clara,0007231,President,,REP,Donald Trump,217,33,184
+Santa Clara,0007235,President,,REP,Donald Trump,455,82,373
+Santa Clara,0007237,President,,REP,Donald Trump,680,102,578
+Santa Clara,0007245,President,,REP,Donald Trump,95,12,83
+Santa Clara,0007246,President,,REP,Donald Trump,364,49,315
+Santa Clara,0007248,President,,REP,Donald Trump,567,98,469
+Santa Clara,0007252,President,,REP,Donald Trump,679,90,589
+Santa Clara,0007255,President,,REP,Donald Trump,932,116,816
+Santa Clara,0007257,President,,REP,Donald Trump,393,46,347
+Santa Clara,0007261,President,,REP,Donald Trump,571,99,472
+Santa Clara,0007264,President,,REP,Donald Trump,613,104,509
+Santa Clara,0007271,President,,REP,Donald Trump,728,81,647
+Santa Clara,0007273,President,,REP,Donald Trump,855,98,757
+Santa Clara,0007282,President,,REP,Donald Trump,499,58,441
+Santa Clara,0007294,President,,REP,Donald Trump,190,30,160
+Santa Clara,0007295,President,,REP,Donald Trump,457,58,399
+Santa Clara,0007298,President,,REP,Donald Trump,359,64,295
+Santa Clara,0007299,President,,REP,Donald Trump,288,39,249
+Santa Clara,0007306,President,,REP,Donald Trump,0,0,0
+Santa Clara,0007401,President,,REP,Donald Trump,0,0,0
+Santa Clara,0007402,President,,REP,Donald Trump,72,12,60
+Santa Clara,0007403,President,,REP,Donald Trump,564,64,500
+Santa Clara,0007408,President,,REP,Donald Trump,129,11,118
+Santa Clara,0007409,President,,REP,Donald Trump,114,14,100
+Santa Clara,0007410,President,,REP,Donald Trump,1,0,1
+Santa Clara,0007411,President,,REP,Donald Trump,5,3,2
+Santa Clara,0007414,President,,REP,Donald Trump,60,7,53
+Santa Clara,0007415,President,,REP,Donald Trump,7,1,6
+Santa Clara,0007416,President,,REP,Donald Trump,22,4,18
+Santa Clara,0007417,President,,REP,Donald Trump,400,65,335
+Santa Clara,0007418,President,,REP,Donald Trump,326,40,286
+Santa Clara,0007419,President,,REP,Donald Trump,161,21,140
+Santa Clara,0007430,President,,REP,Donald Trump,402,62,340
+Santa Clara,0007435,President,,REP,Donald Trump,366,70,296
+Santa Clara,0007436,President,,REP,Donald Trump,740,104,636
+Santa Clara,0007438,President,,REP,Donald Trump,90,23,67
+Santa Clara,0007440,President,,REP,Donald Trump,25,3,22
+Santa Clara,0007441,President,,REP,Donald Trump,795,63,732
+Santa Clara,0007442,President,,REP,Donald Trump,58,15,43
+Santa Clara,0007447,President,,REP,Donald Trump,352,70,282
+Santa Clara,0007458,President,,REP,Donald Trump,326,74,252
+Santa Clara,0007459,President,,REP,Donald Trump,389,92,297
+Santa Clara,0007470,President,,REP,Donald Trump,315,56,259
+Santa Clara,0007471,President,,REP,Donald Trump,555,100,455
+Santa Clara,0007479,President,,REP,Donald Trump,347,61,286
+Santa Clara,0007483,President,,REP,Donald Trump,330,72,258
+Santa Clara,0007601,President,,REP,Donald Trump,609,104,505
+Santa Clara,0007606,President,,REP,Donald Trump,758,114,644
+Santa Clara,0007609,President,,REP,Donald Trump,144,32,112
+Santa Clara,0007615,President,,REP,Donald Trump,326,49,277
+Santa Clara,0007619,President,,REP,Donald Trump,477,87,390
+Santa Clara,0007620,President,,REP,Donald Trump,955,82,873
+Santa Clara,0007621,President,,REP,Donald Trump,1280,158,1122
+Santa Clara,0007624,President,,REP,Donald Trump,892,103,789
+Santa Clara,0007632,President,,REP,Donald Trump,1070,145,925
+Santa Clara,0007634,President,,REP,Donald Trump,559,77,482
+Santa Clara,0007648,President,,REP,Donald Trump,762,95,667
+Santa Clara,0007654,President,,REP,Donald Trump,1316,143,1173
+Santa Clara,0007660,President,,REP,Donald Trump,1036,126,910
+Santa Clara,0007666,President,,REP,Donald Trump,1039,126,913
+Santa Clara,0007670,President,,REP,Donald Trump,33,2,31
+Santa Clara,0007673,President,,REP,Donald Trump,0,0,0
+Santa Clara,0007674,President,,REP,Donald Trump,0,0,0
+Santa Clara,0007677,President,,REP,Donald Trump,1040,112,928
+Santa Clara,0007680,President,,REP,Donald Trump,615,92,523
+Santa Clara,0007689,President,,REP,Donald Trump,3,0,3
+Santa Clara,0007690,President,,REP,Donald Trump,297,27,270
+Santa Clara,0007801,President,,REP,Donald Trump,226,27,199
+Santa Clara,0007802,President,,REP,Donald Trump,97,14,83
+Santa Clara,0007803,President,,REP,Donald Trump,283,41,242
+Santa Clara,0007805,President,,REP,Donald Trump,680,78,602
+Santa Clara,0007810,President,,REP,Donald Trump,80,12,68
+Santa Clara,0007811,President,,REP,Donald Trump,47,6,41
+Santa Clara,0007812,President,,REP,Donald Trump,429,48,381
+Santa Clara,0007816,President,,REP,Donald Trump,45,6,39
+Santa Clara,0007817,President,,REP,Donald Trump,2,0,2
+Santa Clara,0007818,President,,REP,Donald Trump,65,3,62
+Santa Clara,0007821,President,,REP,Donald Trump,1109,127,982
+Santa Clara,0007826,President,,REP,Donald Trump,784,115,669
+Santa Clara,0007827,President,,REP,Donald Trump,206,39,167
+Santa Clara,0007832,President,,REP,Donald Trump,611,112,499
+Santa Clara,0007833,President,,REP,Donald Trump,659,114,545
+Santa Clara,0007843,President,,REP,Donald Trump,779,113,666
+Santa Clara,0007849,President,,REP,Donald Trump,510,93,417
+Santa Clara,0007850,President,,REP,Donald Trump,422,75,347
+Santa Clara,0007851,President,,REP,Donald Trump,377,37,340
+Santa Clara,0007861,President,,REP,Donald Trump,333,55,278
+Santa Clara,0007867,President,,REP,Donald Trump,707,86,621
+Santa Clara,0007874,President,,REP,Donald Trump,82,7,75
+Santa Clara,0007880,President,,REP,Donald Trump,4,2,2
+Santa Clara,0008001,President,,REP,Donald Trump,41,2,39
+Santa Clara,0008002,President,,REP,Donald Trump,63,9,54
+Santa Clara,0008003,President,,REP,Donald Trump,550,85,465
+Santa Clara,0008005,President,,REP,Donald Trump,663,82,581
+Santa Clara,0008007,President,,REP,Donald Trump,97,17,80
+Santa Clara,0008011,President,,REP,Donald Trump,115,14,101
+Santa Clara,0008012,President,,REP,Donald Trump,6,1,5
+Santa Clara,0008013,President,,REP,Donald Trump,16,2,14
+Santa Clara,0008016,President,,REP,Donald Trump,589,92,497
+Santa Clara,0008017,President,,REP,Donald Trump,262,42,220
+Santa Clara,0008022,President,,REP,Donald Trump,58,6,52
+Santa Clara,0008023,President,,REP,Donald Trump,165,33,132
+Santa Clara,0008026,President,,REP,Donald Trump,187,39,148
+Santa Clara,0008028,President,,REP,Donald Trump,42,8,34
+Santa Clara,0008029,President,,REP,Donald Trump,32,5,27
+Santa Clara,0008030,President,,REP,Donald Trump,249,42,207
+Santa Clara,0008033,President,,REP,Donald Trump,66,8,58
+Santa Clara,0008034,President,,REP,Donald Trump,24,5,19
+Santa Clara,0008038,President,,REP,Donald Trump,0,0,0
+Santa Clara,0008040,President,,REP,Donald Trump,76,17,59
+Santa Clara,0008047,President,,REP,Donald Trump,450,74,376
+Santa Clara,0008049,President,,REP,Donald Trump,8,1,7
+Santa Clara,0008050,President,,REP,Donald Trump,295,43,252
+Santa Clara,0008053,President,,REP,Donald Trump,567,74,493
+Santa Clara,0008054,President,,REP,Donald Trump,468,57,411
+Santa Clara,0008055,President,,REP,Donald Trump,46,4,42
+Santa Clara,0008062,President,,REP,Donald Trump,519,72,447
+Santa Clara,0008066,President,,REP,Donald Trump,184,30,154
+Santa Clara,0008067,President,,REP,Donald Trump,486,79,407
+Santa Clara,0008068,President,,REP,Donald Trump,10,3,7
+Santa Clara,0008072,President,,REP,Donald Trump,84,9,75
+Santa Clara,0008073,President,,REP,Donald Trump,81,11,70
+Santa Clara,0008079,President,,REP,Donald Trump,500,71,429
+Santa Clara,0008082,President,,REP,Donald Trump,362,32,330
+Santa Clara,0008085,President,,REP,Donald Trump,332,37,295
+Santa Clara,0008089,President,,REP,Donald Trump,550,68,482
+Santa Clara,0008092,President,,REP,Donald Trump,23,3,20
+Santa Clara,0008093,President,,REP,Donald Trump,21,1,20
+Santa Clara,0008096,President,,REP,Donald Trump,646,77,569
+Santa Clara,0008101,President,,REP,Donald Trump,295,37,258
+Santa Clara,0008104,President,,REP,Donald Trump,29,1,28
+Santa Clara,0008105,President,,REP,Donald Trump,105,4,101
+Santa Clara,0008117,President,,REP,Donald Trump,395,62,333
+Santa Clara,0008122,President,,REP,Donald Trump,556,69,487
+Santa Clara,0008128,President,,REP,Donald Trump,0,0,0
+Santa Clara,0008133,President,,REP,Donald Trump,6,0,6
+Santa Clara,0008201,President,,REP,Donald Trump,1042,170,872
+Santa Clara,0008203,President,,REP,Donald Trump,660,110,550
+Santa Clara,0008205,President,,REP,Donald Trump,1016,188,828
+Santa Clara,0008208,President,,REP,Donald Trump,446,54,392
+Santa Clara,0008212,President,,REP,Donald Trump,208,56,152
+Santa Clara,0008214,President,,REP,Donald Trump,146,22,124
+Santa Clara,0008227,President,,REP,Donald Trump,1064,145,919
+Santa Clara,0008228,President,,REP,Donald Trump,536,58,478
+Santa Clara,0008230,President,,REP,Donald Trump,959,155,804
+Santa Clara,0008231,President,,REP,Donald Trump,806,113,693
+Santa Clara,0008232,President,,REP,Donald Trump,1516,254,1262
+Santa Clara,0008236,President,,REP,Donald Trump,1474,209,1265
+Santa Clara,0008246,President,,REP,Donald Trump,649,100,549
+Santa Clara,0008254,President,,REP,Donald Trump,578,87,491
+Santa Clara,0008262,President,,REP,Donald Trump,742,94,648
+Santa Clara,0008264,President,,REP,Donald Trump,613,92,521
+Santa Clara,0008401,President,,REP,Donald Trump,528,67,461
+Santa Clara,0008404,President,,REP,Donald Trump,1396,181,1215
+Santa Clara,0008408,President,,REP,Donald Trump,415,64,351
+Santa Clara,0008409,President,,REP,Donald Trump,364,51,313
+Santa Clara,0008414,President,,REP,Donald Trump,113,16,97
+Santa Clara,0008418,President,,REP,Donald Trump,142,13,129
+Santa Clara,0008421,President,,REP,Donald Trump,15,1,14
+Santa Clara,0008423,President,,REP,Donald Trump,0,0,0
+Santa Clara,0008430,President,,REP,Donald Trump,1072,164,908
+Santa Clara,0008435,President,,REP,Donald Trump,1037,121,916
+Santa Clara,0008438,President,,REP,Donald Trump,1327,200,1127
+Santa Clara,0008439,President,,REP,Donald Trump,958,138,820
+Santa Clara,0008445,President,,REP,Donald Trump,596,61,535
+Santa Clara,0008447,President,,REP,Donald Trump,0,0,0
+Santa Clara,0008456,President,,REP,Donald Trump,1036,118,918
+Santa Clara,0008457,President,,REP,Donald Trump,1190,167,1023
+Santa Clara,0008464,President,,REP,Donald Trump,976,161,815
+Santa Clara,0008470,President,,REP,Donald Trump,836,105,731
+Santa Clara,0008472,President,,REP,Donald Trump,920,123,797
+Santa Clara,0008486,President,,REP,Donald Trump,1107,122,985
+Santa Clara,0008492,President,,REP,Donald Trump,1104,85,1019
+Santa Clara,0008502,President,,REP,Donald Trump,51,4,47
+Santa Clara,0008601,President,,REP,Donald Trump,131,23,108
+Santa Clara,0008603,President,,REP,Donald Trump,576,69,507
+Santa Clara,0008605,President,,REP,Donald Trump,797,121,676
+Santa Clara,0008609,President,,REP,Donald Trump,2,2,0
+Santa Clara,0008610,President,,REP,Donald Trump,333,56,277
+Santa Clara,0008612,President,,REP,Donald Trump,522,67,455
+Santa Clara,0008615,President,,REP,Donald Trump,554,52,502
+Santa Clara,0008619,President,,REP,Donald Trump,142,13,129
+Santa Clara,0008625,President,,REP,Donald Trump,14,3,11
+Santa Clara,0008627,President,,REP,Donald Trump,262,42,220
+Santa Clara,0008629,President,,REP,Donald Trump,466,57,409
+Santa Clara,0008630,President,,REP,Donald Trump,633,104,529
+Santa Clara,0008631,President,,REP,Donald Trump,355,47,308
+Santa Clara,0008634,President,,REP,Donald Trump,91,19,72
+Santa Clara,0008636,President,,REP,Donald Trump,179,23,156
+Santa Clara,0008645,President,,REP,Donald Trump,908,111,797
+Santa Clara,0008648,President,,REP,Donald Trump,741,75,666
+Santa Clara,0008650,President,,REP,Donald Trump,111,25,86
+Santa Clara,0008653,President,,REP,Donald Trump,67,5,62
+Santa Clara,0008654,President,,REP,Donald Trump,77,10,67
+Santa Clara,0008655,President,,REP,Donald Trump,0,0,0
+Santa Clara,0008657,President,,REP,Donald Trump,169,33,136
+Santa Clara,0008658,President,,REP,Donald Trump,871,104,767
+Santa Clara,0008670,President,,REP,Donald Trump,567,87,480
+Santa Clara,0008675,President,,REP,Donald Trump,348,51,297
+Santa Clara,0008676,President,,REP,Donald Trump,722,81,641
+Santa Clara,0008680,President,,REP,Donald Trump,460,55,405
+Santa Clara,0008683,President,,REP,Donald Trump,859,103,756
+Santa Clara,0008687,President,,REP,Donald Trump,801,104,697
+Santa Clara,0008697,President,,REP,Donald Trump,768,110,658
+Santa Clara,0008801,President,,REP,Donald Trump,588,92,496
+Santa Clara,0008805,President,,REP,Donald Trump,493,57,436
+Santa Clara,0008809,President,,REP,Donald Trump,672,93,579
+Santa Clara,0008812,President,,REP,Donald Trump,370,67,303
+Santa Clara,0008817,President,,REP,Donald Trump,246,24,222
+Santa Clara,0008820,President,,REP,Donald Trump,597,75,522
+Santa Clara,0008822,President,,REP,Donald Trump,551,83,468
+Santa Clara,0008828,President,,REP,Donald Trump,191,25,166
+Santa Clara,0008829,President,,REP,Donald Trump,158,18,140
+Santa Clara,0008832,President,,REP,Donald Trump,541,68,473
+Santa Clara,0008834,President,,REP,Donald Trump,264,43,221
+Santa Clara,0008838,President,,REP,Donald Trump,63,11,52
+Santa Clara,0008839,President,,REP,Donald Trump,681,95,586
+Santa Clara,0008844,President,,REP,Donald Trump,871,119,752
+Santa Clara,0008848,President,,REP,Donald Trump,421,65,356
+Santa Clara,0008853,President,,REP,Donald Trump,594,69,525
+Santa Clara,0008857,President,,REP,Donald Trump,439,42,397
+Santa Clara,0008858,President,,REP,Donald Trump,613,66,547
+Santa Clara,0008862,President,,REP,Donald Trump,687,98,589
+Santa Clara,0008868,President,,REP,Donald Trump,37,3,34
+Santa Clara,0008873,President,,REP,Donald Trump,265,33,232
+Santa Clara,0008874,President,,REP,Donald Trump,4,0,4
+Santa Clara,0008879,President,,REP,Donald Trump,810,105,705
+Santa Clara,0008883,President,,REP,Donald Trump,946,132,814
+Santa Clara,0008885,President,,REP,Donald Trump,743,86,657
+Santa Clara,0008886,President,,REP,Donald Trump,91,2,89
+Santa Clara,0008889,President,,REP,Donald Trump,804,85,719
+Santa Clara,0008898,President,,REP,Donald Trump,658,46,612
+Santa Clara,0008903,President,,REP,Donald Trump,801,75,726
+Santa Clara,0008915,President,,REP,Donald Trump,6,0,6
+Santa Clara,0008916,President,,REP,Donald Trump,9,0,9
+Santa Clara,0008920,President,,REP,Donald Trump,1,0,1
+Santa Clara,0008923,President,,REP,Donald Trump,3,0,3
+Santa Clara,0008924,President,,REP,Donald Trump,3,0,3
+Santa Clara,0009001,President,,REP,Donald Trump,607,107,500
+Santa Clara,0009005,President,,REP,Donald Trump,852,138,714
+Santa Clara,0009051,President,,REP,Donald Trump,576,102,474
+Santa Clara,0009055,President,,REP,Donald Trump,6,0,6
+Santa Clara,0009056,President,,REP,Donald Trump,619,99,520
+Santa Clara,0009059,President,,REP,Donald Trump,542,96,446
+Santa Clara,0009061,President,,REP,Donald Trump,0,0,0
+Santa Clara,0009062,President,,REP,Donald Trump,504,57,447
+Santa Clara,0009101,President,,REP,Donald Trump,669,82,587
+Santa Clara,0009103,President,,REP,Donald Trump,204,24,180
+Santa Clara,0009104,President,,REP,Donald Trump,591,56,535
+Santa Clara,0009109,President,,REP,Donald Trump,358,54,304
+Santa Clara,0009151,President,,REP,Donald Trump,625,78,547
+Santa Clara,0009157,President,,REP,Donald Trump,692,97,595
+Santa Clara,0009163,President,,REP,Donald Trump,262,24,238
+Santa Clara,0009166,President,,REP,Donald Trump,301,44,257
+Santa Clara,0009201,President,,REP,Donald Trump,215,25,190
+Santa Clara,0009203,President,,REP,Donald Trump,321,39,282
+Santa Clara,0009208,President,,REP,Donald Trump,273,41,232
+Santa Clara,0009210,President,,REP,Donald Trump,444,70,374
+Santa Clara,0009219,President,,REP,Donald Trump,33,1,32
+Santa Clara,0009220,President,,REP,Donald Trump,448,68,380
+Santa Clara,0009251,President,,REP,Donald Trump,295,36,259
+Santa Clara,0009252,President,,REP,Donald Trump,411,56,355
+Santa Clara,0009258,President,,REP,Donald Trump,391,49,342
+Santa Clara,0009262,President,,REP,Donald Trump,61,6,55
+Santa Clara,0009264,President,,REP,Donald Trump,383,38,345
+Santa Clara,0009268,President,,REP,Donald Trump,428,33,395
+Santa Clara,0009275,President,,REP,Donald Trump,345,52,293
+Santa Clara,0009282,President,,REP,Donald Trump,2,0,2
+Santa Clara,0002001,President,,LIB,Jo Jorgensen,1,1,0
+Santa Clara,0002002,President,,LIB,Jo Jorgensen,19,3,16
+Santa Clara,0002005,President,,LIB,Jo Jorgensen,18,1,17
+Santa Clara,0002006,President,,LIB,Jo Jorgensen,1,0,1
+Santa Clara,0002009,President,,LIB,Jo Jorgensen,38,5,33
+Santa Clara,0002013,President,,LIB,Jo Jorgensen,38,1,37
+Santa Clara,0002014,President,,LIB,Jo Jorgensen,40,1,39
+Santa Clara,0002018,President,,LIB,Jo Jorgensen,2,1,1
+Santa Clara,0002025,President,,LIB,Jo Jorgensen,35,4,31
+Santa Clara,0002043,President,,LIB,Jo Jorgensen,30,1,29
+Santa Clara,0002046,President,,LIB,Jo Jorgensen,42,3,39
+Santa Clara,0002057,President,,LIB,Jo Jorgensen,37,4,33
+Santa Clara,0002068,President,,LIB,Jo Jorgensen,33,1,32
+Santa Clara,0002098,President,,LIB,Jo Jorgensen,35,2,33
+Santa Clara,0002108,President,,LIB,Jo Jorgensen,34,3,31
+Santa Clara,0002125,President,,LIB,Jo Jorgensen,6,0,6
+Santa Clara,0002274,President,,LIB,Jo Jorgensen,3,0,3
+Santa Clara,0002275,President,,LIB,Jo Jorgensen,12,0,12
+Santa Clara,0002278,President,,LIB,Jo Jorgensen,23,1,22
+Santa Clara,0002281,President,,LIB,Jo Jorgensen,0,0,0
+Santa Clara,0002282,President,,LIB,Jo Jorgensen,20,2,18
+Santa Clara,0002285,President,,LIB,Jo Jorgensen,41,3,38
+Santa Clara,0002301,President,,LIB,Jo Jorgensen,38,0,38
+Santa Clara,0002305,President,,LIB,Jo Jorgensen,61,5,56
+Santa Clara,0002309,President,,LIB,Jo Jorgensen,9,3,6
+Santa Clara,0002314,President,,LIB,Jo Jorgensen,37,2,35
+Santa Clara,0002317,President,,LIB,Jo Jorgensen,36,2,34
+Santa Clara,0002330,President,,LIB,Jo Jorgensen,45,3,42
+Santa Clara,0002338,President,,LIB,Jo Jorgensen,1,0,1
+Santa Clara,0002351,President,,LIB,Jo Jorgensen,38,5,33
+Santa Clara,0002353,President,,LIB,Jo Jorgensen,0,0,0
+Santa Clara,0002539,President,,LIB,Jo Jorgensen,2,0,2
+Santa Clara,0002542,President,,LIB,Jo Jorgensen,23,4,19
+Santa Clara,0002545,President,,LIB,Jo Jorgensen,23,1,22
+Santa Clara,0002720,President,,LIB,Jo Jorgensen,19,0,19
+Santa Clara,0002721,President,,LIB,Jo Jorgensen,12,0,12
+Santa Clara,0002723,President,,LIB,Jo Jorgensen,41,2,39
+Santa Clara,0002724,President,,LIB,Jo Jorgensen,40,0,40
+Santa Clara,0002725,President,,LIB,Jo Jorgensen,32,3,29
+Santa Clara,0002726,President,,LIB,Jo Jorgensen,24,1,23
+Santa Clara,0002727,President,,LIB,Jo Jorgensen,27,0,27
+Santa Clara,0002729,President,,LIB,Jo Jorgensen,16,0,16
+Santa Clara,0002734,President,,LIB,Jo Jorgensen,41,2,39
+Santa Clara,0002740,President,,LIB,Jo Jorgensen,32,1,31
+Santa Clara,0002751,President,,LIB,Jo Jorgensen,0,0,0
+Santa Clara,0002761,President,,LIB,Jo Jorgensen,0,0,0
+Santa Clara,0002802,President,,LIB,Jo Jorgensen,51,2,49
+Santa Clara,0002808,President,,LIB,Jo Jorgensen,0,0,0
+Santa Clara,0002810,President,,LIB,Jo Jorgensen,0,0,0
+Santa Clara,0002811,President,,LIB,Jo Jorgensen,0,0,0
+Santa Clara,0002812,President,,LIB,Jo Jorgensen,2,0,2
+Santa Clara,0002813,President,,LIB,Jo Jorgensen,5,0,5
+Santa Clara,0002816,President,,LIB,Jo Jorgensen,0,0,0
+Santa Clara,0002825,President,,LIB,Jo Jorgensen,0,0,0
+Santa Clara,0002870,President,,LIB,Jo Jorgensen,1,0,1
+Santa Clara,0002951,President,,LIB,Jo Jorgensen,3,0,3
+Santa Clara,0003001,President,,LIB,Jo Jorgensen,35,2,33
+Santa Clara,0003002,President,,LIB,Jo Jorgensen,35,1,34
+Santa Clara,0003005,President,,LIB,Jo Jorgensen,0,0,0
+Santa Clara,0003008,President,,LIB,Jo Jorgensen,0,0,0
+Santa Clara,0003010,President,,LIB,Jo Jorgensen,22,0,22
+Santa Clara,0003011,President,,LIB,Jo Jorgensen,31,4,27
+Santa Clara,0003012,President,,LIB,Jo Jorgensen,0,0,0
+Santa Clara,0003013,President,,LIB,Jo Jorgensen,31,4,27
+Santa Clara,0003016,President,,LIB,Jo Jorgensen,12,0,12
+Santa Clara,0003017,President,,LIB,Jo Jorgensen,5,0,5
+Santa Clara,0003018,President,,LIB,Jo Jorgensen,0,0,0
+Santa Clara,0003019,President,,LIB,Jo Jorgensen,40,4,36
+Santa Clara,0003021,President,,LIB,Jo Jorgensen,1,0,1
+Santa Clara,0003023,President,,LIB,Jo Jorgensen,40,5,35
+Santa Clara,0003026,President,,LIB,Jo Jorgensen,32,2,30
+Santa Clara,0003029,President,,LIB,Jo Jorgensen,0,0,0
+Santa Clara,0003031,President,,LIB,Jo Jorgensen,0,0,0
+Santa Clara,0003032,President,,LIB,Jo Jorgensen,29,0,29
+Santa Clara,0003034,President,,LIB,Jo Jorgensen,35,5,30
+Santa Clara,0003035,President,,LIB,Jo Jorgensen,31,3,28
+Santa Clara,0003039,President,,LIB,Jo Jorgensen,18,1,17
+Santa Clara,0003040,President,,LIB,Jo Jorgensen,0,0,0
+Santa Clara,0003042,President,,LIB,Jo Jorgensen,19,2,17
+Santa Clara,0003043,President,,LIB,Jo Jorgensen,40,2,38
+Santa Clara,0003045,President,,LIB,Jo Jorgensen,49,2,47
+Santa Clara,0003047,President,,LIB,Jo Jorgensen,12,0,12
+Santa Clara,0003048,President,,LIB,Jo Jorgensen,42,3,39
+Santa Clara,0003051,President,,LIB,Jo Jorgensen,41,2,39
+Santa Clara,0003053,President,,LIB,Jo Jorgensen,40,2,38
+Santa Clara,0003061,President,,LIB,Jo Jorgensen,0,0,0
+Santa Clara,0003079,President,,LIB,Jo Jorgensen,6,0,6
+Santa Clara,0003080,President,,LIB,Jo Jorgensen,13,0,13
+Santa Clara,0003086,President,,LIB,Jo Jorgensen,43,3,40
+Santa Clara,0003087,President,,LIB,Jo Jorgensen,12,2,10
+Santa Clara,0003089,President,,LIB,Jo Jorgensen,0,0,0
+Santa Clara,0003095,President,,LIB,Jo Jorgensen,0,0,0
+Santa Clara,0003101,President,,LIB,Jo Jorgensen,3,0,3
+Santa Clara,0003102,President,,LIB,Jo Jorgensen,11,0,11
+Santa Clara,0003103,President,,LIB,Jo Jorgensen,17,0,17
+Santa Clara,0003116,President,,LIB,Jo Jorgensen,5,0,5
+Santa Clara,0003117,President,,LIB,Jo Jorgensen,9,1,8
+Santa Clara,0003120,President,,LIB,Jo Jorgensen,6,0,6
+Santa Clara,0003122,President,,LIB,Jo Jorgensen,26,1,25
+Santa Clara,0003156,President,,LIB,Jo Jorgensen,1,0,1
+Santa Clara,0003402,President,,LIB,Jo Jorgensen,50,6,44
+Santa Clara,0003406,President,,LIB,Jo Jorgensen,42,3,39
+Santa Clara,0003407,President,,LIB,Jo Jorgensen,39,1,38
+Santa Clara,0003408,President,,LIB,Jo Jorgensen,37,2,35
+Santa Clara,0003409,President,,LIB,Jo Jorgensen,36,3,33
+Santa Clara,0003410,President,,LIB,Jo Jorgensen,43,4,39
+Santa Clara,0003417,President,,LIB,Jo Jorgensen,38,1,37
+Santa Clara,0003427,President,,LIB,Jo Jorgensen,34,2,32
+Santa Clara,0003434,President,,LIB,Jo Jorgensen,27,1,26
+Santa Clara,0003438,President,,LIB,Jo Jorgensen,47,2,45
+Santa Clara,0003445,President,,LIB,Jo Jorgensen,33,0,33
+Santa Clara,0003601,President,,LIB,Jo Jorgensen,12,0,12
+Santa Clara,0003602,President,,LIB,Jo Jorgensen,26,1,25
+Santa Clara,0003603,President,,LIB,Jo Jorgensen,12,0,12
+Santa Clara,0003604,President,,LIB,Jo Jorgensen,24,3,21
+Santa Clara,0003605,President,,LIB,Jo Jorgensen,36,2,34
+Santa Clara,0003606,President,,LIB,Jo Jorgensen,16,0,16
+Santa Clara,0003608,President,,LIB,Jo Jorgensen,19,1,18
+Santa Clara,0003609,President,,LIB,Jo Jorgensen,33,1,32
+Santa Clara,0003611,President,,LIB,Jo Jorgensen,19,1,18
+Santa Clara,0003614,President,,LIB,Jo Jorgensen,11,0,11
+Santa Clara,0003624,President,,LIB,Jo Jorgensen,41,2,39
+Santa Clara,0003635,President,,LIB,Jo Jorgensen,0,0,0
+Santa Clara,0003652,President,,LIB,Jo Jorgensen,16,0,16
+Santa Clara,0003655,President,,LIB,Jo Jorgensen,0,0,0
+Santa Clara,0003669,President,,LIB,Jo Jorgensen,0,0,0
+Santa Clara,0003670,President,,LIB,Jo Jorgensen,2,0,2
+Santa Clara,0003777,President,,LIB,Jo Jorgensen,15,1,14
+Santa Clara,0003779,President,,LIB,Jo Jorgensen,3,0,3
+Santa Clara,0003782,President,,LIB,Jo Jorgensen,5,0,5
+Santa Clara,0003783,President,,LIB,Jo Jorgensen,5,0,5
+Santa Clara,0003801,President,,LIB,Jo Jorgensen,30,1,29
+Santa Clara,0003802,President,,LIB,Jo Jorgensen,29,0,29
+Santa Clara,0003803,President,,LIB,Jo Jorgensen,27,0,27
+Santa Clara,0003804,President,,LIB,Jo Jorgensen,6,0,6
+Santa Clara,0003810,President,,LIB,Jo Jorgensen,24,2,22
+Santa Clara,0003811,President,,LIB,Jo Jorgensen,24,0,24
+Santa Clara,0003814,President,,LIB,Jo Jorgensen,38,4,34
+Santa Clara,0003820,President,,LIB,Jo Jorgensen,23,2,21
+Santa Clara,0003821,President,,LIB,Jo Jorgensen,8,1,7
+Santa Clara,0003825,President,,LIB,Jo Jorgensen,22,5,17
+Santa Clara,0003828,President,,LIB,Jo Jorgensen,19,0,19
+Santa Clara,0003835,President,,LIB,Jo Jorgensen,14,2,12
+Santa Clara,0003840,President,,LIB,Jo Jorgensen,30,2,28
+Santa Clara,0003846,President,,LIB,Jo Jorgensen,2,0,2
+Santa Clara,0003861,President,,LIB,Jo Jorgensen,1,0,1
+Santa Clara,0004401,President,,LIB,Jo Jorgensen,23,1,22
+Santa Clara,0004402,President,,LIB,Jo Jorgensen,20,1,19
+Santa Clara,0004403,President,,LIB,Jo Jorgensen,1,0,1
+Santa Clara,0004405,President,,LIB,Jo Jorgensen,18,1,17
+Santa Clara,0004407,President,,LIB,Jo Jorgensen,16,1,15
+Santa Clara,0004409,President,,LIB,Jo Jorgensen,24,2,22
+Santa Clara,0004411,President,,LIB,Jo Jorgensen,24,0,24
+Santa Clara,0004412,President,,LIB,Jo Jorgensen,29,3,26
+Santa Clara,0004414,President,,LIB,Jo Jorgensen,18,1,17
+Santa Clara,0004417,President,,LIB,Jo Jorgensen,35,2,33
+Santa Clara,0004665,President,,LIB,Jo Jorgensen,0,0,0
+Santa Clara,0004666,President,,LIB,Jo Jorgensen,0,0,0
+Santa Clara,0004671,President,,LIB,Jo Jorgensen,18,0,18
+Santa Clara,0004672,President,,LIB,Jo Jorgensen,11,0,11
+Santa Clara,0004674,President,,LIB,Jo Jorgensen,21,0,21
+Santa Clara,0004675,President,,LIB,Jo Jorgensen,41,2,39
+Santa Clara,0004685,President,,LIB,Jo Jorgensen,16,0,16
+Santa Clara,0004687,President,,LIB,Jo Jorgensen,16,2,14
+Santa Clara,0004688,President,,LIB,Jo Jorgensen,28,1,27
+Santa Clara,0004691,President,,LIB,Jo Jorgensen,31,1,30
+Santa Clara,0004696,President,,LIB,Jo Jorgensen,7,0,7
+Santa Clara,0004698,President,,LIB,Jo Jorgensen,7,1,6
+Santa Clara,0004699,President,,LIB,Jo Jorgensen,13,0,13
+Santa Clara,0004702,President,,LIB,Jo Jorgensen,6,0,6
+Santa Clara,0004715,President,,LIB,Jo Jorgensen,7,0,7
+Santa Clara,0004733,President,,LIB,Jo Jorgensen,1,0,1
+Santa Clara,0004801,President,,LIB,Jo Jorgensen,17,0,17
+Santa Clara,0004806,President,,LIB,Jo Jorgensen,47,3,44
+Santa Clara,0004811,President,,LIB,Jo Jorgensen,25,1,24
+Santa Clara,0004826,President,,LIB,Jo Jorgensen,16,0,16
+Santa Clara,0004827,President,,LIB,Jo Jorgensen,38,2,36
+Santa Clara,0004833,President,,LIB,Jo Jorgensen,28,1,27
+Santa Clara,0004851,President,,LIB,Jo Jorgensen,16,2,14
+Santa Clara,0004853,President,,LIB,Jo Jorgensen,30,1,29
+Santa Clara,0004858,President,,LIB,Jo Jorgensen,46,6,40
+Santa Clara,0004876,President,,LIB,Jo Jorgensen,49,6,43
+Santa Clara,0004881,President,,LIB,Jo Jorgensen,73,4,69
+Santa Clara,0004941,President,,LIB,Jo Jorgensen,21,4,17
+Santa Clara,0004942,President,,LIB,Jo Jorgensen,17,0,17
+Santa Clara,0004943,President,,LIB,Jo Jorgensen,2,0,2
+Santa Clara,0004944,President,,LIB,Jo Jorgensen,5,1,4
+Santa Clara,0004945,President,,LIB,Jo Jorgensen,13,1,12
+Santa Clara,0004946,President,,LIB,Jo Jorgensen,35,1,34
+Santa Clara,0004949,President,,LIB,Jo Jorgensen,25,5,20
+Santa Clara,0004950,President,,LIB,Jo Jorgensen,29,1,28
+Santa Clara,0004954,President,,LIB,Jo Jorgensen,19,0,19
+Santa Clara,0004956,President,,LIB,Jo Jorgensen,6,2,4
+Santa Clara,0004958,President,,LIB,Jo Jorgensen,8,0,8
+Santa Clara,0004965,President,,LIB,Jo Jorgensen,37,2,35
+Santa Clara,0004969,President,,LIB,Jo Jorgensen,23,1,22
+Santa Clara,0004971,President,,LIB,Jo Jorgensen,8,1,7
+Santa Clara,0004973,President,,LIB,Jo Jorgensen,35,2,33
+Santa Clara,0004974,President,,LIB,Jo Jorgensen,10,0,10
+Santa Clara,0005449,President,,LIB,Jo Jorgensen,0,0,0
+Santa Clara,0005451,President,,LIB,Jo Jorgensen,0,0,0
+Santa Clara,0005454,President,,LIB,Jo Jorgensen,0,0,0
+Santa Clara,0005455,President,,LIB,Jo Jorgensen,0,0,0
+Santa Clara,0005456,President,,LIB,Jo Jorgensen,0,0,0
+Santa Clara,0005458,President,,LIB,Jo Jorgensen,0,0,0
+Santa Clara,0005502,President,,LIB,Jo Jorgensen,1,0,1
+Santa Clara,0005503,President,,LIB,Jo Jorgensen,2,1,1
+Santa Clara,0005505,President,,LIB,Jo Jorgensen,6,0,6
+Santa Clara,0005507,President,,LIB,Jo Jorgensen,0,0,0
+Santa Clara,0005556,President,,LIB,Jo Jorgensen,15,2,13
+Santa Clara,0005557,President,,LIB,Jo Jorgensen,18,0,18
+Santa Clara,0005567,President,,LIB,Jo Jorgensen,8,1,7
+Santa Clara,0005742,President,,LIB,Jo Jorgensen,0,0,0
+Santa Clara,0005743,President,,LIB,Jo Jorgensen,15,2,13
+Santa Clara,0005745,President,,LIB,Jo Jorgensen,5,0,5
+Santa Clara,0005747,President,,LIB,Jo Jorgensen,8,2,6
+Santa Clara,0005748,President,,LIB,Jo Jorgensen,22,2,20
+Santa Clara,0005756,President,,LIB,Jo Jorgensen,2,0,2
+Santa Clara,0005758,President,,LIB,Jo Jorgensen,4,0,4
+Santa Clara,0005759,President,,LIB,Jo Jorgensen,7,0,7
+Santa Clara,0005762,President,,LIB,Jo Jorgensen,9,1,8
+Santa Clara,0005763,President,,LIB,Jo Jorgensen,1,0,1
+Santa Clara,0005770,President,,LIB,Jo Jorgensen,2,0,2
+Santa Clara,0005775,President,,LIB,Jo Jorgensen,6,0,6
+Santa Clara,0005785,President,,LIB,Jo Jorgensen,0,0,0
+Santa Clara,0005793,President,,LIB,Jo Jorgensen,0,0,0
+Santa Clara,0005795,President,,LIB,Jo Jorgensen,0,0,0
+Santa Clara,0005804,President,,LIB,Jo Jorgensen,10,0,10
+Santa Clara,0005810,President,,LIB,Jo Jorgensen,2,0,2
+Santa Clara,0005811,President,,LIB,Jo Jorgensen,5,1,4
+Santa Clara,0005813,President,,LIB,Jo Jorgensen,1,0,1
+Santa Clara,0005814,President,,LIB,Jo Jorgensen,5,1,4
+Santa Clara,0005854,President,,LIB,Jo Jorgensen,0,0,0
+Santa Clara,0005879,President,,LIB,Jo Jorgensen,0,0,0
+Santa Clara,0005886,President,,LIB,Jo Jorgensen,0,0,0
+Santa Clara,0005888,President,,LIB,Jo Jorgensen,0,0,0
+Santa Clara,0005894,President,,LIB,Jo Jorgensen,4,0,4
+Santa Clara,0005896,President,,LIB,Jo Jorgensen,0,0,0
+Santa Clara,0005901,President,,LIB,Jo Jorgensen,0,0,0
+Santa Clara,0005902,President,,LIB,Jo Jorgensen,11,1,10
+Santa Clara,0005903,President,,LIB,Jo Jorgensen,14,0,14
+Santa Clara,0005906,President,,LIB,Jo Jorgensen,2,0,2
+Santa Clara,0005907,President,,LIB,Jo Jorgensen,1,0,1
+Santa Clara,0005911,President,,LIB,Jo Jorgensen,27,5,22
+Santa Clara,0005912,President,,LIB,Jo Jorgensen,1,1,0
+Santa Clara,0005914,President,,LIB,Jo Jorgensen,26,0,26
+Santa Clara,0005915,President,,LIB,Jo Jorgensen,14,0,14
+Santa Clara,0005916,President,,LIB,Jo Jorgensen,1,0,1
+Santa Clara,0005917,President,,LIB,Jo Jorgensen,2,0,2
+Santa Clara,0005919,President,,LIB,Jo Jorgensen,7,1,6
+Santa Clara,0005922,President,,LIB,Jo Jorgensen,8,0,8
+Santa Clara,0005925,President,,LIB,Jo Jorgensen,0,0,0
+Santa Clara,0005927,President,,LIB,Jo Jorgensen,0,0,0
+Santa Clara,0005929,President,,LIB,Jo Jorgensen,2,0,2
+Santa Clara,0005931,President,,LIB,Jo Jorgensen,3,0,3
+Santa Clara,0005936,President,,LIB,Jo Jorgensen,6,0,6
+Santa Clara,0005940,President,,LIB,Jo Jorgensen,1,0,1
+Santa Clara,0005947,President,,LIB,Jo Jorgensen,14,0,14
+Santa Clara,0005949,President,,LIB,Jo Jorgensen,1,0,1
+Santa Clara,0005950,President,,LIB,Jo Jorgensen,0,0,0
+Santa Clara,0005951,President,,LIB,Jo Jorgensen,0,0,0
+Santa Clara,0005955,President,,LIB,Jo Jorgensen,8,0,8
+Santa Clara,0005956,President,,LIB,Jo Jorgensen,17,1,16
+Santa Clara,0005957,President,,LIB,Jo Jorgensen,2,1,1
+Santa Clara,0005958,President,,LIB,Jo Jorgensen,16,1,15
+Santa Clara,0005959,President,,LIB,Jo Jorgensen,1,0,1
+Santa Clara,0005965,President,,LIB,Jo Jorgensen,12,0,12
+Santa Clara,0005966,President,,LIB,Jo Jorgensen,4,0,4
+Santa Clara,0005975,President,,LIB,Jo Jorgensen,0,0,0
+Santa Clara,0005988,President,,LIB,Jo Jorgensen,0,0,0
+Santa Clara,0006023,President,,LIB,Jo Jorgensen,0,0,0
+Santa Clara,0006028,President,,LIB,Jo Jorgensen,0,0,0
+Santa Clara,0006031,President,,LIB,Jo Jorgensen,0,0,0
+Santa Clara,0006035,President,,LIB,Jo Jorgensen,0,0,0
+Santa Clara,0006036,President,,LIB,Jo Jorgensen,0,0,0
+Santa Clara,0006048,President,,LIB,Jo Jorgensen,0,0,0
+Santa Clara,0006401,President,,LIB,Jo Jorgensen,0,0,0
+Santa Clara,0006402,President,,LIB,Jo Jorgensen,0,0,0
+Santa Clara,0006404,President,,LIB,Jo Jorgensen,26,1,25
+Santa Clara,0006405,President,,LIB,Jo Jorgensen,0,0,0
+Santa Clara,0006410,President,,LIB,Jo Jorgensen,1,0,1
+Santa Clara,0006413,President,,LIB,Jo Jorgensen,0,0,0
+Santa Clara,0006418,President,,LIB,Jo Jorgensen,9,1,8
+Santa Clara,0006419,President,,LIB,Jo Jorgensen,1,0,1
+Santa Clara,0006423,President,,LIB,Jo Jorgensen,0,0,0
+Santa Clara,0006452,President,,LIB,Jo Jorgensen,5,0,5
+Santa Clara,0006454,President,,LIB,Jo Jorgensen,4,0,4
+Santa Clara,0006455,President,,LIB,Jo Jorgensen,16,1,15
+Santa Clara,0006491,President,,LIB,Jo Jorgensen,0,0,0
+Santa Clara,0006502,President,,LIB,Jo Jorgensen,3,0,3
+Santa Clara,0006509,President,,LIB,Jo Jorgensen,0,0,0
+Santa Clara,0006510,President,,LIB,Jo Jorgensen,0,0,0
+Santa Clara,0006511,President,,LIB,Jo Jorgensen,1,0,1
+Santa Clara,0006515,President,,LIB,Jo Jorgensen,0,0,0
+Santa Clara,0006624,President,,LIB,Jo Jorgensen,1,0,1
+Santa Clara,0006625,President,,LIB,Jo Jorgensen,0,0,0
+Santa Clara,0006669,President,,LIB,Jo Jorgensen,1,0,1
+Santa Clara,0006678,President,,LIB,Jo Jorgensen,0,0,0
+Santa Clara,0007001,President,,LIB,Jo Jorgensen,12,2,10
+Santa Clara,0007005,President,,LIB,Jo Jorgensen,24,6,18
+Santa Clara,0007011,President,,LIB,Jo Jorgensen,5,0,5
+Santa Clara,0007012,President,,LIB,Jo Jorgensen,16,2,14
+Santa Clara,0007014,President,,LIB,Jo Jorgensen,19,0,19
+Santa Clara,0007019,President,,LIB,Jo Jorgensen,31,3,28
+Santa Clara,0007025,President,,LIB,Jo Jorgensen,37,3,34
+Santa Clara,0007028,President,,LIB,Jo Jorgensen,30,0,30
+Santa Clara,0007032,President,,LIB,Jo Jorgensen,28,3,25
+Santa Clara,0007036,President,,LIB,Jo Jorgensen,21,2,19
+Santa Clara,0007038,President,,LIB,Jo Jorgensen,1,0,1
+Santa Clara,0007041,President,,LIB,Jo Jorgensen,26,4,22
+Santa Clara,0007044,President,,LIB,Jo Jorgensen,31,2,29
+Santa Clara,0007046,President,,LIB,Jo Jorgensen,36,4,32
+Santa Clara,0007051,President,,LIB,Jo Jorgensen,0,0,0
+Santa Clara,0007059,President,,LIB,Jo Jorgensen,6,3,3
+Santa Clara,0007061,President,,LIB,Jo Jorgensen,20,1,19
+Santa Clara,0007062,President,,LIB,Jo Jorgensen,30,3,27
+Santa Clara,0007079,President,,LIB,Jo Jorgensen,18,1,17
+Santa Clara,0007081,President,,LIB,Jo Jorgensen,32,2,30
+Santa Clara,0007089,President,,LIB,Jo Jorgensen,16,0,16
+Santa Clara,0007201,President,,LIB,Jo Jorgensen,5,1,4
+Santa Clara,0007202,President,,LIB,Jo Jorgensen,5,0,5
+Santa Clara,0007203,President,,LIB,Jo Jorgensen,0,0,0
+Santa Clara,0007205,President,,LIB,Jo Jorgensen,22,3,19
+Santa Clara,0007214,President,,LIB,Jo Jorgensen,11,1,10
+Santa Clara,0007217,President,,LIB,Jo Jorgensen,14,3,11
+Santa Clara,0007219,President,,LIB,Jo Jorgensen,12,0,12
+Santa Clara,0007221,President,,LIB,Jo Jorgensen,15,2,13
+Santa Clara,0007224,President,,LIB,Jo Jorgensen,3,0,3
+Santa Clara,0007231,President,,LIB,Jo Jorgensen,8,1,7
+Santa Clara,0007235,President,,LIB,Jo Jorgensen,22,2,20
+Santa Clara,0007237,President,,LIB,Jo Jorgensen,17,1,16
+Santa Clara,0007245,President,,LIB,Jo Jorgensen,0,0,0
+Santa Clara,0007246,President,,LIB,Jo Jorgensen,14,1,13
+Santa Clara,0007248,President,,LIB,Jo Jorgensen,30,0,30
+Santa Clara,0007252,President,,LIB,Jo Jorgensen,31,0,31
+Santa Clara,0007255,President,,LIB,Jo Jorgensen,27,6,21
+Santa Clara,0007257,President,,LIB,Jo Jorgensen,14,0,14
+Santa Clara,0007261,President,,LIB,Jo Jorgensen,29,1,28
+Santa Clara,0007264,President,,LIB,Jo Jorgensen,37,1,36
+Santa Clara,0007271,President,,LIB,Jo Jorgensen,32,3,29
+Santa Clara,0007273,President,,LIB,Jo Jorgensen,42,5,37
+Santa Clara,0007282,President,,LIB,Jo Jorgensen,22,0,22
+Santa Clara,0007294,President,,LIB,Jo Jorgensen,3,0,3
+Santa Clara,0007295,President,,LIB,Jo Jorgensen,43,3,40
+Santa Clara,0007298,President,,LIB,Jo Jorgensen,14,1,13
+Santa Clara,0007299,President,,LIB,Jo Jorgensen,12,0,12
+Santa Clara,0007306,President,,LIB,Jo Jorgensen,0,0,0
+Santa Clara,0007401,President,,LIB,Jo Jorgensen,0,0,0
+Santa Clara,0007402,President,,LIB,Jo Jorgensen,4,0,4
+Santa Clara,0007403,President,,LIB,Jo Jorgensen,8,1,7
+Santa Clara,0007408,President,,LIB,Jo Jorgensen,9,1,8
+Santa Clara,0007409,President,,LIB,Jo Jorgensen,0,0,0
+Santa Clara,0007410,President,,LIB,Jo Jorgensen,0,0,0
+Santa Clara,0007411,President,,LIB,Jo Jorgensen,0,0,0
+Santa Clara,0007414,President,,LIB,Jo Jorgensen,8,0,8
+Santa Clara,0007415,President,,LIB,Jo Jorgensen,0,0,0
+Santa Clara,0007416,President,,LIB,Jo Jorgensen,2,0,2
+Santa Clara,0007417,President,,LIB,Jo Jorgensen,31,4,27
+Santa Clara,0007418,President,,LIB,Jo Jorgensen,15,2,13
+Santa Clara,0007419,President,,LIB,Jo Jorgensen,20,0,20
+Santa Clara,0007430,President,,LIB,Jo Jorgensen,30,3,27
+Santa Clara,0007435,President,,LIB,Jo Jorgensen,27,2,25
+Santa Clara,0007436,President,,LIB,Jo Jorgensen,32,0,32
+Santa Clara,0007438,President,,LIB,Jo Jorgensen,0,0,0
+Santa Clara,0007440,President,,LIB,Jo Jorgensen,0,0,0
+Santa Clara,0007441,President,,LIB,Jo Jorgensen,7,0,7
+Santa Clara,0007442,President,,LIB,Jo Jorgensen,0,0,0
+Santa Clara,0007447,President,,LIB,Jo Jorgensen,25,7,18
+Santa Clara,0007458,President,,LIB,Jo Jorgensen,26,6,20
+Santa Clara,0007459,President,,LIB,Jo Jorgensen,32,3,29
+Santa Clara,0007470,President,,LIB,Jo Jorgensen,28,4,24
+Santa Clara,0007471,President,,LIB,Jo Jorgensen,32,4,28
+Santa Clara,0007479,President,,LIB,Jo Jorgensen,9,1,8
+Santa Clara,0007483,President,,LIB,Jo Jorgensen,17,4,13
+Santa Clara,0007601,President,,LIB,Jo Jorgensen,24,1,23
+Santa Clara,0007606,President,,LIB,Jo Jorgensen,42,7,35
+Santa Clara,0007609,President,,LIB,Jo Jorgensen,11,0,11
+Santa Clara,0007615,President,,LIB,Jo Jorgensen,3,0,3
+Santa Clara,0007619,President,,LIB,Jo Jorgensen,20,1,19
+Santa Clara,0007620,President,,LIB,Jo Jorgensen,24,2,22
+Santa Clara,0007621,President,,LIB,Jo Jorgensen,28,2,26
+Santa Clara,0007624,President,,LIB,Jo Jorgensen,25,2,23
+Santa Clara,0007632,President,,LIB,Jo Jorgensen,24,1,23
+Santa Clara,0007634,President,,LIB,Jo Jorgensen,16,3,13
+Santa Clara,0007648,President,,LIB,Jo Jorgensen,18,3,15
+Santa Clara,0007654,President,,LIB,Jo Jorgensen,18,1,17
+Santa Clara,0007660,President,,LIB,Jo Jorgensen,23,4,19
+Santa Clara,0007666,President,,LIB,Jo Jorgensen,22,0,22
+Santa Clara,0007670,President,,LIB,Jo Jorgensen,0,0,0
+Santa Clara,0007673,President,,LIB,Jo Jorgensen,0,0,0
+Santa Clara,0007674,President,,LIB,Jo Jorgensen,0,0,0
+Santa Clara,0007677,President,,LIB,Jo Jorgensen,20,1,19
+Santa Clara,0007680,President,,LIB,Jo Jorgensen,14,1,13
+Santa Clara,0007689,President,,LIB,Jo Jorgensen,0,0,0
+Santa Clara,0007690,President,,LIB,Jo Jorgensen,5,0,5
+Santa Clara,0007801,President,,LIB,Jo Jorgensen,1,1,0
+Santa Clara,0007802,President,,LIB,Jo Jorgensen,2,0,2
+Santa Clara,0007803,President,,LIB,Jo Jorgensen,10,0,10
+Santa Clara,0007805,President,,LIB,Jo Jorgensen,11,1,10
+Santa Clara,0007810,President,,LIB,Jo Jorgensen,0,0,0
+Santa Clara,0007811,President,,LIB,Jo Jorgensen,0,0,0
+Santa Clara,0007812,President,,LIB,Jo Jorgensen,7,1,6
+Santa Clara,0007816,President,,LIB,Jo Jorgensen,3,1,2
+Santa Clara,0007817,President,,LIB,Jo Jorgensen,0,0,0
+Santa Clara,0007818,President,,LIB,Jo Jorgensen,4,0,4
+Santa Clara,0007821,President,,LIB,Jo Jorgensen,18,2,16
+Santa Clara,0007826,President,,LIB,Jo Jorgensen,12,4,8
+Santa Clara,0007827,President,,LIB,Jo Jorgensen,8,2,6
+Santa Clara,0007832,President,,LIB,Jo Jorgensen,12,1,11
+Santa Clara,0007833,President,,LIB,Jo Jorgensen,7,0,7
+Santa Clara,0007843,President,,LIB,Jo Jorgensen,17,1,16
+Santa Clara,0007849,President,,LIB,Jo Jorgensen,13,1,12
+Santa Clara,0007850,President,,LIB,Jo Jorgensen,19,2,17
+Santa Clara,0007851,President,,LIB,Jo Jorgensen,11,0,11
+Santa Clara,0007861,President,,LIB,Jo Jorgensen,14,0,14
+Santa Clara,0007867,President,,LIB,Jo Jorgensen,13,0,13
+Santa Clara,0007874,President,,LIB,Jo Jorgensen,1,0,1
+Santa Clara,0007880,President,,LIB,Jo Jorgensen,0,0,0
+Santa Clara,0008001,President,,LIB,Jo Jorgensen,2,0,2
+Santa Clara,0008002,President,,LIB,Jo Jorgensen,4,0,4
+Santa Clara,0008003,President,,LIB,Jo Jorgensen,36,0,36
+Santa Clara,0008005,President,,LIB,Jo Jorgensen,53,6,47
+Santa Clara,0008007,President,,LIB,Jo Jorgensen,8,2,6
+Santa Clara,0008011,President,,LIB,Jo Jorgensen,2,0,2
+Santa Clara,0008012,President,,LIB,Jo Jorgensen,0,0,0
+Santa Clara,0008013,President,,LIB,Jo Jorgensen,0,0,0
+Santa Clara,0008016,President,,LIB,Jo Jorgensen,47,2,45
+Santa Clara,0008017,President,,LIB,Jo Jorgensen,21,1,20
+Santa Clara,0008022,President,,LIB,Jo Jorgensen,11,2,9
+Santa Clara,0008023,President,,LIB,Jo Jorgensen,7,0,7
+Santa Clara,0008026,President,,LIB,Jo Jorgensen,4,0,4
+Santa Clara,0008028,President,,LIB,Jo Jorgensen,5,0,5
+Santa Clara,0008029,President,,LIB,Jo Jorgensen,1,0,1
+Santa Clara,0008030,President,,LIB,Jo Jorgensen,9,2,7
+Santa Clara,0008033,President,,LIB,Jo Jorgensen,2,0,2
+Santa Clara,0008034,President,,LIB,Jo Jorgensen,3,1,2
+Santa Clara,0008038,President,,LIB,Jo Jorgensen,0,0,0
+Santa Clara,0008040,President,,LIB,Jo Jorgensen,2,0,2
+Santa Clara,0008047,President,,LIB,Jo Jorgensen,24,0,24
+Santa Clara,0008049,President,,LIB,Jo Jorgensen,0,0,0
+Santa Clara,0008050,President,,LIB,Jo Jorgensen,16,0,16
+Santa Clara,0008053,President,,LIB,Jo Jorgensen,27,4,23
+Santa Clara,0008054,President,,LIB,Jo Jorgensen,11,1,10
+Santa Clara,0008055,President,,LIB,Jo Jorgensen,6,0,6
+Santa Clara,0008062,President,,LIB,Jo Jorgensen,33,1,32
+Santa Clara,0008066,President,,LIB,Jo Jorgensen,11,0,11
+Santa Clara,0008067,President,,LIB,Jo Jorgensen,40,1,39
+Santa Clara,0008068,President,,LIB,Jo Jorgensen,0,0,0
+Santa Clara,0008072,President,,LIB,Jo Jorgensen,7,0,7
+Santa Clara,0008073,President,,LIB,Jo Jorgensen,4,0,4
+Santa Clara,0008079,President,,LIB,Jo Jorgensen,29,1,28
+Santa Clara,0008082,President,,LIB,Jo Jorgensen,24,4,20
+Santa Clara,0008085,President,,LIB,Jo Jorgensen,26,0,26
+Santa Clara,0008089,President,,LIB,Jo Jorgensen,42,2,40
+Santa Clara,0008092,President,,LIB,Jo Jorgensen,0,0,0
+Santa Clara,0008093,President,,LIB,Jo Jorgensen,0,0,0
+Santa Clara,0008096,President,,LIB,Jo Jorgensen,35,2,33
+Santa Clara,0008101,President,,LIB,Jo Jorgensen,12,0,12
+Santa Clara,0008104,President,,LIB,Jo Jorgensen,1,0,1
+Santa Clara,0008105,President,,LIB,Jo Jorgensen,7,0,7
+Santa Clara,0008117,President,,LIB,Jo Jorgensen,18,0,18
+Santa Clara,0008122,President,,LIB,Jo Jorgensen,24,2,22
+Santa Clara,0008128,President,,LIB,Jo Jorgensen,0,0,0
+Santa Clara,0008133,President,,LIB,Jo Jorgensen,0,0,0
+Santa Clara,0008201,President,,LIB,Jo Jorgensen,14,1,13
+Santa Clara,0008203,President,,LIB,Jo Jorgensen,10,0,10
+Santa Clara,0008205,President,,LIB,Jo Jorgensen,18,2,16
+Santa Clara,0008208,President,,LIB,Jo Jorgensen,11,1,10
+Santa Clara,0008212,President,,LIB,Jo Jorgensen,13,1,12
+Santa Clara,0008214,President,,LIB,Jo Jorgensen,2,0,2
+Santa Clara,0008227,President,,LIB,Jo Jorgensen,15,1,14
+Santa Clara,0008228,President,,LIB,Jo Jorgensen,20,3,17
+Santa Clara,0008230,President,,LIB,Jo Jorgensen,25,2,23
+Santa Clara,0008231,President,,LIB,Jo Jorgensen,9,0,9
+Santa Clara,0008232,President,,LIB,Jo Jorgensen,7,1,6
+Santa Clara,0008236,President,,LIB,Jo Jorgensen,26,2,24
+Santa Clara,0008246,President,,LIB,Jo Jorgensen,12,0,12
+Santa Clara,0008254,President,,LIB,Jo Jorgensen,10,3,7
+Santa Clara,0008262,President,,LIB,Jo Jorgensen,5,2,3
+Santa Clara,0008264,President,,LIB,Jo Jorgensen,13,2,11
+Santa Clara,0008401,President,,LIB,Jo Jorgensen,6,0,6
+Santa Clara,0008404,President,,LIB,Jo Jorgensen,11,0,11
+Santa Clara,0008408,President,,LIB,Jo Jorgensen,10,0,10
+Santa Clara,0008409,President,,LIB,Jo Jorgensen,8,0,8
+Santa Clara,0008414,President,,LIB,Jo Jorgensen,5,0,5
+Santa Clara,0008418,President,,LIB,Jo Jorgensen,4,0,4
+Santa Clara,0008421,President,,LIB,Jo Jorgensen,0,0,0
+Santa Clara,0008423,President,,LIB,Jo Jorgensen,0,0,0
+Santa Clara,0008430,President,,LIB,Jo Jorgensen,15,2,13
+Santa Clara,0008435,President,,LIB,Jo Jorgensen,21,2,19
+Santa Clara,0008438,President,,LIB,Jo Jorgensen,13,1,12
+Santa Clara,0008439,President,,LIB,Jo Jorgensen,9,2,7
+Santa Clara,0008445,President,,LIB,Jo Jorgensen,6,1,5
+Santa Clara,0008447,President,,LIB,Jo Jorgensen,0,0,0
+Santa Clara,0008456,President,,LIB,Jo Jorgensen,30,1,29
+Santa Clara,0008457,President,,LIB,Jo Jorgensen,15,0,15
+Santa Clara,0008464,President,,LIB,Jo Jorgensen,15,3,12
+Santa Clara,0008470,President,,LIB,Jo Jorgensen,23,2,21
+Santa Clara,0008472,President,,LIB,Jo Jorgensen,23,2,21
+Santa Clara,0008486,President,,LIB,Jo Jorgensen,38,4,34
+Santa Clara,0008492,President,,LIB,Jo Jorgensen,26,1,25
+Santa Clara,0008502,President,,LIB,Jo Jorgensen,2,0,2
+Santa Clara,0008601,President,,LIB,Jo Jorgensen,2,1,1
+Santa Clara,0008603,President,,LIB,Jo Jorgensen,43,1,42
+Santa Clara,0008605,President,,LIB,Jo Jorgensen,42,5,37
+Santa Clara,0008609,President,,LIB,Jo Jorgensen,0,0,0
+Santa Clara,0008610,President,,LIB,Jo Jorgensen,37,2,35
+Santa Clara,0008612,President,,LIB,Jo Jorgensen,26,1,25
+Santa Clara,0008615,President,,LIB,Jo Jorgensen,17,1,16
+Santa Clara,0008619,President,,LIB,Jo Jorgensen,9,0,9
+Santa Clara,0008625,President,,LIB,Jo Jorgensen,1,0,1
+Santa Clara,0008627,President,,LIB,Jo Jorgensen,18,2,16
+Santa Clara,0008629,President,,LIB,Jo Jorgensen,30,1,29
+Santa Clara,0008630,President,,LIB,Jo Jorgensen,34,2,32
+Santa Clara,0008631,President,,LIB,Jo Jorgensen,16,0,16
+Santa Clara,0008634,President,,LIB,Jo Jorgensen,4,0,4
+Santa Clara,0008636,President,,LIB,Jo Jorgensen,1,0,1
+Santa Clara,0008645,President,,LIB,Jo Jorgensen,55,4,51
+Santa Clara,0008648,President,,LIB,Jo Jorgensen,32,2,30
+Santa Clara,0008650,President,,LIB,Jo Jorgensen,4,0,4
+Santa Clara,0008653,President,,LIB,Jo Jorgensen,4,0,4
+Santa Clara,0008654,President,,LIB,Jo Jorgensen,2,0,2
+Santa Clara,0008655,President,,LIB,Jo Jorgensen,0,0,0
+Santa Clara,0008657,President,,LIB,Jo Jorgensen,12,0,12
+Santa Clara,0008658,President,,LIB,Jo Jorgensen,34,1,33
+Santa Clara,0008670,President,,LIB,Jo Jorgensen,21,5,16
+Santa Clara,0008675,President,,LIB,Jo Jorgensen,18,1,17
+Santa Clara,0008676,President,,LIB,Jo Jorgensen,23,5,18
+Santa Clara,0008680,President,,LIB,Jo Jorgensen,24,0,24
+Santa Clara,0008683,President,,LIB,Jo Jorgensen,43,2,41
+Santa Clara,0008687,President,,LIB,Jo Jorgensen,45,2,43
+Santa Clara,0008697,President,,LIB,Jo Jorgensen,52,5,47
+Santa Clara,0008801,President,,LIB,Jo Jorgensen,16,2,14
+Santa Clara,0008805,President,,LIB,Jo Jorgensen,21,1,20
+Santa Clara,0008809,President,,LIB,Jo Jorgensen,32,2,30
+Santa Clara,0008812,President,,LIB,Jo Jorgensen,8,0,8
+Santa Clara,0008817,President,,LIB,Jo Jorgensen,7,0,7
+Santa Clara,0008820,President,,LIB,Jo Jorgensen,14,2,12
+Santa Clara,0008822,President,,LIB,Jo Jorgensen,14,1,13
+Santa Clara,0008828,President,,LIB,Jo Jorgensen,7,0,7
+Santa Clara,0008829,President,,LIB,Jo Jorgensen,3,1,2
+Santa Clara,0008832,President,,LIB,Jo Jorgensen,25,2,23
+Santa Clara,0008834,President,,LIB,Jo Jorgensen,4,1,3
+Santa Clara,0008838,President,,LIB,Jo Jorgensen,1,0,1
+Santa Clara,0008839,President,,LIB,Jo Jorgensen,30,3,27
+Santa Clara,0008844,President,,LIB,Jo Jorgensen,45,6,39
+Santa Clara,0008848,President,,LIB,Jo Jorgensen,24,2,22
+Santa Clara,0008853,President,,LIB,Jo Jorgensen,17,0,17
+Santa Clara,0008857,President,,LIB,Jo Jorgensen,24,2,22
+Santa Clara,0008858,President,,LIB,Jo Jorgensen,27,3,24
+Santa Clara,0008862,President,,LIB,Jo Jorgensen,31,1,30
+Santa Clara,0008868,President,,LIB,Jo Jorgensen,1,0,1
+Santa Clara,0008873,President,,LIB,Jo Jorgensen,12,0,12
+Santa Clara,0008874,President,,LIB,Jo Jorgensen,2,0,2
+Santa Clara,0008879,President,,LIB,Jo Jorgensen,42,1,41
+Santa Clara,0008883,President,,LIB,Jo Jorgensen,45,2,43
+Santa Clara,0008885,President,,LIB,Jo Jorgensen,41,3,38
+Santa Clara,0008886,President,,LIB,Jo Jorgensen,3,0,3
+Santa Clara,0008889,President,,LIB,Jo Jorgensen,27,1,26
+Santa Clara,0008898,President,,LIB,Jo Jorgensen,22,1,21
+Santa Clara,0008903,President,,LIB,Jo Jorgensen,28,2,26
+Santa Clara,0008915,President,,LIB,Jo Jorgensen,0,0,0
+Santa Clara,0008916,President,,LIB,Jo Jorgensen,0,0,0
+Santa Clara,0008920,President,,LIB,Jo Jorgensen,0,0,0
+Santa Clara,0008923,President,,LIB,Jo Jorgensen,0,0,0
+Santa Clara,0008924,President,,LIB,Jo Jorgensen,0,0,0
+Santa Clara,0009001,President,,LIB,Jo Jorgensen,19,2,17
+Santa Clara,0009005,President,,LIB,Jo Jorgensen,43,5,38
+Santa Clara,0009051,President,,LIB,Jo Jorgensen,22,4,18
+Santa Clara,0009055,President,,LIB,Jo Jorgensen,0,0,0
+Santa Clara,0009056,President,,LIB,Jo Jorgensen,23,3,20
+Santa Clara,0009059,President,,LIB,Jo Jorgensen,25,2,23
+Santa Clara,0009061,President,,LIB,Jo Jorgensen,0,0,0
+Santa Clara,0009062,President,,LIB,Jo Jorgensen,27,1,26
+Santa Clara,0009101,President,,LIB,Jo Jorgensen,33,4,29
+Santa Clara,0009103,President,,LIB,Jo Jorgensen,5,2,3
+Santa Clara,0009104,President,,LIB,Jo Jorgensen,23,1,22
+Santa Clara,0009109,President,,LIB,Jo Jorgensen,15,0,15
+Santa Clara,0009151,President,,LIB,Jo Jorgensen,20,1,19
+Santa Clara,0009157,President,,LIB,Jo Jorgensen,36,3,33
+Santa Clara,0009163,President,,LIB,Jo Jorgensen,16,0,16
+Santa Clara,0009166,President,,LIB,Jo Jorgensen,13,1,12
+Santa Clara,0009201,President,,LIB,Jo Jorgensen,3,0,3
+Santa Clara,0009203,President,,LIB,Jo Jorgensen,11,3,8
+Santa Clara,0009208,President,,LIB,Jo Jorgensen,13,4,9
+Santa Clara,0009210,President,,LIB,Jo Jorgensen,25,1,24
+Santa Clara,0009219,President,,LIB,Jo Jorgensen,6,1,5
+Santa Clara,0009220,President,,LIB,Jo Jorgensen,27,2,25
+Santa Clara,0009251,President,,LIB,Jo Jorgensen,11,0,11
+Santa Clara,0009252,President,,LIB,Jo Jorgensen,14,1,13
+Santa Clara,0009258,President,,LIB,Jo Jorgensen,12,1,11
+Santa Clara,0009262,President,,LIB,Jo Jorgensen,2,0,2
+Santa Clara,0009264,President,,LIB,Jo Jorgensen,11,0,11
+Santa Clara,0009268,President,,LIB,Jo Jorgensen,18,2,16
+Santa Clara,0009275,President,,LIB,Jo Jorgensen,14,1,13
+Santa Clara,0009282,President,,LIB,Jo Jorgensen,0,0,0
+Santa Clara,0002001,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0002002,President,,GRN,Howie Hawkins,14,0,14
+Santa Clara,0002005,President,,GRN,Howie Hawkins,8,2,6
+Santa Clara,0002006,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0002009,President,,GRN,Howie Hawkins,25,4,21
+Santa Clara,0002013,President,,GRN,Howie Hawkins,28,0,28
+Santa Clara,0002014,President,,GRN,Howie Hawkins,17,0,17
+Santa Clara,0002018,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0002025,President,,GRN,Howie Hawkins,21,0,21
+Santa Clara,0002043,President,,GRN,Howie Hawkins,10,0,10
+Santa Clara,0002046,President,,GRN,Howie Hawkins,19,2,17
+Santa Clara,0002057,President,,GRN,Howie Hawkins,15,0,15
+Santa Clara,0002068,President,,GRN,Howie Hawkins,11,0,11
+Santa Clara,0002098,President,,GRN,Howie Hawkins,24,1,23
+Santa Clara,0002108,President,,GRN,Howie Hawkins,15,3,12
+Santa Clara,0002125,President,,GRN,Howie Hawkins,2,0,2
+Santa Clara,0002274,President,,GRN,Howie Hawkins,2,0,2
+Santa Clara,0002275,President,,GRN,Howie Hawkins,4,0,4
+Santa Clara,0002278,President,,GRN,Howie Hawkins,5,0,5
+Santa Clara,0002281,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0002282,President,,GRN,Howie Hawkins,4,0,4
+Santa Clara,0002285,President,,GRN,Howie Hawkins,6,0,6
+Santa Clara,0002301,President,,GRN,Howie Hawkins,5,1,4
+Santa Clara,0002305,President,,GRN,Howie Hawkins,15,1,14
+Santa Clara,0002309,President,,GRN,Howie Hawkins,3,0,3
+Santa Clara,0002314,President,,GRN,Howie Hawkins,9,0,9
+Santa Clara,0002317,President,,GRN,Howie Hawkins,6,1,5
+Santa Clara,0002330,President,,GRN,Howie Hawkins,11,0,11
+Santa Clara,0002338,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0002351,President,,GRN,Howie Hawkins,11,0,11
+Santa Clara,0002353,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0002539,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0002542,President,,GRN,Howie Hawkins,8,1,7
+Santa Clara,0002545,President,,GRN,Howie Hawkins,4,0,4
+Santa Clara,0002720,President,,GRN,Howie Hawkins,7,0,7
+Santa Clara,0002721,President,,GRN,Howie Hawkins,8,0,8
+Santa Clara,0002723,President,,GRN,Howie Hawkins,10,1,9
+Santa Clara,0002724,President,,GRN,Howie Hawkins,15,0,15
+Santa Clara,0002725,President,,GRN,Howie Hawkins,9,0,9
+Santa Clara,0002726,President,,GRN,Howie Hawkins,8,2,6
+Santa Clara,0002727,President,,GRN,Howie Hawkins,1,0,1
+Santa Clara,0002729,President,,GRN,Howie Hawkins,7,1,6
+Santa Clara,0002734,President,,GRN,Howie Hawkins,11,0,11
+Santa Clara,0002740,President,,GRN,Howie Hawkins,7,0,7
+Santa Clara,0002751,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0002761,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0002802,President,,GRN,Howie Hawkins,13,0,13
+Santa Clara,0002808,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0002810,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0002811,President,,GRN,Howie Hawkins,1,0,1
+Santa Clara,0002812,President,,GRN,Howie Hawkins,3,0,3
+Santa Clara,0002813,President,,GRN,Howie Hawkins,4,0,4
+Santa Clara,0002816,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0002825,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0002870,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0002951,President,,GRN,Howie Hawkins,4,0,4
+Santa Clara,0003001,President,,GRN,Howie Hawkins,15,1,14
+Santa Clara,0003002,President,,GRN,Howie Hawkins,12,0,12
+Santa Clara,0003005,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0003008,President,,GRN,Howie Hawkins,1,0,1
+Santa Clara,0003010,President,,GRN,Howie Hawkins,12,1,11
+Santa Clara,0003011,President,,GRN,Howie Hawkins,16,1,15
+Santa Clara,0003012,President,,GRN,Howie Hawkins,2,0,2
+Santa Clara,0003013,President,,GRN,Howie Hawkins,17,2,15
+Santa Clara,0003016,President,,GRN,Howie Hawkins,4,0,4
+Santa Clara,0003017,President,,GRN,Howie Hawkins,5,0,5
+Santa Clara,0003018,President,,GRN,Howie Hawkins,3,1,2
+Santa Clara,0003019,President,,GRN,Howie Hawkins,15,1,14
+Santa Clara,0003021,President,,GRN,Howie Hawkins,3,0,3
+Santa Clara,0003023,President,,GRN,Howie Hawkins,24,0,24
+Santa Clara,0003026,President,,GRN,Howie Hawkins,11,1,10
+Santa Clara,0003029,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0003031,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0003032,President,,GRN,Howie Hawkins,11,0,11
+Santa Clara,0003034,President,,GRN,Howie Hawkins,10,1,9
+Santa Clara,0003035,President,,GRN,Howie Hawkins,15,1,14
+Santa Clara,0003039,President,,GRN,Howie Hawkins,10,3,7
+Santa Clara,0003040,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0003042,President,,GRN,Howie Hawkins,6,1,5
+Santa Clara,0003043,President,,GRN,Howie Hawkins,9,0,9
+Santa Clara,0003045,President,,GRN,Howie Hawkins,18,2,16
+Santa Clara,0003047,President,,GRN,Howie Hawkins,7,0,7
+Santa Clara,0003048,President,,GRN,Howie Hawkins,10,0,10
+Santa Clara,0003051,President,,GRN,Howie Hawkins,9,0,9
+Santa Clara,0003053,President,,GRN,Howie Hawkins,17,0,17
+Santa Clara,0003061,President,,GRN,Howie Hawkins,1,0,1
+Santa Clara,0003079,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0003080,President,,GRN,Howie Hawkins,6,0,6
+Santa Clara,0003086,President,,GRN,Howie Hawkins,10,1,9
+Santa Clara,0003087,President,,GRN,Howie Hawkins,12,1,11
+Santa Clara,0003089,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0003095,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0003101,President,,GRN,Howie Hawkins,1,0,1
+Santa Clara,0003102,President,,GRN,Howie Hawkins,1,0,1
+Santa Clara,0003103,President,,GRN,Howie Hawkins,5,0,5
+Santa Clara,0003116,President,,GRN,Howie Hawkins,2,0,2
+Santa Clara,0003117,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0003120,President,,GRN,Howie Hawkins,2,0,2
+Santa Clara,0003122,President,,GRN,Howie Hawkins,8,0,8
+Santa Clara,0003156,President,,GRN,Howie Hawkins,1,0,1
+Santa Clara,0003402,President,,GRN,Howie Hawkins,21,1,20
+Santa Clara,0003406,President,,GRN,Howie Hawkins,21,1,20
+Santa Clara,0003407,President,,GRN,Howie Hawkins,24,0,24
+Santa Clara,0003408,President,,GRN,Howie Hawkins,13,0,13
+Santa Clara,0003409,President,,GRN,Howie Hawkins,24,1,23
+Santa Clara,0003410,President,,GRN,Howie Hawkins,20,2,18
+Santa Clara,0003417,President,,GRN,Howie Hawkins,16,1,15
+Santa Clara,0003427,President,,GRN,Howie Hawkins,22,1,21
+Santa Clara,0003434,President,,GRN,Howie Hawkins,13,1,12
+Santa Clara,0003438,President,,GRN,Howie Hawkins,19,2,17
+Santa Clara,0003445,President,,GRN,Howie Hawkins,16,2,14
+Santa Clara,0003601,President,,GRN,Howie Hawkins,4,0,4
+Santa Clara,0003602,President,,GRN,Howie Hawkins,12,0,12
+Santa Clara,0003603,President,,GRN,Howie Hawkins,7,0,7
+Santa Clara,0003604,President,,GRN,Howie Hawkins,29,2,27
+Santa Clara,0003605,President,,GRN,Howie Hawkins,13,1,12
+Santa Clara,0003606,President,,GRN,Howie Hawkins,8,1,7
+Santa Clara,0003608,President,,GRN,Howie Hawkins,18,0,18
+Santa Clara,0003609,President,,GRN,Howie Hawkins,13,0,13
+Santa Clara,0003611,President,,GRN,Howie Hawkins,12,0,12
+Santa Clara,0003614,President,,GRN,Howie Hawkins,5,1,4
+Santa Clara,0003624,President,,GRN,Howie Hawkins,18,0,18
+Santa Clara,0003635,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0003652,President,,GRN,Howie Hawkins,11,1,10
+Santa Clara,0003655,President,,GRN,Howie Hawkins,2,0,2
+Santa Clara,0003669,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0003670,President,,GRN,Howie Hawkins,3,1,2
+Santa Clara,0003777,President,,GRN,Howie Hawkins,8,0,8
+Santa Clara,0003779,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0003782,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0003783,President,,GRN,Howie Hawkins,2,0,2
+Santa Clara,0003801,President,,GRN,Howie Hawkins,7,0,7
+Santa Clara,0003802,President,,GRN,Howie Hawkins,18,1,17
+Santa Clara,0003803,President,,GRN,Howie Hawkins,10,0,10
+Santa Clara,0003804,President,,GRN,Howie Hawkins,9,0,9
+Santa Clara,0003810,President,,GRN,Howie Hawkins,16,2,14
+Santa Clara,0003811,President,,GRN,Howie Hawkins,7,0,7
+Santa Clara,0003814,President,,GRN,Howie Hawkins,8,0,8
+Santa Clara,0003820,President,,GRN,Howie Hawkins,12,1,11
+Santa Clara,0003821,President,,GRN,Howie Hawkins,6,0,6
+Santa Clara,0003825,President,,GRN,Howie Hawkins,8,1,7
+Santa Clara,0003828,President,,GRN,Howie Hawkins,8,2,6
+Santa Clara,0003835,President,,GRN,Howie Hawkins,6,0,6
+Santa Clara,0003840,President,,GRN,Howie Hawkins,13,0,13
+Santa Clara,0003846,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0003861,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0004401,President,,GRN,Howie Hawkins,14,1,13
+Santa Clara,0004402,President,,GRN,Howie Hawkins,8,1,7
+Santa Clara,0004403,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0004405,President,,GRN,Howie Hawkins,14,0,14
+Santa Clara,0004407,President,,GRN,Howie Hawkins,8,0,8
+Santa Clara,0004409,President,,GRN,Howie Hawkins,15,0,15
+Santa Clara,0004411,President,,GRN,Howie Hawkins,12,0,12
+Santa Clara,0004412,President,,GRN,Howie Hawkins,13,0,13
+Santa Clara,0004414,President,,GRN,Howie Hawkins,19,1,18
+Santa Clara,0004417,President,,GRN,Howie Hawkins,14,2,12
+Santa Clara,0004665,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0004666,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0004671,President,,GRN,Howie Hawkins,8,0,8
+Santa Clara,0004672,President,,GRN,Howie Hawkins,2,0,2
+Santa Clara,0004674,President,,GRN,Howie Hawkins,2,1,1
+Santa Clara,0004675,President,,GRN,Howie Hawkins,6,1,5
+Santa Clara,0004685,President,,GRN,Howie Hawkins,11,0,11
+Santa Clara,0004687,President,,GRN,Howie Hawkins,6,0,6
+Santa Clara,0004688,President,,GRN,Howie Hawkins,24,0,24
+Santa Clara,0004691,President,,GRN,Howie Hawkins,8,0,8
+Santa Clara,0004696,President,,GRN,Howie Hawkins,3,0,3
+Santa Clara,0004698,President,,GRN,Howie Hawkins,3,0,3
+Santa Clara,0004699,President,,GRN,Howie Hawkins,10,0,10
+Santa Clara,0004702,President,,GRN,Howie Hawkins,4,2,2
+Santa Clara,0004715,President,,GRN,Howie Hawkins,4,1,3
+Santa Clara,0004733,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0004801,President,,GRN,Howie Hawkins,10,0,10
+Santa Clara,0004806,President,,GRN,Howie Hawkins,8,1,7
+Santa Clara,0004811,President,,GRN,Howie Hawkins,6,2,4
+Santa Clara,0004826,President,,GRN,Howie Hawkins,7,0,7
+Santa Clara,0004827,President,,GRN,Howie Hawkins,10,3,7
+Santa Clara,0004833,President,,GRN,Howie Hawkins,11,1,10
+Santa Clara,0004851,President,,GRN,Howie Hawkins,2,1,1
+Santa Clara,0004853,President,,GRN,Howie Hawkins,11,0,11
+Santa Clara,0004858,President,,GRN,Howie Hawkins,12,2,10
+Santa Clara,0004876,President,,GRN,Howie Hawkins,17,3,14
+Santa Clara,0004881,President,,GRN,Howie Hawkins,9,1,8
+Santa Clara,0004941,President,,GRN,Howie Hawkins,6,0,6
+Santa Clara,0004942,President,,GRN,Howie Hawkins,8,1,7
+Santa Clara,0004943,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0004944,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0004945,President,,GRN,Howie Hawkins,5,0,5
+Santa Clara,0004946,President,,GRN,Howie Hawkins,6,0,6
+Santa Clara,0004949,President,,GRN,Howie Hawkins,13,0,13
+Santa Clara,0004950,President,,GRN,Howie Hawkins,4,0,4
+Santa Clara,0004954,President,,GRN,Howie Hawkins,5,1,4
+Santa Clara,0004956,President,,GRN,Howie Hawkins,1,0,1
+Santa Clara,0004958,President,,GRN,Howie Hawkins,4,1,3
+Santa Clara,0004965,President,,GRN,Howie Hawkins,13,1,12
+Santa Clara,0004969,President,,GRN,Howie Hawkins,9,0,9
+Santa Clara,0004971,President,,GRN,Howie Hawkins,3,0,3
+Santa Clara,0004973,President,,GRN,Howie Hawkins,8,1,7
+Santa Clara,0004974,President,,GRN,Howie Hawkins,4,1,3
+Santa Clara,0005449,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0005451,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0005454,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0005455,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0005456,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0005458,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0005502,President,,GRN,Howie Hawkins,4,0,4
+Santa Clara,0005503,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0005505,President,,GRN,Howie Hawkins,1,0,1
+Santa Clara,0005507,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0005556,President,,GRN,Howie Hawkins,9,1,8
+Santa Clara,0005557,President,,GRN,Howie Hawkins,5,0,5
+Santa Clara,0005567,President,,GRN,Howie Hawkins,6,0,6
+Santa Clara,0005742,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0005743,President,,GRN,Howie Hawkins,2,0,2
+Santa Clara,0005745,President,,GRN,Howie Hawkins,3,0,3
+Santa Clara,0005747,President,,GRN,Howie Hawkins,1,0,1
+Santa Clara,0005748,President,,GRN,Howie Hawkins,11,2,9
+Santa Clara,0005756,President,,GRN,Howie Hawkins,2,0,2
+Santa Clara,0005758,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0005759,President,,GRN,Howie Hawkins,4,0,4
+Santa Clara,0005762,President,,GRN,Howie Hawkins,1,0,1
+Santa Clara,0005763,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0005770,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0005775,President,,GRN,Howie Hawkins,1,0,1
+Santa Clara,0005785,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0005793,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0005795,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0005804,President,,GRN,Howie Hawkins,6,0,6
+Santa Clara,0005810,President,,GRN,Howie Hawkins,1,0,1
+Santa Clara,0005811,President,,GRN,Howie Hawkins,1,0,1
+Santa Clara,0005813,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0005814,President,,GRN,Howie Hawkins,2,0,2
+Santa Clara,0005854,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0005879,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0005886,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0005888,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0005894,President,,GRN,Howie Hawkins,1,0,1
+Santa Clara,0005896,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0005901,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0005902,President,,GRN,Howie Hawkins,3,1,2
+Santa Clara,0005903,President,,GRN,Howie Hawkins,5,0,5
+Santa Clara,0005906,President,,GRN,Howie Hawkins,2,0,2
+Santa Clara,0005907,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0005911,President,,GRN,Howie Hawkins,9,1,8
+Santa Clara,0005912,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0005914,President,,GRN,Howie Hawkins,4,0,4
+Santa Clara,0005915,President,,GRN,Howie Hawkins,3,0,3
+Santa Clara,0005916,President,,GRN,Howie Hawkins,1,0,1
+Santa Clara,0005917,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0005919,President,,GRN,Howie Hawkins,3,0,3
+Santa Clara,0005922,President,,GRN,Howie Hawkins,1,0,1
+Santa Clara,0005925,President,,GRN,Howie Hawkins,1,0,1
+Santa Clara,0005927,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0005929,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0005931,President,,GRN,Howie Hawkins,1,0,1
+Santa Clara,0005936,President,,GRN,Howie Hawkins,1,0,1
+Santa Clara,0005940,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0005947,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0005949,President,,GRN,Howie Hawkins,1,0,1
+Santa Clara,0005950,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0005951,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0005955,President,,GRN,Howie Hawkins,2,0,2
+Santa Clara,0005956,President,,GRN,Howie Hawkins,2,0,2
+Santa Clara,0005957,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0005958,President,,GRN,Howie Hawkins,5,1,4
+Santa Clara,0005959,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0005965,President,,GRN,Howie Hawkins,3,0,3
+Santa Clara,0005966,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0005975,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0005988,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0006023,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0006028,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0006031,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0006035,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0006036,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0006048,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0006401,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0006402,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0006404,President,,GRN,Howie Hawkins,9,1,8
+Santa Clara,0006405,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0006410,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0006413,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0006418,President,,GRN,Howie Hawkins,4,0,4
+Santa Clara,0006419,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0006423,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0006452,President,,GRN,Howie Hawkins,4,0,4
+Santa Clara,0006454,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0006455,President,,GRN,Howie Hawkins,14,1,13
+Santa Clara,0006491,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0006502,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0006509,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0006510,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0006511,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0006515,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0006624,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0006625,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0006669,President,,GRN,Howie Hawkins,1,0,1
+Santa Clara,0006678,President,,GRN,Howie Hawkins,1,0,1
+Santa Clara,0007001,President,,GRN,Howie Hawkins,8,1,7
+Santa Clara,0007005,President,,GRN,Howie Hawkins,8,0,8
+Santa Clara,0007011,President,,GRN,Howie Hawkins,3,0,3
+Santa Clara,0007012,President,,GRN,Howie Hawkins,13,0,13
+Santa Clara,0007014,President,,GRN,Howie Hawkins,14,1,13
+Santa Clara,0007019,President,,GRN,Howie Hawkins,22,3,19
+Santa Clara,0007025,President,,GRN,Howie Hawkins,17,2,15
+Santa Clara,0007028,President,,GRN,Howie Hawkins,12,2,10
+Santa Clara,0007032,President,,GRN,Howie Hawkins,26,0,26
+Santa Clara,0007036,President,,GRN,Howie Hawkins,20,1,19
+Santa Clara,0007038,President,,GRN,Howie Hawkins,1,0,1
+Santa Clara,0007041,President,,GRN,Howie Hawkins,16,0,16
+Santa Clara,0007044,President,,GRN,Howie Hawkins,7,0,7
+Santa Clara,0007046,President,,GRN,Howie Hawkins,13,0,13
+Santa Clara,0007051,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0007059,President,,GRN,Howie Hawkins,5,1,4
+Santa Clara,0007061,President,,GRN,Howie Hawkins,9,1,8
+Santa Clara,0007062,President,,GRN,Howie Hawkins,17,3,14
+Santa Clara,0007079,President,,GRN,Howie Hawkins,7,0,7
+Santa Clara,0007081,President,,GRN,Howie Hawkins,13,1,12
+Santa Clara,0007089,President,,GRN,Howie Hawkins,3,0,3
+Santa Clara,0007201,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0007202,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0007203,President,,GRN,Howie Hawkins,2,0,2
+Santa Clara,0007205,President,,GRN,Howie Hawkins,6,1,5
+Santa Clara,0007214,President,,GRN,Howie Hawkins,8,1,7
+Santa Clara,0007217,President,,GRN,Howie Hawkins,6,1,5
+Santa Clara,0007219,President,,GRN,Howie Hawkins,1,0,1
+Santa Clara,0007221,President,,GRN,Howie Hawkins,6,0,6
+Santa Clara,0007224,President,,GRN,Howie Hawkins,3,0,3
+Santa Clara,0007231,President,,GRN,Howie Hawkins,6,0,6
+Santa Clara,0007235,President,,GRN,Howie Hawkins,12,2,10
+Santa Clara,0007237,President,,GRN,Howie Hawkins,8,3,5
+Santa Clara,0007245,President,,GRN,Howie Hawkins,2,0,2
+Santa Clara,0007246,President,,GRN,Howie Hawkins,14,0,14
+Santa Clara,0007248,President,,GRN,Howie Hawkins,20,0,20
+Santa Clara,0007252,President,,GRN,Howie Hawkins,20,1,19
+Santa Clara,0007255,President,,GRN,Howie Hawkins,8,0,8
+Santa Clara,0007257,President,,GRN,Howie Hawkins,6,0,6
+Santa Clara,0007261,President,,GRN,Howie Hawkins,15,1,14
+Santa Clara,0007264,President,,GRN,Howie Hawkins,12,0,12
+Santa Clara,0007271,President,,GRN,Howie Hawkins,24,0,24
+Santa Clara,0007273,President,,GRN,Howie Hawkins,16,1,15
+Santa Clara,0007282,President,,GRN,Howie Hawkins,12,2,10
+Santa Clara,0007294,President,,GRN,Howie Hawkins,2,0,2
+Santa Clara,0007295,President,,GRN,Howie Hawkins,15,0,15
+Santa Clara,0007298,President,,GRN,Howie Hawkins,7,1,6
+Santa Clara,0007299,President,,GRN,Howie Hawkins,9,2,7
+Santa Clara,0007306,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0007401,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0007402,President,,GRN,Howie Hawkins,4,0,4
+Santa Clara,0007403,President,,GRN,Howie Hawkins,6,1,5
+Santa Clara,0007408,President,,GRN,Howie Hawkins,3,0,3
+Santa Clara,0007409,President,,GRN,Howie Hawkins,1,0,1
+Santa Clara,0007410,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0007411,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0007414,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0007415,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0007416,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0007417,President,,GRN,Howie Hawkins,21,3,18
+Santa Clara,0007418,President,,GRN,Howie Hawkins,6,1,5
+Santa Clara,0007419,President,,GRN,Howie Hawkins,5,0,5
+Santa Clara,0007430,President,,GRN,Howie Hawkins,20,1,19
+Santa Clara,0007435,President,,GRN,Howie Hawkins,24,0,24
+Santa Clara,0007436,President,,GRN,Howie Hawkins,17,2,15
+Santa Clara,0007438,President,,GRN,Howie Hawkins,2,0,2
+Santa Clara,0007440,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0007441,President,,GRN,Howie Hawkins,5,0,5
+Santa Clara,0007442,President,,GRN,Howie Hawkins,4,1,3
+Santa Clara,0007447,President,,GRN,Howie Hawkins,13,1,12
+Santa Clara,0007458,President,,GRN,Howie Hawkins,21,1,20
+Santa Clara,0007459,President,,GRN,Howie Hawkins,14,3,11
+Santa Clara,0007470,President,,GRN,Howie Hawkins,13,1,12
+Santa Clara,0007471,President,,GRN,Howie Hawkins,23,2,21
+Santa Clara,0007479,President,,GRN,Howie Hawkins,11,0,11
+Santa Clara,0007483,President,,GRN,Howie Hawkins,13,1,12
+Santa Clara,0007601,President,,GRN,Howie Hawkins,13,2,11
+Santa Clara,0007606,President,,GRN,Howie Hawkins,20,0,20
+Santa Clara,0007609,President,,GRN,Howie Hawkins,4,0,4
+Santa Clara,0007615,President,,GRN,Howie Hawkins,3,0,3
+Santa Clara,0007619,President,,GRN,Howie Hawkins,19,0,19
+Santa Clara,0007620,President,,GRN,Howie Hawkins,6,0,6
+Santa Clara,0007621,President,,GRN,Howie Hawkins,14,0,14
+Santa Clara,0007624,President,,GRN,Howie Hawkins,8,1,7
+Santa Clara,0007632,President,,GRN,Howie Hawkins,10,0,10
+Santa Clara,0007634,President,,GRN,Howie Hawkins,15,1,14
+Santa Clara,0007648,President,,GRN,Howie Hawkins,15,0,15
+Santa Clara,0007654,President,,GRN,Howie Hawkins,10,0,10
+Santa Clara,0007660,President,,GRN,Howie Hawkins,14,1,13
+Santa Clara,0007666,President,,GRN,Howie Hawkins,16,0,16
+Santa Clara,0007670,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0007673,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0007674,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0007677,President,,GRN,Howie Hawkins,10,0,10
+Santa Clara,0007680,President,,GRN,Howie Hawkins,4,1,3
+Santa Clara,0007689,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0007690,President,,GRN,Howie Hawkins,1,0,1
+Santa Clara,0007801,President,,GRN,Howie Hawkins,2,1,1
+Santa Clara,0007802,President,,GRN,Howie Hawkins,2,0,2
+Santa Clara,0007803,President,,GRN,Howie Hawkins,2,0,2
+Santa Clara,0007805,President,,GRN,Howie Hawkins,8,0,8
+Santa Clara,0007810,President,,GRN,Howie Hawkins,1,0,1
+Santa Clara,0007811,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0007812,President,,GRN,Howie Hawkins,6,0,6
+Santa Clara,0007816,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0007817,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0007818,President,,GRN,Howie Hawkins,1,0,1
+Santa Clara,0007821,President,,GRN,Howie Hawkins,16,1,15
+Santa Clara,0007826,President,,GRN,Howie Hawkins,6,1,5
+Santa Clara,0007827,President,,GRN,Howie Hawkins,6,0,6
+Santa Clara,0007832,President,,GRN,Howie Hawkins,6,0,6
+Santa Clara,0007833,President,,GRN,Howie Hawkins,11,0,11
+Santa Clara,0007843,President,,GRN,Howie Hawkins,17,3,14
+Santa Clara,0007849,President,,GRN,Howie Hawkins,14,0,14
+Santa Clara,0007850,President,,GRN,Howie Hawkins,10,1,9
+Santa Clara,0007851,President,,GRN,Howie Hawkins,5,1,4
+Santa Clara,0007861,President,,GRN,Howie Hawkins,1,0,1
+Santa Clara,0007867,President,,GRN,Howie Hawkins,6,1,5
+Santa Clara,0007874,President,,GRN,Howie Hawkins,4,0,4
+Santa Clara,0007880,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0008001,President,,GRN,Howie Hawkins,2,1,1
+Santa Clara,0008002,President,,GRN,Howie Hawkins,2,1,1
+Santa Clara,0008003,President,,GRN,Howie Hawkins,20,3,17
+Santa Clara,0008005,President,,GRN,Howie Hawkins,19,1,18
+Santa Clara,0008007,President,,GRN,Howie Hawkins,9,0,9
+Santa Clara,0008011,President,,GRN,Howie Hawkins,1,0,1
+Santa Clara,0008012,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0008013,President,,GRN,Howie Hawkins,1,0,1
+Santa Clara,0008016,President,,GRN,Howie Hawkins,28,2,26
+Santa Clara,0008017,President,,GRN,Howie Hawkins,11,1,10
+Santa Clara,0008022,President,,GRN,Howie Hawkins,2,1,1
+Santa Clara,0008023,President,,GRN,Howie Hawkins,5,1,4
+Santa Clara,0008026,President,,GRN,Howie Hawkins,3,0,3
+Santa Clara,0008028,President,,GRN,Howie Hawkins,4,0,4
+Santa Clara,0008029,President,,GRN,Howie Hawkins,1,0,1
+Santa Clara,0008030,President,,GRN,Howie Hawkins,7,1,6
+Santa Clara,0008033,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0008034,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0008038,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0008040,President,,GRN,Howie Hawkins,2,0,2
+Santa Clara,0008047,President,,GRN,Howie Hawkins,15,0,15
+Santa Clara,0008049,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0008050,President,,GRN,Howie Hawkins,13,0,13
+Santa Clara,0008053,President,,GRN,Howie Hawkins,10,0,10
+Santa Clara,0008054,President,,GRN,Howie Hawkins,13,2,11
+Santa Clara,0008055,President,,GRN,Howie Hawkins,3,0,3
+Santa Clara,0008062,President,,GRN,Howie Hawkins,13,0,13
+Santa Clara,0008066,President,,GRN,Howie Hawkins,2,0,2
+Santa Clara,0008067,President,,GRN,Howie Hawkins,13,2,11
+Santa Clara,0008068,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0008072,President,,GRN,Howie Hawkins,2,0,2
+Santa Clara,0008073,President,,GRN,Howie Hawkins,4,0,4
+Santa Clara,0008079,President,,GRN,Howie Hawkins,7,1,6
+Santa Clara,0008082,President,,GRN,Howie Hawkins,13,0,13
+Santa Clara,0008085,President,,GRN,Howie Hawkins,11,0,11
+Santa Clara,0008089,President,,GRN,Howie Hawkins,7,1,6
+Santa Clara,0008092,President,,GRN,Howie Hawkins,1,0,1
+Santa Clara,0008093,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0008096,President,,GRN,Howie Hawkins,15,0,15
+Santa Clara,0008101,President,,GRN,Howie Hawkins,5,0,5
+Santa Clara,0008104,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0008105,President,,GRN,Howie Hawkins,1,0,1
+Santa Clara,0008117,President,,GRN,Howie Hawkins,5,0,5
+Santa Clara,0008122,President,,GRN,Howie Hawkins,9,0,9
+Santa Clara,0008128,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0008133,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0008201,President,,GRN,Howie Hawkins,7,2,5
+Santa Clara,0008203,President,,GRN,Howie Hawkins,9,0,9
+Santa Clara,0008205,President,,GRN,Howie Hawkins,10,0,10
+Santa Clara,0008208,President,,GRN,Howie Hawkins,6,1,5
+Santa Clara,0008212,President,,GRN,Howie Hawkins,6,0,6
+Santa Clara,0008214,President,,GRN,Howie Hawkins,1,0,1
+Santa Clara,0008227,President,,GRN,Howie Hawkins,13,2,11
+Santa Clara,0008228,President,,GRN,Howie Hawkins,8,0,8
+Santa Clara,0008230,President,,GRN,Howie Hawkins,9,0,9
+Santa Clara,0008231,President,,GRN,Howie Hawkins,6,0,6
+Santa Clara,0008232,President,,GRN,Howie Hawkins,8,0,8
+Santa Clara,0008236,President,,GRN,Howie Hawkins,11,1,10
+Santa Clara,0008246,President,,GRN,Howie Hawkins,11,1,10
+Santa Clara,0008254,President,,GRN,Howie Hawkins,8,1,7
+Santa Clara,0008262,President,,GRN,Howie Hawkins,2,0,2
+Santa Clara,0008264,President,,GRN,Howie Hawkins,3,0,3
+Santa Clara,0008401,President,,GRN,Howie Hawkins,5,0,5
+Santa Clara,0008404,President,,GRN,Howie Hawkins,11,1,10
+Santa Clara,0008408,President,,GRN,Howie Hawkins,4,0,4
+Santa Clara,0008409,President,,GRN,Howie Hawkins,5,0,5
+Santa Clara,0008414,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0008418,President,,GRN,Howie Hawkins,5,0,5
+Santa Clara,0008421,President,,GRN,Howie Hawkins,2,0,2
+Santa Clara,0008423,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0008430,President,,GRN,Howie Hawkins,6,0,6
+Santa Clara,0008435,President,,GRN,Howie Hawkins,11,0,11
+Santa Clara,0008438,President,,GRN,Howie Hawkins,11,1,10
+Santa Clara,0008439,President,,GRN,Howie Hawkins,9,0,9
+Santa Clara,0008445,President,,GRN,Howie Hawkins,5,2,3
+Santa Clara,0008447,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0008456,President,,GRN,Howie Hawkins,10,1,9
+Santa Clara,0008457,President,,GRN,Howie Hawkins,11,2,9
+Santa Clara,0008464,President,,GRN,Howie Hawkins,10,0,10
+Santa Clara,0008470,President,,GRN,Howie Hawkins,30,2,28
+Santa Clara,0008472,President,,GRN,Howie Hawkins,8,0,8
+Santa Clara,0008486,President,,GRN,Howie Hawkins,20,1,19
+Santa Clara,0008492,President,,GRN,Howie Hawkins,15,0,15
+Santa Clara,0008502,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0008601,President,,GRN,Howie Hawkins,5,0,5
+Santa Clara,0008603,President,,GRN,Howie Hawkins,11,0,11
+Santa Clara,0008605,President,,GRN,Howie Hawkins,22,1,21
+Santa Clara,0008609,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0008610,President,,GRN,Howie Hawkins,3,0,3
+Santa Clara,0008612,President,,GRN,Howie Hawkins,12,0,12
+Santa Clara,0008615,President,,GRN,Howie Hawkins,2,1,1
+Santa Clara,0008619,President,,GRN,Howie Hawkins,10,1,9
+Santa Clara,0008625,President,,GRN,Howie Hawkins,1,0,1
+Santa Clara,0008627,President,,GRN,Howie Hawkins,6,2,4
+Santa Clara,0008629,President,,GRN,Howie Hawkins,9,0,9
+Santa Clara,0008630,President,,GRN,Howie Hawkins,7,1,6
+Santa Clara,0008631,President,,GRN,Howie Hawkins,9,1,8
+Santa Clara,0008634,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0008636,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0008645,President,,GRN,Howie Hawkins,8,2,6
+Santa Clara,0008648,President,,GRN,Howie Hawkins,7,0,7
+Santa Clara,0008650,President,,GRN,Howie Hawkins,1,0,1
+Santa Clara,0008653,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0008654,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0008655,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0008657,President,,GRN,Howie Hawkins,1,1,0
+Santa Clara,0008658,President,,GRN,Howie Hawkins,26,2,24
+Santa Clara,0008670,President,,GRN,Howie Hawkins,9,0,9
+Santa Clara,0008675,President,,GRN,Howie Hawkins,10,0,10
+Santa Clara,0008676,President,,GRN,Howie Hawkins,17,0,17
+Santa Clara,0008680,President,,GRN,Howie Hawkins,16,0,16
+Santa Clara,0008683,President,,GRN,Howie Hawkins,18,0,18
+Santa Clara,0008687,President,,GRN,Howie Hawkins,6,1,5
+Santa Clara,0008697,President,,GRN,Howie Hawkins,20,1,19
+Santa Clara,0008801,President,,GRN,Howie Hawkins,8,0,8
+Santa Clara,0008805,President,,GRN,Howie Hawkins,10,0,10
+Santa Clara,0008809,President,,GRN,Howie Hawkins,10,0,10
+Santa Clara,0008812,President,,GRN,Howie Hawkins,6,1,5
+Santa Clara,0008817,President,,GRN,Howie Hawkins,3,0,3
+Santa Clara,0008820,President,,GRN,Howie Hawkins,5,1,4
+Santa Clara,0008822,President,,GRN,Howie Hawkins,9,0,9
+Santa Clara,0008828,President,,GRN,Howie Hawkins,1,0,1
+Santa Clara,0008829,President,,GRN,Howie Hawkins,4,0,4
+Santa Clara,0008832,President,,GRN,Howie Hawkins,7,0,7
+Santa Clara,0008834,President,,GRN,Howie Hawkins,6,0,6
+Santa Clara,0008838,President,,GRN,Howie Hawkins,2,0,2
+Santa Clara,0008839,President,,GRN,Howie Hawkins,10,0,10
+Santa Clara,0008844,President,,GRN,Howie Hawkins,16,0,16
+Santa Clara,0008848,President,,GRN,Howie Hawkins,2,0,2
+Santa Clara,0008853,President,,GRN,Howie Hawkins,9,0,9
+Santa Clara,0008857,President,,GRN,Howie Hawkins,3,0,3
+Santa Clara,0008858,President,,GRN,Howie Hawkins,13,0,13
+Santa Clara,0008862,President,,GRN,Howie Hawkins,9,1,8
+Santa Clara,0008868,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0008873,President,,GRN,Howie Hawkins,5,1,4
+Santa Clara,0008874,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0008879,President,,GRN,Howie Hawkins,12,1,11
+Santa Clara,0008883,President,,GRN,Howie Hawkins,12,0,12
+Santa Clara,0008885,President,,GRN,Howie Hawkins,12,1,11
+Santa Clara,0008886,President,,GRN,Howie Hawkins,1,0,1
+Santa Clara,0008889,President,,GRN,Howie Hawkins,11,1,10
+Santa Clara,0008898,President,,GRN,Howie Hawkins,15,3,12
+Santa Clara,0008903,President,,GRN,Howie Hawkins,16,0,16
+Santa Clara,0008915,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0008916,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0008920,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0008923,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0008924,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0009001,President,,GRN,Howie Hawkins,15,0,15
+Santa Clara,0009005,President,,GRN,Howie Hawkins,10,2,8
+Santa Clara,0009051,President,,GRN,Howie Hawkins,7,0,7
+Santa Clara,0009055,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0009056,President,,GRN,Howie Hawkins,16,1,15
+Santa Clara,0009059,President,,GRN,Howie Hawkins,7,1,6
+Santa Clara,0009061,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0009062,President,,GRN,Howie Hawkins,13,0,13
+Santa Clara,0009101,President,,GRN,Howie Hawkins,15,2,13
+Santa Clara,0009103,President,,GRN,Howie Hawkins,4,1,3
+Santa Clara,0009104,President,,GRN,Howie Hawkins,9,0,9
+Santa Clara,0009109,President,,GRN,Howie Hawkins,8,0,8
+Santa Clara,0009151,President,,GRN,Howie Hawkins,16,2,14
+Santa Clara,0009157,President,,GRN,Howie Hawkins,22,1,21
+Santa Clara,0009163,President,,GRN,Howie Hawkins,6,1,5
+Santa Clara,0009166,President,,GRN,Howie Hawkins,5,0,5
+Santa Clara,0009201,President,,GRN,Howie Hawkins,2,0,2
+Santa Clara,0009203,President,,GRN,Howie Hawkins,13,1,12
+Santa Clara,0009208,President,,GRN,Howie Hawkins,4,0,4
+Santa Clara,0009210,President,,GRN,Howie Hawkins,9,0,9
+Santa Clara,0009219,President,,GRN,Howie Hawkins,2,0,2
+Santa Clara,0009220,President,,GRN,Howie Hawkins,12,0,12
+Santa Clara,0009251,President,,GRN,Howie Hawkins,4,0,4
+Santa Clara,0009252,President,,GRN,Howie Hawkins,8,1,7
+Santa Clara,0009258,President,,GRN,Howie Hawkins,6,0,6
+Santa Clara,0009262,President,,GRN,Howie Hawkins,3,0,3
+Santa Clara,0009264,President,,GRN,Howie Hawkins,5,0,5
+Santa Clara,0009268,President,,GRN,Howie Hawkins,10,2,8
+Santa Clara,0009275,President,,GRN,Howie Hawkins,11,1,10
+Santa Clara,0009282,President,,GRN,Howie Hawkins,0,0,0
+Santa Clara,0002001,President,,AI,Rocky de la Fuente Guerra,1,0,1
+Santa Clara,0002002,President,,AI,Rocky de la Fuente Guerra,2,0,2
+Santa Clara,0002005,President,,AI,Rocky de la Fuente Guerra,4,0,4
+Santa Clara,0002006,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0002009,President,,AI,Rocky de la Fuente Guerra,9,1,8
+Santa Clara,0002013,President,,AI,Rocky de la Fuente Guerra,4,0,4
+Santa Clara,0002014,President,,AI,Rocky de la Fuente Guerra,10,0,10
+Santa Clara,0002018,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0002025,President,,AI,Rocky de la Fuente Guerra,6,0,6
+Santa Clara,0002043,President,,AI,Rocky de la Fuente Guerra,9,0,9
+Santa Clara,0002046,President,,AI,Rocky de la Fuente Guerra,6,0,6
+Santa Clara,0002057,President,,AI,Rocky de la Fuente Guerra,3,0,3
+Santa Clara,0002068,President,,AI,Rocky de la Fuente Guerra,4,0,4
+Santa Clara,0002098,President,,AI,Rocky de la Fuente Guerra,7,1,6
+Santa Clara,0002108,President,,AI,Rocky de la Fuente Guerra,6,2,4
+Santa Clara,0002125,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0002274,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0002275,President,,AI,Rocky de la Fuente Guerra,1,0,1
+Santa Clara,0002278,President,,AI,Rocky de la Fuente Guerra,2,0,2
+Santa Clara,0002281,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0002282,President,,AI,Rocky de la Fuente Guerra,5,0,5
+Santa Clara,0002285,President,,AI,Rocky de la Fuente Guerra,12,1,11
+Santa Clara,0002301,President,,AI,Rocky de la Fuente Guerra,7,1,6
+Santa Clara,0002305,President,,AI,Rocky de la Fuente Guerra,11,2,9
+Santa Clara,0002309,President,,AI,Rocky de la Fuente Guerra,1,1,0
+Santa Clara,0002314,President,,AI,Rocky de la Fuente Guerra,7,1,6
+Santa Clara,0002317,President,,AI,Rocky de la Fuente Guerra,7,1,6
+Santa Clara,0002330,President,,AI,Rocky de la Fuente Guerra,7,1,6
+Santa Clara,0002338,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0002351,President,,AI,Rocky de la Fuente Guerra,5,0,5
+Santa Clara,0002353,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0002539,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0002542,President,,AI,Rocky de la Fuente Guerra,2,2,0
+Santa Clara,0002545,President,,AI,Rocky de la Fuente Guerra,3,0,3
+Santa Clara,0002720,President,,AI,Rocky de la Fuente Guerra,5,0,5
+Santa Clara,0002721,President,,AI,Rocky de la Fuente Guerra,8,0,8
+Santa Clara,0002723,President,,AI,Rocky de la Fuente Guerra,8,1,7
+Santa Clara,0002724,President,,AI,Rocky de la Fuente Guerra,3,0,3
+Santa Clara,0002725,President,,AI,Rocky de la Fuente Guerra,7,0,7
+Santa Clara,0002726,President,,AI,Rocky de la Fuente Guerra,5,0,5
+Santa Clara,0002727,President,,AI,Rocky de la Fuente Guerra,14,1,13
+Santa Clara,0002729,President,,AI,Rocky de la Fuente Guerra,5,0,5
+Santa Clara,0002734,President,,AI,Rocky de la Fuente Guerra,10,0,10
+Santa Clara,0002740,President,,AI,Rocky de la Fuente Guerra,7,0,7
+Santa Clara,0002751,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0002761,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0002802,President,,AI,Rocky de la Fuente Guerra,9,1,8
+Santa Clara,0002808,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0002810,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0002811,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0002812,President,,AI,Rocky de la Fuente Guerra,1,0,1
+Santa Clara,0002813,President,,AI,Rocky de la Fuente Guerra,1,0,1
+Santa Clara,0002816,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0002825,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0002870,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0002951,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0003001,President,,AI,Rocky de la Fuente Guerra,10,1,9
+Santa Clara,0003002,President,,AI,Rocky de la Fuente Guerra,6,1,5
+Santa Clara,0003005,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0003008,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0003010,President,,AI,Rocky de la Fuente Guerra,3,2,1
+Santa Clara,0003011,President,,AI,Rocky de la Fuente Guerra,7,1,6
+Santa Clara,0003012,President,,AI,Rocky de la Fuente Guerra,2,1,1
+Santa Clara,0003013,President,,AI,Rocky de la Fuente Guerra,11,1,10
+Santa Clara,0003016,President,,AI,Rocky de la Fuente Guerra,4,0,4
+Santa Clara,0003017,President,,AI,Rocky de la Fuente Guerra,1,0,1
+Santa Clara,0003018,President,,AI,Rocky de la Fuente Guerra,1,0,1
+Santa Clara,0003019,President,,AI,Rocky de la Fuente Guerra,7,1,6
+Santa Clara,0003021,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0003023,President,,AI,Rocky de la Fuente Guerra,5,0,5
+Santa Clara,0003026,President,,AI,Rocky de la Fuente Guerra,6,1,5
+Santa Clara,0003029,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0003031,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0003032,President,,AI,Rocky de la Fuente Guerra,2,1,1
+Santa Clara,0003034,President,,AI,Rocky de la Fuente Guerra,6,0,6
+Santa Clara,0003035,President,,AI,Rocky de la Fuente Guerra,1,0,1
+Santa Clara,0003039,President,,AI,Rocky de la Fuente Guerra,2,0,2
+Santa Clara,0003040,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0003042,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0003043,President,,AI,Rocky de la Fuente Guerra,5,0,5
+Santa Clara,0003045,President,,AI,Rocky de la Fuente Guerra,7,0,7
+Santa Clara,0003047,President,,AI,Rocky de la Fuente Guerra,2,0,2
+Santa Clara,0003048,President,,AI,Rocky de la Fuente Guerra,10,0,10
+Santa Clara,0003051,President,,AI,Rocky de la Fuente Guerra,9,0,9
+Santa Clara,0003053,President,,AI,Rocky de la Fuente Guerra,6,0,6
+Santa Clara,0003061,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0003079,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0003080,President,,AI,Rocky de la Fuente Guerra,3,1,2
+Santa Clara,0003086,President,,AI,Rocky de la Fuente Guerra,12,0,12
+Santa Clara,0003087,President,,AI,Rocky de la Fuente Guerra,8,0,8
+Santa Clara,0003089,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0003095,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0003101,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0003102,President,,AI,Rocky de la Fuente Guerra,1,0,1
+Santa Clara,0003103,President,,AI,Rocky de la Fuente Guerra,4,0,4
+Santa Clara,0003116,President,,AI,Rocky de la Fuente Guerra,1,0,1
+Santa Clara,0003117,President,,AI,Rocky de la Fuente Guerra,1,0,1
+Santa Clara,0003120,President,,AI,Rocky de la Fuente Guerra,1,0,1
+Santa Clara,0003122,President,,AI,Rocky de la Fuente Guerra,8,0,8
+Santa Clara,0003156,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0003402,President,,AI,Rocky de la Fuente Guerra,5,1,4
+Santa Clara,0003406,President,,AI,Rocky de la Fuente Guerra,6,3,3
+Santa Clara,0003407,President,,AI,Rocky de la Fuente Guerra,7,1,6
+Santa Clara,0003408,President,,AI,Rocky de la Fuente Guerra,8,2,6
+Santa Clara,0003409,President,,AI,Rocky de la Fuente Guerra,12,1,11
+Santa Clara,0003410,President,,AI,Rocky de la Fuente Guerra,8,0,8
+Santa Clara,0003417,President,,AI,Rocky de la Fuente Guerra,6,0,6
+Santa Clara,0003427,President,,AI,Rocky de la Fuente Guerra,8,2,6
+Santa Clara,0003434,President,,AI,Rocky de la Fuente Guerra,2,0,2
+Santa Clara,0003438,President,,AI,Rocky de la Fuente Guerra,10,1,9
+Santa Clara,0003445,President,,AI,Rocky de la Fuente Guerra,4,0,4
+Santa Clara,0003601,President,,AI,Rocky de la Fuente Guerra,1,1,0
+Santa Clara,0003602,President,,AI,Rocky de la Fuente Guerra,6,4,2
+Santa Clara,0003603,President,,AI,Rocky de la Fuente Guerra,8,0,8
+Santa Clara,0003604,President,,AI,Rocky de la Fuente Guerra,10,0,10
+Santa Clara,0003605,President,,AI,Rocky de la Fuente Guerra,10,1,9
+Santa Clara,0003606,President,,AI,Rocky de la Fuente Guerra,6,0,6
+Santa Clara,0003608,President,,AI,Rocky de la Fuente Guerra,10,0,10
+Santa Clara,0003609,President,,AI,Rocky de la Fuente Guerra,13,0,13
+Santa Clara,0003611,President,,AI,Rocky de la Fuente Guerra,11,2,9
+Santa Clara,0003614,President,,AI,Rocky de la Fuente Guerra,2,1,1
+Santa Clara,0003624,President,,AI,Rocky de la Fuente Guerra,9,1,8
+Santa Clara,0003635,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0003652,President,,AI,Rocky de la Fuente Guerra,3,2,1
+Santa Clara,0003655,President,,AI,Rocky de la Fuente Guerra,2,1,1
+Santa Clara,0003669,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0003670,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0003777,President,,AI,Rocky de la Fuente Guerra,3,0,3
+Santa Clara,0003779,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0003782,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0003783,President,,AI,Rocky de la Fuente Guerra,1,0,1
+Santa Clara,0003801,President,,AI,Rocky de la Fuente Guerra,4,1,3
+Santa Clara,0003802,President,,AI,Rocky de la Fuente Guerra,10,3,7
+Santa Clara,0003803,President,,AI,Rocky de la Fuente Guerra,4,1,3
+Santa Clara,0003804,President,,AI,Rocky de la Fuente Guerra,4,0,4
+Santa Clara,0003810,President,,AI,Rocky de la Fuente Guerra,3,2,1
+Santa Clara,0003811,President,,AI,Rocky de la Fuente Guerra,10,0,10
+Santa Clara,0003814,President,,AI,Rocky de la Fuente Guerra,11,0,11
+Santa Clara,0003820,President,,AI,Rocky de la Fuente Guerra,9,0,9
+Santa Clara,0003821,President,,AI,Rocky de la Fuente Guerra,3,1,2
+Santa Clara,0003825,President,,AI,Rocky de la Fuente Guerra,3,0,3
+Santa Clara,0003828,President,,AI,Rocky de la Fuente Guerra,6,0,6
+Santa Clara,0003835,President,,AI,Rocky de la Fuente Guerra,4,1,3
+Santa Clara,0003840,President,,AI,Rocky de la Fuente Guerra,3,0,3
+Santa Clara,0003846,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0003861,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0004401,President,,AI,Rocky de la Fuente Guerra,15,2,13
+Santa Clara,0004402,President,,AI,Rocky de la Fuente Guerra,14,2,12
+Santa Clara,0004403,President,,AI,Rocky de la Fuente Guerra,1,0,1
+Santa Clara,0004405,President,,AI,Rocky de la Fuente Guerra,2,0,2
+Santa Clara,0004407,President,,AI,Rocky de la Fuente Guerra,8,1,7
+Santa Clara,0004409,President,,AI,Rocky de la Fuente Guerra,13,0,13
+Santa Clara,0004411,President,,AI,Rocky de la Fuente Guerra,4,1,3
+Santa Clara,0004412,President,,AI,Rocky de la Fuente Guerra,6,1,5
+Santa Clara,0004414,President,,AI,Rocky de la Fuente Guerra,11,1,10
+Santa Clara,0004417,President,,AI,Rocky de la Fuente Guerra,10,0,10
+Santa Clara,0004665,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0004666,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0004671,President,,AI,Rocky de la Fuente Guerra,5,1,4
+Santa Clara,0004672,President,,AI,Rocky de la Fuente Guerra,5,0,5
+Santa Clara,0004674,President,,AI,Rocky de la Fuente Guerra,6,1,5
+Santa Clara,0004675,President,,AI,Rocky de la Fuente Guerra,10,0,10
+Santa Clara,0004685,President,,AI,Rocky de la Fuente Guerra,1,0,1
+Santa Clara,0004687,President,,AI,Rocky de la Fuente Guerra,7,0,7
+Santa Clara,0004688,President,,AI,Rocky de la Fuente Guerra,13,0,13
+Santa Clara,0004691,President,,AI,Rocky de la Fuente Guerra,8,1,7
+Santa Clara,0004696,President,,AI,Rocky de la Fuente Guerra,4,0,4
+Santa Clara,0004698,President,,AI,Rocky de la Fuente Guerra,4,0,4
+Santa Clara,0004699,President,,AI,Rocky de la Fuente Guerra,1,0,1
+Santa Clara,0004702,President,,AI,Rocky de la Fuente Guerra,2,0,2
+Santa Clara,0004715,President,,AI,Rocky de la Fuente Guerra,2,0,2
+Santa Clara,0004733,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0004801,President,,AI,Rocky de la Fuente Guerra,5,0,5
+Santa Clara,0004806,President,,AI,Rocky de la Fuente Guerra,18,1,17
+Santa Clara,0004811,President,,AI,Rocky de la Fuente Guerra,4,2,2
+Santa Clara,0004826,President,,AI,Rocky de la Fuente Guerra,4,0,4
+Santa Clara,0004827,President,,AI,Rocky de la Fuente Guerra,13,0,13
+Santa Clara,0004833,President,,AI,Rocky de la Fuente Guerra,11,0,11
+Santa Clara,0004851,President,,AI,Rocky de la Fuente Guerra,3,0,3
+Santa Clara,0004853,President,,AI,Rocky de la Fuente Guerra,4,0,4
+Santa Clara,0004858,President,,AI,Rocky de la Fuente Guerra,8,0,8
+Santa Clara,0004876,President,,AI,Rocky de la Fuente Guerra,8,1,7
+Santa Clara,0004881,President,,AI,Rocky de la Fuente Guerra,8,0,8
+Santa Clara,0004941,President,,AI,Rocky de la Fuente Guerra,8,1,7
+Santa Clara,0004942,President,,AI,Rocky de la Fuente Guerra,1,0,1
+Santa Clara,0004943,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0004944,President,,AI,Rocky de la Fuente Guerra,2,0,2
+Santa Clara,0004945,President,,AI,Rocky de la Fuente Guerra,7,2,5
+Santa Clara,0004946,President,,AI,Rocky de la Fuente Guerra,2,0,2
+Santa Clara,0004949,President,,AI,Rocky de la Fuente Guerra,9,0,9
+Santa Clara,0004950,President,,AI,Rocky de la Fuente Guerra,4,0,4
+Santa Clara,0004954,President,,AI,Rocky de la Fuente Guerra,4,2,2
+Santa Clara,0004956,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0004958,President,,AI,Rocky de la Fuente Guerra,8,2,6
+Santa Clara,0004965,President,,AI,Rocky de la Fuente Guerra,21,1,20
+Santa Clara,0004969,President,,AI,Rocky de la Fuente Guerra,4,0,4
+Santa Clara,0004971,President,,AI,Rocky de la Fuente Guerra,3,0,3
+Santa Clara,0004973,President,,AI,Rocky de la Fuente Guerra,5,0,5
+Santa Clara,0004974,President,,AI,Rocky de la Fuente Guerra,4,0,4
+Santa Clara,0005449,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0005451,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0005454,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0005455,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0005456,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0005458,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0005502,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0005503,President,,AI,Rocky de la Fuente Guerra,3,1,2
+Santa Clara,0005505,President,,AI,Rocky de la Fuente Guerra,4,0,4
+Santa Clara,0005507,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0005556,President,,AI,Rocky de la Fuente Guerra,13,2,11
+Santa Clara,0005557,President,,AI,Rocky de la Fuente Guerra,6,0,6
+Santa Clara,0005567,President,,AI,Rocky de la Fuente Guerra,1,0,1
+Santa Clara,0005742,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0005743,President,,AI,Rocky de la Fuente Guerra,2,1,1
+Santa Clara,0005745,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0005747,President,,AI,Rocky de la Fuente Guerra,2,0,2
+Santa Clara,0005748,President,,AI,Rocky de la Fuente Guerra,12,1,11
+Santa Clara,0005756,President,,AI,Rocky de la Fuente Guerra,1,0,1
+Santa Clara,0005758,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0005759,President,,AI,Rocky de la Fuente Guerra,3,1,2
+Santa Clara,0005762,President,,AI,Rocky de la Fuente Guerra,1,1,0
+Santa Clara,0005763,President,,AI,Rocky de la Fuente Guerra,1,1,0
+Santa Clara,0005770,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0005775,President,,AI,Rocky de la Fuente Guerra,1,0,1
+Santa Clara,0005785,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0005793,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0005795,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0005804,President,,AI,Rocky de la Fuente Guerra,5,0,5
+Santa Clara,0005810,President,,AI,Rocky de la Fuente Guerra,4,0,4
+Santa Clara,0005811,President,,AI,Rocky de la Fuente Guerra,1,0,1
+Santa Clara,0005813,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0005814,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0005854,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0005879,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0005886,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0005888,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0005894,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0005896,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0005901,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0005902,President,,AI,Rocky de la Fuente Guerra,1,0,1
+Santa Clara,0005903,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0005906,President,,AI,Rocky de la Fuente Guerra,2,0,2
+Santa Clara,0005907,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0005911,President,,AI,Rocky de la Fuente Guerra,8,0,8
+Santa Clara,0005912,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0005914,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0005915,President,,AI,Rocky de la Fuente Guerra,2,0,2
+Santa Clara,0005916,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0005917,President,,AI,Rocky de la Fuente Guerra,1,0,1
+Santa Clara,0005919,President,,AI,Rocky de la Fuente Guerra,2,0,2
+Santa Clara,0005922,President,,AI,Rocky de la Fuente Guerra,1,0,1
+Santa Clara,0005925,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0005927,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0005929,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0005931,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0005936,President,,AI,Rocky de la Fuente Guerra,3,0,3
+Santa Clara,0005940,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0005947,President,,AI,Rocky de la Fuente Guerra,4,0,4
+Santa Clara,0005949,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0005950,President,,AI,Rocky de la Fuente Guerra,1,0,1
+Santa Clara,0005951,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0005955,President,,AI,Rocky de la Fuente Guerra,6,0,6
+Santa Clara,0005956,President,,AI,Rocky de la Fuente Guerra,6,0,6
+Santa Clara,0005957,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0005958,President,,AI,Rocky de la Fuente Guerra,1,0,1
+Santa Clara,0005959,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0005965,President,,AI,Rocky de la Fuente Guerra,4,0,4
+Santa Clara,0005966,President,,AI,Rocky de la Fuente Guerra,1,0,1
+Santa Clara,0005975,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0005988,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0006023,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0006028,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0006031,President,,AI,Rocky de la Fuente Guerra,1,0,1
+Santa Clara,0006035,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0006036,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0006048,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0006401,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0006402,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0006404,President,,AI,Rocky de la Fuente Guerra,12,1,11
+Santa Clara,0006405,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0006410,President,,AI,Rocky de la Fuente Guerra,2,0,2
+Santa Clara,0006413,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0006418,President,,AI,Rocky de la Fuente Guerra,3,0,3
+Santa Clara,0006419,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0006423,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0006452,President,,AI,Rocky de la Fuente Guerra,9,3,6
+Santa Clara,0006454,President,,AI,Rocky de la Fuente Guerra,2,0,2
+Santa Clara,0006455,President,,AI,Rocky de la Fuente Guerra,8,2,6
+Santa Clara,0006491,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0006502,President,,AI,Rocky de la Fuente Guerra,1,0,1
+Santa Clara,0006509,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0006510,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0006511,President,,AI,Rocky de la Fuente Guerra,2,0,2
+Santa Clara,0006515,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0006624,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0006625,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0006669,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0006678,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0007001,President,,AI,Rocky de la Fuente Guerra,8,2,6
+Santa Clara,0007005,President,,AI,Rocky de la Fuente Guerra,7,1,6
+Santa Clara,0007011,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0007012,President,,AI,Rocky de la Fuente Guerra,11,0,11
+Santa Clara,0007014,President,,AI,Rocky de la Fuente Guerra,7,1,6
+Santa Clara,0007019,President,,AI,Rocky de la Fuente Guerra,11,2,9
+Santa Clara,0007025,President,,AI,Rocky de la Fuente Guerra,17,4,13
+Santa Clara,0007028,President,,AI,Rocky de la Fuente Guerra,11,0,11
+Santa Clara,0007032,President,,AI,Rocky de la Fuente Guerra,14,0,14
+Santa Clara,0007036,President,,AI,Rocky de la Fuente Guerra,9,0,9
+Santa Clara,0007038,President,,AI,Rocky de la Fuente Guerra,1,0,1
+Santa Clara,0007041,President,,AI,Rocky de la Fuente Guerra,7,1,6
+Santa Clara,0007044,President,,AI,Rocky de la Fuente Guerra,5,0,5
+Santa Clara,0007046,President,,AI,Rocky de la Fuente Guerra,6,1,5
+Santa Clara,0007051,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0007059,President,,AI,Rocky de la Fuente Guerra,1,1,0
+Santa Clara,0007061,President,,AI,Rocky de la Fuente Guerra,5,0,5
+Santa Clara,0007062,President,,AI,Rocky de la Fuente Guerra,10,2,8
+Santa Clara,0007079,President,,AI,Rocky de la Fuente Guerra,8,1,7
+Santa Clara,0007081,President,,AI,Rocky de la Fuente Guerra,5,0,5
+Santa Clara,0007089,President,,AI,Rocky de la Fuente Guerra,6,0,6
+Santa Clara,0007201,President,,AI,Rocky de la Fuente Guerra,1,0,1
+Santa Clara,0007202,President,,AI,Rocky de la Fuente Guerra,1,0,1
+Santa Clara,0007203,President,,AI,Rocky de la Fuente Guerra,1,0,1
+Santa Clara,0007205,President,,AI,Rocky de la Fuente Guerra,10,2,8
+Santa Clara,0007214,President,,AI,Rocky de la Fuente Guerra,1,0,1
+Santa Clara,0007217,President,,AI,Rocky de la Fuente Guerra,13,0,13
+Santa Clara,0007219,President,,AI,Rocky de la Fuente Guerra,3,0,3
+Santa Clara,0007221,President,,AI,Rocky de la Fuente Guerra,3,1,2
+Santa Clara,0007224,President,,AI,Rocky de la Fuente Guerra,3,1,2
+Santa Clara,0007231,President,,AI,Rocky de la Fuente Guerra,3,1,2
+Santa Clara,0007235,President,,AI,Rocky de la Fuente Guerra,5,0,5
+Santa Clara,0007237,President,,AI,Rocky de la Fuente Guerra,6,0,6
+Santa Clara,0007245,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0007246,President,,AI,Rocky de la Fuente Guerra,4,0,4
+Santa Clara,0007248,President,,AI,Rocky de la Fuente Guerra,13,1,12
+Santa Clara,0007252,President,,AI,Rocky de la Fuente Guerra,6,1,5
+Santa Clara,0007255,President,,AI,Rocky de la Fuente Guerra,5,0,5
+Santa Clara,0007257,President,,AI,Rocky de la Fuente Guerra,3,0,3
+Santa Clara,0007261,President,,AI,Rocky de la Fuente Guerra,8,1,7
+Santa Clara,0007264,President,,AI,Rocky de la Fuente Guerra,8,1,7
+Santa Clara,0007271,President,,AI,Rocky de la Fuente Guerra,8,0,8
+Santa Clara,0007273,President,,AI,Rocky de la Fuente Guerra,21,2,19
+Santa Clara,0007282,President,,AI,Rocky de la Fuente Guerra,13,1,12
+Santa Clara,0007294,President,,AI,Rocky de la Fuente Guerra,2,0,2
+Santa Clara,0007295,President,,AI,Rocky de la Fuente Guerra,7,0,7
+Santa Clara,0007298,President,,AI,Rocky de la Fuente Guerra,3,1,2
+Santa Clara,0007299,President,,AI,Rocky de la Fuente Guerra,1,0,1
+Santa Clara,0007306,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0007401,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0007402,President,,AI,Rocky de la Fuente Guerra,2,0,2
+Santa Clara,0007403,President,,AI,Rocky de la Fuente Guerra,3,1,2
+Santa Clara,0007408,President,,AI,Rocky de la Fuente Guerra,2,0,2
+Santa Clara,0007409,President,,AI,Rocky de la Fuente Guerra,2,0,2
+Santa Clara,0007410,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0007411,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0007414,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0007415,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0007416,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0007417,President,,AI,Rocky de la Fuente Guerra,10,2,8
+Santa Clara,0007418,President,,AI,Rocky de la Fuente Guerra,5,1,4
+Santa Clara,0007419,President,,AI,Rocky de la Fuente Guerra,1,0,1
+Santa Clara,0007430,President,,AI,Rocky de la Fuente Guerra,11,5,6
+Santa Clara,0007435,President,,AI,Rocky de la Fuente Guerra,7,0,7
+Santa Clara,0007436,President,,AI,Rocky de la Fuente Guerra,18,1,17
+Santa Clara,0007438,President,,AI,Rocky de la Fuente Guerra,1,0,1
+Santa Clara,0007440,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0007441,President,,AI,Rocky de la Fuente Guerra,5,0,5
+Santa Clara,0007442,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0007447,President,,AI,Rocky de la Fuente Guerra,5,0,5
+Santa Clara,0007458,President,,AI,Rocky de la Fuente Guerra,12,0,12
+Santa Clara,0007459,President,,AI,Rocky de la Fuente Guerra,9,3,6
+Santa Clara,0007470,President,,AI,Rocky de la Fuente Guerra,12,1,11
+Santa Clara,0007471,President,,AI,Rocky de la Fuente Guerra,11,3,8
+Santa Clara,0007479,President,,AI,Rocky de la Fuente Guerra,2,0,2
+Santa Clara,0007483,President,,AI,Rocky de la Fuente Guerra,10,3,7
+Santa Clara,0007601,President,,AI,Rocky de la Fuente Guerra,12,0,12
+Santa Clara,0007606,President,,AI,Rocky de la Fuente Guerra,15,1,14
+Santa Clara,0007609,President,,AI,Rocky de la Fuente Guerra,2,0,2
+Santa Clara,0007615,President,,AI,Rocky de la Fuente Guerra,1,0,1
+Santa Clara,0007619,President,,AI,Rocky de la Fuente Guerra,8,1,7
+Santa Clara,0007620,President,,AI,Rocky de la Fuente Guerra,8,2,6
+Santa Clara,0007621,President,,AI,Rocky de la Fuente Guerra,7,3,4
+Santa Clara,0007624,President,,AI,Rocky de la Fuente Guerra,8,0,8
+Santa Clara,0007632,President,,AI,Rocky de la Fuente Guerra,10,0,10
+Santa Clara,0007634,President,,AI,Rocky de la Fuente Guerra,1,0,1
+Santa Clara,0007648,President,,AI,Rocky de la Fuente Guerra,9,2,7
+Santa Clara,0007654,President,,AI,Rocky de la Fuente Guerra,14,1,13
+Santa Clara,0007660,President,,AI,Rocky de la Fuente Guerra,6,1,5
+Santa Clara,0007666,President,,AI,Rocky de la Fuente Guerra,10,1,9
+Santa Clara,0007670,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0007673,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0007674,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0007677,President,,AI,Rocky de la Fuente Guerra,9,0,9
+Santa Clara,0007680,President,,AI,Rocky de la Fuente Guerra,6,0,6
+Santa Clara,0007689,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0007690,President,,AI,Rocky de la Fuente Guerra,6,0,6
+Santa Clara,0007801,President,,AI,Rocky de la Fuente Guerra,4,0,4
+Santa Clara,0007802,President,,AI,Rocky de la Fuente Guerra,1,0,1
+Santa Clara,0007803,President,,AI,Rocky de la Fuente Guerra,2,0,2
+Santa Clara,0007805,President,,AI,Rocky de la Fuente Guerra,1,0,1
+Santa Clara,0007810,President,,AI,Rocky de la Fuente Guerra,1,0,1
+Santa Clara,0007811,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0007812,President,,AI,Rocky de la Fuente Guerra,6,1,5
+Santa Clara,0007816,President,,AI,Rocky de la Fuente Guerra,1,0,1
+Santa Clara,0007817,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0007818,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0007821,President,,AI,Rocky de la Fuente Guerra,10,0,10
+Santa Clara,0007826,President,,AI,Rocky de la Fuente Guerra,9,1,8
+Santa Clara,0007827,President,,AI,Rocky de la Fuente Guerra,4,0,4
+Santa Clara,0007832,President,,AI,Rocky de la Fuente Guerra,7,1,6
+Santa Clara,0007833,President,,AI,Rocky de la Fuente Guerra,6,0,6
+Santa Clara,0007843,President,,AI,Rocky de la Fuente Guerra,9,0,9
+Santa Clara,0007849,President,,AI,Rocky de la Fuente Guerra,18,1,17
+Santa Clara,0007850,President,,AI,Rocky de la Fuente Guerra,4,1,3
+Santa Clara,0007851,President,,AI,Rocky de la Fuente Guerra,4,0,4
+Santa Clara,0007861,President,,AI,Rocky de la Fuente Guerra,3,1,2
+Santa Clara,0007867,President,,AI,Rocky de la Fuente Guerra,6,0,6
+Santa Clara,0007874,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0007880,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0008001,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0008002,President,,AI,Rocky de la Fuente Guerra,1,0,1
+Santa Clara,0008003,President,,AI,Rocky de la Fuente Guerra,20,2,18
+Santa Clara,0008005,President,,AI,Rocky de la Fuente Guerra,16,0,16
+Santa Clara,0008007,President,,AI,Rocky de la Fuente Guerra,3,0,3
+Santa Clara,0008011,President,,AI,Rocky de la Fuente Guerra,1,0,1
+Santa Clara,0008012,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0008013,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0008016,President,,AI,Rocky de la Fuente Guerra,8,0,8
+Santa Clara,0008017,President,,AI,Rocky de la Fuente Guerra,5,0,5
+Santa Clara,0008022,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0008023,President,,AI,Rocky de la Fuente Guerra,1,0,1
+Santa Clara,0008026,President,,AI,Rocky de la Fuente Guerra,5,0,5
+Santa Clara,0008028,President,,AI,Rocky de la Fuente Guerra,2,0,2
+Santa Clara,0008029,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0008030,President,,AI,Rocky de la Fuente Guerra,4,0,4
+Santa Clara,0008033,President,,AI,Rocky de la Fuente Guerra,3,0,3
+Santa Clara,0008034,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0008038,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0008040,President,,AI,Rocky de la Fuente Guerra,3,1,2
+Santa Clara,0008047,President,,AI,Rocky de la Fuente Guerra,6,0,6
+Santa Clara,0008049,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0008050,President,,AI,Rocky de la Fuente Guerra,7,0,7
+Santa Clara,0008053,President,,AI,Rocky de la Fuente Guerra,18,2,16
+Santa Clara,0008054,President,,AI,Rocky de la Fuente Guerra,2,0,2
+Santa Clara,0008055,President,,AI,Rocky de la Fuente Guerra,2,0,2
+Santa Clara,0008062,President,,AI,Rocky de la Fuente Guerra,8,2,6
+Santa Clara,0008066,President,,AI,Rocky de la Fuente Guerra,2,0,2
+Santa Clara,0008067,President,,AI,Rocky de la Fuente Guerra,7,2,5
+Santa Clara,0008068,President,,AI,Rocky de la Fuente Guerra,1,0,1
+Santa Clara,0008072,President,,AI,Rocky de la Fuente Guerra,2,0,2
+Santa Clara,0008073,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0008079,President,,AI,Rocky de la Fuente Guerra,14,0,14
+Santa Clara,0008082,President,,AI,Rocky de la Fuente Guerra,6,2,4
+Santa Clara,0008085,President,,AI,Rocky de la Fuente Guerra,6,0,6
+Santa Clara,0008089,President,,AI,Rocky de la Fuente Guerra,9,2,7
+Santa Clara,0008092,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0008093,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0008096,President,,AI,Rocky de la Fuente Guerra,8,0,8
+Santa Clara,0008101,President,,AI,Rocky de la Fuente Guerra,5,0,5
+Santa Clara,0008104,President,,AI,Rocky de la Fuente Guerra,2,0,2
+Santa Clara,0008105,President,,AI,Rocky de la Fuente Guerra,3,0,3
+Santa Clara,0008117,President,,AI,Rocky de la Fuente Guerra,5,1,4
+Santa Clara,0008122,President,,AI,Rocky de la Fuente Guerra,6,0,6
+Santa Clara,0008128,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0008133,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0008201,President,,AI,Rocky de la Fuente Guerra,3,1,2
+Santa Clara,0008203,President,,AI,Rocky de la Fuente Guerra,10,0,10
+Santa Clara,0008205,President,,AI,Rocky de la Fuente Guerra,6,3,3
+Santa Clara,0008208,President,,AI,Rocky de la Fuente Guerra,8,0,8
+Santa Clara,0008212,President,,AI,Rocky de la Fuente Guerra,3,0,3
+Santa Clara,0008214,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0008227,President,,AI,Rocky de la Fuente Guerra,11,1,10
+Santa Clara,0008228,President,,AI,Rocky de la Fuente Guerra,2,0,2
+Santa Clara,0008230,President,,AI,Rocky de la Fuente Guerra,10,0,10
+Santa Clara,0008231,President,,AI,Rocky de la Fuente Guerra,5,0,5
+Santa Clara,0008232,President,,AI,Rocky de la Fuente Guerra,6,0,6
+Santa Clara,0008236,President,,AI,Rocky de la Fuente Guerra,14,1,13
+Santa Clara,0008246,President,,AI,Rocky de la Fuente Guerra,5,2,3
+Santa Clara,0008254,President,,AI,Rocky de la Fuente Guerra,9,1,8
+Santa Clara,0008262,President,,AI,Rocky de la Fuente Guerra,7,0,7
+Santa Clara,0008264,President,,AI,Rocky de la Fuente Guerra,4,2,2
+Santa Clara,0008401,President,,AI,Rocky de la Fuente Guerra,2,1,1
+Santa Clara,0008404,President,,AI,Rocky de la Fuente Guerra,12,2,10
+Santa Clara,0008408,President,,AI,Rocky de la Fuente Guerra,4,1,3
+Santa Clara,0008409,President,,AI,Rocky de la Fuente Guerra,5,2,3
+Santa Clara,0008414,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0008418,President,,AI,Rocky de la Fuente Guerra,1,0,1
+Santa Clara,0008421,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0008423,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0008430,President,,AI,Rocky de la Fuente Guerra,6,0,6
+Santa Clara,0008435,President,,AI,Rocky de la Fuente Guerra,11,1,10
+Santa Clara,0008438,President,,AI,Rocky de la Fuente Guerra,9,1,8
+Santa Clara,0008439,President,,AI,Rocky de la Fuente Guerra,8,1,7
+Santa Clara,0008445,President,,AI,Rocky de la Fuente Guerra,4,0,4
+Santa Clara,0008447,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0008456,President,,AI,Rocky de la Fuente Guerra,8,1,7
+Santa Clara,0008457,President,,AI,Rocky de la Fuente Guerra,14,1,13
+Santa Clara,0008464,President,,AI,Rocky de la Fuente Guerra,10,0,10
+Santa Clara,0008470,President,,AI,Rocky de la Fuente Guerra,6,0,6
+Santa Clara,0008472,President,,AI,Rocky de la Fuente Guerra,8,0,8
+Santa Clara,0008486,President,,AI,Rocky de la Fuente Guerra,6,0,6
+Santa Clara,0008492,President,,AI,Rocky de la Fuente Guerra,12,0,12
+Santa Clara,0008502,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0008601,President,,AI,Rocky de la Fuente Guerra,1,0,1
+Santa Clara,0008603,President,,AI,Rocky de la Fuente Guerra,5,0,5
+Santa Clara,0008605,President,,AI,Rocky de la Fuente Guerra,11,0,11
+Santa Clara,0008609,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0008610,President,,AI,Rocky de la Fuente Guerra,12,1,11
+Santa Clara,0008612,President,,AI,Rocky de la Fuente Guerra,4,0,4
+Santa Clara,0008615,President,,AI,Rocky de la Fuente Guerra,5,1,4
+Santa Clara,0008619,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0008625,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0008627,President,,AI,Rocky de la Fuente Guerra,1,0,1
+Santa Clara,0008629,President,,AI,Rocky de la Fuente Guerra,7,1,6
+Santa Clara,0008630,President,,AI,Rocky de la Fuente Guerra,10,3,7
+Santa Clara,0008631,President,,AI,Rocky de la Fuente Guerra,6,0,6
+Santa Clara,0008634,President,,AI,Rocky de la Fuente Guerra,1,0,1
+Santa Clara,0008636,President,,AI,Rocky de la Fuente Guerra,2,0,2
+Santa Clara,0008645,President,,AI,Rocky de la Fuente Guerra,9,0,9
+Santa Clara,0008648,President,,AI,Rocky de la Fuente Guerra,14,2,12
+Santa Clara,0008650,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0008653,President,,AI,Rocky de la Fuente Guerra,2,0,2
+Santa Clara,0008654,President,,AI,Rocky de la Fuente Guerra,1,1,0
+Santa Clara,0008655,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0008657,President,,AI,Rocky de la Fuente Guerra,3,1,2
+Santa Clara,0008658,President,,AI,Rocky de la Fuente Guerra,15,1,14
+Santa Clara,0008670,President,,AI,Rocky de la Fuente Guerra,10,1,9
+Santa Clara,0008675,President,,AI,Rocky de la Fuente Guerra,5,0,5
+Santa Clara,0008676,President,,AI,Rocky de la Fuente Guerra,11,1,10
+Santa Clara,0008680,President,,AI,Rocky de la Fuente Guerra,10,0,10
+Santa Clara,0008683,President,,AI,Rocky de la Fuente Guerra,18,5,13
+Santa Clara,0008687,President,,AI,Rocky de la Fuente Guerra,10,0,10
+Santa Clara,0008697,President,,AI,Rocky de la Fuente Guerra,14,2,12
+Santa Clara,0008801,President,,AI,Rocky de la Fuente Guerra,5,1,4
+Santa Clara,0008805,President,,AI,Rocky de la Fuente Guerra,10,2,8
+Santa Clara,0008809,President,,AI,Rocky de la Fuente Guerra,6,1,5
+Santa Clara,0008812,President,,AI,Rocky de la Fuente Guerra,7,0,7
+Santa Clara,0008817,President,,AI,Rocky de la Fuente Guerra,3,1,2
+Santa Clara,0008820,President,,AI,Rocky de la Fuente Guerra,4,1,3
+Santa Clara,0008822,President,,AI,Rocky de la Fuente Guerra,5,1,4
+Santa Clara,0008828,President,,AI,Rocky de la Fuente Guerra,3,0,3
+Santa Clara,0008829,President,,AI,Rocky de la Fuente Guerra,1,0,1
+Santa Clara,0008832,President,,AI,Rocky de la Fuente Guerra,9,0,9
+Santa Clara,0008834,President,,AI,Rocky de la Fuente Guerra,5,0,5
+Santa Clara,0008838,President,,AI,Rocky de la Fuente Guerra,1,0,1
+Santa Clara,0008839,President,,AI,Rocky de la Fuente Guerra,7,0,7
+Santa Clara,0008844,President,,AI,Rocky de la Fuente Guerra,5,2,3
+Santa Clara,0008848,President,,AI,Rocky de la Fuente Guerra,1,1,0
+Santa Clara,0008853,President,,AI,Rocky de la Fuente Guerra,4,0,4
+Santa Clara,0008857,President,,AI,Rocky de la Fuente Guerra,6,1,5
+Santa Clara,0008858,President,,AI,Rocky de la Fuente Guerra,7,0,7
+Santa Clara,0008862,President,,AI,Rocky de la Fuente Guerra,7,0,7
+Santa Clara,0008868,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0008873,President,,AI,Rocky de la Fuente Guerra,4,1,3
+Santa Clara,0008874,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0008879,President,,AI,Rocky de la Fuente Guerra,9,2,7
+Santa Clara,0008883,President,,AI,Rocky de la Fuente Guerra,8,0,8
+Santa Clara,0008885,President,,AI,Rocky de la Fuente Guerra,7,1,6
+Santa Clara,0008886,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0008889,President,,AI,Rocky de la Fuente Guerra,2,0,2
+Santa Clara,0008898,President,,AI,Rocky de la Fuente Guerra,5,0,5
+Santa Clara,0008903,President,,AI,Rocky de la Fuente Guerra,5,0,5
+Santa Clara,0008915,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0008916,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0008920,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0008923,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0008924,President,,AI,Rocky de la Fuente Guerra,1,0,1
+Santa Clara,0009001,President,,AI,Rocky de la Fuente Guerra,6,0,6
+Santa Clara,0009005,President,,AI,Rocky de la Fuente Guerra,6,0,6
+Santa Clara,0009051,President,,AI,Rocky de la Fuente Guerra,7,2,5
+Santa Clara,0009055,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0009056,President,,AI,Rocky de la Fuente Guerra,3,0,3
+Santa Clara,0009059,President,,AI,Rocky de la Fuente Guerra,6,1,5
+Santa Clara,0009061,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0009062,President,,AI,Rocky de la Fuente Guerra,6,1,5
+Santa Clara,0009101,President,,AI,Rocky de la Fuente Guerra,4,0,4
+Santa Clara,0009103,President,,AI,Rocky de la Fuente Guerra,2,0,2
+Santa Clara,0009104,President,,AI,Rocky de la Fuente Guerra,13,0,13
+Santa Clara,0009109,President,,AI,Rocky de la Fuente Guerra,2,0,2
+Santa Clara,0009151,President,,AI,Rocky de la Fuente Guerra,7,1,6
+Santa Clara,0009157,President,,AI,Rocky de la Fuente Guerra,18,1,17
+Santa Clara,0009163,President,,AI,Rocky de la Fuente Guerra,1,0,1
+Santa Clara,0009166,President,,AI,Rocky de la Fuente Guerra,2,0,2
+Santa Clara,0009201,President,,AI,Rocky de la Fuente Guerra,4,1,3
+Santa Clara,0009203,President,,AI,Rocky de la Fuente Guerra,6,0,6
+Santa Clara,0009208,President,,AI,Rocky de la Fuente Guerra,4,0,4
+Santa Clara,0009210,President,,AI,Rocky de la Fuente Guerra,1,0,1
+Santa Clara,0009219,President,,AI,Rocky de la Fuente Guerra,1,0,1
+Santa Clara,0009220,President,,AI,Rocky de la Fuente Guerra,9,0,9
+Santa Clara,0009251,President,,AI,Rocky de la Fuente Guerra,6,0,6
+Santa Clara,0009252,President,,AI,Rocky de la Fuente Guerra,3,0,3
+Santa Clara,0009258,President,,AI,Rocky de la Fuente Guerra,7,1,6
+Santa Clara,0009262,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0009264,President,,AI,Rocky de la Fuente Guerra,2,0,2
+Santa Clara,0009268,President,,AI,Rocky de la Fuente Guerra,7,1,6
+Santa Clara,0009275,President,,AI,Rocky de la Fuente Guerra,5,0,5
+Santa Clara,0009282,President,,AI,Rocky de la Fuente Guerra,0,0,0
+Santa Clara,0002001,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0002002,President,,PF,Gloria LaRiva,8,1,7
+Santa Clara,0002005,President,,PF,Gloria LaRiva,3,0,3
+Santa Clara,0002006,President,,PF,Gloria LaRiva,1,0,1
+Santa Clara,0002009,President,,PF,Gloria LaRiva,14,0,14
+Santa Clara,0002013,President,,PF,Gloria LaRiva,2,0,2
+Santa Clara,0002014,President,,PF,Gloria LaRiva,6,1,5
+Santa Clara,0002018,President,,PF,Gloria LaRiva,1,0,1
+Santa Clara,0002025,President,,PF,Gloria LaRiva,3,0,3
+Santa Clara,0002043,President,,PF,Gloria LaRiva,1,0,1
+Santa Clara,0002046,President,,PF,Gloria LaRiva,6,0,6
+Santa Clara,0002057,President,,PF,Gloria LaRiva,5,0,5
+Santa Clara,0002068,President,,PF,Gloria LaRiva,5,0,5
+Santa Clara,0002098,President,,PF,Gloria LaRiva,5,0,5
+Santa Clara,0002108,President,,PF,Gloria LaRiva,3,1,2
+Santa Clara,0002125,President,,PF,Gloria LaRiva,2,0,2
+Santa Clara,0002274,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0002275,President,,PF,Gloria LaRiva,1,0,1
+Santa Clara,0002278,President,,PF,Gloria LaRiva,3,0,3
+Santa Clara,0002281,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0002282,President,,PF,Gloria LaRiva,2,0,2
+Santa Clara,0002285,President,,PF,Gloria LaRiva,3,0,3
+Santa Clara,0002301,President,,PF,Gloria LaRiva,3,0,3
+Santa Clara,0002305,President,,PF,Gloria LaRiva,4,0,4
+Santa Clara,0002309,President,,PF,Gloria LaRiva,1,0,1
+Santa Clara,0002314,President,,PF,Gloria LaRiva,5,0,5
+Santa Clara,0002317,President,,PF,Gloria LaRiva,1,0,1
+Santa Clara,0002330,President,,PF,Gloria LaRiva,4,0,4
+Santa Clara,0002338,President,,PF,Gloria LaRiva,1,0,1
+Santa Clara,0002351,President,,PF,Gloria LaRiva,2,0,2
+Santa Clara,0002353,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0002539,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0002542,President,,PF,Gloria LaRiva,6,2,4
+Santa Clara,0002545,President,,PF,Gloria LaRiva,7,1,6
+Santa Clara,0002720,President,,PF,Gloria LaRiva,2,0,2
+Santa Clara,0002721,President,,PF,Gloria LaRiva,2,0,2
+Santa Clara,0002723,President,,PF,Gloria LaRiva,3,0,3
+Santa Clara,0002724,President,,PF,Gloria LaRiva,5,0,5
+Santa Clara,0002725,President,,PF,Gloria LaRiva,2,0,2
+Santa Clara,0002726,President,,PF,Gloria LaRiva,1,0,1
+Santa Clara,0002727,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0002729,President,,PF,Gloria LaRiva,2,2,0
+Santa Clara,0002734,President,,PF,Gloria LaRiva,3,0,3
+Santa Clara,0002740,President,,PF,Gloria LaRiva,7,0,7
+Santa Clara,0002751,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0002761,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0002802,President,,PF,Gloria LaRiva,5,0,5
+Santa Clara,0002808,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0002810,President,,PF,Gloria LaRiva,1,0,1
+Santa Clara,0002811,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0002812,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0002813,President,,PF,Gloria LaRiva,1,0,1
+Santa Clara,0002816,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0002825,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0002870,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0002951,President,,PF,Gloria LaRiva,2,1,1
+Santa Clara,0003001,President,,PF,Gloria LaRiva,9,1,8
+Santa Clara,0003002,President,,PF,Gloria LaRiva,11,1,10
+Santa Clara,0003005,President,,PF,Gloria LaRiva,1,0,1
+Santa Clara,0003008,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0003010,President,,PF,Gloria LaRiva,7,0,7
+Santa Clara,0003011,President,,PF,Gloria LaRiva,6,1,5
+Santa Clara,0003012,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0003013,President,,PF,Gloria LaRiva,9,0,9
+Santa Clara,0003016,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0003017,President,,PF,Gloria LaRiva,2,1,1
+Santa Clara,0003018,President,,PF,Gloria LaRiva,1,0,1
+Santa Clara,0003019,President,,PF,Gloria LaRiva,7,0,7
+Santa Clara,0003021,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0003023,President,,PF,Gloria LaRiva,9,0,9
+Santa Clara,0003026,President,,PF,Gloria LaRiva,5,0,5
+Santa Clara,0003029,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0003031,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0003032,President,,PF,Gloria LaRiva,2,0,2
+Santa Clara,0003034,President,,PF,Gloria LaRiva,11,2,9
+Santa Clara,0003035,President,,PF,Gloria LaRiva,4,0,4
+Santa Clara,0003039,President,,PF,Gloria LaRiva,1,1,0
+Santa Clara,0003040,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0003042,President,,PF,Gloria LaRiva,5,0,5
+Santa Clara,0003043,President,,PF,Gloria LaRiva,2,1,1
+Santa Clara,0003045,President,,PF,Gloria LaRiva,4,0,4
+Santa Clara,0003047,President,,PF,Gloria LaRiva,3,0,3
+Santa Clara,0003048,President,,PF,Gloria LaRiva,11,0,11
+Santa Clara,0003051,President,,PF,Gloria LaRiva,6,0,6
+Santa Clara,0003053,President,,PF,Gloria LaRiva,5,0,5
+Santa Clara,0003061,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0003079,President,,PF,Gloria LaRiva,3,0,3
+Santa Clara,0003080,President,,PF,Gloria LaRiva,1,1,0
+Santa Clara,0003086,President,,PF,Gloria LaRiva,3,0,3
+Santa Clara,0003087,President,,PF,Gloria LaRiva,2,1,1
+Santa Clara,0003089,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0003095,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0003101,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0003102,President,,PF,Gloria LaRiva,1,0,1
+Santa Clara,0003103,President,,PF,Gloria LaRiva,3,0,3
+Santa Clara,0003116,President,,PF,Gloria LaRiva,1,0,1
+Santa Clara,0003117,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0003120,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0003122,President,,PF,Gloria LaRiva,9,1,8
+Santa Clara,0003156,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0003402,President,,PF,Gloria LaRiva,8,0,8
+Santa Clara,0003406,President,,PF,Gloria LaRiva,3,0,3
+Santa Clara,0003407,President,,PF,Gloria LaRiva,1,0,1
+Santa Clara,0003408,President,,PF,Gloria LaRiva,5,0,5
+Santa Clara,0003409,President,,PF,Gloria LaRiva,6,2,4
+Santa Clara,0003410,President,,PF,Gloria LaRiva,8,0,8
+Santa Clara,0003417,President,,PF,Gloria LaRiva,9,1,8
+Santa Clara,0003427,President,,PF,Gloria LaRiva,7,0,7
+Santa Clara,0003434,President,,PF,Gloria LaRiva,3,0,3
+Santa Clara,0003438,President,,PF,Gloria LaRiva,3,0,3
+Santa Clara,0003445,President,,PF,Gloria LaRiva,13,2,11
+Santa Clara,0003601,President,,PF,Gloria LaRiva,4,0,4
+Santa Clara,0003602,President,,PF,Gloria LaRiva,7,0,7
+Santa Clara,0003603,President,,PF,Gloria LaRiva,1,0,1
+Santa Clara,0003604,President,,PF,Gloria LaRiva,8,0,8
+Santa Clara,0003605,President,,PF,Gloria LaRiva,10,0,10
+Santa Clara,0003606,President,,PF,Gloria LaRiva,4,0,4
+Santa Clara,0003608,President,,PF,Gloria LaRiva,10,1,9
+Santa Clara,0003609,President,,PF,Gloria LaRiva,11,0,11
+Santa Clara,0003611,President,,PF,Gloria LaRiva,11,0,11
+Santa Clara,0003614,President,,PF,Gloria LaRiva,7,0,7
+Santa Clara,0003624,President,,PF,Gloria LaRiva,9,0,9
+Santa Clara,0003635,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0003652,President,,PF,Gloria LaRiva,2,0,2
+Santa Clara,0003655,President,,PF,Gloria LaRiva,1,0,1
+Santa Clara,0003669,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0003670,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0003777,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0003779,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0003782,President,,PF,Gloria LaRiva,1,0,1
+Santa Clara,0003783,President,,PF,Gloria LaRiva,1,0,1
+Santa Clara,0003801,President,,PF,Gloria LaRiva,3,1,2
+Santa Clara,0003802,President,,PF,Gloria LaRiva,6,1,5
+Santa Clara,0003803,President,,PF,Gloria LaRiva,5,1,4
+Santa Clara,0003804,President,,PF,Gloria LaRiva,3,0,3
+Santa Clara,0003810,President,,PF,Gloria LaRiva,5,1,4
+Santa Clara,0003811,President,,PF,Gloria LaRiva,2,0,2
+Santa Clara,0003814,President,,PF,Gloria LaRiva,4,0,4
+Santa Clara,0003820,President,,PF,Gloria LaRiva,4,0,4
+Santa Clara,0003821,President,,PF,Gloria LaRiva,4,0,4
+Santa Clara,0003825,President,,PF,Gloria LaRiva,2,0,2
+Santa Clara,0003828,President,,PF,Gloria LaRiva,2,1,1
+Santa Clara,0003835,President,,PF,Gloria LaRiva,2,0,2
+Santa Clara,0003840,President,,PF,Gloria LaRiva,6,0,6
+Santa Clara,0003846,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0003861,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0004401,President,,PF,Gloria LaRiva,6,0,6
+Santa Clara,0004402,President,,PF,Gloria LaRiva,8,1,7
+Santa Clara,0004403,President,,PF,Gloria LaRiva,1,0,1
+Santa Clara,0004405,President,,PF,Gloria LaRiva,5,1,4
+Santa Clara,0004407,President,,PF,Gloria LaRiva,11,1,10
+Santa Clara,0004409,President,,PF,Gloria LaRiva,9,1,8
+Santa Clara,0004411,President,,PF,Gloria LaRiva,5,0,5
+Santa Clara,0004412,President,,PF,Gloria LaRiva,10,0,10
+Santa Clara,0004414,President,,PF,Gloria LaRiva,12,1,11
+Santa Clara,0004417,President,,PF,Gloria LaRiva,9,0,9
+Santa Clara,0004665,President,,PF,Gloria LaRiva,1,1,0
+Santa Clara,0004666,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0004671,President,,PF,Gloria LaRiva,4,0,4
+Santa Clara,0004672,President,,PF,Gloria LaRiva,2,0,2
+Santa Clara,0004674,President,,PF,Gloria LaRiva,2,0,2
+Santa Clara,0004675,President,,PF,Gloria LaRiva,7,0,7
+Santa Clara,0004685,President,,PF,Gloria LaRiva,3,0,3
+Santa Clara,0004687,President,,PF,Gloria LaRiva,3,1,2
+Santa Clara,0004688,President,,PF,Gloria LaRiva,9,1,8
+Santa Clara,0004691,President,,PF,Gloria LaRiva,2,0,2
+Santa Clara,0004696,President,,PF,Gloria LaRiva,5,0,5
+Santa Clara,0004698,President,,PF,Gloria LaRiva,2,0,2
+Santa Clara,0004699,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0004702,President,,PF,Gloria LaRiva,1,0,1
+Santa Clara,0004715,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0004733,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0004801,President,,PF,Gloria LaRiva,5,0,5
+Santa Clara,0004806,President,,PF,Gloria LaRiva,5,0,5
+Santa Clara,0004811,President,,PF,Gloria LaRiva,2,1,1
+Santa Clara,0004826,President,,PF,Gloria LaRiva,3,1,2
+Santa Clara,0004827,President,,PF,Gloria LaRiva,9,1,8
+Santa Clara,0004833,President,,PF,Gloria LaRiva,3,2,1
+Santa Clara,0004851,President,,PF,Gloria LaRiva,3,0,3
+Santa Clara,0004853,President,,PF,Gloria LaRiva,4,0,4
+Santa Clara,0004858,President,,PF,Gloria LaRiva,7,1,6
+Santa Clara,0004876,President,,PF,Gloria LaRiva,7,0,7
+Santa Clara,0004881,President,,PF,Gloria LaRiva,6,2,4
+Santa Clara,0004941,President,,PF,Gloria LaRiva,7,2,5
+Santa Clara,0004942,President,,PF,Gloria LaRiva,4,2,2
+Santa Clara,0004943,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0004944,President,,PF,Gloria LaRiva,6,0,6
+Santa Clara,0004945,President,,PF,Gloria LaRiva,4,0,4
+Santa Clara,0004946,President,,PF,Gloria LaRiva,12,1,11
+Santa Clara,0004949,President,,PF,Gloria LaRiva,4,0,4
+Santa Clara,0004950,President,,PF,Gloria LaRiva,5,0,5
+Santa Clara,0004954,President,,PF,Gloria LaRiva,7,1,6
+Santa Clara,0004956,President,,PF,Gloria LaRiva,2,0,2
+Santa Clara,0004958,President,,PF,Gloria LaRiva,14,1,13
+Santa Clara,0004965,President,,PF,Gloria LaRiva,7,0,7
+Santa Clara,0004969,President,,PF,Gloria LaRiva,4,0,4
+Santa Clara,0004971,President,,PF,Gloria LaRiva,2,0,2
+Santa Clara,0004973,President,,PF,Gloria LaRiva,6,1,5
+Santa Clara,0004974,President,,PF,Gloria LaRiva,3,1,2
+Santa Clara,0005449,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0005451,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0005454,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0005455,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0005456,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0005458,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0005502,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0005503,President,,PF,Gloria LaRiva,1,0,1
+Santa Clara,0005505,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0005507,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0005556,President,,PF,Gloria LaRiva,11,3,8
+Santa Clara,0005557,President,,PF,Gloria LaRiva,1,1,0
+Santa Clara,0005567,President,,PF,Gloria LaRiva,3,0,3
+Santa Clara,0005742,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0005743,President,,PF,Gloria LaRiva,1,0,1
+Santa Clara,0005745,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0005747,President,,PF,Gloria LaRiva,1,0,1
+Santa Clara,0005748,President,,PF,Gloria LaRiva,2,0,2
+Santa Clara,0005756,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0005758,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0005759,President,,PF,Gloria LaRiva,1,0,1
+Santa Clara,0005762,President,,PF,Gloria LaRiva,2,0,2
+Santa Clara,0005763,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0005770,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0005775,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0005785,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0005793,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0005795,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0005804,President,,PF,Gloria LaRiva,2,0,2
+Santa Clara,0005810,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0005811,President,,PF,Gloria LaRiva,2,0,2
+Santa Clara,0005813,President,,PF,Gloria LaRiva,1,0,1
+Santa Clara,0005814,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0005854,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0005879,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0005886,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0005888,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0005894,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0005896,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0005901,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0005902,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0005903,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0005906,President,,PF,Gloria LaRiva,2,0,2
+Santa Clara,0005907,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0005911,President,,PF,Gloria LaRiva,5,1,4
+Santa Clara,0005912,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0005914,President,,PF,Gloria LaRiva,2,0,2
+Santa Clara,0005915,President,,PF,Gloria LaRiva,1,1,0
+Santa Clara,0005916,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0005917,President,,PF,Gloria LaRiva,1,0,1
+Santa Clara,0005919,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0005922,President,,PF,Gloria LaRiva,1,0,1
+Santa Clara,0005925,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0005927,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0005929,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0005931,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0005936,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0005940,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0005947,President,,PF,Gloria LaRiva,1,0,1
+Santa Clara,0005949,President,,PF,Gloria LaRiva,2,0,2
+Santa Clara,0005950,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0005951,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0005955,President,,PF,Gloria LaRiva,1,0,1
+Santa Clara,0005956,President,,PF,Gloria LaRiva,1,0,1
+Santa Clara,0005957,President,,PF,Gloria LaRiva,1,0,1
+Santa Clara,0005958,President,,PF,Gloria LaRiva,2,0,2
+Santa Clara,0005959,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0005965,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0005966,President,,PF,Gloria LaRiva,2,0,2
+Santa Clara,0005975,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0005988,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0006023,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0006028,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0006031,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0006035,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0006036,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0006048,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0006401,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0006402,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0006404,President,,PF,Gloria LaRiva,5,2,3
+Santa Clara,0006405,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0006410,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0006413,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0006418,President,,PF,Gloria LaRiva,1,0,1
+Santa Clara,0006419,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0006423,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0006452,President,,PF,Gloria LaRiva,4,1,3
+Santa Clara,0006454,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0006455,President,,PF,Gloria LaRiva,3,0,3
+Santa Clara,0006491,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0006502,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0006509,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0006510,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0006511,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0006515,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0006624,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0006625,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0006669,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0006678,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0007001,President,,PF,Gloria LaRiva,5,1,4
+Santa Clara,0007005,President,,PF,Gloria LaRiva,3,0,3
+Santa Clara,0007011,President,,PF,Gloria LaRiva,4,0,4
+Santa Clara,0007012,President,,PF,Gloria LaRiva,3,0,3
+Santa Clara,0007014,President,,PF,Gloria LaRiva,1,0,1
+Santa Clara,0007019,President,,PF,Gloria LaRiva,4,0,4
+Santa Clara,0007025,President,,PF,Gloria LaRiva,2,0,2
+Santa Clara,0007028,President,,PF,Gloria LaRiva,6,1,5
+Santa Clara,0007032,President,,PF,Gloria LaRiva,8,0,8
+Santa Clara,0007036,President,,PF,Gloria LaRiva,7,0,7
+Santa Clara,0007038,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0007041,President,,PF,Gloria LaRiva,12,6,6
+Santa Clara,0007044,President,,PF,Gloria LaRiva,5,1,4
+Santa Clara,0007046,President,,PF,Gloria LaRiva,7,0,7
+Santa Clara,0007051,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0007059,President,,PF,Gloria LaRiva,1,0,1
+Santa Clara,0007061,President,,PF,Gloria LaRiva,5,0,5
+Santa Clara,0007062,President,,PF,Gloria LaRiva,7,1,6
+Santa Clara,0007079,President,,PF,Gloria LaRiva,1,0,1
+Santa Clara,0007081,President,,PF,Gloria LaRiva,6,0,6
+Santa Clara,0007089,President,,PF,Gloria LaRiva,3,0,3
+Santa Clara,0007201,President,,PF,Gloria LaRiva,1,0,1
+Santa Clara,0007202,President,,PF,Gloria LaRiva,3,0,3
+Santa Clara,0007203,President,,PF,Gloria LaRiva,2,1,1
+Santa Clara,0007205,President,,PF,Gloria LaRiva,5,2,3
+Santa Clara,0007214,President,,PF,Gloria LaRiva,4,0,4
+Santa Clara,0007217,President,,PF,Gloria LaRiva,25,4,21
+Santa Clara,0007219,President,,PF,Gloria LaRiva,1,0,1
+Santa Clara,0007221,President,,PF,Gloria LaRiva,6,0,6
+Santa Clara,0007224,President,,PF,Gloria LaRiva,2,0,2
+Santa Clara,0007231,President,,PF,Gloria LaRiva,3,1,2
+Santa Clara,0007235,President,,PF,Gloria LaRiva,11,2,9
+Santa Clara,0007237,President,,PF,Gloria LaRiva,6,2,4
+Santa Clara,0007245,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0007246,President,,PF,Gloria LaRiva,2,0,2
+Santa Clara,0007248,President,,PF,Gloria LaRiva,2,0,2
+Santa Clara,0007252,President,,PF,Gloria LaRiva,7,1,6
+Santa Clara,0007255,President,,PF,Gloria LaRiva,8,0,8
+Santa Clara,0007257,President,,PF,Gloria LaRiva,3,0,3
+Santa Clara,0007261,President,,PF,Gloria LaRiva,1,0,1
+Santa Clara,0007264,President,,PF,Gloria LaRiva,5,0,5
+Santa Clara,0007271,President,,PF,Gloria LaRiva,5,0,5
+Santa Clara,0007273,President,,PF,Gloria LaRiva,7,2,5
+Santa Clara,0007282,President,,PF,Gloria LaRiva,2,1,1
+Santa Clara,0007294,President,,PF,Gloria LaRiva,1,0,1
+Santa Clara,0007295,President,,PF,Gloria LaRiva,7,0,7
+Santa Clara,0007298,President,,PF,Gloria LaRiva,1,0,1
+Santa Clara,0007299,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0007306,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0007401,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0007402,President,,PF,Gloria LaRiva,3,0,3
+Santa Clara,0007403,President,,PF,Gloria LaRiva,3,0,3
+Santa Clara,0007408,President,,PF,Gloria LaRiva,1,0,1
+Santa Clara,0007409,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0007410,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0007411,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0007414,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0007415,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0007416,President,,PF,Gloria LaRiva,1,1,0
+Santa Clara,0007417,President,,PF,Gloria LaRiva,7,0,7
+Santa Clara,0007418,President,,PF,Gloria LaRiva,11,2,9
+Santa Clara,0007419,President,,PF,Gloria LaRiva,1,0,1
+Santa Clara,0007430,President,,PF,Gloria LaRiva,9,1,8
+Santa Clara,0007435,President,,PF,Gloria LaRiva,24,2,22
+Santa Clara,0007436,President,,PF,Gloria LaRiva,16,4,12
+Santa Clara,0007438,President,,PF,Gloria LaRiva,1,0,1
+Santa Clara,0007440,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0007441,President,,PF,Gloria LaRiva,8,2,6
+Santa Clara,0007442,President,,PF,Gloria LaRiva,1,0,1
+Santa Clara,0007447,President,,PF,Gloria LaRiva,17,4,13
+Santa Clara,0007458,President,,PF,Gloria LaRiva,15,1,14
+Santa Clara,0007459,President,,PF,Gloria LaRiva,12,1,11
+Santa Clara,0007470,President,,PF,Gloria LaRiva,6,2,4
+Santa Clara,0007471,President,,PF,Gloria LaRiva,17,4,13
+Santa Clara,0007479,President,,PF,Gloria LaRiva,4,0,4
+Santa Clara,0007483,President,,PF,Gloria LaRiva,12,4,8
+Santa Clara,0007601,President,,PF,Gloria LaRiva,7,1,6
+Santa Clara,0007606,President,,PF,Gloria LaRiva,5,0,5
+Santa Clara,0007609,President,,PF,Gloria LaRiva,4,0,4
+Santa Clara,0007615,President,,PF,Gloria LaRiva,6,1,5
+Santa Clara,0007619,President,,PF,Gloria LaRiva,7,0,7
+Santa Clara,0007620,President,,PF,Gloria LaRiva,6,0,6
+Santa Clara,0007621,President,,PF,Gloria LaRiva,6,0,6
+Santa Clara,0007624,President,,PF,Gloria LaRiva,6,0,6
+Santa Clara,0007632,President,,PF,Gloria LaRiva,8,0,8
+Santa Clara,0007634,President,,PF,Gloria LaRiva,3,0,3
+Santa Clara,0007648,President,,PF,Gloria LaRiva,10,0,10
+Santa Clara,0007654,President,,PF,Gloria LaRiva,8,0,8
+Santa Clara,0007660,President,,PF,Gloria LaRiva,8,1,7
+Santa Clara,0007666,President,,PF,Gloria LaRiva,8,1,7
+Santa Clara,0007670,President,,PF,Gloria LaRiva,2,0,2
+Santa Clara,0007673,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0007674,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0007677,President,,PF,Gloria LaRiva,15,1,14
+Santa Clara,0007680,President,,PF,Gloria LaRiva,3,1,2
+Santa Clara,0007689,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0007690,President,,PF,Gloria LaRiva,3,0,3
+Santa Clara,0007801,President,,PF,Gloria LaRiva,2,0,2
+Santa Clara,0007802,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0007803,President,,PF,Gloria LaRiva,2,0,2
+Santa Clara,0007805,President,,PF,Gloria LaRiva,4,0,4
+Santa Clara,0007810,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0007811,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0007812,President,,PF,Gloria LaRiva,6,0,6
+Santa Clara,0007816,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0007817,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0007818,President,,PF,Gloria LaRiva,2,0,2
+Santa Clara,0007821,President,,PF,Gloria LaRiva,13,4,9
+Santa Clara,0007826,President,,PF,Gloria LaRiva,6,2,4
+Santa Clara,0007827,President,,PF,Gloria LaRiva,5,0,5
+Santa Clara,0007832,President,,PF,Gloria LaRiva,3,0,3
+Santa Clara,0007833,President,,PF,Gloria LaRiva,16,6,10
+Santa Clara,0007843,President,,PF,Gloria LaRiva,22,0,22
+Santa Clara,0007849,President,,PF,Gloria LaRiva,11,4,7
+Santa Clara,0007850,President,,PF,Gloria LaRiva,13,2,11
+Santa Clara,0007851,President,,PF,Gloria LaRiva,3,0,3
+Santa Clara,0007861,President,,PF,Gloria LaRiva,10,5,5
+Santa Clara,0007867,President,,PF,Gloria LaRiva,18,1,17
+Santa Clara,0007874,President,,PF,Gloria LaRiva,3,0,3
+Santa Clara,0007880,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0008001,President,,PF,Gloria LaRiva,1,0,1
+Santa Clara,0008002,President,,PF,Gloria LaRiva,1,0,1
+Santa Clara,0008003,President,,PF,Gloria LaRiva,6,0,6
+Santa Clara,0008005,President,,PF,Gloria LaRiva,4,0,4
+Santa Clara,0008007,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0008011,President,,PF,Gloria LaRiva,1,0,1
+Santa Clara,0008012,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0008013,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0008016,President,,PF,Gloria LaRiva,12,2,10
+Santa Clara,0008017,President,,PF,Gloria LaRiva,4,0,4
+Santa Clara,0008022,President,,PF,Gloria LaRiva,1,1,0
+Santa Clara,0008023,President,,PF,Gloria LaRiva,7,2,5
+Santa Clara,0008026,President,,PF,Gloria LaRiva,7,2,5
+Santa Clara,0008028,President,,PF,Gloria LaRiva,1,0,1
+Santa Clara,0008029,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0008030,President,,PF,Gloria LaRiva,1,0,1
+Santa Clara,0008033,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0008034,President,,PF,Gloria LaRiva,2,1,1
+Santa Clara,0008038,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0008040,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0008047,President,,PF,Gloria LaRiva,5,0,5
+Santa Clara,0008049,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0008050,President,,PF,Gloria LaRiva,5,0,5
+Santa Clara,0008053,President,,PF,Gloria LaRiva,7,0,7
+Santa Clara,0008054,President,,PF,Gloria LaRiva,2,1,1
+Santa Clara,0008055,President,,PF,Gloria LaRiva,2,0,2
+Santa Clara,0008062,President,,PF,Gloria LaRiva,10,0,10
+Santa Clara,0008066,President,,PF,Gloria LaRiva,5,1,4
+Santa Clara,0008067,President,,PF,Gloria LaRiva,7,0,7
+Santa Clara,0008068,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0008072,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0008073,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0008079,President,,PF,Gloria LaRiva,2,0,2
+Santa Clara,0008082,President,,PF,Gloria LaRiva,4,0,4
+Santa Clara,0008085,President,,PF,Gloria LaRiva,4,1,3
+Santa Clara,0008089,President,,PF,Gloria LaRiva,2,0,2
+Santa Clara,0008092,President,,PF,Gloria LaRiva,1,0,1
+Santa Clara,0008093,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0008096,President,,PF,Gloria LaRiva,7,1,6
+Santa Clara,0008101,President,,PF,Gloria LaRiva,3,1,2
+Santa Clara,0008104,President,,PF,Gloria LaRiva,1,0,1
+Santa Clara,0008105,President,,PF,Gloria LaRiva,2,0,2
+Santa Clara,0008117,President,,PF,Gloria LaRiva,3,0,3
+Santa Clara,0008122,President,,PF,Gloria LaRiva,9,0,9
+Santa Clara,0008128,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0008133,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0008201,President,,PF,Gloria LaRiva,5,1,4
+Santa Clara,0008203,President,,PF,Gloria LaRiva,12,3,9
+Santa Clara,0008205,President,,PF,Gloria LaRiva,11,2,9
+Santa Clara,0008208,President,,PF,Gloria LaRiva,12,1,11
+Santa Clara,0008212,President,,PF,Gloria LaRiva,10,2,8
+Santa Clara,0008214,President,,PF,Gloria LaRiva,1,1,0
+Santa Clara,0008227,President,,PF,Gloria LaRiva,6,0,6
+Santa Clara,0008228,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0008230,President,,PF,Gloria LaRiva,6,1,5
+Santa Clara,0008231,President,,PF,Gloria LaRiva,5,0,5
+Santa Clara,0008232,President,,PF,Gloria LaRiva,9,2,7
+Santa Clara,0008236,President,,PF,Gloria LaRiva,13,0,13
+Santa Clara,0008246,President,,PF,Gloria LaRiva,12,2,10
+Santa Clara,0008254,President,,PF,Gloria LaRiva,15,4,11
+Santa Clara,0008262,President,,PF,Gloria LaRiva,2,0,2
+Santa Clara,0008264,President,,PF,Gloria LaRiva,4,2,2
+Santa Clara,0008401,President,,PF,Gloria LaRiva,5,1,4
+Santa Clara,0008404,President,,PF,Gloria LaRiva,10,0,10
+Santa Clara,0008408,President,,PF,Gloria LaRiva,3,1,2
+Santa Clara,0008409,President,,PF,Gloria LaRiva,6,3,3
+Santa Clara,0008414,President,,PF,Gloria LaRiva,2,0,2
+Santa Clara,0008418,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0008421,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0008423,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0008430,President,,PF,Gloria LaRiva,12,0,12
+Santa Clara,0008435,President,,PF,Gloria LaRiva,10,0,10
+Santa Clara,0008438,President,,PF,Gloria LaRiva,11,2,9
+Santa Clara,0008439,President,,PF,Gloria LaRiva,10,2,8
+Santa Clara,0008445,President,,PF,Gloria LaRiva,4,0,4
+Santa Clara,0008447,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0008456,President,,PF,Gloria LaRiva,5,1,4
+Santa Clara,0008457,President,,PF,Gloria LaRiva,12,1,11
+Santa Clara,0008464,President,,PF,Gloria LaRiva,11,1,10
+Santa Clara,0008470,President,,PF,Gloria LaRiva,11,0,11
+Santa Clara,0008472,President,,PF,Gloria LaRiva,7,1,6
+Santa Clara,0008486,President,,PF,Gloria LaRiva,7,3,4
+Santa Clara,0008492,President,,PF,Gloria LaRiva,6,0,6
+Santa Clara,0008502,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0008601,President,,PF,Gloria LaRiva,1,0,1
+Santa Clara,0008603,President,,PF,Gloria LaRiva,11,1,10
+Santa Clara,0008605,President,,PF,Gloria LaRiva,7,1,6
+Santa Clara,0008609,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0008610,President,,PF,Gloria LaRiva,4,1,3
+Santa Clara,0008612,President,,PF,Gloria LaRiva,3,1,2
+Santa Clara,0008615,President,,PF,Gloria LaRiva,1,0,1
+Santa Clara,0008619,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0008625,President,,PF,Gloria LaRiva,2,0,2
+Santa Clara,0008627,President,,PF,Gloria LaRiva,3,0,3
+Santa Clara,0008629,President,,PF,Gloria LaRiva,4,0,4
+Santa Clara,0008630,President,,PF,Gloria LaRiva,4,0,4
+Santa Clara,0008631,President,,PF,Gloria LaRiva,5,0,5
+Santa Clara,0008634,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0008636,President,,PF,Gloria LaRiva,1,0,1
+Santa Clara,0008645,President,,PF,Gloria LaRiva,6,0,6
+Santa Clara,0008648,President,,PF,Gloria LaRiva,2,0,2
+Santa Clara,0008650,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0008653,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0008654,President,,PF,Gloria LaRiva,1,0,1
+Santa Clara,0008655,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0008657,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0008658,President,,PF,Gloria LaRiva,5,1,4
+Santa Clara,0008670,President,,PF,Gloria LaRiva,6,4,2
+Santa Clara,0008675,President,,PF,Gloria LaRiva,4,0,4
+Santa Clara,0008676,President,,PF,Gloria LaRiva,6,0,6
+Santa Clara,0008680,President,,PF,Gloria LaRiva,6,0,6
+Santa Clara,0008683,President,,PF,Gloria LaRiva,4,0,4
+Santa Clara,0008687,President,,PF,Gloria LaRiva,7,0,7
+Santa Clara,0008697,President,,PF,Gloria LaRiva,6,0,6
+Santa Clara,0008801,President,,PF,Gloria LaRiva,8,0,8
+Santa Clara,0008805,President,,PF,Gloria LaRiva,6,3,3
+Santa Clara,0008809,President,,PF,Gloria LaRiva,15,4,11
+Santa Clara,0008812,President,,PF,Gloria LaRiva,4,1,3
+Santa Clara,0008817,President,,PF,Gloria LaRiva,3,0,3
+Santa Clara,0008820,President,,PF,Gloria LaRiva,3,0,3
+Santa Clara,0008822,President,,PF,Gloria LaRiva,5,0,5
+Santa Clara,0008828,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0008829,President,,PF,Gloria LaRiva,2,1,1
+Santa Clara,0008832,President,,PF,Gloria LaRiva,1,0,1
+Santa Clara,0008834,President,,PF,Gloria LaRiva,2,0,2
+Santa Clara,0008838,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0008839,President,,PF,Gloria LaRiva,5,0,5
+Santa Clara,0008844,President,,PF,Gloria LaRiva,12,4,8
+Santa Clara,0008848,President,,PF,Gloria LaRiva,3,0,3
+Santa Clara,0008853,President,,PF,Gloria LaRiva,4,1,3
+Santa Clara,0008857,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0008858,President,,PF,Gloria LaRiva,8,0,8
+Santa Clara,0008862,President,,PF,Gloria LaRiva,5,0,5
+Santa Clara,0008868,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0008873,President,,PF,Gloria LaRiva,1,0,1
+Santa Clara,0008874,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0008879,President,,PF,Gloria LaRiva,4,0,4
+Santa Clara,0008883,President,,PF,Gloria LaRiva,6,0,6
+Santa Clara,0008885,President,,PF,Gloria LaRiva,2,0,2
+Santa Clara,0008886,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0008889,President,,PF,Gloria LaRiva,1,0,1
+Santa Clara,0008898,President,,PF,Gloria LaRiva,4,0,4
+Santa Clara,0008903,President,,PF,Gloria LaRiva,5,0,5
+Santa Clara,0008915,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0008916,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0008920,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0008923,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0008924,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0009001,President,,PF,Gloria LaRiva,5,0,5
+Santa Clara,0009005,President,,PF,Gloria LaRiva,10,1,9
+Santa Clara,0009051,President,,PF,Gloria LaRiva,6,1,5
+Santa Clara,0009055,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0009056,President,,PF,Gloria LaRiva,4,0,4
+Santa Clara,0009059,President,,PF,Gloria LaRiva,6,0,6
+Santa Clara,0009061,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0009062,President,,PF,Gloria LaRiva,4,0,4
+Santa Clara,0009101,President,,PF,Gloria LaRiva,6,0,6
+Santa Clara,0009103,President,,PF,Gloria LaRiva,2,0,2
+Santa Clara,0009104,President,,PF,Gloria LaRiva,7,1,6
+Santa Clara,0009109,President,,PF,Gloria LaRiva,1,0,1
+Santa Clara,0009151,President,,PF,Gloria LaRiva,8,1,7
+Santa Clara,0009157,President,,PF,Gloria LaRiva,8,0,8
+Santa Clara,0009163,President,,PF,Gloria LaRiva,2,1,1
+Santa Clara,0009166,President,,PF,Gloria LaRiva,2,0,2
+Santa Clara,0009201,President,,PF,Gloria LaRiva,5,0,5
+Santa Clara,0009203,President,,PF,Gloria LaRiva,2,0,2
+Santa Clara,0009208,President,,PF,Gloria LaRiva,5,1,4
+Santa Clara,0009210,President,,PF,Gloria LaRiva,2,1,1
+Santa Clara,0009219,President,,PF,Gloria LaRiva,1,0,1
+Santa Clara,0009220,President,,PF,Gloria LaRiva,5,0,5
+Santa Clara,0009251,President,,PF,Gloria LaRiva,2,0,2
+Santa Clara,0009252,President,,PF,Gloria LaRiva,6,1,5
+Santa Clara,0009258,President,,PF,Gloria LaRiva,5,0,5
+Santa Clara,0009262,President,,PF,Gloria LaRiva,2,0,2
+Santa Clara,0009264,President,,PF,Gloria LaRiva,3,0,3
+Santa Clara,0009268,President,,PF,Gloria LaRiva,2,0,2
+Santa Clara,0009275,President,,PF,Gloria LaRiva,3,0,3
+Santa Clara,0009282,President,,PF,Gloria LaRiva,0,0,0
+Santa Clara,0002001,President,,,Brian Carroll,0,0,0
+Santa Clara,0002002,President,,,Brian Carroll,0,0,0
+Santa Clara,0002005,President,,,Brian Carroll,0,0,0
+Santa Clara,0002006,President,,,Brian Carroll,0,0,0
+Santa Clara,0002009,President,,,Brian Carroll,1,1,0
+Santa Clara,0002013,President,,,Brian Carroll,0,0,0
+Santa Clara,0002014,President,,,Brian Carroll,0,0,0
+Santa Clara,0002018,President,,,Brian Carroll,0,0,0
+Santa Clara,0002025,President,,,Brian Carroll,1,1,0
+Santa Clara,0002043,President,,,Brian Carroll,0,0,0
+Santa Clara,0002046,President,,,Brian Carroll,0,0,0
+Santa Clara,0002057,President,,,Brian Carroll,1,0,1
+Santa Clara,0002068,President,,,Brian Carroll,0,0,0
+Santa Clara,0002098,President,,,Brian Carroll,0,0,0
+Santa Clara,0002108,President,,,Brian Carroll,0,0,0
+Santa Clara,0002125,President,,,Brian Carroll,0,0,0
+Santa Clara,0002274,President,,,Brian Carroll,0,0,0
+Santa Clara,0002275,President,,,Brian Carroll,0,0,0
+Santa Clara,0002278,President,,,Brian Carroll,0,0,0
+Santa Clara,0002281,President,,,Brian Carroll,0,0,0
+Santa Clara,0002282,President,,,Brian Carroll,1,0,1
+Santa Clara,0002285,President,,,Brian Carroll,0,0,0
+Santa Clara,0002301,President,,,Brian Carroll,0,0,0
+Santa Clara,0002305,President,,,Brian Carroll,0,0,0
+Santa Clara,0002309,President,,,Brian Carroll,1,0,1
+Santa Clara,0002314,President,,,Brian Carroll,0,0,0
+Santa Clara,0002317,President,,,Brian Carroll,3,0,3
+Santa Clara,0002330,President,,,Brian Carroll,0,0,0
+Santa Clara,0002338,President,,,Brian Carroll,0,0,0
+Santa Clara,0002351,President,,,Brian Carroll,1,1,0
+Santa Clara,0002353,President,,,Brian Carroll,0,0,0
+Santa Clara,0002539,President,,,Brian Carroll,0,0,0
+Santa Clara,0002542,President,,,Brian Carroll,3,0,3
+Santa Clara,0002545,President,,,Brian Carroll,1,0,1
+Santa Clara,0002720,President,,,Brian Carroll,1,0,1
+Santa Clara,0002721,President,,,Brian Carroll,0,0,0
+Santa Clara,0002723,President,,,Brian Carroll,0,0,0
+Santa Clara,0002724,President,,,Brian Carroll,1,0,1
+Santa Clara,0002725,President,,,Brian Carroll,0,0,0
+Santa Clara,0002726,President,,,Brian Carroll,0,0,0
+Santa Clara,0002727,President,,,Brian Carroll,0,0,0
+Santa Clara,0002729,President,,,Brian Carroll,2,0,2
+Santa Clara,0002734,President,,,Brian Carroll,1,0,1
+Santa Clara,0002740,President,,,Brian Carroll,1,0,1
+Santa Clara,0002751,President,,,Brian Carroll,0,0,0
+Santa Clara,0002761,President,,,Brian Carroll,0,0,0
+Santa Clara,0002802,President,,,Brian Carroll,0,0,0
+Santa Clara,0002808,President,,,Brian Carroll,0,0,0
+Santa Clara,0002810,President,,,Brian Carroll,0,0,0
+Santa Clara,0002811,President,,,Brian Carroll,0,0,0
+Santa Clara,0002812,President,,,Brian Carroll,0,0,0
+Santa Clara,0002813,President,,,Brian Carroll,0,0,0
+Santa Clara,0002816,President,,,Brian Carroll,0,0,0
+Santa Clara,0002825,President,,,Brian Carroll,0,0,0
+Santa Clara,0002870,President,,,Brian Carroll,0,0,0
+Santa Clara,0002951,President,,,Brian Carroll,0,0,0
+Santa Clara,0003001,President,,,Brian Carroll,0,0,0
+Santa Clara,0003002,President,,,Brian Carroll,0,0,0
+Santa Clara,0003005,President,,,Brian Carroll,0,0,0
+Santa Clara,0003008,President,,,Brian Carroll,0,0,0
+Santa Clara,0003010,President,,,Brian Carroll,1,0,1
+Santa Clara,0003011,President,,,Brian Carroll,0,0,0
+Santa Clara,0003012,President,,,Brian Carroll,0,0,0
+Santa Clara,0003013,President,,,Brian Carroll,0,0,0
+Santa Clara,0003016,President,,,Brian Carroll,1,0,1
+Santa Clara,0003017,President,,,Brian Carroll,0,0,0
+Santa Clara,0003018,President,,,Brian Carroll,0,0,0
+Santa Clara,0003019,President,,,Brian Carroll,1,0,1
+Santa Clara,0003021,President,,,Brian Carroll,0,0,0
+Santa Clara,0003023,President,,,Brian Carroll,0,0,0
+Santa Clara,0003026,President,,,Brian Carroll,0,0,0
+Santa Clara,0003029,President,,,Brian Carroll,0,0,0
+Santa Clara,0003031,President,,,Brian Carroll,0,0,0
+Santa Clara,0003032,President,,,Brian Carroll,0,0,0
+Santa Clara,0003034,President,,,Brian Carroll,0,0,0
+Santa Clara,0003035,President,,,Brian Carroll,0,0,0
+Santa Clara,0003039,President,,,Brian Carroll,0,0,0
+Santa Clara,0003040,President,,,Brian Carroll,0,0,0
+Santa Clara,0003042,President,,,Brian Carroll,0,0,0
+Santa Clara,0003043,President,,,Brian Carroll,2,0,2
+Santa Clara,0003045,President,,,Brian Carroll,4,0,4
+Santa Clara,0003047,President,,,Brian Carroll,0,0,0
+Santa Clara,0003048,President,,,Brian Carroll,1,0,1
+Santa Clara,0003051,President,,,Brian Carroll,0,0,0
+Santa Clara,0003053,President,,,Brian Carroll,0,0,0
+Santa Clara,0003061,President,,,Brian Carroll,0,0,0
+Santa Clara,0003079,President,,,Brian Carroll,0,0,0
+Santa Clara,0003080,President,,,Brian Carroll,0,0,0
+Santa Clara,0003086,President,,,Brian Carroll,0,0,0
+Santa Clara,0003087,President,,,Brian Carroll,0,0,0
+Santa Clara,0003089,President,,,Brian Carroll,0,0,0
+Santa Clara,0003095,President,,,Brian Carroll,0,0,0
+Santa Clara,0003101,President,,,Brian Carroll,0,0,0
+Santa Clara,0003102,President,,,Brian Carroll,0,0,0
+Santa Clara,0003103,President,,,Brian Carroll,1,0,1
+Santa Clara,0003116,President,,,Brian Carroll,1,1,0
+Santa Clara,0003117,President,,,Brian Carroll,1,0,1
+Santa Clara,0003120,President,,,Brian Carroll,0,0,0
+Santa Clara,0003122,President,,,Brian Carroll,0,0,0
+Santa Clara,0003156,President,,,Brian Carroll,0,0,0
+Santa Clara,0003402,President,,,Brian Carroll,1,0,1
+Santa Clara,0003406,President,,,Brian Carroll,0,0,0
+Santa Clara,0003407,President,,,Brian Carroll,3,0,3
+Santa Clara,0003408,President,,,Brian Carroll,0,0,0
+Santa Clara,0003409,President,,,Brian Carroll,2,0,2
+Santa Clara,0003410,President,,,Brian Carroll,0,0,0
+Santa Clara,0003417,President,,,Brian Carroll,1,0,1
+Santa Clara,0003427,President,,,Brian Carroll,0,0,0
+Santa Clara,0003434,President,,,Brian Carroll,1,0,1
+Santa Clara,0003438,President,,,Brian Carroll,0,0,0
+Santa Clara,0003445,President,,,Brian Carroll,0,0,0
+Santa Clara,0003601,President,,,Brian Carroll,0,0,0
+Santa Clara,0003602,President,,,Brian Carroll,0,0,0
+Santa Clara,0003603,President,,,Brian Carroll,0,0,0
+Santa Clara,0003604,President,,,Brian Carroll,0,0,0
+Santa Clara,0003605,President,,,Brian Carroll,0,0,0
+Santa Clara,0003606,President,,,Brian Carroll,0,0,0
+Santa Clara,0003608,President,,,Brian Carroll,0,0,0
+Santa Clara,0003609,President,,,Brian Carroll,0,0,0
+Santa Clara,0003611,President,,,Brian Carroll,0,0,0
+Santa Clara,0003614,President,,,Brian Carroll,1,1,0
+Santa Clara,0003624,President,,,Brian Carroll,2,0,2
+Santa Clara,0003635,President,,,Brian Carroll,0,0,0
+Santa Clara,0003652,President,,,Brian Carroll,1,0,1
+Santa Clara,0003655,President,,,Brian Carroll,0,0,0
+Santa Clara,0003669,President,,,Brian Carroll,0,0,0
+Santa Clara,0003670,President,,,Brian Carroll,0,0,0
+Santa Clara,0003777,President,,,Brian Carroll,0,0,0
+Santa Clara,0003779,President,,,Brian Carroll,0,0,0
+Santa Clara,0003782,President,,,Brian Carroll,0,0,0
+Santa Clara,0003783,President,,,Brian Carroll,0,0,0
+Santa Clara,0003801,President,,,Brian Carroll,0,0,0
+Santa Clara,0003802,President,,,Brian Carroll,0,0,0
+Santa Clara,0003803,President,,,Brian Carroll,0,0,0
+Santa Clara,0003804,President,,,Brian Carroll,0,0,0
+Santa Clara,0003810,President,,,Brian Carroll,0,0,0
+Santa Clara,0003811,President,,,Brian Carroll,0,0,0
+Santa Clara,0003814,President,,,Brian Carroll,0,0,0
+Santa Clara,0003820,President,,,Brian Carroll,0,0,0
+Santa Clara,0003821,President,,,Brian Carroll,0,0,0
+Santa Clara,0003825,President,,,Brian Carroll,0,0,0
+Santa Clara,0003828,President,,,Brian Carroll,0,0,0
+Santa Clara,0003835,President,,,Brian Carroll,0,0,0
+Santa Clara,0003840,President,,,Brian Carroll,0,0,0
+Santa Clara,0003846,President,,,Brian Carroll,0,0,0
+Santa Clara,0003861,President,,,Brian Carroll,0,0,0
+Santa Clara,0004401,President,,,Brian Carroll,0,0,0
+Santa Clara,0004402,President,,,Brian Carroll,0,0,0
+Santa Clara,0004403,President,,,Brian Carroll,0,0,0
+Santa Clara,0004405,President,,,Brian Carroll,0,0,0
+Santa Clara,0004407,President,,,Brian Carroll,0,0,0
+Santa Clara,0004409,President,,,Brian Carroll,1,0,1
+Santa Clara,0004411,President,,,Brian Carroll,1,0,1
+Santa Clara,0004412,President,,,Brian Carroll,0,0,0
+Santa Clara,0004414,President,,,Brian Carroll,2,0,2
+Santa Clara,0004417,President,,,Brian Carroll,0,0,0
+Santa Clara,0004665,President,,,Brian Carroll,0,0,0
+Santa Clara,0004666,President,,,Brian Carroll,0,0,0
+Santa Clara,0004671,President,,,Brian Carroll,0,0,0
+Santa Clara,0004672,President,,,Brian Carroll,0,0,0
+Santa Clara,0004674,President,,,Brian Carroll,0,0,0
+Santa Clara,0004675,President,,,Brian Carroll,0,0,0
+Santa Clara,0004685,President,,,Brian Carroll,0,0,0
+Santa Clara,0004687,President,,,Brian Carroll,3,0,3
+Santa Clara,0004688,President,,,Brian Carroll,0,0,0
+Santa Clara,0004691,President,,,Brian Carroll,1,0,1
+Santa Clara,0004696,President,,,Brian Carroll,0,0,0
+Santa Clara,0004698,President,,,Brian Carroll,0,0,0
+Santa Clara,0004699,President,,,Brian Carroll,0,0,0
+Santa Clara,0004702,President,,,Brian Carroll,0,0,0
+Santa Clara,0004715,President,,,Brian Carroll,0,0,0
+Santa Clara,0004733,President,,,Brian Carroll,0,0,0
+Santa Clara,0004801,President,,,Brian Carroll,0,0,0
+Santa Clara,0004806,President,,,Brian Carroll,4,0,4
+Santa Clara,0004811,President,,,Brian Carroll,0,0,0
+Santa Clara,0004826,President,,,Brian Carroll,2,0,2
+Santa Clara,0004827,President,,,Brian Carroll,0,0,0
+Santa Clara,0004833,President,,,Brian Carroll,0,0,0
+Santa Clara,0004851,President,,,Brian Carroll,0,0,0
+Santa Clara,0004853,President,,,Brian Carroll,0,0,0
+Santa Clara,0004858,President,,,Brian Carroll,0,0,0
+Santa Clara,0004876,President,,,Brian Carroll,2,0,2
+Santa Clara,0004881,President,,,Brian Carroll,0,0,0
+Santa Clara,0004941,President,,,Brian Carroll,2,0,2
+Santa Clara,0004942,President,,,Brian Carroll,0,0,0
+Santa Clara,0004943,President,,,Brian Carroll,0,0,0
+Santa Clara,0004944,President,,,Brian Carroll,0,0,0
+Santa Clara,0004945,President,,,Brian Carroll,0,0,0
+Santa Clara,0004946,President,,,Brian Carroll,0,0,0
+Santa Clara,0004949,President,,,Brian Carroll,0,0,0
+Santa Clara,0004950,President,,,Brian Carroll,0,0,0
+Santa Clara,0004954,President,,,Brian Carroll,0,0,0
+Santa Clara,0004956,President,,,Brian Carroll,0,0,0
+Santa Clara,0004958,President,,,Brian Carroll,0,0,0
+Santa Clara,0004965,President,,,Brian Carroll,3,1,2
+Santa Clara,0004969,President,,,Brian Carroll,0,0,0
+Santa Clara,0004971,President,,,Brian Carroll,0,0,0
+Santa Clara,0004973,President,,,Brian Carroll,0,0,0
+Santa Clara,0004974,President,,,Brian Carroll,0,0,0
+Santa Clara,0005449,President,,,Brian Carroll,0,0,0
+Santa Clara,0005451,President,,,Brian Carroll,0,0,0
+Santa Clara,0005454,President,,,Brian Carroll,0,0,0
+Santa Clara,0005455,President,,,Brian Carroll,0,0,0
+Santa Clara,0005456,President,,,Brian Carroll,0,0,0
+Santa Clara,0005458,President,,,Brian Carroll,0,0,0
+Santa Clara,0005502,President,,,Brian Carroll,0,0,0
+Santa Clara,0005503,President,,,Brian Carroll,0,0,0
+Santa Clara,0005505,President,,,Brian Carroll,0,0,0
+Santa Clara,0005507,President,,,Brian Carroll,0,0,0
+Santa Clara,0005556,President,,,Brian Carroll,0,0,0
+Santa Clara,0005557,President,,,Brian Carroll,0,0,0
+Santa Clara,0005567,President,,,Brian Carroll,0,0,0
+Santa Clara,0005742,President,,,Brian Carroll,0,0,0
+Santa Clara,0005743,President,,,Brian Carroll,1,0,1
+Santa Clara,0005745,President,,,Brian Carroll,0,0,0
+Santa Clara,0005747,President,,,Brian Carroll,0,0,0
+Santa Clara,0005748,President,,,Brian Carroll,0,0,0
+Santa Clara,0005756,President,,,Brian Carroll,0,0,0
+Santa Clara,0005758,President,,,Brian Carroll,0,0,0
+Santa Clara,0005759,President,,,Brian Carroll,0,0,0
+Santa Clara,0005762,President,,,Brian Carroll,0,0,0
+Santa Clara,0005763,President,,,Brian Carroll,0,0,0
+Santa Clara,0005770,President,,,Brian Carroll,0,0,0
+Santa Clara,0005775,President,,,Brian Carroll,0,0,0
+Santa Clara,0005785,President,,,Brian Carroll,0,0,0
+Santa Clara,0005793,President,,,Brian Carroll,0,0,0
+Santa Clara,0005795,President,,,Brian Carroll,0,0,0
+Santa Clara,0005804,President,,,Brian Carroll,0,0,0
+Santa Clara,0005810,President,,,Brian Carroll,0,0,0
+Santa Clara,0005811,President,,,Brian Carroll,0,0,0
+Santa Clara,0005813,President,,,Brian Carroll,0,0,0
+Santa Clara,0005814,President,,,Brian Carroll,0,0,0
+Santa Clara,0005854,President,,,Brian Carroll,0,0,0
+Santa Clara,0005879,President,,,Brian Carroll,0,0,0
+Santa Clara,0005886,President,,,Brian Carroll,0,0,0
+Santa Clara,0005888,President,,,Brian Carroll,0,0,0
+Santa Clara,0005894,President,,,Brian Carroll,0,0,0
+Santa Clara,0005896,President,,,Brian Carroll,0,0,0
+Santa Clara,0005901,President,,,Brian Carroll,0,0,0
+Santa Clara,0005902,President,,,Brian Carroll,0,0,0
+Santa Clara,0005903,President,,,Brian Carroll,0,0,0
+Santa Clara,0005906,President,,,Brian Carroll,0,0,0
+Santa Clara,0005907,President,,,Brian Carroll,0,0,0
+Santa Clara,0005911,President,,,Brian Carroll,0,0,0
+Santa Clara,0005912,President,,,Brian Carroll,0,0,0
+Santa Clara,0005914,President,,,Brian Carroll,0,0,0
+Santa Clara,0005915,President,,,Brian Carroll,0,0,0
+Santa Clara,0005916,President,,,Brian Carroll,0,0,0
+Santa Clara,0005917,President,,,Brian Carroll,0,0,0
+Santa Clara,0005919,President,,,Brian Carroll,0,0,0
+Santa Clara,0005922,President,,,Brian Carroll,1,1,0
+Santa Clara,0005925,President,,,Brian Carroll,0,0,0
+Santa Clara,0005927,President,,,Brian Carroll,0,0,0
+Santa Clara,0005929,President,,,Brian Carroll,0,0,0
+Santa Clara,0005931,President,,,Brian Carroll,0,0,0
+Santa Clara,0005936,President,,,Brian Carroll,0,0,0
+Santa Clara,0005940,President,,,Brian Carroll,0,0,0
+Santa Clara,0005947,President,,,Brian Carroll,0,0,0
+Santa Clara,0005949,President,,,Brian Carroll,0,0,0
+Santa Clara,0005950,President,,,Brian Carroll,0,0,0
+Santa Clara,0005951,President,,,Brian Carroll,0,0,0
+Santa Clara,0005955,President,,,Brian Carroll,0,0,0
+Santa Clara,0005956,President,,,Brian Carroll,0,0,0
+Santa Clara,0005957,President,,,Brian Carroll,0,0,0
+Santa Clara,0005958,President,,,Brian Carroll,0,0,0
+Santa Clara,0005959,President,,,Brian Carroll,0,0,0
+Santa Clara,0005965,President,,,Brian Carroll,0,0,0
+Santa Clara,0005966,President,,,Brian Carroll,0,0,0
+Santa Clara,0005975,President,,,Brian Carroll,0,0,0
+Santa Clara,0005988,President,,,Brian Carroll,0,0,0
+Santa Clara,0006023,President,,,Brian Carroll,0,0,0
+Santa Clara,0006028,President,,,Brian Carroll,0,0,0
+Santa Clara,0006031,President,,,Brian Carroll,0,0,0
+Santa Clara,0006035,President,,,Brian Carroll,0,0,0
+Santa Clara,0006036,President,,,Brian Carroll,0,0,0
+Santa Clara,0006048,President,,,Brian Carroll,0,0,0
+Santa Clara,0006401,President,,,Brian Carroll,0,0,0
+Santa Clara,0006402,President,,,Brian Carroll,0,0,0
+Santa Clara,0006404,President,,,Brian Carroll,0,0,0
+Santa Clara,0006405,President,,,Brian Carroll,0,0,0
+Santa Clara,0006410,President,,,Brian Carroll,0,0,0
+Santa Clara,0006413,President,,,Brian Carroll,0,0,0
+Santa Clara,0006418,President,,,Brian Carroll,0,0,0
+Santa Clara,0006419,President,,,Brian Carroll,0,0,0
+Santa Clara,0006423,President,,,Brian Carroll,0,0,0
+Santa Clara,0006452,President,,,Brian Carroll,0,0,0
+Santa Clara,0006454,President,,,Brian Carroll,0,0,0
+Santa Clara,0006455,President,,,Brian Carroll,0,0,0
+Santa Clara,0006491,President,,,Brian Carroll,0,0,0
+Santa Clara,0006502,President,,,Brian Carroll,0,0,0
+Santa Clara,0006509,President,,,Brian Carroll,0,0,0
+Santa Clara,0006510,President,,,Brian Carroll,0,0,0
+Santa Clara,0006511,President,,,Brian Carroll,0,0,0
+Santa Clara,0006515,President,,,Brian Carroll,0,0,0
+Santa Clara,0006624,President,,,Brian Carroll,0,0,0
+Santa Clara,0006625,President,,,Brian Carroll,0,0,0
+Santa Clara,0006669,President,,,Brian Carroll,0,0,0
+Santa Clara,0006678,President,,,Brian Carroll,0,0,0
+Santa Clara,0007001,President,,,Brian Carroll,1,0,1
+Santa Clara,0007005,President,,,Brian Carroll,0,0,0
+Santa Clara,0007011,President,,,Brian Carroll,1,0,1
+Santa Clara,0007012,President,,,Brian Carroll,0,0,0
+Santa Clara,0007014,President,,,Brian Carroll,0,0,0
+Santa Clara,0007019,President,,,Brian Carroll,1,0,1
+Santa Clara,0007025,President,,,Brian Carroll,0,0,0
+Santa Clara,0007028,President,,,Brian Carroll,0,0,0
+Santa Clara,0007032,President,,,Brian Carroll,1,0,1
+Santa Clara,0007036,President,,,Brian Carroll,0,0,0
+Santa Clara,0007038,President,,,Brian Carroll,0,0,0
+Santa Clara,0007041,President,,,Brian Carroll,3,0,3
+Santa Clara,0007044,President,,,Brian Carroll,1,0,1
+Santa Clara,0007046,President,,,Brian Carroll,0,0,0
+Santa Clara,0007051,President,,,Brian Carroll,0,0,0
+Santa Clara,0007059,President,,,Brian Carroll,0,0,0
+Santa Clara,0007061,President,,,Brian Carroll,0,0,0
+Santa Clara,0007062,President,,,Brian Carroll,0,0,0
+Santa Clara,0007079,President,,,Brian Carroll,0,0,0
+Santa Clara,0007081,President,,,Brian Carroll,0,0,0
+Santa Clara,0007089,President,,,Brian Carroll,0,0,0
+Santa Clara,0007201,President,,,Brian Carroll,0,0,0
+Santa Clara,0007202,President,,,Brian Carroll,0,0,0
+Santa Clara,0007203,President,,,Brian Carroll,0,0,0
+Santa Clara,0007205,President,,,Brian Carroll,1,1,0
+Santa Clara,0007214,President,,,Brian Carroll,0,0,0
+Santa Clara,0007217,President,,,Brian Carroll,0,0,0
+Santa Clara,0007219,President,,,Brian Carroll,0,0,0
+Santa Clara,0007221,President,,,Brian Carroll,0,0,0
+Santa Clara,0007224,President,,,Brian Carroll,0,0,0
+Santa Clara,0007231,President,,,Brian Carroll,0,0,0
+Santa Clara,0007235,President,,,Brian Carroll,0,0,0
+Santa Clara,0007237,President,,,Brian Carroll,0,0,0
+Santa Clara,0007245,President,,,Brian Carroll,0,0,0
+Santa Clara,0007246,President,,,Brian Carroll,1,0,1
+Santa Clara,0007248,President,,,Brian Carroll,1,0,1
+Santa Clara,0007252,President,,,Brian Carroll,2,0,2
+Santa Clara,0007255,President,,,Brian Carroll,0,0,0
+Santa Clara,0007257,President,,,Brian Carroll,1,0,1
+Santa Clara,0007261,President,,,Brian Carroll,0,0,0
+Santa Clara,0007264,President,,,Brian Carroll,0,0,0
+Santa Clara,0007271,President,,,Brian Carroll,0,0,0
+Santa Clara,0007273,President,,,Brian Carroll,1,0,1
+Santa Clara,0007282,President,,,Brian Carroll,1,0,1
+Santa Clara,0007294,President,,,Brian Carroll,0,0,0
+Santa Clara,0007295,President,,,Brian Carroll,0,0,0
+Santa Clara,0007298,President,,,Brian Carroll,0,0,0
+Santa Clara,0007299,President,,,Brian Carroll,0,0,0
+Santa Clara,0007306,President,,,Brian Carroll,0,0,0
+Santa Clara,0007401,President,,,Brian Carroll,0,0,0
+Santa Clara,0007402,President,,,Brian Carroll,0,0,0
+Santa Clara,0007403,President,,,Brian Carroll,0,0,0
+Santa Clara,0007408,President,,,Brian Carroll,1,0,1
+Santa Clara,0007409,President,,,Brian Carroll,0,0,0
+Santa Clara,0007410,President,,,Brian Carroll,0,0,0
+Santa Clara,0007411,President,,,Brian Carroll,0,0,0
+Santa Clara,0007414,President,,,Brian Carroll,0,0,0
+Santa Clara,0007415,President,,,Brian Carroll,0,0,0
+Santa Clara,0007416,President,,,Brian Carroll,0,0,0
+Santa Clara,0007417,President,,,Brian Carroll,0,0,0
+Santa Clara,0007418,President,,,Brian Carroll,0,0,0
+Santa Clara,0007419,President,,,Brian Carroll,0,0,0
+Santa Clara,0007430,President,,,Brian Carroll,0,0,0
+Santa Clara,0007435,President,,,Brian Carroll,1,0,1
+Santa Clara,0007436,President,,,Brian Carroll,0,0,0
+Santa Clara,0007438,President,,,Brian Carroll,0,0,0
+Santa Clara,0007440,President,,,Brian Carroll,0,0,0
+Santa Clara,0007441,President,,,Brian Carroll,0,0,0
+Santa Clara,0007442,President,,,Brian Carroll,0,0,0
+Santa Clara,0007447,President,,,Brian Carroll,0,0,0
+Santa Clara,0007458,President,,,Brian Carroll,0,0,0
+Santa Clara,0007459,President,,,Brian Carroll,2,0,2
+Santa Clara,0007470,President,,,Brian Carroll,3,0,3
+Santa Clara,0007471,President,,,Brian Carroll,2,0,2
+Santa Clara,0007479,President,,,Brian Carroll,0,0,0
+Santa Clara,0007483,President,,,Brian Carroll,0,0,0
+Santa Clara,0007601,President,,,Brian Carroll,0,0,0
+Santa Clara,0007606,President,,,Brian Carroll,0,0,0
+Santa Clara,0007609,President,,,Brian Carroll,0,0,0
+Santa Clara,0007615,President,,,Brian Carroll,0,0,0
+Santa Clara,0007619,President,,,Brian Carroll,0,0,0
+Santa Clara,0007620,President,,,Brian Carroll,2,0,2
+Santa Clara,0007621,President,,,Brian Carroll,0,0,0
+Santa Clara,0007624,President,,,Brian Carroll,2,1,1
+Santa Clara,0007632,President,,,Brian Carroll,0,0,0
+Santa Clara,0007634,President,,,Brian Carroll,0,0,0
+Santa Clara,0007648,President,,,Brian Carroll,1,0,1
+Santa Clara,0007654,President,,,Brian Carroll,1,0,1
+Santa Clara,0007660,President,,,Brian Carroll,2,0,2
+Santa Clara,0007666,President,,,Brian Carroll,0,0,0
+Santa Clara,0007670,President,,,Brian Carroll,0,0,0
+Santa Clara,0007673,President,,,Brian Carroll,0,0,0
+Santa Clara,0007674,President,,,Brian Carroll,0,0,0
+Santa Clara,0007677,President,,,Brian Carroll,1,0,1
+Santa Clara,0007680,President,,,Brian Carroll,0,0,0
+Santa Clara,0007689,President,,,Brian Carroll,0,0,0
+Santa Clara,0007690,President,,,Brian Carroll,0,0,0
+Santa Clara,0007801,President,,,Brian Carroll,0,0,0
+Santa Clara,0007802,President,,,Brian Carroll,0,0,0
+Santa Clara,0007803,President,,,Brian Carroll,0,0,0
+Santa Clara,0007805,President,,,Brian Carroll,0,0,0
+Santa Clara,0007810,President,,,Brian Carroll,0,0,0
+Santa Clara,0007811,President,,,Brian Carroll,0,0,0
+Santa Clara,0007812,President,,,Brian Carroll,0,0,0
+Santa Clara,0007816,President,,,Brian Carroll,0,0,0
+Santa Clara,0007817,President,,,Brian Carroll,0,0,0
+Santa Clara,0007818,President,,,Brian Carroll,0,0,0
+Santa Clara,0007821,President,,,Brian Carroll,0,0,0
+Santa Clara,0007826,President,,,Brian Carroll,1,0,1
+Santa Clara,0007827,President,,,Brian Carroll,0,0,0
+Santa Clara,0007832,President,,,Brian Carroll,0,0,0
+Santa Clara,0007833,President,,,Brian Carroll,0,0,0
+Santa Clara,0007843,President,,,Brian Carroll,1,0,1
+Santa Clara,0007849,President,,,Brian Carroll,1,0,1
+Santa Clara,0007850,President,,,Brian Carroll,1,0,1
+Santa Clara,0007851,President,,,Brian Carroll,0,0,0
+Santa Clara,0007861,President,,,Brian Carroll,0,0,0
+Santa Clara,0007867,President,,,Brian Carroll,0,0,0
+Santa Clara,0007874,President,,,Brian Carroll,0,0,0
+Santa Clara,0007880,President,,,Brian Carroll,0,0,0
+Santa Clara,0008001,President,,,Brian Carroll,0,0,0
+Santa Clara,0008002,President,,,Brian Carroll,0,0,0
+Santa Clara,0008003,President,,,Brian Carroll,0,0,0
+Santa Clara,0008005,President,,,Brian Carroll,0,0,0
+Santa Clara,0008007,President,,,Brian Carroll,0,0,0
+Santa Clara,0008011,President,,,Brian Carroll,0,0,0
+Santa Clara,0008012,President,,,Brian Carroll,0,0,0
+Santa Clara,0008013,President,,,Brian Carroll,0,0,0
+Santa Clara,0008016,President,,,Brian Carroll,1,0,1
+Santa Clara,0008017,President,,,Brian Carroll,0,0,0
+Santa Clara,0008022,President,,,Brian Carroll,0,0,0
+Santa Clara,0008023,President,,,Brian Carroll,0,0,0
+Santa Clara,0008026,President,,,Brian Carroll,0,0,0
+Santa Clara,0008028,President,,,Brian Carroll,0,0,0
+Santa Clara,0008029,President,,,Brian Carroll,0,0,0
+Santa Clara,0008030,President,,,Brian Carroll,0,0,0
+Santa Clara,0008033,President,,,Brian Carroll,0,0,0
+Santa Clara,0008034,President,,,Brian Carroll,0,0,0
+Santa Clara,0008038,President,,,Brian Carroll,0,0,0
+Santa Clara,0008040,President,,,Brian Carroll,0,0,0
+Santa Clara,0008047,President,,,Brian Carroll,2,0,2
+Santa Clara,0008049,President,,,Brian Carroll,0,0,0
+Santa Clara,0008050,President,,,Brian Carroll,0,0,0
+Santa Clara,0008053,President,,,Brian Carroll,0,0,0
+Santa Clara,0008054,President,,,Brian Carroll,0,0,0
+Santa Clara,0008055,President,,,Brian Carroll,0,0,0
+Santa Clara,0008062,President,,,Brian Carroll,0,0,0
+Santa Clara,0008066,President,,,Brian Carroll,1,0,1
+Santa Clara,0008067,President,,,Brian Carroll,1,0,1
+Santa Clara,0008068,President,,,Brian Carroll,0,0,0
+Santa Clara,0008072,President,,,Brian Carroll,2,0,2
+Santa Clara,0008073,President,,,Brian Carroll,0,0,0
+Santa Clara,0008079,President,,,Brian Carroll,0,0,0
+Santa Clara,0008082,President,,,Brian Carroll,1,1,0
+Santa Clara,0008085,President,,,Brian Carroll,0,0,0
+Santa Clara,0008089,President,,,Brian Carroll,0,0,0
+Santa Clara,0008092,President,,,Brian Carroll,0,0,0
+Santa Clara,0008093,President,,,Brian Carroll,0,0,0
+Santa Clara,0008096,President,,,Brian Carroll,1,0,1
+Santa Clara,0008101,President,,,Brian Carroll,0,0,0
+Santa Clara,0008104,President,,,Brian Carroll,0,0,0
+Santa Clara,0008105,President,,,Brian Carroll,0,0,0
+Santa Clara,0008117,President,,,Brian Carroll,1,0,1
+Santa Clara,0008122,President,,,Brian Carroll,0,0,0
+Santa Clara,0008128,President,,,Brian Carroll,0,0,0
+Santa Clara,0008133,President,,,Brian Carroll,0,0,0
+Santa Clara,0008201,President,,,Brian Carroll,0,0,0
+Santa Clara,0008203,President,,,Brian Carroll,0,0,0
+Santa Clara,0008205,President,,,Brian Carroll,0,0,0
+Santa Clara,0008208,President,,,Brian Carroll,0,0,0
+Santa Clara,0008212,President,,,Brian Carroll,0,0,0
+Santa Clara,0008214,President,,,Brian Carroll,0,0,0
+Santa Clara,0008227,President,,,Brian Carroll,0,0,0
+Santa Clara,0008228,President,,,Brian Carroll,0,0,0
+Santa Clara,0008230,President,,,Brian Carroll,0,0,0
+Santa Clara,0008231,President,,,Brian Carroll,0,0,0
+Santa Clara,0008232,President,,,Brian Carroll,0,0,0
+Santa Clara,0008236,President,,,Brian Carroll,0,0,0
+Santa Clara,0008246,President,,,Brian Carroll,0,0,0
+Santa Clara,0008254,President,,,Brian Carroll,0,0,0
+Santa Clara,0008262,President,,,Brian Carroll,0,0,0
+Santa Clara,0008264,President,,,Brian Carroll,0,0,0
+Santa Clara,0008401,President,,,Brian Carroll,0,0,0
+Santa Clara,0008404,President,,,Brian Carroll,0,0,0
+Santa Clara,0008408,President,,,Brian Carroll,0,0,0
+Santa Clara,0008409,President,,,Brian Carroll,0,0,0
+Santa Clara,0008414,President,,,Brian Carroll,0,0,0
+Santa Clara,0008418,President,,,Brian Carroll,0,0,0
+Santa Clara,0008421,President,,,Brian Carroll,0,0,0
+Santa Clara,0008423,President,,,Brian Carroll,0,0,0
+Santa Clara,0008430,President,,,Brian Carroll,0,0,0
+Santa Clara,0008435,President,,,Brian Carroll,0,0,0
+Santa Clara,0008438,President,,,Brian Carroll,0,0,0
+Santa Clara,0008439,President,,,Brian Carroll,0,0,0
+Santa Clara,0008445,President,,,Brian Carroll,0,0,0
+Santa Clara,0008447,President,,,Brian Carroll,0,0,0
+Santa Clara,0008456,President,,,Brian Carroll,0,0,0
+Santa Clara,0008457,President,,,Brian Carroll,0,0,0
+Santa Clara,0008464,President,,,Brian Carroll,0,0,0
+Santa Clara,0008470,President,,,Brian Carroll,0,0,0
+Santa Clara,0008472,President,,,Brian Carroll,1,0,1
+Santa Clara,0008486,President,,,Brian Carroll,1,0,1
+Santa Clara,0008492,President,,,Brian Carroll,2,0,2
+Santa Clara,0008502,President,,,Brian Carroll,0,0,0
+Santa Clara,0008601,President,,,Brian Carroll,0,0,0
+Santa Clara,0008603,President,,,Brian Carroll,0,0,0
+Santa Clara,0008605,President,,,Brian Carroll,0,0,0
+Santa Clara,0008609,President,,,Brian Carroll,0,0,0
+Santa Clara,0008610,President,,,Brian Carroll,0,0,0
+Santa Clara,0008612,President,,,Brian Carroll,0,0,0
+Santa Clara,0008615,President,,,Brian Carroll,0,0,0
+Santa Clara,0008619,President,,,Brian Carroll,0,0,0
+Santa Clara,0008625,President,,,Brian Carroll,0,0,0
+Santa Clara,0008627,President,,,Brian Carroll,0,0,0
+Santa Clara,0008629,President,,,Brian Carroll,0,0,0
+Santa Clara,0008630,President,,,Brian Carroll,0,0,0
+Santa Clara,0008631,President,,,Brian Carroll,0,0,0
+Santa Clara,0008634,President,,,Brian Carroll,0,0,0
+Santa Clara,0008636,President,,,Brian Carroll,0,0,0
+Santa Clara,0008645,President,,,Brian Carroll,1,0,1
+Santa Clara,0008648,President,,,Brian Carroll,0,0,0
+Santa Clara,0008650,President,,,Brian Carroll,0,0,0
+Santa Clara,0008653,President,,,Brian Carroll,0,0,0
+Santa Clara,0008654,President,,,Brian Carroll,0,0,0
+Santa Clara,0008655,President,,,Brian Carroll,0,0,0
+Santa Clara,0008657,President,,,Brian Carroll,0,0,0
+Santa Clara,0008658,President,,,Brian Carroll,0,0,0
+Santa Clara,0008670,President,,,Brian Carroll,0,0,0
+Santa Clara,0008675,President,,,Brian Carroll,0,0,0
+Santa Clara,0008676,President,,,Brian Carroll,1,0,1
+Santa Clara,0008680,President,,,Brian Carroll,0,0,0
+Santa Clara,0008683,President,,,Brian Carroll,2,1,1
+Santa Clara,0008687,President,,,Brian Carroll,0,0,0
+Santa Clara,0008697,President,,,Brian Carroll,0,0,0
+Santa Clara,0008801,President,,,Brian Carroll,0,0,0
+Santa Clara,0008805,President,,,Brian Carroll,0,0,0
+Santa Clara,0008809,President,,,Brian Carroll,0,0,0
+Santa Clara,0008812,President,,,Brian Carroll,0,0,0
+Santa Clara,0008817,President,,,Brian Carroll,0,0,0
+Santa Clara,0008820,President,,,Brian Carroll,0,0,0
+Santa Clara,0008822,President,,,Brian Carroll,0,0,0
+Santa Clara,0008828,President,,,Brian Carroll,0,0,0
+Santa Clara,0008829,President,,,Brian Carroll,0,0,0
+Santa Clara,0008832,President,,,Brian Carroll,0,0,0
+Santa Clara,0008834,President,,,Brian Carroll,1,0,1
+Santa Clara,0008838,President,,,Brian Carroll,0,0,0
+Santa Clara,0008839,President,,,Brian Carroll,1,0,1
+Santa Clara,0008844,President,,,Brian Carroll,0,0,0
+Santa Clara,0008848,President,,,Brian Carroll,0,0,0
+Santa Clara,0008853,President,,,Brian Carroll,0,0,0
+Santa Clara,0008857,President,,,Brian Carroll,0,0,0
+Santa Clara,0008858,President,,,Brian Carroll,0,0,0
+Santa Clara,0008862,President,,,Brian Carroll,0,0,0
+Santa Clara,0008868,President,,,Brian Carroll,0,0,0
+Santa Clara,0008873,President,,,Brian Carroll,0,0,0
+Santa Clara,0008874,President,,,Brian Carroll,0,0,0
+Santa Clara,0008879,President,,,Brian Carroll,0,0,0
+Santa Clara,0008883,President,,,Brian Carroll,0,0,0
+Santa Clara,0008885,President,,,Brian Carroll,0,0,0
+Santa Clara,0008886,President,,,Brian Carroll,0,0,0
+Santa Clara,0008889,President,,,Brian Carroll,1,0,1
+Santa Clara,0008898,President,,,Brian Carroll,3,0,3
+Santa Clara,0008903,President,,,Brian Carroll,1,0,1
+Santa Clara,0008915,President,,,Brian Carroll,0,0,0
+Santa Clara,0008916,President,,,Brian Carroll,0,0,0
+Santa Clara,0008920,President,,,Brian Carroll,0,0,0
+Santa Clara,0008923,President,,,Brian Carroll,0,0,0
+Santa Clara,0008924,President,,,Brian Carroll,0,0,0
+Santa Clara,0009001,President,,,Brian Carroll,2,0,2
+Santa Clara,0009005,President,,,Brian Carroll,0,0,0
+Santa Clara,0009051,President,,,Brian Carroll,1,0,1
+Santa Clara,0009055,President,,,Brian Carroll,0,0,0
+Santa Clara,0009056,President,,,Brian Carroll,0,0,0
+Santa Clara,0009059,President,,,Brian Carroll,1,0,1
+Santa Clara,0009061,President,,,Brian Carroll,0,0,0
+Santa Clara,0009062,President,,,Brian Carroll,5,0,5
+Santa Clara,0009101,President,,,Brian Carroll,0,0,0
+Santa Clara,0009103,President,,,Brian Carroll,0,0,0
+Santa Clara,0009104,President,,,Brian Carroll,0,0,0
+Santa Clara,0009109,President,,,Brian Carroll,2,1,1
+Santa Clara,0009151,President,,,Brian Carroll,0,0,0
+Santa Clara,0009157,President,,,Brian Carroll,0,0,0
+Santa Clara,0009163,President,,,Brian Carroll,0,0,0
+Santa Clara,0009166,President,,,Brian Carroll,1,0,1
+Santa Clara,0009201,President,,,Brian Carroll,2,0,2
+Santa Clara,0009203,President,,,Brian Carroll,0,0,0
+Santa Clara,0009208,President,,,Brian Carroll,0,0,0
+Santa Clara,0009210,President,,,Brian Carroll,2,0,2
+Santa Clara,0009219,President,,,Brian Carroll,0,0,0
+Santa Clara,0009220,President,,,Brian Carroll,1,0,1
+Santa Clara,0009251,President,,,Brian Carroll,0,0,0
+Santa Clara,0009252,President,,,Brian Carroll,0,0,0
+Santa Clara,0009258,President,,,Brian Carroll,2,1,1
+Santa Clara,0009262,President,,,Brian Carroll,0,0,0
+Santa Clara,0009264,President,,,Brian Carroll,0,0,0
+Santa Clara,0009268,President,,,Brian Carroll,0,0,0
+Santa Clara,0009275,President,,,Brian Carroll,2,0,2
+Santa Clara,0009282,President,,,Brian Carroll,0,0,0
+Santa Clara,0002001,President,,,Jesse Ventura,0,0,0
+Santa Clara,0002002,President,,,Jesse Ventura,0,0,0
+Santa Clara,0002005,President,,,Jesse Ventura,1,0,1
+Santa Clara,0002006,President,,,Jesse Ventura,0,0,0
+Santa Clara,0002009,President,,,Jesse Ventura,0,0,0
+Santa Clara,0002013,President,,,Jesse Ventura,0,0,0
+Santa Clara,0002014,President,,,Jesse Ventura,0,0,0
+Santa Clara,0002018,President,,,Jesse Ventura,0,0,0
+Santa Clara,0002025,President,,,Jesse Ventura,0,0,0
+Santa Clara,0002043,President,,,Jesse Ventura,0,0,0
+Santa Clara,0002046,President,,,Jesse Ventura,1,0,1
+Santa Clara,0002057,President,,,Jesse Ventura,0,0,0
+Santa Clara,0002068,President,,,Jesse Ventura,0,0,0
+Santa Clara,0002098,President,,,Jesse Ventura,0,0,0
+Santa Clara,0002108,President,,,Jesse Ventura,0,0,0
+Santa Clara,0002125,President,,,Jesse Ventura,0,0,0
+Santa Clara,0002274,President,,,Jesse Ventura,0,0,0
+Santa Clara,0002275,President,,,Jesse Ventura,0,0,0
+Santa Clara,0002278,President,,,Jesse Ventura,0,0,0
+Santa Clara,0002281,President,,,Jesse Ventura,0,0,0
+Santa Clara,0002282,President,,,Jesse Ventura,0,0,0
+Santa Clara,0002285,President,,,Jesse Ventura,0,0,0
+Santa Clara,0002301,President,,,Jesse Ventura,0,0,0
+Santa Clara,0002305,President,,,Jesse Ventura,0,0,0
+Santa Clara,0002309,President,,,Jesse Ventura,0,0,0
+Santa Clara,0002314,President,,,Jesse Ventura,0,0,0
+Santa Clara,0002317,President,,,Jesse Ventura,0,0,0
+Santa Clara,0002330,President,,,Jesse Ventura,0,0,0
+Santa Clara,0002338,President,,,Jesse Ventura,0,0,0
+Santa Clara,0002351,President,,,Jesse Ventura,0,0,0
+Santa Clara,0002353,President,,,Jesse Ventura,0,0,0
+Santa Clara,0002539,President,,,Jesse Ventura,0,0,0
+Santa Clara,0002542,President,,,Jesse Ventura,0,0,0
+Santa Clara,0002545,President,,,Jesse Ventura,0,0,0
+Santa Clara,0002720,President,,,Jesse Ventura,0,0,0
+Santa Clara,0002721,President,,,Jesse Ventura,0,0,0
+Santa Clara,0002723,President,,,Jesse Ventura,0,0,0
+Santa Clara,0002724,President,,,Jesse Ventura,0,0,0
+Santa Clara,0002725,President,,,Jesse Ventura,0,0,0
+Santa Clara,0002726,President,,,Jesse Ventura,0,0,0
+Santa Clara,0002727,President,,,Jesse Ventura,0,0,0
+Santa Clara,0002729,President,,,Jesse Ventura,0,0,0
+Santa Clara,0002734,President,,,Jesse Ventura,0,0,0
+Santa Clara,0002740,President,,,Jesse Ventura,0,0,0
+Santa Clara,0002751,President,,,Jesse Ventura,0,0,0
+Santa Clara,0002761,President,,,Jesse Ventura,0,0,0
+Santa Clara,0002802,President,,,Jesse Ventura,0,0,0
+Santa Clara,0002808,President,,,Jesse Ventura,0,0,0
+Santa Clara,0002810,President,,,Jesse Ventura,0,0,0
+Santa Clara,0002811,President,,,Jesse Ventura,0,0,0
+Santa Clara,0002812,President,,,Jesse Ventura,0,0,0
+Santa Clara,0002813,President,,,Jesse Ventura,0,0,0
+Santa Clara,0002816,President,,,Jesse Ventura,0,0,0
+Santa Clara,0002825,President,,,Jesse Ventura,0,0,0
+Santa Clara,0002870,President,,,Jesse Ventura,0,0,0
+Santa Clara,0002951,President,,,Jesse Ventura,0,0,0
+Santa Clara,0003001,President,,,Jesse Ventura,0,0,0
+Santa Clara,0003002,President,,,Jesse Ventura,0,0,0
+Santa Clara,0003005,President,,,Jesse Ventura,0,0,0
+Santa Clara,0003008,President,,,Jesse Ventura,0,0,0
+Santa Clara,0003010,President,,,Jesse Ventura,0,0,0
+Santa Clara,0003011,President,,,Jesse Ventura,0,0,0
+Santa Clara,0003012,President,,,Jesse Ventura,0,0,0
+Santa Clara,0003013,President,,,Jesse Ventura,1,0,1
+Santa Clara,0003016,President,,,Jesse Ventura,0,0,0
+Santa Clara,0003017,President,,,Jesse Ventura,0,0,0
+Santa Clara,0003018,President,,,Jesse Ventura,0,0,0
+Santa Clara,0003019,President,,,Jesse Ventura,0,0,0
+Santa Clara,0003021,President,,,Jesse Ventura,0,0,0
+Santa Clara,0003023,President,,,Jesse Ventura,0,0,0
+Santa Clara,0003026,President,,,Jesse Ventura,0,0,0
+Santa Clara,0003029,President,,,Jesse Ventura,0,0,0
+Santa Clara,0003031,President,,,Jesse Ventura,0,0,0
+Santa Clara,0003032,President,,,Jesse Ventura,0,0,0
+Santa Clara,0003034,President,,,Jesse Ventura,0,0,0
+Santa Clara,0003035,President,,,Jesse Ventura,0,0,0
+Santa Clara,0003039,President,,,Jesse Ventura,0,0,0
+Santa Clara,0003040,President,,,Jesse Ventura,0,0,0
+Santa Clara,0003042,President,,,Jesse Ventura,0,0,0
+Santa Clara,0003043,President,,,Jesse Ventura,0,0,0
+Santa Clara,0003045,President,,,Jesse Ventura,0,0,0
+Santa Clara,0003047,President,,,Jesse Ventura,0,0,0
+Santa Clara,0003048,President,,,Jesse Ventura,0,0,0
+Santa Clara,0003051,President,,,Jesse Ventura,0,0,0
+Santa Clara,0003053,President,,,Jesse Ventura,0,0,0
+Santa Clara,0003061,President,,,Jesse Ventura,0,0,0
+Santa Clara,0003079,President,,,Jesse Ventura,0,0,0
+Santa Clara,0003080,President,,,Jesse Ventura,0,0,0
+Santa Clara,0003086,President,,,Jesse Ventura,0,0,0
+Santa Clara,0003087,President,,,Jesse Ventura,0,0,0
+Santa Clara,0003089,President,,,Jesse Ventura,0,0,0
+Santa Clara,0003095,President,,,Jesse Ventura,0,0,0
+Santa Clara,0003101,President,,,Jesse Ventura,0,0,0
+Santa Clara,0003102,President,,,Jesse Ventura,0,0,0
+Santa Clara,0003103,President,,,Jesse Ventura,0,0,0
+Santa Clara,0003116,President,,,Jesse Ventura,0,0,0
+Santa Clara,0003117,President,,,Jesse Ventura,0,0,0
+Santa Clara,0003120,President,,,Jesse Ventura,0,0,0
+Santa Clara,0003122,President,,,Jesse Ventura,0,0,0
+Santa Clara,0003156,President,,,Jesse Ventura,0,0,0
+Santa Clara,0003402,President,,,Jesse Ventura,0,0,0
+Santa Clara,0003406,President,,,Jesse Ventura,1,0,1
+Santa Clara,0003407,President,,,Jesse Ventura,0,0,0
+Santa Clara,0003408,President,,,Jesse Ventura,0,0,0
+Santa Clara,0003409,President,,,Jesse Ventura,0,0,0
+Santa Clara,0003410,President,,,Jesse Ventura,0,0,0
+Santa Clara,0003417,President,,,Jesse Ventura,0,0,0
+Santa Clara,0003427,President,,,Jesse Ventura,0,0,0
+Santa Clara,0003434,President,,,Jesse Ventura,0,0,0
+Santa Clara,0003438,President,,,Jesse Ventura,0,0,0
+Santa Clara,0003445,President,,,Jesse Ventura,0,0,0
+Santa Clara,0003601,President,,,Jesse Ventura,0,0,0
+Santa Clara,0003602,President,,,Jesse Ventura,0,0,0
+Santa Clara,0003603,President,,,Jesse Ventura,0,0,0
+Santa Clara,0003604,President,,,Jesse Ventura,0,0,0
+Santa Clara,0003605,President,,,Jesse Ventura,0,0,0
+Santa Clara,0003606,President,,,Jesse Ventura,0,0,0
+Santa Clara,0003608,President,,,Jesse Ventura,0,0,0
+Santa Clara,0003609,President,,,Jesse Ventura,0,0,0
+Santa Clara,0003611,President,,,Jesse Ventura,0,0,0
+Santa Clara,0003614,President,,,Jesse Ventura,0,0,0
+Santa Clara,0003624,President,,,Jesse Ventura,0,0,0
+Santa Clara,0003635,President,,,Jesse Ventura,0,0,0
+Santa Clara,0003652,President,,,Jesse Ventura,0,0,0
+Santa Clara,0003655,President,,,Jesse Ventura,0,0,0
+Santa Clara,0003669,President,,,Jesse Ventura,0,0,0
+Santa Clara,0003670,President,,,Jesse Ventura,0,0,0
+Santa Clara,0003777,President,,,Jesse Ventura,0,0,0
+Santa Clara,0003779,President,,,Jesse Ventura,0,0,0
+Santa Clara,0003782,President,,,Jesse Ventura,0,0,0
+Santa Clara,0003783,President,,,Jesse Ventura,0,0,0
+Santa Clara,0003801,President,,,Jesse Ventura,0,0,0
+Santa Clara,0003802,President,,,Jesse Ventura,0,0,0
+Santa Clara,0003803,President,,,Jesse Ventura,0,0,0
+Santa Clara,0003804,President,,,Jesse Ventura,0,0,0
+Santa Clara,0003810,President,,,Jesse Ventura,0,0,0
+Santa Clara,0003811,President,,,Jesse Ventura,0,0,0
+Santa Clara,0003814,President,,,Jesse Ventura,0,0,0
+Santa Clara,0003820,President,,,Jesse Ventura,0,0,0
+Santa Clara,0003821,President,,,Jesse Ventura,0,0,0
+Santa Clara,0003825,President,,,Jesse Ventura,1,0,1
+Santa Clara,0003828,President,,,Jesse Ventura,0,0,0
+Santa Clara,0003835,President,,,Jesse Ventura,0,0,0
+Santa Clara,0003840,President,,,Jesse Ventura,0,0,0
+Santa Clara,0003846,President,,,Jesse Ventura,0,0,0
+Santa Clara,0003861,President,,,Jesse Ventura,0,0,0
+Santa Clara,0004401,President,,,Jesse Ventura,0,0,0
+Santa Clara,0004402,President,,,Jesse Ventura,0,0,0
+Santa Clara,0004403,President,,,Jesse Ventura,0,0,0
+Santa Clara,0004405,President,,,Jesse Ventura,0,0,0
+Santa Clara,0004407,President,,,Jesse Ventura,0,0,0
+Santa Clara,0004409,President,,,Jesse Ventura,0,0,0
+Santa Clara,0004411,President,,,Jesse Ventura,0,0,0
+Santa Clara,0004412,President,,,Jesse Ventura,0,0,0
+Santa Clara,0004414,President,,,Jesse Ventura,0,0,0
+Santa Clara,0004417,President,,,Jesse Ventura,0,0,0
+Santa Clara,0004665,President,,,Jesse Ventura,0,0,0
+Santa Clara,0004666,President,,,Jesse Ventura,0,0,0
+Santa Clara,0004671,President,,,Jesse Ventura,0,0,0
+Santa Clara,0004672,President,,,Jesse Ventura,0,0,0
+Santa Clara,0004674,President,,,Jesse Ventura,0,0,0
+Santa Clara,0004675,President,,,Jesse Ventura,0,0,0
+Santa Clara,0004685,President,,,Jesse Ventura,0,0,0
+Santa Clara,0004687,President,,,Jesse Ventura,0,0,0
+Santa Clara,0004688,President,,,Jesse Ventura,0,0,0
+Santa Clara,0004691,President,,,Jesse Ventura,1,0,1
+Santa Clara,0004696,President,,,Jesse Ventura,0,0,0
+Santa Clara,0004698,President,,,Jesse Ventura,0,0,0
+Santa Clara,0004699,President,,,Jesse Ventura,0,0,0
+Santa Clara,0004702,President,,,Jesse Ventura,0,0,0
+Santa Clara,0004715,President,,,Jesse Ventura,0,0,0
+Santa Clara,0004733,President,,,Jesse Ventura,0,0,0
+Santa Clara,0004801,President,,,Jesse Ventura,0,0,0
+Santa Clara,0004806,President,,,Jesse Ventura,0,0,0
+Santa Clara,0004811,President,,,Jesse Ventura,0,0,0
+Santa Clara,0004826,President,,,Jesse Ventura,1,0,1
+Santa Clara,0004827,President,,,Jesse Ventura,0,0,0
+Santa Clara,0004833,President,,,Jesse Ventura,0,0,0
+Santa Clara,0004851,President,,,Jesse Ventura,0,0,0
+Santa Clara,0004853,President,,,Jesse Ventura,0,0,0
+Santa Clara,0004858,President,,,Jesse Ventura,0,0,0
+Santa Clara,0004876,President,,,Jesse Ventura,0,0,0
+Santa Clara,0004881,President,,,Jesse Ventura,0,0,0
+Santa Clara,0004941,President,,,Jesse Ventura,0,0,0
+Santa Clara,0004942,President,,,Jesse Ventura,0,0,0
+Santa Clara,0004943,President,,,Jesse Ventura,0,0,0
+Santa Clara,0004944,President,,,Jesse Ventura,0,0,0
+Santa Clara,0004945,President,,,Jesse Ventura,0,0,0
+Santa Clara,0004946,President,,,Jesse Ventura,0,0,0
+Santa Clara,0004949,President,,,Jesse Ventura,0,0,0
+Santa Clara,0004950,President,,,Jesse Ventura,0,0,0
+Santa Clara,0004954,President,,,Jesse Ventura,0,0,0
+Santa Clara,0004956,President,,,Jesse Ventura,0,0,0
+Santa Clara,0004958,President,,,Jesse Ventura,0,0,0
+Santa Clara,0004965,President,,,Jesse Ventura,0,0,0
+Santa Clara,0004969,President,,,Jesse Ventura,0,0,0
+Santa Clara,0004971,President,,,Jesse Ventura,0,0,0
+Santa Clara,0004973,President,,,Jesse Ventura,0,0,0
+Santa Clara,0004974,President,,,Jesse Ventura,0,0,0
+Santa Clara,0005449,President,,,Jesse Ventura,0,0,0
+Santa Clara,0005451,President,,,Jesse Ventura,0,0,0
+Santa Clara,0005454,President,,,Jesse Ventura,0,0,0
+Santa Clara,0005455,President,,,Jesse Ventura,0,0,0
+Santa Clara,0005456,President,,,Jesse Ventura,0,0,0
+Santa Clara,0005458,President,,,Jesse Ventura,0,0,0
+Santa Clara,0005502,President,,,Jesse Ventura,0,0,0
+Santa Clara,0005503,President,,,Jesse Ventura,0,0,0
+Santa Clara,0005505,President,,,Jesse Ventura,0,0,0
+Santa Clara,0005507,President,,,Jesse Ventura,0,0,0
+Santa Clara,0005556,President,,,Jesse Ventura,0,0,0
+Santa Clara,0005557,President,,,Jesse Ventura,0,0,0
+Santa Clara,0005567,President,,,Jesse Ventura,0,0,0
+Santa Clara,0005742,President,,,Jesse Ventura,0,0,0
+Santa Clara,0005743,President,,,Jesse Ventura,0,0,0
+Santa Clara,0005745,President,,,Jesse Ventura,0,0,0
+Santa Clara,0005747,President,,,Jesse Ventura,0,0,0
+Santa Clara,0005748,President,,,Jesse Ventura,0,0,0
+Santa Clara,0005756,President,,,Jesse Ventura,0,0,0
+Santa Clara,0005758,President,,,Jesse Ventura,0,0,0
+Santa Clara,0005759,President,,,Jesse Ventura,0,0,0
+Santa Clara,0005762,President,,,Jesse Ventura,0,0,0
+Santa Clara,0005763,President,,,Jesse Ventura,0,0,0
+Santa Clara,0005770,President,,,Jesse Ventura,0,0,0
+Santa Clara,0005775,President,,,Jesse Ventura,0,0,0
+Santa Clara,0005785,President,,,Jesse Ventura,0,0,0
+Santa Clara,0005793,President,,,Jesse Ventura,0,0,0
+Santa Clara,0005795,President,,,Jesse Ventura,0,0,0
+Santa Clara,0005804,President,,,Jesse Ventura,0,0,0
+Santa Clara,0005810,President,,,Jesse Ventura,0,0,0
+Santa Clara,0005811,President,,,Jesse Ventura,0,0,0
+Santa Clara,0005813,President,,,Jesse Ventura,0,0,0
+Santa Clara,0005814,President,,,Jesse Ventura,0,0,0
+Santa Clara,0005854,President,,,Jesse Ventura,0,0,0
+Santa Clara,0005879,President,,,Jesse Ventura,0,0,0
+Santa Clara,0005886,President,,,Jesse Ventura,0,0,0
+Santa Clara,0005888,President,,,Jesse Ventura,0,0,0
+Santa Clara,0005894,President,,,Jesse Ventura,0,0,0
+Santa Clara,0005896,President,,,Jesse Ventura,0,0,0
+Santa Clara,0005901,President,,,Jesse Ventura,0,0,0
+Santa Clara,0005902,President,,,Jesse Ventura,0,0,0
+Santa Clara,0005903,President,,,Jesse Ventura,0,0,0
+Santa Clara,0005906,President,,,Jesse Ventura,0,0,0
+Santa Clara,0005907,President,,,Jesse Ventura,0,0,0
+Santa Clara,0005911,President,,,Jesse Ventura,0,0,0
+Santa Clara,0005912,President,,,Jesse Ventura,0,0,0
+Santa Clara,0005914,President,,,Jesse Ventura,0,0,0
+Santa Clara,0005915,President,,,Jesse Ventura,0,0,0
+Santa Clara,0005916,President,,,Jesse Ventura,0,0,0
+Santa Clara,0005917,President,,,Jesse Ventura,0,0,0
+Santa Clara,0005919,President,,,Jesse Ventura,0,0,0
+Santa Clara,0005922,President,,,Jesse Ventura,0,0,0
+Santa Clara,0005925,President,,,Jesse Ventura,0,0,0
+Santa Clara,0005927,President,,,Jesse Ventura,0,0,0
+Santa Clara,0005929,President,,,Jesse Ventura,0,0,0
+Santa Clara,0005931,President,,,Jesse Ventura,0,0,0
+Santa Clara,0005936,President,,,Jesse Ventura,0,0,0
+Santa Clara,0005940,President,,,Jesse Ventura,0,0,0
+Santa Clara,0005947,President,,,Jesse Ventura,0,0,0
+Santa Clara,0005949,President,,,Jesse Ventura,0,0,0
+Santa Clara,0005950,President,,,Jesse Ventura,0,0,0
+Santa Clara,0005951,President,,,Jesse Ventura,0,0,0
+Santa Clara,0005955,President,,,Jesse Ventura,0,0,0
+Santa Clara,0005956,President,,,Jesse Ventura,0,0,0
+Santa Clara,0005957,President,,,Jesse Ventura,0,0,0
+Santa Clara,0005958,President,,,Jesse Ventura,0,0,0
+Santa Clara,0005959,President,,,Jesse Ventura,0,0,0
+Santa Clara,0005965,President,,,Jesse Ventura,0,0,0
+Santa Clara,0005966,President,,,Jesse Ventura,0,0,0
+Santa Clara,0005975,President,,,Jesse Ventura,0,0,0
+Santa Clara,0005988,President,,,Jesse Ventura,0,0,0
+Santa Clara,0006023,President,,,Jesse Ventura,0,0,0
+Santa Clara,0006028,President,,,Jesse Ventura,0,0,0
+Santa Clara,0006031,President,,,Jesse Ventura,0,0,0
+Santa Clara,0006035,President,,,Jesse Ventura,0,0,0
+Santa Clara,0006036,President,,,Jesse Ventura,0,0,0
+Santa Clara,0006048,President,,,Jesse Ventura,0,0,0
+Santa Clara,0006401,President,,,Jesse Ventura,0,0,0
+Santa Clara,0006402,President,,,Jesse Ventura,0,0,0
+Santa Clara,0006404,President,,,Jesse Ventura,0,0,0
+Santa Clara,0006405,President,,,Jesse Ventura,0,0,0
+Santa Clara,0006410,President,,,Jesse Ventura,0,0,0
+Santa Clara,0006413,President,,,Jesse Ventura,0,0,0
+Santa Clara,0006418,President,,,Jesse Ventura,0,0,0
+Santa Clara,0006419,President,,,Jesse Ventura,0,0,0
+Santa Clara,0006423,President,,,Jesse Ventura,0,0,0
+Santa Clara,0006452,President,,,Jesse Ventura,0,0,0
+Santa Clara,0006454,President,,,Jesse Ventura,0,0,0
+Santa Clara,0006455,President,,,Jesse Ventura,0,0,0
+Santa Clara,0006491,President,,,Jesse Ventura,0,0,0
+Santa Clara,0006502,President,,,Jesse Ventura,0,0,0
+Santa Clara,0006509,President,,,Jesse Ventura,0,0,0
+Santa Clara,0006510,President,,,Jesse Ventura,0,0,0
+Santa Clara,0006511,President,,,Jesse Ventura,0,0,0
+Santa Clara,0006515,President,,,Jesse Ventura,0,0,0
+Santa Clara,0006624,President,,,Jesse Ventura,0,0,0
+Santa Clara,0006625,President,,,Jesse Ventura,0,0,0
+Santa Clara,0006669,President,,,Jesse Ventura,0,0,0
+Santa Clara,0006678,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007001,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007005,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007011,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007012,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007014,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007019,President,,,Jesse Ventura,1,0,1
+Santa Clara,0007025,President,,,Jesse Ventura,1,0,1
+Santa Clara,0007028,President,,,Jesse Ventura,2,0,2
+Santa Clara,0007032,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007036,President,,,Jesse Ventura,1,0,1
+Santa Clara,0007038,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007041,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007044,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007046,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007051,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007059,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007061,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007062,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007079,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007081,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007089,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007201,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007202,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007203,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007205,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007214,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007217,President,,,Jesse Ventura,1,0,1
+Santa Clara,0007219,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007221,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007224,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007231,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007235,President,,,Jesse Ventura,1,0,1
+Santa Clara,0007237,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007245,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007246,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007248,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007252,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007255,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007257,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007261,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007264,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007271,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007273,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007282,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007294,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007295,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007298,President,,,Jesse Ventura,1,0,1
+Santa Clara,0007299,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007306,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007401,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007402,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007403,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007408,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007409,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007410,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007411,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007414,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007415,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007416,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007417,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007418,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007419,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007430,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007435,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007436,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007438,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007440,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007441,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007442,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007447,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007458,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007459,President,,,Jesse Ventura,1,0,1
+Santa Clara,0007470,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007471,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007479,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007483,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007601,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007606,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007609,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007615,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007619,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007620,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007621,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007624,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007632,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007634,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007648,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007654,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007660,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007666,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007670,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007673,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007674,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007677,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007680,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007689,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007690,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007801,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007802,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007803,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007805,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007810,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007811,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007812,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007816,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007817,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007818,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007821,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007826,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007827,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007832,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007833,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007843,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007849,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007850,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007851,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007861,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007867,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007874,President,,,Jesse Ventura,0,0,0
+Santa Clara,0007880,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008001,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008002,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008003,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008005,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008007,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008011,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008012,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008013,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008016,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008017,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008022,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008023,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008026,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008028,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008029,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008030,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008033,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008034,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008038,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008040,President,,,Jesse Ventura,1,0,1
+Santa Clara,0008047,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008049,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008050,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008053,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008054,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008055,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008062,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008066,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008067,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008068,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008072,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008073,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008079,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008082,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008085,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008089,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008092,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008093,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008096,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008101,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008104,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008105,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008117,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008122,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008128,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008133,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008201,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008203,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008205,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008208,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008212,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008214,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008227,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008228,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008230,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008231,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008232,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008236,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008246,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008254,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008262,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008264,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008401,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008404,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008408,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008409,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008414,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008418,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008421,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008423,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008430,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008435,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008438,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008439,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008445,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008447,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008456,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008457,President,,,Jesse Ventura,1,0,1
+Santa Clara,0008464,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008470,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008472,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008486,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008492,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008502,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008601,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008603,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008605,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008609,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008610,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008612,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008615,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008619,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008625,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008627,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008629,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008630,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008631,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008634,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008636,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008645,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008648,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008650,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008653,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008654,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008655,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008657,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008658,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008670,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008675,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008676,President,,,Jesse Ventura,1,0,1
+Santa Clara,0008680,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008683,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008687,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008697,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008801,President,,,Jesse Ventura,1,0,1
+Santa Clara,0008805,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008809,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008812,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008817,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008820,President,,,Jesse Ventura,1,0,1
+Santa Clara,0008822,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008828,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008829,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008832,President,,,Jesse Ventura,1,0,1
+Santa Clara,0008834,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008838,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008839,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008844,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008848,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008853,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008857,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008858,President,,,Jesse Ventura,2,0,2
+Santa Clara,0008862,President,,,Jesse Ventura,1,1,0
+Santa Clara,0008868,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008873,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008874,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008879,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008883,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008885,President,,,Jesse Ventura,2,0,2
+Santa Clara,0008886,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008889,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008898,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008903,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008915,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008916,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008920,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008923,President,,,Jesse Ventura,0,0,0
+Santa Clara,0008924,President,,,Jesse Ventura,0,0,0
+Santa Clara,0009001,President,,,Jesse Ventura,0,0,0
+Santa Clara,0009005,President,,,Jesse Ventura,0,0,0
+Santa Clara,0009051,President,,,Jesse Ventura,0,0,0
+Santa Clara,0009055,President,,,Jesse Ventura,0,0,0
+Santa Clara,0009056,President,,,Jesse Ventura,0,0,0
+Santa Clara,0009059,President,,,Jesse Ventura,0,0,0
+Santa Clara,0009061,President,,,Jesse Ventura,0,0,0
+Santa Clara,0009062,President,,,Jesse Ventura,0,0,0
+Santa Clara,0009101,President,,,Jesse Ventura,0,0,0
+Santa Clara,0009103,President,,,Jesse Ventura,0,0,0
+Santa Clara,0009104,President,,,Jesse Ventura,0,0,0
+Santa Clara,0009109,President,,,Jesse Ventura,1,0,1
+Santa Clara,0009151,President,,,Jesse Ventura,0,0,0
+Santa Clara,0009157,President,,,Jesse Ventura,0,0,0
+Santa Clara,0009163,President,,,Jesse Ventura,0,0,0
+Santa Clara,0009166,President,,,Jesse Ventura,0,0,0
+Santa Clara,0009201,President,,,Jesse Ventura,0,0,0
+Santa Clara,0009203,President,,,Jesse Ventura,0,0,0
+Santa Clara,0009208,President,,,Jesse Ventura,0,0,0
+Santa Clara,0009210,President,,,Jesse Ventura,1,0,1
+Santa Clara,0009219,President,,,Jesse Ventura,0,0,0
+Santa Clara,0009220,President,,,Jesse Ventura,0,0,0
+Santa Clara,0009251,President,,,Jesse Ventura,0,0,0
+Santa Clara,0009252,President,,,Jesse Ventura,0,0,0
+Santa Clara,0009258,President,,,Jesse Ventura,0,0,0
+Santa Clara,0009262,President,,,Jesse Ventura,0,0,0
+Santa Clara,0009264,President,,,Jesse Ventura,0,0,0
+Santa Clara,0009268,President,,,Jesse Ventura,0,0,0
+Santa Clara,0009275,President,,,Jesse Ventura,0,0,0
+Santa Clara,0009282,President,,,Jesse Ventura,0,0,0
+Santa Clara,0002001,President,,,Mark Charles,0,0,0
+Santa Clara,0002002,President,,,Mark Charles,0,0,0
+Santa Clara,0002005,President,,,Mark Charles,0,0,0
+Santa Clara,0002006,President,,,Mark Charles,0,0,0
+Santa Clara,0002009,President,,,Mark Charles,0,0,0
+Santa Clara,0002013,President,,,Mark Charles,0,0,0
+Santa Clara,0002014,President,,,Mark Charles,0,0,0
+Santa Clara,0002018,President,,,Mark Charles,0,0,0
+Santa Clara,0002025,President,,,Mark Charles,0,0,0
+Santa Clara,0002043,President,,,Mark Charles,0,0,0
+Santa Clara,0002046,President,,,Mark Charles,0,0,0
+Santa Clara,0002057,President,,,Mark Charles,0,0,0
+Santa Clara,0002068,President,,,Mark Charles,0,0,0
+Santa Clara,0002098,President,,,Mark Charles,0,0,0
+Santa Clara,0002108,President,,,Mark Charles,0,0,0
+Santa Clara,0002125,President,,,Mark Charles,0,0,0
+Santa Clara,0002274,President,,,Mark Charles,0,0,0
+Santa Clara,0002275,President,,,Mark Charles,0,0,0
+Santa Clara,0002278,President,,,Mark Charles,0,0,0
+Santa Clara,0002281,President,,,Mark Charles,0,0,0
+Santa Clara,0002282,President,,,Mark Charles,0,0,0
+Santa Clara,0002285,President,,,Mark Charles,0,0,0
+Santa Clara,0002301,President,,,Mark Charles,0,0,0
+Santa Clara,0002305,President,,,Mark Charles,0,0,0
+Santa Clara,0002309,President,,,Mark Charles,0,0,0
+Santa Clara,0002314,President,,,Mark Charles,0,0,0
+Santa Clara,0002317,President,,,Mark Charles,0,0,0
+Santa Clara,0002330,President,,,Mark Charles,0,0,0
+Santa Clara,0002338,President,,,Mark Charles,0,0,0
+Santa Clara,0002351,President,,,Mark Charles,0,0,0
+Santa Clara,0002353,President,,,Mark Charles,0,0,0
+Santa Clara,0002539,President,,,Mark Charles,0,0,0
+Santa Clara,0002542,President,,,Mark Charles,0,0,0
+Santa Clara,0002545,President,,,Mark Charles,0,0,0
+Santa Clara,0002720,President,,,Mark Charles,0,0,0
+Santa Clara,0002721,President,,,Mark Charles,0,0,0
+Santa Clara,0002723,President,,,Mark Charles,0,0,0
+Santa Clara,0002724,President,,,Mark Charles,0,0,0
+Santa Clara,0002725,President,,,Mark Charles,0,0,0
+Santa Clara,0002726,President,,,Mark Charles,0,0,0
+Santa Clara,0002727,President,,,Mark Charles,0,0,0
+Santa Clara,0002729,President,,,Mark Charles,0,0,0
+Santa Clara,0002734,President,,,Mark Charles,0,0,0
+Santa Clara,0002740,President,,,Mark Charles,0,0,0
+Santa Clara,0002751,President,,,Mark Charles,0,0,0
+Santa Clara,0002761,President,,,Mark Charles,0,0,0
+Santa Clara,0002802,President,,,Mark Charles,0,0,0
+Santa Clara,0002808,President,,,Mark Charles,0,0,0
+Santa Clara,0002810,President,,,Mark Charles,0,0,0
+Santa Clara,0002811,President,,,Mark Charles,0,0,0
+Santa Clara,0002812,President,,,Mark Charles,0,0,0
+Santa Clara,0002813,President,,,Mark Charles,0,0,0
+Santa Clara,0002816,President,,,Mark Charles,0,0,0
+Santa Clara,0002825,President,,,Mark Charles,0,0,0
+Santa Clara,0002870,President,,,Mark Charles,0,0,0
+Santa Clara,0002951,President,,,Mark Charles,0,0,0
+Santa Clara,0003001,President,,,Mark Charles,0,0,0
+Santa Clara,0003002,President,,,Mark Charles,1,0,1
+Santa Clara,0003005,President,,,Mark Charles,0,0,0
+Santa Clara,0003008,President,,,Mark Charles,0,0,0
+Santa Clara,0003010,President,,,Mark Charles,0,0,0
+Santa Clara,0003011,President,,,Mark Charles,0,0,0
+Santa Clara,0003012,President,,,Mark Charles,0,0,0
+Santa Clara,0003013,President,,,Mark Charles,0,0,0
+Santa Clara,0003016,President,,,Mark Charles,0,0,0
+Santa Clara,0003017,President,,,Mark Charles,0,0,0
+Santa Clara,0003018,President,,,Mark Charles,0,0,0
+Santa Clara,0003019,President,,,Mark Charles,0,0,0
+Santa Clara,0003021,President,,,Mark Charles,0,0,0
+Santa Clara,0003023,President,,,Mark Charles,0,0,0
+Santa Clara,0003026,President,,,Mark Charles,0,0,0
+Santa Clara,0003029,President,,,Mark Charles,0,0,0
+Santa Clara,0003031,President,,,Mark Charles,0,0,0
+Santa Clara,0003032,President,,,Mark Charles,0,0,0
+Santa Clara,0003034,President,,,Mark Charles,0,0,0
+Santa Clara,0003035,President,,,Mark Charles,1,0,1
+Santa Clara,0003039,President,,,Mark Charles,0,0,0
+Santa Clara,0003040,President,,,Mark Charles,0,0,0
+Santa Clara,0003042,President,,,Mark Charles,0,0,0
+Santa Clara,0003043,President,,,Mark Charles,0,0,0
+Santa Clara,0003045,President,,,Mark Charles,0,0,0
+Santa Clara,0003047,President,,,Mark Charles,0,0,0
+Santa Clara,0003048,President,,,Mark Charles,0,0,0
+Santa Clara,0003051,President,,,Mark Charles,1,0,1
+Santa Clara,0003053,President,,,Mark Charles,0,0,0
+Santa Clara,0003061,President,,,Mark Charles,0,0,0
+Santa Clara,0003079,President,,,Mark Charles,0,0,0
+Santa Clara,0003080,President,,,Mark Charles,0,0,0
+Santa Clara,0003086,President,,,Mark Charles,0,0,0
+Santa Clara,0003087,President,,,Mark Charles,0,0,0
+Santa Clara,0003089,President,,,Mark Charles,0,0,0
+Santa Clara,0003095,President,,,Mark Charles,0,0,0
+Santa Clara,0003101,President,,,Mark Charles,0,0,0
+Santa Clara,0003102,President,,,Mark Charles,0,0,0
+Santa Clara,0003103,President,,,Mark Charles,0,0,0
+Santa Clara,0003116,President,,,Mark Charles,0,0,0
+Santa Clara,0003117,President,,,Mark Charles,0,0,0
+Santa Clara,0003120,President,,,Mark Charles,0,0,0
+Santa Clara,0003122,President,,,Mark Charles,0,0,0
+Santa Clara,0003156,President,,,Mark Charles,0,0,0
+Santa Clara,0003402,President,,,Mark Charles,1,1,0
+Santa Clara,0003406,President,,,Mark Charles,0,0,0
+Santa Clara,0003407,President,,,Mark Charles,1,0,1
+Santa Clara,0003408,President,,,Mark Charles,0,0,0
+Santa Clara,0003409,President,,,Mark Charles,0,0,0
+Santa Clara,0003410,President,,,Mark Charles,1,0,1
+Santa Clara,0003417,President,,,Mark Charles,0,0,0
+Santa Clara,0003427,President,,,Mark Charles,0,0,0
+Santa Clara,0003434,President,,,Mark Charles,0,0,0
+Santa Clara,0003438,President,,,Mark Charles,0,0,0
+Santa Clara,0003445,President,,,Mark Charles,2,0,2
+Santa Clara,0003601,President,,,Mark Charles,0,0,0
+Santa Clara,0003602,President,,,Mark Charles,0,0,0
+Santa Clara,0003603,President,,,Mark Charles,0,0,0
+Santa Clara,0003604,President,,,Mark Charles,0,0,0
+Santa Clara,0003605,President,,,Mark Charles,0,0,0
+Santa Clara,0003606,President,,,Mark Charles,0,0,0
+Santa Clara,0003608,President,,,Mark Charles,0,0,0
+Santa Clara,0003609,President,,,Mark Charles,0,0,0
+Santa Clara,0003611,President,,,Mark Charles,0,0,0
+Santa Clara,0003614,President,,,Mark Charles,0,0,0
+Santa Clara,0003624,President,,,Mark Charles,0,0,0
+Santa Clara,0003635,President,,,Mark Charles,0,0,0
+Santa Clara,0003652,President,,,Mark Charles,0,0,0
+Santa Clara,0003655,President,,,Mark Charles,0,0,0
+Santa Clara,0003669,President,,,Mark Charles,0,0,0
+Santa Clara,0003670,President,,,Mark Charles,0,0,0
+Santa Clara,0003777,President,,,Mark Charles,0,0,0
+Santa Clara,0003779,President,,,Mark Charles,0,0,0
+Santa Clara,0003782,President,,,Mark Charles,0,0,0
+Santa Clara,0003783,President,,,Mark Charles,0,0,0
+Santa Clara,0003801,President,,,Mark Charles,0,0,0
+Santa Clara,0003802,President,,,Mark Charles,0,0,0
+Santa Clara,0003803,President,,,Mark Charles,0,0,0
+Santa Clara,0003804,President,,,Mark Charles,0,0,0
+Santa Clara,0003810,President,,,Mark Charles,0,0,0
+Santa Clara,0003811,President,,,Mark Charles,0,0,0
+Santa Clara,0003814,President,,,Mark Charles,0,0,0
+Santa Clara,0003820,President,,,Mark Charles,0,0,0
+Santa Clara,0003821,President,,,Mark Charles,0,0,0
+Santa Clara,0003825,President,,,Mark Charles,0,0,0
+Santa Clara,0003828,President,,,Mark Charles,0,0,0
+Santa Clara,0003835,President,,,Mark Charles,0,0,0
+Santa Clara,0003840,President,,,Mark Charles,0,0,0
+Santa Clara,0003846,President,,,Mark Charles,0,0,0
+Santa Clara,0003861,President,,,Mark Charles,0,0,0
+Santa Clara,0004401,President,,,Mark Charles,0,0,0
+Santa Clara,0004402,President,,,Mark Charles,0,0,0
+Santa Clara,0004403,President,,,Mark Charles,0,0,0
+Santa Clara,0004405,President,,,Mark Charles,0,0,0
+Santa Clara,0004407,President,,,Mark Charles,0,0,0
+Santa Clara,0004409,President,,,Mark Charles,0,0,0
+Santa Clara,0004411,President,,,Mark Charles,0,0,0
+Santa Clara,0004412,President,,,Mark Charles,1,0,1
+Santa Clara,0004414,President,,,Mark Charles,0,0,0
+Santa Clara,0004417,President,,,Mark Charles,0,0,0
+Santa Clara,0004665,President,,,Mark Charles,0,0,0
+Santa Clara,0004666,President,,,Mark Charles,0,0,0
+Santa Clara,0004671,President,,,Mark Charles,0,0,0
+Santa Clara,0004672,President,,,Mark Charles,0,0,0
+Santa Clara,0004674,President,,,Mark Charles,0,0,0
+Santa Clara,0004675,President,,,Mark Charles,0,0,0
+Santa Clara,0004685,President,,,Mark Charles,0,0,0
+Santa Clara,0004687,President,,,Mark Charles,0,0,0
+Santa Clara,0004688,President,,,Mark Charles,0,0,0
+Santa Clara,0004691,President,,,Mark Charles,0,0,0
+Santa Clara,0004696,President,,,Mark Charles,0,0,0
+Santa Clara,0004698,President,,,Mark Charles,0,0,0
+Santa Clara,0004699,President,,,Mark Charles,0,0,0
+Santa Clara,0004702,President,,,Mark Charles,0,0,0
+Santa Clara,0004715,President,,,Mark Charles,0,0,0
+Santa Clara,0004733,President,,,Mark Charles,0,0,0
+Santa Clara,0004801,President,,,Mark Charles,0,0,0
+Santa Clara,0004806,President,,,Mark Charles,0,0,0
+Santa Clara,0004811,President,,,Mark Charles,0,0,0
+Santa Clara,0004826,President,,,Mark Charles,0,0,0
+Santa Clara,0004827,President,,,Mark Charles,0,0,0
+Santa Clara,0004833,President,,,Mark Charles,1,0,1
+Santa Clara,0004851,President,,,Mark Charles,0,0,0
+Santa Clara,0004853,President,,,Mark Charles,0,0,0
+Santa Clara,0004858,President,,,Mark Charles,0,0,0
+Santa Clara,0004876,President,,,Mark Charles,0,0,0
+Santa Clara,0004881,President,,,Mark Charles,0,0,0
+Santa Clara,0004941,President,,,Mark Charles,0,0,0
+Santa Clara,0004942,President,,,Mark Charles,0,0,0
+Santa Clara,0004943,President,,,Mark Charles,0,0,0
+Santa Clara,0004944,President,,,Mark Charles,0,0,0
+Santa Clara,0004945,President,,,Mark Charles,0,0,0
+Santa Clara,0004946,President,,,Mark Charles,0,0,0
+Santa Clara,0004949,President,,,Mark Charles,0,0,0
+Santa Clara,0004950,President,,,Mark Charles,0,0,0
+Santa Clara,0004954,President,,,Mark Charles,0,0,0
+Santa Clara,0004956,President,,,Mark Charles,0,0,0
+Santa Clara,0004958,President,,,Mark Charles,0,0,0
+Santa Clara,0004965,President,,,Mark Charles,0,0,0
+Santa Clara,0004969,President,,,Mark Charles,0,0,0
+Santa Clara,0004971,President,,,Mark Charles,0,0,0
+Santa Clara,0004973,President,,,Mark Charles,0,0,0
+Santa Clara,0004974,President,,,Mark Charles,0,0,0
+Santa Clara,0005449,President,,,Mark Charles,0,0,0
+Santa Clara,0005451,President,,,Mark Charles,0,0,0
+Santa Clara,0005454,President,,,Mark Charles,0,0,0
+Santa Clara,0005455,President,,,Mark Charles,0,0,0
+Santa Clara,0005456,President,,,Mark Charles,0,0,0
+Santa Clara,0005458,President,,,Mark Charles,0,0,0
+Santa Clara,0005502,President,,,Mark Charles,0,0,0
+Santa Clara,0005503,President,,,Mark Charles,0,0,0
+Santa Clara,0005505,President,,,Mark Charles,0,0,0
+Santa Clara,0005507,President,,,Mark Charles,0,0,0
+Santa Clara,0005556,President,,,Mark Charles,0,0,0
+Santa Clara,0005557,President,,,Mark Charles,0,0,0
+Santa Clara,0005567,President,,,Mark Charles,0,0,0
+Santa Clara,0005742,President,,,Mark Charles,0,0,0
+Santa Clara,0005743,President,,,Mark Charles,0,0,0
+Santa Clara,0005745,President,,,Mark Charles,0,0,0
+Santa Clara,0005747,President,,,Mark Charles,0,0,0
+Santa Clara,0005748,President,,,Mark Charles,0,0,0
+Santa Clara,0005756,President,,,Mark Charles,0,0,0
+Santa Clara,0005758,President,,,Mark Charles,0,0,0
+Santa Clara,0005759,President,,,Mark Charles,0,0,0
+Santa Clara,0005762,President,,,Mark Charles,0,0,0
+Santa Clara,0005763,President,,,Mark Charles,0,0,0
+Santa Clara,0005770,President,,,Mark Charles,0,0,0
+Santa Clara,0005775,President,,,Mark Charles,0,0,0
+Santa Clara,0005785,President,,,Mark Charles,0,0,0
+Santa Clara,0005793,President,,,Mark Charles,0,0,0
+Santa Clara,0005795,President,,,Mark Charles,0,0,0
+Santa Clara,0005804,President,,,Mark Charles,0,0,0
+Santa Clara,0005810,President,,,Mark Charles,0,0,0
+Santa Clara,0005811,President,,,Mark Charles,0,0,0
+Santa Clara,0005813,President,,,Mark Charles,0,0,0
+Santa Clara,0005814,President,,,Mark Charles,0,0,0
+Santa Clara,0005854,President,,,Mark Charles,0,0,0
+Santa Clara,0005879,President,,,Mark Charles,0,0,0
+Santa Clara,0005886,President,,,Mark Charles,0,0,0
+Santa Clara,0005888,President,,,Mark Charles,0,0,0
+Santa Clara,0005894,President,,,Mark Charles,0,0,0
+Santa Clara,0005896,President,,,Mark Charles,0,0,0
+Santa Clara,0005901,President,,,Mark Charles,0,0,0
+Santa Clara,0005902,President,,,Mark Charles,0,0,0
+Santa Clara,0005903,President,,,Mark Charles,0,0,0
+Santa Clara,0005906,President,,,Mark Charles,0,0,0
+Santa Clara,0005907,President,,,Mark Charles,0,0,0
+Santa Clara,0005911,President,,,Mark Charles,0,0,0
+Santa Clara,0005912,President,,,Mark Charles,0,0,0
+Santa Clara,0005914,President,,,Mark Charles,0,0,0
+Santa Clara,0005915,President,,,Mark Charles,0,0,0
+Santa Clara,0005916,President,,,Mark Charles,0,0,0
+Santa Clara,0005917,President,,,Mark Charles,0,0,0
+Santa Clara,0005919,President,,,Mark Charles,0,0,0
+Santa Clara,0005922,President,,,Mark Charles,0,0,0
+Santa Clara,0005925,President,,,Mark Charles,0,0,0
+Santa Clara,0005927,President,,,Mark Charles,0,0,0
+Santa Clara,0005929,President,,,Mark Charles,0,0,0
+Santa Clara,0005931,President,,,Mark Charles,0,0,0
+Santa Clara,0005936,President,,,Mark Charles,0,0,0
+Santa Clara,0005940,President,,,Mark Charles,0,0,0
+Santa Clara,0005947,President,,,Mark Charles,0,0,0
+Santa Clara,0005949,President,,,Mark Charles,0,0,0
+Santa Clara,0005950,President,,,Mark Charles,0,0,0
+Santa Clara,0005951,President,,,Mark Charles,0,0,0
+Santa Clara,0005955,President,,,Mark Charles,0,0,0
+Santa Clara,0005956,President,,,Mark Charles,0,0,0
+Santa Clara,0005957,President,,,Mark Charles,0,0,0
+Santa Clara,0005958,President,,,Mark Charles,0,0,0
+Santa Clara,0005959,President,,,Mark Charles,0,0,0
+Santa Clara,0005965,President,,,Mark Charles,0,0,0
+Santa Clara,0005966,President,,,Mark Charles,0,0,0
+Santa Clara,0005975,President,,,Mark Charles,0,0,0
+Santa Clara,0005988,President,,,Mark Charles,0,0,0
+Santa Clara,0006023,President,,,Mark Charles,0,0,0
+Santa Clara,0006028,President,,,Mark Charles,0,0,0
+Santa Clara,0006031,President,,,Mark Charles,0,0,0
+Santa Clara,0006035,President,,,Mark Charles,0,0,0
+Santa Clara,0006036,President,,,Mark Charles,0,0,0
+Santa Clara,0006048,President,,,Mark Charles,0,0,0
+Santa Clara,0006401,President,,,Mark Charles,0,0,0
+Santa Clara,0006402,President,,,Mark Charles,0,0,0
+Santa Clara,0006404,President,,,Mark Charles,1,0,1
+Santa Clara,0006405,President,,,Mark Charles,0,0,0
+Santa Clara,0006410,President,,,Mark Charles,0,0,0
+Santa Clara,0006413,President,,,Mark Charles,0,0,0
+Santa Clara,0006418,President,,,Mark Charles,0,0,0
+Santa Clara,0006419,President,,,Mark Charles,0,0,0
+Santa Clara,0006423,President,,,Mark Charles,0,0,0
+Santa Clara,0006452,President,,,Mark Charles,0,0,0
+Santa Clara,0006454,President,,,Mark Charles,0,0,0
+Santa Clara,0006455,President,,,Mark Charles,0,0,0
+Santa Clara,0006491,President,,,Mark Charles,0,0,0
+Santa Clara,0006502,President,,,Mark Charles,0,0,0
+Santa Clara,0006509,President,,,Mark Charles,0,0,0
+Santa Clara,0006510,President,,,Mark Charles,0,0,0
+Santa Clara,0006511,President,,,Mark Charles,0,0,0
+Santa Clara,0006515,President,,,Mark Charles,0,0,0
+Santa Clara,0006624,President,,,Mark Charles,0,0,0
+Santa Clara,0006625,President,,,Mark Charles,0,0,0
+Santa Clara,0006669,President,,,Mark Charles,0,0,0
+Santa Clara,0006678,President,,,Mark Charles,0,0,0
+Santa Clara,0007001,President,,,Mark Charles,0,0,0
+Santa Clara,0007005,President,,,Mark Charles,1,0,1
+Santa Clara,0007011,President,,,Mark Charles,0,0,0
+Santa Clara,0007012,President,,,Mark Charles,0,0,0
+Santa Clara,0007014,President,,,Mark Charles,0,0,0
+Santa Clara,0007019,President,,,Mark Charles,0,0,0
+Santa Clara,0007025,President,,,Mark Charles,0,0,0
+Santa Clara,0007028,President,,,Mark Charles,0,0,0
+Santa Clara,0007032,President,,,Mark Charles,0,0,0
+Santa Clara,0007036,President,,,Mark Charles,0,0,0
+Santa Clara,0007038,President,,,Mark Charles,0,0,0
+Santa Clara,0007041,President,,,Mark Charles,0,0,0
+Santa Clara,0007044,President,,,Mark Charles,0,0,0
+Santa Clara,0007046,President,,,Mark Charles,0,0,0
+Santa Clara,0007051,President,,,Mark Charles,0,0,0
+Santa Clara,0007059,President,,,Mark Charles,0,0,0
+Santa Clara,0007061,President,,,Mark Charles,0,0,0
+Santa Clara,0007062,President,,,Mark Charles,0,0,0
+Santa Clara,0007079,President,,,Mark Charles,0,0,0
+Santa Clara,0007081,President,,,Mark Charles,0,0,0
+Santa Clara,0007089,President,,,Mark Charles,0,0,0
+Santa Clara,0007201,President,,,Mark Charles,0,0,0
+Santa Clara,0007202,President,,,Mark Charles,0,0,0
+Santa Clara,0007203,President,,,Mark Charles,0,0,0
+Santa Clara,0007205,President,,,Mark Charles,0,0,0
+Santa Clara,0007214,President,,,Mark Charles,0,0,0
+Santa Clara,0007217,President,,,Mark Charles,0,0,0
+Santa Clara,0007219,President,,,Mark Charles,0,0,0
+Santa Clara,0007221,President,,,Mark Charles,0,0,0
+Santa Clara,0007224,President,,,Mark Charles,0,0,0
+Santa Clara,0007231,President,,,Mark Charles,0,0,0
+Santa Clara,0007235,President,,,Mark Charles,0,0,0
+Santa Clara,0007237,President,,,Mark Charles,0,0,0
+Santa Clara,0007245,President,,,Mark Charles,0,0,0
+Santa Clara,0007246,President,,,Mark Charles,0,0,0
+Santa Clara,0007248,President,,,Mark Charles,0,0,0
+Santa Clara,0007252,President,,,Mark Charles,0,0,0
+Santa Clara,0007255,President,,,Mark Charles,0,0,0
+Santa Clara,0007257,President,,,Mark Charles,0,0,0
+Santa Clara,0007261,President,,,Mark Charles,0,0,0
+Santa Clara,0007264,President,,,Mark Charles,0,0,0
+Santa Clara,0007271,President,,,Mark Charles,0,0,0
+Santa Clara,0007273,President,,,Mark Charles,0,0,0
+Santa Clara,0007282,President,,,Mark Charles,0,0,0
+Santa Clara,0007294,President,,,Mark Charles,0,0,0
+Santa Clara,0007295,President,,,Mark Charles,0,0,0
+Santa Clara,0007298,President,,,Mark Charles,0,0,0
+Santa Clara,0007299,President,,,Mark Charles,0,0,0
+Santa Clara,0007306,President,,,Mark Charles,0,0,0
+Santa Clara,0007401,President,,,Mark Charles,0,0,0
+Santa Clara,0007402,President,,,Mark Charles,0,0,0
+Santa Clara,0007403,President,,,Mark Charles,0,0,0
+Santa Clara,0007408,President,,,Mark Charles,0,0,0
+Santa Clara,0007409,President,,,Mark Charles,0,0,0
+Santa Clara,0007410,President,,,Mark Charles,0,0,0
+Santa Clara,0007411,President,,,Mark Charles,0,0,0
+Santa Clara,0007414,President,,,Mark Charles,0,0,0
+Santa Clara,0007415,President,,,Mark Charles,0,0,0
+Santa Clara,0007416,President,,,Mark Charles,0,0,0
+Santa Clara,0007417,President,,,Mark Charles,1,1,0
+Santa Clara,0007418,President,,,Mark Charles,0,0,0
+Santa Clara,0007419,President,,,Mark Charles,0,0,0
+Santa Clara,0007430,President,,,Mark Charles,0,0,0
+Santa Clara,0007435,President,,,Mark Charles,0,0,0
+Santa Clara,0007436,President,,,Mark Charles,0,0,0
+Santa Clara,0007438,President,,,Mark Charles,0,0,0
+Santa Clara,0007440,President,,,Mark Charles,0,0,0
+Santa Clara,0007441,President,,,Mark Charles,0,0,0
+Santa Clara,0007442,President,,,Mark Charles,0,0,0
+Santa Clara,0007447,President,,,Mark Charles,0,0,0
+Santa Clara,0007458,President,,,Mark Charles,0,0,0
+Santa Clara,0007459,President,,,Mark Charles,0,0,0
+Santa Clara,0007470,President,,,Mark Charles,2,0,2
+Santa Clara,0007471,President,,,Mark Charles,0,0,0
+Santa Clara,0007479,President,,,Mark Charles,0,0,0
+Santa Clara,0007483,President,,,Mark Charles,0,0,0
+Santa Clara,0007601,President,,,Mark Charles,0,0,0
+Santa Clara,0007606,President,,,Mark Charles,0,0,0
+Santa Clara,0007609,President,,,Mark Charles,0,0,0
+Santa Clara,0007615,President,,,Mark Charles,0,0,0
+Santa Clara,0007619,President,,,Mark Charles,0,0,0
+Santa Clara,0007620,President,,,Mark Charles,0,0,0
+Santa Clara,0007621,President,,,Mark Charles,0,0,0
+Santa Clara,0007624,President,,,Mark Charles,1,0,1
+Santa Clara,0007632,President,,,Mark Charles,0,0,0
+Santa Clara,0007634,President,,,Mark Charles,0,0,0
+Santa Clara,0007648,President,,,Mark Charles,0,0,0
+Santa Clara,0007654,President,,,Mark Charles,0,0,0
+Santa Clara,0007660,President,,,Mark Charles,0,0,0
+Santa Clara,0007666,President,,,Mark Charles,0,0,0
+Santa Clara,0007670,President,,,Mark Charles,0,0,0
+Santa Clara,0007673,President,,,Mark Charles,0,0,0
+Santa Clara,0007674,President,,,Mark Charles,0,0,0
+Santa Clara,0007677,President,,,Mark Charles,0,0,0
+Santa Clara,0007680,President,,,Mark Charles,0,0,0
+Santa Clara,0007689,President,,,Mark Charles,0,0,0
+Santa Clara,0007690,President,,,Mark Charles,0,0,0
+Santa Clara,0007801,President,,,Mark Charles,0,0,0
+Santa Clara,0007802,President,,,Mark Charles,0,0,0
+Santa Clara,0007803,President,,,Mark Charles,0,0,0
+Santa Clara,0007805,President,,,Mark Charles,0,0,0
+Santa Clara,0007810,President,,,Mark Charles,0,0,0
+Santa Clara,0007811,President,,,Mark Charles,0,0,0
+Santa Clara,0007812,President,,,Mark Charles,0,0,0
+Santa Clara,0007816,President,,,Mark Charles,0,0,0
+Santa Clara,0007817,President,,,Mark Charles,0,0,0
+Santa Clara,0007818,President,,,Mark Charles,0,0,0
+Santa Clara,0007821,President,,,Mark Charles,0,0,0
+Santa Clara,0007826,President,,,Mark Charles,0,0,0
+Santa Clara,0007827,President,,,Mark Charles,0,0,0
+Santa Clara,0007832,President,,,Mark Charles,0,0,0
+Santa Clara,0007833,President,,,Mark Charles,0,0,0
+Santa Clara,0007843,President,,,Mark Charles,1,0,1
+Santa Clara,0007849,President,,,Mark Charles,0,0,0
+Santa Clara,0007850,President,,,Mark Charles,0,0,0
+Santa Clara,0007851,President,,,Mark Charles,0,0,0
+Santa Clara,0007861,President,,,Mark Charles,0,0,0
+Santa Clara,0007867,President,,,Mark Charles,0,0,0
+Santa Clara,0007874,President,,,Mark Charles,0,0,0
+Santa Clara,0007880,President,,,Mark Charles,0,0,0
+Santa Clara,0008001,President,,,Mark Charles,0,0,0
+Santa Clara,0008002,President,,,Mark Charles,0,0,0
+Santa Clara,0008003,President,,,Mark Charles,0,0,0
+Santa Clara,0008005,President,,,Mark Charles,0,0,0
+Santa Clara,0008007,President,,,Mark Charles,0,0,0
+Santa Clara,0008011,President,,,Mark Charles,0,0,0
+Santa Clara,0008012,President,,,Mark Charles,0,0,0
+Santa Clara,0008013,President,,,Mark Charles,0,0,0
+Santa Clara,0008016,President,,,Mark Charles,0,0,0
+Santa Clara,0008017,President,,,Mark Charles,0,0,0
+Santa Clara,0008022,President,,,Mark Charles,0,0,0
+Santa Clara,0008023,President,,,Mark Charles,0,0,0
+Santa Clara,0008026,President,,,Mark Charles,0,0,0
+Santa Clara,0008028,President,,,Mark Charles,0,0,0
+Santa Clara,0008029,President,,,Mark Charles,0,0,0
+Santa Clara,0008030,President,,,Mark Charles,0,0,0
+Santa Clara,0008033,President,,,Mark Charles,0,0,0
+Santa Clara,0008034,President,,,Mark Charles,0,0,0
+Santa Clara,0008038,President,,,Mark Charles,0,0,0
+Santa Clara,0008040,President,,,Mark Charles,0,0,0
+Santa Clara,0008047,President,,,Mark Charles,0,0,0
+Santa Clara,0008049,President,,,Mark Charles,0,0,0
+Santa Clara,0008050,President,,,Mark Charles,0,0,0
+Santa Clara,0008053,President,,,Mark Charles,0,0,0
+Santa Clara,0008054,President,,,Mark Charles,0,0,0
+Santa Clara,0008055,President,,,Mark Charles,0,0,0
+Santa Clara,0008062,President,,,Mark Charles,0,0,0
+Santa Clara,0008066,President,,,Mark Charles,0,0,0
+Santa Clara,0008067,President,,,Mark Charles,0,0,0
+Santa Clara,0008068,President,,,Mark Charles,0,0,0
+Santa Clara,0008072,President,,,Mark Charles,0,0,0
+Santa Clara,0008073,President,,,Mark Charles,0,0,0
+Santa Clara,0008079,President,,,Mark Charles,0,0,0
+Santa Clara,0008082,President,,,Mark Charles,0,0,0
+Santa Clara,0008085,President,,,Mark Charles,0,0,0
+Santa Clara,0008089,President,,,Mark Charles,0,0,0
+Santa Clara,0008092,President,,,Mark Charles,0,0,0
+Santa Clara,0008093,President,,,Mark Charles,0,0,0
+Santa Clara,0008096,President,,,Mark Charles,0,0,0
+Santa Clara,0008101,President,,,Mark Charles,0,0,0
+Santa Clara,0008104,President,,,Mark Charles,0,0,0
+Santa Clara,0008105,President,,,Mark Charles,0,0,0
+Santa Clara,0008117,President,,,Mark Charles,0,0,0
+Santa Clara,0008122,President,,,Mark Charles,0,0,0
+Santa Clara,0008128,President,,,Mark Charles,0,0,0
+Santa Clara,0008133,President,,,Mark Charles,0,0,0
+Santa Clara,0008201,President,,,Mark Charles,1,0,1
+Santa Clara,0008203,President,,,Mark Charles,0,0,0
+Santa Clara,0008205,President,,,Mark Charles,0,0,0
+Santa Clara,0008208,President,,,Mark Charles,0,0,0
+Santa Clara,0008212,President,,,Mark Charles,0,0,0
+Santa Clara,0008214,President,,,Mark Charles,0,0,0
+Santa Clara,0008227,President,,,Mark Charles,0,0,0
+Santa Clara,0008228,President,,,Mark Charles,0,0,0
+Santa Clara,0008230,President,,,Mark Charles,0,0,0
+Santa Clara,0008231,President,,,Mark Charles,0,0,0
+Santa Clara,0008232,President,,,Mark Charles,0,0,0
+Santa Clara,0008236,President,,,Mark Charles,0,0,0
+Santa Clara,0008246,President,,,Mark Charles,0,0,0
+Santa Clara,0008254,President,,,Mark Charles,0,0,0
+Santa Clara,0008262,President,,,Mark Charles,0,0,0
+Santa Clara,0008264,President,,,Mark Charles,0,0,0
+Santa Clara,0008401,President,,,Mark Charles,0,0,0
+Santa Clara,0008404,President,,,Mark Charles,0,0,0
+Santa Clara,0008408,President,,,Mark Charles,0,0,0
+Santa Clara,0008409,President,,,Mark Charles,0,0,0
+Santa Clara,0008414,President,,,Mark Charles,0,0,0
+Santa Clara,0008418,President,,,Mark Charles,0,0,0
+Santa Clara,0008421,President,,,Mark Charles,0,0,0
+Santa Clara,0008423,President,,,Mark Charles,0,0,0
+Santa Clara,0008430,President,,,Mark Charles,0,0,0
+Santa Clara,0008435,President,,,Mark Charles,0,0,0
+Santa Clara,0008438,President,,,Mark Charles,0,0,0
+Santa Clara,0008439,President,,,Mark Charles,0,0,0
+Santa Clara,0008445,President,,,Mark Charles,0,0,0
+Santa Clara,0008447,President,,,Mark Charles,0,0,0
+Santa Clara,0008456,President,,,Mark Charles,0,0,0
+Santa Clara,0008457,President,,,Mark Charles,0,0,0
+Santa Clara,0008464,President,,,Mark Charles,0,0,0
+Santa Clara,0008470,President,,,Mark Charles,0,0,0
+Santa Clara,0008472,President,,,Mark Charles,0,0,0
+Santa Clara,0008486,President,,,Mark Charles,0,0,0
+Santa Clara,0008492,President,,,Mark Charles,0,0,0
+Santa Clara,0008502,President,,,Mark Charles,0,0,0
+Santa Clara,0008601,President,,,Mark Charles,0,0,0
+Santa Clara,0008603,President,,,Mark Charles,0,0,0
+Santa Clara,0008605,President,,,Mark Charles,0,0,0
+Santa Clara,0008609,President,,,Mark Charles,0,0,0
+Santa Clara,0008610,President,,,Mark Charles,0,0,0
+Santa Clara,0008612,President,,,Mark Charles,0,0,0
+Santa Clara,0008615,President,,,Mark Charles,0,0,0
+Santa Clara,0008619,President,,,Mark Charles,0,0,0
+Santa Clara,0008625,President,,,Mark Charles,0,0,0
+Santa Clara,0008627,President,,,Mark Charles,0,0,0
+Santa Clara,0008629,President,,,Mark Charles,0,0,0
+Santa Clara,0008630,President,,,Mark Charles,0,0,0
+Santa Clara,0008631,President,,,Mark Charles,0,0,0
+Santa Clara,0008634,President,,,Mark Charles,0,0,0
+Santa Clara,0008636,President,,,Mark Charles,0,0,0
+Santa Clara,0008645,President,,,Mark Charles,0,0,0
+Santa Clara,0008648,President,,,Mark Charles,0,0,0
+Santa Clara,0008650,President,,,Mark Charles,0,0,0
+Santa Clara,0008653,President,,,Mark Charles,0,0,0
+Santa Clara,0008654,President,,,Mark Charles,0,0,0
+Santa Clara,0008655,President,,,Mark Charles,0,0,0
+Santa Clara,0008657,President,,,Mark Charles,0,0,0
+Santa Clara,0008658,President,,,Mark Charles,0,0,0
+Santa Clara,0008670,President,,,Mark Charles,0,0,0
+Santa Clara,0008675,President,,,Mark Charles,0,0,0
+Santa Clara,0008676,President,,,Mark Charles,0,0,0
+Santa Clara,0008680,President,,,Mark Charles,0,0,0
+Santa Clara,0008683,President,,,Mark Charles,0,0,0
+Santa Clara,0008687,President,,,Mark Charles,0,0,0
+Santa Clara,0008697,President,,,Mark Charles,0,0,0
+Santa Clara,0008801,President,,,Mark Charles,0,0,0
+Santa Clara,0008805,President,,,Mark Charles,0,0,0
+Santa Clara,0008809,President,,,Mark Charles,0,0,0
+Santa Clara,0008812,President,,,Mark Charles,0,0,0
+Santa Clara,0008817,President,,,Mark Charles,1,0,1
+Santa Clara,0008820,President,,,Mark Charles,0,0,0
+Santa Clara,0008822,President,,,Mark Charles,0,0,0
+Santa Clara,0008828,President,,,Mark Charles,0,0,0
+Santa Clara,0008829,President,,,Mark Charles,0,0,0
+Santa Clara,0008832,President,,,Mark Charles,0,0,0
+Santa Clara,0008834,President,,,Mark Charles,0,0,0
+Santa Clara,0008838,President,,,Mark Charles,0,0,0
+Santa Clara,0008839,President,,,Mark Charles,0,0,0
+Santa Clara,0008844,President,,,Mark Charles,0,0,0
+Santa Clara,0008848,President,,,Mark Charles,0,0,0
+Santa Clara,0008853,President,,,Mark Charles,1,0,1
+Santa Clara,0008857,President,,,Mark Charles,0,0,0
+Santa Clara,0008858,President,,,Mark Charles,0,0,0
+Santa Clara,0008862,President,,,Mark Charles,0,0,0
+Santa Clara,0008868,President,,,Mark Charles,0,0,0
+Santa Clara,0008873,President,,,Mark Charles,0,0,0
+Santa Clara,0008874,President,,,Mark Charles,0,0,0
+Santa Clara,0008879,President,,,Mark Charles,0,0,0
+Santa Clara,0008883,President,,,Mark Charles,1,0,1
+Santa Clara,0008885,President,,,Mark Charles,0,0,0
+Santa Clara,0008886,President,,,Mark Charles,0,0,0
+Santa Clara,0008889,President,,,Mark Charles,0,0,0
+Santa Clara,0008898,President,,,Mark Charles,0,0,0
+Santa Clara,0008903,President,,,Mark Charles,0,0,0
+Santa Clara,0008915,President,,,Mark Charles,0,0,0
+Santa Clara,0008916,President,,,Mark Charles,0,0,0
+Santa Clara,0008920,President,,,Mark Charles,0,0,0
+Santa Clara,0008923,President,,,Mark Charles,0,0,0
+Santa Clara,0008924,President,,,Mark Charles,0,0,0
+Santa Clara,0009001,President,,,Mark Charles,0,0,0
+Santa Clara,0009005,President,,,Mark Charles,0,0,0
+Santa Clara,0009051,President,,,Mark Charles,0,0,0
+Santa Clara,0009055,President,,,Mark Charles,0,0,0
+Santa Clara,0009056,President,,,Mark Charles,0,0,0
+Santa Clara,0009059,President,,,Mark Charles,0,0,0
+Santa Clara,0009061,President,,,Mark Charles,0,0,0
+Santa Clara,0009062,President,,,Mark Charles,0,0,0
+Santa Clara,0009101,President,,,Mark Charles,2,0,2
+Santa Clara,0009103,President,,,Mark Charles,0,0,0
+Santa Clara,0009104,President,,,Mark Charles,0,0,0
+Santa Clara,0009109,President,,,Mark Charles,1,0,1
+Santa Clara,0009151,President,,,Mark Charles,0,0,0
+Santa Clara,0009157,President,,,Mark Charles,0,0,0
+Santa Clara,0009163,President,,,Mark Charles,0,0,0
+Santa Clara,0009166,President,,,Mark Charles,0,0,0
+Santa Clara,0009201,President,,,Mark Charles,0,0,0
+Santa Clara,0009203,President,,,Mark Charles,0,0,0
+Santa Clara,0009208,President,,,Mark Charles,0,0,0
+Santa Clara,0009210,President,,,Mark Charles,0,0,0
+Santa Clara,0009219,President,,,Mark Charles,0,0,0
+Santa Clara,0009220,President,,,Mark Charles,0,0,0
+Santa Clara,0009251,President,,,Mark Charles,0,0,0
+Santa Clara,0009252,President,,,Mark Charles,0,0,0
+Santa Clara,0009258,President,,,Mark Charles,0,0,0
+Santa Clara,0009262,President,,,Mark Charles,0,0,0
+Santa Clara,0009264,President,,,Mark Charles,0,0,0
+Santa Clara,0009268,President,,,Mark Charles,0,0,0
+Santa Clara,0009275,President,,,Mark Charles,0,0,0
+Santa Clara,0009282,President,,,Mark Charles,0,0,0
+Santa Clara,0002001,President,,,Joseph Kishore,0,0,0
+Santa Clara,0002002,President,,,Joseph Kishore,0,0,0
+Santa Clara,0002005,President,,,Joseph Kishore,0,0,0
+Santa Clara,0002006,President,,,Joseph Kishore,0,0,0
+Santa Clara,0002009,President,,,Joseph Kishore,0,0,0
+Santa Clara,0002013,President,,,Joseph Kishore,0,0,0
+Santa Clara,0002014,President,,,Joseph Kishore,0,0,0
+Santa Clara,0002018,President,,,Joseph Kishore,0,0,0
+Santa Clara,0002025,President,,,Joseph Kishore,0,0,0
+Santa Clara,0002043,President,,,Joseph Kishore,0,0,0
+Santa Clara,0002046,President,,,Joseph Kishore,0,0,0
+Santa Clara,0002057,President,,,Joseph Kishore,0,0,0
+Santa Clara,0002068,President,,,Joseph Kishore,0,0,0
+Santa Clara,0002098,President,,,Joseph Kishore,0,0,0
+Santa Clara,0002108,President,,,Joseph Kishore,0,0,0
+Santa Clara,0002125,President,,,Joseph Kishore,0,0,0
+Santa Clara,0002274,President,,,Joseph Kishore,0,0,0
+Santa Clara,0002275,President,,,Joseph Kishore,0,0,0
+Santa Clara,0002278,President,,,Joseph Kishore,0,0,0
+Santa Clara,0002281,President,,,Joseph Kishore,0,0,0
+Santa Clara,0002282,President,,,Joseph Kishore,0,0,0
+Santa Clara,0002285,President,,,Joseph Kishore,0,0,0
+Santa Clara,0002301,President,,,Joseph Kishore,0,0,0
+Santa Clara,0002305,President,,,Joseph Kishore,0,0,0
+Santa Clara,0002309,President,,,Joseph Kishore,0,0,0
+Santa Clara,0002314,President,,,Joseph Kishore,0,0,0
+Santa Clara,0002317,President,,,Joseph Kishore,0,0,0
+Santa Clara,0002330,President,,,Joseph Kishore,0,0,0
+Santa Clara,0002338,President,,,Joseph Kishore,0,0,0
+Santa Clara,0002351,President,,,Joseph Kishore,0,0,0
+Santa Clara,0002353,President,,,Joseph Kishore,0,0,0
+Santa Clara,0002539,President,,,Joseph Kishore,0,0,0
+Santa Clara,0002542,President,,,Joseph Kishore,0,0,0
+Santa Clara,0002545,President,,,Joseph Kishore,0,0,0
+Santa Clara,0002720,President,,,Joseph Kishore,0,0,0
+Santa Clara,0002721,President,,,Joseph Kishore,0,0,0
+Santa Clara,0002723,President,,,Joseph Kishore,0,0,0
+Santa Clara,0002724,President,,,Joseph Kishore,0,0,0
+Santa Clara,0002725,President,,,Joseph Kishore,0,0,0
+Santa Clara,0002726,President,,,Joseph Kishore,0,0,0
+Santa Clara,0002727,President,,,Joseph Kishore,0,0,0
+Santa Clara,0002729,President,,,Joseph Kishore,0,0,0
+Santa Clara,0002734,President,,,Joseph Kishore,0,0,0
+Santa Clara,0002740,President,,,Joseph Kishore,0,0,0
+Santa Clara,0002751,President,,,Joseph Kishore,0,0,0
+Santa Clara,0002761,President,,,Joseph Kishore,0,0,0
+Santa Clara,0002802,President,,,Joseph Kishore,0,0,0
+Santa Clara,0002808,President,,,Joseph Kishore,0,0,0
+Santa Clara,0002810,President,,,Joseph Kishore,0,0,0
+Santa Clara,0002811,President,,,Joseph Kishore,0,0,0
+Santa Clara,0002812,President,,,Joseph Kishore,0,0,0
+Santa Clara,0002813,President,,,Joseph Kishore,0,0,0
+Santa Clara,0002816,President,,,Joseph Kishore,0,0,0
+Santa Clara,0002825,President,,,Joseph Kishore,0,0,0
+Santa Clara,0002870,President,,,Joseph Kishore,0,0,0
+Santa Clara,0002951,President,,,Joseph Kishore,0,0,0
+Santa Clara,0003001,President,,,Joseph Kishore,0,0,0
+Santa Clara,0003002,President,,,Joseph Kishore,0,0,0
+Santa Clara,0003005,President,,,Joseph Kishore,0,0,0
+Santa Clara,0003008,President,,,Joseph Kishore,0,0,0
+Santa Clara,0003010,President,,,Joseph Kishore,0,0,0
+Santa Clara,0003011,President,,,Joseph Kishore,0,0,0
+Santa Clara,0003012,President,,,Joseph Kishore,0,0,0
+Santa Clara,0003013,President,,,Joseph Kishore,0,0,0
+Santa Clara,0003016,President,,,Joseph Kishore,0,0,0
+Santa Clara,0003017,President,,,Joseph Kishore,0,0,0
+Santa Clara,0003018,President,,,Joseph Kishore,0,0,0
+Santa Clara,0003019,President,,,Joseph Kishore,0,0,0
+Santa Clara,0003021,President,,,Joseph Kishore,0,0,0
+Santa Clara,0003023,President,,,Joseph Kishore,0,0,0
+Santa Clara,0003026,President,,,Joseph Kishore,0,0,0
+Santa Clara,0003029,President,,,Joseph Kishore,0,0,0
+Santa Clara,0003031,President,,,Joseph Kishore,0,0,0
+Santa Clara,0003032,President,,,Joseph Kishore,0,0,0
+Santa Clara,0003034,President,,,Joseph Kishore,0,0,0
+Santa Clara,0003035,President,,,Joseph Kishore,0,0,0
+Santa Clara,0003039,President,,,Joseph Kishore,0,0,0
+Santa Clara,0003040,President,,,Joseph Kishore,0,0,0
+Santa Clara,0003042,President,,,Joseph Kishore,0,0,0
+Santa Clara,0003043,President,,,Joseph Kishore,0,0,0
+Santa Clara,0003045,President,,,Joseph Kishore,0,0,0
+Santa Clara,0003047,President,,,Joseph Kishore,0,0,0
+Santa Clara,0003048,President,,,Joseph Kishore,0,0,0
+Santa Clara,0003051,President,,,Joseph Kishore,0,0,0
+Santa Clara,0003053,President,,,Joseph Kishore,0,0,0
+Santa Clara,0003061,President,,,Joseph Kishore,0,0,0
+Santa Clara,0003079,President,,,Joseph Kishore,0,0,0
+Santa Clara,0003080,President,,,Joseph Kishore,0,0,0
+Santa Clara,0003086,President,,,Joseph Kishore,0,0,0
+Santa Clara,0003087,President,,,Joseph Kishore,0,0,0
+Santa Clara,0003089,President,,,Joseph Kishore,0,0,0
+Santa Clara,0003095,President,,,Joseph Kishore,0,0,0
+Santa Clara,0003101,President,,,Joseph Kishore,0,0,0
+Santa Clara,0003102,President,,,Joseph Kishore,0,0,0
+Santa Clara,0003103,President,,,Joseph Kishore,0,0,0
+Santa Clara,0003116,President,,,Joseph Kishore,0,0,0
+Santa Clara,0003117,President,,,Joseph Kishore,0,0,0
+Santa Clara,0003120,President,,,Joseph Kishore,0,0,0
+Santa Clara,0003122,President,,,Joseph Kishore,0,0,0
+Santa Clara,0003156,President,,,Joseph Kishore,0,0,0
+Santa Clara,0003402,President,,,Joseph Kishore,0,0,0
+Santa Clara,0003406,President,,,Joseph Kishore,0,0,0
+Santa Clara,0003407,President,,,Joseph Kishore,0,0,0
+Santa Clara,0003408,President,,,Joseph Kishore,0,0,0
+Santa Clara,0003409,President,,,Joseph Kishore,0,0,0
+Santa Clara,0003410,President,,,Joseph Kishore,0,0,0
+Santa Clara,0003417,President,,,Joseph Kishore,0,0,0
+Santa Clara,0003427,President,,,Joseph Kishore,1,0,1
+Santa Clara,0003434,President,,,Joseph Kishore,0,0,0
+Santa Clara,0003438,President,,,Joseph Kishore,0,0,0
+Santa Clara,0003445,President,,,Joseph Kishore,0,0,0
+Santa Clara,0003601,President,,,Joseph Kishore,0,0,0
+Santa Clara,0003602,President,,,Joseph Kishore,0,0,0
+Santa Clara,0003603,President,,,Joseph Kishore,0,0,0
+Santa Clara,0003604,President,,,Joseph Kishore,0,0,0
+Santa Clara,0003605,President,,,Joseph Kishore,0,0,0
+Santa Clara,0003606,President,,,Joseph Kishore,0,0,0
+Santa Clara,0003608,President,,,Joseph Kishore,0,0,0
+Santa Clara,0003609,President,,,Joseph Kishore,0,0,0
+Santa Clara,0003611,President,,,Joseph Kishore,0,0,0
+Santa Clara,0003614,President,,,Joseph Kishore,0,0,0
+Santa Clara,0003624,President,,,Joseph Kishore,0,0,0
+Santa Clara,0003635,President,,,Joseph Kishore,0,0,0
+Santa Clara,0003652,President,,,Joseph Kishore,0,0,0
+Santa Clara,0003655,President,,,Joseph Kishore,0,0,0
+Santa Clara,0003669,President,,,Joseph Kishore,0,0,0
+Santa Clara,0003670,President,,,Joseph Kishore,0,0,0
+Santa Clara,0003777,President,,,Joseph Kishore,0,0,0
+Santa Clara,0003779,President,,,Joseph Kishore,0,0,0
+Santa Clara,0003782,President,,,Joseph Kishore,0,0,0
+Santa Clara,0003783,President,,,Joseph Kishore,0,0,0
+Santa Clara,0003801,President,,,Joseph Kishore,0,0,0
+Santa Clara,0003802,President,,,Joseph Kishore,0,0,0
+Santa Clara,0003803,President,,,Joseph Kishore,0,0,0
+Santa Clara,0003804,President,,,Joseph Kishore,0,0,0
+Santa Clara,0003810,President,,,Joseph Kishore,0,0,0
+Santa Clara,0003811,President,,,Joseph Kishore,0,0,0
+Santa Clara,0003814,President,,,Joseph Kishore,0,0,0
+Santa Clara,0003820,President,,,Joseph Kishore,0,0,0
+Santa Clara,0003821,President,,,Joseph Kishore,0,0,0
+Santa Clara,0003825,President,,,Joseph Kishore,0,0,0
+Santa Clara,0003828,President,,,Joseph Kishore,0,0,0
+Santa Clara,0003835,President,,,Joseph Kishore,0,0,0
+Santa Clara,0003840,President,,,Joseph Kishore,0,0,0
+Santa Clara,0003846,President,,,Joseph Kishore,0,0,0
+Santa Clara,0003861,President,,,Joseph Kishore,0,0,0
+Santa Clara,0004401,President,,,Joseph Kishore,0,0,0
+Santa Clara,0004402,President,,,Joseph Kishore,0,0,0
+Santa Clara,0004403,President,,,Joseph Kishore,0,0,0
+Santa Clara,0004405,President,,,Joseph Kishore,0,0,0
+Santa Clara,0004407,President,,,Joseph Kishore,0,0,0
+Santa Clara,0004409,President,,,Joseph Kishore,0,0,0
+Santa Clara,0004411,President,,,Joseph Kishore,0,0,0
+Santa Clara,0004412,President,,,Joseph Kishore,0,0,0
+Santa Clara,0004414,President,,,Joseph Kishore,0,0,0
+Santa Clara,0004417,President,,,Joseph Kishore,0,0,0
+Santa Clara,0004665,President,,,Joseph Kishore,0,0,0
+Santa Clara,0004666,President,,,Joseph Kishore,0,0,0
+Santa Clara,0004671,President,,,Joseph Kishore,0,0,0
+Santa Clara,0004672,President,,,Joseph Kishore,0,0,0
+Santa Clara,0004674,President,,,Joseph Kishore,0,0,0
+Santa Clara,0004675,President,,,Joseph Kishore,0,0,0
+Santa Clara,0004685,President,,,Joseph Kishore,0,0,0
+Santa Clara,0004687,President,,,Joseph Kishore,0,0,0
+Santa Clara,0004688,President,,,Joseph Kishore,0,0,0
+Santa Clara,0004691,President,,,Joseph Kishore,0,0,0
+Santa Clara,0004696,President,,,Joseph Kishore,0,0,0
+Santa Clara,0004698,President,,,Joseph Kishore,0,0,0
+Santa Clara,0004699,President,,,Joseph Kishore,0,0,0
+Santa Clara,0004702,President,,,Joseph Kishore,0,0,0
+Santa Clara,0004715,President,,,Joseph Kishore,0,0,0
+Santa Clara,0004733,President,,,Joseph Kishore,0,0,0
+Santa Clara,0004801,President,,,Joseph Kishore,0,0,0
+Santa Clara,0004806,President,,,Joseph Kishore,0,0,0
+Santa Clara,0004811,President,,,Joseph Kishore,0,0,0
+Santa Clara,0004826,President,,,Joseph Kishore,0,0,0
+Santa Clara,0004827,President,,,Joseph Kishore,0,0,0
+Santa Clara,0004833,President,,,Joseph Kishore,0,0,0
+Santa Clara,0004851,President,,,Joseph Kishore,0,0,0
+Santa Clara,0004853,President,,,Joseph Kishore,0,0,0
+Santa Clara,0004858,President,,,Joseph Kishore,0,0,0
+Santa Clara,0004876,President,,,Joseph Kishore,0,0,0
+Santa Clara,0004881,President,,,Joseph Kishore,0,0,0
+Santa Clara,0004941,President,,,Joseph Kishore,0,0,0
+Santa Clara,0004942,President,,,Joseph Kishore,0,0,0
+Santa Clara,0004943,President,,,Joseph Kishore,0,0,0
+Santa Clara,0004944,President,,,Joseph Kishore,0,0,0
+Santa Clara,0004945,President,,,Joseph Kishore,0,0,0
+Santa Clara,0004946,President,,,Joseph Kishore,0,0,0
+Santa Clara,0004949,President,,,Joseph Kishore,0,0,0
+Santa Clara,0004950,President,,,Joseph Kishore,0,0,0
+Santa Clara,0004954,President,,,Joseph Kishore,0,0,0
+Santa Clara,0004956,President,,,Joseph Kishore,0,0,0
+Santa Clara,0004958,President,,,Joseph Kishore,0,0,0
+Santa Clara,0004965,President,,,Joseph Kishore,0,0,0
+Santa Clara,0004969,President,,,Joseph Kishore,0,0,0
+Santa Clara,0004971,President,,,Joseph Kishore,0,0,0
+Santa Clara,0004973,President,,,Joseph Kishore,0,0,0
+Santa Clara,0004974,President,,,Joseph Kishore,0,0,0
+Santa Clara,0005449,President,,,Joseph Kishore,0,0,0
+Santa Clara,0005451,President,,,Joseph Kishore,0,0,0
+Santa Clara,0005454,President,,,Joseph Kishore,0,0,0
+Santa Clara,0005455,President,,,Joseph Kishore,0,0,0
+Santa Clara,0005456,President,,,Joseph Kishore,0,0,0
+Santa Clara,0005458,President,,,Joseph Kishore,0,0,0
+Santa Clara,0005502,President,,,Joseph Kishore,0,0,0
+Santa Clara,0005503,President,,,Joseph Kishore,0,0,0
+Santa Clara,0005505,President,,,Joseph Kishore,0,0,0
+Santa Clara,0005507,President,,,Joseph Kishore,0,0,0
+Santa Clara,0005556,President,,,Joseph Kishore,0,0,0
+Santa Clara,0005557,President,,,Joseph Kishore,0,0,0
+Santa Clara,0005567,President,,,Joseph Kishore,0,0,0
+Santa Clara,0005742,President,,,Joseph Kishore,0,0,0
+Santa Clara,0005743,President,,,Joseph Kishore,0,0,0
+Santa Clara,0005745,President,,,Joseph Kishore,0,0,0
+Santa Clara,0005747,President,,,Joseph Kishore,0,0,0
+Santa Clara,0005748,President,,,Joseph Kishore,0,0,0
+Santa Clara,0005756,President,,,Joseph Kishore,0,0,0
+Santa Clara,0005758,President,,,Joseph Kishore,0,0,0
+Santa Clara,0005759,President,,,Joseph Kishore,0,0,0
+Santa Clara,0005762,President,,,Joseph Kishore,0,0,0
+Santa Clara,0005763,President,,,Joseph Kishore,0,0,0
+Santa Clara,0005770,President,,,Joseph Kishore,0,0,0
+Santa Clara,0005775,President,,,Joseph Kishore,0,0,0
+Santa Clara,0005785,President,,,Joseph Kishore,0,0,0
+Santa Clara,0005793,President,,,Joseph Kishore,0,0,0
+Santa Clara,0005795,President,,,Joseph Kishore,0,0,0
+Santa Clara,0005804,President,,,Joseph Kishore,0,0,0
+Santa Clara,0005810,President,,,Joseph Kishore,0,0,0
+Santa Clara,0005811,President,,,Joseph Kishore,0,0,0
+Santa Clara,0005813,President,,,Joseph Kishore,0,0,0
+Santa Clara,0005814,President,,,Joseph Kishore,0,0,0
+Santa Clara,0005854,President,,,Joseph Kishore,0,0,0
+Santa Clara,0005879,President,,,Joseph Kishore,0,0,0
+Santa Clara,0005886,President,,,Joseph Kishore,0,0,0
+Santa Clara,0005888,President,,,Joseph Kishore,0,0,0
+Santa Clara,0005894,President,,,Joseph Kishore,0,0,0
+Santa Clara,0005896,President,,,Joseph Kishore,0,0,0
+Santa Clara,0005901,President,,,Joseph Kishore,0,0,0
+Santa Clara,0005902,President,,,Joseph Kishore,0,0,0
+Santa Clara,0005903,President,,,Joseph Kishore,0,0,0
+Santa Clara,0005906,President,,,Joseph Kishore,0,0,0
+Santa Clara,0005907,President,,,Joseph Kishore,0,0,0
+Santa Clara,0005911,President,,,Joseph Kishore,0,0,0
+Santa Clara,0005912,President,,,Joseph Kishore,0,0,0
+Santa Clara,0005914,President,,,Joseph Kishore,0,0,0
+Santa Clara,0005915,President,,,Joseph Kishore,0,0,0
+Santa Clara,0005916,President,,,Joseph Kishore,0,0,0
+Santa Clara,0005917,President,,,Joseph Kishore,0,0,0
+Santa Clara,0005919,President,,,Joseph Kishore,0,0,0
+Santa Clara,0005922,President,,,Joseph Kishore,0,0,0
+Santa Clara,0005925,President,,,Joseph Kishore,0,0,0
+Santa Clara,0005927,President,,,Joseph Kishore,0,0,0
+Santa Clara,0005929,President,,,Joseph Kishore,0,0,0
+Santa Clara,0005931,President,,,Joseph Kishore,0,0,0
+Santa Clara,0005936,President,,,Joseph Kishore,0,0,0
+Santa Clara,0005940,President,,,Joseph Kishore,0,0,0
+Santa Clara,0005947,President,,,Joseph Kishore,0,0,0
+Santa Clara,0005949,President,,,Joseph Kishore,0,0,0
+Santa Clara,0005950,President,,,Joseph Kishore,0,0,0
+Santa Clara,0005951,President,,,Joseph Kishore,0,0,0
+Santa Clara,0005955,President,,,Joseph Kishore,0,0,0
+Santa Clara,0005956,President,,,Joseph Kishore,0,0,0
+Santa Clara,0005957,President,,,Joseph Kishore,0,0,0
+Santa Clara,0005958,President,,,Joseph Kishore,0,0,0
+Santa Clara,0005959,President,,,Joseph Kishore,0,0,0
+Santa Clara,0005965,President,,,Joseph Kishore,0,0,0
+Santa Clara,0005966,President,,,Joseph Kishore,0,0,0
+Santa Clara,0005975,President,,,Joseph Kishore,0,0,0
+Santa Clara,0005988,President,,,Joseph Kishore,0,0,0
+Santa Clara,0006023,President,,,Joseph Kishore,0,0,0
+Santa Clara,0006028,President,,,Joseph Kishore,0,0,0
+Santa Clara,0006031,President,,,Joseph Kishore,0,0,0
+Santa Clara,0006035,President,,,Joseph Kishore,0,0,0
+Santa Clara,0006036,President,,,Joseph Kishore,0,0,0
+Santa Clara,0006048,President,,,Joseph Kishore,0,0,0
+Santa Clara,0006401,President,,,Joseph Kishore,0,0,0
+Santa Clara,0006402,President,,,Joseph Kishore,0,0,0
+Santa Clara,0006404,President,,,Joseph Kishore,0,0,0
+Santa Clara,0006405,President,,,Joseph Kishore,0,0,0
+Santa Clara,0006410,President,,,Joseph Kishore,0,0,0
+Santa Clara,0006413,President,,,Joseph Kishore,0,0,0
+Santa Clara,0006418,President,,,Joseph Kishore,0,0,0
+Santa Clara,0006419,President,,,Joseph Kishore,0,0,0
+Santa Clara,0006423,President,,,Joseph Kishore,0,0,0
+Santa Clara,0006452,President,,,Joseph Kishore,0,0,0
+Santa Clara,0006454,President,,,Joseph Kishore,0,0,0
+Santa Clara,0006455,President,,,Joseph Kishore,0,0,0
+Santa Clara,0006491,President,,,Joseph Kishore,0,0,0
+Santa Clara,0006502,President,,,Joseph Kishore,0,0,0
+Santa Clara,0006509,President,,,Joseph Kishore,0,0,0
+Santa Clara,0006510,President,,,Joseph Kishore,0,0,0
+Santa Clara,0006511,President,,,Joseph Kishore,0,0,0
+Santa Clara,0006515,President,,,Joseph Kishore,0,0,0
+Santa Clara,0006624,President,,,Joseph Kishore,0,0,0
+Santa Clara,0006625,President,,,Joseph Kishore,0,0,0
+Santa Clara,0006669,President,,,Joseph Kishore,0,0,0
+Santa Clara,0006678,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007001,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007005,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007011,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007012,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007014,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007019,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007025,President,,,Joseph Kishore,1,0,1
+Santa Clara,0007028,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007032,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007036,President,,,Joseph Kishore,1,0,1
+Santa Clara,0007038,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007041,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007044,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007046,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007051,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007059,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007061,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007062,President,,,Joseph Kishore,2,0,2
+Santa Clara,0007079,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007081,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007089,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007201,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007202,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007203,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007205,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007214,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007217,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007219,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007221,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007224,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007231,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007235,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007237,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007245,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007246,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007248,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007252,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007255,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007257,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007261,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007264,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007271,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007273,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007282,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007294,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007295,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007298,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007299,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007306,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007401,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007402,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007403,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007408,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007409,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007410,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007411,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007414,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007415,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007416,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007417,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007418,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007419,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007430,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007435,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007436,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007438,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007440,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007441,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007442,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007447,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007458,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007459,President,,,Joseph Kishore,1,0,1
+Santa Clara,0007470,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007471,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007479,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007483,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007601,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007606,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007609,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007615,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007619,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007620,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007621,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007624,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007632,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007634,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007648,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007654,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007660,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007666,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007670,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007673,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007674,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007677,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007680,President,,,Joseph Kishore,1,0,1
+Santa Clara,0007689,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007690,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007801,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007802,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007803,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007805,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007810,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007811,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007812,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007816,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007817,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007818,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007821,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007826,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007827,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007832,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007833,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007843,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007849,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007850,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007851,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007861,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007867,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007874,President,,,Joseph Kishore,0,0,0
+Santa Clara,0007880,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008001,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008002,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008003,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008005,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008007,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008011,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008012,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008013,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008016,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008017,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008022,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008023,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008026,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008028,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008029,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008030,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008033,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008034,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008038,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008040,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008047,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008049,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008050,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008053,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008054,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008055,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008062,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008066,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008067,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008068,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008072,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008073,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008079,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008082,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008085,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008089,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008092,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008093,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008096,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008101,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008104,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008105,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008117,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008122,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008128,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008133,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008201,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008203,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008205,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008208,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008212,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008214,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008227,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008228,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008230,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008231,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008232,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008236,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008246,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008254,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008262,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008264,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008401,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008404,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008408,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008409,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008414,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008418,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008421,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008423,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008430,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008435,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008438,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008439,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008445,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008447,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008456,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008457,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008464,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008470,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008472,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008486,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008492,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008502,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008601,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008603,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008605,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008609,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008610,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008612,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008615,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008619,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008625,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008627,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008629,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008630,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008631,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008634,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008636,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008645,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008648,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008650,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008653,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008654,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008655,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008657,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008658,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008670,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008675,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008676,President,,,Joseph Kishore,1,0,1
+Santa Clara,0008680,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008683,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008687,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008697,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008801,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008805,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008809,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008812,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008817,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008820,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008822,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008828,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008829,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008832,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008834,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008838,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008839,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008844,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008848,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008853,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008857,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008858,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008862,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008868,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008873,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008874,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008879,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008883,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008885,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008886,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008889,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008898,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008903,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008915,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008916,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008920,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008923,President,,,Joseph Kishore,0,0,0
+Santa Clara,0008924,President,,,Joseph Kishore,0,0,0
+Santa Clara,0009001,President,,,Joseph Kishore,0,0,0
+Santa Clara,0009005,President,,,Joseph Kishore,0,0,0
+Santa Clara,0009051,President,,,Joseph Kishore,0,0,0
+Santa Clara,0009055,President,,,Joseph Kishore,0,0,0
+Santa Clara,0009056,President,,,Joseph Kishore,0,0,0
+Santa Clara,0009059,President,,,Joseph Kishore,0,0,0
+Santa Clara,0009061,President,,,Joseph Kishore,0,0,0
+Santa Clara,0009062,President,,,Joseph Kishore,0,0,0
+Santa Clara,0009101,President,,,Joseph Kishore,0,0,0
+Santa Clara,0009103,President,,,Joseph Kishore,0,0,0
+Santa Clara,0009104,President,,,Joseph Kishore,0,0,0
+Santa Clara,0009109,President,,,Joseph Kishore,0,0,0
+Santa Clara,0009151,President,,,Joseph Kishore,0,0,0
+Santa Clara,0009157,President,,,Joseph Kishore,0,0,0
+Santa Clara,0009163,President,,,Joseph Kishore,0,0,0
+Santa Clara,0009166,President,,,Joseph Kishore,0,0,0
+Santa Clara,0009201,President,,,Joseph Kishore,0,0,0
+Santa Clara,0009203,President,,,Joseph Kishore,0,0,0
+Santa Clara,0009208,President,,,Joseph Kishore,0,0,0
+Santa Clara,0009210,President,,,Joseph Kishore,0,0,0
+Santa Clara,0009219,President,,,Joseph Kishore,0,0,0
+Santa Clara,0009220,President,,,Joseph Kishore,0,0,0
+Santa Clara,0009251,President,,,Joseph Kishore,0,0,0
+Santa Clara,0009252,President,,,Joseph Kishore,0,0,0
+Santa Clara,0009258,President,,,Joseph Kishore,0,0,0
+Santa Clara,0009262,President,,,Joseph Kishore,0,0,0
+Santa Clara,0009264,President,,,Joseph Kishore,0,0,0
+Santa Clara,0009268,President,,,Joseph Kishore,0,0,0
+Santa Clara,0009275,President,,,Joseph Kishore,0,0,0
+Santa Clara,0009282,President,,,Joseph Kishore,0,0,0
+Santa Clara,0002001,President,,,Brock Pierce,0,0,0
+Santa Clara,0002002,President,,,Brock Pierce,0,0,0
+Santa Clara,0002005,President,,,Brock Pierce,0,0,0
+Santa Clara,0002006,President,,,Brock Pierce,0,0,0
+Santa Clara,0002009,President,,,Brock Pierce,0,0,0
+Santa Clara,0002013,President,,,Brock Pierce,0,0,0
+Santa Clara,0002014,President,,,Brock Pierce,0,0,0
+Santa Clara,0002018,President,,,Brock Pierce,0,0,0
+Santa Clara,0002025,President,,,Brock Pierce,0,0,0
+Santa Clara,0002043,President,,,Brock Pierce,0,0,0
+Santa Clara,0002046,President,,,Brock Pierce,0,0,0
+Santa Clara,0002057,President,,,Brock Pierce,0,0,0
+Santa Clara,0002068,President,,,Brock Pierce,0,0,0
+Santa Clara,0002098,President,,,Brock Pierce,0,0,0
+Santa Clara,0002108,President,,,Brock Pierce,0,0,0
+Santa Clara,0002125,President,,,Brock Pierce,0,0,0
+Santa Clara,0002274,President,,,Brock Pierce,0,0,0
+Santa Clara,0002275,President,,,Brock Pierce,0,0,0
+Santa Clara,0002278,President,,,Brock Pierce,0,0,0
+Santa Clara,0002281,President,,,Brock Pierce,0,0,0
+Santa Clara,0002282,President,,,Brock Pierce,0,0,0
+Santa Clara,0002285,President,,,Brock Pierce,0,0,0
+Santa Clara,0002301,President,,,Brock Pierce,0,0,0
+Santa Clara,0002305,President,,,Brock Pierce,0,0,0
+Santa Clara,0002309,President,,,Brock Pierce,0,0,0
+Santa Clara,0002314,President,,,Brock Pierce,0,0,0
+Santa Clara,0002317,President,,,Brock Pierce,0,0,0
+Santa Clara,0002330,President,,,Brock Pierce,0,0,0
+Santa Clara,0002338,President,,,Brock Pierce,0,0,0
+Santa Clara,0002351,President,,,Brock Pierce,0,0,0
+Santa Clara,0002353,President,,,Brock Pierce,0,0,0
+Santa Clara,0002539,President,,,Brock Pierce,0,0,0
+Santa Clara,0002542,President,,,Brock Pierce,0,0,0
+Santa Clara,0002545,President,,,Brock Pierce,0,0,0
+Santa Clara,0002720,President,,,Brock Pierce,0,0,0
+Santa Clara,0002721,President,,,Brock Pierce,0,0,0
+Santa Clara,0002723,President,,,Brock Pierce,1,0,1
+Santa Clara,0002724,President,,,Brock Pierce,1,0,1
+Santa Clara,0002725,President,,,Brock Pierce,0,0,0
+Santa Clara,0002726,President,,,Brock Pierce,0,0,0
+Santa Clara,0002727,President,,,Brock Pierce,1,0,1
+Santa Clara,0002729,President,,,Brock Pierce,0,0,0
+Santa Clara,0002734,President,,,Brock Pierce,0,0,0
+Santa Clara,0002740,President,,,Brock Pierce,0,0,0
+Santa Clara,0002751,President,,,Brock Pierce,0,0,0
+Santa Clara,0002761,President,,,Brock Pierce,0,0,0
+Santa Clara,0002802,President,,,Brock Pierce,0,0,0
+Santa Clara,0002808,President,,,Brock Pierce,0,0,0
+Santa Clara,0002810,President,,,Brock Pierce,0,0,0
+Santa Clara,0002811,President,,,Brock Pierce,0,0,0
+Santa Clara,0002812,President,,,Brock Pierce,0,0,0
+Santa Clara,0002813,President,,,Brock Pierce,0,0,0
+Santa Clara,0002816,President,,,Brock Pierce,0,0,0
+Santa Clara,0002825,President,,,Brock Pierce,0,0,0
+Santa Clara,0002870,President,,,Brock Pierce,0,0,0
+Santa Clara,0002951,President,,,Brock Pierce,0,0,0
+Santa Clara,0003001,President,,,Brock Pierce,0,0,0
+Santa Clara,0003002,President,,,Brock Pierce,0,0,0
+Santa Clara,0003005,President,,,Brock Pierce,0,0,0
+Santa Clara,0003008,President,,,Brock Pierce,0,0,0
+Santa Clara,0003010,President,,,Brock Pierce,0,0,0
+Santa Clara,0003011,President,,,Brock Pierce,0,0,0
+Santa Clara,0003012,President,,,Brock Pierce,0,0,0
+Santa Clara,0003013,President,,,Brock Pierce,0,0,0
+Santa Clara,0003016,President,,,Brock Pierce,0,0,0
+Santa Clara,0003017,President,,,Brock Pierce,0,0,0
+Santa Clara,0003018,President,,,Brock Pierce,0,0,0
+Santa Clara,0003019,President,,,Brock Pierce,0,0,0
+Santa Clara,0003021,President,,,Brock Pierce,0,0,0
+Santa Clara,0003023,President,,,Brock Pierce,0,0,0
+Santa Clara,0003026,President,,,Brock Pierce,0,0,0
+Santa Clara,0003029,President,,,Brock Pierce,0,0,0
+Santa Clara,0003031,President,,,Brock Pierce,0,0,0
+Santa Clara,0003032,President,,,Brock Pierce,0,0,0
+Santa Clara,0003034,President,,,Brock Pierce,0,0,0
+Santa Clara,0003035,President,,,Brock Pierce,0,0,0
+Santa Clara,0003039,President,,,Brock Pierce,0,0,0
+Santa Clara,0003040,President,,,Brock Pierce,0,0,0
+Santa Clara,0003042,President,,,Brock Pierce,0,0,0
+Santa Clara,0003043,President,,,Brock Pierce,0,0,0
+Santa Clara,0003045,President,,,Brock Pierce,0,0,0
+Santa Clara,0003047,President,,,Brock Pierce,0,0,0
+Santa Clara,0003048,President,,,Brock Pierce,0,0,0
+Santa Clara,0003051,President,,,Brock Pierce,0,0,0
+Santa Clara,0003053,President,,,Brock Pierce,0,0,0
+Santa Clara,0003061,President,,,Brock Pierce,0,0,0
+Santa Clara,0003079,President,,,Brock Pierce,0,0,0
+Santa Clara,0003080,President,,,Brock Pierce,0,0,0
+Santa Clara,0003086,President,,,Brock Pierce,0,0,0
+Santa Clara,0003087,President,,,Brock Pierce,0,0,0
+Santa Clara,0003089,President,,,Brock Pierce,0,0,0
+Santa Clara,0003095,President,,,Brock Pierce,0,0,0
+Santa Clara,0003101,President,,,Brock Pierce,0,0,0
+Santa Clara,0003102,President,,,Brock Pierce,0,0,0
+Santa Clara,0003103,President,,,Brock Pierce,0,0,0
+Santa Clara,0003116,President,,,Brock Pierce,0,0,0
+Santa Clara,0003117,President,,,Brock Pierce,0,0,0
+Santa Clara,0003120,President,,,Brock Pierce,0,0,0
+Santa Clara,0003122,President,,,Brock Pierce,0,0,0
+Santa Clara,0003156,President,,,Brock Pierce,0,0,0
+Santa Clara,0003402,President,,,Brock Pierce,0,0,0
+Santa Clara,0003406,President,,,Brock Pierce,0,0,0
+Santa Clara,0003407,President,,,Brock Pierce,0,0,0
+Santa Clara,0003408,President,,,Brock Pierce,0,0,0
+Santa Clara,0003409,President,,,Brock Pierce,0,0,0
+Santa Clara,0003410,President,,,Brock Pierce,0,0,0
+Santa Clara,0003417,President,,,Brock Pierce,0,0,0
+Santa Clara,0003427,President,,,Brock Pierce,0,0,0
+Santa Clara,0003434,President,,,Brock Pierce,0,0,0
+Santa Clara,0003438,President,,,Brock Pierce,0,0,0
+Santa Clara,0003445,President,,,Brock Pierce,1,0,1
+Santa Clara,0003601,President,,,Brock Pierce,0,0,0
+Santa Clara,0003602,President,,,Brock Pierce,0,0,0
+Santa Clara,0003603,President,,,Brock Pierce,0,0,0
+Santa Clara,0003604,President,,,Brock Pierce,0,0,0
+Santa Clara,0003605,President,,,Brock Pierce,0,0,0
+Santa Clara,0003606,President,,,Brock Pierce,0,0,0
+Santa Clara,0003608,President,,,Brock Pierce,0,0,0
+Santa Clara,0003609,President,,,Brock Pierce,0,0,0
+Santa Clara,0003611,President,,,Brock Pierce,0,0,0
+Santa Clara,0003614,President,,,Brock Pierce,0,0,0
+Santa Clara,0003624,President,,,Brock Pierce,2,0,2
+Santa Clara,0003635,President,,,Brock Pierce,0,0,0
+Santa Clara,0003652,President,,,Brock Pierce,0,0,0
+Santa Clara,0003655,President,,,Brock Pierce,0,0,0
+Santa Clara,0003669,President,,,Brock Pierce,0,0,0
+Santa Clara,0003670,President,,,Brock Pierce,0,0,0
+Santa Clara,0003777,President,,,Brock Pierce,0,0,0
+Santa Clara,0003779,President,,,Brock Pierce,0,0,0
+Santa Clara,0003782,President,,,Brock Pierce,0,0,0
+Santa Clara,0003783,President,,,Brock Pierce,0,0,0
+Santa Clara,0003801,President,,,Brock Pierce,0,0,0
+Santa Clara,0003802,President,,,Brock Pierce,0,0,0
+Santa Clara,0003803,President,,,Brock Pierce,0,0,0
+Santa Clara,0003804,President,,,Brock Pierce,0,0,0
+Santa Clara,0003810,President,,,Brock Pierce,0,0,0
+Santa Clara,0003811,President,,,Brock Pierce,0,0,0
+Santa Clara,0003814,President,,,Brock Pierce,0,0,0
+Santa Clara,0003820,President,,,Brock Pierce,0,0,0
+Santa Clara,0003821,President,,,Brock Pierce,0,0,0
+Santa Clara,0003825,President,,,Brock Pierce,0,0,0
+Santa Clara,0003828,President,,,Brock Pierce,0,0,0
+Santa Clara,0003835,President,,,Brock Pierce,0,0,0
+Santa Clara,0003840,President,,,Brock Pierce,0,0,0
+Santa Clara,0003846,President,,,Brock Pierce,0,0,0
+Santa Clara,0003861,President,,,Brock Pierce,0,0,0
+Santa Clara,0004401,President,,,Brock Pierce,0,0,0
+Santa Clara,0004402,President,,,Brock Pierce,0,0,0
+Santa Clara,0004403,President,,,Brock Pierce,0,0,0
+Santa Clara,0004405,President,,,Brock Pierce,0,0,0
+Santa Clara,0004407,President,,,Brock Pierce,0,0,0
+Santa Clara,0004409,President,,,Brock Pierce,0,0,0
+Santa Clara,0004411,President,,,Brock Pierce,0,0,0
+Santa Clara,0004412,President,,,Brock Pierce,0,0,0
+Santa Clara,0004414,President,,,Brock Pierce,0,0,0
+Santa Clara,0004417,President,,,Brock Pierce,0,0,0
+Santa Clara,0004665,President,,,Brock Pierce,0,0,0
+Santa Clara,0004666,President,,,Brock Pierce,0,0,0
+Santa Clara,0004671,President,,,Brock Pierce,0,0,0
+Santa Clara,0004672,President,,,Brock Pierce,0,0,0
+Santa Clara,0004674,President,,,Brock Pierce,0,0,0
+Santa Clara,0004675,President,,,Brock Pierce,0,0,0
+Santa Clara,0004685,President,,,Brock Pierce,0,0,0
+Santa Clara,0004687,President,,,Brock Pierce,0,0,0
+Santa Clara,0004688,President,,,Brock Pierce,0,0,0
+Santa Clara,0004691,President,,,Brock Pierce,0,0,0
+Santa Clara,0004696,President,,,Brock Pierce,0,0,0
+Santa Clara,0004698,President,,,Brock Pierce,0,0,0
+Santa Clara,0004699,President,,,Brock Pierce,0,0,0
+Santa Clara,0004702,President,,,Brock Pierce,0,0,0
+Santa Clara,0004715,President,,,Brock Pierce,0,0,0
+Santa Clara,0004733,President,,,Brock Pierce,0,0,0
+Santa Clara,0004801,President,,,Brock Pierce,0,0,0
+Santa Clara,0004806,President,,,Brock Pierce,0,0,0
+Santa Clara,0004811,President,,,Brock Pierce,0,0,0
+Santa Clara,0004826,President,,,Brock Pierce,0,0,0
+Santa Clara,0004827,President,,,Brock Pierce,0,0,0
+Santa Clara,0004833,President,,,Brock Pierce,0,0,0
+Santa Clara,0004851,President,,,Brock Pierce,0,0,0
+Santa Clara,0004853,President,,,Brock Pierce,0,0,0
+Santa Clara,0004858,President,,,Brock Pierce,1,0,1
+Santa Clara,0004876,President,,,Brock Pierce,0,0,0
+Santa Clara,0004881,President,,,Brock Pierce,0,0,0
+Santa Clara,0004941,President,,,Brock Pierce,0,0,0
+Santa Clara,0004942,President,,,Brock Pierce,0,0,0
+Santa Clara,0004943,President,,,Brock Pierce,0,0,0
+Santa Clara,0004944,President,,,Brock Pierce,0,0,0
+Santa Clara,0004945,President,,,Brock Pierce,0,0,0
+Santa Clara,0004946,President,,,Brock Pierce,0,0,0
+Santa Clara,0004949,President,,,Brock Pierce,0,0,0
+Santa Clara,0004950,President,,,Brock Pierce,0,0,0
+Santa Clara,0004954,President,,,Brock Pierce,0,0,0
+Santa Clara,0004956,President,,,Brock Pierce,0,0,0
+Santa Clara,0004958,President,,,Brock Pierce,0,0,0
+Santa Clara,0004965,President,,,Brock Pierce,0,0,0
+Santa Clara,0004969,President,,,Brock Pierce,0,0,0
+Santa Clara,0004971,President,,,Brock Pierce,0,0,0
+Santa Clara,0004973,President,,,Brock Pierce,0,0,0
+Santa Clara,0004974,President,,,Brock Pierce,0,0,0
+Santa Clara,0005449,President,,,Brock Pierce,0,0,0
+Santa Clara,0005451,President,,,Brock Pierce,0,0,0
+Santa Clara,0005454,President,,,Brock Pierce,0,0,0
+Santa Clara,0005455,President,,,Brock Pierce,0,0,0
+Santa Clara,0005456,President,,,Brock Pierce,0,0,0
+Santa Clara,0005458,President,,,Brock Pierce,0,0,0
+Santa Clara,0005502,President,,,Brock Pierce,0,0,0
+Santa Clara,0005503,President,,,Brock Pierce,0,0,0
+Santa Clara,0005505,President,,,Brock Pierce,0,0,0
+Santa Clara,0005507,President,,,Brock Pierce,0,0,0
+Santa Clara,0005556,President,,,Brock Pierce,0,0,0
+Santa Clara,0005557,President,,,Brock Pierce,0,0,0
+Santa Clara,0005567,President,,,Brock Pierce,0,0,0
+Santa Clara,0005742,President,,,Brock Pierce,0,0,0
+Santa Clara,0005743,President,,,Brock Pierce,0,0,0
+Santa Clara,0005745,President,,,Brock Pierce,0,0,0
+Santa Clara,0005747,President,,,Brock Pierce,0,0,0
+Santa Clara,0005748,President,,,Brock Pierce,0,0,0
+Santa Clara,0005756,President,,,Brock Pierce,0,0,0
+Santa Clara,0005758,President,,,Brock Pierce,0,0,0
+Santa Clara,0005759,President,,,Brock Pierce,0,0,0
+Santa Clara,0005762,President,,,Brock Pierce,0,0,0
+Santa Clara,0005763,President,,,Brock Pierce,0,0,0
+Santa Clara,0005770,President,,,Brock Pierce,0,0,0
+Santa Clara,0005775,President,,,Brock Pierce,0,0,0
+Santa Clara,0005785,President,,,Brock Pierce,0,0,0
+Santa Clara,0005793,President,,,Brock Pierce,0,0,0
+Santa Clara,0005795,President,,,Brock Pierce,0,0,0
+Santa Clara,0005804,President,,,Brock Pierce,0,0,0
+Santa Clara,0005810,President,,,Brock Pierce,0,0,0
+Santa Clara,0005811,President,,,Brock Pierce,0,0,0
+Santa Clara,0005813,President,,,Brock Pierce,0,0,0
+Santa Clara,0005814,President,,,Brock Pierce,0,0,0
+Santa Clara,0005854,President,,,Brock Pierce,0,0,0
+Santa Clara,0005879,President,,,Brock Pierce,0,0,0
+Santa Clara,0005886,President,,,Brock Pierce,0,0,0
+Santa Clara,0005888,President,,,Brock Pierce,0,0,0
+Santa Clara,0005894,President,,,Brock Pierce,0,0,0
+Santa Clara,0005896,President,,,Brock Pierce,0,0,0
+Santa Clara,0005901,President,,,Brock Pierce,0,0,0
+Santa Clara,0005902,President,,,Brock Pierce,0,0,0
+Santa Clara,0005903,President,,,Brock Pierce,0,0,0
+Santa Clara,0005906,President,,,Brock Pierce,0,0,0
+Santa Clara,0005907,President,,,Brock Pierce,0,0,0
+Santa Clara,0005911,President,,,Brock Pierce,0,0,0
+Santa Clara,0005912,President,,,Brock Pierce,0,0,0
+Santa Clara,0005914,President,,,Brock Pierce,0,0,0
+Santa Clara,0005915,President,,,Brock Pierce,0,0,0
+Santa Clara,0005916,President,,,Brock Pierce,0,0,0
+Santa Clara,0005917,President,,,Brock Pierce,0,0,0
+Santa Clara,0005919,President,,,Brock Pierce,0,0,0
+Santa Clara,0005922,President,,,Brock Pierce,0,0,0
+Santa Clara,0005925,President,,,Brock Pierce,0,0,0
+Santa Clara,0005927,President,,,Brock Pierce,0,0,0
+Santa Clara,0005929,President,,,Brock Pierce,0,0,0
+Santa Clara,0005931,President,,,Brock Pierce,0,0,0
+Santa Clara,0005936,President,,,Brock Pierce,0,0,0
+Santa Clara,0005940,President,,,Brock Pierce,0,0,0
+Santa Clara,0005947,President,,,Brock Pierce,0,0,0
+Santa Clara,0005949,President,,,Brock Pierce,0,0,0
+Santa Clara,0005950,President,,,Brock Pierce,0,0,0
+Santa Clara,0005951,President,,,Brock Pierce,0,0,0
+Santa Clara,0005955,President,,,Brock Pierce,0,0,0
+Santa Clara,0005956,President,,,Brock Pierce,0,0,0
+Santa Clara,0005957,President,,,Brock Pierce,0,0,0
+Santa Clara,0005958,President,,,Brock Pierce,0,0,0
+Santa Clara,0005959,President,,,Brock Pierce,0,0,0
+Santa Clara,0005965,President,,,Brock Pierce,0,0,0
+Santa Clara,0005966,President,,,Brock Pierce,0,0,0
+Santa Clara,0005975,President,,,Brock Pierce,0,0,0
+Santa Clara,0005988,President,,,Brock Pierce,0,0,0
+Santa Clara,0006023,President,,,Brock Pierce,0,0,0
+Santa Clara,0006028,President,,,Brock Pierce,0,0,0
+Santa Clara,0006031,President,,,Brock Pierce,0,0,0
+Santa Clara,0006035,President,,,Brock Pierce,0,0,0
+Santa Clara,0006036,President,,,Brock Pierce,0,0,0
+Santa Clara,0006048,President,,,Brock Pierce,0,0,0
+Santa Clara,0006401,President,,,Brock Pierce,0,0,0
+Santa Clara,0006402,President,,,Brock Pierce,0,0,0
+Santa Clara,0006404,President,,,Brock Pierce,0,0,0
+Santa Clara,0006405,President,,,Brock Pierce,0,0,0
+Santa Clara,0006410,President,,,Brock Pierce,0,0,0
+Santa Clara,0006413,President,,,Brock Pierce,0,0,0
+Santa Clara,0006418,President,,,Brock Pierce,0,0,0
+Santa Clara,0006419,President,,,Brock Pierce,0,0,0
+Santa Clara,0006423,President,,,Brock Pierce,0,0,0
+Santa Clara,0006452,President,,,Brock Pierce,0,0,0
+Santa Clara,0006454,President,,,Brock Pierce,0,0,0
+Santa Clara,0006455,President,,,Brock Pierce,0,0,0
+Santa Clara,0006491,President,,,Brock Pierce,0,0,0
+Santa Clara,0006502,President,,,Brock Pierce,0,0,0
+Santa Clara,0006509,President,,,Brock Pierce,0,0,0
+Santa Clara,0006510,President,,,Brock Pierce,0,0,0
+Santa Clara,0006511,President,,,Brock Pierce,0,0,0
+Santa Clara,0006515,President,,,Brock Pierce,0,0,0
+Santa Clara,0006624,President,,,Brock Pierce,0,0,0
+Santa Clara,0006625,President,,,Brock Pierce,0,0,0
+Santa Clara,0006669,President,,,Brock Pierce,0,0,0
+Santa Clara,0006678,President,,,Brock Pierce,0,0,0
+Santa Clara,0007001,President,,,Brock Pierce,0,0,0
+Santa Clara,0007005,President,,,Brock Pierce,0,0,0
+Santa Clara,0007011,President,,,Brock Pierce,0,0,0
+Santa Clara,0007012,President,,,Brock Pierce,0,0,0
+Santa Clara,0007014,President,,,Brock Pierce,0,0,0
+Santa Clara,0007019,President,,,Brock Pierce,0,0,0
+Santa Clara,0007025,President,,,Brock Pierce,0,0,0
+Santa Clara,0007028,President,,,Brock Pierce,0,0,0
+Santa Clara,0007032,President,,,Brock Pierce,0,0,0
+Santa Clara,0007036,President,,,Brock Pierce,0,0,0
+Santa Clara,0007038,President,,,Brock Pierce,0,0,0
+Santa Clara,0007041,President,,,Brock Pierce,0,0,0
+Santa Clara,0007044,President,,,Brock Pierce,0,0,0
+Santa Clara,0007046,President,,,Brock Pierce,0,0,0
+Santa Clara,0007051,President,,,Brock Pierce,0,0,0
+Santa Clara,0007059,President,,,Brock Pierce,0,0,0
+Santa Clara,0007061,President,,,Brock Pierce,0,0,0
+Santa Clara,0007062,President,,,Brock Pierce,0,0,0
+Santa Clara,0007079,President,,,Brock Pierce,0,0,0
+Santa Clara,0007081,President,,,Brock Pierce,0,0,0
+Santa Clara,0007089,President,,,Brock Pierce,0,0,0
+Santa Clara,0007201,President,,,Brock Pierce,0,0,0
+Santa Clara,0007202,President,,,Brock Pierce,0,0,0
+Santa Clara,0007203,President,,,Brock Pierce,0,0,0
+Santa Clara,0007205,President,,,Brock Pierce,0,0,0
+Santa Clara,0007214,President,,,Brock Pierce,0,0,0
+Santa Clara,0007217,President,,,Brock Pierce,0,0,0
+Santa Clara,0007219,President,,,Brock Pierce,0,0,0
+Santa Clara,0007221,President,,,Brock Pierce,0,0,0
+Santa Clara,0007224,President,,,Brock Pierce,0,0,0
+Santa Clara,0007231,President,,,Brock Pierce,0,0,0
+Santa Clara,0007235,President,,,Brock Pierce,0,0,0
+Santa Clara,0007237,President,,,Brock Pierce,0,0,0
+Santa Clara,0007245,President,,,Brock Pierce,0,0,0
+Santa Clara,0007246,President,,,Brock Pierce,0,0,0
+Santa Clara,0007248,President,,,Brock Pierce,0,0,0
+Santa Clara,0007252,President,,,Brock Pierce,0,0,0
+Santa Clara,0007255,President,,,Brock Pierce,0,0,0
+Santa Clara,0007257,President,,,Brock Pierce,0,0,0
+Santa Clara,0007261,President,,,Brock Pierce,0,0,0
+Santa Clara,0007264,President,,,Brock Pierce,0,0,0
+Santa Clara,0007271,President,,,Brock Pierce,0,0,0
+Santa Clara,0007273,President,,,Brock Pierce,0,0,0
+Santa Clara,0007282,President,,,Brock Pierce,0,0,0
+Santa Clara,0007294,President,,,Brock Pierce,0,0,0
+Santa Clara,0007295,President,,,Brock Pierce,0,0,0
+Santa Clara,0007298,President,,,Brock Pierce,0,0,0
+Santa Clara,0007299,President,,,Brock Pierce,0,0,0
+Santa Clara,0007306,President,,,Brock Pierce,0,0,0
+Santa Clara,0007401,President,,,Brock Pierce,0,0,0
+Santa Clara,0007402,President,,,Brock Pierce,0,0,0
+Santa Clara,0007403,President,,,Brock Pierce,0,0,0
+Santa Clara,0007408,President,,,Brock Pierce,0,0,0
+Santa Clara,0007409,President,,,Brock Pierce,0,0,0
+Santa Clara,0007410,President,,,Brock Pierce,0,0,0
+Santa Clara,0007411,President,,,Brock Pierce,0,0,0
+Santa Clara,0007414,President,,,Brock Pierce,0,0,0
+Santa Clara,0007415,President,,,Brock Pierce,0,0,0
+Santa Clara,0007416,President,,,Brock Pierce,0,0,0
+Santa Clara,0007417,President,,,Brock Pierce,0,0,0
+Santa Clara,0007418,President,,,Brock Pierce,0,0,0
+Santa Clara,0007419,President,,,Brock Pierce,0,0,0
+Santa Clara,0007430,President,,,Brock Pierce,0,0,0
+Santa Clara,0007435,President,,,Brock Pierce,0,0,0
+Santa Clara,0007436,President,,,Brock Pierce,0,0,0
+Santa Clara,0007438,President,,,Brock Pierce,0,0,0
+Santa Clara,0007440,President,,,Brock Pierce,0,0,0
+Santa Clara,0007441,President,,,Brock Pierce,0,0,0
+Santa Clara,0007442,President,,,Brock Pierce,0,0,0
+Santa Clara,0007447,President,,,Brock Pierce,0,0,0
+Santa Clara,0007458,President,,,Brock Pierce,0,0,0
+Santa Clara,0007459,President,,,Brock Pierce,0,0,0
+Santa Clara,0007470,President,,,Brock Pierce,0,0,0
+Santa Clara,0007471,President,,,Brock Pierce,0,0,0
+Santa Clara,0007479,President,,,Brock Pierce,0,0,0
+Santa Clara,0007483,President,,,Brock Pierce,0,0,0
+Santa Clara,0007601,President,,,Brock Pierce,0,0,0
+Santa Clara,0007606,President,,,Brock Pierce,0,0,0
+Santa Clara,0007609,President,,,Brock Pierce,0,0,0
+Santa Clara,0007615,President,,,Brock Pierce,0,0,0
+Santa Clara,0007619,President,,,Brock Pierce,0,0,0
+Santa Clara,0007620,President,,,Brock Pierce,0,0,0
+Santa Clara,0007621,President,,,Brock Pierce,0,0,0
+Santa Clara,0007624,President,,,Brock Pierce,0,0,0
+Santa Clara,0007632,President,,,Brock Pierce,0,0,0
+Santa Clara,0007634,President,,,Brock Pierce,0,0,0
+Santa Clara,0007648,President,,,Brock Pierce,0,0,0
+Santa Clara,0007654,President,,,Brock Pierce,0,0,0
+Santa Clara,0007660,President,,,Brock Pierce,0,0,0
+Santa Clara,0007666,President,,,Brock Pierce,0,0,0
+Santa Clara,0007670,President,,,Brock Pierce,0,0,0
+Santa Clara,0007673,President,,,Brock Pierce,0,0,0
+Santa Clara,0007674,President,,,Brock Pierce,0,0,0
+Santa Clara,0007677,President,,,Brock Pierce,0,0,0
+Santa Clara,0007680,President,,,Brock Pierce,0,0,0
+Santa Clara,0007689,President,,,Brock Pierce,0,0,0
+Santa Clara,0007690,President,,,Brock Pierce,0,0,0
+Santa Clara,0007801,President,,,Brock Pierce,0,0,0
+Santa Clara,0007802,President,,,Brock Pierce,0,0,0
+Santa Clara,0007803,President,,,Brock Pierce,0,0,0
+Santa Clara,0007805,President,,,Brock Pierce,0,0,0
+Santa Clara,0007810,President,,,Brock Pierce,0,0,0
+Santa Clara,0007811,President,,,Brock Pierce,0,0,0
+Santa Clara,0007812,President,,,Brock Pierce,0,0,0
+Santa Clara,0007816,President,,,Brock Pierce,0,0,0
+Santa Clara,0007817,President,,,Brock Pierce,0,0,0
+Santa Clara,0007818,President,,,Brock Pierce,0,0,0
+Santa Clara,0007821,President,,,Brock Pierce,0,0,0
+Santa Clara,0007826,President,,,Brock Pierce,0,0,0
+Santa Clara,0007827,President,,,Brock Pierce,0,0,0
+Santa Clara,0007832,President,,,Brock Pierce,0,0,0
+Santa Clara,0007833,President,,,Brock Pierce,0,0,0
+Santa Clara,0007843,President,,,Brock Pierce,0,0,0
+Santa Clara,0007849,President,,,Brock Pierce,0,0,0
+Santa Clara,0007850,President,,,Brock Pierce,0,0,0
+Santa Clara,0007851,President,,,Brock Pierce,0,0,0
+Santa Clara,0007861,President,,,Brock Pierce,0,0,0
+Santa Clara,0007867,President,,,Brock Pierce,0,0,0
+Santa Clara,0007874,President,,,Brock Pierce,0,0,0
+Santa Clara,0007880,President,,,Brock Pierce,0,0,0
+Santa Clara,0008001,President,,,Brock Pierce,0,0,0
+Santa Clara,0008002,President,,,Brock Pierce,0,0,0
+Santa Clara,0008003,President,,,Brock Pierce,0,0,0
+Santa Clara,0008005,President,,,Brock Pierce,0,0,0
+Santa Clara,0008007,President,,,Brock Pierce,0,0,0
+Santa Clara,0008011,President,,,Brock Pierce,0,0,0
+Santa Clara,0008012,President,,,Brock Pierce,0,0,0
+Santa Clara,0008013,President,,,Brock Pierce,0,0,0
+Santa Clara,0008016,President,,,Brock Pierce,0,0,0
+Santa Clara,0008017,President,,,Brock Pierce,0,0,0
+Santa Clara,0008022,President,,,Brock Pierce,0,0,0
+Santa Clara,0008023,President,,,Brock Pierce,0,0,0
+Santa Clara,0008026,President,,,Brock Pierce,0,0,0
+Santa Clara,0008028,President,,,Brock Pierce,0,0,0
+Santa Clara,0008029,President,,,Brock Pierce,0,0,0
+Santa Clara,0008030,President,,,Brock Pierce,0,0,0
+Santa Clara,0008033,President,,,Brock Pierce,0,0,0
+Santa Clara,0008034,President,,,Brock Pierce,0,0,0
+Santa Clara,0008038,President,,,Brock Pierce,0,0,0
+Santa Clara,0008040,President,,,Brock Pierce,0,0,0
+Santa Clara,0008047,President,,,Brock Pierce,0,0,0
+Santa Clara,0008049,President,,,Brock Pierce,0,0,0
+Santa Clara,0008050,President,,,Brock Pierce,0,0,0
+Santa Clara,0008053,President,,,Brock Pierce,0,0,0
+Santa Clara,0008054,President,,,Brock Pierce,0,0,0
+Santa Clara,0008055,President,,,Brock Pierce,0,0,0
+Santa Clara,0008062,President,,,Brock Pierce,0,0,0
+Santa Clara,0008066,President,,,Brock Pierce,0,0,0
+Santa Clara,0008067,President,,,Brock Pierce,0,0,0
+Santa Clara,0008068,President,,,Brock Pierce,0,0,0
+Santa Clara,0008072,President,,,Brock Pierce,0,0,0
+Santa Clara,0008073,President,,,Brock Pierce,0,0,0
+Santa Clara,0008079,President,,,Brock Pierce,0,0,0
+Santa Clara,0008082,President,,,Brock Pierce,0,0,0
+Santa Clara,0008085,President,,,Brock Pierce,0,0,0
+Santa Clara,0008089,President,,,Brock Pierce,0,0,0
+Santa Clara,0008092,President,,,Brock Pierce,0,0,0
+Santa Clara,0008093,President,,,Brock Pierce,0,0,0
+Santa Clara,0008096,President,,,Brock Pierce,0,0,0
+Santa Clara,0008101,President,,,Brock Pierce,0,0,0
+Santa Clara,0008104,President,,,Brock Pierce,0,0,0
+Santa Clara,0008105,President,,,Brock Pierce,0,0,0
+Santa Clara,0008117,President,,,Brock Pierce,0,0,0
+Santa Clara,0008122,President,,,Brock Pierce,0,0,0
+Santa Clara,0008128,President,,,Brock Pierce,0,0,0
+Santa Clara,0008133,President,,,Brock Pierce,0,0,0
+Santa Clara,0008201,President,,,Brock Pierce,0,0,0
+Santa Clara,0008203,President,,,Brock Pierce,0,0,0
+Santa Clara,0008205,President,,,Brock Pierce,0,0,0
+Santa Clara,0008208,President,,,Brock Pierce,0,0,0
+Santa Clara,0008212,President,,,Brock Pierce,0,0,0
+Santa Clara,0008214,President,,,Brock Pierce,0,0,0
+Santa Clara,0008227,President,,,Brock Pierce,0,0,0
+Santa Clara,0008228,President,,,Brock Pierce,0,0,0
+Santa Clara,0008230,President,,,Brock Pierce,0,0,0
+Santa Clara,0008231,President,,,Brock Pierce,0,0,0
+Santa Clara,0008232,President,,,Brock Pierce,0,0,0
+Santa Clara,0008236,President,,,Brock Pierce,0,0,0
+Santa Clara,0008246,President,,,Brock Pierce,0,0,0
+Santa Clara,0008254,President,,,Brock Pierce,0,0,0
+Santa Clara,0008262,President,,,Brock Pierce,0,0,0
+Santa Clara,0008264,President,,,Brock Pierce,0,0,0
+Santa Clara,0008401,President,,,Brock Pierce,0,0,0
+Santa Clara,0008404,President,,,Brock Pierce,0,0,0
+Santa Clara,0008408,President,,,Brock Pierce,0,0,0
+Santa Clara,0008409,President,,,Brock Pierce,0,0,0
+Santa Clara,0008414,President,,,Brock Pierce,0,0,0
+Santa Clara,0008418,President,,,Brock Pierce,0,0,0
+Santa Clara,0008421,President,,,Brock Pierce,0,0,0
+Santa Clara,0008423,President,,,Brock Pierce,0,0,0
+Santa Clara,0008430,President,,,Brock Pierce,0,0,0
+Santa Clara,0008435,President,,,Brock Pierce,0,0,0
+Santa Clara,0008438,President,,,Brock Pierce,0,0,0
+Santa Clara,0008439,President,,,Brock Pierce,0,0,0
+Santa Clara,0008445,President,,,Brock Pierce,0,0,0
+Santa Clara,0008447,President,,,Brock Pierce,0,0,0
+Santa Clara,0008456,President,,,Brock Pierce,0,0,0
+Santa Clara,0008457,President,,,Brock Pierce,0,0,0
+Santa Clara,0008464,President,,,Brock Pierce,0,0,0
+Santa Clara,0008470,President,,,Brock Pierce,0,0,0
+Santa Clara,0008472,President,,,Brock Pierce,0,0,0
+Santa Clara,0008486,President,,,Brock Pierce,0,0,0
+Santa Clara,0008492,President,,,Brock Pierce,0,0,0
+Santa Clara,0008502,President,,,Brock Pierce,0,0,0
+Santa Clara,0008601,President,,,Brock Pierce,0,0,0
+Santa Clara,0008603,President,,,Brock Pierce,0,0,0
+Santa Clara,0008605,President,,,Brock Pierce,0,0,0
+Santa Clara,0008609,President,,,Brock Pierce,0,0,0
+Santa Clara,0008610,President,,,Brock Pierce,0,0,0
+Santa Clara,0008612,President,,,Brock Pierce,0,0,0
+Santa Clara,0008615,President,,,Brock Pierce,0,0,0
+Santa Clara,0008619,President,,,Brock Pierce,0,0,0
+Santa Clara,0008625,President,,,Brock Pierce,0,0,0
+Santa Clara,0008627,President,,,Brock Pierce,0,0,0
+Santa Clara,0008629,President,,,Brock Pierce,0,0,0
+Santa Clara,0008630,President,,,Brock Pierce,0,0,0
+Santa Clara,0008631,President,,,Brock Pierce,0,0,0
+Santa Clara,0008634,President,,,Brock Pierce,0,0,0
+Santa Clara,0008636,President,,,Brock Pierce,0,0,0
+Santa Clara,0008645,President,,,Brock Pierce,0,0,0
+Santa Clara,0008648,President,,,Brock Pierce,0,0,0
+Santa Clara,0008650,President,,,Brock Pierce,0,0,0
+Santa Clara,0008653,President,,,Brock Pierce,0,0,0
+Santa Clara,0008654,President,,,Brock Pierce,0,0,0
+Santa Clara,0008655,President,,,Brock Pierce,0,0,0
+Santa Clara,0008657,President,,,Brock Pierce,0,0,0
+Santa Clara,0008658,President,,,Brock Pierce,0,0,0
+Santa Clara,0008670,President,,,Brock Pierce,0,0,0
+Santa Clara,0008675,President,,,Brock Pierce,0,0,0
+Santa Clara,0008676,President,,,Brock Pierce,0,0,0
+Santa Clara,0008680,President,,,Brock Pierce,0,0,0
+Santa Clara,0008683,President,,,Brock Pierce,0,0,0
+Santa Clara,0008687,President,,,Brock Pierce,0,0,0
+Santa Clara,0008697,President,,,Brock Pierce,0,0,0
+Santa Clara,0008801,President,,,Brock Pierce,0,0,0
+Santa Clara,0008805,President,,,Brock Pierce,0,0,0
+Santa Clara,0008809,President,,,Brock Pierce,0,0,0
+Santa Clara,0008812,President,,,Brock Pierce,0,0,0
+Santa Clara,0008817,President,,,Brock Pierce,0,0,0
+Santa Clara,0008820,President,,,Brock Pierce,0,0,0
+Santa Clara,0008822,President,,,Brock Pierce,0,0,0
+Santa Clara,0008828,President,,,Brock Pierce,0,0,0
+Santa Clara,0008829,President,,,Brock Pierce,0,0,0
+Santa Clara,0008832,President,,,Brock Pierce,0,0,0
+Santa Clara,0008834,President,,,Brock Pierce,0,0,0
+Santa Clara,0008838,President,,,Brock Pierce,0,0,0
+Santa Clara,0008839,President,,,Brock Pierce,0,0,0
+Santa Clara,0008844,President,,,Brock Pierce,0,0,0
+Santa Clara,0008848,President,,,Brock Pierce,0,0,0
+Santa Clara,0008853,President,,,Brock Pierce,0,0,0
+Santa Clara,0008857,President,,,Brock Pierce,0,0,0
+Santa Clara,0008858,President,,,Brock Pierce,0,0,0
+Santa Clara,0008862,President,,,Brock Pierce,0,0,0
+Santa Clara,0008868,President,,,Brock Pierce,0,0,0
+Santa Clara,0008873,President,,,Brock Pierce,0,0,0
+Santa Clara,0008874,President,,,Brock Pierce,0,0,0
+Santa Clara,0008879,President,,,Brock Pierce,0,0,0
+Santa Clara,0008883,President,,,Brock Pierce,0,0,0
+Santa Clara,0008885,President,,,Brock Pierce,0,0,0
+Santa Clara,0008886,President,,,Brock Pierce,0,0,0
+Santa Clara,0008889,President,,,Brock Pierce,0,0,0
+Santa Clara,0008898,President,,,Brock Pierce,0,0,0
+Santa Clara,0008903,President,,,Brock Pierce,0,0,0
+Santa Clara,0008915,President,,,Brock Pierce,0,0,0
+Santa Clara,0008916,President,,,Brock Pierce,0,0,0
+Santa Clara,0008920,President,,,Brock Pierce,0,0,0
+Santa Clara,0008923,President,,,Brock Pierce,0,0,0
+Santa Clara,0008924,President,,,Brock Pierce,0,0,0
+Santa Clara,0009001,President,,,Brock Pierce,0,0,0
+Santa Clara,0009005,President,,,Brock Pierce,0,0,0
+Santa Clara,0009051,President,,,Brock Pierce,0,0,0
+Santa Clara,0009055,President,,,Brock Pierce,0,0,0
+Santa Clara,0009056,President,,,Brock Pierce,0,0,0
+Santa Clara,0009059,President,,,Brock Pierce,0,0,0
+Santa Clara,0009061,President,,,Brock Pierce,0,0,0
+Santa Clara,0009062,President,,,Brock Pierce,0,0,0
+Santa Clara,0009101,President,,,Brock Pierce,0,0,0
+Santa Clara,0009103,President,,,Brock Pierce,0,0,0
+Santa Clara,0009104,President,,,Brock Pierce,0,0,0
+Santa Clara,0009109,President,,,Brock Pierce,0,0,0
+Santa Clara,0009151,President,,,Brock Pierce,0,0,0
+Santa Clara,0009157,President,,,Brock Pierce,0,0,0
+Santa Clara,0009163,President,,,Brock Pierce,0,0,0
+Santa Clara,0009166,President,,,Brock Pierce,0,0,0
+Santa Clara,0009201,President,,,Brock Pierce,0,0,0
+Santa Clara,0009203,President,,,Brock Pierce,0,0,0
+Santa Clara,0009208,President,,,Brock Pierce,0,0,0
+Santa Clara,0009210,President,,,Brock Pierce,0,0,0
+Santa Clara,0009219,President,,,Brock Pierce,0,0,0
+Santa Clara,0009220,President,,,Brock Pierce,0,0,0
+Santa Clara,0009251,President,,,Brock Pierce,0,0,0
+Santa Clara,0009252,President,,,Brock Pierce,0,0,0
+Santa Clara,0009258,President,,,Brock Pierce,0,0,0
+Santa Clara,0009262,President,,,Brock Pierce,0,0,0
+Santa Clara,0009264,President,,,Brock Pierce,0,0,0
+Santa Clara,0009268,President,,,Brock Pierce,0,0,0
+Santa Clara,0009275,President,,,Brock Pierce,0,0,0
+Santa Clara,0009282,President,,,Brock Pierce,0,0,0
+Santa Clara,0002825,U.S. House,,DEM,Ro Khanna,9,0,9
+Santa Clara,0003001,U.S. House,,DEM,Ro Khanna,1828,78,1750
+Santa Clara,0003002,U.S. House,,DEM,Ro Khanna,1828,114,1714
+Santa Clara,0003005,U.S. House,,DEM,Ro Khanna,40,3,37
+Santa Clara,0003008,U.S. House,,DEM,Ro Khanna,23,0,23
+Santa Clara,0003010,U.S. House,,DEM,Ro Khanna,1657,100,1557
+Santa Clara,0003011,U.S. House,,DEM,Ro Khanna,1603,113,1490
+Santa Clara,0003012,U.S. House,,DEM,Ro Khanna,87,3,84
+Santa Clara,0003013,U.S. House,,DEM,Ro Khanna,2182,131,2051
+Santa Clara,0003016,U.S. House,,DEM,Ro Khanna,660,24,636
+Santa Clara,0003017,U.S. House,,DEM,Ro Khanna,472,30,442
+Santa Clara,0003018,U.S. House,,DEM,Ro Khanna,243,21,222
+Santa Clara,0003019,U.S. House,,DEM,Ro Khanna,2281,104,2177
+Santa Clara,0003021,U.S. House,,DEM,Ro Khanna,205,10,195
+Santa Clara,0003023,U.S. House,,DEM,Ro Khanna,1735,95,1640
+Santa Clara,0003026,U.S. House,,DEM,Ro Khanna,1256,37,1219
+Santa Clara,0003029,U.S. House,,DEM,Ro Khanna,0,0,0
+Santa Clara,0003031,U.S. House,,DEM,Ro Khanna,0,0,0
+Santa Clara,0003032,U.S. House,,DEM,Ro Khanna,1057,49,1008
+Santa Clara,0003034,U.S. House,,DEM,Ro Khanna,2171,90,2081
+Santa Clara,0003035,U.S. House,,DEM,Ro Khanna,1603,100,1503
+Santa Clara,0003039,U.S. House,,DEM,Ro Khanna,1143,42,1101
+Santa Clara,0003040,U.S. House,,DEM,Ro Khanna,0,0,0
+Santa Clara,0003042,U.S. House,,DEM,Ro Khanna,1095,61,1034
+Santa Clara,0003043,U.S. House,,DEM,Ro Khanna,1834,63,1771
+Santa Clara,0003045,U.S. House,,DEM,Ro Khanna,2425,107,2318
+Santa Clara,0003047,U.S. House,,DEM,Ro Khanna,812,25,787
+Santa Clara,0003048,U.S. House,,DEM,Ro Khanna,2251,104,2147
+Santa Clara,0003051,U.S. House,,DEM,Ro Khanna,1597,33,1564
+Santa Clara,0003053,U.S. House,,DEM,Ro Khanna,1861,52,1809
+Santa Clara,0003061,U.S. House,,DEM,Ro Khanna,69,7,62
+Santa Clara,0003079,U.S. House,,DEM,Ro Khanna,375,9,366
+Santa Clara,0003080,U.S. House,,DEM,Ro Khanna,750,28,722
+Santa Clara,0003086,U.S. House,,DEM,Ro Khanna,2169,62,2107
+Santa Clara,0003087,U.S. House,,DEM,Ro Khanna,859,64,795
+Santa Clara,0003089,U.S. House,,DEM,Ro Khanna,0,0,0
+Santa Clara,0003095,U.S. House,,DEM,Ro Khanna,2,0,2
+Santa Clara,0003101,U.S. House,,DEM,Ro Khanna,107,4,103
+Santa Clara,0003102,U.S. House,,DEM,Ro Khanna,366,25,341
+Santa Clara,0003103,U.S. House,,DEM,Ro Khanna,881,55,826
+Santa Clara,0003116,U.S. House,,DEM,Ro Khanna,587,17,570
+Santa Clara,0003117,U.S. House,,DEM,Ro Khanna,633,25,608
+Santa Clara,0003120,U.S. House,,DEM,Ro Khanna,390,22,368
+Santa Clara,0003122,U.S. House,,DEM,Ro Khanna,1671,66,1605
+Santa Clara,0003156,U.S. House,,DEM,Ro Khanna,97,2,95
+Santa Clara,0003601,U.S. House,,DEM,Ro Khanna,938,13,925
+Santa Clara,0003602,U.S. House,,DEM,Ro Khanna,1583,55,1528
+Santa Clara,0003603,U.S. House,,DEM,Ro Khanna,831,24,807
+Santa Clara,0003604,U.S. House,,DEM,Ro Khanna,1860,60,1800
+Santa Clara,0003605,U.S. House,,DEM,Ro Khanna,2087,91,1996
+Santa Clara,0003606,U.S. House,,DEM,Ro Khanna,1727,42,1685
+Santa Clara,0003608,U.S. House,,DEM,Ro Khanna,1830,58,1772
+Santa Clara,0003609,U.S. House,,DEM,Ro Khanna,2553,64,2489
+Santa Clara,0003611,U.S. House,,DEM,Ro Khanna,1777,53,1724
+Santa Clara,0003614,U.S. House,,DEM,Ro Khanna,837,30,807
+Santa Clara,0003624,U.S. House,,DEM,Ro Khanna,2306,57,2249
+Santa Clara,0003635,U.S. House,,DEM,Ro Khanna,0,0,0
+Santa Clara,0003652,U.S. House,,DEM,Ro Khanna,811,60,751
+Santa Clara,0003655,U.S. House,,DEM,Ro Khanna,116,5,111
+Santa Clara,0003670,U.S. House,,DEM,Ro Khanna,94,7,87
+Santa Clara,0004401,U.S. House,,DEM,Ro Khanna,1865,110,1755
+Santa Clara,0004402,U.S. House,,DEM,Ro Khanna,2242,107,2135
+Santa Clara,0004403,U.S. House,,DEM,Ro Khanna,182,23,159
+Santa Clara,0004405,U.S. House,,DEM,Ro Khanna,2369,131,2238
+Santa Clara,0004407,U.S. House,,DEM,Ro Khanna,2039,122,1917
+Santa Clara,0004409,U.S. House,,DEM,Ro Khanna,2646,146,2500
+Santa Clara,0004411,U.S. House,,DEM,Ro Khanna,1452,60,1392
+Santa Clara,0004412,U.S. House,,DEM,Ro Khanna,2312,93,2219
+Santa Clara,0004414,U.S. House,,DEM,Ro Khanna,2639,107,2532
+Santa Clara,0004417,U.S. House,,DEM,Ro Khanna,2148,90,2058
+Santa Clara,0006401,U.S. House,,DEM,Ro Khanna,0,0,0
+Santa Clara,0006402,U.S. House,,DEM,Ro Khanna,42,1,41
+Santa Clara,0006405,U.S. House,,DEM,Ro Khanna,3,0,3
+Santa Clara,0006419,U.S. House,,DEM,Ro Khanna,26,3,23
+Santa Clara,0006423,U.S. House,,DEM,Ro Khanna,26,1,25
+Santa Clara,0006502,U.S. House,,DEM,Ro Khanna,207,11,196
+Santa Clara,0006511,U.S. House,,DEM,Ro Khanna,78,3,75
+Santa Clara,0007011,U.S. House,,DEM,Ro Khanna,252,20,232
+Santa Clara,0007028,U.S. House,,DEM,Ro Khanna,1642,74,1568
+Santa Clara,0007032,U.S. House,,DEM,Ro Khanna,2217,70,2147
+Santa Clara,0007036,U.S. House,,DEM,Ro Khanna,2067,52,2015
+Santa Clara,0007051,U.S. House,,DEM,Ro Khanna,0,0,0
+Santa Clara,0007403,U.S. House,,DEM,Ro Khanna,798,47,751
+Santa Clara,0007410,U.S. House,,DEM,Ro Khanna,5,2,3
+Santa Clara,0007411,U.S. House,,DEM,Ro Khanna,17,2,15
+Santa Clara,0007440,U.S. House,,DEM,Ro Khanna,24,4,20
+Santa Clara,0007441,U.S. House,,DEM,Ro Khanna,1070,54,1016
+Santa Clara,0007442,U.S. House,,DEM,Ro Khanna,190,19,171
+Santa Clara,0007601,U.S. House,,DEM,Ro Khanna,2349,160,2189
+Santa Clara,0007606,U.S. House,,DEM,Ro Khanna,2528,152,2376
+Santa Clara,0007609,U.S. House,,DEM,Ro Khanna,589,56,533
+Santa Clara,0007615,U.S. House,,DEM,Ro Khanna,713,59,654
+Santa Clara,0007619,U.S. House,,DEM,Ro Khanna,1382,59,1323
+Santa Clara,0007620,U.S. House,,DEM,Ro Khanna,2038,90,1948
+Santa Clara,0007621,U.S. House,,DEM,Ro Khanna,2244,90,2154
+Santa Clara,0007624,U.S. House,,DEM,Ro Khanna,1629,61,1568
+Santa Clara,0007632,U.S. House,,DEM,Ro Khanna,1894,93,1801
+Santa Clara,0007634,U.S. House,,DEM,Ro Khanna,1097,40,1057
+Santa Clara,0007648,U.S. House,,DEM,Ro Khanna,1991,73,1918
+Santa Clara,0007654,U.S. House,,DEM,Ro Khanna,2448,104,2344
+Santa Clara,0007660,U.S. House,,DEM,Ro Khanna,2027,85,1942
+Santa Clara,0007666,U.S. House,,DEM,Ro Khanna,2131,98,2033
+Santa Clara,0007670,U.S. House,,DEM,Ro Khanna,62,0,62
+Santa Clara,0007673,U.S. House,,DEM,Ro Khanna,0,0,0
+Santa Clara,0007674,U.S. House,,DEM,Ro Khanna,0,0,0
+Santa Clara,0007677,U.S. House,,DEM,Ro Khanna,2265,81,2184
+Santa Clara,0007680,U.S. House,,DEM,Ro Khanna,1325,53,1272
+Santa Clara,0007689,U.S. House,,DEM,Ro Khanna,10,0,10
+Santa Clara,0007690,U.S. House,,DEM,Ro Khanna,702,26,676
+Santa Clara,0007801,U.S. House,,DEM,Ro Khanna,483,24,459
+Santa Clara,0007802,U.S. House,,DEM,Ro Khanna,253,10,243
+Santa Clara,0007803,U.S. House,,DEM,Ro Khanna,660,18,642
+Santa Clara,0007805,U.S. House,,DEM,Ro Khanna,1137,46,1091
+Santa Clara,0007810,U.S. House,,DEM,Ro Khanna,165,5,160
+Santa Clara,0007811,U.S. House,,DEM,Ro Khanna,132,10,122
+Santa Clara,0007812,U.S. House,,DEM,Ro Khanna,977,45,932
+Santa Clara,0009001,U.S. House,,DEM,Ro Khanna,1865,111,1754
+Santa Clara,0009005,U.S. House,,DEM,Ro Khanna,2828,180,2648
+Santa Clara,0009051,U.S. House,,DEM,Ro Khanna,954,58,896
+Santa Clara,0009055,U.S. House,,DEM,Ro Khanna,45,1,44
+Santa Clara,0009056,U.S. House,,DEM,Ro Khanna,1919,105,1814
+Santa Clara,0009059,U.S. House,,DEM,Ro Khanna,1556,111,1445
+Santa Clara,0009061,U.S. House,,DEM,Ro Khanna,0,0,0
+Santa Clara,0009062,U.S. House,,DEM,Ro Khanna,1488,58,1430
+Santa Clara,0009101,U.S. House,,DEM,Ro Khanna,1934,83,1851
+Santa Clara,0009103,U.S. House,,DEM,Ro Khanna,563,34,529
+Santa Clara,0009104,U.S. House,,DEM,Ro Khanna,1768,62,1706
+Santa Clara,0009109,U.S. House,,DEM,Ro Khanna,1161,66,1095
+Santa Clara,0009151,U.S. House,,DEM,Ro Khanna,1657,90,1567
+Santa Clara,0009157,U.S. House,,DEM,Ro Khanna,2062,98,1964
+Santa Clara,0009163,U.S. House,,DEM,Ro Khanna,919,28,891
+Santa Clara,0009166,U.S. House,,DEM,Ro Khanna,893,25,868
+Santa Clara,0009201,U.S. House,,DEM,Ro Khanna,510,18,492
+Santa Clara,0009203,U.S. House,,DEM,Ro Khanna,1110,38,1072
+Santa Clara,0009208,U.S. House,,DEM,Ro Khanna,894,53,841
+Santa Clara,0009210,U.S. House,,DEM,Ro Khanna,1358,48,1310
+Santa Clara,0009219,U.S. House,,DEM,Ro Khanna,136,9,127
+Santa Clara,0009220,U.S. House,,DEM,Ro Khanna,1770,77,1693
+Santa Clara,0009251,U.S. House,,DEM,Ro Khanna,846,24,822
+Santa Clara,0009252,U.S. House,,DEM,Ro Khanna,1302,43,1259
+Santa Clara,0009258,U.S. House,,DEM,Ro Khanna,1142,77,1065
+Santa Clara,0009262,U.S. House,,DEM,Ro Khanna,135,4,131
+Santa Clara,0009264,U.S. House,,DEM,Ro Khanna,1205,25,1180
+Santa Clara,0009268,U.S. House,,DEM,Ro Khanna,1208,41,1167
+Santa Clara,0009275,U.S. House,,DEM,Ro Khanna,1196,63,1133
+Santa Clara,0009282,U.S. House,,DEM,Ro Khanna,6,3,3
+Santa Clara,0002825,U.S. House,,REP,Ritesh Tandon,2,0,2
+Santa Clara,0003001,U.S. House,,REP,Ritesh Tandon,751,95,656
+Santa Clara,0003002,U.S. House,,REP,Ritesh Tandon,572,80,492
+Santa Clara,0003005,U.S. House,,REP,Ritesh Tandon,12,1,11
+Santa Clara,0003008,U.S. House,,REP,Ritesh Tandon,6,0,6
+Santa Clara,0003010,U.S. House,,REP,Ritesh Tandon,510,60,450
+Santa Clara,0003011,U.S. House,,REP,Ritesh Tandon,419,60,359
+Santa Clara,0003012,U.S. House,,REP,Ritesh Tandon,27,5,22
+Santa Clara,0003013,U.S. House,,REP,Ritesh Tandon,550,71,479
+Santa Clara,0003016,U.S. House,,REP,Ritesh Tandon,172,14,158
+Santa Clara,0003017,U.S. House,,REP,Ritesh Tandon,132,25,107
+Santa Clara,0003018,U.S. House,,REP,Ritesh Tandon,72,6,66
+Santa Clara,0003019,U.S. House,,REP,Ritesh Tandon,579,76,503
+Santa Clara,0003021,U.S. House,,REP,Ritesh Tandon,50,7,43
+Santa Clara,0003023,U.S. House,,REP,Ritesh Tandon,603,84,519
+Santa Clara,0003026,U.S. House,,REP,Ritesh Tandon,443,51,392
+Santa Clara,0003029,U.S. House,,REP,Ritesh Tandon,0,0,0
+Santa Clara,0003031,U.S. House,,REP,Ritesh Tandon,0,0,0
+Santa Clara,0003032,U.S. House,,REP,Ritesh Tandon,352,49,303
+Santa Clara,0003034,U.S. House,,REP,Ritesh Tandon,765,90,675
+Santa Clara,0003035,U.S. House,,REP,Ritesh Tandon,467,63,404
+Santa Clara,0003039,U.S. House,,REP,Ritesh Tandon,353,31,322
+Santa Clara,0003040,U.S. House,,REP,Ritesh Tandon,0,0,0
+Santa Clara,0003042,U.S. House,,REP,Ritesh Tandon,351,44,307
+Santa Clara,0003043,U.S. House,,REP,Ritesh Tandon,711,62,649
+Santa Clara,0003045,U.S. House,,REP,Ritesh Tandon,785,80,705
+Santa Clara,0003047,U.S. House,,REP,Ritesh Tandon,283,27,256
+Santa Clara,0003048,U.S. House,,REP,Ritesh Tandon,636,85,551
+Santa Clara,0003051,U.S. House,,REP,Ritesh Tandon,592,33,559
+Santa Clara,0003053,U.S. House,,REP,Ritesh Tandon,738,61,677
+Santa Clara,0003061,U.S. House,,REP,Ritesh Tandon,15,3,12
+Santa Clara,0003079,U.S. House,,REP,Ritesh Tandon,169,14,155
+Santa Clara,0003080,U.S. House,,REP,Ritesh Tandon,188,15,173
+Santa Clara,0003086,U.S. House,,REP,Ritesh Tandon,828,68,760
+Santa Clara,0003087,U.S. House,,REP,Ritesh Tandon,289,38,251
+Santa Clara,0003089,U.S. House,,REP,Ritesh Tandon,0,0,0
+Santa Clara,0003095,U.S. House,,REP,Ritesh Tandon,0,0,0
+Santa Clara,0003101,U.S. House,,REP,Ritesh Tandon,35,6,29
+Santa Clara,0003102,U.S. House,,REP,Ritesh Tandon,139,9,130
+Santa Clara,0003103,U.S. House,,REP,Ritesh Tandon,297,31,266
+Santa Clara,0003116,U.S. House,,REP,Ritesh Tandon,194,19,175
+Santa Clara,0003117,U.S. House,,REP,Ritesh Tandon,184,22,162
+Santa Clara,0003120,U.S. House,,REP,Ritesh Tandon,114,10,104
+Santa Clara,0003122,U.S. House,,REP,Ritesh Tandon,514,55,459
+Santa Clara,0003156,U.S. House,,REP,Ritesh Tandon,36,7,29
+Santa Clara,0003601,U.S. House,,REP,Ritesh Tandon,334,23,311
+Santa Clara,0003602,U.S. House,,REP,Ritesh Tandon,650,61,589
+Santa Clara,0003603,U.S. House,,REP,Ritesh Tandon,386,30,356
+Santa Clara,0003604,U.S. House,,REP,Ritesh Tandon,772,65,707
+Santa Clara,0003605,U.S. House,,REP,Ritesh Tandon,876,69,807
+Santa Clara,0003606,U.S. House,,REP,Ritesh Tandon,663,47,616
+Santa Clara,0003608,U.S. House,,REP,Ritesh Tandon,815,69,746
+Santa Clara,0003609,U.S. House,,REP,Ritesh Tandon,1146,90,1056
+Santa Clara,0003611,U.S. House,,REP,Ritesh Tandon,809,52,757
+Santa Clara,0003614,U.S. House,,REP,Ritesh Tandon,418,47,371
+Santa Clara,0003624,U.S. House,,REP,Ritesh Tandon,937,89,848
+Santa Clara,0003635,U.S. House,,REP,Ritesh Tandon,0,0,0
+Santa Clara,0003652,U.S. House,,REP,Ritesh Tandon,388,40,348
+Santa Clara,0003655,U.S. House,,REP,Ritesh Tandon,74,7,67
+Santa Clara,0003670,U.S. House,,REP,Ritesh Tandon,25,0,25
+Santa Clara,0004401,U.S. House,,REP,Ritesh Tandon,912,132,780
+Santa Clara,0004402,U.S. House,,REP,Ritesh Tandon,927,140,787
+Santa Clara,0004403,U.S. House,,REP,Ritesh Tandon,57,7,50
+Santa Clara,0004405,U.S. House,,REP,Ritesh Tandon,1065,151,914
+Santa Clara,0004407,U.S. House,,REP,Ritesh Tandon,932,140,792
+Santa Clara,0004409,U.S. House,,REP,Ritesh Tandon,1154,168,986
+Santa Clara,0004411,U.S. House,,REP,Ritesh Tandon,712,85,627
+Santa Clara,0004412,U.S. House,,REP,Ritesh Tandon,1137,135,1002
+Santa Clara,0004414,U.S. House,,REP,Ritesh Tandon,1222,130,1092
+Santa Clara,0004417,U.S. House,,REP,Ritesh Tandon,1027,114,913
+Santa Clara,0006401,U.S. House,,REP,Ritesh Tandon,0,0,0
+Santa Clara,0006402,U.S. House,,REP,Ritesh Tandon,48,1,47
+Santa Clara,0006405,U.S. House,,REP,Ritesh Tandon,6,0,6
+Santa Clara,0006419,U.S. House,,REP,Ritesh Tandon,30,1,29
+Santa Clara,0006423,U.S. House,,REP,Ritesh Tandon,23,3,20
+Santa Clara,0006502,U.S. House,,REP,Ritesh Tandon,64,9,55
+Santa Clara,0006511,U.S. House,,REP,Ritesh Tandon,48,2,46
+Santa Clara,0007011,U.S. House,,REP,Ritesh Tandon,41,6,35
+Santa Clara,0007028,U.S. House,,REP,Ritesh Tandon,900,83,817
+Santa Clara,0007032,U.S. House,,REP,Ritesh Tandon,1181,108,1073
+Santa Clara,0007036,U.S. House,,REP,Ritesh Tandon,1038,71,967
+Santa Clara,0007051,U.S. House,,REP,Ritesh Tandon,0,0,0
+Santa Clara,0007403,U.S. House,,REP,Ritesh Tandon,499,46,453
+Santa Clara,0007410,U.S. House,,REP,Ritesh Tandon,0,0,0
+Santa Clara,0007411,U.S. House,,REP,Ritesh Tandon,8,4,4
+Santa Clara,0007440,U.S. House,,REP,Ritesh Tandon,21,2,19
+Santa Clara,0007441,U.S. House,,REP,Ritesh Tandon,681,66,615
+Santa Clara,0007442,U.S. House,,REP,Ritesh Tandon,55,15,40
+Santa Clara,0007601,U.S. House,,REP,Ritesh Tandon,633,98,535
+Santa Clara,0007606,U.S. House,,REP,Ritesh Tandon,820,122,698
+Santa Clara,0007609,U.S. House,,REP,Ritesh Tandon,171,36,135
+Santa Clara,0007615,U.S. House,,REP,Ritesh Tandon,306,45,261
+Santa Clara,0007619,U.S. House,,REP,Ritesh Tandon,508,77,431
+Santa Clara,0007620,U.S. House,,REP,Ritesh Tandon,918,78,840
+Santa Clara,0007621,U.S. House,,REP,Ritesh Tandon,1211,137,1074
+Santa Clara,0007624,U.S. House,,REP,Ritesh Tandon,845,103,742
+Santa Clara,0007632,U.S. House,,REP,Ritesh Tandon,997,131,866
+Santa Clara,0007634,U.S. House,,REP,Ritesh Tandon,563,75,488
+Santa Clara,0007648,U.S. House,,REP,Ritesh Tandon,808,92,716
+Santa Clara,0007654,U.S. House,,REP,Ritesh Tandon,1227,130,1097
+Santa Clara,0007660,U.S. House,,REP,Ritesh Tandon,965,118,847
+Santa Clara,0007666,U.S. House,,REP,Ritesh Tandon,1031,107,924
+Santa Clara,0007670,U.S. House,,REP,Ritesh Tandon,32,2,30
+Santa Clara,0007673,U.S. House,,REP,Ritesh Tandon,0,0,0
+Santa Clara,0007674,U.S. House,,REP,Ritesh Tandon,0,0,0
+Santa Clara,0007677,U.S. House,,REP,Ritesh Tandon,1049,107,942
+Santa Clara,0007680,U.S. House,,REP,Ritesh Tandon,644,91,553
+Santa Clara,0007689,U.S. House,,REP,Ritesh Tandon,3,0,3
+Santa Clara,0007690,U.S. House,,REP,Ritesh Tandon,262,26,236
+Santa Clara,0007801,U.S. House,,REP,Ritesh Tandon,219,22,197
+Santa Clara,0007802,U.S. House,,REP,Ritesh Tandon,96,12,84
+Santa Clara,0007803,U.S. House,,REP,Ritesh Tandon,259,35,224
+Santa Clara,0007805,U.S. House,,REP,Ritesh Tandon,582,63,519
+Santa Clara,0007810,U.S. House,,REP,Ritesh Tandon,66,11,55
+Santa Clara,0007811,U.S. House,,REP,Ritesh Tandon,42,6,36
+Santa Clara,0007812,U.S. House,,REP,Ritesh Tandon,364,43,321
+Santa Clara,0009001,U.S. House,,REP,Ritesh Tandon,655,98,557
+Santa Clara,0009005,U.S. House,,REP,Ritesh Tandon,992,154,838
+Santa Clara,0009051,U.S. House,,REP,Ritesh Tandon,595,93,502
+Santa Clara,0009055,U.S. House,,REP,Ritesh Tandon,13,0,13
+Santa Clara,0009056,U.S. House,,REP,Ritesh Tandon,632,95,537
+Santa Clara,0009059,U.S. House,,REP,Ritesh Tandon,526,91,435
+Santa Clara,0009061,U.S. House,,REP,Ritesh Tandon,0,0,0
+Santa Clara,0009062,U.S. House,,REP,Ritesh Tandon,565,51,514
+Santa Clara,0009101,U.S. House,,REP,Ritesh Tandon,751,83,668
+Santa Clara,0009103,U.S. House,,REP,Ritesh Tandon,206,22,184
+Santa Clara,0009104,U.S. House,,REP,Ritesh Tandon,639,59,580
+Santa Clara,0009109,U.S. House,,REP,Ritesh Tandon,399,54,345
+Santa Clara,0009151,U.S. House,,REP,Ritesh Tandon,643,73,570
+Santa Clara,0009157,U.S. House,,REP,Ritesh Tandon,726,98,628
+Santa Clara,0009163,U.S. House,,REP,Ritesh Tandon,287,20,267
+Santa Clara,0009166,U.S. House,,REP,Ritesh Tandon,308,39,269
+Santa Clara,0009201,U.S. House,,REP,Ritesh Tandon,210,21,189
+Santa Clara,0009203,U.S. House,,REP,Ritesh Tandon,352,45,307
+Santa Clara,0009208,U.S. House,,REP,Ritesh Tandon,289,40,249
+Santa Clara,0009210,U.S. House,,REP,Ritesh Tandon,475,64,411
+Santa Clara,0009219,U.S. House,,REP,Ritesh Tandon,33,2,31
+Santa Clara,0009220,U.S. House,,REP,Ritesh Tandon,512,73,439
+Santa Clara,0009251,U.S. House,,REP,Ritesh Tandon,319,38,281
+Santa Clara,0009252,U.S. House,,REP,Ritesh Tandon,447,58,389
+Santa Clara,0009258,U.S. House,,REP,Ritesh Tandon,396,44,352
+Santa Clara,0009262,U.S. House,,REP,Ritesh Tandon,73,7,66
+Santa Clara,0009264,U.S. House,,REP,Ritesh Tandon,487,38,449
+Santa Clara,0009268,U.S. House,,REP,Ritesh Tandon,488,32,456
+Santa Clara,0009275,U.S. House,,REP,Ritesh Tandon,387,54,333
+Santa Clara,0009282,U.S. House,,REP,Ritesh Tandon,2,0,2
+Santa Clara,0002001,U.S. House,,DEM,Anna G. Eshoo,23,17,6
+Santa Clara,0002002,U.S. House,,DEM,Anna G. Eshoo,1590,82,1508
+Santa Clara,0002005,U.S. House,,DEM,Anna G. Eshoo,1077,37,1040
+Santa Clara,0002006,U.S. House,,DEM,Anna G. Eshoo,44,1,43
+Santa Clara,0002009,U.S. House,,DEM,Anna G. Eshoo,2402,113,2289
+Santa Clara,0002013,U.S. House,,DEM,Anna G. Eshoo,2046,79,1967
+Santa Clara,0002014,U.S. House,,DEM,Anna G. Eshoo,1670,111,1559
+Santa Clara,0002018,U.S. House,,DEM,Anna G. Eshoo,60,2,58
+Santa Clara,0002025,U.S. House,,DEM,Anna G. Eshoo,2317,59,2258
+Santa Clara,0002043,U.S. House,,DEM,Anna G. Eshoo,1862,54,1808
+Santa Clara,0002046,U.S. House,,DEM,Anna G. Eshoo,2534,111,2423
+Santa Clara,0002057,U.S. House,,DEM,Anna G. Eshoo,2372,97,2275
+Santa Clara,0002068,U.S. House,,DEM,Anna G. Eshoo,2242,74,2168
+Santa Clara,0002098,U.S. House,,DEM,Anna G. Eshoo,2240,90,2150
+Santa Clara,0002108,U.S. House,,DEM,Anna G. Eshoo,2086,69,2017
+Santa Clara,0002125,U.S. House,,DEM,Anna G. Eshoo,210,3,207
+Santa Clara,0002274,U.S. House,,DEM,Anna G. Eshoo,124,3,121
+Santa Clara,0002275,U.S. House,,DEM,Anna G. Eshoo,587,21,566
+Santa Clara,0002278,U.S. House,,DEM,Anna G. Eshoo,574,30,544
+Santa Clara,0002281,U.S. House,,DEM,Anna G. Eshoo,0,0,0
+Santa Clara,0002282,U.S. House,,DEM,Anna G. Eshoo,726,26,700
+Santa Clara,0002285,U.S. House,,DEM,Anna G. Eshoo,1291,63,1228
+Santa Clara,0002301,U.S. House,,DEM,Anna G. Eshoo,1957,51,1906
+Santa Clara,0002305,U.S. House,,DEM,Anna G. Eshoo,2706,103,2603
+Santa Clara,0002309,U.S. House,,DEM,Anna G. Eshoo,676,11,665
+Santa Clara,0002314,U.S. House,,DEM,Anna G. Eshoo,1481,49,1432
+Santa Clara,0002317,U.S. House,,DEM,Anna G. Eshoo,1456,69,1387
+Santa Clara,0002330,U.S. House,,DEM,Anna G. Eshoo,2284,57,2227
+Santa Clara,0002338,U.S. House,,DEM,Anna G. Eshoo,73,4,69
+Santa Clara,0002351,U.S. House,,DEM,Anna G. Eshoo,1282,40,1242
+Santa Clara,0002353,U.S. House,,DEM,Anna G. Eshoo,14,2,12
+Santa Clara,0002539,U.S. House,,DEM,Anna G. Eshoo,95,2,93
+Santa Clara,0002542,U.S. House,,DEM,Anna G. Eshoo,953,124,829
+Santa Clara,0002545,U.S. House,,DEM,Anna G. Eshoo,1489,68,1421
+Santa Clara,0002720,U.S. House,,DEM,Anna G. Eshoo,698,30,668
+Santa Clara,0002721,U.S. House,,DEM,Anna G. Eshoo,607,20,587
+Santa Clara,0002723,U.S. House,,DEM,Anna G. Eshoo,1539,41,1498
+Santa Clara,0002724,U.S. House,,DEM,Anna G. Eshoo,1173,58,1115
+Santa Clara,0002725,U.S. House,,DEM,Anna G. Eshoo,1131,54,1077
+Santa Clara,0002726,U.S. House,,DEM,Anna G. Eshoo,692,36,656
+Santa Clara,0002727,U.S. House,,DEM,Anna G. Eshoo,847,20,827
+Santa Clara,0002729,U.S. House,,DEM,Anna G. Eshoo,967,19,948
+Santa Clara,0002734,U.S. House,,DEM,Anna G. Eshoo,1231,45,1186
+Santa Clara,0002740,U.S. House,,DEM,Anna G. Eshoo,1350,51,1299
+Santa Clara,0002751,U.S. House,,DEM,Anna G. Eshoo,7,0,7
+Santa Clara,0002761,U.S. House,,DEM,Anna G. Eshoo,0,0,0
+Santa Clara,0002802,U.S. House,,DEM,Anna G. Eshoo,1314,49,1265
+Santa Clara,0002808,U.S. House,,DEM,Anna G. Eshoo,39,1,38
+Santa Clara,0002810,U.S. House,,DEM,Anna G. Eshoo,13,0,13
+Santa Clara,0002811,U.S. House,,DEM,Anna G. Eshoo,16,0,16
+Santa Clara,0002812,U.S. House,,DEM,Anna G. Eshoo,143,6,137
+Santa Clara,0002813,U.S. House,,DEM,Anna G. Eshoo,122,1,121
+Santa Clara,0002816,U.S. House,,DEM,Anna G. Eshoo,12,0,12
+Santa Clara,0002870,U.S. House,,DEM,Anna G. Eshoo,74,2,72
+Santa Clara,0002951,U.S. House,,DEM,Anna G. Eshoo,122,7,115
+Santa Clara,0003402,U.S. House,,DEM,Anna G. Eshoo,1892,68,1824
+Santa Clara,0003406,U.S. House,,DEM,Anna G. Eshoo,1612,124,1488
+Santa Clara,0003407,U.S. House,,DEM,Anna G. Eshoo,1756,76,1680
+Santa Clara,0003408,U.S. House,,DEM,Anna G. Eshoo,2132,105,2027
+Santa Clara,0003409,U.S. House,,DEM,Anna G. Eshoo,2047,97,1950
+Santa Clara,0003410,U.S. House,,DEM,Anna G. Eshoo,2069,84,1985
+Santa Clara,0003417,U.S. House,,DEM,Anna G. Eshoo,2032,76,1956
+Santa Clara,0003427,U.S. House,,DEM,Anna G. Eshoo,1633,88,1545
+Santa Clara,0003434,U.S. House,,DEM,Anna G. Eshoo,1381,32,1349
+Santa Clara,0003438,U.S. House,,DEM,Anna G. Eshoo,2323,66,2257
+Santa Clara,0003445,U.S. House,,DEM,Anna G. Eshoo,2010,89,1921
+Santa Clara,0003669,U.S. House,,DEM,Anna G. Eshoo,2,0,2
+Santa Clara,0003777,U.S. House,,DEM,Anna G. Eshoo,833,25,808
+Santa Clara,0003779,U.S. House,,DEM,Anna G. Eshoo,55,0,55
+Santa Clara,0003782,U.S. House,,DEM,Anna G. Eshoo,164,7,157
+Santa Clara,0003783,U.S. House,,DEM,Anna G. Eshoo,186,4,182
+Santa Clara,0003801,U.S. House,,DEM,Anna G. Eshoo,799,53,746
+Santa Clara,0003802,U.S. House,,DEM,Anna G. Eshoo,1318,52,1266
+Santa Clara,0003803,U.S. House,,DEM,Anna G. Eshoo,1105,45,1060
+Santa Clara,0003804,U.S. House,,DEM,Anna G. Eshoo,570,31,539
+Santa Clara,0003810,U.S. House,,DEM,Anna G. Eshoo,960,77,883
+Santa Clara,0003811,U.S. House,,DEM,Anna G. Eshoo,1310,53,1257
+Santa Clara,0003814,U.S. House,,DEM,Anna G. Eshoo,1123,69,1054
+Santa Clara,0003820,U.S. House,,DEM,Anna G. Eshoo,1006,46,960
+Santa Clara,0003821,U.S. House,,DEM,Anna G. Eshoo,446,25,421
+Santa Clara,0003825,U.S. House,,DEM,Anna G. Eshoo,609,40,569
+Santa Clara,0003828,U.S. House,,DEM,Anna G. Eshoo,507,18,489
+Santa Clara,0003835,U.S. House,,DEM,Anna G. Eshoo,595,20,575
+Santa Clara,0003840,U.S. House,,DEM,Anna G. Eshoo,1017,53,964
+Santa Clara,0003846,U.S. House,,DEM,Anna G. Eshoo,55,1,54
+Santa Clara,0003861,U.S. House,,DEM,Anna G. Eshoo,30,1,29
+Santa Clara,0004665,U.S. House,,DEM,Anna G. Eshoo,13,0,13
+Santa Clara,0004666,U.S. House,,DEM,Anna G. Eshoo,5,0,5
+Santa Clara,0004671,U.S. House,,DEM,Anna G. Eshoo,749,25,724
+Santa Clara,0004672,U.S. House,,DEM,Anna G. Eshoo,419,18,401
+Santa Clara,0004674,U.S. House,,DEM,Anna G. Eshoo,651,35,616
+Santa Clara,0004675,U.S. House,,DEM,Anna G. Eshoo,1242,62,1180
+Santa Clara,0004685,U.S. House,,DEM,Anna G. Eshoo,724,22,702
+Santa Clara,0004687,U.S. House,,DEM,Anna G. Eshoo,731,23,708
+Santa Clara,0004688,U.S. House,,DEM,Anna G. Eshoo,1320,53,1267
+Santa Clara,0004691,U.S. House,,DEM,Anna G. Eshoo,903,41,862
+Santa Clara,0004696,U.S. House,,DEM,Anna G. Eshoo,523,11,512
+Santa Clara,0004698,U.S. House,,DEM,Anna G. Eshoo,469,11,458
+Santa Clara,0004699,U.S. House,,DEM,Anna G. Eshoo,702,24,678
+Santa Clara,0004702,U.S. House,,DEM,Anna G. Eshoo,443,19,424
+Santa Clara,0004715,U.S. House,,DEM,Anna G. Eshoo,212,11,201
+Santa Clara,0004733,U.S. House,,DEM,Anna G. Eshoo,20,2,18
+Santa Clara,0005556,U.S. House,,DEM,Anna G. Eshoo,744,69,675
+Santa Clara,0005557,U.S. House,,DEM,Anna G. Eshoo,492,21,471
+Santa Clara,0005567,U.S. House,,DEM,Anna G. Eshoo,275,15,260
+Santa Clara,0005742,U.S. House,,DEM,Anna G. Eshoo,3,0,3
+Santa Clara,0005743,U.S. House,,DEM,Anna G. Eshoo,312,16,296
+Santa Clara,0005745,U.S. House,,DEM,Anna G. Eshoo,237,10,227
+Santa Clara,0005747,U.S. House,,DEM,Anna G. Eshoo,443,12,431
+Santa Clara,0005748,U.S. House,,DEM,Anna G. Eshoo,934,80,854
+Santa Clara,0005756,U.S. House,,DEM,Anna G. Eshoo,47,2,45
+Santa Clara,0005758,U.S. House,,DEM,Anna G. Eshoo,70,1,69
+Santa Clara,0005759,U.S. House,,DEM,Anna G. Eshoo,203,5,198
+Santa Clara,0005762,U.S. House,,DEM,Anna G. Eshoo,128,3,125
+Santa Clara,0005763,U.S. House,,DEM,Anna G. Eshoo,42,2,40
+Santa Clara,0005770,U.S. House,,DEM,Anna G. Eshoo,69,0,69
+Santa Clara,0005775,U.S. House,,DEM,Anna G. Eshoo,157,3,154
+Santa Clara,0005785,U.S. House,,DEM,Anna G. Eshoo,0,0,0
+Santa Clara,0005793,U.S. House,,DEM,Anna G. Eshoo,0,0,0
+Santa Clara,0005795,U.S. House,,DEM,Anna G. Eshoo,2,0,2
+Santa Clara,0005804,U.S. House,,DEM,Anna G. Eshoo,560,26,534
+Santa Clara,0005810,U.S. House,,DEM,Anna G. Eshoo,171,8,163
+Santa Clara,0005811,U.S. House,,DEM,Anna G. Eshoo,111,6,105
+Santa Clara,0005813,U.S. House,,DEM,Anna G. Eshoo,28,2,26
+Santa Clara,0005814,U.S. House,,DEM,Anna G. Eshoo,114,6,108
+Santa Clara,0005854,U.S. House,,DEM,Anna G. Eshoo,1,0,1
+Santa Clara,0005901,U.S. House,,DEM,Anna G. Eshoo,0,0,0
+Santa Clara,0005902,U.S. House,,DEM,Anna G. Eshoo,201,10,191
+Santa Clara,0005903,U.S. House,,DEM,Anna G. Eshoo,257,12,245
+Santa Clara,0005907,U.S. House,,DEM,Anna G. Eshoo,2,0,2
+Santa Clara,0005927,U.S. House,,DEM,Anna G. Eshoo,0,0,0
+Santa Clara,0006023,U.S. House,,DEM,Anna G. Eshoo,5,0,5
+Santa Clara,0006624,U.S. House,,DEM,Anna G. Eshoo,3,0,3
+Santa Clara,0006625,U.S. House,,DEM,Anna G. Eshoo,5,0,5
+Santa Clara,0006669,U.S. House,,DEM,Anna G. Eshoo,39,0,39
+Santa Clara,0006678,U.S. House,,DEM,Anna G. Eshoo,21,0,21
+Santa Clara,0007001,U.S. House,,DEM,Anna G. Eshoo,826,71,755
+Santa Clara,0007005,U.S. House,,DEM,Anna G. Eshoo,1167,88,1079
+Santa Clara,0007012,U.S. House,,DEM,Anna G. Eshoo,830,39,791
+Santa Clara,0007014,U.S. House,,DEM,Anna G. Eshoo,1044,39,1005
+Santa Clara,0007019,U.S. House,,DEM,Anna G. Eshoo,1615,114,1501
+Santa Clara,0007025,U.S. House,,DEM,Anna G. Eshoo,1512,97,1415
+Santa Clara,0007038,U.S. House,,DEM,Anna G. Eshoo,135,6,129
+Santa Clara,0007041,U.S. House,,DEM,Anna G. Eshoo,1387,112,1275
+Santa Clara,0007044,U.S. House,,DEM,Anna G. Eshoo,872,56,816
+Santa Clara,0007046,U.S. House,,DEM,Anna G. Eshoo,1464,108,1356
+Santa Clara,0007059,U.S. House,,DEM,Anna G. Eshoo,236,18,218
+Santa Clara,0007061,U.S. House,,DEM,Anna G. Eshoo,1043,49,994
+Santa Clara,0007062,U.S. House,,DEM,Anna G. Eshoo,1250,91,1159
+Santa Clara,0007079,U.S. House,,DEM,Anna G. Eshoo,931,35,896
+Santa Clara,0007081,U.S. House,,DEM,Anna G. Eshoo,880,32,848
+Santa Clara,0007089,U.S. House,,DEM,Anna G. Eshoo,611,17,594
+Santa Clara,0008003,U.S. House,,DEM,Anna G. Eshoo,1345,66,1279
+Santa Clara,0008011,U.S. House,,DEM,Anna G. Eshoo,244,9,235
+Santa Clara,0008012,U.S. House,,DEM,Anna G. Eshoo,8,0,8
+Santa Clara,0008013,U.S. House,,DEM,Anna G. Eshoo,38,2,36
+Santa Clara,0008030,U.S. House,,DEM,Anna G. Eshoo,456,31,425
+Santa Clara,0008033,U.S. House,,DEM,Anna G. Eshoo,119,8,111
+Santa Clara,0008034,U.S. House,,DEM,Anna G. Eshoo,121,9,112
+Santa Clara,0008040,U.S. House,,DEM,Anna G. Eshoo,310,19,291
+Santa Clara,0008047,U.S. House,,DEM,Anna G. Eshoo,993,51,942
+Santa Clara,0008049,U.S. House,,DEM,Anna G. Eshoo,23,0,23
+Santa Clara,0008050,U.S. House,,DEM,Anna G. Eshoo,827,54,773
+Santa Clara,0008053,U.S. House,,DEM,Anna G. Eshoo,1393,74,1319
+Santa Clara,0008062,U.S. House,,DEM,Anna G. Eshoo,1443,99,1344
+Santa Clara,0008068,U.S. House,,DEM,Anna G. Eshoo,27,2,25
+Santa Clara,0008104,U.S. House,,DEM,Anna G. Eshoo,84,2,82
+Santa Clara,0008128,U.S. House,,DEM,Anna G. Eshoo,0,0,0
+Santa Clara,0008601,U.S. House,,DEM,Anna G. Eshoo,251,23,228
+Santa Clara,0008603,U.S. House,,DEM,Anna G. Eshoo,1194,62,1132
+Santa Clara,0008605,U.S. House,,DEM,Anna G. Eshoo,1548,87,1461
+Santa Clara,0008610,U.S. House,,DEM,Anna G. Eshoo,813,36,777
+Santa Clara,0008619,U.S. House,,DEM,Anna G. Eshoo,407,17,390
+Santa Clara,0008627,U.S. House,,DEM,Anna G. Eshoo,649,28,621
+Santa Clara,0008629,U.S. House,,DEM,Anna G. Eshoo,909,47,862
+Santa Clara,0008630,U.S. House,,DEM,Anna G. Eshoo,1274,58,1216
+Santa Clara,0008645,U.S. House,,DEM,Anna G. Eshoo,1535,61,1474
+Santa Clara,0008650,U.S. House,,DEM,Anna G. Eshoo,167,6,161
+Santa Clara,0008653,U.S. House,,DEM,Anna G. Eshoo,106,3,103
+Santa Clara,0008654,U.S. House,,DEM,Anna G. Eshoo,148,11,137
+Santa Clara,0008655,U.S. House,,DEM,Anna G. Eshoo,0,0,0
+Santa Clara,0008657,U.S. House,,DEM,Anna G. Eshoo,321,11,310
+Santa Clara,0008658,U.S. House,,DEM,Anna G. Eshoo,1633,80,1553
+Santa Clara,0008670,U.S. House,,DEM,Anna G. Eshoo,1137,79,1058
+Santa Clara,0008675,U.S. House,,DEM,Anna G. Eshoo,683,60,623
+Santa Clara,0008680,U.S. House,,DEM,Anna G. Eshoo,1022,38,984
+Santa Clara,0008683,U.S. House,,DEM,Anna G. Eshoo,1609,64,1545
+Santa Clara,0008687,U.S. House,,DEM,Anna G. Eshoo,1456,86,1370
+Santa Clara,0008697,U.S. House,,DEM,Anna G. Eshoo,1579,73,1506
+Santa Clara,0008832,U.S. House,,DEM,Anna G. Eshoo,946,40,906
+Santa Clara,0008834,U.S. House,,DEM,Anna G. Eshoo,517,39,478
+Santa Clara,0008838,U.S. House,,DEM,Anna G. Eshoo,128,13,115
+Santa Clara,0008857,U.S. House,,DEM,Anna G. Eshoo,729,23,706
+Santa Clara,0008858,U.S. House,,DEM,Anna G. Eshoo,1111,39,1072
+Santa Clara,0008862,U.S. House,,DEM,Anna G. Eshoo,1074,54,1020
+Santa Clara,0008879,U.S. House,,DEM,Anna G. Eshoo,1388,52,1336
+Santa Clara,0008883,U.S. House,,DEM,Anna G. Eshoo,1392,81,1311
+Santa Clara,0008885,U.S. House,,DEM,Anna G. Eshoo,1232,55,1177
+Santa Clara,0008886,U.S. House,,DEM,Anna G. Eshoo,147,2,145
+Santa Clara,0008889,U.S. House,,DEM,Anna G. Eshoo,1080,37,1043
+Santa Clara,0008898,U.S. House,,DEM,Anna G. Eshoo,1181,44,1137
+Santa Clara,0008903,U.S. House,,DEM,Anna G. Eshoo,1418,46,1372
+Santa Clara,0008923,U.S. House,,DEM,Anna G. Eshoo,0,0,0
+Santa Clara,0008924,U.S. House,,DEM,Anna G. Eshoo,7,0,7
+Santa Clara,0002001,U.S. House,,DEM,Rishi Kumar,17,14,3
+Santa Clara,0002002,U.S. House,,DEM,Rishi Kumar,574,42,532
+Santa Clara,0002005,U.S. House,,DEM,Rishi Kumar,364,30,334
+Santa Clara,0002006,U.S. House,,DEM,Rishi Kumar,17,1,16
+Santa Clara,0002009,U.S. House,,DEM,Rishi Kumar,1025,94,931
+Santa Clara,0002013,U.S. House,,DEM,Rishi Kumar,840,60,780
+Santa Clara,0002014,U.S. House,,DEM,Rishi Kumar,848,65,783
+Santa Clara,0002018,U.S. House,,DEM,Rishi Kumar,40,7,33
+Santa Clara,0002025,U.S. House,,DEM,Rishi Kumar,946,63,883
+Santa Clara,0002043,U.S. House,,DEM,Rishi Kumar,715,47,668
+Santa Clara,0002046,U.S. House,,DEM,Rishi Kumar,858,70,788
+Santa Clara,0002057,U.S. House,,DEM,Rishi Kumar,835,66,769
+Santa Clara,0002068,U.S. House,,DEM,Rishi Kumar,849,51,798
+Santa Clara,0002098,U.S. House,,DEM,Rishi Kumar,999,62,937
+Santa Clara,0002108,U.S. House,,DEM,Rishi Kumar,755,46,709
+Santa Clara,0002125,U.S. House,,DEM,Rishi Kumar,81,4,77
+Santa Clara,0002274,U.S. House,,DEM,Rishi Kumar,82,2,80
+Santa Clara,0002275,U.S. House,,DEM,Rishi Kumar,341,31,310
+Santa Clara,0002278,U.S. House,,DEM,Rishi Kumar,306,31,275
+Santa Clara,0002281,U.S. House,,DEM,Rishi Kumar,5,0,5
+Santa Clara,0002282,U.S. House,,DEM,Rishi Kumar,402,31,371
+Santa Clara,0002285,U.S. House,,DEM,Rishi Kumar,772,64,708
+Santa Clara,0002301,U.S. House,,DEM,Rishi Kumar,945,57,888
+Santa Clara,0002305,U.S. House,,DEM,Rishi Kumar,1234,74,1160
+Santa Clara,0002309,U.S. House,,DEM,Rishi Kumar,332,27,305
+Santa Clara,0002314,U.S. House,,DEM,Rishi Kumar,851,49,802
+Santa Clara,0002317,U.S. House,,DEM,Rishi Kumar,738,32,706
+Santa Clara,0002330,U.S. House,,DEM,Rishi Kumar,1229,53,1176
+Santa Clara,0002338,U.S. House,,DEM,Rishi Kumar,50,1,49
+Santa Clara,0002351,U.S. House,,DEM,Rishi Kumar,698,33,665
+Santa Clara,0002353,U.S. House,,DEM,Rishi Kumar,15,4,11
+Santa Clara,0002539,U.S. House,,DEM,Rishi Kumar,36,3,33
+Santa Clara,0002542,U.S. House,,DEM,Rishi Kumar,435,73,362
+Santa Clara,0002545,U.S. House,,DEM,Rishi Kumar,360,29,331
+Santa Clara,0002720,U.S. House,,DEM,Rishi Kumar,603,24,579
+Santa Clara,0002721,U.S. House,,DEM,Rishi Kumar,473,23,450
+Santa Clara,0002723,U.S. House,,DEM,Rishi Kumar,1035,57,978
+Santa Clara,0002724,U.S. House,,DEM,Rishi Kumar,818,54,764
+Santa Clara,0002725,U.S. House,,DEM,Rishi Kumar,738,41,697
+Santa Clara,0002726,U.S. House,,DEM,Rishi Kumar,521,40,481
+Santa Clara,0002727,U.S. House,,DEM,Rishi Kumar,583,26,557
+Santa Clara,0002729,U.S. House,,DEM,Rishi Kumar,573,21,552
+Santa Clara,0002734,U.S. House,,DEM,Rishi Kumar,809,56,753
+Santa Clara,0002740,U.S. House,,DEM,Rishi Kumar,956,64,892
+Santa Clara,0002751,U.S. House,,DEM,Rishi Kumar,9,0,9
+Santa Clara,0002761,U.S. House,,DEM,Rishi Kumar,4,0,4
+Santa Clara,0002802,U.S. House,,DEM,Rishi Kumar,769,43,726
+Santa Clara,0002808,U.S. House,,DEM,Rishi Kumar,40,1,39
+Santa Clara,0002810,U.S. House,,DEM,Rishi Kumar,8,0,8
+Santa Clara,0002811,U.S. House,,DEM,Rishi Kumar,13,0,13
+Santa Clara,0002812,U.S. House,,DEM,Rishi Kumar,85,8,77
+Santa Clara,0002813,U.S. House,,DEM,Rishi Kumar,73,2,71
+Santa Clara,0002816,U.S. House,,DEM,Rishi Kumar,8,0,8
+Santa Clara,0002870,U.S. House,,DEM,Rishi Kumar,34,3,31
+Santa Clara,0002951,U.S. House,,DEM,Rishi Kumar,116,15,101
+Santa Clara,0003402,U.S. House,,DEM,Rishi Kumar,826,58,768
+Santa Clara,0003406,U.S. House,,DEM,Rishi Kumar,902,101,801
+Santa Clara,0003407,U.S. House,,DEM,Rishi Kumar,888,52,836
+Santa Clara,0003408,U.S. House,,DEM,Rishi Kumar,1074,91,983
+Santa Clara,0003409,U.S. House,,DEM,Rishi Kumar,1107,113,994
+Santa Clara,0003410,U.S. House,,DEM,Rishi Kumar,1241,86,1155
+Santa Clara,0003417,U.S. House,,DEM,Rishi Kumar,926,59,867
+Santa Clara,0003427,U.S. House,,DEM,Rishi Kumar,909,66,843
+Santa Clara,0003434,U.S. House,,DEM,Rishi Kumar,604,35,569
+Santa Clara,0003438,U.S. House,,DEM,Rishi Kumar,1204,73,1131
+Santa Clara,0003445,U.S. House,,DEM,Rishi Kumar,1130,70,1060
+Santa Clara,0003669,U.S. House,,DEM,Rishi Kumar,0,0,0
+Santa Clara,0003777,U.S. House,,DEM,Rishi Kumar,564,24,540
+Santa Clara,0003779,U.S. House,,DEM,Rishi Kumar,49,3,46
+Santa Clara,0003782,U.S. House,,DEM,Rishi Kumar,156,5,151
+Santa Clara,0003783,U.S. House,,DEM,Rishi Kumar,130,6,124
+Santa Clara,0003801,U.S. House,,DEM,Rishi Kumar,552,33,519
+Santa Clara,0003802,U.S. House,,DEM,Rishi Kumar,824,57,767
+Santa Clara,0003803,U.S. House,,DEM,Rishi Kumar,744,42,702
+Santa Clara,0003804,U.S. House,,DEM,Rishi Kumar,294,34,260
+Santa Clara,0003810,U.S. House,,DEM,Rishi Kumar,644,59,585
+Santa Clara,0003811,U.S. House,,DEM,Rishi Kumar,812,65,747
+Santa Clara,0003814,U.S. House,,DEM,Rishi Kumar,887,69,818
+Santa Clara,0003820,U.S. House,,DEM,Rishi Kumar,759,49,710
+Santa Clara,0003821,U.S. House,,DEM,Rishi Kumar,333,20,313
+Santa Clara,0003825,U.S. House,,DEM,Rishi Kumar,475,39,436
+Santa Clara,0003828,U.S. House,,DEM,Rishi Kumar,444,27,417
+Santa Clara,0003835,U.S. House,,DEM,Rishi Kumar,512,16,496
+Santa Clara,0003840,U.S. House,,DEM,Rishi Kumar,641,53,588
+Santa Clara,0003846,U.S. House,,DEM,Rishi Kumar,32,1,31
+Santa Clara,0003861,U.S. House,,DEM,Rishi Kumar,29,2,27
+Santa Clara,0004665,U.S. House,,DEM,Rishi Kumar,11,1,10
+Santa Clara,0004666,U.S. House,,DEM,Rishi Kumar,0,0,0
+Santa Clara,0004671,U.S. House,,DEM,Rishi Kumar,722,53,669
+Santa Clara,0004672,U.S. House,,DEM,Rishi Kumar,399,17,382
+Santa Clara,0004674,U.S. House,,DEM,Rishi Kumar,630,38,592
+Santa Clara,0004675,U.S. House,,DEM,Rishi Kumar,1270,104,1166
+Santa Clara,0004685,U.S. House,,DEM,Rishi Kumar,619,31,588
+Santa Clara,0004687,U.S. House,,DEM,Rishi Kumar,712,36,676
+Santa Clara,0004688,U.S. House,,DEM,Rishi Kumar,1413,63,1350
+Santa Clara,0004691,U.S. House,,DEM,Rishi Kumar,891,50,841
+Santa Clara,0004696,U.S. House,,DEM,Rishi Kumar,551,20,531
+Santa Clara,0004698,U.S. House,,DEM,Rishi Kumar,475,26,449
+Santa Clara,0004699,U.S. House,,DEM,Rishi Kumar,696,28,668
+Santa Clara,0004702,U.S. House,,DEM,Rishi Kumar,416,20,396
+Santa Clara,0004715,U.S. House,,DEM,Rishi Kumar,241,9,232
+Santa Clara,0004733,U.S. House,,DEM,Rishi Kumar,18,2,16
+Santa Clara,0005556,U.S. House,,DEM,Rishi Kumar,387,40,347
+Santa Clara,0005557,U.S. House,,DEM,Rishi Kumar,306,17,289
+Santa Clara,0005567,U.S. House,,DEM,Rishi Kumar,160,13,147
+Santa Clara,0005742,U.S. House,,DEM,Rishi Kumar,6,0,6
+Santa Clara,0005743,U.S. House,,DEM,Rishi Kumar,148,17,131
+Santa Clara,0005745,U.S. House,,DEM,Rishi Kumar,149,13,136
+Santa Clara,0005747,U.S. House,,DEM,Rishi Kumar,327,16,311
+Santa Clara,0005748,U.S. House,,DEM,Rishi Kumar,507,54,453
+Santa Clara,0005756,U.S. House,,DEM,Rishi Kumar,28,0,28
+Santa Clara,0005758,U.S. House,,DEM,Rishi Kumar,69,1,68
+Santa Clara,0005759,U.S. House,,DEM,Rishi Kumar,165,10,155
+Santa Clara,0005762,U.S. House,,DEM,Rishi Kumar,96,4,92
+Santa Clara,0005763,U.S. House,,DEM,Rishi Kumar,27,4,23
+Santa Clara,0005770,U.S. House,,DEM,Rishi Kumar,76,3,73
+Santa Clara,0005775,U.S. House,,DEM,Rishi Kumar,113,1,112
+Santa Clara,0005785,U.S. House,,DEM,Rishi Kumar,0,0,0
+Santa Clara,0005793,U.S. House,,DEM,Rishi Kumar,0,0,0
+Santa Clara,0005795,U.S. House,,DEM,Rishi Kumar,0,0,0
+Santa Clara,0005804,U.S. House,,DEM,Rishi Kumar,363,17,346
+Santa Clara,0005810,U.S. House,,DEM,Rishi Kumar,117,10,107
+Santa Clara,0005811,U.S. House,,DEM,Rishi Kumar,121,7,114
+Santa Clara,0005813,U.S. House,,DEM,Rishi Kumar,19,2,17
+Santa Clara,0005814,U.S. House,,DEM,Rishi Kumar,70,4,66
+Santa Clara,0005854,U.S. House,,DEM,Rishi Kumar,1,0,1
+Santa Clara,0005901,U.S. House,,DEM,Rishi Kumar,0,0,0
+Santa Clara,0005902,U.S. House,,DEM,Rishi Kumar,173,8,165
+Santa Clara,0005903,U.S. House,,DEM,Rishi Kumar,240,27,213
+Santa Clara,0005907,U.S. House,,DEM,Rishi Kumar,6,0,6
+Santa Clara,0005927,U.S. House,,DEM,Rishi Kumar,1,0,1
+Santa Clara,0006023,U.S. House,,DEM,Rishi Kumar,6,0,6
+Santa Clara,0006624,U.S. House,,DEM,Rishi Kumar,4,0,4
+Santa Clara,0006625,U.S. House,,DEM,Rishi Kumar,0,0,0
+Santa Clara,0006669,U.S. House,,DEM,Rishi Kumar,31,1,30
+Santa Clara,0006678,U.S. House,,DEM,Rishi Kumar,30,1,29
+Santa Clara,0007001,U.S. House,,DEM,Rishi Kumar,614,55,559
+Santa Clara,0007005,U.S. House,,DEM,Rishi Kumar,708,55,653
+Santa Clara,0007012,U.S. House,,DEM,Rishi Kumar,741,45,696
+Santa Clara,0007014,U.S. House,,DEM,Rishi Kumar,790,44,746
+Santa Clara,0007019,U.S. House,,DEM,Rishi Kumar,1215,99,1116
+Santa Clara,0007025,U.S. House,,DEM,Rishi Kumar,902,57,845
+Santa Clara,0007038,U.S. House,,DEM,Rishi Kumar,120,7,113
+Santa Clara,0007041,U.S. House,,DEM,Rishi Kumar,1003,92,911
+Santa Clara,0007044,U.S. House,,DEM,Rishi Kumar,582,46,536
+Santa Clara,0007046,U.S. House,,DEM,Rishi Kumar,971,74,897
+Santa Clara,0007059,U.S. House,,DEM,Rishi Kumar,157,19,138
+Santa Clara,0007061,U.S. House,,DEM,Rishi Kumar,674,37,637
+Santa Clara,0007062,U.S. House,,DEM,Rishi Kumar,898,48,850
+Santa Clara,0007079,U.S. House,,DEM,Rishi Kumar,675,47,628
+Santa Clara,0007081,U.S. House,,DEM,Rishi Kumar,605,41,564
+Santa Clara,0007089,U.S. House,,DEM,Rishi Kumar,413,21,392
+Santa Clara,0008003,U.S. House,,DEM,Rishi Kumar,853,60,793
+Santa Clara,0008011,U.S. House,,DEM,Rishi Kumar,131,4,127
+Santa Clara,0008012,U.S. House,,DEM,Rishi Kumar,7,1,6
+Santa Clara,0008013,U.S. House,,DEM,Rishi Kumar,31,2,29
+Santa Clara,0008030,U.S. House,,DEM,Rishi Kumar,322,28,294
+Santa Clara,0008033,U.S. House,,DEM,Rishi Kumar,72,0,72
+Santa Clara,0008034,U.S. House,,DEM,Rishi Kumar,57,7,50
+Santa Clara,0008040,U.S. House,,DEM,Rishi Kumar,148,21,127
+Santa Clara,0008047,U.S. House,,DEM,Rishi Kumar,624,48,576
+Santa Clara,0008049,U.S. House,,DEM,Rishi Kumar,11,2,9
+Santa Clara,0008050,U.S. House,,DEM,Rishi Kumar,473,32,441
+Santa Clara,0008053,U.S. House,,DEM,Rishi Kumar,771,50,721
+Santa Clara,0008062,U.S. House,,DEM,Rishi Kumar,843,65,778
+Santa Clara,0008068,U.S. House,,DEM,Rishi Kumar,9,2,7
+Santa Clara,0008104,U.S. House,,DEM,Rishi Kumar,50,2,48
+Santa Clara,0008128,U.S. House,,DEM,Rishi Kumar,0,0,0
+Santa Clara,0008601,U.S. House,,DEM,Rishi Kumar,169,13,156
+Santa Clara,0008603,U.S. House,,DEM,Rishi Kumar,796,59,737
+Santa Clara,0008605,U.S. House,,DEM,Rishi Kumar,1033,84,949
+Santa Clara,0008610,U.S. House,,DEM,Rishi Kumar,535,38,497
+Santa Clara,0008619,U.S. House,,DEM,Rishi Kumar,238,8,230
+Santa Clara,0008627,U.S. House,,DEM,Rishi Kumar,430,40,390
+Santa Clara,0008629,U.S. House,,DEM,Rishi Kumar,640,53,587
+Santa Clara,0008630,U.S. House,,DEM,Rishi Kumar,884,71,813
+Santa Clara,0008645,U.S. House,,DEM,Rishi Kumar,1038,78,960
+Santa Clara,0008650,U.S. House,,DEM,Rishi Kumar,137,14,123
+Santa Clara,0008653,U.S. House,,DEM,Rishi Kumar,102,5,97
+Santa Clara,0008654,U.S. House,,DEM,Rishi Kumar,82,7,75
+Santa Clara,0008655,U.S. House,,DEM,Rishi Kumar,0,0,0
+Santa Clara,0008657,U.S. House,,DEM,Rishi Kumar,255,22,233
+Santa Clara,0008658,U.S. House,,DEM,Rishi Kumar,1251,85,1166
+Santa Clara,0008670,U.S. House,,DEM,Rishi Kumar,721,66,655
+Santa Clara,0008675,U.S. House,,DEM,Rishi Kumar,453,39,414
+Santa Clara,0008680,U.S. House,,DEM,Rishi Kumar,715,39,676
+Santa Clara,0008683,U.S. House,,DEM,Rishi Kumar,1141,73,1068
+Santa Clara,0008687,U.S. House,,DEM,Rishi Kumar,1096,77,1019
+Santa Clara,0008697,U.S. House,,DEM,Rishi Kumar,1125,81,1044
+Santa Clara,0008832,U.S. House,,DEM,Rishi Kumar,650,38,612
+Santa Clara,0008834,U.S. House,,DEM,Rishi Kumar,324,31,293
+Santa Clara,0008838,U.S. House,,DEM,Rishi Kumar,91,4,87
+Santa Clara,0008857,U.S. House,,DEM,Rishi Kumar,564,30,534
+Santa Clara,0008858,U.S. House,,DEM,Rishi Kumar,739,46,693
+Santa Clara,0008862,U.S. House,,DEM,Rishi Kumar,820,55,765
+Santa Clara,0008879,U.S. House,,DEM,Rishi Kumar,1080,68,1012
+Santa Clara,0008883,U.S. House,,DEM,Rishi Kumar,1216,89,1127
+Santa Clara,0008885,U.S. House,,DEM,Rishi Kumar,1171,69,1102
+Santa Clara,0008886,U.S. House,,DEM,Rishi Kumar,142,0,142
+Santa Clara,0008889,U.S. House,,DEM,Rishi Kumar,991,58,933
+Santa Clara,0008898,U.S. House,,DEM,Rishi Kumar,977,43,934
+Santa Clara,0008903,U.S. House,,DEM,Rishi Kumar,1245,54,1191
+Santa Clara,0008923,U.S. House,,DEM,Rishi Kumar,3,0,3
+Santa Clara,0008924,U.S. House,,DEM,Rishi Kumar,6,0,6
+Santa Clara,0004801,U.S. House,,DEM,Zoe Lofgren,840,55,785
+Santa Clara,0004806,U.S. House,,DEM,Zoe Lofgren,1598,72,1526
+Santa Clara,0004811,U.S. House,,DEM,Zoe Lofgren,916,48,868
+Santa Clara,0004826,U.S. House,,DEM,Zoe Lofgren,845,43,802
+Santa Clara,0004827,U.S. House,,DEM,Zoe Lofgren,1821,77,1744
+Santa Clara,0004833,U.S. House,,DEM,Zoe Lofgren,1161,53,1108
+Santa Clara,0004851,U.S. House,,DEM,Zoe Lofgren,612,22,590
+Santa Clara,0004853,U.S. House,,DEM,Zoe Lofgren,1139,34,1105
+Santa Clara,0004858,U.S. House,,DEM,Zoe Lofgren,1569,94,1475
+Santa Clara,0004876,U.S. House,,DEM,Zoe Lofgren,1954,90,1864
+Santa Clara,0004881,U.S. House,,DEM,Zoe Lofgren,2384,82,2302
+Santa Clara,0004941,U.S. House,,DEM,Zoe Lofgren,1676,118,1558
+Santa Clara,0004942,U.S. House,,DEM,Zoe Lofgren,1159,57,1102
+Santa Clara,0004946,U.S. House,,DEM,Zoe Lofgren,1820,130,1690
+Santa Clara,0004949,U.S. House,,DEM,Zoe Lofgren,1445,67,1378
+Santa Clara,0004950,U.S. House,,DEM,Zoe Lofgren,1124,45,1079
+Santa Clara,0004954,U.S. House,,DEM,Zoe Lofgren,1152,66,1086
+Santa Clara,0004965,U.S. House,,DEM,Zoe Lofgren,1645,91,1554
+Santa Clara,0004971,U.S. House,,DEM,Zoe Lofgren,551,16,535
+Santa Clara,0004973,U.S. House,,DEM,Zoe Lofgren,1245,39,1206
+Santa Clara,0005449,U.S. House,,DEM,Zoe Lofgren,75,3,72
+Santa Clara,0005451,U.S. House,,DEM,Zoe Lofgren,12,0,12
+Santa Clara,0005454,U.S. House,,DEM,Zoe Lofgren,5,1,4
+Santa Clara,0005455,U.S. House,,DEM,Zoe Lofgren,0,0,0
+Santa Clara,0005456,U.S. House,,DEM,Zoe Lofgren,3,0,3
+Santa Clara,0005458,U.S. House,,DEM,Zoe Lofgren,0,0,0
+Santa Clara,0005502,U.S. House,,DEM,Zoe Lofgren,248,15,233
+Santa Clara,0005503,U.S. House,,DEM,Zoe Lofgren,224,19,205
+Santa Clara,0005505,U.S. House,,DEM,Zoe Lofgren,189,7,182
+Santa Clara,0005507,U.S. House,,DEM,Zoe Lofgren,0,0,0
+Santa Clara,0005879,U.S. House,,DEM,Zoe Lofgren,13,1,12
+Santa Clara,0005886,U.S. House,,DEM,Zoe Lofgren,13,3,10
+Santa Clara,0005888,U.S. House,,DEM,Zoe Lofgren,0,0,0
+Santa Clara,0005894,U.S. House,,DEM,Zoe Lofgren,145,5,140
+Santa Clara,0005896,U.S. House,,DEM,Zoe Lofgren,3,0,3
+Santa Clara,0005906,U.S. House,,DEM,Zoe Lofgren,252,15,237
+Santa Clara,0005911,U.S. House,,DEM,Zoe Lofgren,1008,68,940
+Santa Clara,0005912,U.S. House,,DEM,Zoe Lofgren,94,4,90
+Santa Clara,0005914,U.S. House,,DEM,Zoe Lofgren,587,21,566
+Santa Clara,0005915,U.S. House,,DEM,Zoe Lofgren,482,14,468
+Santa Clara,0005916,U.S. House,,DEM,Zoe Lofgren,40,1,39
+Santa Clara,0005917,U.S. House,,DEM,Zoe Lofgren,138,3,135
+Santa Clara,0005919,U.S. House,,DEM,Zoe Lofgren,179,11,168
+Santa Clara,0005922,U.S. House,,DEM,Zoe Lofgren,275,10,265
+Santa Clara,0005925,U.S. House,,DEM,Zoe Lofgren,34,0,34
+Santa Clara,0005929,U.S. House,,DEM,Zoe Lofgren,61,9,52
+Santa Clara,0005931,U.S. House,,DEM,Zoe Lofgren,78,3,75
+Santa Clara,0005936,U.S. House,,DEM,Zoe Lofgren,264,16,248
+Santa Clara,0005940,U.S. House,,DEM,Zoe Lofgren,28,3,25
+Santa Clara,0005947,U.S. House,,DEM,Zoe Lofgren,219,3,216
+Santa Clara,0005950,U.S. House,,DEM,Zoe Lofgren,75,7,68
+Santa Clara,0005955,U.S. House,,DEM,Zoe Lofgren,560,23,537
+Santa Clara,0005956,U.S. House,,DEM,Zoe Lofgren,542,14,528
+Santa Clara,0005957,U.S. House,,DEM,Zoe Lofgren,55,3,52
+Santa Clara,0005958,U.S. House,,DEM,Zoe Lofgren,436,22,414
+Santa Clara,0005959,U.S. House,,DEM,Zoe Lofgren,26,0,26
+Santa Clara,0005965,U.S. House,,DEM,Zoe Lofgren,625,36,589
+Santa Clara,0005966,U.S. House,,DEM,Zoe Lofgren,112,3,109
+Santa Clara,0005988,U.S. House,,DEM,Zoe Lofgren,0,0,0
+Santa Clara,0006028,U.S. House,,DEM,Zoe Lofgren,19,0,19
+Santa Clara,0006031,U.S. House,,DEM,Zoe Lofgren,14,1,13
+Santa Clara,0006035,U.S. House,,DEM,Zoe Lofgren,0,0,0
+Santa Clara,0006036,U.S. House,,DEM,Zoe Lofgren,0,0,0
+Santa Clara,0006404,U.S. House,,DEM,Zoe Lofgren,1677,63,1614
+Santa Clara,0006410,U.S. House,,DEM,Zoe Lofgren,58,3,55
+Santa Clara,0006413,U.S. House,,DEM,Zoe Lofgren,6,0,6
+Santa Clara,0006418,U.S. House,,DEM,Zoe Lofgren,484,18,466
+Santa Clara,0006452,U.S. House,,DEM,Zoe Lofgren,694,53,641
+Santa Clara,0006454,U.S. House,,DEM,Zoe Lofgren,160,3,157
+Santa Clara,0006455,U.S. House,,DEM,Zoe Lofgren,1909,103,1806
+Santa Clara,0006491,U.S. House,,DEM,Zoe Lofgren,20,0,20
+Santa Clara,0006509,U.S. House,,DEM,Zoe Lofgren,6,2,4
+Santa Clara,0006510,U.S. House,,DEM,Zoe Lofgren,27,2,25
+Santa Clara,0006515,U.S. House,,DEM,Zoe Lofgren,66,1,65
+Santa Clara,0007201,U.S. House,,DEM,Zoe Lofgren,264,14,250
+Santa Clara,0007202,U.S. House,,DEM,Zoe Lofgren,508,28,480
+Santa Clara,0007203,U.S. House,,DEM,Zoe Lofgren,337,26,311
+Santa Clara,0007205,U.S. House,,DEM,Zoe Lofgren,1857,112,1745
+Santa Clara,0007214,U.S. House,,DEM,Zoe Lofgren,1152,64,1088
+Santa Clara,0007217,U.S. House,,DEM,Zoe Lofgren,2196,170,2026
+Santa Clara,0007219,U.S. House,,DEM,Zoe Lofgren,663,21,642
+Santa Clara,0007221,U.S. House,,DEM,Zoe Lofgren,1081,45,1036
+Santa Clara,0007224,U.S. House,,DEM,Zoe Lofgren,525,29,496
+Santa Clara,0007231,U.S. House,,DEM,Zoe Lofgren,480,28,452
+Santa Clara,0007235,U.S. House,,DEM,Zoe Lofgren,1582,125,1457
+Santa Clara,0007237,U.S. House,,DEM,Zoe Lofgren,1540,112,1428
+Santa Clara,0007245,U.S. House,,DEM,Zoe Lofgren,155,1,154
+Santa Clara,0007246,U.S. House,,DEM,Zoe Lofgren,935,30,905
+Santa Clara,0007248,U.S. House,,DEM,Zoe Lofgren,1607,78,1529
+Santa Clara,0007252,U.S. House,,DEM,Zoe Lofgren,2061,132,1929
+Santa Clara,0007255,U.S. House,,DEM,Zoe Lofgren,1939,121,1818
+Santa Clara,0007257,U.S. House,,DEM,Zoe Lofgren,953,27,926
+Santa Clara,0007261,U.S. House,,DEM,Zoe Lofgren,1359,84,1275
+Santa Clara,0007264,U.S. House,,DEM,Zoe Lofgren,1512,87,1425
+Santa Clara,0007271,U.S. House,,DEM,Zoe Lofgren,1867,78,1789
+Santa Clara,0007273,U.S. House,,DEM,Zoe Lofgren,2171,104,2067
+Santa Clara,0007282,U.S. House,,DEM,Zoe Lofgren,1241,61,1180
+Santa Clara,0007294,U.S. House,,DEM,Zoe Lofgren,445,14,431
+Santa Clara,0007295,U.S. House,,DEM,Zoe Lofgren,1140,48,1092
+Santa Clara,0007298,U.S. House,,DEM,Zoe Lofgren,780,18,762
+Santa Clara,0007299,U.S. House,,DEM,Zoe Lofgren,616,29,587
+Santa Clara,0007306,U.S. House,,DEM,Zoe Lofgren,0,0,0
+Santa Clara,0007401,U.S. House,,DEM,Zoe Lofgren,1,1,0
+Santa Clara,0007402,U.S. House,,DEM,Zoe Lofgren,398,18,380
+Santa Clara,0007408,U.S. House,,DEM,Zoe Lofgren,622,16,606
+Santa Clara,0007409,U.S. House,,DEM,Zoe Lofgren,219,14,205
+Santa Clara,0007414,U.S. House,,DEM,Zoe Lofgren,235,13,222
+Santa Clara,0007415,U.S. House,,DEM,Zoe Lofgren,37,0,37
+Santa Clara,0007416,U.S. House,,DEM,Zoe Lofgren,139,11,128
+Santa Clara,0007417,U.S. House,,DEM,Zoe Lofgren,2348,119,2229
+Santa Clara,0007418,U.S. House,,DEM,Zoe Lofgren,1317,71,1246
+Santa Clara,0007419,U.S. House,,DEM,Zoe Lofgren,936,39,897
+Santa Clara,0007430,U.S. House,,DEM,Zoe Lofgren,2019,155,1864
+Santa Clara,0007435,U.S. House,,DEM,Zoe Lofgren,1908,132,1776
+Santa Clara,0007436,U.S. House,,DEM,Zoe Lofgren,2815,165,2650
+Santa Clara,0007438,U.S. House,,DEM,Zoe Lofgren,237,24,213
+Santa Clara,0007447,U.S. House,,DEM,Zoe Lofgren,1523,146,1377
+Santa Clara,0007458,U.S. House,,DEM,Zoe Lofgren,1440,210,1230
+Santa Clara,0007459,U.S. House,,DEM,Zoe Lofgren,2086,168,1918
+Santa Clara,0007470,U.S. House,,DEM,Zoe Lofgren,1728,113,1615
+Santa Clara,0007471,U.S. House,,DEM,Zoe Lofgren,2337,180,2157
+Santa Clara,0007479,U.S. House,,DEM,Zoe Lofgren,950,73,877
+Santa Clara,0007483,U.S. House,,DEM,Zoe Lofgren,1883,181,1702
+Santa Clara,0007816,U.S. House,,DEM,Zoe Lofgren,185,20,165
+Santa Clara,0007817,U.S. House,,DEM,Zoe Lofgren,7,0,7
+Santa Clara,0007818,U.S. House,,DEM,Zoe Lofgren,153,4,149
+Santa Clara,0007821,U.S. House,,DEM,Zoe Lofgren,2401,159,2242
+Santa Clara,0007826,U.S. House,,DEM,Zoe Lofgren,2216,134,2082
+Santa Clara,0007827,U.S. House,,DEM,Zoe Lofgren,852,70,782
+Santa Clara,0007832,U.S. House,,DEM,Zoe Lofgren,1339,99,1240
+Santa Clara,0007833,U.S. House,,DEM,Zoe Lofgren,1797,136,1661
+Santa Clara,0007843,U.S. House,,DEM,Zoe Lofgren,2833,245,2588
+Santa Clara,0007849,U.S. House,,DEM,Zoe Lofgren,1867,123,1744
+Santa Clara,0007850,U.S. House,,DEM,Zoe Lofgren,1322,115,1207
+Santa Clara,0007851,U.S. House,,DEM,Zoe Lofgren,771,34,737
+Santa Clara,0007861,U.S. House,,DEM,Zoe Lofgren,1189,93,1096
+Santa Clara,0007867,U.S. House,,DEM,Zoe Lofgren,2101,139,1962
+Santa Clara,0007874,U.S. House,,DEM,Zoe Lofgren,282,11,271
+Santa Clara,0007880,U.S. House,,DEM,Zoe Lofgren,3,1,2
+Santa Clara,0008001,U.S. House,,DEM,Zoe Lofgren,183,8,175
+Santa Clara,0008002,U.S. House,,DEM,Zoe Lofgren,289,13,276
+Santa Clara,0008005,U.S. House,,DEM,Zoe Lofgren,2664,86,2578
+Santa Clara,0008007,U.S. House,,DEM,Zoe Lofgren,510,36,474
+Santa Clara,0008016,U.S. House,,DEM,Zoe Lofgren,3007,198,2809
+Santa Clara,0008017,U.S. House,,DEM,Zoe Lofgren,1238,90,1148
+Santa Clara,0008022,U.S. House,,DEM,Zoe Lofgren,729,47,682
+Santa Clara,0008023,U.S. House,,DEM,Zoe Lofgren,618,27,591
+Santa Clara,0008026,U.S. House,,DEM,Zoe Lofgren,617,56,561
+Santa Clara,0008028,U.S. House,,DEM,Zoe Lofgren,233,17,216
+Santa Clara,0008029,U.S. House,,DEM,Zoe Lofgren,98,3,95
+Santa Clara,0008038,U.S. House,,DEM,Zoe Lofgren,4,0,4
+Santa Clara,0008054,U.S. House,,DEM,Zoe Lofgren,1519,50,1469
+Santa Clara,0008055,U.S. House,,DEM,Zoe Lofgren,218,11,207
+Santa Clara,0008066,U.S. House,,DEM,Zoe Lofgren,688,43,645
+Santa Clara,0008067,U.S. House,,DEM,Zoe Lofgren,2096,80,2016
+Santa Clara,0008072,U.S. House,,DEM,Zoe Lofgren,424,19,405
+Santa Clara,0008073,U.S. House,,DEM,Zoe Lofgren,364,24,340
+Santa Clara,0008079,U.S. House,,DEM,Zoe Lofgren,1854,38,1816
+Santa Clara,0008082,U.S. House,,DEM,Zoe Lofgren,1385,49,1336
+Santa Clara,0008085,U.S. House,,DEM,Zoe Lofgren,810,16,794
+Santa Clara,0008089,U.S. House,,DEM,Zoe Lofgren,1894,45,1849
+Santa Clara,0008092,U.S. House,,DEM,Zoe Lofgren,50,2,48
+Santa Clara,0008093,U.S. House,,DEM,Zoe Lofgren,29,0,29
+Santa Clara,0008096,U.S. House,,DEM,Zoe Lofgren,1684,54,1630
+Santa Clara,0008101,U.S. House,,DEM,Zoe Lofgren,833,56,777
+Santa Clara,0008105,U.S. House,,DEM,Zoe Lofgren,269,3,266
+Santa Clara,0008117,U.S. House,,DEM,Zoe Lofgren,1250,32,1218
+Santa Clara,0008122,U.S. House,,DEM,Zoe Lofgren,1556,81,1475
+Santa Clara,0008133,U.S. House,,DEM,Zoe Lofgren,9,0,9
+Santa Clara,0008201,U.S. House,,DEM,Zoe Lofgren,1295,92,1203
+Santa Clara,0008203,U.S. House,,DEM,Zoe Lofgren,1534,144,1390
+Santa Clara,0008205,U.S. House,,DEM,Zoe Lofgren,1794,151,1643
+Santa Clara,0008208,U.S. House,,DEM,Zoe Lofgren,1695,118,1577
+Santa Clara,0008212,U.S. House,,DEM,Zoe Lofgren,886,91,795
+Santa Clara,0008214,U.S. House,,DEM,Zoe Lofgren,187,18,169
+Santa Clara,0008227,U.S. House,,DEM,Zoe Lofgren,1935,137,1798
+Santa Clara,0008228,U.S. House,,DEM,Zoe Lofgren,1350,48,1302
+Santa Clara,0008230,U.S. House,,DEM,Zoe Lofgren,2017,103,1914
+Santa Clara,0008231,U.S. House,,DEM,Zoe Lofgren,1153,83,1070
+Santa Clara,0008232,U.S. House,,DEM,Zoe Lofgren,2106,129,1977
+Santa Clara,0008236,U.S. House,,DEM,Zoe Lofgren,2283,124,2159
+Santa Clara,0008246,U.S. House,,DEM,Zoe Lofgren,1595,115,1480
+Santa Clara,0008254,U.S. House,,DEM,Zoe Lofgren,1556,128,1428
+Santa Clara,0008262,U.S. House,,DEM,Zoe Lofgren,977,38,939
+Santa Clara,0008264,U.S. House,,DEM,Zoe Lofgren,1089,54,1035
+Santa Clara,0008401,U.S. House,,DEM,Zoe Lofgren,1387,68,1319
+Santa Clara,0008404,U.S. House,,DEM,Zoe Lofgren,2538,172,2366
+Santa Clara,0008408,U.S. House,,DEM,Zoe Lofgren,863,51,812
+Santa Clara,0008409,U.S. House,,DEM,Zoe Lofgren,878,32,846
+Santa Clara,0008414,U.S. House,,DEM,Zoe Lofgren,271,15,256
+Santa Clara,0008418,U.S. House,,DEM,Zoe Lofgren,305,5,300
+Santa Clara,0008421,U.S. House,,DEM,Zoe Lofgren,32,0,32
+Santa Clara,0008423,U.S. House,,DEM,Zoe Lofgren,2,1,1
+Santa Clara,0008430,U.S. House,,DEM,Zoe Lofgren,2152,109,2043
+Santa Clara,0008435,U.S. House,,DEM,Zoe Lofgren,2528,88,2440
+Santa Clara,0008438,U.S. House,,DEM,Zoe Lofgren,2599,150,2449
+Santa Clara,0008439,U.S. House,,DEM,Zoe Lofgren,2165,90,2075
+Santa Clara,0008445,U.S. House,,DEM,Zoe Lofgren,1474,46,1428
+Santa Clara,0008447,U.S. House,,DEM,Zoe Lofgren,6,0,6
+Santa Clara,0008456,U.S. House,,DEM,Zoe Lofgren,2757,128,2629
+Santa Clara,0008457,U.S. House,,DEM,Zoe Lofgren,2553,118,2435
+Santa Clara,0008464,U.S. House,,DEM,Zoe Lofgren,2443,119,2324
+Santa Clara,0008470,U.S. House,,DEM,Zoe Lofgren,2651,104,2547
+Santa Clara,0008472,U.S. House,,DEM,Zoe Lofgren,1992,70,1922
+Santa Clara,0008486,U.S. House,,DEM,Zoe Lofgren,2383,87,2296
+Santa Clara,0008492,U.S. House,,DEM,Zoe Lofgren,2714,44,2670
+Santa Clara,0008502,U.S. House,,DEM,Zoe Lofgren,160,3,157
+Santa Clara,0008609,U.S. House,,DEM,Zoe Lofgren,0,0,0
+Santa Clara,0008612,U.S. House,,DEM,Zoe Lofgren,1583,53,1530
+Santa Clara,0008615,U.S. House,,DEM,Zoe Lofgren,1400,46,1354
+Santa Clara,0008625,U.S. House,,DEM,Zoe Lofgren,76,4,72
+Santa Clara,0008631,U.S. House,,DEM,Zoe Lofgren,1058,40,1018
+Santa Clara,0008634,U.S. House,,DEM,Zoe Lofgren,290,17,273
+Santa Clara,0008636,U.S. House,,DEM,Zoe Lofgren,224,8,216
+Santa Clara,0008648,U.S. House,,DEM,Zoe Lofgren,1702,58,1644
+Santa Clara,0008676,U.S. House,,DEM,Zoe Lofgren,1775,83,1692
+Santa Clara,0008801,U.S. House,,DEM,Zoe Lofgren,1345,84,1261
+Santa Clara,0008805,U.S. House,,DEM,Zoe Lofgren,1090,45,1045
+Santa Clara,0008809,U.S. House,,DEM,Zoe Lofgren,1969,81,1888
+Santa Clara,0008812,U.S. House,,DEM,Zoe Lofgren,1120,101,1019
+Santa Clara,0008817,U.S. House,,DEM,Zoe Lofgren,630,30,600
+Santa Clara,0008820,U.S. House,,DEM,Zoe Lofgren,1192,40,1152
+Santa Clara,0008822,U.S. House,,DEM,Zoe Lofgren,1295,52,1243
+Santa Clara,0008828,U.S. House,,DEM,Zoe Lofgren,463,25,438
+Santa Clara,0008829,U.S. House,,DEM,Zoe Lofgren,423,23,400
+Santa Clara,0008839,U.S. House,,DEM,Zoe Lofgren,1935,108,1827
+Santa Clara,0008844,U.S. House,,DEM,Zoe Lofgren,1931,82,1849
+Santa Clara,0008848,U.S. House,,DEM,Zoe Lofgren,1047,48,999
+Santa Clara,0008853,U.S. House,,DEM,Zoe Lofgren,1354,60,1294
+Santa Clara,0008868,U.S. House,,DEM,Zoe Lofgren,81,4,77
+Santa Clara,0008873,U.S. House,,DEM,Zoe Lofgren,592,21,571
+Santa Clara,0008874,U.S. House,,DEM,Zoe Lofgren,10,0,10
+Santa Clara,0008915,U.S. House,,DEM,Zoe Lofgren,9,1,8
+Santa Clara,0008916,U.S. House,,DEM,Zoe Lofgren,6,0,6
+Santa Clara,0008920,U.S. House,,DEM,Zoe Lofgren,0,0,0
+Santa Clara,0004801,U.S. House,,REP,Justin James Aguilera,386,62,324
+Santa Clara,0004806,U.S. House,,REP,Justin James Aguilera,1027,132,895
+Santa Clara,0004811,U.S. House,,REP,Justin James Aguilera,628,67,561
+Santa Clara,0004826,U.S. House,,REP,Justin James Aguilera,492,56,436
+Santa Clara,0004827,U.S. House,,REP,Justin James Aguilera,808,107,701
+Santa Clara,0004833,U.S. House,,REP,Justin James Aguilera,615,74,541
+Santa Clara,0004851,U.S. House,,REP,Justin James Aguilera,371,55,316
+Santa Clara,0004853,U.S. House,,REP,Justin James Aguilera,703,73,630
+Santa Clara,0004858,U.S. House,,REP,Justin James Aguilera,860,149,711
+Santa Clara,0004876,U.S. House,,REP,Justin James Aguilera,1239,129,1110
+Santa Clara,0004881,U.S. House,,REP,Justin James Aguilera,1485,152,1333
+Santa Clara,0004941,U.S. House,,REP,Justin James Aguilera,740,86,654
+Santa Clara,0004942,U.S. House,,REP,Justin James Aguilera,679,81,598
+Santa Clara,0004946,U.S. House,,REP,Justin James Aguilera,820,119,701
+Santa Clara,0004949,U.S. House,,REP,Justin James Aguilera,821,112,709
+Santa Clara,0004950,U.S. House,,REP,Justin James Aguilera,817,131,686
+Santa Clara,0004954,U.S. House,,REP,Justin James Aguilera,456,57,399
+Santa Clara,0004965,U.S. House,,REP,Justin James Aguilera,956,103,853
+Santa Clara,0004971,U.S. House,,REP,Justin James Aguilera,248,33,215
+Santa Clara,0004973,U.S. House,,REP,Justin James Aguilera,906,111,795
+Santa Clara,0005449,U.S. House,,REP,Justin James Aguilera,60,4,56
+Santa Clara,0005451,U.S. House,,REP,Justin James Aguilera,2,0,2
+Santa Clara,0005454,U.S. House,,REP,Justin James Aguilera,2,0,2
+Santa Clara,0005455,U.S. House,,REP,Justin James Aguilera,0,0,0
+Santa Clara,0005456,U.S. House,,REP,Justin James Aguilera,0,0,0
+Santa Clara,0005458,U.S. House,,REP,Justin James Aguilera,0,0,0
+Santa Clara,0005502,U.S. House,,REP,Justin James Aguilera,138,11,127
+Santa Clara,0005503,U.S. House,,REP,Justin James Aguilera,66,8,58
+Santa Clara,0005505,U.S. House,,REP,Justin James Aguilera,116,8,108
+Santa Clara,0005507,U.S. House,,REP,Justin James Aguilera,0,0,0
+Santa Clara,0005879,U.S. House,,REP,Justin James Aguilera,10,2,8
+Santa Clara,0005886,U.S. House,,REP,Justin James Aguilera,3,0,3
+Santa Clara,0005888,U.S. House,,REP,Justin James Aguilera,0,0,0
+Santa Clara,0005894,U.S. House,,REP,Justin James Aguilera,73,2,71
+Santa Clara,0005896,U.S. House,,REP,Justin James Aguilera,0,0,0
+Santa Clara,0005906,U.S. House,,REP,Justin James Aguilera,127,19,108
+Santa Clara,0005911,U.S. House,,REP,Justin James Aguilera,693,113,580
+Santa Clara,0005912,U.S. House,,REP,Justin James Aguilera,60,11,49
+Santa Clara,0005914,U.S. House,,REP,Justin James Aguilera,472,60,412
+Santa Clara,0005915,U.S. House,,REP,Justin James Aguilera,410,45,365
+Santa Clara,0005916,U.S. House,,REP,Justin James Aguilera,35,4,31
+Santa Clara,0005917,U.S. House,,REP,Justin James Aguilera,110,18,92
+Santa Clara,0005919,U.S. House,,REP,Justin James Aguilera,151,18,133
+Santa Clara,0005922,U.S. House,,REP,Justin James Aguilera,235,42,193
+Santa Clara,0005925,U.S. House,,REP,Justin James Aguilera,44,2,42
+Santa Clara,0005929,U.S. House,,REP,Justin James Aguilera,60,6,54
+Santa Clara,0005931,U.S. House,,REP,Justin James Aguilera,58,2,56
+Santa Clara,0005936,U.S. House,,REP,Justin James Aguilera,133,17,116
+Santa Clara,0005940,U.S. House,,REP,Justin James Aguilera,23,5,18
+Santa Clara,0005947,U.S. House,,REP,Justin James Aguilera,266,16,250
+Santa Clara,0005950,U.S. House,,REP,Justin James Aguilera,53,7,46
+Santa Clara,0005955,U.S. House,,REP,Justin James Aguilera,554,73,481
+Santa Clara,0005956,U.S. House,,REP,Justin James Aguilera,464,37,427
+Santa Clara,0005957,U.S. House,,REP,Justin James Aguilera,65,6,59
+Santa Clara,0005958,U.S. House,,REP,Justin James Aguilera,325,51,274
+Santa Clara,0005959,U.S. House,,REP,Justin James Aguilera,52,2,50
+Santa Clara,0005965,U.S. House,,REP,Justin James Aguilera,404,54,350
+Santa Clara,0005966,U.S. House,,REP,Justin James Aguilera,66,10,56
+Santa Clara,0005988,U.S. House,,REP,Justin James Aguilera,0,0,0
+Santa Clara,0006028,U.S. House,,REP,Justin James Aguilera,40,1,39
+Santa Clara,0006031,U.S. House,,REP,Justin James Aguilera,13,1,12
+Santa Clara,0006035,U.S. House,,REP,Justin James Aguilera,0,0,0
+Santa Clara,0006036,U.S. House,,REP,Justin James Aguilera,0,0,0
+Santa Clara,0006404,U.S. House,,REP,Justin James Aguilera,726,73,653
+Santa Clara,0006410,U.S. House,,REP,Justin James Aguilera,35,3,32
+Santa Clara,0006413,U.S. House,,REP,Justin James Aguilera,3,0,3
+Santa Clara,0006418,U.S. House,,REP,Justin James Aguilera,237,30,207
+Santa Clara,0006452,U.S. House,,REP,Justin James Aguilera,207,43,164
+Santa Clara,0006454,U.S. House,,REP,Justin James Aguilera,73,9,64
+Santa Clara,0006455,U.S. House,,REP,Justin James Aguilera,598,84,514
+Santa Clara,0006491,U.S. House,,REP,Justin James Aguilera,3,0,3
+Santa Clara,0006509,U.S. House,,REP,Justin James Aguilera,9,1,8
+Santa Clara,0006510,U.S. House,,REP,Justin James Aguilera,4,1,3
+Santa Clara,0006515,U.S. House,,REP,Justin James Aguilera,42,7,35
+Santa Clara,0007201,U.S. House,,REP,Justin James Aguilera,139,6,133
+Santa Clara,0007202,U.S. House,,REP,Justin James Aguilera,264,38,226
+Santa Clara,0007203,U.S. House,,REP,Justin James Aguilera,149,20,129
+Santa Clara,0007205,U.S. House,,REP,Justin James Aguilera,637,97,540
+Santa Clara,0007214,U.S. House,,REP,Justin James Aguilera,532,83,449
+Santa Clara,0007217,U.S. House,,REP,Justin James Aguilera,750,115,635
+Santa Clara,0007219,U.S. House,,REP,Justin James Aguilera,265,29,236
+Santa Clara,0007221,U.S. House,,REP,Justin James Aguilera,402,38,364
+Santa Clara,0007224,U.S. House,,REP,Justin James Aguilera,251,37,214
+Santa Clara,0007231,U.S. House,,REP,Justin James Aguilera,203,33,170
+Santa Clara,0007235,U.S. House,,REP,Justin James Aguilera,457,85,372
+Santa Clara,0007237,U.S. House,,REP,Justin James Aguilera,626,95,531
+Santa Clara,0007245,U.S. House,,REP,Justin James Aguilera,97,12,85
+Santa Clara,0007246,U.S. House,,REP,Justin James Aguilera,368,45,323
+Santa Clara,0007248,U.S. House,,REP,Justin James Aguilera,582,95,487
+Santa Clara,0007252,U.S. House,,REP,Justin James Aguilera,697,92,605
+Santa Clara,0007255,U.S. House,,REP,Justin James Aguilera,874,116,758
+Santa Clara,0007257,U.S. House,,REP,Justin James Aguilera,410,46,364
+Santa Clara,0007261,U.S. House,,REP,Justin James Aguilera,558,93,465
+Santa Clara,0007264,U.S. House,,REP,Justin James Aguilera,626,100,526
+Santa Clara,0007271,U.S. House,,REP,Justin James Aguilera,794,83,711
+Santa Clara,0007273,U.S. House,,REP,Justin James Aguilera,913,101,812
+Santa Clara,0007282,U.S. House,,REP,Justin James Aguilera,515,54,461
+Santa Clara,0007294,U.S. House,,REP,Justin James Aguilera,181,25,156
+Santa Clara,0007295,U.S. House,,REP,Justin James Aguilera,511,57,454
+Santa Clara,0007298,U.S. House,,REP,Justin James Aguilera,378,59,319
+Santa Clara,0007299,U.S. House,,REP,Justin James Aguilera,302,37,265
+Santa Clara,0007306,U.S. House,,REP,Justin James Aguilera,0,0,0
+Santa Clara,0007401,U.S. House,,REP,Justin James Aguilera,0,0,0
+Santa Clara,0007402,U.S. House,,REP,Justin James Aguilera,72,9,63
+Santa Clara,0007408,U.S. House,,REP,Justin James Aguilera,124,12,112
+Santa Clara,0007409,U.S. House,,REP,Justin James Aguilera,103,14,89
+Santa Clara,0007414,U.S. House,,REP,Justin James Aguilera,69,5,64
+Santa Clara,0007415,U.S. House,,REP,Justin James Aguilera,6,0,6
+Santa Clara,0007416,U.S. House,,REP,Justin James Aguilera,25,4,21
+Santa Clara,0007417,U.S. House,,REP,Justin James Aguilera,458,71,387
+Santa Clara,0007418,U.S. House,,REP,Justin James Aguilera,301,41,260
+Santa Clara,0007419,U.S. House,,REP,Justin James Aguilera,171,21,150
+Santa Clara,0007430,U.S. House,,REP,Justin James Aguilera,402,63,339
+Santa Clara,0007435,U.S. House,,REP,Justin James Aguilera,369,64,305
+Santa Clara,0007436,U.S. House,,REP,Justin James Aguilera,692,95,597
+Santa Clara,0007438,U.S. House,,REP,Justin James Aguilera,73,16,57
+Santa Clara,0007447,U.S. House,,REP,Justin James Aguilera,367,72,295
+Santa Clara,0007458,U.S. House,,REP,Justin James Aguilera,311,62,249
+Santa Clara,0007459,U.S. House,,REP,Justin James Aguilera,406,89,317
+Santa Clara,0007470,U.S. House,,REP,Justin James Aguilera,354,61,293
+Santa Clara,0007471,U.S. House,,REP,Justin James Aguilera,560,92,468
+Santa Clara,0007479,U.S. House,,REP,Justin James Aguilera,294,52,242
+Santa Clara,0007483,U.S. House,,REP,Justin James Aguilera,342,67,275
+Santa Clara,0007816,U.S. House,,REP,Justin James Aguilera,45,7,38
+Santa Clara,0007817,U.S. House,,REP,Justin James Aguilera,2,0,2
+Santa Clara,0007818,U.S. House,,REP,Justin James Aguilera,61,3,58
+Santa Clara,0007821,U.S. House,,REP,Justin James Aguilera,887,101,786
+Santa Clara,0007826,U.S. House,,REP,Justin James Aguilera,676,97,579
+Santa Clara,0007827,U.S. House,,REP,Justin James Aguilera,203,36,167
+Santa Clara,0007832,U.S. House,,REP,Justin James Aguilera,526,86,440
+Santa Clara,0007833,U.S. House,,REP,Justin James Aguilera,584,94,490
+Santa Clara,0007843,U.S. House,,REP,Justin James Aguilera,680,110,570
+Santa Clara,0007849,U.S. House,,REP,Justin James Aguilera,485,86,399
+Santa Clara,0007850,U.S. House,,REP,Justin James Aguilera,392,66,326
+Santa Clara,0007851,U.S. House,,REP,Justin James Aguilera,367,32,335
+Santa Clara,0007861,U.S. House,,REP,Justin James Aguilera,291,48,243
+Santa Clara,0007867,U.S. House,,REP,Justin James Aguilera,606,73,533
+Santa Clara,0007874,U.S. House,,REP,Justin James Aguilera,72,7,65
+Santa Clara,0007880,U.S. House,,REP,Justin James Aguilera,4,2,2
+Santa Clara,0008001,U.S. House,,REP,Justin James Aguilera,46,2,44
+Santa Clara,0008002,U.S. House,,REP,Justin James Aguilera,64,9,55
+Santa Clara,0008005,U.S. House,,REP,Justin James Aguilera,727,78,649
+Santa Clara,0008007,U.S. House,,REP,Justin James Aguilera,105,20,85
+Santa Clara,0008016,U.S. House,,REP,Justin James Aguilera,644,98,546
+Santa Clara,0008017,U.S. House,,REP,Justin James Aguilera,278,39,239
+Santa Clara,0008022,U.S. House,,REP,Justin James Aguilera,68,10,58
+Santa Clara,0008023,U.S. House,,REP,Justin James Aguilera,162,30,132
+Santa Clara,0008026,U.S. House,,REP,Justin James Aguilera,189,40,149
+Santa Clara,0008028,U.S. House,,REP,Justin James Aguilera,55,9,46
+Santa Clara,0008029,U.S. House,,REP,Justin James Aguilera,24,5,19
+Santa Clara,0008038,U.S. House,,REP,Justin James Aguilera,0,0,0
+Santa Clara,0008054,U.S. House,,REP,Justin James Aguilera,500,55,445
+Santa Clara,0008055,U.S. House,,REP,Justin James Aguilera,50,5,45
+Santa Clara,0008066,U.S. House,,REP,Justin James Aguilera,202,31,171
+Santa Clara,0008067,U.S. House,,REP,Justin James Aguilera,558,76,482
+Santa Clara,0008072,U.S. House,,REP,Justin James Aguilera,109,10,99
+Santa Clara,0008073,U.S. House,,REP,Justin James Aguilera,69,10,59
+Santa Clara,0008079,U.S. House,,REP,Justin James Aguilera,613,76,537
+Santa Clara,0008082,U.S. House,,REP,Justin James Aguilera,418,38,380
+Santa Clara,0008085,U.S. House,,REP,Justin James Aguilera,400,36,364
+Santa Clara,0008089,U.S. House,,REP,Justin James Aguilera,675,75,600
+Santa Clara,0008092,U.S. House,,REP,Justin James Aguilera,21,2,19
+Santa Clara,0008093,U.S. House,,REP,Justin James Aguilera,19,1,18
+Santa Clara,0008096,U.S. House,,REP,Justin James Aguilera,699,70,629
+Santa Clara,0008101,U.S. House,,REP,Justin James Aguilera,279,39,240
+Santa Clara,0008105,U.S. House,,REP,Justin James Aguilera,112,5,107
+Santa Clara,0008117,U.S. House,,REP,Justin James Aguilera,426,65,361
+Santa Clara,0008122,U.S. House,,REP,Justin James Aguilera,585,68,517
+Santa Clara,0008133,U.S. House,,REP,Justin James Aguilera,5,0,5
+Santa Clara,0008201,U.S. House,,REP,Justin James Aguilera,838,148,690
+Santa Clara,0008203,U.S. House,,REP,Justin James Aguilera,554,97,457
+Santa Clara,0008205,U.S. House,,REP,Justin James Aguilera,860,164,696
+Santa Clara,0008208,U.S. House,,REP,Justin James Aguilera,421,59,362
+Santa Clara,0008212,U.S. House,,REP,Justin James Aguilera,200,47,153
+Santa Clara,0008214,U.S. House,,REP,Justin James Aguilera,129,21,108
+Santa Clara,0008227,U.S. House,,REP,Justin James Aguilera,867,111,756
+Santa Clara,0008228,U.S. House,,REP,Justin James Aguilera,515,59,456
+Santa Clara,0008230,U.S. House,,REP,Justin James Aguilera,854,126,728
+Santa Clara,0008231,U.S. House,,REP,Justin James Aguilera,654,93,561
+Santa Clara,0008232,U.S. House,,REP,Justin James Aguilera,1235,199,1036
+Santa Clara,0008236,U.S. House,,REP,Justin James Aguilera,1264,185,1079
+Santa Clara,0008246,U.S. House,,REP,Justin James Aguilera,562,84,478
+Santa Clara,0008254,U.S. House,,REP,Justin James Aguilera,505,83,422
+Santa Clara,0008262,U.S. House,,REP,Justin James Aguilera,640,78,562
+Santa Clara,0008264,U.S. House,,REP,Justin James Aguilera,496,74,422
+Santa Clara,0008401,U.S. House,,REP,Justin James Aguilera,446,59,387
+Santa Clara,0008404,U.S. House,,REP,Justin James Aguilera,1139,149,990
+Santa Clara,0008408,U.S. House,,REP,Justin James Aguilera,375,59,316
+Santa Clara,0008409,U.S. House,,REP,Justin James Aguilera,337,51,286
+Santa Clara,0008414,U.S. House,,REP,Justin James Aguilera,115,15,100
+Santa Clara,0008418,U.S. House,,REP,Justin James Aguilera,141,12,129
+Santa Clara,0008421,U.S. House,,REP,Justin James Aguilera,11,1,10
+Santa Clara,0008423,U.S. House,,REP,Justin James Aguilera,0,0,0
+Santa Clara,0008430,U.S. House,,REP,Justin James Aguilera,904,147,757
+Santa Clara,0008435,U.S. House,,REP,Justin James Aguilera,934,106,828
+Santa Clara,0008438,U.S. House,,REP,Justin James Aguilera,1101,162,939
+Santa Clara,0008439,U.S. House,,REP,Justin James Aguilera,804,123,681
+Santa Clara,0008445,U.S. House,,REP,Justin James Aguilera,566,56,510
+Santa Clara,0008447,U.S. House,,REP,Justin James Aguilera,1,0,1
+Santa Clara,0008456,U.S. House,,REP,Justin James Aguilera,933,108,825
+Santa Clara,0008457,U.S. House,,REP,Justin James Aguilera,1042,145,897
+Santa Clara,0008464,U.S. House,,REP,Justin James Aguilera,850,144,706
+Santa Clara,0008470,U.S. House,,REP,Justin James Aguilera,808,92,716
+Santa Clara,0008472,U.S. House,,REP,Justin James Aguilera,839,111,728
+Santa Clara,0008486,U.S. House,,REP,Justin James Aguilera,1178,122,1056
+Santa Clara,0008492,U.S. House,,REP,Justin James Aguilera,1163,86,1077
+Santa Clara,0008502,U.S. House,,REP,Justin James Aguilera,56,4,52
+Santa Clara,0008609,U.S. House,,REP,Justin James Aguilera,1,1,0
+Santa Clara,0008612,U.S. House,,REP,Justin James Aguilera,585,67,518
+Santa Clara,0008615,U.S. House,,REP,Justin James Aguilera,617,57,560
+Santa Clara,0008625,U.S. House,,REP,Justin James Aguilera,12,3,9
+Santa Clara,0008631,U.S. House,,REP,Justin James Aguilera,367,43,324
+Santa Clara,0008634,U.S. House,,REP,Justin James Aguilera,89,16,73
+Santa Clara,0008636,U.S. House,,REP,Justin James Aguilera,156,20,136
+Santa Clara,0008648,U.S. House,,REP,Justin James Aguilera,811,74,737
+Santa Clara,0008676,U.S. House,,REP,Justin James Aguilera,683,72,611
+Santa Clara,0008801,U.S. House,,REP,Justin James Aguilera,545,88,457
+Santa Clara,0008805,U.S. House,,REP,Justin James Aguilera,500,53,447
+Santa Clara,0008809,U.S. House,,REP,Justin James Aguilera,637,89,548
+Santa Clara,0008812,U.S. House,,REP,Justin James Aguilera,344,48,296
+Santa Clara,0008817,U.S. House,,REP,Justin James Aguilera,241,21,220
+Santa Clara,0008820,U.S. House,,REP,Justin James Aguilera,573,69,504
+Santa Clara,0008822,U.S. House,,REP,Justin James Aguilera,553,83,470
+Santa Clara,0008828,U.S. House,,REP,Justin James Aguilera,179,23,156
+Santa Clara,0008829,U.S. House,,REP,Justin James Aguilera,151,16,135
+Santa Clara,0008839,U.S. House,,REP,Justin James Aguilera,663,96,567
+Santa Clara,0008844,U.S. House,,REP,Justin James Aguilera,903,116,787
+Santa Clara,0008848,U.S. House,,REP,Justin James Aguilera,434,67,367
+Santa Clara,0008853,U.S. House,,REP,Justin James Aguilera,571,66,505
+Santa Clara,0008868,U.S. House,,REP,Justin James Aguilera,38,4,34
+Santa Clara,0008873,U.S. House,,REP,Justin James Aguilera,286,32,254
+Santa Clara,0008874,U.S. House,,REP,Justin James Aguilera,9,0,9
+Santa Clara,0008915,U.S. House,,REP,Justin James Aguilera,7,0,7
+Santa Clara,0008916,U.S. House,,REP,Justin James Aguilera,9,0,9
+Santa Clara,0008920,U.S. House,,REP,Justin James Aguilera,1,0,1
+Santa Clara,0004943,U.S. House,,DEM,Jimmy Panetta,68,5,63
+Santa Clara,0004944,U.S. House,,DEM,Jimmy Panetta,589,76,513
+Santa Clara,0004945,U.S. House,,DEM,Jimmy Panetta,878,74,804
+Santa Clara,0004956,U.S. House,,DEM,Jimmy Panetta,152,14,138
+Santa Clara,0004958,U.S. House,,DEM,Jimmy Panetta,965,87,878
+Santa Clara,0004969,U.S. House,,DEM,Jimmy Panetta,1441,86,1355
+Santa Clara,0004974,U.S. House,,DEM,Jimmy Panetta,693,54,639
+Santa Clara,0005949,U.S. House,,DEM,Jimmy Panetta,325,20,305
+Santa Clara,0005951,U.S. House,,DEM,Jimmy Panetta,5,0,5
+Santa Clara,0005975,U.S. House,,DEM,Jimmy Panetta,26,0,26
+Santa Clara,0006048,U.S. House,,DEM,Jimmy Panetta,16,0,16
+Santa Clara,0004943,U.S. House,,REP,Jeff Gorman,20,3,17
+Santa Clara,0004944,U.S. House,,REP,Jeff Gorman,185,36,149
+Santa Clara,0004945,U.S. House,,REP,Jeff Gorman,314,50,264
+Santa Clara,0004956,U.S. House,,REP,Jeff Gorman,48,11,37
+Santa Clara,0004958,U.S. House,,REP,Jeff Gorman,232,48,184
+Santa Clara,0004969,U.S. House,,REP,Jeff Gorman,410,52,358
+Santa Clara,0004974,U.S. House,,REP,Jeff Gorman,193,33,160
+Santa Clara,0005949,U.S. House,,REP,Jeff Gorman,188,28,160
+Santa Clara,0005951,U.S. House,,REP,Jeff Gorman,1,0,1
+Santa Clara,0005975,U.S. House,,REP,Jeff Gorman,7,4,3
+Santa Clara,0006048,U.S. House,,REP,Jeff Gorman,5,0,5
+Santa Clara,0002001,State Senate,,DEM,JOSH BECKER,22,17,5
+Santa Clara,0002002,State Senate,,DEM,JOSH BECKER,1862,94,1768
+Santa Clara,0002005,State Senate,,DEM,JOSH BECKER,1219,42,1177
+Santa Clara,0002006,State Senate,,DEM,JOSH BECKER,51,0,51
+Santa Clara,0002009,State Senate,,DEM,JOSH BECKER,2865,128,2737
+Santa Clara,0002013,State Senate,,DEM,JOSH BECKER,2286,91,2195
+Santa Clara,0002014,State Senate,,DEM,JOSH BECKER,1979,108,1871
+Santa Clara,0002018,State Senate,,DEM,JOSH BECKER,63,3,60
+Santa Clara,0002025,State Senate,,DEM,JOSH BECKER,2654,80,2574
+Santa Clara,0002043,State Senate,,DEM,JOSH BECKER,2081,64,2017
+Santa Clara,0002046,State Senate,,DEM,JOSH BECKER,2895,110,2785
+Santa Clara,0002057,State Senate,,DEM,JOSH BECKER,2743,116,2627
+Santa Clara,0002068,State Senate,,DEM,JOSH BECKER,2546,87,2459
+Santa Clara,0002098,State Senate,,DEM,JOSH BECKER,2630,97,2533
+Santa Clara,0002108,State Senate,,DEM,JOSH BECKER,2339,72,2267
+Santa Clara,0002125,State Senate,,DEM,JOSH BECKER,240,4,236
+Santa Clara,0002274,State Senate,,DEM,JOSH BECKER,144,2,142
+Santa Clara,0002275,State Senate,,DEM,JOSH BECKER,617,15,602
+Santa Clara,0002278,State Senate,,DEM,JOSH BECKER,636,29,607
+Santa Clara,0002281,State Senate,,DEM,JOSH BECKER,3,0,3
+Santa Clara,0002282,State Senate,,DEM,JOSH BECKER,804,33,771
+Santa Clara,0002285,State Senate,,DEM,JOSH BECKER,1395,61,1334
+Santa Clara,0002301,State Senate,,DEM,JOSH BECKER,2234,62,2172
+Santa Clara,0002305,State Senate,,DEM,JOSH BECKER,3013,108,2905
+Santa Clara,0002309,State Senate,,DEM,JOSH BECKER,764,13,751
+Santa Clara,0002314,State Senate,,DEM,JOSH BECKER,1762,55,1707
+Santa Clara,0002317,State Senate,,DEM,JOSH BECKER,1666,61,1605
+Santa Clara,0002330,State Senate,,DEM,JOSH BECKER,2674,49,2625
+Santa Clara,0002338,State Senate,,DEM,JOSH BECKER,100,4,96
+Santa Clara,0002351,State Senate,,DEM,JOSH BECKER,1484,45,1439
+Santa Clara,0002353,State Senate,,DEM,JOSH BECKER,19,3,16
+Santa Clara,0002539,State Senate,,DEM,JOSH BECKER,122,4,118
+Santa Clara,0002542,State Senate,,DEM,JOSH BECKER,1304,179,1125
+Santa Clara,0002545,State Senate,,DEM,JOSH BECKER,1714,88,1626
+Santa Clara,0002802,State Senate,,DEM,JOSH BECKER,1467,46,1421
+Santa Clara,0002811,State Senate,,DEM,JOSH BECKER,21,0,21
+Santa Clara,0002813,State Senate,,DEM,JOSH BECKER,130,3,127
+Santa Clara,0002816,State Senate,,DEM,JOSH BECKER,18,0,18
+Santa Clara,0002870,State Senate,,DEM,JOSH BECKER,77,3,74
+Santa Clara,0002951,State Senate,,DEM,JOSH BECKER,177,12,165
+Santa Clara,0003001,State Senate,,DEM,JOSH BECKER,1758,73,1685
+Santa Clara,0003002,State Senate,,DEM,JOSH BECKER,1798,112,1686
+Santa Clara,0003005,State Senate,,DEM,JOSH BECKER,38,2,36
+Santa Clara,0003010,State Senate,,DEM,JOSH BECKER,1612,97,1515
+Santa Clara,0003011,State Senate,,DEM,JOSH BECKER,1534,103,1431
+Santa Clara,0003012,State Senate,,DEM,JOSH BECKER,81,3,78
+Santa Clara,0003013,State Senate,,DEM,JOSH BECKER,2118,125,1993
+Santa Clara,0003016,State Senate,,DEM,JOSH BECKER,652,23,629
+Santa Clara,0003017,State Senate,,DEM,JOSH BECKER,469,31,438
+Santa Clara,0003018,State Senate,,DEM,JOSH BECKER,240,20,220
+Santa Clara,0003019,State Senate,,DEM,JOSH BECKER,2201,98,2103
+Santa Clara,0003021,State Senate,,DEM,JOSH BECKER,196,7,189
+Santa Clara,0003023,State Senate,,DEM,JOSH BECKER,1698,89,1609
+Santa Clara,0003026,State Senate,,DEM,JOSH BECKER,1215,36,1179
+Santa Clara,0003029,State Senate,,DEM,JOSH BECKER,0,0,0
+Santa Clara,0003031,State Senate,,DEM,JOSH BECKER,0,0,0
+Santa Clara,0003032,State Senate,,DEM,JOSH BECKER,1012,50,962
+Santa Clara,0003034,State Senate,,DEM,JOSH BECKER,2084,87,1997
+Santa Clara,0003035,State Senate,,DEM,JOSH BECKER,1558,91,1467
+Santa Clara,0003039,State Senate,,DEM,JOSH BECKER,1100,43,1057
+Santa Clara,0003040,State Senate,,DEM,JOSH BECKER,0,0,0
+Santa Clara,0003042,State Senate,,DEM,JOSH BECKER,1075,63,1012
+Santa Clara,0003043,State Senate,,DEM,JOSH BECKER,1762,58,1704
+Santa Clara,0003045,State Senate,,DEM,JOSH BECKER,2331,98,2233
+Santa Clara,0003047,State Senate,,DEM,JOSH BECKER,786,23,763
+Santa Clara,0003048,State Senate,,DEM,JOSH BECKER,2183,101,2082
+Santa Clara,0003051,State Senate,,DEM,JOSH BECKER,1562,33,1529
+Santa Clara,0003053,State Senate,,DEM,JOSH BECKER,1774,48,1726
+Santa Clara,0003061,State Senate,,DEM,JOSH BECKER,64,6,58
+Santa Clara,0003079,State Senate,,DEM,JOSH BECKER,370,10,360
+Santa Clara,0003080,State Senate,,DEM,JOSH BECKER,725,28,697
+Santa Clara,0003086,State Senate,,DEM,JOSH BECKER,2108,65,2043
+Santa Clara,0003087,State Senate,,DEM,JOSH BECKER,828,58,770
+Santa Clara,0003089,State Senate,,DEM,JOSH BECKER,0,0,0
+Santa Clara,0003095,State Senate,,DEM,JOSH BECKER,2,0,2
+Santa Clara,0003101,State Senate,,DEM,JOSH BECKER,103,3,100
+Santa Clara,0003102,State Senate,,DEM,JOSH BECKER,349,25,324
+Santa Clara,0003103,State Senate,,DEM,JOSH BECKER,881,48,833
+Santa Clara,0003116,State Senate,,DEM,JOSH BECKER,554,16,538
+Santa Clara,0003117,State Senate,,DEM,JOSH BECKER,606,23,583
+Santa Clara,0003120,State Senate,,DEM,JOSH BECKER,380,21,359
+Santa Clara,0003122,State Senate,,DEM,JOSH BECKER,1615,62,1553
+Santa Clara,0003156,State Senate,,DEM,JOSH BECKER,94,2,92
+Santa Clara,0003402,State Senate,,DEM,JOSH BECKER,2263,65,2198
+Santa Clara,0003406,State Senate,,DEM,JOSH BECKER,2131,161,1970
+Santa Clara,0003407,State Senate,,DEM,JOSH BECKER,2237,83,2154
+Santa Clara,0003408,State Senate,,DEM,JOSH BECKER,2715,129,2586
+Santa Clara,0003409,State Senate,,DEM,JOSH BECKER,2634,139,2495
+Santa Clara,0003410,State Senate,,DEM,JOSH BECKER,2766,111,2655
+Santa Clara,0003417,State Senate,,DEM,JOSH BECKER,2552,87,2465
+Santa Clara,0003427,State Senate,,DEM,JOSH BECKER,2127,98,2029
+Santa Clara,0003434,State Senate,,DEM,JOSH BECKER,1570,35,1535
+Santa Clara,0003438,State Senate,,DEM,JOSH BECKER,2795,80,2715
+Santa Clara,0003445,State Senate,,DEM,JOSH BECKER,2624,101,2523
+Santa Clara,0004733,State Senate,,DEM,JOSH BECKER,17,1,16
+Santa Clara,0006678,State Senate,,DEM,JOSH BECKER,32,0,32
+Santa Clara,0002001,State Senate,,REP,ALEXANDER GLEW,35,32,3
+Santa Clara,0002002,State Senate,,REP,ALEXANDER GLEW,405,46,359
+Santa Clara,0002005,State Senate,,REP,ALEXANDER GLEW,280,30,250
+Santa Clara,0002006,State Senate,,REP,ALEXANDER GLEW,18,1,17
+Santa Clara,0002009,State Senate,,REP,ALEXANDER GLEW,713,94,619
+Santa Clara,0002013,State Senate,,REP,ALEXANDER GLEW,687,64,623
+Santa Clara,0002014,State Senate,,REP,ALEXANDER GLEW,678,97,581
+Santa Clara,0002018,State Senate,,REP,ALEXANDER GLEW,46,6,40
+Santa Clara,0002025,State Senate,,REP,ALEXANDER GLEW,733,53,680
+Santa Clara,0002043,State Senate,,REP,ALEXANDER GLEW,583,50,533
+Santa Clara,0002046,State Senate,,REP,ALEXANDER GLEW,628,80,548
+Santa Clara,0002057,State Senate,,REP,ALEXANDER GLEW,560,53,507
+Santa Clara,0002068,State Senate,,REP,ALEXANDER GLEW,662,41,621
+Santa Clara,0002098,State Senate,,REP,ALEXANDER GLEW,772,63,709
+Santa Clara,0002108,State Senate,,REP,ALEXANDER GLEW,582,67,515
+Santa Clara,0002125,State Senate,,REP,ALEXANDER GLEW,70,8,62
+Santa Clara,0002274,State Senate,,REP,ALEXANDER GLEW,88,3,85
+Santa Clara,0002275,State Senate,,REP,ALEXANDER GLEW,400,42,358
+Santa Clara,0002278,State Senate,,REP,ALEXANDER GLEW,307,34,273
+Santa Clara,0002281,State Senate,,REP,ALEXANDER GLEW,2,0,2
+Santa Clara,0002282,State Senate,,REP,ALEXANDER GLEW,387,31,356
+Santa Clara,0002285,State Senate,,REP,ALEXANDER GLEW,769,76,693
+Santa Clara,0002301,State Senate,,REP,ALEXANDER GLEW,829,56,773
+Santa Clara,0002305,State Senate,,REP,ALEXANDER GLEW,1094,82,1012
+Santa Clara,0002309,State Senate,,REP,ALEXANDER GLEW,302,29,273
+Santa Clara,0002314,State Senate,,REP,ALEXANDER GLEW,693,55,638
+Santa Clara,0002317,State Senate,,REP,ALEXANDER GLEW,681,58,623
+Santa Clara,0002330,State Senate,,REP,ALEXANDER GLEW,993,77,916
+Santa Clara,0002338,State Senate,,REP,ALEXANDER GLEW,31,3,28
+Santa Clara,0002351,State Senate,,REP,ALEXANDER GLEW,584,39,545
+Santa Clara,0002353,State Senate,,REP,ALEXANDER GLEW,14,3,11
+Santa Clara,0002539,State Senate,,REP,ALEXANDER GLEW,17,2,15
+Santa Clara,0002542,State Senate,,REP,ALEXANDER GLEW,151,30,121
+Santa Clara,0002545,State Senate,,REP,ALEXANDER GLEW,170,19,151
+Santa Clara,0002802,State Senate,,REP,ALEXANDER GLEW,756,56,700
+Santa Clara,0002811,State Senate,,REP,ALEXANDER GLEW,11,0,11
+Santa Clara,0002813,State Senate,,REP,ALEXANDER GLEW,88,4,84
+Santa Clara,0002816,State Senate,,REP,ALEXANDER GLEW,3,0,3
+Santa Clara,0002870,State Senate,,REP,ALEXANDER GLEW,38,2,36
+Santa Clara,0002951,State Senate,,REP,ALEXANDER GLEW,87,15,72
+Santa Clara,0003001,State Senate,,REP,ALEXANDER GLEW,781,100,681
+Santa Clara,0003002,State Senate,,REP,ALEXANDER GLEW,557,77,480
+Santa Clara,0003005,State Senate,,REP,ALEXANDER GLEW,13,2,11
+Santa Clara,0003010,State Senate,,REP,ALEXANDER GLEW,538,64,474
+Santa Clara,0003011,State Senate,,REP,ALEXANDER GLEW,454,67,387
+Santa Clara,0003012,State Senate,,REP,ALEXANDER GLEW,33,5,28
+Santa Clara,0003013,State Senate,,REP,ALEXANDER GLEW,575,77,498
+Santa Clara,0003016,State Senate,,REP,ALEXANDER GLEW,170,14,156
+Santa Clara,0003017,State Senate,,REP,ALEXANDER GLEW,126,22,104
+Santa Clara,0003018,State Senate,,REP,ALEXANDER GLEW,73,6,67
+Santa Clara,0003019,State Senate,,REP,ALEXANDER GLEW,615,81,534
+Santa Clara,0003021,State Senate,,REP,ALEXANDER GLEW,55,8,47
+Santa Clara,0003023,State Senate,,REP,ALEXANDER GLEW,607,86,521
+Santa Clara,0003026,State Senate,,REP,ALEXANDER GLEW,455,51,404
+Santa Clara,0003029,State Senate,,REP,ALEXANDER GLEW,0,0,0
+Santa Clara,0003031,State Senate,,REP,ALEXANDER GLEW,0,0,0
+Santa Clara,0003032,State Senate,,REP,ALEXANDER GLEW,372,46,326
+Santa Clara,0003034,State Senate,,REP,ALEXANDER GLEW,805,91,714
+Santa Clara,0003035,State Senate,,REP,ALEXANDER GLEW,485,69,416
+Santa Clara,0003039,State Senate,,REP,ALEXANDER GLEW,367,29,338
+Santa Clara,0003040,State Senate,,REP,ALEXANDER GLEW,0,0,0
+Santa Clara,0003042,State Senate,,REP,ALEXANDER GLEW,335,41,294
+Santa Clara,0003043,State Senate,,REP,ALEXANDER GLEW,710,64,646
+Santa Clara,0003045,State Senate,,REP,ALEXANDER GLEW,807,86,721
+Santa Clara,0003047,State Senate,,REP,ALEXANDER GLEW,281,26,255
+Santa Clara,0003048,State Senate,,REP,ALEXANDER GLEW,657,86,571
+Santa Clara,0003051,State Senate,,REP,ALEXANDER GLEW,594,32,562
+Santa Clara,0003053,State Senate,,REP,ALEXANDER GLEW,784,67,717
+Santa Clara,0003061,State Senate,,REP,ALEXANDER GLEW,20,4,16
+Santa Clara,0003079,State Senate,,REP,ALEXANDER GLEW,169,15,154
+Santa Clara,0003080,State Senate,,REP,ALEXANDER GLEW,199,13,186
+Santa Clara,0003086,State Senate,,REP,ALEXANDER GLEW,840,66,774
+Santa Clara,0003087,State Senate,,REP,ALEXANDER GLEW,302,42,260
+Santa Clara,0003089,State Senate,,REP,ALEXANDER GLEW,0,0,0
+Santa Clara,0003095,State Senate,,REP,ALEXANDER GLEW,0,0,0
+Santa Clara,0003101,State Senate,,REP,ALEXANDER GLEW,37,6,31
+Santa Clara,0003102,State Senate,,REP,ALEXANDER GLEW,140,8,132
+Santa Clara,0003103,State Senate,,REP,ALEXANDER GLEW,282,32,250
+Santa Clara,0003116,State Senate,,REP,ALEXANDER GLEW,207,18,189
+Santa Clara,0003117,State Senate,,REP,ALEXANDER GLEW,200,22,178
+Santa Clara,0003120,State Senate,,REP,ALEXANDER GLEW,118,11,107
+Santa Clara,0003122,State Senate,,REP,ALEXANDER GLEW,518,58,460
+Santa Clara,0003156,State Senate,,REP,ALEXANDER GLEW,35,7,28
+Santa Clara,0003402,State Senate,,REP,ALEXANDER GLEW,571,82,489
+Santa Clara,0003406,State Senate,,REP,ALEXANDER GLEW,531,92,439
+Santa Clara,0003407,State Senate,,REP,ALEXANDER GLEW,536,61,475
+Santa Clara,0003408,State Senate,,REP,ALEXANDER GLEW,654,94,560
+Santa Clara,0003409,State Senate,,REP,ALEXANDER GLEW,682,109,573
+Santa Clara,0003410,State Senate,,REP,ALEXANDER GLEW,712,84,628
+Santa Clara,0003417,State Senate,,REP,ALEXANDER GLEW,531,68,463
+Santa Clara,0003427,State Senate,,REP,ALEXANDER GLEW,527,68,459
+Santa Clara,0003434,State Senate,,REP,ALEXANDER GLEW,491,38,453
+Santa Clara,0003438,State Senate,,REP,ALEXANDER GLEW,884,80,804
+Santa Clara,0003445,State Senate,,REP,ALEXANDER GLEW,686,83,603
+Santa Clara,0004733,State Senate,,REP,ALEXANDER GLEW,25,6,19
+Santa Clara,0006678,State Senate,,REP,ALEXANDER GLEW,18,1,17
+Santa Clara,0002720,State Senate,,DEM,DAVE CORTESE,488,22,466
+Santa Clara,0002721,State Senate,,DEM,DAVE CORTESE,460,16,444
+Santa Clara,0002723,State Senate,,DEM,DAVE CORTESE,1004,47,957
+Santa Clara,0002724,State Senate,,DEM,DAVE CORTESE,841,56,785
+Santa Clara,0002725,State Senate,,DEM,DAVE CORTESE,754,43,711
+Santa Clara,0002726,State Senate,,DEM,DAVE CORTESE,539,38,501
+Santa Clara,0002727,State Senate,,DEM,DAVE CORTESE,478,16,462
+Santa Clara,0002729,State Senate,,DEM,DAVE CORTESE,549,17,532
+Santa Clara,0002734,State Senate,,DEM,DAVE CORTESE,755,37,718
+Santa Clara,0002740,State Senate,,DEM,DAVE CORTESE,903,47,856
+Santa Clara,0002751,State Senate,,DEM,DAVE CORTESE,3,0,3
+Santa Clara,0002761,State Senate,,DEM,DAVE CORTESE,4,0,4
+Santa Clara,0002808,State Senate,,DEM,DAVE CORTESE,34,1,33
+Santa Clara,0002810,State Senate,,DEM,DAVE CORTESE,7,0,7
+Santa Clara,0002812,State Senate,,DEM,DAVE CORTESE,104,4,100
+Santa Clara,0002825,State Senate,,DEM,DAVE CORTESE,7,0,7
+Santa Clara,0003601,State Senate,,DEM,DAVE CORTESE,526,17,509
+Santa Clara,0003602,State Senate,,DEM,DAVE CORTESE,988,46,942
+Santa Clara,0003603,State Senate,,DEM,DAVE CORTESE,512,19,493
+Santa Clara,0003604,State Senate,,DEM,DAVE CORTESE,1213,46,1167
+Santa Clara,0003605,State Senate,,DEM,DAVE CORTESE,1349,73,1276
+Santa Clara,0003606,State Senate,,DEM,DAVE CORTESE,1026,49,977
+Santa Clara,0003608,State Senate,,DEM,DAVE CORTESE,1184,41,1143
+Santa Clara,0003609,State Senate,,DEM,DAVE CORTESE,1628,61,1567
+Santa Clara,0003611,State Senate,,DEM,DAVE CORTESE,1057,48,1009
+Santa Clara,0003614,State Senate,,DEM,DAVE CORTESE,576,29,547
+Santa Clara,0003624,State Senate,,DEM,DAVE CORTESE,1465,53,1412
+Santa Clara,0003635,State Senate,,DEM,DAVE CORTESE,0,0,0
+Santa Clara,0003652,State Senate,,DEM,DAVE CORTESE,583,52,531
+Santa Clara,0003655,State Senate,,DEM,DAVE CORTESE,87,3,84
+Santa Clara,0003669,State Senate,,DEM,DAVE CORTESE,2,0,2
+Santa Clara,0003670,State Senate,,DEM,DAVE CORTESE,54,2,52
+Santa Clara,0003777,State Senate,,DEM,DAVE CORTESE,526,19,507
+Santa Clara,0003779,State Senate,,DEM,DAVE CORTESE,38,1,37
+Santa Clara,0003782,State Senate,,DEM,DAVE CORTESE,151,10,141
+Santa Clara,0003783,State Senate,,DEM,DAVE CORTESE,137,4,133
+Santa Clara,0003801,State Senate,,DEM,DAVE CORTESE,635,44,591
+Santa Clara,0003802,State Senate,,DEM,DAVE CORTESE,962,56,906
+Santa Clara,0003803,State Senate,,DEM,DAVE CORTESE,921,55,866
+Santa Clara,0003804,State Senate,,DEM,DAVE CORTESE,443,44,399
+Santa Clara,0003810,State Senate,,DEM,DAVE CORTESE,792,68,724
+Santa Clara,0003811,State Senate,,DEM,DAVE CORTESE,1011,49,962
+Santa Clara,0003814,State Senate,,DEM,DAVE CORTESE,949,76,873
+Santa Clara,0003820,State Senate,,DEM,DAVE CORTESE,856,51,805
+Santa Clara,0003821,State Senate,,DEM,DAVE CORTESE,385,21,364
+Santa Clara,0003825,State Senate,,DEM,DAVE CORTESE,494,37,457
+Santa Clara,0003828,State Senate,,DEM,DAVE CORTESE,459,24,435
+Santa Clara,0003835,State Senate,,DEM,DAVE CORTESE,479,15,464
+Santa Clara,0003840,State Senate,,DEM,DAVE CORTESE,817,52,765
+Santa Clara,0003846,State Senate,,DEM,DAVE CORTESE,41,1,40
+Santa Clara,0003861,State Senate,,DEM,DAVE CORTESE,34,3,31
+Santa Clara,0004665,State Senate,,DEM,DAVE CORTESE,9,1,8
+Santa Clara,0004666,State Senate,,DEM,DAVE CORTESE,4,0,4
+Santa Clara,0004671,State Senate,,DEM,DAVE CORTESE,579,37,542
+Santa Clara,0004672,State Senate,,DEM,DAVE CORTESE,300,14,286
+Santa Clara,0004674,State Senate,,DEM,DAVE CORTESE,519,35,484
+Santa Clara,0004675,State Senate,,DEM,DAVE CORTESE,1030,58,972
+Santa Clara,0004685,State Senate,,DEM,DAVE CORTESE,475,19,456
+Santa Clara,0004687,State Senate,,DEM,DAVE CORTESE,574,27,547
+Santa Clara,0004688,State Senate,,DEM,DAVE CORTESE,1035,45,990
+Santa Clara,0004691,State Senate,,DEM,DAVE CORTESE,739,33,706
+Santa Clara,0004696,State Senate,,DEM,DAVE CORTESE,466,15,451
+Santa Clara,0004698,State Senate,,DEM,DAVE CORTESE,441,11,430
+Santa Clara,0004699,State Senate,,DEM,DAVE CORTESE,596,27,569
+Santa Clara,0004702,State Senate,,DEM,DAVE CORTESE,357,9,348
+Santa Clara,0004715,State Senate,,DEM,DAVE CORTESE,192,10,182
+Santa Clara,0005449,State Senate,,DEM,DAVE CORTESE,90,3,87
+Santa Clara,0005451,State Senate,,DEM,DAVE CORTESE,9,0,9
+Santa Clara,0005454,State Senate,,DEM,DAVE CORTESE,5,1,4
+Santa Clara,0005455,State Senate,,DEM,DAVE CORTESE,0,0,0
+Santa Clara,0005456,State Senate,,DEM,DAVE CORTESE,3,0,3
+Santa Clara,0005502,State Senate,,DEM,DAVE CORTESE,214,16,198
+Santa Clara,0005503,State Senate,,DEM,DAVE CORTESE,191,23,168
+Santa Clara,0005505,State Senate,,DEM,DAVE CORTESE,163,11,152
+Santa Clara,0005507,State Senate,,DEM,DAVE CORTESE,0,0,0
+Santa Clara,0005556,State Senate,,DEM,DAVE CORTESE,625,57,568
+Santa Clara,0005557,State Senate,,DEM,DAVE CORTESE,419,19,400
+Santa Clara,0005567,State Senate,,DEM,DAVE CORTESE,239,15,224
+Santa Clara,0005742,State Senate,,DEM,DAVE CORTESE,5,0,5
+Santa Clara,0005743,State Senate,,DEM,DAVE CORTESE,202,21,181
+Santa Clara,0005745,State Senate,,DEM,DAVE CORTESE,174,11,163
+Santa Clara,0005747,State Senate,,DEM,DAVE CORTESE,267,16,251
+Santa Clara,0005748,State Senate,,DEM,DAVE CORTESE,586,68,518
+Santa Clara,0005756,State Senate,,DEM,DAVE CORTESE,36,1,35
+Santa Clara,0005758,State Senate,,DEM,DAVE CORTESE,68,1,67
+Santa Clara,0005759,State Senate,,DEM,DAVE CORTESE,144,6,138
+Santa Clara,0005762,State Senate,,DEM,DAVE CORTESE,90,2,88
+Santa Clara,0005763,State Senate,,DEM,DAVE CORTESE,24,3,21
+Santa Clara,0005770,State Senate,,DEM,DAVE CORTESE,59,2,57
+Santa Clara,0005775,State Senate,,DEM,DAVE CORTESE,116,3,113
+Santa Clara,0005785,State Senate,,DEM,DAVE CORTESE,0,0,0
+Santa Clara,0005793,State Senate,,DEM,DAVE CORTESE,0,0,0
+Santa Clara,0005795,State Senate,,DEM,DAVE CORTESE,2,0,2
+Santa Clara,0005804,State Senate,,DEM,DAVE CORTESE,466,29,437
+Santa Clara,0005810,State Senate,,DEM,DAVE CORTESE,143,6,137
+Santa Clara,0005811,State Senate,,DEM,DAVE CORTESE,125,5,120
+Santa Clara,0005813,State Senate,,DEM,DAVE CORTESE,20,2,18
+Santa Clara,0005814,State Senate,,DEM,DAVE CORTESE,84,4,80
+Santa Clara,0005854,State Senate,,DEM,DAVE CORTESE,2,0,2
+Santa Clara,0005879,State Senate,,DEM,DAVE CORTESE,9,1,8
+Santa Clara,0005888,State Senate,,DEM,DAVE CORTESE,0,0,0
+Santa Clara,0005894,State Senate,,DEM,DAVE CORTESE,101,5,96
+Santa Clara,0005896,State Senate,,DEM,DAVE CORTESE,0,0,0
+Santa Clara,0005901,State Senate,,DEM,DAVE CORTESE,0,0,0
+Santa Clara,0005902,State Senate,,DEM,DAVE CORTESE,165,8,157
+Santa Clara,0005903,State Senate,,DEM,DAVE CORTESE,238,19,219
+Santa Clara,0005907,State Senate,,DEM,DAVE CORTESE,2,0,2
+Santa Clara,0005927,State Senate,,DEM,DAVE CORTESE,1,0,1
+Santa Clara,0006028,State Senate,,DEM,DAVE CORTESE,19,0,19
+Santa Clara,0006036,State Senate,,DEM,DAVE CORTESE,0,0,0
+Santa Clara,0006404,State Senate,,DEM,DAVE CORTESE,1371,62,1309
+Santa Clara,0006405,State Senate,,DEM,DAVE CORTESE,2,0,2
+Santa Clara,0006410,State Senate,,DEM,DAVE CORTESE,33,2,31
+Santa Clara,0006413,State Senate,,DEM,DAVE CORTESE,4,0,4
+Santa Clara,0006418,State Senate,,DEM,DAVE CORTESE,385,20,365
+Santa Clara,0006423,State Senate,,DEM,DAVE CORTESE,17,1,16
+Santa Clara,0006452,State Senate,,DEM,DAVE CORTESE,566,53,513
+Santa Clara,0006454,State Senate,,DEM,DAVE CORTESE,160,9,151
+Santa Clara,0006455,State Senate,,DEM,DAVE CORTESE,1560,109,1451
+Santa Clara,0006491,State Senate,,DEM,DAVE CORTESE,14,0,14
+Santa Clara,0006502,State Senate,,DEM,DAVE CORTESE,165,13,152
+Santa Clara,0006509,State Senate,,DEM,DAVE CORTESE,8,2,6
+Santa Clara,0006510,State Senate,,DEM,DAVE CORTESE,21,2,19
+Santa Clara,0006624,State Senate,,DEM,DAVE CORTESE,1,0,1
+Santa Clara,0006625,State Senate,,DEM,DAVE CORTESE,3,0,3
+Santa Clara,0006669,State Senate,,DEM,DAVE CORTESE,32,0,32
+Santa Clara,0007001,State Senate,,DEM,DAVE CORTESE,770,63,707
+Santa Clara,0007005,State Senate,,DEM,DAVE CORTESE,1044,85,959
+Santa Clara,0007011,State Senate,,DEM,DAVE CORTESE,144,14,130
+Santa Clara,0007012,State Senate,,DEM,DAVE CORTESE,828,41,787
+Santa Clara,0007014,State Senate,,DEM,DAVE CORTESE,883,33,850
+Santa Clara,0007019,State Senate,,DEM,DAVE CORTESE,1440,116,1324
+Santa Clara,0007025,State Senate,,DEM,DAVE CORTESE,1284,82,1202
+Santa Clara,0007028,State Senate,,DEM,DAVE CORTESE,1154,70,1084
+Santa Clara,0007032,State Senate,,DEM,DAVE CORTESE,1605,71,1534
+Santa Clara,0007036,State Senate,,DEM,DAVE CORTESE,1402,46,1356
+Santa Clara,0007038,State Senate,,DEM,DAVE CORTESE,106,6,100
+Santa Clara,0007041,State Senate,,DEM,DAVE CORTESE,1316,113,1203
+Santa Clara,0007044,State Senate,,DEM,DAVE CORTESE,707,48,659
+Santa Clara,0007046,State Senate,,DEM,DAVE CORTESE,1259,93,1166
+Santa Clara,0007051,State Senate,,DEM,DAVE CORTESE,0,0,0
+Santa Clara,0007059,State Senate,,DEM,DAVE CORTESE,184,14,170
+Santa Clara,0007061,State Senate,,DEM,DAVE CORTESE,765,38,727
+Santa Clara,0007062,State Senate,,DEM,DAVE CORTESE,1105,67,1038
+Santa Clara,0007079,State Senate,,DEM,DAVE CORTESE,738,36,702
+Santa Clara,0007081,State Senate,,DEM,DAVE CORTESE,688,28,660
+Santa Clara,0007089,State Senate,,DEM,DAVE CORTESE,468,21,447
+Santa Clara,0007201,State Senate,,DEM,DAVE CORTESE,246,7,239
+Santa Clara,0007202,State Senate,,DEM,DAVE CORTESE,476,43,433
+Santa Clara,0007221,State Senate,,DEM,DAVE CORTESE,828,44,784
+Santa Clara,0007224,State Senate,,DEM,DAVE CORTESE,459,31,428
+Santa Clara,0007416,State Senate,,DEM,DAVE CORTESE,96,11,85
+Santa Clara,0007417,State Senate,,DEM,DAVE CORTESE,1402,98,1304
+Santa Clara,0007430,State Senate,,DEM,DAVE CORTESE,1331,120,1211
+Santa Clara,0007435,State Senate,,DEM,DAVE CORTESE,1174,103,1071
+Santa Clara,0007436,State Senate,,DEM,DAVE CORTESE,2066,156,1910
+Santa Clara,0007438,State Senate,,DEM,DAVE CORTESE,207,30,177
+Santa Clara,0007440,State Senate,,DEM,DAVE CORTESE,28,3,25
+Santa Clara,0007441,State Senate,,DEM,DAVE CORTESE,1059,58,1001
+Santa Clara,0007442,State Senate,,DEM,DAVE CORTESE,163,23,140
+Santa Clara,0007447,State Senate,,DEM,DAVE CORTESE,1036,127,909
+Santa Clara,0007458,State Senate,,DEM,DAVE CORTESE,960,154,806
+Santa Clara,0007459,State Senate,,DEM,DAVE CORTESE,1318,137,1181
+Santa Clara,0007470,State Senate,,DEM,DAVE CORTESE,960,88,872
+Santa Clara,0007471,State Senate,,DEM,DAVE CORTESE,1668,150,1518
+Santa Clara,0007479,State Senate,,DEM,DAVE CORTESE,812,88,724
+Santa Clara,0007483,State Senate,,DEM,DAVE CORTESE,1373,161,1212
+Santa Clara,0007689,State Senate,,DEM,DAVE CORTESE,7,0,7
+Santa Clara,0007690,State Senate,,DEM,DAVE CORTESE,570,28,542
+Santa Clara,0007802,State Senate,,DEM,DAVE CORTESE,221,10,211
+Santa Clara,0007803,State Senate,,DEM,DAVE CORTESE,577,28,549
+Santa Clara,0007805,State Senate,,DEM,DAVE CORTESE,1026,54,972
+Santa Clara,0007810,State Senate,,DEM,DAVE CORTESE,161,8,153
+Santa Clara,0007811,State Senate,,DEM,DAVE CORTESE,117,10,107
+Santa Clara,0007812,State Senate,,DEM,DAVE CORTESE,879,57,822
+Santa Clara,0007816,State Senate,,DEM,DAVE CORTESE,128,17,111
+Santa Clara,0007817,State Senate,,DEM,DAVE CORTESE,6,0,6
+Santa Clara,0007818,State Senate,,DEM,DAVE CORTESE,113,2,111
+Santa Clara,0007821,State Senate,,DEM,DAVE CORTESE,1997,158,1839
+Santa Clara,0007826,State Senate,,DEM,DAVE CORTESE,1839,133,1706
+Santa Clara,0007827,State Senate,,DEM,DAVE CORTESE,632,62,570
+Santa Clara,0007832,State Senate,,DEM,DAVE CORTESE,1169,107,1062
+Santa Clara,0007833,State Senate,,DEM,DAVE CORTESE,1509,123,1386
+Santa Clara,0007843,State Senate,,DEM,DAVE CORTESE,2234,220,2014
+Santa Clara,0007849,State Senate,,DEM,DAVE CORTESE,1489,123,1366
+Santa Clara,0007850,State Senate,,DEM,DAVE CORTESE,1074,107,967
+Santa Clara,0007851,State Senate,,DEM,DAVE CORTESE,669,39,630
+Santa Clara,0007861,State Senate,,DEM,DAVE CORTESE,949,78,871
+Santa Clara,0007867,State Senate,,DEM,DAVE CORTESE,1757,136,1621
+Santa Clara,0007874,State Senate,,DEM,DAVE CORTESE,244,11,233
+Santa Clara,0008016,State Senate,,DEM,DAVE CORTESE,1715,129,1586
+Santa Clara,0008017,State Senate,,DEM,DAVE CORTESE,759,60,699
+Santa Clara,0008022,State Senate,,DEM,DAVE CORTESE,381,32,349
+Santa Clara,0008023,State Senate,,DEM,DAVE CORTESE,427,27,400
+Santa Clara,0008026,State Senate,,DEM,DAVE CORTESE,441,52,389
+Santa Clara,0008028,State Senate,,DEM,DAVE CORTESE,145,12,133
+Santa Clara,0008029,State Senate,,DEM,DAVE CORTESE,65,5,60
+Santa Clara,0008030,State Senate,,DEM,DAVE CORTESE,406,21,385
+Santa Clara,0008033,State Senate,,DEM,DAVE CORTESE,128,6,122
+Santa Clara,0008034,State Senate,,DEM,DAVE CORTESE,117,12,105
+Santa Clara,0008038,State Senate,,DEM,DAVE CORTESE,0,0,0
+Santa Clara,0008040,State Senate,,DEM,DAVE CORTESE,276,20,256
+Santa Clara,0008047,State Senate,,DEM,DAVE CORTESE,877,60,817
+Santa Clara,0008049,State Senate,,DEM,DAVE CORTESE,24,1,23
+Santa Clara,0008050,State Senate,,DEM,DAVE CORTESE,731,46,685
+Santa Clara,0008053,State Senate,,DEM,DAVE CORTESE,1136,74,1062
+Santa Clara,0008054,State Senate,,DEM,DAVE CORTESE,903,50,853
+Santa Clara,0008055,State Senate,,DEM,DAVE CORTESE,136,11,125
+Santa Clara,0008062,State Senate,,DEM,DAVE CORTESE,1243,94,1149
+Santa Clara,0008066,State Senate,,DEM,DAVE CORTESE,421,39,382
+Santa Clara,0008067,State Senate,,DEM,DAVE CORTESE,1159,66,1093
+Santa Clara,0008068,State Senate,,DEM,DAVE CORTESE,18,0,18
+Santa Clara,0008072,State Senate,,DEM,DAVE CORTESE,251,16,235
+Santa Clara,0008073,State Senate,,DEM,DAVE CORTESE,261,19,242
+Santa Clara,0008079,State Senate,,DEM,DAVE CORTESE,1029,48,981
+Santa Clara,0008082,State Senate,,DEM,DAVE CORTESE,889,36,853
+Santa Clara,0008085,State Senate,,DEM,DAVE CORTESE,530,21,509
+Santa Clara,0008089,State Senate,,DEM,DAVE CORTESE,1127,49,1078
+Santa Clara,0008092,State Senate,,DEM,DAVE CORTESE,31,2,29
+Santa Clara,0008093,State Senate,,DEM,DAVE CORTESE,26,0,26
+Santa Clara,0008096,State Senate,,DEM,DAVE CORTESE,1027,41,986
+Santa Clara,0008101,State Senate,,DEM,DAVE CORTESE,633,55,578
+Santa Clara,0008104,State Senate,,DEM,DAVE CORTESE,49,2,47
+Santa Clara,0008105,State Senate,,DEM,DAVE CORTESE,154,3,151
+Santa Clara,0008117,State Senate,,DEM,DAVE CORTESE,766,49,717
+Santa Clara,0008122,State Senate,,DEM,DAVE CORTESE,1052,75,977
+Santa Clara,0008128,State Senate,,DEM,DAVE CORTESE,0,0,0
+Santa Clara,0008133,State Senate,,DEM,DAVE CORTESE,6,0,6
+Santa Clara,0008201,State Senate,,DEM,DAVE CORTESE,1300,122,1178
+Santa Clara,0008203,State Senate,,DEM,DAVE CORTESE,1296,143,1153
+Santa Clara,0008205,State Senate,,DEM,DAVE CORTESE,1700,181,1519
+Santa Clara,0008208,State Senate,,DEM,DAVE CORTESE,1411,118,1293
+Santa Clara,0008212,State Senate,,DEM,DAVE CORTESE,636,81,555
+Santa Clara,0008214,State Senate,,DEM,DAVE CORTESE,192,19,173
+Santa Clara,0008227,State Senate,,DEM,DAVE CORTESE,1765,142,1623
+Santa Clara,0008228,State Senate,,DEM,DAVE CORTESE,923,53,870
+Santa Clara,0008230,State Senate,,DEM,DAVE CORTESE,1634,106,1528
+Santa Clara,0008231,State Senate,,DEM,DAVE CORTESE,1125,95,1030
+Santa Clara,0008232,State Senate,,DEM,DAVE CORTESE,2086,178,1908
+Santa Clara,0008236,State Senate,,DEM,DAVE CORTESE,2163,162,2001
+Santa Clara,0008262,State Senate,,DEM,DAVE CORTESE,989,64,925
+Santa Clara,0008264,State Senate,,DEM,DAVE CORTESE,1020,85,935
+Santa Clara,0008401,State Senate,,DEM,DAVE CORTESE,1170,75,1095
+Santa Clara,0008404,State Senate,,DEM,DAVE CORTESE,2362,191,2171
+Santa Clara,0008408,State Senate,,DEM,DAVE CORTESE,807,64,743
+Santa Clara,0008409,State Senate,,DEM,DAVE CORTESE,777,46,731
+Santa Clara,0008414,State Senate,,DEM,DAVE CORTESE,233,17,216
+Santa Clara,0008418,State Senate,,DEM,DAVE CORTESE,258,5,253
+Santa Clara,0008421,State Senate,,DEM,DAVE CORTESE,24,1,23
+Santa Clara,0008423,State Senate,,DEM,DAVE CORTESE,2,1,1
+Santa Clara,0008430,State Senate,,DEM,DAVE CORTESE,2053,137,1916
+Santa Clara,0008435,State Senate,,DEM,DAVE CORTESE,2086,92,1994
+Santa Clara,0008438,State Senate,,DEM,DAVE CORTESE,2422,172,2250
+Santa Clara,0008439,State Senate,,DEM,DAVE CORTESE,1954,109,1845
+Santa Clara,0008445,State Senate,,DEM,DAVE CORTESE,1208,50,1158
+Santa Clara,0008447,State Senate,,DEM,DAVE CORTESE,5,0,5
+Santa Clara,0008456,State Senate,,DEM,DAVE CORTESE,2278,144,2134
+Santa Clara,0008457,State Senate,,DEM,DAVE CORTESE,2398,158,2240
+Santa Clara,0008464,State Senate,,DEM,DAVE CORTESE,2168,137,2031
+Santa Clara,0008470,State Senate,,DEM,DAVE CORTESE,2277,112,2165
+Santa Clara,0008472,State Senate,,DEM,DAVE CORTESE,1750,94,1656
+Santa Clara,0008486,State Senate,,DEM,DAVE CORTESE,1890,93,1797
+Santa Clara,0008492,State Senate,,DEM,DAVE CORTESE,2146,52,2094
+Santa Clara,0008502,State Senate,,DEM,DAVE CORTESE,117,4,113
+Santa Clara,0008601,State Senate,,DEM,DAVE CORTESE,209,20,189
+Santa Clara,0008603,State Senate,,DEM,DAVE CORTESE,1031,63,968
+Santa Clara,0008605,State Senate,,DEM,DAVE CORTESE,1260,93,1167
+Santa Clara,0008609,State Senate,,DEM,DAVE CORTESE,0,0,0
+Santa Clara,0008610,State Senate,,DEM,DAVE CORTESE,676,39,637
+Santa Clara,0008612,State Senate,,DEM,DAVE CORTESE,987,41,946
+Santa Clara,0008615,State Senate,,DEM,DAVE CORTESE,812,46,766
+Santa Clara,0008619,State Senate,,DEM,DAVE CORTESE,301,13,288
+Santa Clara,0008625,State Senate,,DEM,DAVE CORTESE,53,7,46
+Santa Clara,0008627,State Senate,,DEM,DAVE CORTESE,593,38,555
+Santa Clara,0008629,State Senate,,DEM,DAVE CORTESE,856,56,800
+Santa Clara,0008630,State Senate,,DEM,DAVE CORTESE,1100,71,1029
+Santa Clara,0008631,State Senate,,DEM,DAVE CORTESE,685,32,653
+Santa Clara,0008634,State Senate,,DEM,DAVE CORTESE,194,19,175
+Santa Clara,0008636,State Senate,,DEM,DAVE CORTESE,217,12,205
+Santa Clara,0008645,State Senate,,DEM,DAVE CORTESE,1307,64,1243
+Santa Clara,0008648,State Senate,,DEM,DAVE CORTESE,1202,59,1143
+Santa Clara,0008650,State Senate,,DEM,DAVE CORTESE,143,11,132
+Santa Clara,0008653,State Senate,,DEM,DAVE CORTESE,92,3,89
+Santa Clara,0008654,State Senate,,DEM,DAVE CORTESE,121,6,115
+Santa Clara,0008655,State Senate,,DEM,DAVE CORTESE,0,0,0
+Santa Clara,0008657,State Senate,,DEM,DAVE CORTESE,285,21,264
+Santa Clara,0008658,State Senate,,DEM,DAVE CORTESE,1500,100,1400
+Santa Clara,0008670,State Senate,,DEM,DAVE CORTESE,1002,82,920
+Santa Clara,0008675,State Senate,,DEM,DAVE CORTESE,592,52,540
+Santa Clara,0008676,State Senate,,DEM,DAVE CORTESE,1235,83,1152
+Santa Clara,0008680,State Senate,,DEM,DAVE CORTESE,775,24,751
+Santa Clara,0008683,State Senate,,DEM,DAVE CORTESE,1325,77,1248
+Santa Clara,0008687,State Senate,,DEM,DAVE CORTESE,1343,91,1252
+Santa Clara,0008697,State Senate,,DEM,DAVE CORTESE,1297,75,1222
+Santa Clara,0008801,State Senate,,DEM,DAVE CORTESE,973,88,885
+Santa Clara,0008805,State Senate,,DEM,DAVE CORTESE,811,53,758
+Santa Clara,0008809,State Senate,,DEM,DAVE CORTESE,1464,86,1378
+Santa Clara,0008812,State Senate,,DEM,DAVE CORTESE,838,90,748
+Santa Clara,0008817,State Senate,,DEM,DAVE CORTESE,446,27,419
+Santa Clara,0008820,State Senate,,DEM,DAVE CORTESE,830,47,783
+Santa Clara,0008822,State Senate,,DEM,DAVE CORTESE,980,67,913
+Santa Clara,0008828,State Senate,,DEM,DAVE CORTESE,345,23,322
+Santa Clara,0008829,State Senate,,DEM,DAVE CORTESE,289,21,268
+Santa Clara,0008832,State Senate,,DEM,DAVE CORTESE,781,42,739
+Santa Clara,0008834,State Senate,,DEM,DAVE CORTESE,473,47,426
+Santa Clara,0008838,State Senate,,DEM,DAVE CORTESE,107,6,101
+Santa Clara,0008839,State Senate,,DEM,DAVE CORTESE,1294,91,1203
+Santa Clara,0008844,State Senate,,DEM,DAVE CORTESE,1343,98,1245
+Santa Clara,0008848,State Senate,,DEM,DAVE CORTESE,726,45,681
+Santa Clara,0008853,State Senate,,DEM,DAVE CORTESE,969,72,897
+Santa Clara,0008857,State Senate,,DEM,DAVE CORTESE,589,30,559
+Santa Clara,0008858,State Senate,,DEM,DAVE CORTESE,793,38,755
+Santa Clara,0008862,State Senate,,DEM,DAVE CORTESE,898,46,852
+Santa Clara,0008868,State Senate,,DEM,DAVE CORTESE,50,1,49
+Santa Clara,0008873,State Senate,,DEM,DAVE CORTESE,417,25,392
+Santa Clara,0008874,State Senate,,DEM,DAVE CORTESE,12,0,12
+Santa Clara,0008879,State Senate,,DEM,DAVE CORTESE,1144,55,1089
+Santa Clara,0008883,State Senate,,DEM,DAVE CORTESE,1189,84,1105
+Santa Clara,0008885,State Senate,,DEM,DAVE CORTESE,1066,58,1008
+Santa Clara,0008886,State Senate,,DEM,DAVE CORTESE,108,1,107
+Santa Clara,0008889,State Senate,,DEM,DAVE CORTESE,924,55,869
+Santa Clara,0008898,State Senate,,DEM,DAVE CORTESE,1013,36,977
+Santa Clara,0008903,State Senate,,DEM,DAVE CORTESE,1177,52,1125
+Santa Clara,0008923,State Senate,,DEM,DAVE CORTESE,2,0,2
+Santa Clara,0008924,State Senate,,DEM,DAVE CORTESE,6,0,6
+Santa Clara,0002720,State Senate,,DEM,ANN M. RAVEL,777,32,745
+Santa Clara,0002721,State Senate,,DEM,ANN M. RAVEL,593,24,569
+Santa Clara,0002723,State Senate,,DEM,ANN M. RAVEL,1523,49,1474
+Santa Clara,0002724,State Senate,,DEM,ANN M. RAVEL,1149,51,1098
+Santa Clara,0002725,State Senate,,DEM,ANN M. RAVEL,1090,52,1038
+Santa Clara,0002726,State Senate,,DEM,ANN M. RAVEL,654,33,621
+Santa Clara,0002727,State Senate,,DEM,ANN M. RAVEL,914,29,885
+Santa Clara,0002729,State Senate,,DEM,ANN M. RAVEL,999,21,978
+Santa Clara,0002734,State Senate,,DEM,ANN M. RAVEL,1261,61,1200
+Santa Clara,0002740,State Senate,,DEM,ANN M. RAVEL,1351,60,1291
+Santa Clara,0002751,State Senate,,DEM,ANN M. RAVEL,12,0,12
+Santa Clara,0002761,State Senate,,DEM,ANN M. RAVEL,0,0,0
+Santa Clara,0002808,State Senate,,DEM,ANN M. RAVEL,41,1,40
+Santa Clara,0002810,State Senate,,DEM,ANN M. RAVEL,14,0,14
+Santa Clara,0002812,State Senate,,DEM,ANN M. RAVEL,128,9,119
+Santa Clara,0002825,State Senate,,DEM,ANN M. RAVEL,4,0,4
+Santa Clara,0003601,State Senate,,DEM,ANN M. RAVEL,614,10,604
+Santa Clara,0003602,State Senate,,DEM,ANN M. RAVEL,1025,46,979
+Santa Clara,0003603,State Senate,,DEM,ANN M. RAVEL,557,22,535
+Santa Clara,0003604,State Senate,,DEM,ANN M. RAVEL,1138,53,1085
+Santa Clara,0003605,State Senate,,DEM,ANN M. RAVEL,1323,62,1261
+Santa Clara,0003606,State Senate,,DEM,ANN M. RAVEL,1140,27,1113
+Santa Clara,0003608,State Senate,,DEM,ANN M. RAVEL,1130,53,1077
+Santa Clara,0003609,State Senate,,DEM,ANN M. RAVEL,1655,62,1593
+Santa Clara,0003611,State Senate,,DEM,ANN M. RAVEL,1254,39,1215
+Santa Clara,0003614,State Senate,,DEM,ANN M. RAVEL,491,30,461
+Santa Clara,0003624,State Senate,,DEM,ANN M. RAVEL,1421,53,1368
+Santa Clara,0003635,State Senate,,DEM,ANN M. RAVEL,0,0,0
+Santa Clara,0003652,State Senate,,DEM,ANN M. RAVEL,481,36,445
+Santa Clara,0003655,State Senate,,DEM,ANN M. RAVEL,85,7,78
+Santa Clara,0003669,State Senate,,DEM,ANN M. RAVEL,0,0,0
+Santa Clara,0003670,State Senate,,DEM,ANN M. RAVEL,60,5,55
+Santa Clara,0003777,State Senate,,DEM,ANN M. RAVEL,839,30,809
+Santa Clara,0003779,State Senate,,DEM,ANN M. RAVEL,61,2,59
+Santa Clara,0003782,State Senate,,DEM,ANN M. RAVEL,157,3,154
+Santa Clara,0003783,State Senate,,DEM,ANN M. RAVEL,184,5,179
+Santa Clara,0003801,State Senate,,DEM,ANN M. RAVEL,731,44,687
+Santa Clara,0003802,State Senate,,DEM,ANN M. RAVEL,1174,50,1124
+Santa Clara,0003803,State Senate,,DEM,ANN M. RAVEL,935,33,902
+Santa Clara,0003804,State Senate,,DEM,ANN M. RAVEL,415,21,394
+Santa Clara,0003810,State Senate,,DEM,ANN M. RAVEL,804,69,735
+Santa Clara,0003811,State Senate,,DEM,ANN M. RAVEL,1103,65,1038
+Santa Clara,0003814,State Senate,,DEM,ANN M. RAVEL,1045,60,985
+Santa Clara,0003820,State Senate,,DEM,ANN M. RAVEL,880,42,838
+Santa Clara,0003821,State Senate,,DEM,ANN M. RAVEL,386,22,364
+Santa Clara,0003825,State Senate,,DEM,ANN M. RAVEL,594,41,553
+Santa Clara,0003828,State Senate,,DEM,ANN M. RAVEL,473,21,452
+Santa Clara,0003835,State Senate,,DEM,ANN M. RAVEL,612,20,592
+Santa Clara,0003840,State Senate,,DEM,ANN M. RAVEL,841,56,785
+Santa Clara,0003846,State Senate,,DEM,ANN M. RAVEL,46,1,45
+Santa Clara,0003861,State Senate,,DEM,ANN M. RAVEL,24,0,24
+Santa Clara,0004665,State Senate,,DEM,ANN M. RAVEL,16,0,16
+Santa Clara,0004666,State Senate,,DEM,ANN M. RAVEL,2,0,2
+Santa Clara,0004671,State Senate,,DEM,ANN M. RAVEL,830,36,794
+Santa Clara,0004672,State Senate,,DEM,ANN M. RAVEL,458,19,439
+Santa Clara,0004674,State Senate,,DEM,ANN M. RAVEL,709,36,673
+Santa Clara,0004675,State Senate,,DEM,ANN M. RAVEL,1365,93,1272
+Santa Clara,0004685,State Senate,,DEM,ANN M. RAVEL,803,30,773
+Santa Clara,0004687,State Senate,,DEM,ANN M. RAVEL,743,30,713
+Santa Clara,0004688,State Senate,,DEM,ANN M. RAVEL,1521,55,1466
+Santa Clara,0004691,State Senate,,DEM,ANN M. RAVEL,966,43,923
+Santa Clara,0004696,State Senate,,DEM,ANN M. RAVEL,548,12,536
+Santa Clara,0004698,State Senate,,DEM,ANN M. RAVEL,450,20,430
+Santa Clara,0004699,State Senate,,DEM,ANN M. RAVEL,723,21,702
+Santa Clara,0004702,State Senate,,DEM,ANN M. RAVEL,459,23,436
+Santa Clara,0004715,State Senate,,DEM,ANN M. RAVEL,229,9,220
+Santa Clara,0005449,State Senate,,DEM,ANN M. RAVEL,33,3,30
+Santa Clara,0005451,State Senate,,DEM,ANN M. RAVEL,4,0,4
+Santa Clara,0005454,State Senate,,DEM,ANN M. RAVEL,1,0,1
+Santa Clara,0005455,State Senate,,DEM,ANN M. RAVEL,0,0,0
+Santa Clara,0005456,State Senate,,DEM,ANN M. RAVEL,0,0,0
+Santa Clara,0005502,State Senate,,DEM,ANN M. RAVEL,125,9,116
+Santa Clara,0005503,State Senate,,DEM,ANN M. RAVEL,76,2,74
+Santa Clara,0005505,State Senate,,DEM,ANN M. RAVEL,107,2,105
+Santa Clara,0005507,State Senate,,DEM,ANN M. RAVEL,0,0,0
+Santa Clara,0005556,State Senate,,DEM,ANN M. RAVEL,524,56,468
+Santa Clara,0005557,State Senate,,DEM,ANN M. RAVEL,389,20,369
+Santa Clara,0005567,State Senate,,DEM,ANN M. RAVEL,209,14,195
+Santa Clara,0005742,State Senate,,DEM,ANN M. RAVEL,6,0,6
+Santa Clara,0005743,State Senate,,DEM,ANN M. RAVEL,241,14,227
+Santa Clara,0005745,State Senate,,DEM,ANN M. RAVEL,195,12,183
+Santa Clara,0005747,State Senate,,DEM,ANN M. RAVEL,495,11,484
+Santa Clara,0005748,State Senate,,DEM,ANN M. RAVEL,841,65,776
+Santa Clara,0005756,State Senate,,DEM,ANN M. RAVEL,36,1,35
+Santa Clara,0005758,State Senate,,DEM,ANN M. RAVEL,61,1,60
+Santa Clara,0005759,State Senate,,DEM,ANN M. RAVEL,218,9,209
+Santa Clara,0005762,State Senate,,DEM,ANN M. RAVEL,128,4,124
+Santa Clara,0005763,State Senate,,DEM,ANN M. RAVEL,45,3,42
+Santa Clara,0005770,State Senate,,DEM,ANN M. RAVEL,77,1,76
+Santa Clara,0005775,State Senate,,DEM,ANN M. RAVEL,155,2,153
+Santa Clara,0005785,State Senate,,DEM,ANN M. RAVEL,0,0,0
+Santa Clara,0005793,State Senate,,DEM,ANN M. RAVEL,0,0,0
+Santa Clara,0005795,State Senate,,DEM,ANN M. RAVEL,0,0,0
+Santa Clara,0005804,State Senate,,DEM,ANN M. RAVEL,457,16,441
+Santa Clara,0005810,State Senate,,DEM,ANN M. RAVEL,141,12,129
+Santa Clara,0005811,State Senate,,DEM,ANN M. RAVEL,111,8,103
+Santa Clara,0005813,State Senate,,DEM,ANN M. RAVEL,29,2,27
+Santa Clara,0005814,State Senate,,DEM,ANN M. RAVEL,98,6,92
+Santa Clara,0005854,State Senate,,DEM,ANN M. RAVEL,0,0,0
+Santa Clara,0005879,State Senate,,DEM,ANN M. RAVEL,10,1,9
+Santa Clara,0005888,State Senate,,DEM,ANN M. RAVEL,0,0,0
+Santa Clara,0005894,State Senate,,DEM,ANN M. RAVEL,93,2,91
+Santa Clara,0005896,State Senate,,DEM,ANN M. RAVEL,3,0,3
+Santa Clara,0005901,State Senate,,DEM,ANN M. RAVEL,0,0,0
+Santa Clara,0005902,State Senate,,DEM,ANN M. RAVEL,210,11,199
+Santa Clara,0005903,State Senate,,DEM,ANN M. RAVEL,263,15,248
+Santa Clara,0005907,State Senate,,DEM,ANN M. RAVEL,5,0,5
+Santa Clara,0005927,State Senate,,DEM,ANN M. RAVEL,0,0,0
+Santa Clara,0006028,State Senate,,DEM,ANN M. RAVEL,20,1,19
+Santa Clara,0006036,State Senate,,DEM,ANN M. RAVEL,0,0,0
+Santa Clara,0006404,State Senate,,DEM,ANN M. RAVEL,877,45,832
+Santa Clara,0006405,State Senate,,DEM,ANN M. RAVEL,5,0,5
+Santa Clara,0006410,State Senate,,DEM,ANN M. RAVEL,54,4,50
+Santa Clara,0006413,State Senate,,DEM,ANN M. RAVEL,2,0,2
+Santa Clara,0006418,State Senate,,DEM,ANN M. RAVEL,264,19,245
+Santa Clara,0006423,State Senate,,DEM,ANN M. RAVEL,22,3,19
+Santa Clara,0006452,State Senate,,DEM,ANN M. RAVEL,288,31,257
+Santa Clara,0006454,State Senate,,DEM,ANN M. RAVEL,54,3,51
+Santa Clara,0006455,State Senate,,DEM,ANN M. RAVEL,790,51,739
+Santa Clara,0006491,State Senate,,DEM,ANN M. RAVEL,7,0,7
+Santa Clara,0006502,State Senate,,DEM,ANN M. RAVEL,93,5,88
+Santa Clara,0006509,State Senate,,DEM,ANN M. RAVEL,5,0,5
+Santa Clara,0006510,State Senate,,DEM,ANN M. RAVEL,10,1,9
+Santa Clara,0006624,State Senate,,DEM,ANN M. RAVEL,6,0,6
+Santa Clara,0006625,State Senate,,DEM,ANN M. RAVEL,2,0,2
+Santa Clara,0006669,State Senate,,DEM,ANN M. RAVEL,36,1,35
+Santa Clara,0007001,State Senate,,DEM,ANN M. RAVEL,652,59,593
+Santa Clara,0007005,State Senate,,DEM,ANN M. RAVEL,834,58,776
+Santa Clara,0007011,State Senate,,DEM,ANN M. RAVEL,123,11,112
+Santa Clara,0007012,State Senate,,DEM,ANN M. RAVEL,721,42,679
+Santa Clara,0007014,State Senate,,DEM,ANN M. RAVEL,962,51,911
+Santa Clara,0007019,State Senate,,DEM,ANN M. RAVEL,1358,90,1268
+Santa Clara,0007025,State Senate,,DEM,ANN M. RAVEL,1133,73,1060
+Santa Clara,0007028,State Senate,,DEM,ANN M. RAVEL,1071,58,1013
+Santa Clara,0007032,State Senate,,DEM,ANN M. RAVEL,1390,68,1322
+Santa Clara,0007036,State Senate,,DEM,ANN M. RAVEL,1352,50,1302
+Santa Clara,0007038,State Senate,,DEM,ANN M. RAVEL,134,7,127
+Santa Clara,0007041,State Senate,,DEM,ANN M. RAVEL,1083,86,997
+Santa Clara,0007044,State Senate,,DEM,ANN M. RAVEL,750,51,699
+Santa Clara,0007046,State Senate,,DEM,ANN M. RAVEL,1146,85,1061
+Santa Clara,0007051,State Senate,,DEM,ANN M. RAVEL,0,0,0
+Santa Clara,0007059,State Senate,,DEM,ANN M. RAVEL,207,21,186
+Santa Clara,0007061,State Senate,,DEM,ANN M. RAVEL,921,44,877
+Santa Clara,0007062,State Senate,,DEM,ANN M. RAVEL,1022,67,955
+Santa Clara,0007079,State Senate,,DEM,ANN M. RAVEL,852,44,808
+Santa Clara,0007081,State Senate,,DEM,ANN M. RAVEL,779,39,740
+Santa Clara,0007089,State Senate,,DEM,ANN M. RAVEL,540,15,525
+Santa Clara,0007201,State Senate,,DEM,ANN M. RAVEL,127,12,115
+Santa Clara,0007202,State Senate,,DEM,ANN M. RAVEL,208,14,194
+Santa Clara,0007221,State Senate,,DEM,ANN M. RAVEL,529,27,502
+Santa Clara,0007224,State Senate,,DEM,ANN M. RAVEL,232,19,213
+Santa Clara,0007416,State Senate,,DEM,ANN M. RAVEL,64,3,61
+Santa Clara,0007417,State Senate,,DEM,ANN M. RAVEL,1276,78,1198
+Santa Clara,0007430,State Senate,,DEM,ANN M. RAVEL,976,82,894
+Santa Clara,0007435,State Senate,,DEM,ANN M. RAVEL,999,75,924
+Santa Clara,0007436,State Senate,,DEM,ANN M. RAVEL,1256,79,1177
+Santa Clara,0007438,State Senate,,DEM,ANN M. RAVEL,92,7,85
+Santa Clara,0007440,State Senate,,DEM,ANN M. RAVEL,14,3,11
+Santa Clara,0007441,State Senate,,DEM,ANN M. RAVEL,512,43,469
+Santa Clara,0007442,State Senate,,DEM,ANN M. RAVEL,71,10,61
+Santa Clara,0007447,State Senate,,DEM,ANN M. RAVEL,746,79,667
+Santa Clara,0007458,State Senate,,DEM,ANN M. RAVEL,707,100,607
+Santa Clara,0007459,State Senate,,DEM,ANN M. RAVEL,1044,95,949
+Santa Clara,0007470,State Senate,,DEM,ANN M. RAVEL,995,71,924
+Santa Clara,0007471,State Senate,,DEM,ANN M. RAVEL,1107,92,1015
+Santa Clara,0007479,State Senate,,DEM,ANN M. RAVEL,363,26,337
+Santa Clara,0007483,State Senate,,DEM,ANN M. RAVEL,787,83,704
+Santa Clara,0007689,State Senate,,DEM,ANN M. RAVEL,4,0,4
+Santa Clara,0007690,State Senate,,DEM,ANN M. RAVEL,313,12,301
+Santa Clara,0007802,State Senate,,DEM,ANN M. RAVEL,99,5,94
+Santa Clara,0007803,State Senate,,DEM,ANN M. RAVEL,271,16,255
+Santa Clara,0007805,State Senate,,DEM,ANN M. RAVEL,514,23,491
+Santa Clara,0007810,State Senate,,DEM,ANN M. RAVEL,58,1,57
+Santa Clara,0007811,State Senate,,DEM,ANN M. RAVEL,48,4,44
+Santa Clara,0007812,State Senate,,DEM,ANN M. RAVEL,376,15,361
+Santa Clara,0007816,State Senate,,DEM,ANN M. RAVEL,91,8,83
+Santa Clara,0007817,State Senate,,DEM,ANN M. RAVEL,1,0,1
+Santa Clara,0007818,State Senate,,DEM,ANN M. RAVEL,76,4,72
+Santa Clara,0007821,State Senate,,DEM,ANN M. RAVEL,1016,68,948
+Santa Clara,0007826,State Senate,,DEM,ANN M. RAVEL,859,72,787
+Santa Clara,0007827,State Senate,,DEM,ANN M. RAVEL,385,33,352
+Santa Clara,0007832,State Senate,,DEM,ANN M. RAVEL,546,46,500
+Santa Clara,0007833,State Senate,,DEM,ANN M. RAVEL,712,69,643
+Santa Clara,0007843,State Senate,,DEM,ANN M. RAVEL,1080,94,986
+Santa Clara,0007849,State Senate,,DEM,ANN M. RAVEL,765,62,703
+Santa Clara,0007850,State Senate,,DEM,ANN M. RAVEL,554,53,501
+Santa Clara,0007851,State Senate,,DEM,ANN M. RAVEL,400,21,379
+Santa Clara,0007861,State Senate,,DEM,ANN M. RAVEL,454,43,411
+Santa Clara,0007867,State Senate,,DEM,ANN M. RAVEL,803,46,757
+Santa Clara,0007874,State Senate,,DEM,ANN M. RAVEL,97,7,90
+Santa Clara,0008016,State Senate,,DEM,ANN M. RAVEL,1720,137,1583
+Santa Clara,0008017,State Senate,,DEM,ANN M. RAVEL,684,54,630
+Santa Clara,0008022,State Senate,,DEM,ANN M. RAVEL,376,20,356
+Santa Clara,0008023,State Senate,,DEM,ANN M. RAVEL,298,17,281
+Santa Clara,0008026,State Senate,,DEM,ANN M. RAVEL,310,32,278
+Santa Clara,0008028,State Senate,,DEM,ANN M. RAVEL,132,11,121
+Santa Clara,0008029,State Senate,,DEM,ANN M. RAVEL,51,2,49
+Santa Clara,0008030,State Senate,,DEM,ANN M. RAVEL,362,38,324
+Santa Clara,0008033,State Senate,,DEM,ANN M. RAVEL,66,3,63
+Santa Clara,0008034,State Senate,,DEM,ANN M. RAVEL,63,3,60
+Santa Clara,0008038,State Senate,,DEM,ANN M. RAVEL,4,0,4
+Santa Clara,0008040,State Senate,,DEM,ANN M. RAVEL,198,21,177
+Santa Clara,0008047,State Senate,,DEM,ANN M. RAVEL,739,42,697
+Santa Clara,0008049,State Senate,,DEM,ANN M. RAVEL,15,1,14
+Santa Clara,0008050,State Senate,,DEM,ANN M. RAVEL,562,37,525
+Santa Clara,0008053,State Senate,,DEM,ANN M. RAVEL,1065,56,1009
+Santa Clara,0008054,State Senate,,DEM,ANN M. RAVEL,980,40,940
+Santa Clara,0008055,State Senate,,DEM,ANN M. RAVEL,120,4,116
+Santa Clara,0008062,State Senate,,DEM,ANN M. RAVEL,1051,73,978
+Santa Clara,0008066,State Senate,,DEM,ANN M. RAVEL,398,24,374
+Santa Clara,0008067,State Senate,,DEM,ANN M. RAVEL,1357,73,1284
+Santa Clara,0008068,State Senate,,DEM,ANN M. RAVEL,17,3,14
+Santa Clara,0008072,State Senate,,DEM,ANN M. RAVEL,254,8,246
+Santa Clara,0008073,State Senate,,DEM,ANN M. RAVEL,144,10,134
+Santa Clara,0008079,State Senate,,DEM,ANN M. RAVEL,1301,46,1255
+Santa Clara,0008082,State Senate,,DEM,ANN M. RAVEL,806,36,770
+Santa Clara,0008085,State Senate,,DEM,ANN M. RAVEL,584,26,558
+Santa Clara,0008089,State Senate,,DEM,ANN M. RAVEL,1252,52,1200
+Santa Clara,0008092,State Senate,,DEM,ANN M. RAVEL,32,2,30
+Santa Clara,0008093,State Senate,,DEM,ANN M. RAVEL,15,0,15
+Santa Clara,0008096,State Senate,,DEM,ANN M. RAVEL,1162,62,1100
+Santa Clara,0008101,State Senate,,DEM,ANN M. RAVEL,409,29,380
+Santa Clara,0008104,State Senate,,DEM,ANN M. RAVEL,83,2,81
+Santa Clara,0008105,State Senate,,DEM,ANN M. RAVEL,197,3,194
+Santa Clara,0008117,State Senate,,DEM,ANN M. RAVEL,807,35,772
+Santa Clara,0008122,State Senate,,DEM,ANN M. RAVEL,915,49,866
+Santa Clara,0008128,State Senate,,DEM,ANN M. RAVEL,0,0,0
+Santa Clara,0008133,State Senate,,DEM,ANN M. RAVEL,8,0,8
+Santa Clara,0008201,State Senate,,DEM,ANN M. RAVEL,597,61,536
+Santa Clara,0008203,State Senate,,DEM,ANN M. RAVEL,644,63,581
+Santa Clara,0008205,State Senate,,DEM,ANN M. RAVEL,759,90,669
+Santa Clara,0008208,State Senate,,DEM,ANN M. RAVEL,632,41,591
+Santa Clara,0008212,State Senate,,DEM,ANN M. RAVEL,406,42,364
+Santa Clara,0008214,State Senate,,DEM,ANN M. RAVEL,88,10,78
+Santa Clara,0008227,State Senate,,DEM,ANN M. RAVEL,804,66,738
+Santa Clara,0008228,State Senate,,DEM,ANN M. RAVEL,792,38,754
+Santa Clara,0008230,State Senate,,DEM,ANN M. RAVEL,989,67,922
+Santa Clara,0008231,State Senate,,DEM,ANN M. RAVEL,532,46,486
+Santa Clara,0008232,State Senate,,DEM,ANN M. RAVEL,943,82,861
+Santa Clara,0008236,State Senate,,DEM,ANN M. RAVEL,1037,92,945
+Santa Clara,0008262,State Senate,,DEM,ANN M. RAVEL,465,30,435
+Santa Clara,0008264,State Senate,,DEM,ANN M. RAVEL,452,18,434
+Santa Clara,0008401,State Senate,,DEM,ANN M. RAVEL,565,36,529
+Santa Clara,0008404,State Senate,,DEM,ANN M. RAVEL,1070,81,989
+Santa Clara,0008408,State Senate,,DEM,ANN M. RAVEL,321,33,288
+Santa Clara,0008409,State Senate,,DEM,ANN M. RAVEL,351,18,333
+Santa Clara,0008414,State Senate,,DEM,ANN M. RAVEL,122,10,112
+Santa Clara,0008418,State Senate,,DEM,ANN M. RAVEL,150,6,144
+Santa Clara,0008421,State Senate,,DEM,ANN M. RAVEL,15,0,15
+Santa Clara,0008423,State Senate,,DEM,ANN M. RAVEL,0,0,0
+Santa Clara,0008430,State Senate,,DEM,ANN M. RAVEL,824,85,739
+Santa Clara,0008435,State Senate,,DEM,ANN M. RAVEL,1142,60,1082
+Santa Clara,0008438,State Senate,,DEM,ANN M. RAVEL,1056,86,970
+Santa Clara,0008439,State Senate,,DEM,ANN M. RAVEL,825,63,762
+Santa Clara,0008445,State Senate,,DEM,ANN M. RAVEL,684,32,652
+Santa Clara,0008447,State Senate,,DEM,ANN M. RAVEL,2,0,2
+Santa Clara,0008456,State Senate,,DEM,ANN M. RAVEL,1190,56,1134
+Santa Clara,0008457,State Senate,,DEM,ANN M. RAVEL,978,79,899
+Santa Clara,0008464,State Senate,,DEM,ANN M. RAVEL,913,81,832
+Santa Clara,0008470,State Senate,,DEM,ANN M. RAVEL,1029,63,966
+Santa Clara,0008472,State Senate,,DEM,ANN M. RAVEL,897,58,839
+Santa Clara,0008486,State Senate,,DEM,ANN M. RAVEL,1393,85,1308
+Santa Clara,0008492,State Senate,,DEM,ANN M. RAVEL,1454,52,1402
+Santa Clara,0008502,State Senate,,DEM,ANN M. RAVEL,84,1,83
+Santa Clara,0008601,State Senate,,DEM,ANN M. RAVEL,215,16,199
+Santa Clara,0008603,State Senate,,DEM,ANN M. RAVEL,962,58,904
+Santa Clara,0008605,State Senate,,DEM,ANN M. RAVEL,1318,82,1236
+Santa Clara,0008609,State Senate,,DEM,ANN M. RAVEL,1,1,0
+Santa Clara,0008610,State Senate,,DEM,ANN M. RAVEL,684,35,649
+Santa Clara,0008612,State Senate,,DEM,ANN M. RAVEL,1031,59,972
+Santa Clara,0008615,State Senate,,DEM,ANN M. RAVEL,1059,42,1017
+Santa Clara,0008619,State Senate,,DEM,ANN M. RAVEL,346,10,336
+Santa Clara,0008625,State Senate,,DEM,ANN M. RAVEL,34,0,34
+Santa Clara,0008627,State Senate,,DEM,ANN M. RAVEL,491,30,461
+Santa Clara,0008629,State Senate,,DEM,ANN M. RAVEL,714,45,669
+Santa Clara,0008630,State Senate,,DEM,ANN M. RAVEL,1066,60,1006
+Santa Clara,0008631,State Senate,,DEM,ANN M. RAVEL,646,40,606
+Santa Clara,0008634,State Senate,,DEM,ANN M. RAVEL,153,9,144
+Santa Clara,0008636,State Senate,,DEM,ANN M. RAVEL,108,9,99
+Santa Clara,0008645,State Senate,,DEM,ANN M. RAVEL,1262,70,1192
+Santa Clara,0008648,State Senate,,DEM,ANN M. RAVEL,1066,50,1016
+Santa Clara,0008650,State Senate,,DEM,ANN M. RAVEL,166,8,158
+Santa Clara,0008653,State Senate,,DEM,ANN M. RAVEL,109,6,103
+Santa Clara,0008654,State Senate,,DEM,ANN M. RAVEL,108,13,95
+Santa Clara,0008655,State Senate,,DEM,ANN M. RAVEL,0,0,0
+Santa Clara,0008657,State Senate,,DEM,ANN M. RAVEL,285,10,275
+Santa Clara,0008658,State Senate,,DEM,ANN M. RAVEL,1387,65,1322
+Santa Clara,0008670,State Senate,,DEM,ANN M. RAVEL,855,68,787
+Santa Clara,0008675,State Senate,,DEM,ANN M. RAVEL,543,52,491
+Santa Clara,0008676,State Senate,,DEM,ANN M. RAVEL,1043,55,988
+Santa Clara,0008680,State Senate,,DEM,ANN M. RAVEL,953,47,906
+Santa Clara,0008683,State Senate,,DEM,ANN M. RAVEL,1387,54,1333
+Santa Clara,0008687,State Senate,,DEM,ANN M. RAVEL,1196,67,1129
+Santa Clara,0008697,State Senate,,DEM,ANN M. RAVEL,1364,72,1292
+Santa Clara,0008801,State Senate,,DEM,ANN M. RAVEL,738,54,684
+Santa Clara,0008805,State Senate,,DEM,ANN M. RAVEL,643,35,608
+Santa Clara,0008809,State Senate,,DEM,ANN M. RAVEL,935,56,879
+Santa Clara,0008812,State Senate,,DEM,ANN M. RAVEL,525,46,479
+Santa Clara,0008817,State Senate,,DEM,ANN M. RAVEL,377,21,356
+Santa Clara,0008820,State Senate,,DEM,ANN M. RAVEL,785,38,747
+Santa Clara,0008822,State Senate,,DEM,ANN M. RAVEL,706,39,667
+Santa Clara,0008828,State Senate,,DEM,ANN M. RAVEL,256,15,241
+Santa Clara,0008829,State Senate,,DEM,ANN M. RAVEL,235,16,219
+Santa Clara,0008832,State Senate,,DEM,ANN M. RAVEL,803,33,770
+Santa Clara,0008834,State Senate,,DEM,ANN M. RAVEL,383,26,357
+Santa Clara,0008838,State Senate,,DEM,ANN M. RAVEL,117,12,105
+Santa Clara,0008839,State Senate,,DEM,ANN M. RAVEL,1082,80,1002
+Santa Clara,0008844,State Senate,,DEM,ANN M. RAVEL,1209,72,1137
+Santa Clara,0008848,State Senate,,DEM,ANN M. RAVEL,641,50,591
+Santa Clara,0008853,State Senate,,DEM,ANN M. RAVEL,779,39,740
+Santa Clara,0008857,State Senate,,DEM,ANN M. RAVEL,706,28,678
+Santa Clara,0008858,State Senate,,DEM,ANN M. RAVEL,1032,41,991
+Santa Clara,0008862,State Senate,,DEM,ANN M. RAVEL,1005,63,942
+Santa Clara,0008868,State Senate,,DEM,ANN M. RAVEL,58,7,51
+Santa Clara,0008873,State Senate,,DEM,ANN M. RAVEL,380,18,362
+Santa Clara,0008874,State Senate,,DEM,ANN M. RAVEL,5,0,5
+Santa Clara,0008879,State Senate,,DEM,ANN M. RAVEL,1322,57,1265
+Santa Clara,0008883,State Senate,,DEM,ANN M. RAVEL,1405,82,1323
+Santa Clara,0008885,State Senate,,DEM,ANN M. RAVEL,1339,69,1270
+Santa Clara,0008886,State Senate,,DEM,ANN M. RAVEL,174,1,173
+Santa Clara,0008889,State Senate,,DEM,ANN M. RAVEL,1126,36,1090
+Santa Clara,0008898,State Senate,,DEM,ANN M. RAVEL,1115,48,1067
+Santa Clara,0008903,State Senate,,DEM,ANN M. RAVEL,1433,47,1386
+Santa Clara,0008923,State Senate,,DEM,ANN M. RAVEL,1,0,1
+Santa Clara,0008924,State Senate,,DEM,ANN M. RAVEL,6,0,6
+Santa Clara,0004801,State Senate,,DEM,JOHN LAIRD,817,55,762
+Santa Clara,0004806,State Senate,,DEM,JOHN LAIRD,1521,67,1454
+Santa Clara,0004811,State Senate,,DEM,JOHN LAIRD,889,50,839
+Santa Clara,0004826,State Senate,,DEM,JOHN LAIRD,795,37,758
+Santa Clara,0004827,State Senate,,DEM,JOHN LAIRD,1738,74,1664
+Santa Clara,0004833,State Senate,,DEM,JOHN LAIRD,1113,47,1066
+Santa Clara,0004851,State Senate,,DEM,JOHN LAIRD,575,22,553
+Santa Clara,0004853,State Senate,,DEM,JOHN LAIRD,1092,35,1057
+Santa Clara,0004858,State Senate,,DEM,JOHN LAIRD,1510,94,1416
+Santa Clara,0004876,State Senate,,DEM,JOHN LAIRD,1846,82,1764
+Santa Clara,0004881,State Senate,,DEM,JOHN LAIRD,2283,79,2204
+Santa Clara,0004941,State Senate,,DEM,JOHN LAIRD,1630,104,1526
+Santa Clara,0004942,State Senate,,DEM,JOHN LAIRD,1148,53,1095
+Santa Clara,0004943,State Senate,,DEM,JOHN LAIRD,65,5,60
+Santa Clara,0004944,State Senate,,DEM,JOHN LAIRD,559,70,489
+Santa Clara,0004945,State Senate,,DEM,JOHN LAIRD,835,67,768
+Santa Clara,0004946,State Senate,,DEM,JOHN LAIRD,1791,135,1656
+Santa Clara,0004949,State Senate,,DEM,JOHN LAIRD,1360,61,1299
+Santa Clara,0004950,State Senate,,DEM,JOHN LAIRD,1079,39,1040
+Santa Clara,0004954,State Senate,,DEM,JOHN LAIRD,1109,66,1043
+Santa Clara,0004956,State Senate,,DEM,JOHN LAIRD,142,13,129
+Santa Clara,0004958,State Senate,,DEM,JOHN LAIRD,892,78,814
+Santa Clara,0004965,State Senate,,DEM,JOHN LAIRD,1572,88,1484
+Santa Clara,0004969,State Senate,,DEM,JOHN LAIRD,1358,82,1276
+Santa Clara,0004971,State Senate,,DEM,JOHN LAIRD,533,17,516
+Santa Clara,0004973,State Senate,,DEM,JOHN LAIRD,1202,39,1163
+Santa Clara,0004974,State Senate,,DEM,JOHN LAIRD,670,51,619
+Santa Clara,0005458,State Senate,,DEM,JOHN LAIRD,0,0,0
+Santa Clara,0005886,State Senate,,DEM,JOHN LAIRD,13,3,10
+Santa Clara,0005906,State Senate,,DEM,JOHN LAIRD,246,16,230
+Santa Clara,0005911,State Senate,,DEM,JOHN LAIRD,967,61,906
+Santa Clara,0005912,State Senate,,DEM,JOHN LAIRD,88,3,85
+Santa Clara,0005914,State Senate,,DEM,JOHN LAIRD,557,20,537
+Santa Clara,0005915,State Senate,,DEM,JOHN LAIRD,465,13,452
+Santa Clara,0005916,State Senate,,DEM,JOHN LAIRD,38,1,37
+Santa Clara,0005917,State Senate,,DEM,JOHN LAIRD,133,3,130
+Santa Clara,0005919,State Senate,,DEM,JOHN LAIRD,177,10,167
+Santa Clara,0005922,State Senate,,DEM,JOHN LAIRD,259,9,250
+Santa Clara,0005925,State Senate,,DEM,JOHN LAIRD,34,0,34
+Santa Clara,0005929,State Senate,,DEM,JOHN LAIRD,59,8,51
+Santa Clara,0005931,State Senate,,DEM,JOHN LAIRD,79,3,76
+Santa Clara,0005936,State Senate,,DEM,JOHN LAIRD,246,16,230
+Santa Clara,0005940,State Senate,,DEM,JOHN LAIRD,30,3,27
+Santa Clara,0005947,State Senate,,DEM,JOHN LAIRD,200,3,197
+Santa Clara,0005949,State Senate,,DEM,JOHN LAIRD,306,19,287
+Santa Clara,0005950,State Senate,,DEM,JOHN LAIRD,70,7,63
+Santa Clara,0005951,State Senate,,DEM,JOHN LAIRD,6,0,6
+Santa Clara,0005955,State Senate,,DEM,JOHN LAIRD,550,23,527
+Santa Clara,0005956,State Senate,,DEM,JOHN LAIRD,522,13,509
+Santa Clara,0005957,State Senate,,DEM,JOHN LAIRD,53,3,50
+Santa Clara,0005958,State Senate,,DEM,JOHN LAIRD,424,25,399
+Santa Clara,0005959,State Senate,,DEM,JOHN LAIRD,27,0,27
+Santa Clara,0005965,State Senate,,DEM,JOHN LAIRD,581,31,550
+Santa Clara,0005966,State Senate,,DEM,JOHN LAIRD,102,2,100
+Santa Clara,0005975,State Senate,,DEM,JOHN LAIRD,27,0,27
+Santa Clara,0005988,State Senate,,DEM,JOHN LAIRD,0,0,0
+Santa Clara,0006023,State Senate,,DEM,JOHN LAIRD,10,0,10
+Santa Clara,0006031,State Senate,,DEM,JOHN LAIRD,16,1,15
+Santa Clara,0006035,State Senate,,DEM,JOHN LAIRD,0,0,0
+Santa Clara,0006048,State Senate,,DEM,JOHN LAIRD,14,0,14
+Santa Clara,0007203,State Senate,,DEM,JOHN LAIRD,325,26,299
+Santa Clara,0007205,State Senate,,DEM,JOHN LAIRD,1762,108,1654
+Santa Clara,0007214,State Senate,,DEM,JOHN LAIRD,1065,57,1008
+Santa Clara,0007217,State Senate,,DEM,JOHN LAIRD,2100,165,1935
+Santa Clara,0007219,State Senate,,DEM,JOHN LAIRD,632,18,614
+Santa Clara,0007231,State Senate,,DEM,JOHN LAIRD,471,29,442
+Santa Clara,0007235,State Senate,,DEM,JOHN LAIRD,1503,116,1387
+Santa Clara,0007237,State Senate,,DEM,JOHN LAIRD,1433,103,1330
+Santa Clara,0007245,State Senate,,DEM,JOHN LAIRD,149,1,148
+Santa Clara,0007246,State Senate,,DEM,JOHN LAIRD,888,30,858
+Santa Clara,0007248,State Senate,,DEM,JOHN LAIRD,1526,74,1452
+Santa Clara,0007252,State Senate,,DEM,JOHN LAIRD,1990,127,1863
+Santa Clara,0007255,State Senate,,DEM,JOHN LAIRD,1809,116,1693
+Santa Clara,0007257,State Senate,,DEM,JOHN LAIRD,893,24,869
+Santa Clara,0007261,State Senate,,DEM,JOHN LAIRD,1264,76,1188
+Santa Clara,0007264,State Senate,,DEM,JOHN LAIRD,1442,83,1359
+Santa Clara,0007271,State Senate,,DEM,JOHN LAIRD,1801,82,1719
+Santa Clara,0007273,State Senate,,DEM,JOHN LAIRD,2037,95,1942
+Santa Clara,0007282,State Senate,,DEM,JOHN LAIRD,1155,59,1096
+Santa Clara,0007294,State Senate,,DEM,JOHN LAIRD,422,9,413
+Santa Clara,0007295,State Senate,,DEM,JOHN LAIRD,1082,43,1039
+Santa Clara,0007298,State Senate,,DEM,JOHN LAIRD,734,17,717
+Santa Clara,0007299,State Senate,,DEM,JOHN LAIRD,586,23,563
+Santa Clara,0007306,State Senate,,DEM,JOHN LAIRD,0,0,0
+Santa Clara,0008246,State Senate,,DEM,JOHN LAIRD,1544,108,1436
+Santa Clara,0008254,State Senate,,DEM,JOHN LAIRD,1492,122,1370
+Santa Clara,0008915,State Senate,,DEM,JOHN LAIRD,9,1,8
+Santa Clara,0008916,State Senate,,DEM,JOHN LAIRD,6,0,6
+Santa Clara,0008920,State Senate,,DEM,JOHN LAIRD,0,0,0
+Santa Clara,0004801,State Senate,,REP,VICKI NOHRDEN,398,59,339
+Santa Clara,0004806,State Senate,,REP,VICKI NOHRDEN,1077,134,943
+Santa Clara,0004811,State Senate,,REP,VICKI NOHRDEN,648,64,584
+Santa Clara,0004826,State Senate,,REP,VICKI NOHRDEN,532,60,472
+Santa Clara,0004827,State Senate,,REP,VICKI NOHRDEN,870,108,762
+Santa Clara,0004833,State Senate,,REP,VICKI NOHRDEN,653,77,576
+Santa Clara,0004851,State Senate,,REP,VICKI NOHRDEN,393,55,338
+Santa Clara,0004853,State Senate,,REP,VICKI NOHRDEN,736,72,664
+Santa Clara,0004858,State Senate,,REP,VICKI NOHRDEN,900,145,755
+Santa Clara,0004876,State Senate,,REP,VICKI NOHRDEN,1326,138,1188
+Santa Clara,0004881,State Senate,,REP,VICKI NOHRDEN,1558,153,1405
+Santa Clara,0004941,State Senate,,REP,VICKI NOHRDEN,764,96,668
+Santa Clara,0004942,State Senate,,REP,VICKI NOHRDEN,680,84,596
+Santa Clara,0004943,State Senate,,REP,VICKI NOHRDEN,23,3,20
+Santa Clara,0004944,State Senate,,REP,VICKI NOHRDEN,201,40,161
+Santa Clara,0004945,State Senate,,REP,VICKI NOHRDEN,333,55,278
+Santa Clara,0004946,State Senate,,REP,VICKI NOHRDEN,842,114,728
+Santa Clara,0004949,State Senate,,REP,VICKI NOHRDEN,881,115,766
+Santa Clara,0004950,State Senate,,REP,VICKI NOHRDEN,859,138,721
+Santa Clara,0004954,State Senate,,REP,VICKI NOHRDEN,486,55,431
+Santa Clara,0004956,State Senate,,REP,VICKI NOHRDEN,57,12,45
+Santa Clara,0004958,State Senate,,REP,VICKI NOHRDEN,278,52,226
+Santa Clara,0004965,State Senate,,REP,VICKI NOHRDEN,1016,105,911
+Santa Clara,0004969,State Senate,,REP,VICKI NOHRDEN,465,55,410
+Santa Clara,0004971,State Senate,,REP,VICKI NOHRDEN,258,33,225
+Santa Clara,0004973,State Senate,,REP,VICKI NOHRDEN,935,110,825
+Santa Clara,0004974,State Senate,,REP,VICKI NOHRDEN,210,35,175
+Santa Clara,0005458,State Senate,,REP,VICKI NOHRDEN,0,0,0
+Santa Clara,0005886,State Senate,,REP,VICKI NOHRDEN,3,0,3
+Santa Clara,0005906,State Senate,,REP,VICKI NOHRDEN,127,17,110
+Santa Clara,0005911,State Senate,,REP,VICKI NOHRDEN,721,121,600
+Santa Clara,0005912,State Senate,,REP,VICKI NOHRDEN,65,12,53
+Santa Clara,0005914,State Senate,,REP,VICKI NOHRDEN,504,60,444
+Santa Clara,0005915,State Senate,,REP,VICKI NOHRDEN,423,46,377
+Santa Clara,0005916,State Senate,,REP,VICKI NOHRDEN,37,4,33
+Santa Clara,0005917,State Senate,,REP,VICKI NOHRDEN,115,18,97
+Santa Clara,0005919,State Senate,,REP,VICKI NOHRDEN,153,19,134
+Santa Clara,0005922,State Senate,,REP,VICKI NOHRDEN,245,42,203
+Santa Clara,0005925,State Senate,,REP,VICKI NOHRDEN,44,2,42
+Santa Clara,0005929,State Senate,,REP,VICKI NOHRDEN,64,7,57
+Santa Clara,0005931,State Senate,,REP,VICKI NOHRDEN,56,2,54
+Santa Clara,0005936,State Senate,,REP,VICKI NOHRDEN,144,17,127
+Santa Clara,0005940,State Senate,,REP,VICKI NOHRDEN,21,5,16
+Santa Clara,0005947,State Senate,,REP,VICKI NOHRDEN,279,16,263
+Santa Clara,0005949,State Senate,,REP,VICKI NOHRDEN,202,29,173
+Santa Clara,0005950,State Senate,,REP,VICKI NOHRDEN,56,7,49
+Santa Clara,0005951,State Senate,,REP,VICKI NOHRDEN,0,0,0
+Santa Clara,0005955,State Senate,,REP,VICKI NOHRDEN,554,74,480
+Santa Clara,0005956,State Senate,,REP,VICKI NOHRDEN,477,37,440
+Santa Clara,0005957,State Senate,,REP,VICKI NOHRDEN,66,6,60
+Santa Clara,0005958,State Senate,,REP,VICKI NOHRDEN,333,46,287
+Santa Clara,0005959,State Senate,,REP,VICKI NOHRDEN,49,2,47
+Santa Clara,0005965,State Senate,,REP,VICKI NOHRDEN,437,55,382
+Santa Clara,0005966,State Senate,,REP,VICKI NOHRDEN,75,11,64
+Santa Clara,0005975,State Senate,,REP,VICKI NOHRDEN,7,4,3
+Santa Clara,0005988,State Senate,,REP,VICKI NOHRDEN,0,0,0
+Santa Clara,0006023,State Senate,,REP,VICKI NOHRDEN,2,0,2
+Santa Clara,0006031,State Senate,,REP,VICKI NOHRDEN,11,1,10
+Santa Clara,0006035,State Senate,,REP,VICKI NOHRDEN,0,0,0
+Santa Clara,0006048,State Senate,,REP,VICKI NOHRDEN,5,0,5
+Santa Clara,0007203,State Senate,,REP,VICKI NOHRDEN,154,18,136
+Santa Clara,0007205,State Senate,,REP,VICKI NOHRDEN,700,104,596
+Santa Clara,0007214,State Senate,,REP,VICKI NOHRDEN,591,88,503
+Santa Clara,0007217,State Senate,,REP,VICKI NOHRDEN,813,117,696
+Santa Clara,0007219,State Senate,,REP,VICKI NOHRDEN,287,31,256
+Santa Clara,0007231,State Senate,,REP,VICKI NOHRDEN,211,33,178
+Santa Clara,0007235,State Senate,,REP,VICKI NOHRDEN,498,88,410
+Santa Clara,0007237,State Senate,,REP,VICKI NOHRDEN,690,102,588
+Santa Clara,0007245,State Senate,,REP,VICKI NOHRDEN,101,12,89
+Santa Clara,0007246,State Senate,,REP,VICKI NOHRDEN,394,43,351
+Santa Clara,0007248,State Senate,,REP,VICKI NOHRDEN,632,94,538
+Santa Clara,0007252,State Senate,,REP,VICKI NOHRDEN,752,96,656
+Santa Clara,0007255,State Senate,,REP,VICKI NOHRDEN,964,119,845
+Santa Clara,0007257,State Senate,,REP,VICKI NOHRDEN,458,48,410
+Santa Clara,0007261,State Senate,,REP,VICKI NOHRDEN,628,98,530
+Santa Clara,0007264,State Senate,,REP,VICKI NOHRDEN,688,105,583
+Santa Clara,0007271,State Senate,,REP,VICKI NOHRDEN,833,79,754
+Santa Clara,0007273,State Senate,,REP,VICKI NOHRDEN,1001,106,895
+Santa Clara,0007282,State Senate,,REP,VICKI NOHRDEN,574,55,519
+Santa Clara,0007294,State Senate,,REP,VICKI NOHRDEN,196,29,167
+Santa Clara,0007295,State Senate,,REP,VICKI NOHRDEN,551,62,489
+Santa Clara,0007298,State Senate,,REP,VICKI NOHRDEN,409,61,348
+Santa Clara,0007299,State Senate,,REP,VICKI NOHRDEN,327,40,287
+Santa Clara,0007306,State Senate,,REP,VICKI NOHRDEN,0,0,0
+Santa Clara,0008246,State Senate,,REP,VICKI NOHRDEN,574,88,486
+Santa Clara,0008254,State Senate,,REP,VICKI NOHRDEN,547,88,459
+Santa Clara,0008915,State Senate,,REP,VICKI NOHRDEN,7,0,7
+Santa Clara,0008916,State Senate,,REP,VICKI NOHRDEN,9,0,9
+Santa Clara,0008920,State Senate,,REP,VICKI NOHRDEN,1,0,1
+Santa Clara,0002001,State Assembly,,DEM,MARC BERMAN,26,21,5
+Santa Clara,0002002,State Assembly,,DEM,MARC BERMAN,1767,92,1675
+Santa Clara,0002005,State Assembly,,DEM,MARC BERMAN,1200,41,1159
+Santa Clara,0002006,State Assembly,,DEM,MARC BERMAN,49,0,49
+Santa Clara,0002009,State Assembly,,DEM,MARC BERMAN,2737,124,2613
+Santa Clara,0002013,State Assembly,,DEM,MARC BERMAN,2211,84,2127
+Santa Clara,0002014,State Assembly,,DEM,MARC BERMAN,1858,102,1756
+Santa Clara,0002018,State Assembly,,DEM,MARC BERMAN,58,2,56
+Santa Clara,0002025,State Assembly,,DEM,MARC BERMAN,2518,78,2440
+Santa Clara,0002043,State Assembly,,DEM,MARC BERMAN,1968,59,1909
+Santa Clara,0002046,State Assembly,,DEM,MARC BERMAN,2756,109,2647
+Santa Clara,0002057,State Assembly,,DEM,MARC BERMAN,2639,111,2528
+Santa Clara,0002068,State Assembly,,DEM,MARC BERMAN,2386,79,2307
+Santa Clara,0002098,State Assembly,,DEM,MARC BERMAN,2487,94,2393
+Santa Clara,0002108,State Assembly,,DEM,MARC BERMAN,2187,72,2115
+Santa Clara,0002125,State Assembly,,DEM,MARC BERMAN,239,4,235
+Santa Clara,0002274,State Assembly,,DEM,MARC BERMAN,127,2,125
+Santa Clara,0002275,State Assembly,,DEM,MARC BERMAN,560,13,547
+Santa Clara,0002278,State Assembly,,DEM,MARC BERMAN,587,30,557
+Santa Clara,0002281,State Assembly,,DEM,MARC BERMAN,3,0,3
+Santa Clara,0002282,State Assembly,,DEM,MARC BERMAN,754,33,721
+Santa Clara,0002285,State Assembly,,DEM,MARC BERMAN,1272,59,1213
+Santa Clara,0002301,State Assembly,,DEM,MARC BERMAN,2115,61,2054
+Santa Clara,0002305,State Assembly,,DEM,MARC BERMAN,2828,102,2726
+Santa Clara,0002309,State Assembly,,DEM,MARC BERMAN,733,16,717
+Santa Clara,0002314,State Assembly,,DEM,MARC BERMAN,1657,50,1607
+Santa Clara,0002317,State Assembly,,DEM,MARC BERMAN,1575,60,1515
+Santa Clara,0002330,State Assembly,,DEM,MARC BERMAN,2540,51,2489
+Santa Clara,0002338,State Assembly,,DEM,MARC BERMAN,99,4,95
+Santa Clara,0002351,State Assembly,,DEM,MARC BERMAN,1411,47,1364
+Santa Clara,0002353,State Assembly,,DEM,MARC BERMAN,18,3,15
+Santa Clara,0002539,State Assembly,,DEM,MARC BERMAN,108,3,105
+Santa Clara,0002542,State Assembly,,DEM,MARC BERMAN,1213,168,1045
+Santa Clara,0002545,State Assembly,,DEM,MARC BERMAN,1649,91,1558
+Santa Clara,0002802,State Assembly,,DEM,MARC BERMAN,1396,43,1353
+Santa Clara,0002812,State Assembly,,DEM,MARC BERMAN,156,4,152
+Santa Clara,0002825,State Assembly,,DEM,MARC BERMAN,10,0,10
+Santa Clara,0002870,State Assembly,,DEM,MARC BERMAN,84,3,81
+Santa Clara,0002951,State Assembly,,DEM,MARC BERMAN,161,10,151
+Santa Clara,0003001,State Assembly,,DEM,MARC BERMAN,1689,71,1618
+Santa Clara,0003002,State Assembly,,DEM,MARC BERMAN,1725,111,1614
+Santa Clara,0003005,State Assembly,,DEM,MARC BERMAN,38,2,36
+Santa Clara,0003010,State Assembly,,DEM,MARC BERMAN,1568,94,1474
+Santa Clara,0003011,State Assembly,,DEM,MARC BERMAN,1480,105,1375
+Santa Clara,0003012,State Assembly,,DEM,MARC BERMAN,76,3,73
+Santa Clara,0003013,State Assembly,,DEM,MARC BERMAN,2022,114,1908
+Santa Clara,0003016,State Assembly,,DEM,MARC BERMAN,629,21,608
+Santa Clara,0003017,State Assembly,,DEM,MARC BERMAN,440,27,413
+Santa Clara,0003018,State Assembly,,DEM,MARC BERMAN,243,19,224
+Santa Clara,0003019,State Assembly,,DEM,MARC BERMAN,2107,101,2006
+Santa Clara,0003021,State Assembly,,DEM,MARC BERMAN,187,9,178
+Santa Clara,0003023,State Assembly,,DEM,MARC BERMAN,1588,91,1497
+Santa Clara,0003026,State Assembly,,DEM,MARC BERMAN,1165,37,1128
+Santa Clara,0003029,State Assembly,,DEM,MARC BERMAN,0,0,0
+Santa Clara,0003031,State Assembly,,DEM,MARC BERMAN,0,0,0
+Santa Clara,0003032,State Assembly,,DEM,MARC BERMAN,958,46,912
+Santa Clara,0003034,State Assembly,,DEM,MARC BERMAN,1980,85,1895
+Santa Clara,0003035,State Assembly,,DEM,MARC BERMAN,1509,87,1422
+Santa Clara,0003039,State Assembly,,DEM,MARC BERMAN,1057,38,1019
+Santa Clara,0003040,State Assembly,,DEM,MARC BERMAN,0,0,0
+Santa Clara,0003042,State Assembly,,DEM,MARC BERMAN,1012,67,945
+Santa Clara,0003043,State Assembly,,DEM,MARC BERMAN,1663,60,1603
+Santa Clara,0003045,State Assembly,,DEM,MARC BERMAN,2213,97,2116
+Santa Clara,0003047,State Assembly,,DEM,MARC BERMAN,738,22,716
+Santa Clara,0003048,State Assembly,,DEM,MARC BERMAN,2105,100,2005
+Santa Clara,0003051,State Assembly,,DEM,MARC BERMAN,1483,35,1448
+Santa Clara,0003053,State Assembly,,DEM,MARC BERMAN,1686,48,1638
+Santa Clara,0003061,State Assembly,,DEM,MARC BERMAN,66,6,60
+Santa Clara,0003079,State Assembly,,DEM,MARC BERMAN,341,10,331
+Santa Clara,0003080,State Assembly,,DEM,MARC BERMAN,687,27,660
+Santa Clara,0003086,State Assembly,,DEM,MARC BERMAN,1988,60,1928
+Santa Clara,0003087,State Assembly,,DEM,MARC BERMAN,774,56,718
+Santa Clara,0003089,State Assembly,,DEM,MARC BERMAN,0,0,0
+Santa Clara,0003095,State Assembly,,DEM,MARC BERMAN,2,0,2
+Santa Clara,0003101,State Assembly,,DEM,MARC BERMAN,98,4,94
+Santa Clara,0003102,State Assembly,,DEM,MARC BERMAN,330,24,306
+Santa Clara,0003103,State Assembly,,DEM,MARC BERMAN,812,46,766
+Santa Clara,0003116,State Assembly,,DEM,MARC BERMAN,530,16,514
+Santa Clara,0003117,State Assembly,,DEM,MARC BERMAN,597,25,572
+Santa Clara,0003120,State Assembly,,DEM,MARC BERMAN,340,16,324
+Santa Clara,0003122,State Assembly,,DEM,MARC BERMAN,1517,58,1459
+Santa Clara,0003156,State Assembly,,DEM,MARC BERMAN,98,3,95
+Santa Clara,0003402,State Assembly,,DEM,MARC BERMAN,2148,68,2080
+Santa Clara,0003406,State Assembly,,DEM,MARC BERMAN,2038,165,1873
+Santa Clara,0003407,State Assembly,,DEM,MARC BERMAN,2148,84,2064
+Santa Clara,0003408,State Assembly,,DEM,MARC BERMAN,2569,117,2452
+Santa Clara,0003409,State Assembly,,DEM,MARC BERMAN,2509,130,2379
+Santa Clara,0003410,State Assembly,,DEM,MARC BERMAN,2577,101,2476
+Santa Clara,0003417,State Assembly,,DEM,MARC BERMAN,2432,93,2339
+Santa Clara,0003427,State Assembly,,DEM,MARC BERMAN,1983,90,1893
+Santa Clara,0003434,State Assembly,,DEM,MARC BERMAN,1487,36,1451
+Santa Clara,0003438,State Assembly,,DEM,MARC BERMAN,2636,79,2557
+Santa Clara,0003445,State Assembly,,DEM,MARC BERMAN,2463,96,2367
+Santa Clara,0003601,State Assembly,,DEM,MARC BERMAN,845,12,833
+Santa Clara,0003603,State Assembly,,DEM,MARC BERMAN,743,23,720
+Santa Clara,0003669,State Assembly,,DEM,MARC BERMAN,2,0,2
+Santa Clara,0002001,State Assembly,,REP,PETER OHTAKI,33,30,3
+Santa Clara,0002002,State Assembly,,REP,PETER OHTAKI,443,46,397
+Santa Clara,0002005,State Assembly,,REP,PETER OHTAKI,284,32,252
+Santa Clara,0002006,State Assembly,,REP,PETER OHTAKI,17,1,16
+Santa Clara,0002009,State Assembly,,REP,PETER OHTAKI,774,93,681
+Santa Clara,0002013,State Assembly,,REP,PETER OHTAKI,722,70,652
+Santa Clara,0002014,State Assembly,,REP,PETER OHTAKI,733,98,635
+Santa Clara,0002018,State Assembly,,REP,PETER OHTAKI,45,8,37
+Santa Clara,0002025,State Assembly,,REP,PETER OHTAKI,786,56,730
+Santa Clara,0002043,State Assembly,,REP,PETER OHTAKI,647,52,595
+Santa Clara,0002046,State Assembly,,REP,PETER OHTAKI,702,83,619
+Santa Clara,0002057,State Assembly,,REP,PETER OHTAKI,620,60,560
+Santa Clara,0002068,State Assembly,,REP,PETER OHTAKI,744,44,700
+Santa Clara,0002098,State Assembly,,REP,PETER OHTAKI,853,65,788
+Santa Clara,0002108,State Assembly,,REP,PETER OHTAKI,667,66,601
+Santa Clara,0002125,State Assembly,,REP,PETER OHTAKI,70,8,62
+Santa Clara,0002274,State Assembly,,REP,PETER OHTAKI,101,3,98
+Santa Clara,0002275,State Assembly,,REP,PETER OHTAKI,437,43,394
+Santa Clara,0002278,State Assembly,,REP,PETER OHTAKI,336,36,300
+Santa Clara,0002281,State Assembly,,REP,PETER OHTAKI,2,0,2
+Santa Clara,0002282,State Assembly,,REP,PETER OHTAKI,419,32,387
+Santa Clara,0002285,State Assembly,,REP,PETER OHTAKI,853,78,775
+Santa Clara,0002301,State Assembly,,REP,PETER OHTAKI,881,59,822
+Santa Clara,0002305,State Assembly,,REP,PETER OHTAKI,1181,80,1101
+Santa Clara,0002309,State Assembly,,REP,PETER OHTAKI,317,27,290
+Santa Clara,0002314,State Assembly,,REP,PETER OHTAKI,760,60,700
+Santa Clara,0002317,State Assembly,,REP,PETER OHTAKI,730,59,671
+Santa Clara,0002330,State Assembly,,REP,PETER OHTAKI,1044,75,969
+Santa Clara,0002338,State Assembly,,REP,PETER OHTAKI,29,2,27
+Santa Clara,0002351,State Assembly,,REP,PETER OHTAKI,631,34,597
+Santa Clara,0002353,State Assembly,,REP,PETER OHTAKI,12,3,9
+Santa Clara,0002539,State Assembly,,REP,PETER OHTAKI,25,3,22
+Santa Clara,0002542,State Assembly,,REP,PETER OHTAKI,184,34,150
+Santa Clara,0002545,State Assembly,,REP,PETER OHTAKI,200,13,187
+Santa Clara,0002802,State Assembly,,REP,PETER OHTAKI,788,59,729
+Santa Clara,0002812,State Assembly,,REP,PETER OHTAKI,90,12,78
+Santa Clara,0002825,State Assembly,,REP,PETER OHTAKI,2,0,2
+Santa Clara,0002870,State Assembly,,REP,PETER OHTAKI,28,2,26
+Santa Clara,0002951,State Assembly,,REP,PETER OHTAKI,94,17,77
+Santa Clara,0003001,State Assembly,,REP,PETER OHTAKI,801,105,696
+Santa Clara,0003002,State Assembly,,REP,PETER OHTAKI,615,83,532
+Santa Clara,0003005,State Assembly,,REP,PETER OHTAKI,12,1,11
+Santa Clara,0003010,State Assembly,,REP,PETER OHTAKI,556,64,492
+Santa Clara,0003011,State Assembly,,REP,PETER OHTAKI,480,61,419
+Santa Clara,0003012,State Assembly,,REP,PETER OHTAKI,34,5,29
+Santa Clara,0003013,State Assembly,,REP,PETER OHTAKI,605,82,523
+Santa Clara,0003016,State Assembly,,REP,PETER OHTAKI,175,12,163
+Santa Clara,0003017,State Assembly,,REP,PETER OHTAKI,142,25,117
+Santa Clara,0003018,State Assembly,,REP,PETER OHTAKI,71,7,64
+Santa Clara,0003019,State Assembly,,REP,PETER OHTAKI,656,78,578
+Santa Clara,0003021,State Assembly,,REP,PETER OHTAKI,55,5,50
+Santa Clara,0003023,State Assembly,,REP,PETER OHTAKI,659,83,576
+Santa Clara,0003026,State Assembly,,REP,PETER OHTAKI,481,46,435
+Santa Clara,0003029,State Assembly,,REP,PETER OHTAKI,0,0,0
+Santa Clara,0003031,State Assembly,,REP,PETER OHTAKI,0,0,0
+Santa Clara,0003032,State Assembly,,REP,PETER OHTAKI,390,52,338
+Santa Clara,0003034,State Assembly,,REP,PETER OHTAKI,867,88,779
+Santa Clara,0003035,State Assembly,,REP,PETER OHTAKI,497,68,429
+Santa Clara,0003039,State Assembly,,REP,PETER OHTAKI,397,31,366
+Santa Clara,0003040,State Assembly,,REP,PETER OHTAKI,0,0,0
+Santa Clara,0003042,State Assembly,,REP,PETER OHTAKI,366,39,327
+Santa Clara,0003043,State Assembly,,REP,PETER OHTAKI,770,62,708
+Santa Clara,0003045,State Assembly,,REP,PETER OHTAKI,870,86,784
+Santa Clara,0003047,State Assembly,,REP,PETER OHTAKI,308,26,282
+Santa Clara,0003048,State Assembly,,REP,PETER OHTAKI,697,84,613
+Santa Clara,0003051,State Assembly,,REP,PETER OHTAKI,633,30,603
+Santa Clara,0003053,State Assembly,,REP,PETER OHTAKI,813,64,749
+Santa Clara,0003061,State Assembly,,REP,PETER OHTAKI,13,1,12
+Santa Clara,0003079,State Assembly,,REP,PETER OHTAKI,180,15,165
+Santa Clara,0003080,State Assembly,,REP,PETER OHTAKI,223,13,210
+Santa Clara,0003086,State Assembly,,REP,PETER OHTAKI,907,66,841
+Santa Clara,0003087,State Assembly,,REP,PETER OHTAKI,335,38,297
+Santa Clara,0003089,State Assembly,,REP,PETER OHTAKI,0,0,0
+Santa Clara,0003095,State Assembly,,REP,PETER OHTAKI,0,0,0
+Santa Clara,0003101,State Assembly,,REP,PETER OHTAKI,38,5,33
+Santa Clara,0003102,State Assembly,,REP,PETER OHTAKI,145,10,135
+Santa Clara,0003103,State Assembly,,REP,PETER OHTAKI,321,35,286
+Santa Clara,0003116,State Assembly,,REP,PETER OHTAKI,221,19,202
+Santa Clara,0003117,State Assembly,,REP,PETER OHTAKI,198,21,177
+Santa Clara,0003120,State Assembly,,REP,PETER OHTAKI,135,15,120
+Santa Clara,0003122,State Assembly,,REP,PETER OHTAKI,589,62,527
+Santa Clara,0003156,State Assembly,,REP,PETER OHTAKI,33,6,27
+Santa Clara,0003402,State Assembly,,REP,PETER OHTAKI,635,80,555
+Santa Clara,0003406,State Assembly,,REP,PETER OHTAKI,561,80,481
+Santa Clara,0003407,State Assembly,,REP,PETER OHTAKI,572,60,512
+Santa Clara,0003408,State Assembly,,REP,PETER OHTAKI,716,97,619
+Santa Clara,0003409,State Assembly,,REP,PETER OHTAKI,730,106,624
+Santa Clara,0003410,State Assembly,,REP,PETER OHTAKI,810,84,726
+Santa Clara,0003417,State Assembly,,REP,PETER OHTAKI,581,59,522
+Santa Clara,0003427,State Assembly,,REP,PETER OHTAKI,601,72,529
+Santa Clara,0003434,State Assembly,,REP,PETER OHTAKI,565,39,526
+Santa Clara,0003438,State Assembly,,REP,PETER OHTAKI,999,78,921
+Santa Clara,0003445,State Assembly,,REP,PETER OHTAKI,756,83,673
+Santa Clara,0003601,State Assembly,,REP,PETER OHTAKI,356,22,334
+Santa Clara,0003603,State Assembly,,REP,PETER OHTAKI,417,30,387
+Santa Clara,0003669,State Assembly,,REP,PETER OHTAKI,0,0,0
+Santa Clara,0003008,State Assembly,,DEM,ALEX LEE,23,0,23
+Santa Clara,0004401,State Assembly,,DEM,ALEX LEE,1849,102,1747
+Santa Clara,0004402,State Assembly,,DEM,ALEX LEE,2260,121,2139
+Santa Clara,0004403,State Assembly,,DEM,ALEX LEE,185,20,165
+Santa Clara,0004405,State Assembly,,DEM,ALEX LEE,2333,125,2208
+Santa Clara,0004407,State Assembly,,DEM,ALEX LEE,2022,120,1902
+Santa Clara,0004409,State Assembly,,DEM,ALEX LEE,2592,142,2450
+Santa Clara,0004411,State Assembly,,DEM,ALEX LEE,1449,70,1379
+Santa Clara,0004412,State Assembly,,DEM,ALEX LEE,2335,94,2241
+Santa Clara,0004414,State Assembly,,DEM,ALEX LEE,2633,106,2527
+Santa Clara,0004417,State Assembly,,DEM,ALEX LEE,2082,87,1995
+Santa Clara,0005449,State Assembly,,DEM,ALEX LEE,71,3,68
+Santa Clara,0005454,State Assembly,,DEM,ALEX LEE,5,1,4
+Santa Clara,0005456,State Assembly,,DEM,ALEX LEE,3,0,3
+Santa Clara,0005458,State Assembly,,DEM,ALEX LEE,0,0,0
+Santa Clara,0005502,State Assembly,,DEM,ALEX LEE,234,14,220
+Santa Clara,0005505,State Assembly,,DEM,ALEX LEE,175,7,168
+Santa Clara,0005925,State Assembly,,DEM,ALEX LEE,33,0,33
+Santa Clara,0006028,State Assembly,,DEM,ALEX LEE,14,0,14
+Santa Clara,0006401,State Assembly,,DEM,ALEX LEE,0,0,0
+Santa Clara,0006402,State Assembly,,DEM,ALEX LEE,44,1,43
+Santa Clara,0006405,State Assembly,,DEM,ALEX LEE,4,0,4
+Santa Clara,0006410,State Assembly,,DEM,ALEX LEE,53,3,50
+Santa Clara,0006413,State Assembly,,DEM,ALEX LEE,5,0,5
+Santa Clara,0006418,State Assembly,,DEM,ALEX LEE,449,16,433
+Santa Clara,0006419,State Assembly,,DEM,ALEX LEE,20,1,19
+Santa Clara,0006423,State Assembly,,DEM,ALEX LEE,21,1,20
+Santa Clara,0006491,State Assembly,,DEM,ALEX LEE,19,0,19
+Santa Clara,0006502,State Assembly,,DEM,ALEX LEE,196,12,184
+Santa Clara,0006509,State Assembly,,DEM,ALEX LEE,5,2,3
+Santa Clara,0006510,State Assembly,,DEM,ALEX LEE,26,2,24
+Santa Clara,0006511,State Assembly,,DEM,ALEX LEE,71,2,69
+Santa Clara,0006515,State Assembly,,DEM,ALEX LEE,64,2,62
+Santa Clara,0007306,State Assembly,,DEM,ALEX LEE,0,0,0
+Santa Clara,0007401,State Assembly,,DEM,ALEX LEE,1,1,0
+Santa Clara,0007402,State Assembly,,DEM,ALEX LEE,379,17,362
+Santa Clara,0007403,State Assembly,,DEM,ALEX LEE,790,45,745
+Santa Clara,0007408,State Assembly,,DEM,ALEX LEE,599,16,583
+Santa Clara,0007409,State Assembly,,DEM,ALEX LEE,230,14,216
+Santa Clara,0007410,State Assembly,,DEM,ALEX LEE,5,2,3
+Santa Clara,0007411,State Assembly,,DEM,ALEX LEE,20,3,17
+Santa Clara,0007415,State Assembly,,DEM,ALEX LEE,37,0,37
+Santa Clara,0007438,State Assembly,,DEM,ALEX LEE,234,25,209
+Santa Clara,0007440,State Assembly,,DEM,ALEX LEE,24,4,20
+Santa Clara,0007441,State Assembly,,DEM,ALEX LEE,1038,58,980
+Santa Clara,0007442,State Assembly,,DEM,ALEX LEE,192,19,173
+Santa Clara,0007601,State Assembly,,DEM,ALEX LEE,2330,156,2174
+Santa Clara,0007606,State Assembly,,DEM,ALEX LEE,2491,153,2338
+Santa Clara,0007609,State Assembly,,DEM,ALEX LEE,586,55,531
+Santa Clara,0007615,State Assembly,,DEM,ALEX LEE,677,56,621
+Santa Clara,0007619,State Assembly,,DEM,ALEX LEE,1370,56,1314
+Santa Clara,0007620,State Assembly,,DEM,ALEX LEE,2022,94,1928
+Santa Clara,0007621,State Assembly,,DEM,ALEX LEE,2255,92,2163
+Santa Clara,0007624,State Assembly,,DEM,ALEX LEE,1635,62,1573
+Santa Clara,0007632,State Assembly,,DEM,ALEX LEE,1857,96,1761
+Santa Clara,0007634,State Assembly,,DEM,ALEX LEE,1086,43,1043
+Santa Clara,0007648,State Assembly,,DEM,ALEX LEE,2027,76,1951
+Santa Clara,0007654,State Assembly,,DEM,ALEX LEE,2421,104,2317
+Santa Clara,0007660,State Assembly,,DEM,ALEX LEE,1996,84,1912
+Santa Clara,0007666,State Assembly,,DEM,ALEX LEE,2094,88,2006
+Santa Clara,0007670,State Assembly,,DEM,ALEX LEE,62,0,62
+Santa Clara,0007673,State Assembly,,DEM,ALEX LEE,0,0,0
+Santa Clara,0007674,State Assembly,,DEM,ALEX LEE,0,0,0
+Santa Clara,0007677,State Assembly,,DEM,ALEX LEE,2277,82,2195
+Santa Clara,0007680,State Assembly,,DEM,ALEX LEE,1324,54,1270
+Santa Clara,0007689,State Assembly,,DEM,ALEX LEE,10,0,10
+Santa Clara,0007690,State Assembly,,DEM,ALEX LEE,675,25,650
+Santa Clara,0007801,State Assembly,,DEM,ALEX LEE,468,21,447
+Santa Clara,0007802,State Assembly,,DEM,ALEX LEE,252,11,241
+Santa Clara,0007803,State Assembly,,DEM,ALEX LEE,650,20,630
+Santa Clara,0007805,State Assembly,,DEM,ALEX LEE,1127,47,1080
+Santa Clara,0007810,State Assembly,,DEM,ALEX LEE,169,4,165
+Santa Clara,0007811,State Assembly,,DEM,ALEX LEE,135,9,126
+Santa Clara,0007812,State Assembly,,DEM,ALEX LEE,936,41,895
+Santa Clara,0007816,State Assembly,,DEM,ALEX LEE,182,19,163
+Santa Clara,0007880,State Assembly,,DEM,ALEX LEE,3,1,2
+Santa Clara,0008423,State Assembly,,DEM,ALEX LEE,2,1,1
+Santa Clara,0008447,State Assembly,,DEM,ALEX LEE,5,0,5
+Santa Clara,0008502,State Assembly,,DEM,ALEX LEE,143,3,140
+Santa Clara,0009001,State Assembly,,DEM,ALEX LEE,1826,106,1720
+Santa Clara,0009005,State Assembly,,DEM,ALEX LEE,2762,184,2578
+Santa Clara,0009051,State Assembly,,DEM,ALEX LEE,917,52,865
+Santa Clara,0009055,State Assembly,,DEM,ALEX LEE,49,1,48
+Santa Clara,0009056,State Assembly,,DEM,ALEX LEE,1887,102,1785
+Santa Clara,0009059,State Assembly,,DEM,ALEX LEE,1504,105,1399
+Santa Clara,0009061,State Assembly,,DEM,ALEX LEE,0,0,0
+Santa Clara,0009062,State Assembly,,DEM,ALEX LEE,1494,54,1440
+Santa Clara,0009101,State Assembly,,DEM,ALEX LEE,1906,77,1829
+Santa Clara,0009103,State Assembly,,DEM,ALEX LEE,558,31,527
+Santa Clara,0009104,State Assembly,,DEM,ALEX LEE,1743,60,1683
+Santa Clara,0009109,State Assembly,,DEM,ALEX LEE,1140,68,1072
+Santa Clara,0009151,State Assembly,,DEM,ALEX LEE,1639,92,1547
+Santa Clara,0009157,State Assembly,,DEM,ALEX LEE,2047,104,1943
+Santa Clara,0009163,State Assembly,,DEM,ALEX LEE,874,26,848
+Santa Clara,0009166,State Assembly,,DEM,ALEX LEE,844,22,822
+Santa Clara,0009201,State Assembly,,DEM,ALEX LEE,512,16,496
+Santa Clara,0009203,State Assembly,,DEM,ALEX LEE,1067,38,1029
+Santa Clara,0009208,State Assembly,,DEM,ALEX LEE,857,55,802
+Santa Clara,0009210,State Assembly,,DEM,ALEX LEE,1323,46,1277
+Santa Clara,0009219,State Assembly,,DEM,ALEX LEE,128,9,119
+Santa Clara,0009220,State Assembly,,DEM,ALEX LEE,1734,74,1660
+Santa Clara,0009251,State Assembly,,DEM,ALEX LEE,797,22,775
+Santa Clara,0009252,State Assembly,,DEM,ALEX LEE,1262,49,1213
+Santa Clara,0009258,State Assembly,,DEM,ALEX LEE,1109,72,1037
+Santa Clara,0009262,State Assembly,,DEM,ALEX LEE,129,4,125
+Santa Clara,0009264,State Assembly,,DEM,ALEX LEE,1199,24,1175
+Santa Clara,0009268,State Assembly,,DEM,ALEX LEE,1184,40,1144
+Santa Clara,0009275,State Assembly,,DEM,ALEX LEE,1158,61,1097
+Santa Clara,0009282,State Assembly,,DEM,ALEX LEE,6,3,3
+Santa Clara,0003008,State Assembly,,REP,BOB BRUNTON,6,0,6
+Santa Clara,0004401,State Assembly,,REP,BOB BRUNTON,892,134,758
+Santa Clara,0004402,State Assembly,,REP,BOB BRUNTON,878,120,758
+Santa Clara,0004403,State Assembly,,REP,BOB BRUNTON,57,9,48
+Santa Clara,0004405,State Assembly,,REP,BOB BRUNTON,1051,151,900
+Santa Clara,0004407,State Assembly,,REP,BOB BRUNTON,911,132,779
+Santa Clara,0004409,State Assembly,,REP,BOB BRUNTON,1153,159,994
+Santa Clara,0004411,State Assembly,,REP,BOB BRUNTON,676,75,601
+Santa Clara,0004412,State Assembly,,REP,BOB BRUNTON,1084,132,952
+Santa Clara,0004414,State Assembly,,REP,BOB BRUNTON,1192,128,1064
+Santa Clara,0004417,State Assembly,,REP,BOB BRUNTON,1042,114,928
+Santa Clara,0005449,State Assembly,,REP,BOB BRUNTON,61,4,57
+Santa Clara,0005454,State Assembly,,REP,BOB BRUNTON,2,0,2
+Santa Clara,0005456,State Assembly,,REP,BOB BRUNTON,0,0,0
+Santa Clara,0005458,State Assembly,,REP,BOB BRUNTON,0,0,0
+Santa Clara,0005502,State Assembly,,REP,BOB BRUNTON,140,12,128
+Santa Clara,0005505,State Assembly,,REP,BOB BRUNTON,126,8,118
+Santa Clara,0005925,State Assembly,,REP,BOB BRUNTON,39,2,37
+Santa Clara,0006028,State Assembly,,REP,BOB BRUNTON,40,1,39
+Santa Clara,0006401,State Assembly,,REP,BOB BRUNTON,0,0,0
+Santa Clara,0006402,State Assembly,,REP,BOB BRUNTON,44,1,43
+Santa Clara,0006405,State Assembly,,REP,BOB BRUNTON,6,0,6
+Santa Clara,0006410,State Assembly,,REP,BOB BRUNTON,40,3,37
+Santa Clara,0006413,State Assembly,,REP,BOB BRUNTON,3,0,3
+Santa Clara,0006418,State Assembly,,REP,BOB BRUNTON,247,31,216
+Santa Clara,0006419,State Assembly,,REP,BOB BRUNTON,35,3,32
+Santa Clara,0006423,State Assembly,,REP,BOB BRUNTON,23,3,20
+Santa Clara,0006491,State Assembly,,REP,BOB BRUNTON,3,0,3
+Santa Clara,0006502,State Assembly,,REP,BOB BRUNTON,69,9,60
+Santa Clara,0006509,State Assembly,,REP,BOB BRUNTON,10,1,9
+Santa Clara,0006510,State Assembly,,REP,BOB BRUNTON,6,1,5
+Santa Clara,0006511,State Assembly,,REP,BOB BRUNTON,56,3,53
+Santa Clara,0006515,State Assembly,,REP,BOB BRUNTON,42,6,36
+Santa Clara,0007306,State Assembly,,REP,BOB BRUNTON,0,0,0
+Santa Clara,0007401,State Assembly,,REP,BOB BRUNTON,0,0,0
+Santa Clara,0007402,State Assembly,,REP,BOB BRUNTON,90,9,81
+Santa Clara,0007403,State Assembly,,REP,BOB BRUNTON,501,50,451
+Santa Clara,0007408,State Assembly,,REP,BOB BRUNTON,137,9,128
+Santa Clara,0007409,State Assembly,,REP,BOB BRUNTON,94,14,80
+Santa Clara,0007410,State Assembly,,REP,BOB BRUNTON,0,0,0
+Santa Clara,0007411,State Assembly,,REP,BOB BRUNTON,6,3,3
+Santa Clara,0007415,State Assembly,,REP,BOB BRUNTON,6,0,6
+Santa Clara,0007438,State Assembly,,REP,BOB BRUNTON,71,15,56
+Santa Clara,0007440,State Assembly,,REP,BOB BRUNTON,19,2,17
+Santa Clara,0007441,State Assembly,,REP,BOB BRUNTON,674,58,616
+Santa Clara,0007442,State Assembly,,REP,BOB BRUNTON,49,14,35
+Santa Clara,0007601,State Assembly,,REP,BOB BRUNTON,607,95,512
+Santa Clara,0007606,State Assembly,,REP,BOB BRUNTON,818,118,700
+Santa Clara,0007609,State Assembly,,REP,BOB BRUNTON,162,34,128
+Santa Clara,0007615,State Assembly,,REP,BOB BRUNTON,319,48,271
+Santa Clara,0007619,State Assembly,,REP,BOB BRUNTON,510,80,430
+Santa Clara,0007620,State Assembly,,REP,BOB BRUNTON,887,71,816
+Santa Clara,0007621,State Assembly,,REP,BOB BRUNTON,1162,130,1032
+Santa Clara,0007624,State Assembly,,REP,BOB BRUNTON,808,100,708
+Santa Clara,0007632,State Assembly,,REP,BOB BRUNTON,1025,130,895
+Santa Clara,0007634,State Assembly,,REP,BOB BRUNTON,565,70,495
+Santa Clara,0007648,State Assembly,,REP,BOB BRUNTON,758,88,670
+Santa Clara,0007654,State Assembly,,REP,BOB BRUNTON,1206,125,1081
+Santa Clara,0007660,State Assembly,,REP,BOB BRUNTON,948,114,834
+Santa Clara,0007666,State Assembly,,REP,BOB BRUNTON,1020,108,912
+Santa Clara,0007670,State Assembly,,REP,BOB BRUNTON,34,2,32
+Santa Clara,0007673,State Assembly,,REP,BOB BRUNTON,0,0,0
+Santa Clara,0007674,State Assembly,,REP,BOB BRUNTON,0,0,0
+Santa Clara,0007677,State Assembly,,REP,BOB BRUNTON,992,101,891
+Santa Clara,0007680,State Assembly,,REP,BOB BRUNTON,611,84,527
+Santa Clara,0007689,State Assembly,,REP,BOB BRUNTON,3,0,3
+Santa Clara,0007690,State Assembly,,REP,BOB BRUNTON,251,24,227
+Santa Clara,0007801,State Assembly,,REP,BOB BRUNTON,229,27,202
+Santa Clara,0007802,State Assembly,,REP,BOB BRUNTON,88,11,77
+Santa Clara,0007803,State Assembly,,REP,BOB BRUNTON,253,33,220
+Santa Clara,0007805,State Assembly,,REP,BOB BRUNTON,568,61,507
+Santa Clara,0007810,State Assembly,,REP,BOB BRUNTON,64,11,53
+Santa Clara,0007811,State Assembly,,REP,BOB BRUNTON,38,6,32
+Santa Clara,0007812,State Assembly,,REP,BOB BRUNTON,366,42,324
+Santa Clara,0007816,State Assembly,,REP,BOB BRUNTON,39,7,32
+Santa Clara,0007880,State Assembly,,REP,BOB BRUNTON,4,2,2
+Santa Clara,0008423,State Assembly,,REP,BOB BRUNTON,0,0,0
+Santa Clara,0008447,State Assembly,,REP,BOB BRUNTON,2,0,2
+Santa Clara,0008502,State Assembly,,REP,BOB BRUNTON,74,5,69
+Santa Clara,0009001,State Assembly,,REP,BOB BRUNTON,645,97,548
+Santa Clara,0009005,State Assembly,,REP,BOB BRUNTON,987,143,844
+Santa Clara,0009051,State Assembly,,REP,BOB BRUNTON,612,96,516
+Santa Clara,0009055,State Assembly,,REP,BOB BRUNTON,9,0,9
+Santa Clara,0009056,State Assembly,,REP,BOB BRUNTON,608,90,518
+Santa Clara,0009059,State Assembly,,REP,BOB BRUNTON,556,93,463
+Santa Clara,0009061,State Assembly,,REP,BOB BRUNTON,0,0,0
+Santa Clara,0009062,State Assembly,,REP,BOB BRUNTON,533,54,479
+Santa Clara,0009101,State Assembly,,REP,BOB BRUNTON,729,83,646
+Santa Clara,0009103,State Assembly,,REP,BOB BRUNTON,200,22,178
+Santa Clara,0009104,State Assembly,,REP,BOB BRUNTON,626,57,569
+Santa Clara,0009109,State Assembly,,REP,BOB BRUNTON,384,49,335
+Santa Clara,0009151,State Assembly,,REP,BOB BRUNTON,625,71,554
+Santa Clara,0009157,State Assembly,,REP,BOB BRUNTON,718,88,630
+Santa Clara,0009163,State Assembly,,REP,BOB BRUNTON,310,20,290
+Santa Clara,0009166,State Assembly,,REP,BOB BRUNTON,331,41,290
+Santa Clara,0009201,State Assembly,,REP,BOB BRUNTON,201,23,178
+Santa Clara,0009203,State Assembly,,REP,BOB BRUNTON,370,46,324
+Santa Clara,0009208,State Assembly,,REP,BOB BRUNTON,305,34,271
+Santa Clara,0009210,State Assembly,,REP,BOB BRUNTON,485,66,419
+Santa Clara,0009219,State Assembly,,REP,BOB BRUNTON,38,2,36
+Santa Clara,0009220,State Assembly,,REP,BOB BRUNTON,505,71,434
+Santa Clara,0009251,State Assembly,,REP,BOB BRUNTON,348,39,309
+Santa Clara,0009252,State Assembly,,REP,BOB BRUNTON,467,51,416
+Santa Clara,0009258,State Assembly,,REP,BOB BRUNTON,406,47,359
+Santa Clara,0009262,State Assembly,,REP,BOB BRUNTON,77,6,71
+Santa Clara,0009264,State Assembly,,REP,BOB BRUNTON,454,38,416
+Santa Clara,0009268,State Assembly,,REP,BOB BRUNTON,492,31,461
+Santa Clara,0009275,State Assembly,,REP,BOB BRUNTON,414,57,357
+Santa Clara,0009282,State Assembly,,REP,BOB BRUNTON,2,0,2
+Santa Clara,0005451,State Assembly,,DEM,ASH KALRA,11,0,11
+Santa Clara,0005455,State Assembly,,DEM,ASH KALRA,0,0,0
+Santa Clara,0005503,State Assembly,,DEM,ASH KALRA,219,17,202
+Santa Clara,0005507,State Assembly,,DEM,ASH KALRA,0,0,0
+Santa Clara,0005879,State Assembly,,DEM,ASH KALRA,13,1,12
+Santa Clara,0005886,State Assembly,,DEM,ASH KALRA,13,3,10
+Santa Clara,0005888,State Assembly,,DEM,ASH KALRA,0,0,0
+Santa Clara,0006404,State Assembly,,DEM,ASH KALRA,1606,60,1546
+Santa Clara,0006452,State Assembly,,DEM,ASH KALRA,681,54,627
+Santa Clara,0006454,State Assembly,,DEM,ASH KALRA,154,4,150
+Santa Clara,0006455,State Assembly,,DEM,ASH KALRA,1865,102,1763
+Santa Clara,0007201,State Assembly,,DEM,ASH KALRA,251,14,237
+Santa Clara,0007202,State Assembly,,DEM,ASH KALRA,490,30,460
+Santa Clara,0007203,State Assembly,,DEM,ASH KALRA,330,26,304
+Santa Clara,0007205,State Assembly,,DEM,ASH KALRA,1816,111,1705
+Santa Clara,0007214,State Assembly,,DEM,ASH KALRA,1109,64,1045
+Santa Clara,0007217,State Assembly,,DEM,ASH KALRA,2158,163,1995
+Santa Clara,0007219,State Assembly,,DEM,ASH KALRA,657,20,637
+Santa Clara,0007221,State Assembly,,DEM,ASH KALRA,1047,43,1004
+Santa Clara,0007224,State Assembly,,DEM,ASH KALRA,524,28,496
+Santa Clara,0007231,State Assembly,,DEM,ASH KALRA,475,33,442
+Santa Clara,0007255,State Assembly,,DEM,ASH KALRA,1918,116,1802
+Santa Clara,0007257,State Assembly,,DEM,ASH KALRA,884,27,857
+Santa Clara,0007294,State Assembly,,DEM,ASH KALRA,423,12,411
+Santa Clara,0007416,State Assembly,,DEM,ASH KALRA,138,13,125
+Santa Clara,0007417,State Assembly,,DEM,ASH KALRA,2263,111,2152
+Santa Clara,0007418,State Assembly,,DEM,ASH KALRA,1288,68,1220
+Santa Clara,0007419,State Assembly,,DEM,ASH KALRA,923,39,884
+Santa Clara,0007430,State Assembly,,DEM,ASH KALRA,1967,156,1811
+Santa Clara,0007435,State Assembly,,DEM,ASH KALRA,1846,129,1717
+Santa Clara,0007436,State Assembly,,DEM,ASH KALRA,2747,165,2582
+Santa Clara,0007447,State Assembly,,DEM,ASH KALRA,1489,143,1346
+Santa Clara,0007458,State Assembly,,DEM,ASH KALRA,1398,203,1195
+Santa Clara,0007459,State Assembly,,DEM,ASH KALRA,2035,163,1872
+Santa Clara,0007470,State Assembly,,DEM,ASH KALRA,1682,112,1570
+Santa Clara,0007471,State Assembly,,DEM,ASH KALRA,2315,187,2128
+Santa Clara,0007479,State Assembly,,DEM,ASH KALRA,937,67,870
+Santa Clara,0007483,State Assembly,,DEM,ASH KALRA,1867,179,1688
+Santa Clara,0007817,State Assembly,,DEM,ASH KALRA,8,0,8
+Santa Clara,0007818,State Assembly,,DEM,ASH KALRA,143,5,138
+Santa Clara,0007821,State Assembly,,DEM,ASH KALRA,2309,153,2156
+Santa Clara,0007826,State Assembly,,DEM,ASH KALRA,2155,125,2030
+Santa Clara,0007827,State Assembly,,DEM,ASH KALRA,844,69,775
+Santa Clara,0007832,State Assembly,,DEM,ASH KALRA,1304,93,1211
+Santa Clara,0007833,State Assembly,,DEM,ASH KALRA,1716,120,1596
+Santa Clara,0007843,State Assembly,,DEM,ASH KALRA,2787,233,2554
+Santa Clara,0007849,State Assembly,,DEM,ASH KALRA,1833,119,1714
+Santa Clara,0007850,State Assembly,,DEM,ASH KALRA,1312,110,1202
+Santa Clara,0007851,State Assembly,,DEM,ASH KALRA,748,31,717
+Santa Clara,0007861,State Assembly,,DEM,ASH KALRA,1144,90,1054
+Santa Clara,0007867,State Assembly,,DEM,ASH KALRA,2058,133,1925
+Santa Clara,0007874,State Assembly,,DEM,ASH KALRA,270,12,258
+Santa Clara,0008022,State Assembly,,DEM,ASH KALRA,711,46,665
+Santa Clara,0008023,State Assembly,,DEM,ASH KALRA,607,26,581
+Santa Clara,0008026,State Assembly,,DEM,ASH KALRA,608,53,555
+Santa Clara,0008029,State Assembly,,DEM,ASH KALRA,93,3,90
+Santa Clara,0008073,State Assembly,,DEM,ASH KALRA,348,25,323
+Santa Clara,0008101,State Assembly,,DEM,ASH KALRA,817,52,765
+Santa Clara,0008122,State Assembly,,DEM,ASH KALRA,1523,75,1448
+Santa Clara,0008201,State Assembly,,DEM,ASH KALRA,1215,83,1132
+Santa Clara,0008203,State Assembly,,DEM,ASH KALRA,1491,142,1349
+Santa Clara,0008205,State Assembly,,DEM,ASH KALRA,1707,155,1552
+Santa Clara,0008208,State Assembly,,DEM,ASH KALRA,1689,119,1570
+Santa Clara,0008212,State Assembly,,DEM,ASH KALRA,875,88,787
+Santa Clara,0008214,State Assembly,,DEM,ASH KALRA,170,19,151
+Santa Clara,0008227,State Assembly,,DEM,ASH KALRA,1885,129,1756
+Santa Clara,0008228,State Assembly,,DEM,ASH KALRA,1302,49,1253
+Santa Clara,0008230,State Assembly,,DEM,ASH KALRA,1983,108,1875
+Santa Clara,0008231,State Assembly,,DEM,ASH KALRA,1122,77,1045
+Santa Clara,0008232,State Assembly,,DEM,ASH KALRA,2001,116,1885
+Santa Clara,0008236,State Assembly,,DEM,ASH KALRA,2243,122,2121
+Santa Clara,0008246,State Assembly,,DEM,ASH KALRA,1563,109,1454
+Santa Clara,0008254,State Assembly,,DEM,ASH KALRA,1544,127,1417
+Santa Clara,0008262,State Assembly,,DEM,ASH KALRA,923,35,888
+Santa Clara,0008264,State Assembly,,DEM,ASH KALRA,1048,48,1000
+Santa Clara,0008401,State Assembly,,DEM,ASH KALRA,1352,67,1285
+Santa Clara,0008404,State Assembly,,DEM,ASH KALRA,2462,163,2299
+Santa Clara,0008408,State Assembly,,DEM,ASH KALRA,864,51,813
+Santa Clara,0008409,State Assembly,,DEM,ASH KALRA,865,32,833
+Santa Clara,0008414,State Assembly,,DEM,ASH KALRA,268,12,256
+Santa Clara,0008418,State Assembly,,DEM,ASH KALRA,296,4,292
+Santa Clara,0008421,State Assembly,,DEM,ASH KALRA,27,0,27
+Santa Clara,0008430,State Assembly,,DEM,ASH KALRA,2050,94,1956
+Santa Clara,0008435,State Assembly,,DEM,ASH KALRA,2421,81,2340
+Santa Clara,0008438,State Assembly,,DEM,ASH KALRA,2524,135,2389
+Santa Clara,0008439,State Assembly,,DEM,ASH KALRA,2074,88,1986
+Santa Clara,0008445,State Assembly,,DEM,ASH KALRA,1413,49,1364
+Santa Clara,0008456,State Assembly,,DEM,ASH KALRA,2634,123,2511
+Santa Clara,0008457,State Assembly,,DEM,ASH KALRA,2444,117,2327
+Santa Clara,0008464,State Assembly,,DEM,ASH KALRA,2343,116,2227
+Santa Clara,0008470,State Assembly,,DEM,ASH KALRA,2566,106,2460
+Santa Clara,0008472,State Assembly,,DEM,ASH KALRA,1910,65,1845
+Santa Clara,0008486,State Assembly,,DEM,ASH KALRA,2266,81,2185
+Santa Clara,0008492,State Assembly,,DEM,ASH KALRA,2506,46,2460
+Santa Clara,0008634,State Assembly,,DEM,ASH KALRA,293,16,277
+Santa Clara,0008636,State Assembly,,DEM,ASH KALRA,216,5,211
+Santa Clara,0008801,State Assembly,,DEM,ASH KALRA,1283,82,1201
+Santa Clara,0008805,State Assembly,,DEM,ASH KALRA,1061,40,1021
+Santa Clara,0008809,State Assembly,,DEM,ASH KALRA,1861,78,1783
+Santa Clara,0008812,State Assembly,,DEM,ASH KALRA,1101,91,1010
+Santa Clara,0008817,State Assembly,,DEM,ASH KALRA,615,28,587
+Santa Clara,0008820,State Assembly,,DEM,ASH KALRA,1146,38,1108
+Santa Clara,0008822,State Assembly,,DEM,ASH KALRA,1273,58,1215
+Santa Clara,0005451,State Assembly,,REP,G. BURT LANCASTER,2,0,2
+Santa Clara,0005455,State Assembly,,REP,G. BURT LANCASTER,0,0,0
+Santa Clara,0005503,State Assembly,,REP,G. BURT LANCASTER,61,10,51
+Santa Clara,0005507,State Assembly,,REP,G. BURT LANCASTER,0,0,0
+Santa Clara,0005879,State Assembly,,REP,G. BURT LANCASTER,8,2,6
+Santa Clara,0005886,State Assembly,,REP,G. BURT LANCASTER,3,0,3
+Santa Clara,0005888,State Assembly,,REP,G. BURT LANCASTER,0,0,0
+Santa Clara,0006404,State Assembly,,REP,G. BURT LANCASTER,749,73,676
+Santa Clara,0006452,State Assembly,,REP,G. BURT LANCASTER,206,40,166
+Santa Clara,0006454,State Assembly,,REP,G. BURT LANCASTER,76,9,67
+Santa Clara,0006455,State Assembly,,REP,G. BURT LANCASTER,601,83,518
+Santa Clara,0007201,State Assembly,,REP,G. BURT LANCASTER,148,5,143
+Santa Clara,0007202,State Assembly,,REP,G. BURT LANCASTER,278,37,241
+Santa Clara,0007203,State Assembly,,REP,G. BURT LANCASTER,145,19,126
+Santa Clara,0007205,State Assembly,,REP,G. BURT LANCASTER,644,99,545
+Santa Clara,0007214,State Assembly,,REP,G. BURT LANCASTER,537,85,452
+Santa Clara,0007217,State Assembly,,REP,G. BURT LANCASTER,722,113,609
+Santa Clara,0007219,State Assembly,,REP,G. BURT LANCASTER,260,30,230
+Santa Clara,0007221,State Assembly,,REP,G. BURT LANCASTER,404,38,366
+Santa Clara,0007224,State Assembly,,REP,G. BURT LANCASTER,246,37,209
+Santa Clara,0007231,State Assembly,,REP,G. BURT LANCASTER,208,30,178
+Santa Clara,0007255,State Assembly,,REP,G. BURT LANCASTER,888,114,774
+Santa Clara,0007257,State Assembly,,REP,G. BURT LANCASTER,431,44,387
+Santa Clara,0007294,State Assembly,,REP,G. BURT LANCASTER,187,25,162
+Santa Clara,0007416,State Assembly,,REP,G. BURT LANCASTER,20,2,18
+Santa Clara,0007417,State Assembly,,REP,G. BURT LANCASTER,475,76,399
+Santa Clara,0007418,State Assembly,,REP,G. BURT LANCASTER,303,40,263
+Santa Clara,0007419,State Assembly,,REP,G. BURT LANCASTER,172,21,151
+Santa Clara,0007430,State Assembly,,REP,G. BURT LANCASTER,405,60,345
+Santa Clara,0007435,State Assembly,,REP,G. BURT LANCASTER,384,64,320
+Santa Clara,0007436,State Assembly,,REP,G. BURT LANCASTER,695,91,604
+Santa Clara,0007447,State Assembly,,REP,G. BURT LANCASTER,357,71,286
+Santa Clara,0007458,State Assembly,,REP,G. BURT LANCASTER,303,62,241
+Santa Clara,0007459,State Assembly,,REP,G. BURT LANCASTER,407,91,316
+Santa Clara,0007470,State Assembly,,REP,G. BURT LANCASTER,346,53,293
+Santa Clara,0007471,State Assembly,,REP,G. BURT LANCASTER,554,82,472
+Santa Clara,0007479,State Assembly,,REP,G. BURT LANCASTER,303,58,245
+Santa Clara,0007483,State Assembly,,REP,G. BURT LANCASTER,327,57,270
+Santa Clara,0007817,State Assembly,,REP,G. BURT LANCASTER,1,0,1
+Santa Clara,0007818,State Assembly,,REP,G. BURT LANCASTER,71,3,68
+Santa Clara,0007821,State Assembly,,REP,G. BURT LANCASTER,951,106,845
+Santa Clara,0007826,State Assembly,,REP,G. BURT LANCASTER,694,100,594
+Santa Clara,0007827,State Assembly,,REP,G. BURT LANCASTER,190,29,161
+Santa Clara,0007832,State Assembly,,REP,G. BURT LANCASTER,530,81,449
+Santa Clara,0007833,State Assembly,,REP,G. BURT LANCASTER,625,109,516
+Santa Clara,0007843,State Assembly,,REP,G. BURT LANCASTER,681,114,567
+Santa Clara,0007849,State Assembly,,REP,G. BURT LANCASTER,493,90,403
+Santa Clara,0007850,State Assembly,,REP,G. BURT LANCASTER,377,69,308
+Santa Clara,0007851,State Assembly,,REP,G. BURT LANCASTER,375,35,340
+Santa Clara,0007861,State Assembly,,REP,G. BURT LANCASTER,322,50,272
+Santa Clara,0007867,State Assembly,,REP,G. BURT LANCASTER,617,78,539
+Santa Clara,0007874,State Assembly,,REP,G. BURT LANCASTER,77,5,72
+Santa Clara,0008022,State Assembly,,REP,G. BURT LANCASTER,63,9,54
+Santa Clara,0008023,State Assembly,,REP,G. BURT LANCASTER,156,29,127
+Santa Clara,0008026,State Assembly,,REP,G. BURT LANCASTER,188,40,148
+Santa Clara,0008029,State Assembly,,REP,G. BURT LANCASTER,31,5,26
+Santa Clara,0008073,State Assembly,,REP,G. BURT LANCASTER,78,8,70
+Santa Clara,0008101,State Assembly,,REP,G. BURT LANCASTER,294,43,251
+Santa Clara,0008122,State Assembly,,REP,G. BURT LANCASTER,589,66,523
+Santa Clara,0008201,State Assembly,,REP,G. BURT LANCASTER,890,143,747
+Santa Clara,0008203,State Assembly,,REP,G. BURT LANCASTER,579,100,479
+Santa Clara,0008205,State Assembly,,REP,G. BURT LANCASTER,897,145,752
+Santa Clara,0008208,State Assembly,,REP,G. BURT LANCASTER,409,58,351
+Santa Clara,0008212,State Assembly,,REP,G. BURT LANCASTER,193,45,148
+Santa Clara,0008214,State Assembly,,REP,G. BURT LANCASTER,132,20,112
+Santa Clara,0008227,State Assembly,,REP,G. BURT LANCASTER,887,122,765
+Santa Clara,0008228,State Assembly,,REP,G. BURT LANCASTER,527,57,470
+Santa Clara,0008230,State Assembly,,REP,G. BURT LANCASTER,844,117,727
+Santa Clara,0008231,State Assembly,,REP,G. BURT LANCASTER,669,98,571
+Santa Clara,0008232,State Assembly,,REP,G. BURT LANCASTER,1282,199,1083
+Santa Clara,0008236,State Assembly,,REP,G. BURT LANCASTER,1271,184,1087
+Santa Clara,0008246,State Assembly,,REP,G. BURT LANCASTER,574,85,489
+Santa Clara,0008254,State Assembly,,REP,G. BURT LANCASTER,500,79,421
+Santa Clara,0008262,State Assembly,,REP,G. BURT LANCASTER,672,81,591
+Santa Clara,0008264,State Assembly,,REP,G. BURT LANCASTER,512,77,435
+Santa Clara,0008401,State Assembly,,REP,G. BURT LANCASTER,467,60,407
+Santa Clara,0008404,State Assembly,,REP,G. BURT LANCASTER,1179,154,1025
+Santa Clara,0008408,State Assembly,,REP,G. BURT LANCASTER,363,53,310
+Santa Clara,0008409,State Assembly,,REP,G. BURT LANCASTER,351,51,300
+Santa Clara,0008414,State Assembly,,REP,G. BURT LANCASTER,118,17,101
+Santa Clara,0008418,State Assembly,,REP,G. BURT LANCASTER,148,12,136
+Santa Clara,0008421,State Assembly,,REP,G. BURT LANCASTER,15,1,14
+Santa Clara,0008430,State Assembly,,REP,G. BURT LANCASTER,951,157,794
+Santa Clara,0008435,State Assembly,,REP,G. BURT LANCASTER,968,109,859
+Santa Clara,0008438,State Assembly,,REP,G. BURT LANCASTER,1107,168,939
+Santa Clara,0008439,State Assembly,,REP,G. BURT LANCASTER,841,126,715
+Santa Clara,0008445,State Assembly,,REP,G. BURT LANCASTER,604,54,550
+Santa Clara,0008456,State Assembly,,REP,G. BURT LANCASTER,1004,110,894
+Santa Clara,0008457,State Assembly,,REP,G. BURT LANCASTER,1109,147,962
+Santa Clara,0008464,State Assembly,,REP,G. BURT LANCASTER,882,143,739
+Santa Clara,0008470,State Assembly,,REP,G. BURT LANCASTER,829,85,744
+Santa Clara,0008472,State Assembly,,REP,G. BURT LANCASTER,880,108,772
+Santa Clara,0008486,State Assembly,,REP,G. BURT LANCASTER,1208,120,1088
+Santa Clara,0008492,State Assembly,,REP,G. BURT LANCASTER,1300,84,1216
+Santa Clara,0008634,State Assembly,,REP,G. BURT LANCASTER,84,17,67
+Santa Clara,0008636,State Assembly,,REP,G. BURT LANCASTER,159,19,140
+Santa Clara,0008801,State Assembly,,REP,G. BURT LANCASTER,562,90,472
+Santa Clara,0008805,State Assembly,,REP,G. BURT LANCASTER,497,53,444
+Santa Clara,0008809,State Assembly,,REP,G. BURT LANCASTER,670,85,585
+Santa Clara,0008812,State Assembly,,REP,G. BURT LANCASTER,348,56,292
+Santa Clara,0008817,State Assembly,,REP,G. BURT LANCASTER,235,22,213
+Santa Clara,0008820,State Assembly,,REP,G. BURT LANCASTER,585,70,515
+Santa Clara,0008822,State Assembly,,REP,G. BURT LANCASTER,552,77,475
+Santa Clara,0002720,State Assembly,,DEM,EVAN LOW,945,33,912
+Santa Clara,0002721,State Assembly,,DEM,EVAN LOW,773,19,754
+Santa Clara,0002723,State Assembly,,DEM,EVAN LOW,1865,35,1830
+Santa Clara,0002724,State Assembly,,DEM,EVAN LOW,1482,52,1430
+Santa Clara,0002725,State Assembly,,DEM,EVAN LOW,1405,50,1355
+Santa Clara,0002726,State Assembly,,DEM,EVAN LOW,902,36,866
+Santa Clara,0002727,State Assembly,,DEM,EVAN LOW,1030,22,1008
+Santa Clara,0002729,State Assembly,,DEM,EVAN LOW,1179,17,1162
+Santa Clara,0002734,State Assembly,,DEM,EVAN LOW,1476,42,1434
+Santa Clara,0002740,State Assembly,,DEM,EVAN LOW,1721,60,1661
+Santa Clara,0002751,State Assembly,,DEM,EVAN LOW,13,0,13
+Santa Clara,0002761,State Assembly,,DEM,EVAN LOW,2,0,2
+Santa Clara,0002808,State Assembly,,DEM,EVAN LOW,57,1,56
+Santa Clara,0002810,State Assembly,,DEM,EVAN LOW,16,0,16
+Santa Clara,0002811,State Assembly,,DEM,EVAN LOW,21,0,21
+Santa Clara,0002813,State Assembly,,DEM,EVAN LOW,132,1,131
+Santa Clara,0002816,State Assembly,,DEM,EVAN LOW,18,0,18
+Santa Clara,0003602,State Assembly,,DEM,EVAN LOW,1564,58,1506
+Santa Clara,0003604,State Assembly,,DEM,EVAN LOW,1849,59,1790
+Santa Clara,0003605,State Assembly,,DEM,EVAN LOW,2139,95,2044
+Santa Clara,0003606,State Assembly,,DEM,EVAN LOW,1726,40,1686
+Santa Clara,0003608,State Assembly,,DEM,EVAN LOW,1870,60,1810
+Santa Clara,0003609,State Assembly,,DEM,EVAN LOW,2599,57,2542
+Santa Clara,0003611,State Assembly,,DEM,EVAN LOW,1788,53,1735
+Santa Clara,0003614,State Assembly,,DEM,EVAN LOW,821,25,796
+Santa Clara,0003624,State Assembly,,DEM,EVAN LOW,2301,63,2238
+Santa Clara,0003635,State Assembly,,DEM,EVAN LOW,0,0,0
+Santa Clara,0003652,State Assembly,,DEM,EVAN LOW,809,55,754
+Santa Clara,0003655,State Assembly,,DEM,EVAN LOW,138,5,133
+Santa Clara,0003670,State Assembly,,DEM,EVAN LOW,96,5,91
+Santa Clara,0003777,State Assembly,,DEM,EVAN LOW,969,24,945
+Santa Clara,0003779,State Assembly,,DEM,EVAN LOW,65,1,64
+Santa Clara,0003782,State Assembly,,DEM,EVAN LOW,181,5,176
+Santa Clara,0003783,State Assembly,,DEM,EVAN LOW,209,4,205
+Santa Clara,0003801,State Assembly,,DEM,EVAN LOW,1045,42,1003
+Santa Clara,0003802,State Assembly,,DEM,EVAN LOW,1737,54,1683
+Santa Clara,0003803,State Assembly,,DEM,EVAN LOW,1466,55,1411
+Santa Clara,0003804,State Assembly,,DEM,EVAN LOW,684,28,656
+Santa Clara,0003810,State Assembly,,DEM,EVAN LOW,1284,70,1214
+Santa Clara,0003811,State Assembly,,DEM,EVAN LOW,1704,65,1639
+Santa Clara,0003814,State Assembly,,DEM,EVAN LOW,1584,65,1519
+Santa Clara,0003820,State Assembly,,DEM,EVAN LOW,1417,56,1361
+Santa Clara,0003821,State Assembly,,DEM,EVAN LOW,637,24,613
+Santa Clara,0003825,State Assembly,,DEM,EVAN LOW,862,32,830
+Santa Clara,0003828,State Assembly,,DEM,EVAN LOW,736,17,719
+Santa Clara,0003835,State Assembly,,DEM,EVAN LOW,824,17,807
+Santa Clara,0003840,State Assembly,,DEM,EVAN LOW,1305,45,1260
+Santa Clara,0003846,State Assembly,,DEM,EVAN LOW,66,1,65
+Santa Clara,0003861,State Assembly,,DEM,EVAN LOW,48,1,47
+Santa Clara,0004665,State Assembly,,DEM,EVAN LOW,19,1,18
+Santa Clara,0004666,State Assembly,,DEM,EVAN LOW,4,0,4
+Santa Clara,0004671,State Assembly,,DEM,EVAN LOW,1036,32,1004
+Santa Clara,0004672,State Assembly,,DEM,EVAN LOW,527,16,511
+Santa Clara,0004674,State Assembly,,DEM,EVAN LOW,891,35,856
+Santa Clara,0004675,State Assembly,,DEM,EVAN LOW,1793,74,1719
+Santa Clara,0004685,State Assembly,,DEM,EVAN LOW,903,27,876
+Santa Clara,0004687,State Assembly,,DEM,EVAN LOW,994,21,973
+Santa Clara,0004688,State Assembly,,DEM,EVAN LOW,1914,61,1853
+Santa Clara,0004691,State Assembly,,DEM,EVAN LOW,1223,40,1183
+Santa Clara,0004696,State Assembly,,DEM,EVAN LOW,773,7,766
+Santa Clara,0004698,State Assembly,,DEM,EVAN LOW,701,11,690
+Santa Clara,0004699,State Assembly,,DEM,EVAN LOW,1036,38,998
+Santa Clara,0004702,State Assembly,,DEM,EVAN LOW,629,21,608
+Santa Clara,0004715,State Assembly,,DEM,EVAN LOW,324,12,312
+Santa Clara,0004733,State Assembly,,DEM,EVAN LOW,22,1,21
+Santa Clara,0005556,State Assembly,,DEM,EVAN LOW,957,66,891
+Santa Clara,0005557,State Assembly,,DEM,EVAN LOW,653,21,632
+Santa Clara,0005567,State Assembly,,DEM,EVAN LOW,352,15,337
+Santa Clara,0005743,State Assembly,,DEM,EVAN LOW,335,19,316
+Santa Clara,0005745,State Assembly,,DEM,EVAN LOW,281,9,272
+Santa Clara,0005747,State Assembly,,DEM,EVAN LOW,579,10,569
+Santa Clara,0005748,State Assembly,,DEM,EVAN LOW,1080,74,1006
+Santa Clara,0005758,State Assembly,,DEM,EVAN LOW,90,1,89
+Santa Clara,0005759,State Assembly,,DEM,EVAN LOW,240,7,233
+Santa Clara,0005762,State Assembly,,DEM,EVAN LOW,158,2,156
+Santa Clara,0005763,State Assembly,,DEM,EVAN LOW,58,4,54
+Santa Clara,0005770,State Assembly,,DEM,EVAN LOW,84,3,81
+Santa Clara,0005775,State Assembly,,DEM,EVAN LOW,207,3,204
+Santa Clara,0005793,State Assembly,,DEM,EVAN LOW,0,0,0
+Santa Clara,0005804,State Assembly,,DEM,EVAN LOW,691,21,670
+Santa Clara,0005810,State Assembly,,DEM,EVAN LOW,233,17,216
+Santa Clara,0005811,State Assembly,,DEM,EVAN LOW,173,9,164
+Santa Clara,0005813,State Assembly,,DEM,EVAN LOW,36,1,35
+Santa Clara,0005814,State Assembly,,DEM,EVAN LOW,121,2,119
+Santa Clara,0005901,State Assembly,,DEM,EVAN LOW,0,0,0
+Santa Clara,0006624,State Assembly,,DEM,EVAN LOW,5,0,5
+Santa Clara,0006625,State Assembly,,DEM,EVAN LOW,5,0,5
+Santa Clara,0006669,State Assembly,,DEM,EVAN LOW,49,0,49
+Santa Clara,0006678,State Assembly,,DEM,EVAN LOW,36,0,36
+Santa Clara,0007001,State Assembly,,DEM,EVAN LOW,1144,68,1076
+Santa Clara,0007005,State Assembly,,DEM,EVAN LOW,1518,88,1430
+Santa Clara,0007011,State Assembly,,DEM,EVAN LOW,251,19,232
+Santa Clara,0007012,State Assembly,,DEM,EVAN LOW,1188,48,1140
+Santa Clara,0007014,State Assembly,,DEM,EVAN LOW,1453,45,1408
+Santa Clara,0007019,State Assembly,,DEM,EVAN LOW,2252,129,2123
+Santa Clara,0007025,State Assembly,,DEM,EVAN LOW,1963,96,1867
+Santa Clara,0007028,State Assembly,,DEM,EVAN LOW,1709,76,1633
+Santa Clara,0007032,State Assembly,,DEM,EVAN LOW,2222,66,2156
+Santa Clara,0007036,State Assembly,,DEM,EVAN LOW,2087,49,2038
+Santa Clara,0007038,State Assembly,,DEM,EVAN LOW,190,5,185
+Santa Clara,0007041,State Assembly,,DEM,EVAN LOW,1872,129,1743
+Santa Clara,0007044,State Assembly,,DEM,EVAN LOW,1110,68,1042
+Santa Clara,0007046,State Assembly,,DEM,EVAN LOW,1899,114,1785
+Santa Clara,0007051,State Assembly,,DEM,EVAN LOW,0,0,0
+Santa Clara,0007059,State Assembly,,DEM,EVAN LOW,313,20,293
+Santa Clara,0007061,State Assembly,,DEM,EVAN LOW,1356,58,1298
+Santa Clara,0007062,State Assembly,,DEM,EVAN LOW,1660,87,1573
+Santa Clara,0007079,State Assembly,,DEM,EVAN LOW,1244,41,1203
+Santa Clara,0007081,State Assembly,,DEM,EVAN LOW,1147,41,1106
+Santa Clara,0007089,State Assembly,,DEM,EVAN LOW,775,18,757
+Santa Clara,0007414,State Assembly,,DEM,EVAN LOW,235,14,221
+Santa Clara,0008001,State Assembly,,DEM,EVAN LOW,180,8,172
+Santa Clara,0008002,State Assembly,,DEM,EVAN LOW,291,12,279
+Santa Clara,0008003,State Assembly,,DEM,EVAN LOW,1728,67,1661
+Santa Clara,0008005,State Assembly,,DEM,EVAN LOW,2601,83,2518
+Santa Clara,0008007,State Assembly,,DEM,EVAN LOW,497,36,461
+Santa Clara,0008011,State Assembly,,DEM,EVAN LOW,286,7,279
+Santa Clara,0008012,State Assembly,,DEM,EVAN LOW,11,1,10
+Santa Clara,0008013,State Assembly,,DEM,EVAN LOW,58,2,56
+Santa Clara,0008016,State Assembly,,DEM,EVAN LOW,2967,192,2775
+Santa Clara,0008017,State Assembly,,DEM,EVAN LOW,1205,84,1121
+Santa Clara,0008028,State Assembly,,DEM,EVAN LOW,230,16,214
+Santa Clara,0008030,State Assembly,,DEM,EVAN LOW,611,36,575
+Santa Clara,0008033,State Assembly,,DEM,EVAN LOW,144,6,138
+Santa Clara,0008034,State Assembly,,DEM,EVAN LOW,160,14,146
+Santa Clara,0008038,State Assembly,,DEM,EVAN LOW,4,0,4
+Santa Clara,0008040,State Assembly,,DEM,EVAN LOW,378,26,352
+Santa Clara,0008047,State Assembly,,DEM,EVAN LOW,1261,47,1214
+Santa Clara,0008049,State Assembly,,DEM,EVAN LOW,31,1,30
+Santa Clara,0008050,State Assembly,,DEM,EVAN LOW,1044,54,990
+Santa Clara,0008053,State Assembly,,DEM,EVAN LOW,1737,76,1661
+Santa Clara,0008054,State Assembly,,DEM,EVAN LOW,1448,49,1399
+Santa Clara,0008055,State Assembly,,DEM,EVAN LOW,206,10,196
+Santa Clara,0008062,State Assembly,,DEM,EVAN LOW,1891,108,1783
+Santa Clara,0008066,State Assembly,,DEM,EVAN LOW,659,41,618
+Santa Clara,0008067,State Assembly,,DEM,EVAN LOW,2016,81,1935
+Santa Clara,0008068,State Assembly,,DEM,EVAN LOW,28,2,26
+Santa Clara,0008072,State Assembly,,DEM,EVAN LOW,417,18,399
+Santa Clara,0008079,State Assembly,,DEM,EVAN LOW,1766,36,1730
+Santa Clara,0008082,State Assembly,,DEM,EVAN LOW,1349,44,1305
+Santa Clara,0008085,State Assembly,,DEM,EVAN LOW,797,17,780
+Santa Clara,0008089,State Assembly,,DEM,EVAN LOW,1863,44,1819
+Santa Clara,0008092,State Assembly,,DEM,EVAN LOW,46,2,44
+Santa Clara,0008093,State Assembly,,DEM,EVAN LOW,29,0,29
+Santa Clara,0008096,State Assembly,,DEM,EVAN LOW,1605,51,1554
+Santa Clara,0008104,State Assembly,,DEM,EVAN LOW,100,1,99
+Santa Clara,0008105,State Assembly,,DEM,EVAN LOW,258,4,254
+Santa Clara,0008117,State Assembly,,DEM,EVAN LOW,1196,27,1169
+Santa Clara,0008128,State Assembly,,DEM,EVAN LOW,0,0,0
+Santa Clara,0008133,State Assembly,,DEM,EVAN LOW,9,0,9
+Santa Clara,0008601,State Assembly,,DEM,EVAN LOW,337,16,321
+Santa Clara,0008603,State Assembly,,DEM,EVAN LOW,1530,72,1458
+Santa Clara,0008605,State Assembly,,DEM,EVAN LOW,1981,92,1889
+Santa Clara,0008609,State Assembly,,DEM,EVAN LOW,0,0,0
+Santa Clara,0008610,State Assembly,,DEM,EVAN LOW,1053,40,1013
+Santa Clara,0008612,State Assembly,,DEM,EVAN LOW,1555,49,1506
+Santa Clara,0008615,State Assembly,,DEM,EVAN LOW,1317,41,1276
+Santa Clara,0008619,State Assembly,,DEM,EVAN LOW,501,17,484
+Santa Clara,0008625,State Assembly,,DEM,EVAN LOW,68,3,65
+Santa Clara,0008627,State Assembly,,DEM,EVAN LOW,864,38,826
+Santa Clara,0008629,State Assembly,,DEM,EVAN LOW,1184,51,1133
+Santa Clara,0008630,State Assembly,,DEM,EVAN LOW,1667,63,1604
+Santa Clara,0008631,State Assembly,,DEM,EVAN LOW,1014,39,975
+Santa Clara,0008645,State Assembly,,DEM,EVAN LOW,1845,60,1785
+Santa Clara,0008648,State Assembly,,DEM,EVAN LOW,1669,48,1621
+Santa Clara,0008650,State Assembly,,DEM,EVAN LOW,230,8,222
+Santa Clara,0008653,State Assembly,,DEM,EVAN LOW,142,4,138
+Santa Clara,0008654,State Assembly,,DEM,EVAN LOW,176,9,167
+Santa Clara,0008655,State Assembly,,DEM,EVAN LOW,0,0,0
+Santa Clara,0008657,State Assembly,,DEM,EVAN LOW,431,9,422
+Santa Clara,0008658,State Assembly,,DEM,EVAN LOW,2198,92,2106
+Santa Clara,0008670,State Assembly,,DEM,EVAN LOW,1431,84,1347
+Santa Clara,0008675,State Assembly,,DEM,EVAN LOW,847,55,792
+Santa Clara,0008676,State Assembly,,DEM,EVAN LOW,1705,75,1630
+Santa Clara,0008680,State Assembly,,DEM,EVAN LOW,1301,35,1266
+Santa Clara,0008683,State Assembly,,DEM,EVAN LOW,2083,75,2008
+Santa Clara,0008687,State Assembly,,DEM,EVAN LOW,1903,82,1821
+Santa Clara,0008697,State Assembly,,DEM,EVAN LOW,2029,77,1952
+Santa Clara,0008828,State Assembly,,DEM,EVAN LOW,448,22,426
+Santa Clara,0008829,State Assembly,,DEM,EVAN LOW,400,19,381
+Santa Clara,0008832,State Assembly,,DEM,EVAN LOW,1180,28,1152
+Santa Clara,0008834,State Assembly,,DEM,EVAN LOW,651,45,606
+Santa Clara,0008857,State Assembly,,DEM,EVAN LOW,933,22,911
+Santa Clara,0008858,State Assembly,,DEM,EVAN LOW,1337,37,1300
+Santa Clara,0008879,State Assembly,,DEM,EVAN LOW,1791,47,1744
+Santa Clara,0008883,State Assembly,,DEM,EVAN LOW,1848,66,1782
+Santa Clara,0008886,State Assembly,,DEM,EVAN LOW,192,2,190
+Santa Clara,0008889,State Assembly,,DEM,EVAN LOW,1414,36,1378
+Santa Clara,0008923,State Assembly,,DEM,EVAN LOW,0,0,0
+Santa Clara,0008924,State Assembly,,DEM,EVAN LOW,11,0,11
+Santa Clara,0002720,State Assembly,,REP,CARLOS RAFAEL CRUZ,434,30,404
+Santa Clara,0002721,State Assembly,,REP,CARLOS RAFAEL CRUZ,412,26,386
+Santa Clara,0002723,State Assembly,,REP,CARLOS RAFAEL CRUZ,877,72,805
+Santa Clara,0002724,State Assembly,,REP,CARLOS RAFAEL CRUZ,662,74,588
+Santa Clara,0002725,State Assembly,,REP,CARLOS RAFAEL CRUZ,612,60,552
+Santa Clara,0002726,State Assembly,,REP,CARLOS RAFAEL CRUZ,412,56,356
+Santa Clara,0002727,State Assembly,,REP,CARLOS RAFAEL CRUZ,487,38,449
+Santa Clara,0002729,State Assembly,,REP,CARLOS RAFAEL CRUZ,446,32,414
+Santa Clara,0002734,State Assembly,,REP,CARLOS RAFAEL CRUZ,684,72,612
+Santa Clara,0002740,State Assembly,,REP,CARLOS RAFAEL CRUZ,738,71,667
+Santa Clara,0002751,State Assembly,,REP,CARLOS RAFAEL CRUZ,4,0,4
+Santa Clara,0002761,State Assembly,,REP,CARLOS RAFAEL CRUZ,2,0,2
+Santa Clara,0002808,State Assembly,,REP,CARLOS RAFAEL CRUZ,17,1,16
+Santa Clara,0002810,State Assembly,,REP,CARLOS RAFAEL CRUZ,1,0,1
+Santa Clara,0002811,State Assembly,,REP,CARLOS RAFAEL CRUZ,12,0,12
+Santa Clara,0002813,State Assembly,,REP,CARLOS RAFAEL CRUZ,90,6,84
+Santa Clara,0002816,State Assembly,,REP,CARLOS RAFAEL CRUZ,3,0,3
+Santa Clara,0003602,State Assembly,,REP,CARLOS RAFAEL CRUZ,569,55,514
+Santa Clara,0003604,State Assembly,,REP,CARLOS RAFAEL CRUZ,660,56,604
+Santa Clara,0003605,State Assembly,,REP,CARLOS RAFAEL CRUZ,747,67,680
+Santa Clara,0003606,State Assembly,,REP,CARLOS RAFAEL CRUZ,585,48,537
+Santa Clara,0003608,State Assembly,,REP,CARLOS RAFAEL CRUZ,655,62,593
+Santa Clara,0003609,State Assembly,,REP,CARLOS RAFAEL CRUZ,951,88,863
+Santa Clara,0003611,State Assembly,,REP,CARLOS RAFAEL CRUZ,697,49,648
+Santa Clara,0003614,State Assembly,,REP,CARLOS RAFAEL CRUZ,388,48,340
+Santa Clara,0003624,State Assembly,,REP,CARLOS RAFAEL CRUZ,800,76,724
+Santa Clara,0003635,State Assembly,,REP,CARLOS RAFAEL CRUZ,0,0,0
+Santa Clara,0003652,State Assembly,,REP,CARLOS RAFAEL CRUZ,349,40,309
+Santa Clara,0003655,State Assembly,,REP,CARLOS RAFAEL CRUZ,56,8,48
+Santa Clara,0003670,State Assembly,,REP,CARLOS RAFAEL CRUZ,19,2,17
+Santa Clara,0003777,State Assembly,,REP,CARLOS RAFAEL CRUZ,511,34,477
+Santa Clara,0003779,State Assembly,,REP,CARLOS RAFAEL CRUZ,48,1,47
+Santa Clara,0003782,State Assembly,,REP,CARLOS RAFAEL CRUZ,153,8,145
+Santa Clara,0003783,State Assembly,,REP,CARLOS RAFAEL CRUZ,136,7,129
+Santa Clara,0003801,State Assembly,,REP,CARLOS RAFAEL CRUZ,413,58,355
+Santa Clara,0003802,State Assembly,,REP,CARLOS RAFAEL CRUZ,543,67,476
+Santa Clara,0003803,State Assembly,,REP,CARLOS RAFAEL CRUZ,500,45,455
+Santa Clara,0003804,State Assembly,,REP,CARLOS RAFAEL CRUZ,247,47,200
+Santa Clara,0003810,State Assembly,,REP,CARLOS RAFAEL CRUZ,433,81,352
+Santa Clara,0003811,State Assembly,,REP,CARLOS RAFAEL CRUZ,632,80,552
+Santa Clara,0003814,State Assembly,,REP,CARLOS RAFAEL CRUZ,614,100,514
+Santa Clara,0003820,State Assembly,,REP,CARLOS RAFAEL CRUZ,451,62,389
+Santa Clara,0003821,State Assembly,,REP,CARLOS RAFAEL CRUZ,191,32,159
+Santa Clara,0003825,State Assembly,,REP,CARLOS RAFAEL CRUZ,317,60,257
+Santa Clara,0003828,State Assembly,,REP,CARLOS RAFAEL CRUZ,282,37,245
+Santa Clara,0003835,State Assembly,,REP,CARLOS RAFAEL CRUZ,360,30,330
+Santa Clara,0003840,State Assembly,,REP,CARLOS RAFAEL CRUZ,543,88,455
+Santa Clara,0003846,State Assembly,,REP,CARLOS RAFAEL CRUZ,31,2,29
+Santa Clara,0003861,State Assembly,,REP,CARLOS RAFAEL CRUZ,15,2,13
+Santa Clara,0004665,State Assembly,,REP,CARLOS RAFAEL CRUZ,7,0,7
+Santa Clara,0004666,State Assembly,,REP,CARLOS RAFAEL CRUZ,2,0,2
+Santa Clara,0004671,State Assembly,,REP,CARLOS RAFAEL CRUZ,477,56,421
+Santa Clara,0004672,State Assembly,,REP,CARLOS RAFAEL CRUZ,309,25,284
+Santa Clara,0004674,State Assembly,,REP,CARLOS RAFAEL CRUZ,420,43,377
+Santa Clara,0004675,State Assembly,,REP,CARLOS RAFAEL CRUZ,821,110,711
+Santa Clara,0004685,State Assembly,,REP,CARLOS RAFAEL CRUZ,476,33,443
+Santa Clara,0004687,State Assembly,,REP,CARLOS RAFAEL CRUZ,471,40,431
+Santa Clara,0004688,State Assembly,,REP,CARLOS RAFAEL CRUZ,834,59,775
+Santa Clara,0004691,State Assembly,,REP,CARLOS RAFAEL CRUZ,632,56,576
+Santa Clara,0004696,State Assembly,,REP,CARLOS RAFAEL CRUZ,316,31,285
+Santa Clara,0004698,State Assembly,,REP,CARLOS RAFAEL CRUZ,268,30,238
+Santa Clara,0004699,State Assembly,,REP,CARLOS RAFAEL CRUZ,380,19,361
+Santa Clara,0004702,State Assembly,,REP,CARLOS RAFAEL CRUZ,232,26,206
+Santa Clara,0004715,State Assembly,,REP,CARLOS RAFAEL CRUZ,149,11,138
+Santa Clara,0004733,State Assembly,,REP,CARLOS RAFAEL CRUZ,19,4,15
+Santa Clara,0005556,State Assembly,,REP,CARLOS RAFAEL CRUZ,245,53,192
+Santa Clara,0005557,State Assembly,,REP,CARLOS RAFAEL CRUZ,180,26,154
+Santa Clara,0005567,State Assembly,,REP,CARLOS RAFAEL CRUZ,113,20,93
+Santa Clara,0005743,State Assembly,,REP,CARLOS RAFAEL CRUZ,148,20,128
+Santa Clara,0005745,State Assembly,,REP,CARLOS RAFAEL CRUZ,129,16,113
+Santa Clara,0005747,State Assembly,,REP,CARLOS RAFAEL CRUZ,239,18,221
+Santa Clara,0005748,State Assembly,,REP,CARLOS RAFAEL CRUZ,475,83,392
+Santa Clara,0005758,State Assembly,,REP,CARLOS RAFAEL CRUZ,58,0,58
+Santa Clara,0005759,State Assembly,,REP,CARLOS RAFAEL CRUZ,146,13,133
+Santa Clara,0005762,State Assembly,,REP,CARLOS RAFAEL CRUZ,89,4,85
+Santa Clara,0005763,State Assembly,,REP,CARLOS RAFAEL CRUZ,12,2,10
+Santa Clara,0005770,State Assembly,,REP,CARLOS RAFAEL CRUZ,68,0,68
+Santa Clara,0005775,State Assembly,,REP,CARLOS RAFAEL CRUZ,87,6,81
+Santa Clara,0005793,State Assembly,,REP,CARLOS RAFAEL CRUZ,0,0,0
+Santa Clara,0005804,State Assembly,,REP,CARLOS RAFAEL CRUZ,338,36,302
+Santa Clara,0005810,State Assembly,,REP,CARLOS RAFAEL CRUZ,110,9,101
+Santa Clara,0005811,State Assembly,,REP,CARLOS RAFAEL CRUZ,84,6,78
+Santa Clara,0005813,State Assembly,,REP,CARLOS RAFAEL CRUZ,12,1,11
+Santa Clara,0005814,State Assembly,,REP,CARLOS RAFAEL CRUZ,95,15,80
+Santa Clara,0005901,State Assembly,,REP,CARLOS RAFAEL CRUZ,0,0,0
+Santa Clara,0006624,State Assembly,,REP,CARLOS RAFAEL CRUZ,1,0,1
+Santa Clara,0006625,State Assembly,,REP,CARLOS RAFAEL CRUZ,0,0,0
+Santa Clara,0006669,State Assembly,,REP,CARLOS RAFAEL CRUZ,21,1,20
+Santa Clara,0006678,State Assembly,,REP,CARLOS RAFAEL CRUZ,13,1,12
+Santa Clara,0007001,State Assembly,,REP,CARLOS RAFAEL CRUZ,418,68,350
+Santa Clara,0007005,State Assembly,,REP,CARLOS RAFAEL CRUZ,517,69,448
+Santa Clara,0007011,State Assembly,,REP,CARLOS RAFAEL CRUZ,31,7,24
+Santa Clara,0007012,State Assembly,,REP,CARLOS RAFAEL CRUZ,456,49,407
+Santa Clara,0007014,State Assembly,,REP,CARLOS RAFAEL CRUZ,514,48,466
+Santa Clara,0007019,State Assembly,,REP,CARLOS RAFAEL CRUZ,771,106,665
+Santa Clara,0007025,State Assembly,,REP,CARLOS RAFAEL CRUZ,612,82,530
+Santa Clara,0007028,State Assembly,,REP,CARLOS RAFAEL CRUZ,769,74,695
+Santa Clara,0007032,State Assembly,,REP,CARLOS RAFAEL CRUZ,1074,105,969
+Santa Clara,0007036,State Assembly,,REP,CARLOS RAFAEL CRUZ,943,71,872
+Santa Clara,0007038,State Assembly,,REP,CARLOS RAFAEL CRUZ,86,9,77
+Santa Clara,0007041,State Assembly,,REP,CARLOS RAFAEL CRUZ,727,112,615
+Santa Clara,0007044,State Assembly,,REP,CARLOS RAFAEL CRUZ,489,58,431
+Santa Clara,0007046,State Assembly,,REP,CARLOS RAFAEL CRUZ,655,79,576
+Santa Clara,0007051,State Assembly,,REP,CARLOS RAFAEL CRUZ,0,0,0
+Santa Clara,0007059,State Assembly,,REP,CARLOS RAFAEL CRUZ,102,19,83
+Santa Clara,0007061,State Assembly,,REP,CARLOS RAFAEL CRUZ,461,37,424
+Santa Clara,0007062,State Assembly,,REP,CARLOS RAFAEL CRUZ,639,73,566
+Santa Clara,0007079,State Assembly,,REP,CARLOS RAFAEL CRUZ,516,62,454
+Santa Clara,0007081,State Assembly,,REP,CARLOS RAFAEL CRUZ,463,52,411
+Santa Clara,0007089,State Assembly,,REP,CARLOS RAFAEL CRUZ,356,29,327
+Santa Clara,0007414,State Assembly,,REP,CARLOS RAFAEL CRUZ,72,4,68
+Santa Clara,0008001,State Assembly,,REP,CARLOS RAFAEL CRUZ,46,2,44
+Santa Clara,0008002,State Assembly,,REP,CARLOS RAFAEL CRUZ,66,11,55
+Santa Clara,0008003,State Assembly,,REP,CARLOS RAFAEL CRUZ,617,78,539
+Santa Clara,0008005,State Assembly,,REP,CARLOS RAFAEL CRUZ,757,83,674
+Santa Clara,0008007,State Assembly,,REP,CARLOS RAFAEL CRUZ,112,19,93
+Santa Clara,0008011,State Assembly,,REP,CARLOS RAFAEL CRUZ,122,14,108
+Santa Clara,0008012,State Assembly,,REP,CARLOS RAFAEL CRUZ,5,0,5
+Santa Clara,0008013,State Assembly,,REP,CARLOS RAFAEL CRUZ,16,3,13
+Santa Clara,0008016,State Assembly,,REP,CARLOS RAFAEL CRUZ,626,98,528
+Santa Clara,0008017,State Assembly,,REP,CARLOS RAFAEL CRUZ,282,41,241
+Santa Clara,0008028,State Assembly,,REP,CARLOS RAFAEL CRUZ,51,6,45
+Santa Clara,0008030,State Assembly,,REP,CARLOS RAFAEL CRUZ,254,41,213
+Santa Clara,0008033,State Assembly,,REP,CARLOS RAFAEL CRUZ,62,4,58
+Santa Clara,0008034,State Assembly,,REP,CARLOS RAFAEL CRUZ,27,6,21
+Santa Clara,0008038,State Assembly,,REP,CARLOS RAFAEL CRUZ,0,0,0
+Santa Clara,0008040,State Assembly,,REP,CARLOS RAFAEL CRUZ,96,20,76
+Santa Clara,0008047,State Assembly,,REP,CARLOS RAFAEL CRUZ,473,75,398
+Santa Clara,0008049,State Assembly,,REP,CARLOS RAFAEL CRUZ,8,1,7
+Santa Clara,0008050,State Assembly,,REP,CARLOS RAFAEL CRUZ,301,39,262
+Santa Clara,0008053,State Assembly,,REP,CARLOS RAFAEL CRUZ,606,72,534
+Santa Clara,0008054,State Assembly,,REP,CARLOS RAFAEL CRUZ,532,58,474
+Santa Clara,0008055,State Assembly,,REP,CARLOS RAFAEL CRUZ,54,5,49
+Santa Clara,0008062,State Assembly,,REP,CARLOS RAFAEL CRUZ,540,72,468
+Santa Clara,0008066,State Assembly,,REP,CARLOS RAFAEL CRUZ,215,32,183
+Santa Clara,0008067,State Assembly,,REP,CARLOS RAFAEL CRUZ,575,77,498
+Santa Clara,0008068,State Assembly,,REP,CARLOS RAFAEL CRUZ,10,3,7
+Santa Clara,0008072,State Assembly,,REP,CARLOS RAFAEL CRUZ,111,11,100
+Santa Clara,0008079,State Assembly,,REP,CARLOS RAFAEL CRUZ,628,73,555
+Santa Clara,0008082,State Assembly,,REP,CARLOS RAFAEL CRUZ,406,35,371
+Santa Clara,0008085,State Assembly,,REP,CARLOS RAFAEL CRUZ,390,35,355
+Santa Clara,0008089,State Assembly,,REP,CARLOS RAFAEL CRUZ,651,70,581
+Santa Clara,0008092,State Assembly,,REP,CARLOS RAFAEL CRUZ,25,2,23
+Santa Clara,0008093,State Assembly,,REP,CARLOS RAFAEL CRUZ,18,1,17
+Santa Clara,0008096,State Assembly,,REP,CARLOS RAFAEL CRUZ,728,79,649
+Santa Clara,0008104,State Assembly,,REP,CARLOS RAFAEL CRUZ,36,2,34
+Santa Clara,0008105,State Assembly,,REP,CARLOS RAFAEL CRUZ,121,5,116
+Santa Clara,0008117,State Assembly,,REP,CARLOS RAFAEL CRUZ,425,63,362
+Santa Clara,0008128,State Assembly,,REP,CARLOS RAFAEL CRUZ,0,0,0
+Santa Clara,0008133,State Assembly,,REP,CARLOS RAFAEL CRUZ,4,0,4
+Santa Clara,0008601,State Assembly,,REP,CARLOS RAFAEL CRUZ,123,21,102
+Santa Clara,0008603,State Assembly,,REP,CARLOS RAFAEL CRUZ,629,62,567
+Santa Clara,0008605,State Assembly,,REP,CARLOS RAFAEL CRUZ,848,121,727
+Santa Clara,0008609,State Assembly,,REP,CARLOS RAFAEL CRUZ,1,1,0
+Santa Clara,0008610,State Assembly,,REP,CARLOS RAFAEL CRUZ,372,55,317
+Santa Clara,0008612,State Assembly,,REP,CARLOS RAFAEL CRUZ,572,69,503
+Santa Clara,0008615,State Assembly,,REP,CARLOS RAFAEL CRUZ,641,57,584
+Santa Clara,0008619,State Assembly,,REP,CARLOS RAFAEL CRUZ,158,11,147
+Santa Clara,0008625,State Assembly,,REP,CARLOS RAFAEL CRUZ,15,3,12
+Santa Clara,0008627,State Assembly,,REP,CARLOS RAFAEL CRUZ,281,44,237
+Santa Clara,0008629,State Assembly,,REP,CARLOS RAFAEL CRUZ,477,61,416
+Santa Clara,0008630,State Assembly,,REP,CARLOS RAFAEL CRUZ,669,97,572
+Santa Clara,0008631,State Assembly,,REP,CARLOS RAFAEL CRUZ,374,44,330
+Santa Clara,0008645,State Assembly,,REP,CARLOS RAFAEL CRUZ,959,103,856
+Santa Clara,0008648,State Assembly,,REP,CARLOS RAFAEL CRUZ,785,80,705
+Santa Clara,0008650,State Assembly,,REP,CARLOS RAFAEL CRUZ,117,22,95
+Santa Clara,0008653,State Assembly,,REP,CARLOS RAFAEL CRUZ,73,6,67
+Santa Clara,0008654,State Assembly,,REP,CARLOS RAFAEL CRUZ,68,9,59
+Santa Clara,0008655,State Assembly,,REP,CARLOS RAFAEL CRUZ,0,0,0
+Santa Clara,0008657,State Assembly,,REP,CARLOS RAFAEL CRUZ,176,33,143
+Santa Clara,0008658,State Assembly,,REP,CARLOS RAFAEL CRUZ,912,97,815
+Santa Clara,0008670,State Assembly,,REP,CARLOS RAFAEL CRUZ,571,84,487
+Santa Clara,0008675,State Assembly,,REP,CARLOS RAFAEL CRUZ,355,57,298
+Santa Clara,0008676,State Assembly,,REP,CARLOS RAFAEL CRUZ,700,76,624
+Santa Clara,0008680,State Assembly,,REP,CARLOS RAFAEL CRUZ,520,55,465
+Santa Clara,0008683,State Assembly,,REP,CARLOS RAFAEL CRUZ,906,95,811
+Santa Clara,0008687,State Assembly,,REP,CARLOS RAFAEL CRUZ,846,105,741
+Santa Clara,0008697,State Assembly,,REP,CARLOS RAFAEL CRUZ,844,103,741
+Santa Clara,0008828,State Assembly,,REP,CARLOS RAFAEL CRUZ,176,23,153
+Santa Clara,0008829,State Assembly,,REP,CARLOS RAFAEL CRUZ,152,18,134
+Santa Clara,0008832,State Assembly,,REP,CARLOS RAFAEL CRUZ,549,62,487
+Santa Clara,0008834,State Assembly,,REP,CARLOS RAFAEL CRUZ,268,36,232
+Santa Clara,0008857,State Assembly,,REP,CARLOS RAFAEL CRUZ,473,40,433
+Santa Clara,0008858,State Assembly,,REP,CARLOS RAFAEL CRUZ,657,63,594
+Santa Clara,0008879,State Assembly,,REP,CARLOS RAFAEL CRUZ,875,93,782
+Santa Clara,0008883,State Assembly,,REP,CARLOS RAFAEL CRUZ,954,132,822
+Santa Clara,0008886,State Assembly,,REP,CARLOS RAFAEL CRUZ,99,2,97
+Santa Clara,0008889,State Assembly,,REP,CARLOS RAFAEL CRUZ,843,82,761
+Santa Clara,0008923,State Assembly,,REP,CARLOS RAFAEL CRUZ,3,0,3
+Santa Clara,0008924,State Assembly,,REP,CARLOS RAFAEL CRUZ,3,0,3
+Santa Clara,0005742,State Assembly,,DEM,MARK STONE,8,0,8
+Santa Clara,0005756,State Assembly,,DEM,MARK STONE,61,2,59
+Santa Clara,0005785,State Assembly,,DEM,MARK STONE,0,0,0
+Santa Clara,0005795,State Assembly,,DEM,MARK STONE,2,0,2
+Santa Clara,0005854,State Assembly,,DEM,MARK STONE,0,0,0
+Santa Clara,0005894,State Assembly,,DEM,MARK STONE,131,5,126
+Santa Clara,0005896,State Assembly,,DEM,MARK STONE,3,0,3
+Santa Clara,0005902,State Assembly,,DEM,MARK STONE,231,7,224
+Santa Clara,0005903,State Assembly,,DEM,MARK STONE,318,11,307
+Santa Clara,0005907,State Assembly,,DEM,MARK STONE,5,0,5
+Santa Clara,0005912,State Assembly,,DEM,MARK STONE,91,2,89
+Santa Clara,0005914,State Assembly,,DEM,MARK STONE,552,19,533
+Santa Clara,0005916,State Assembly,,DEM,MARK STONE,36,2,34
+Santa Clara,0005919,State Assembly,,DEM,MARK STONE,177,11,166
+Santa Clara,0005922,State Assembly,,DEM,MARK STONE,271,11,260
+Santa Clara,0005927,State Assembly,,DEM,MARK STONE,1,0,1
+Santa Clara,0005931,State Assembly,,DEM,MARK STONE,73,3,70
+Santa Clara,0005940,State Assembly,,DEM,MARK STONE,27,3,24
+Santa Clara,0005988,State Assembly,,DEM,MARK STONE,0,0,0
+Santa Clara,0006023,State Assembly,,DEM,MARK STONE,10,0,10
+Santa Clara,0006035,State Assembly,,DEM,MARK STONE,0,0,0
+Santa Clara,0006036,State Assembly,,DEM,MARK STONE,0,0,0
+Santa Clara,0007235,State Assembly,,DEM,MARK STONE,1533,122,1411
+Santa Clara,0007237,State Assembly,,DEM,MARK STONE,1470,111,1359
+Santa Clara,0007245,State Assembly,,DEM,MARK STONE,143,3,140
+Santa Clara,0007246,State Assembly,,DEM,MARK STONE,912,30,882
+Santa Clara,0007248,State Assembly,,DEM,MARK STONE,1563,81,1482
+Santa Clara,0007252,State Assembly,,DEM,MARK STONE,1976,132,1844
+Santa Clara,0007261,State Assembly,,DEM,MARK STONE,1283,73,1210
+Santa Clara,0007264,State Assembly,,DEM,MARK STONE,1463,81,1382
+Santa Clara,0007271,State Assembly,,DEM,MARK STONE,1811,82,1729
+Santa Clara,0007273,State Assembly,,DEM,MARK STONE,2072,100,1972
+Santa Clara,0007282,State Assembly,,DEM,MARK STONE,1186,60,1126
+Santa Clara,0007295,State Assembly,,DEM,MARK STONE,1110,50,1060
+Santa Clara,0007298,State Assembly,,DEM,MARK STONE,739,17,722
+Santa Clara,0007299,State Assembly,,DEM,MARK STONE,605,29,576
+Santa Clara,0008838,State Assembly,,DEM,MARK STONE,159,9,150
+Santa Clara,0008839,State Assembly,,DEM,MARK STONE,1865,105,1760
+Santa Clara,0008844,State Assembly,,DEM,MARK STONE,1848,75,1773
+Santa Clara,0008848,State Assembly,,DEM,MARK STONE,1006,45,961
+Santa Clara,0008853,State Assembly,,DEM,MARK STONE,1314,58,1256
+Santa Clara,0008862,State Assembly,,DEM,MARK STONE,1317,40,1277
+Santa Clara,0008868,State Assembly,,DEM,MARK STONE,75,2,73
+Santa Clara,0008873,State Assembly,,DEM,MARK STONE,579,19,560
+Santa Clara,0008874,State Assembly,,DEM,MARK STONE,12,0,12
+Santa Clara,0008885,State Assembly,,DEM,MARK STONE,1632,54,1578
+Santa Clara,0008898,State Assembly,,DEM,MARK STONE,1517,46,1471
+Santa Clara,0008903,State Assembly,,DEM,MARK STONE,1774,44,1730
+Santa Clara,0008915,State Assembly,,DEM,MARK STONE,7,1,6
+Santa Clara,0008916,State Assembly,,DEM,MARK STONE,5,0,5
+Santa Clara,0008920,State Assembly,,DEM,MARK STONE,0,0,0
+Santa Clara,0005742,State Assembly,,REP,SHOMIR BANERJEE,9,0,9
+Santa Clara,0005756,State Assembly,,REP,SHOMIR BANERJEE,23,1,22
+Santa Clara,0005785,State Assembly,,REP,SHOMIR BANERJEE,0,0,0
+Santa Clara,0005795,State Assembly,,REP,SHOMIR BANERJEE,0,0,0
+Santa Clara,0005854,State Assembly,,REP,SHOMIR BANERJEE,2,0,2
+Santa Clara,0005894,State Assembly,,REP,SHOMIR BANERJEE,83,2,81
+Santa Clara,0005896,State Assembly,,REP,SHOMIR BANERJEE,0,0,0
+Santa Clara,0005902,State Assembly,,REP,SHOMIR BANERJEE,194,17,177
+Santa Clara,0005903,State Assembly,,REP,SHOMIR BANERJEE,222,36,186
+Santa Clara,0005907,State Assembly,,REP,SHOMIR BANERJEE,3,0,3
+Santa Clara,0005912,State Assembly,,REP,SHOMIR BANERJEE,60,13,47
+Santa Clara,0005914,State Assembly,,REP,SHOMIR BANERJEE,498,62,436
+Santa Clara,0005916,State Assembly,,REP,SHOMIR BANERJEE,39,4,35
+Santa Clara,0005919,State Assembly,,REP,SHOMIR BANERJEE,147,18,129
+Santa Clara,0005922,State Assembly,,REP,SHOMIR BANERJEE,222,36,186
+Santa Clara,0005927,State Assembly,,REP,SHOMIR BANERJEE,0,0,0
+Santa Clara,0005931,State Assembly,,REP,SHOMIR BANERJEE,58,2,56
+Santa Clara,0005940,State Assembly,,REP,SHOMIR BANERJEE,22,5,17
+Santa Clara,0005988,State Assembly,,REP,SHOMIR BANERJEE,0,0,0
+Santa Clara,0006023,State Assembly,,REP,SHOMIR BANERJEE,2,0,2
+Santa Clara,0006035,State Assembly,,REP,SHOMIR BANERJEE,0,0,0
+Santa Clara,0006036,State Assembly,,REP,SHOMIR BANERJEE,0,0,0
+Santa Clara,0007235,State Assembly,,REP,SHOMIR BANERJEE,458,85,373
+Santa Clara,0007237,State Assembly,,REP,SHOMIR BANERJEE,637,94,543
+Santa Clara,0007245,State Assembly,,REP,SHOMIR BANERJEE,107,10,97
+Santa Clara,0007246,State Assembly,,REP,SHOMIR BANERJEE,366,42,324
+Santa Clara,0007248,State Assembly,,REP,SHOMIR BANERJEE,589,86,503
+Santa Clara,0007252,State Assembly,,REP,SHOMIR BANERJEE,733,84,649
+Santa Clara,0007261,State Assembly,,REP,SHOMIR BANERJEE,580,92,488
+Santa Clara,0007264,State Assembly,,REP,SHOMIR BANERJEE,638,104,534
+Santa Clara,0007271,State Assembly,,REP,SHOMIR BANERJEE,776,75,701
+Santa Clara,0007273,State Assembly,,REP,SHOMIR BANERJEE,931,98,833
+Santa Clara,0007282,State Assembly,,REP,SHOMIR BANERJEE,537,53,484
+Santa Clara,0007295,State Assembly,,REP,SHOMIR BANERJEE,523,53,470
+Santa Clara,0007298,State Assembly,,REP,SHOMIR BANERJEE,390,61,329
+Santa Clara,0007299,State Assembly,,REP,SHOMIR BANERJEE,295,34,261
+Santa Clara,0008838,State Assembly,,REP,SHOMIR BANERJEE,68,10,58
+Santa Clara,0008839,State Assembly,,REP,SHOMIR BANERJEE,685,96,589
+Santa Clara,0008844,State Assembly,,REP,SHOMIR BANERJEE,937,118,819
+Santa Clara,0008848,State Assembly,,REP,SHOMIR BANERJEE,439,62,377
+Santa Clara,0008853,State Assembly,,REP,SHOMIR BANERJEE,572,66,506
+Santa Clara,0008862,State Assembly,,REP,SHOMIR BANERJEE,718,87,631
+Santa Clara,0008868,State Assembly,,REP,SHOMIR BANERJEE,42,6,36
+Santa Clara,0008873,State Assembly,,REP,SHOMIR BANERJEE,288,34,254
+Santa Clara,0008874,State Assembly,,REP,SHOMIR BANERJEE,7,0,7
+Santa Clara,0008885,State Assembly,,REP,SHOMIR BANERJEE,909,87,822
+Santa Clara,0008898,State Assembly,,REP,SHOMIR BANERJEE,770,49,721
+Santa Clara,0008903,State Assembly,,REP,SHOMIR BANERJEE,991,78,913
+Santa Clara,0008915,State Assembly,,REP,SHOMIR BANERJEE,7,0,7
+Santa Clara,0008916,State Assembly,,REP,SHOMIR BANERJEE,9,0,9
+Santa Clara,0008920,State Assembly,,REP,SHOMIR BANERJEE,1,0,1
+Santa Clara,0004801,State Assembly,,DEM,ROBERT RIVAS,837,58,779
+Santa Clara,0004806,State Assembly,,DEM,ROBERT RIVAS,1545,67,1478
+Santa Clara,0004811,State Assembly,,DEM,ROBERT RIVAS,885,48,837
+Santa Clara,0004826,State Assembly,,DEM,ROBERT RIVAS,798,40,758
+Santa Clara,0004827,State Assembly,,DEM,ROBERT RIVAS,1768,80,1688
+Santa Clara,0004833,State Assembly,,DEM,ROBERT RIVAS,1111,49,1062
+Santa Clara,0004851,State Assembly,,DEM,ROBERT RIVAS,587,19,568
+Santa Clara,0004853,State Assembly,,DEM,ROBERT RIVAS,1110,35,1075
+Santa Clara,0004858,State Assembly,,DEM,ROBERT RIVAS,1539,96,1443
+Santa Clara,0004876,State Assembly,,DEM,ROBERT RIVAS,1863,85,1778
+Santa Clara,0004881,State Assembly,,DEM,ROBERT RIVAS,2245,77,2168
+Santa Clara,0004941,State Assembly,,DEM,ROBERT RIVAS,1659,110,1549
+Santa Clara,0004942,State Assembly,,DEM,ROBERT RIVAS,1178,62,1116
+Santa Clara,0004943,State Assembly,,DEM,ROBERT RIVAS,69,5,64
+Santa Clara,0004944,State Assembly,,DEM,ROBERT RIVAS,580,73,507
+Santa Clara,0004945,State Assembly,,DEM,ROBERT RIVAS,852,69,783
+Santa Clara,0004946,State Assembly,,DEM,ROBERT RIVAS,1821,147,1674
+Santa Clara,0004949,State Assembly,,DEM,ROBERT RIVAS,1380,66,1314
+Santa Clara,0004950,State Assembly,,DEM,ROBERT RIVAS,1108,44,1064
+Santa Clara,0004954,State Assembly,,DEM,ROBERT RIVAS,1148,72,1076
+Santa Clara,0004956,State Assembly,,DEM,ROBERT RIVAS,153,16,137
+Santa Clara,0004958,State Assembly,,DEM,ROBERT RIVAS,974,86,888
+Santa Clara,0004965,State Assembly,,DEM,ROBERT RIVAS,1605,93,1512
+Santa Clara,0004969,State Assembly,,DEM,ROBERT RIVAS,1423,85,1338
+Santa Clara,0004971,State Assembly,,DEM,ROBERT RIVAS,538,17,521
+Santa Clara,0004973,State Assembly,,DEM,ROBERT RIVAS,1225,41,1184
+Santa Clara,0004974,State Assembly,,DEM,ROBERT RIVAS,700,53,647
+Santa Clara,0005906,State Assembly,,DEM,ROBERT RIVAS,248,17,231
+Santa Clara,0005911,State Assembly,,DEM,ROBERT RIVAS,969,67,902
+Santa Clara,0005915,State Assembly,,DEM,ROBERT RIVAS,465,14,451
+Santa Clara,0005917,State Assembly,,DEM,ROBERT RIVAS,131,3,128
+Santa Clara,0005929,State Assembly,,DEM,ROBERT RIVAS,59,8,51
+Santa Clara,0005936,State Assembly,,DEM,ROBERT RIVAS,256,17,239
+Santa Clara,0005947,State Assembly,,DEM,ROBERT RIVAS,204,3,201
+Santa Clara,0005949,State Assembly,,DEM,ROBERT RIVAS,312,19,293
+Santa Clara,0005950,State Assembly,,DEM,ROBERT RIVAS,77,6,71
+Santa Clara,0005951,State Assembly,,DEM,ROBERT RIVAS,5,0,5
+Santa Clara,0005955,State Assembly,,DEM,ROBERT RIVAS,553,28,525
+Santa Clara,0005956,State Assembly,,DEM,ROBERT RIVAS,522,12,510
+Santa Clara,0005957,State Assembly,,DEM,ROBERT RIVAS,51,2,49
+Santa Clara,0005958,State Assembly,,DEM,ROBERT RIVAS,425,22,403
+Santa Clara,0005959,State Assembly,,DEM,ROBERT RIVAS,31,0,31
+Santa Clara,0005965,State Assembly,,DEM,ROBERT RIVAS,607,38,569
+Santa Clara,0005966,State Assembly,,DEM,ROBERT RIVAS,104,3,101
+Santa Clara,0005975,State Assembly,,DEM,ROBERT RIVAS,27,0,27
+Santa Clara,0006031,State Assembly,,DEM,ROBERT RIVAS,19,1,18
+Santa Clara,0006048,State Assembly,,DEM,ROBERT RIVAS,15,0,15
+Santa Clara,0004801,State Assembly,,REP,GREGORY SWETT,362,55,307
+Santa Clara,0004806,State Assembly,,REP,GREGORY SWETT,1018,128,890
+Santa Clara,0004811,State Assembly,,REP,GREGORY SWETT,628,62,566
+Santa Clara,0004826,State Assembly,,REP,GREGORY SWETT,498,56,442
+Santa Clara,0004827,State Assembly,,REP,GREGORY SWETT,805,96,709
+Santa Clara,0004833,State Assembly,,REP,GREGORY SWETT,614,72,542
+Santa Clara,0004851,State Assembly,,REP,GREGORY SWETT,392,55,337
+Santa Clara,0004853,State Assembly,,REP,GREGORY SWETT,684,70,614
+Santa Clara,0004858,State Assembly,,REP,GREGORY SWETT,837,136,701
+Santa Clara,0004876,State Assembly,,REP,GREGORY SWETT,1260,132,1128
+Santa Clara,0004881,State Assembly,,REP,GREGORY SWETT,1540,149,1391
+Santa Clara,0004941,State Assembly,,REP,GREGORY SWETT,712,89,623
+Santa Clara,0004942,State Assembly,,REP,GREGORY SWETT,639,75,564
+Santa Clara,0004943,State Assembly,,REP,GREGORY SWETT,21,3,18
+Santa Clara,0004944,State Assembly,,REP,GREGORY SWETT,174,36,138
+Santa Clara,0004945,State Assembly,,REP,GREGORY SWETT,327,48,279
+Santa Clara,0004946,State Assembly,,REP,GREGORY SWETT,789,100,689
+Santa Clara,0004949,State Assembly,,REP,GREGORY SWETT,838,107,731
+Santa Clara,0004950,State Assembly,,REP,GREGORY SWETT,817,130,687
+Santa Clara,0004954,State Assembly,,REP,GREGORY SWETT,443,51,392
+Santa Clara,0004956,State Assembly,,REP,GREGORY SWETT,47,8,39
+Santa Clara,0004958,State Assembly,,REP,GREGORY SWETT,223,48,175
+Santa Clara,0004965,State Assembly,,REP,GREGORY SWETT,973,103,870
+Santa Clara,0004969,State Assembly,,REP,GREGORY SWETT,402,52,350
+Santa Clara,0004971,State Assembly,,REP,GREGORY SWETT,250,33,217
+Santa Clara,0004973,State Assembly,,REP,GREGORY SWETT,882,104,778
+Santa Clara,0004974,State Assembly,,REP,GREGORY SWETT,182,31,151
+Santa Clara,0005906,State Assembly,,REP,GREGORY SWETT,125,16,109
+Santa Clara,0005911,State Assembly,,REP,GREGORY SWETT,701,108,593
+Santa Clara,0005915,State Assembly,,REP,GREGORY SWETT,405,43,362
+Santa Clara,0005917,State Assembly,,REP,GREGORY SWETT,113,17,96
+Santa Clara,0005929,State Assembly,,REP,GREGORY SWETT,65,6,59
+Santa Clara,0005936,State Assembly,,REP,GREGORY SWETT,134,16,118
+Santa Clara,0005947,State Assembly,,REP,GREGORY SWETT,272,17,255
+Santa Clara,0005949,State Assembly,,REP,GREGORY SWETT,186,28,158
+Santa Clara,0005950,State Assembly,,REP,GREGORY SWETT,53,7,46
+Santa Clara,0005951,State Assembly,,REP,GREGORY SWETT,0,0,0
+Santa Clara,0005955,State Assembly,,REP,GREGORY SWETT,533,69,464
+Santa Clara,0005956,State Assembly,,REP,GREGORY SWETT,481,39,442
+Santa Clara,0005957,State Assembly,,REP,GREGORY SWETT,64,7,57
+Santa Clara,0005958,State Assembly,,REP,GREGORY SWETT,318,49,269
+Santa Clara,0005959,State Assembly,,REP,GREGORY SWETT,45,2,43
+Santa Clara,0005965,State Assembly,,REP,GREGORY SWETT,421,51,370
+Santa Clara,0005966,State Assembly,,REP,GREGORY SWETT,72,10,62
+Santa Clara,0005975,State Assembly,,REP,GREGORY SWETT,6,3,3
+Santa Clara,0006031,State Assembly,,REP,GREGORY SWETT,9,1,8
+Santa Clara,0006048,State Assembly,,REP,GREGORY SWETT,5,0,5


### PR DESCRIPTION
Fix tests 2014 madera primary.

 Adds a missing candidate with "Unknown" catchall precinct because this candidate was not mentioned in the [Statement of the Vote](https://votemadera.com/wp-content/uploads/2017/12/SOV-JUNE-2014.pdf).