### PR TITLE
fix 2014 Merced primary tests by adding a missing candidate

### DIFF
--- a/2014/20140603__ca__primary__merced__precinct.csv
+++ b/2014/20140603__ca__primary__merced__precinct.csv
@@ -7932,3 +7932,4 @@ Merced,99,U.S. House,16,DEM,Job Melton,5
 Merced,99,U.S. House,16,REP,Johnny Tacherra,34
 Merced,99,U.S. House,16,REP,Mel Levey,5
 Merced,99,U.S. House,16,REP,Steve Crass,42
+Merced,Unknown,State Assembly,21,REP,Jack Mobley,1220


### PR DESCRIPTION
Fix 2014 Merced primary tests by adding a missing candidate.

Uses the "Unknown" precinct id in new records because of lack of precinct-level write-in vote counts.