### PR TITLE
Fix tests 2014 Imperial primary

### DIFF
--- a/2014/20140603__ca__primary__imperial__precinct.csv
+++ b/2014/20140603__ca__primary__imperial__precinct.csv
@@ -6968,3 +6968,5 @@ Imperial,588215,Treasurer,,REP,Greg Conlon,59
 Imperial,588215,Treasurer,,DEM,John Chiang,62
 Imperial,588215,U.S. House,51,DEM,Juan Vargas,84
 Imperial,588215,U.S. House,51,REP,Stephen Meade,49
+Imperial,Unknown,U.S. House,51,REP,Ernest Griffes,109
+Imperial,Unknown,State Senate,40,REP,Michael Diaz,5


### PR DESCRIPTION
Fix tests 2014 Imperial primary.

This involved adding new catch-all records for each candidate in the tests as there is no precinct-level data for these candidates.