### PR TITLE
Fix 2014 Madera primary tests

### DIFF
--- a/2014/20140603__ca__primary__madera__precinct.csv
+++ b/2014/20140603__ca__primary__madera__precinct.csv
@@ -4150,3 +4150,4 @@ Madera,5432,Superintendent of Public Instruction,,NOP,Tom Torlakson,2
 Madera,5432,Treasurer,,DEM,John Chiang,2
 Madera,5432,U.S. House,4,IND,Jeffrey D. Gerlach,1
 Madera,5432,U.S. House,4,REP,Tom McClintock,1
+Madera,Unknown,State Assembly,5,LIB,Patrick D. Hogan,18


### PR DESCRIPTION
Fix tests 2014 Merced primary.

Added an "Unknown" precinct catchall for the one candidate in tests missing in the precinct CSV. No precinct-level details.