### PR TITLE
Fix 2014 Santa Cruz primary tests

### DIFF
--- a/2014/20140603__ca__primary__santa_cruz__precinct.csv
+++ b/2014/20140603__ca__primary__santa_cruz__precinct.csv
@@ -10006,3 +10006,4 @@ Santa Cruz,54070,U.S. House,18,DEM,Anna G. Eshoo,309
 Santa Cruz,54070,U.S. House,18,REP,Bruce Anderson,44
 Santa Cruz,54070,U.S. House,18,REP,Oscar Alejandro Braun,9
 Santa Cruz,54070,U.S. House,18,REP,Richard B. Fox,112
+Santa Cruz,Unknown,Governor,,DEM,Karen Jill Bernal,1


### PR DESCRIPTION
Fix 2014 Santa Cruz primary tests by adding missing candidates.

As usual, I added "Unknown" precinct catch-all records for those candidates in tests who did not get official precinct-level vote counts.