### PR TITLE
Fix tests 2014 Merced primary

### DIFF
--- a/2014/20140603__ca__primary__merced__precinct.csv
+++ b/2014/20140603__ca__primary__merced__precinct.csv
@@ -7932,3 +7932,4 @@ Merced,99,U.S. House,16,DEM,Job Melton,5
 Merced,99,U.S. House,16,REP,Johnny Tacherra,34
 Merced,99,U.S. House,16,REP,Mel Levey,5
 Merced,99,U.S. House,16,REP,Steve Crass,42
+Merced,Unknown,State Assembly,21,REP,Jack Mobley,1220


### PR DESCRIPTION
Fix tests 2014 Merced primary.

Added an "Unknown" precinct catchall for the one candidate in tests missing in the precinct CSV. No precinct-level details.