### PR TITLE
Fix 2014 Santa Clara primary tests

### DIFF
--- a/2014/20140603__ca__primary__santa_clara__precinct.csv
+++ b/2014/20140603__ca__primary__santa_clara__precinct.csv
@@ -59732,3 +59732,4 @@ Santa Clara,6669,Treasurer,,DEM,John Chiang,11
 Santa Clara,6669,U.S. House,18,DEM,Anna G. Eshoo,17
 Santa Clara,6669,U.S. House,18,REP,Bruce Anderson,2
 Santa Clara,6669,U.S. House,18,REP,Richard B. Fox,12
+Santa Clara,Unknown,Governor,,DEM,Karen Jill Bernal,1


### PR DESCRIPTION
Fix 2014 Santa Clara primary tests by adding missing candidates.

As usual, I added "Unknown" precinct catch-all records for those candidates in tests who did not get official precinct-level vote counts.