### PR TITLE
Fix 2014 Sacramento primary tests by adding missing candidates

### DIFF
--- a/2014/20140603__ca__primary__sacramento__precinct.csv
+++ b/2014/20140603__ca__primary__sacramento__precinct.csv
@@ -66504,3 +66504,4 @@ Sacramento,96100,U.S. House,7,REP,Doug Ose,34
 Sacramento,96100,U.S. House,7,LIB,Douglas Arthur Tuma,1
 Sacramento,96100,U.S. House,7,REP,Elizabeth Emken,8
 Sacramento,96100,U.S. House,7,REP,Igor Birman,31
+Sacramento,Unknown,Governor,,IND,Nickolas Wildstar,1


### PR DESCRIPTION
Fix 2014 Sacramento primary tests by adding missing candidates.