### PR TITLE
Fix 2014 Stanislaus primary tests by adding missing candidates

### DIFF
--- a/2014/20140603__ca__primary__stanislaus__precinct.csv
+++ b/2014/20140603__ca__primary__stanislaus__precinct.csv
@@ -11633,3 +11633,4 @@ Stanislaus,932012,Treasurer,,DEM,John Chiang,31
 Stanislaus,932012,U.S. House,10,REP,Jeff Denham,35
 Stanislaus,932012,U.S. House,10,DEM,Michael Eggman,28
 Stanislaus,932012,U.S. House,10,DEM,"Michael J. ""Mike"" Barkley",3
+Stanislaus,Unknown,State Assembly,21,REP,Jack Mobley,66


### PR DESCRIPTION
Fix 2014 Stanislaus primary tests by adding missing candidates.

New "Unknown" precinct catch-all records for the write-ins which are not in precinct-level vote counts.