### PR TITLE
fix 2014 Solano primary tests by adding missing candidates

### DIFF
--- a/2014/20140603__ca__primary__solano__precinct.csv
+++ b/2014/20140603__ca__primary__solano__precinct.csv
@@ -406,6 +406,7 @@ Solano,17100,Secretary of State,,DEM,Jeffrey H. Drobman,27
 Solano,17100,Secretary of State,,DEM,Leland Yee,46
 Solano,17100,Secretary of State,,REP,Pete Peterson,20
 Solano,17100,Secretary of State,,REP,Roy Allmond,11
+Solano,17100,State Assembly,14,REP,Joy D. Delepine,2
 Solano,17100,State Assembly,14,DEM,Susan A. Bonilla,208
 Solano,17100,Superintendent of Public Instruction,,NOP,Lydia A. Gutiérrez,61
 Solano,17100,Superintendent of Public Instruction,,NOP,Marshall Tuck,35
@@ -762,6 +763,7 @@ Solano,17185,Secretary of State,,DEM,Jeffrey H. Drobman,45
 Solano,17185,Secretary of State,,DEM,Leland Yee,65
 Solano,17185,Secretary of State,,REP,Pete Peterson,47
 Solano,17185,Secretary of State,,REP,Roy Allmond,23
+Solano,17185,State Assembly,14,REP,Joy D. Delepine,1
 Solano,17185,State Assembly,14,DEM,Susan A. Bonilla,343
 Solano,17185,Superintendent of Public Instruction,,NOP,Lydia A. Gutiérrez,94
 Solano,17185,Superintendent of Public Instruction,,NOP,Marshall Tuck,66
@@ -942,6 +944,7 @@ Solano,17245,Secretary of State,,DEM,Jeffrey H. Drobman,37
 Solano,17245,Secretary of State,,DEM,Leland Yee,30
 Solano,17245,Secretary of State,,REP,Pete Peterson,33
 Solano,17245,Secretary of State,,REP,Roy Allmond,23
+Solano,17245,State Assembly,14,REP,Joy D. Delepine,1
 Solano,17245,State Assembly,14,DEM,Susan A. Bonilla,207
 Solano,17245,Superintendent of Public Instruction,,NOP,Lydia A. Gutiérrez,53
 Solano,17245,Superintendent of Public Instruction,,NOP,Marshall Tuck,38
@@ -1610,6 +1613,7 @@ Solano,21005,Secretary of State,,DEM,Jeffrey H. Drobman,55
 Solano,21005,Secretary of State,,DEM,Leland Yee,71
 Solano,21005,Secretary of State,,REP,Pete Peterson,102
 Solano,21005,Secretary of State,,REP,Roy Allmond,56
+Solano,21005,State Assembly,14,REP,Joy D. Delepine,1
 Solano,21005,State Assembly,14,DEM,Susan A. Bonilla,423
 Solano,21005,Superintendent of Public Instruction,,NOP,Lydia A. Gutiérrez,104
 Solano,21005,Superintendent of Public Instruction,,NOP,Marshall Tuck,101
@@ -1913,6 +1917,7 @@ Solano,21090,Secretary of State,,DEM,Jeffrey H. Drobman,37
 Solano,21090,Secretary of State,,DEM,Leland Yee,36
 Solano,21090,Secretary of State,,REP,Pete Peterson,77
 Solano,21090,Secretary of State,,REP,Roy Allmond,44
+Solano,21090,State Assembly,14,REP,Joy D. Delepine,2
 Solano,21090,State Assembly,14,DEM,Susan A. Bonilla,327
 Solano,21090,Superintendent of Public Instruction,,NOP,Lydia A. Gutiérrez,73
 Solano,21090,Superintendent of Public Instruction,,NOP,Marshall Tuck,64
@@ -2568,6 +2573,7 @@ Solano,27050,Secretary of State,,DEM,Jeffrey H. Drobman,30
 Solano,27050,Secretary of State,,DEM,Leland Yee,55
 Solano,27050,Secretary of State,,REP,Pete Peterson,23
 Solano,27050,Secretary of State,,REP,Roy Allmond,10
+Solano,27050,State Assembly,14,REP,Joy D. Delepine,4
 Solano,27050,State Assembly,14,DEM,Susan A. Bonilla,226
 Solano,27050,Superintendent of Public Instruction,,NOP,Lydia A. Gutiérrez,71
 Solano,27050,Superintendent of Public Instruction,,NOP,Marshall Tuck,32
@@ -2627,6 +2633,7 @@ Solano,27055,Secretary of State,,DEM,Jeffrey H. Drobman,15
 Solano,27055,Secretary of State,,DEM,Leland Yee,37
 Solano,27055,Secretary of State,,REP,Pete Peterson,44
 Solano,27055,Secretary of State,,REP,Roy Allmond,13
+Solano,27055,State Assembly,14,REP,Joy D. Delepine,2
 Solano,27055,State Assembly,14,DEM,Susan A. Bonilla,171
 Solano,27055,Superintendent of Public Instruction,,NOP,Lydia A. Gutiérrez,60
 Solano,27055,Superintendent of Public Instruction,,NOP,Marshall Tuck,24
@@ -2929,6 +2936,7 @@ Solano,27115,Secretary of State,,DEM,Jeffrey H. Drobman,49
 Solano,27115,Secretary of State,,DEM,Leland Yee,45
 Solano,27115,Secretary of State,,REP,Pete Peterson,41
 Solano,27115,Secretary of State,,REP,Roy Allmond,25
+Solano,27115,State Assembly,14,REP,Joy D. Delepine,3
 Solano,27115,State Assembly,14,DEM,Susan A. Bonilla,310
 Solano,27115,Superintendent of Public Instruction,,NOP,Lydia A. Gutiérrez,60
 Solano,27115,Superintendent of Public Instruction,,NOP,Marshall Tuck,53


### PR DESCRIPTION
Fix 2014 Solano primary tests by adding missing candidates.

Missing data sourced from [this Solano County Registrar of Voters precinct-level write-in votes document](https://www.solanocounty.com/civicax/filebank/blobdload.aspx?BlobID=18482)