### PR TITLE
Fix 2014 San Mateo primary tests

### DIFF
--- a/2014/20140603__ca__primary__san_mateo__precinct.csv
+++ b/2014/20140603__ca__primary__san_mateo__precinct.csv
@@ -24659,3 +24659,4 @@ San Mateo,5832,Treasurer,,REP,Greg Conlon,25
 San Mateo,5832,Treasurer,,DEM,John Chiang,109
 San Mateo,5832,U.S. House,14,DEM,Jackie Speier,113
 San Mateo,5832,U.S. House,14,REP,Robin Chew,36
+San Mateo,Unknown,Governor,,DEM,Karen Jill Bernal,1


### PR DESCRIPTION
Fix 2014 San Mateo primary tests by adding missing candidates.

As usual, I added "Unknown" precinct catch-all records for those candidates in tests who did not get official precinct-level vote counts.