### PR TITLE
fix 2014 San Bernardino primary tests by adding missing candidates

### DIFF
--- a/2014/20140603__ca__primary__san_bernardino__precinct.csv
+++ b/2014/20140603__ca__primary__san_bernardino__precinct.csv
@@ -58653,3 +58653,13 @@ San Bernardino,YUV0275,U.S. House,8,DEM,Bob Conaway,81
 San Bernardino,YUV0275,U.S. House,8,DEM,Odessia D. Lee,34
 San Bernardino,YUV0275,U.S. House,8,REP,Paul Cook,276
 San Bernardino,YUV0275,U.S. House,8,REP,Paul Hannosh,43
+San Bernardino,Unknown,Board of Equalization,3,IND,G. Rick Marshall,9
+San Bernardino,Unknown,Board of Equalization,3,LIB,Jose E. Castaneda,1
+San Bernardino,Unknown,Governor,,IND,Nickolas Wildstar,1
+San Bernardino,Unknown,State Assembly,41,REP,Linda Hazelton,34
+San Bernardino,Unknown,State Assembly,41,REP,Nathaniel Tsai,8
+San Bernardino,Unknown,State Assembly,41,REP,Samuel S. Forsen,97
+San Bernardino,Unknown,State Assembly,41,LIB,Ted Brown,6
+San Bernardino,Unknown,State Assembly,47,REP,Kelly J. Chastain,32
+San Bernardino,Unknown,State Senate,16,DEM,Ruth Musser-Lopez,89
+San Bernardino,Unknown,U.S. House,35,REP,"Benjamin ""Ben"" Lopez",546


### PR DESCRIPTION
Fix 2014 San Bernardino primary tests by adding missing candidates.

These added candidates didn't show in precinct-level results, so I added new precinct records with id "Unknown" for each candidate+office. I researched candidate parties from SmartVoter and Ballotpedia.