### PR TITLE
Fix 2014 San Luis Obispo tests

### DIFF
--- a/2014/20140603__ca__primary__san_luis_obispo__precinct.csv
+++ b/2014/20140603__ca__primary__san_luis_obispo__precinct.csv
@@ -40,6 +40,10 @@ San Luis Obispo,101,Lieutenant Governor,,DEM,Gavin Newsom,124
 San Luis Obispo,101,Lieutenant Governor,,REP,George Yang,57
 San Luis Obispo,101,Lieutenant Governor,,GRN,Jena F. Goodman,15
 San Luis Obispo,101,Lieutenant Governor,,REP,Ron Nehring,140
+San Luis Obispo,101,Proposition 41,,,No,265
+San Luis Obispo,101,Proposition 41,,,Yes,215
+San Luis Obispo,101,Proposition 42,,,No,257
+San Luis Obispo,101,Proposition 42,,,Yes,214
 San Luis Obispo,101,Secretary of State,,DEM,Alex Padilla,76
 San Luis Obispo,101,Secretary of State,,IND,Dan Schnur,17
 San Luis Obispo,101,Secretary of State,,GRN,David Curtis,15
@@ -106,6 +110,10 @@ San Luis Obispo,102,Lieutenant Governor,,DEM,Gavin Newsom,165
 San Luis Obispo,102,Lieutenant Governor,,REP,George Yang,71
 San Luis Obispo,102,Lieutenant Governor,,GRN,Jena F. Goodman,2
 San Luis Obispo,102,Lieutenant Governor,,REP,Ron Nehring,201
+San Luis Obispo,102,Proposition 41,,,No,352
+San Luis Obispo,102,Proposition 41,,,Yes,317
+San Luis Obispo,102,Proposition 42,,,No,364
+San Luis Obispo,102,Proposition 42,,,Yes,284
 San Luis Obispo,102,Secretary of State,,DEM,Alex Padilla,78
 San Luis Obispo,102,Secretary of State,,IND,Dan Schnur,30
 San Luis Obispo,102,Secretary of State,,GRN,David Curtis,16
@@ -172,6 +180,10 @@ San Luis Obispo,103,Lieutenant Governor,,DEM,Gavin Newsom,118
 San Luis Obispo,103,Lieutenant Governor,,REP,George Yang,39
 San Luis Obispo,103,Lieutenant Governor,,GRN,Jena F. Goodman,6
 San Luis Obispo,103,Lieutenant Governor,,REP,Ron Nehring,147
+San Luis Obispo,103,Proposition 41,,,No,254
+San Luis Obispo,103,Proposition 41,,,Yes,204
+San Luis Obispo,103,Proposition 42,,,No,238
+San Luis Obispo,103,Proposition 42,,,Yes,210
 San Luis Obispo,103,Secretary of State,,DEM,Alex Padilla,65
 San Luis Obispo,103,Secretary of State,,IND,Dan Schnur,25
 San Luis Obispo,103,Secretary of State,,GRN,David Curtis,13
@@ -238,6 +250,10 @@ San Luis Obispo,104,Lieutenant Governor,,DEM,Gavin Newsom,77
 San Luis Obispo,104,Lieutenant Governor,,REP,George Yang,31
 San Luis Obispo,104,Lieutenant Governor,,GRN,Jena F. Goodman,6
 San Luis Obispo,104,Lieutenant Governor,,REP,Ron Nehring,94
+San Luis Obispo,104,Proposition 41,,,No,145
+San Luis Obispo,104,Proposition 41,,,Yes,130
+San Luis Obispo,104,Proposition 42,,,No,137
+San Luis Obispo,104,Proposition 42,,,Yes,127
 San Luis Obispo,104,Secretary of State,,DEM,Alex Padilla,44
 San Luis Obispo,104,Secretary of State,,IND,Dan Schnur,10
 San Luis Obispo,104,Secretary of State,,GRN,David Curtis,9
@@ -304,6 +320,10 @@ San Luis Obispo,105,Lieutenant Governor,,DEM,Gavin Newsom,67
 San Luis Obispo,105,Lieutenant Governor,,REP,George Yang,34
 San Luis Obispo,105,Lieutenant Governor,,GRN,Jena F. Goodman,2
 San Luis Obispo,105,Lieutenant Governor,,REP,Ron Nehring,130
+San Luis Obispo,105,Proposition 41,,,No,209
+San Luis Obispo,105,Proposition 41,,,Yes,109
+San Luis Obispo,105,Proposition 42,,,No,175
+San Luis Obispo,105,Proposition 42,,,Yes,138
 San Luis Obispo,105,Secretary of State,,DEM,Alex Padilla,39
 San Luis Obispo,105,Secretary of State,,IND,Dan Schnur,14
 San Luis Obispo,105,Secretary of State,,GRN,David Curtis,7
@@ -370,6 +390,10 @@ San Luis Obispo,106,Lieutenant Governor,,DEM,Gavin Newsom,119
 San Luis Obispo,106,Lieutenant Governor,,REP,George Yang,51
 San Luis Obispo,106,Lieutenant Governor,,GRN,Jena F. Goodman,4
 San Luis Obispo,106,Lieutenant Governor,,REP,Ron Nehring,167
+San Luis Obispo,106,Proposition 41,,,No,271
+San Luis Obispo,106,Proposition 41,,,Yes,179
+San Luis Obispo,106,Proposition 42,,,No,242
+San Luis Obispo,106,Proposition 42,,,Yes,196
 San Luis Obispo,106,Secretary of State,,DEM,Alex Padilla,66
 San Luis Obispo,106,Secretary of State,,IND,Dan Schnur,31
 San Luis Obispo,106,Secretary of State,,GRN,David Curtis,13
@@ -436,6 +460,10 @@ San Luis Obispo,107,Lieutenant Governor,,DEM,Gavin Newsom,44
 San Luis Obispo,107,Lieutenant Governor,,REP,George Yang,13
 San Luis Obispo,107,Lieutenant Governor,,GRN,Jena F. Goodman,2
 San Luis Obispo,107,Lieutenant Governor,,REP,Ron Nehring,63
+San Luis Obispo,107,Proposition 41,,,No,76
+San Luis Obispo,107,Proposition 41,,,Yes,92
+San Luis Obispo,107,Proposition 42,,,No,87
+San Luis Obispo,107,Proposition 42,,,Yes,80
 San Luis Obispo,107,Secretary of State,,DEM,Alex Padilla,31
 San Luis Obispo,107,Secretary of State,,IND,Dan Schnur,9
 San Luis Obispo,107,Secretary of State,,GRN,David Curtis,7
@@ -502,6 +530,10 @@ San Luis Obispo,108,Lieutenant Governor,,DEM,Gavin Newsom,192
 San Luis Obispo,108,Lieutenant Governor,,REP,George Yang,53
 San Luis Obispo,108,Lieutenant Governor,,GRN,Jena F. Goodman,9
 San Luis Obispo,108,Lieutenant Governor,,REP,Ron Nehring,162
+San Luis Obispo,108,Proposition 41,,,No,222
+San Luis Obispo,108,Proposition 41,,,Yes,330
+San Luis Obispo,108,Proposition 42,,,No,274
+San Luis Obispo,108,Proposition 42,,,Yes,265
 San Luis Obispo,108,Secretary of State,,DEM,Alex Padilla,104
 San Luis Obispo,108,Secretary of State,,IND,Dan Schnur,25
 San Luis Obispo,108,Secretary of State,,GRN,David Curtis,16
@@ -568,6 +600,10 @@ San Luis Obispo,109,Lieutenant Governor,,DEM,Gavin Newsom,178
 San Luis Obispo,109,Lieutenant Governor,,REP,George Yang,44
 San Luis Obispo,109,Lieutenant Governor,,GRN,Jena F. Goodman,9
 San Luis Obispo,109,Lieutenant Governor,,REP,Ron Nehring,108
+San Luis Obispo,109,Proposition 41,,,No,192
+San Luis Obispo,109,Proposition 41,,,Yes,264
+San Luis Obispo,109,Proposition 42,,,No,252
+San Luis Obispo,109,Proposition 42,,,Yes,193
 San Luis Obispo,109,Secretary of State,,DEM,Alex Padilla,87
 San Luis Obispo,109,Secretary of State,,IND,Dan Schnur,21
 San Luis Obispo,109,Secretary of State,,GRN,David Curtis,20
@@ -634,6 +670,10 @@ San Luis Obispo,110,Lieutenant Governor,,DEM,Gavin Newsom,82
 San Luis Obispo,110,Lieutenant Governor,,REP,George Yang,31
 San Luis Obispo,110,Lieutenant Governor,,GRN,Jena F. Goodman,6
 San Luis Obispo,110,Lieutenant Governor,,REP,Ron Nehring,75
+San Luis Obispo,110,Proposition 41,,,No,109
+San Luis Obispo,110,Proposition 41,,,Yes,144
+San Luis Obispo,110,Proposition 42,,,No,131
+San Luis Obispo,110,Proposition 42,,,Yes,121
 San Luis Obispo,110,Secretary of State,,DEM,Alex Padilla,51
 San Luis Obispo,110,Secretary of State,,IND,Dan Schnur,12
 San Luis Obispo,110,Secretary of State,,GRN,David Curtis,9
@@ -700,6 +740,10 @@ San Luis Obispo,111,Lieutenant Governor,,DEM,Gavin Newsom,108
 San Luis Obispo,111,Lieutenant Governor,,REP,George Yang,42
 San Luis Obispo,111,Lieutenant Governor,,GRN,Jena F. Goodman,1
 San Luis Obispo,111,Lieutenant Governor,,REP,Ron Nehring,100
+San Luis Obispo,111,Proposition 41,,,No,185
+San Luis Obispo,111,Proposition 41,,,Yes,161
+San Luis Obispo,111,Proposition 42,,,No,181
+San Luis Obispo,111,Proposition 42,,,Yes,147
 San Luis Obispo,111,Secretary of State,,DEM,Alex Padilla,56
 San Luis Obispo,111,Secretary of State,,IND,Dan Schnur,21
 San Luis Obispo,111,Secretary of State,,GRN,David Curtis,3
@@ -766,6 +810,10 @@ San Luis Obispo,112,Lieutenant Governor,,DEM,Gavin Newsom,199
 San Luis Obispo,112,Lieutenant Governor,,REP,George Yang,85
 San Luis Obispo,112,Lieutenant Governor,,GRN,Jena F. Goodman,8
 San Luis Obispo,112,Lieutenant Governor,,REP,Ron Nehring,148
+San Luis Obispo,112,Proposition 41,,,No,242
+San Luis Obispo,112,Proposition 41,,,Yes,295
+San Luis Obispo,112,Proposition 42,,,No,295
+San Luis Obispo,112,Proposition 42,,,Yes,235
 San Luis Obispo,112,Secretary of State,,DEM,Alex Padilla,105
 San Luis Obispo,112,Secretary of State,,IND,Dan Schnur,29
 San Luis Obispo,112,Secretary of State,,GRN,David Curtis,13
@@ -832,6 +880,10 @@ San Luis Obispo,113,Lieutenant Governor,,DEM,Gavin Newsom,90
 San Luis Obispo,113,Lieutenant Governor,,REP,George Yang,28
 San Luis Obispo,113,Lieutenant Governor,,GRN,Jena F. Goodman,0
 San Luis Obispo,113,Lieutenant Governor,,REP,Ron Nehring,63
+San Luis Obispo,113,Proposition 41,,,No,98
+San Luis Obispo,113,Proposition 41,,,Yes,144
+San Luis Obispo,113,Proposition 42,,,No,125
+San Luis Obispo,113,Proposition 42,,,Yes,105
 San Luis Obispo,113,Secretary of State,,DEM,Alex Padilla,40
 San Luis Obispo,113,Secretary of State,,IND,Dan Schnur,11
 San Luis Obispo,113,Secretary of State,,GRN,David Curtis,7
@@ -898,6 +950,10 @@ San Luis Obispo,114,Lieutenant Governor,,DEM,Gavin Newsom,96
 San Luis Obispo,114,Lieutenant Governor,,REP,George Yang,18
 San Luis Obispo,114,Lieutenant Governor,,GRN,Jena F. Goodman,6
 San Luis Obispo,114,Lieutenant Governor,,REP,Ron Nehring,88
+San Luis Obispo,114,Proposition 41,,,No,118
+San Luis Obispo,114,Proposition 41,,,Yes,151
+San Luis Obispo,114,Proposition 42,,,No,135
+San Luis Obispo,114,Proposition 42,,,Yes,125
 San Luis Obispo,114,Secretary of State,,DEM,Alex Padilla,49
 San Luis Obispo,114,Secretary of State,,IND,Dan Schnur,11
 San Luis Obispo,114,Secretary of State,,GRN,David Curtis,9
@@ -964,6 +1020,10 @@ San Luis Obispo,115,Lieutenant Governor,,DEM,Gavin Newsom,161
 San Luis Obispo,115,Lieutenant Governor,,REP,George Yang,38
 San Luis Obispo,115,Lieutenant Governor,,GRN,Jena F. Goodman,5
 San Luis Obispo,115,Lieutenant Governor,,REP,Ron Nehring,82
+San Luis Obispo,115,Proposition 41,,,No,138
+San Luis Obispo,115,Proposition 41,,,Yes,245
+San Luis Obispo,115,Proposition 42,,,No,196
+San Luis Obispo,115,Proposition 42,,,Yes,174
 San Luis Obispo,115,Secretary of State,,DEM,Alex Padilla,68
 San Luis Obispo,115,Secretary of State,,IND,Dan Schnur,13
 San Luis Obispo,115,Secretary of State,,GRN,David Curtis,6
@@ -1030,6 +1090,10 @@ San Luis Obispo,116,Lieutenant Governor,,DEM,Gavin Newsom,94
 San Luis Obispo,116,Lieutenant Governor,,REP,George Yang,22
 San Luis Obispo,116,Lieutenant Governor,,GRN,Jena F. Goodman,4
 San Luis Obispo,116,Lieutenant Governor,,REP,Ron Nehring,46
+San Luis Obispo,116,Proposition 41,,,No,118
+San Luis Obispo,116,Proposition 41,,,Yes,117
+San Luis Obispo,116,Proposition 42,,,No,116
+San Luis Obispo,116,Proposition 42,,,Yes,114
 San Luis Obispo,116,Secretary of State,,DEM,Alex Padilla,43
 San Luis Obispo,116,Secretary of State,,IND,Dan Schnur,11
 San Luis Obispo,116,Secretary of State,,GRN,David Curtis,3
@@ -1096,6 +1160,10 @@ San Luis Obispo,117,Lieutenant Governor,,DEM,Gavin Newsom,87
 San Luis Obispo,117,Lieutenant Governor,,REP,George Yang,26
 San Luis Obispo,117,Lieutenant Governor,,GRN,Jena F. Goodman,5
 San Luis Obispo,117,Lieutenant Governor,,REP,Ron Nehring,98
+San Luis Obispo,117,Proposition 41,,,No,139
+San Luis Obispo,117,Proposition 41,,,Yes,155
+San Luis Obispo,117,Proposition 42,,,No,146
+San Luis Obispo,117,Proposition 42,,,Yes,136
 San Luis Obispo,117,Secretary of State,,DEM,Alex Padilla,48
 San Luis Obispo,117,Secretary of State,,IND,Dan Schnur,11
 San Luis Obispo,117,Secretary of State,,GRN,David Curtis,6
@@ -1162,6 +1230,10 @@ San Luis Obispo,118,Lieutenant Governor,,DEM,Gavin Newsom,103
 San Luis Obispo,118,Lieutenant Governor,,REP,George Yang,20
 San Luis Obispo,118,Lieutenant Governor,,GRN,Jena F. Goodman,8
 San Luis Obispo,118,Lieutenant Governor,,REP,Ron Nehring,87
+San Luis Obispo,118,Proposition 41,,,No,107
+San Luis Obispo,118,Proposition 41,,,Yes,182
+San Luis Obispo,118,Proposition 42,,,No,132
+San Luis Obispo,118,Proposition 42,,,Yes,144
 San Luis Obispo,118,Secretary of State,,DEM,Alex Padilla,52
 San Luis Obispo,118,Secretary of State,,IND,Dan Schnur,15
 San Luis Obispo,118,Secretary of State,,GRN,David Curtis,10
@@ -1228,6 +1300,10 @@ San Luis Obispo,119,Lieutenant Governor,,DEM,Gavin Newsom,102
 San Luis Obispo,119,Lieutenant Governor,,REP,George Yang,32
 San Luis Obispo,119,Lieutenant Governor,,GRN,Jena F. Goodman,5
 San Luis Obispo,119,Lieutenant Governor,,REP,Ron Nehring,80
+San Luis Obispo,119,Proposition 41,,,No,131
+San Luis Obispo,119,Proposition 41,,,Yes,169
+San Luis Obispo,119,Proposition 42,,,No,167
+San Luis Obispo,119,Proposition 42,,,Yes,130
 San Luis Obispo,119,Secretary of State,,DEM,Alex Padilla,54
 San Luis Obispo,119,Secretary of State,,IND,Dan Schnur,19
 San Luis Obispo,119,Secretary of State,,GRN,David Curtis,8
@@ -1294,6 +1370,10 @@ San Luis Obispo,120,Lieutenant Governor,,DEM,Gavin Newsom,78
 San Luis Obispo,120,Lieutenant Governor,,REP,George Yang,18
 San Luis Obispo,120,Lieutenant Governor,,GRN,Jena F. Goodman,2
 San Luis Obispo,120,Lieutenant Governor,,REP,Ron Nehring,51
+San Luis Obispo,120,Proposition 41,,,No,90
+San Luis Obispo,120,Proposition 41,,,Yes,110
+San Luis Obispo,120,Proposition 42,,,No,83
+San Luis Obispo,120,Proposition 42,,,Yes,106
 San Luis Obispo,120,Secretary of State,,DEM,Alex Padilla,44
 San Luis Obispo,120,Secretary of State,,IND,Dan Schnur,14
 San Luis Obispo,120,Secretary of State,,GRN,David Curtis,6
@@ -1360,6 +1440,10 @@ San Luis Obispo,121,Lieutenant Governor,,DEM,Gavin Newsom,169
 San Luis Obispo,121,Lieutenant Governor,,REP,George Yang,37
 San Luis Obispo,121,Lieutenant Governor,,GRN,Jena F. Goodman,4
 San Luis Obispo,121,Lieutenant Governor,,REP,Ron Nehring,153
+San Luis Obispo,121,Proposition 41,,,No,228
+San Luis Obispo,121,Proposition 41,,,Yes,250
+San Luis Obispo,121,Proposition 42,,,No,256
+San Luis Obispo,121,Proposition 42,,,Yes,208
 San Luis Obispo,121,Secretary of State,,DEM,Alex Padilla,90
 San Luis Obispo,121,Secretary of State,,IND,Dan Schnur,16
 San Luis Obispo,121,Secretary of State,,GRN,David Curtis,10
@@ -1426,6 +1510,10 @@ San Luis Obispo,122,Lieutenant Governor,,DEM,Gavin Newsom,133
 San Luis Obispo,122,Lieutenant Governor,,REP,George Yang,21
 San Luis Obispo,122,Lieutenant Governor,,GRN,Jena F. Goodman,4
 San Luis Obispo,122,Lieutenant Governor,,REP,Ron Nehring,94
+San Luis Obispo,122,Proposition 41,,,No,137
+San Luis Obispo,122,Proposition 41,,,Yes,170
+San Luis Obispo,122,Proposition 42,,,No,140
+San Luis Obispo,122,Proposition 42,,,Yes,158
 San Luis Obispo,122,Secretary of State,,DEM,Alex Padilla,52
 San Luis Obispo,122,Secretary of State,,IND,Dan Schnur,18
 San Luis Obispo,122,Secretary of State,,GRN,David Curtis,11
@@ -1492,6 +1580,10 @@ San Luis Obispo,123,Lieutenant Governor,,DEM,Gavin Newsom,73
 San Luis Obispo,123,Lieutenant Governor,,REP,George Yang,32
 San Luis Obispo,123,Lieutenant Governor,,GRN,Jena F. Goodman,3
 San Luis Obispo,123,Lieutenant Governor,,REP,Ron Nehring,88
+San Luis Obispo,123,Proposition 41,,,No,173
+San Luis Obispo,123,Proposition 41,,,Yes,111
+San Luis Obispo,123,Proposition 42,,,No,146
+San Luis Obispo,123,Proposition 42,,,Yes,131
 San Luis Obispo,123,Secretary of State,,DEM,Alex Padilla,32
 San Luis Obispo,123,Secretary of State,,IND,Dan Schnur,11
 San Luis Obispo,123,Secretary of State,,GRN,David Curtis,8
@@ -1558,6 +1650,10 @@ San Luis Obispo,124,Lieutenant Governor,,DEM,Gavin Newsom,194
 San Luis Obispo,124,Lieutenant Governor,,REP,George Yang,62
 San Luis Obispo,124,Lieutenant Governor,,GRN,Jena F. Goodman,6
 San Luis Obispo,124,Lieutenant Governor,,REP,Ron Nehring,144
+San Luis Obispo,124,Proposition 41,,,No,301
+San Luis Obispo,124,Proposition 41,,,Yes,245
+San Luis Obispo,124,Proposition 42,,,No,256
+San Luis Obispo,124,Proposition 42,,,Yes,272
 San Luis Obispo,124,Secretary of State,,DEM,Alex Padilla,89
 San Luis Obispo,124,Secretary of State,,IND,Dan Schnur,29
 San Luis Obispo,124,Secretary of State,,GRN,David Curtis,14
@@ -1624,6 +1720,10 @@ San Luis Obispo,125,Lieutenant Governor,,DEM,Gavin Newsom,128
 San Luis Obispo,125,Lieutenant Governor,,REP,George Yang,32
 San Luis Obispo,125,Lieutenant Governor,,GRN,Jena F. Goodman,6
 San Luis Obispo,125,Lieutenant Governor,,REP,Ron Nehring,119
+San Luis Obispo,125,Proposition 41,,,No,205
+San Luis Obispo,125,Proposition 41,,,Yes,195
+San Luis Obispo,125,Proposition 42,,,No,194
+San Luis Obispo,125,Proposition 42,,,Yes,197
 San Luis Obispo,125,Secretary of State,,DEM,Alex Padilla,69
 San Luis Obispo,125,Secretary of State,,IND,Dan Schnur,8
 San Luis Obispo,125,Secretary of State,,GRN,David Curtis,14
@@ -1690,6 +1790,10 @@ San Luis Obispo,126,Lieutenant Governor,,DEM,Gavin Newsom,148
 San Luis Obispo,126,Lieutenant Governor,,REP,George Yang,47
 San Luis Obispo,126,Lieutenant Governor,,GRN,Jena F. Goodman,5
 San Luis Obispo,126,Lieutenant Governor,,REP,Ron Nehring,121
+San Luis Obispo,126,Proposition 41,,,No,207
+San Luis Obispo,126,Proposition 41,,,Yes,233
+San Luis Obispo,126,Proposition 42,,,No,239
+San Luis Obispo,126,Proposition 42,,,Yes,193
 San Luis Obispo,126,Secretary of State,,DEM,Alex Padilla,98
 San Luis Obispo,126,Secretary of State,,IND,Dan Schnur,14
 San Luis Obispo,126,Secretary of State,,GRN,David Curtis,13
@@ -1756,6 +1860,10 @@ San Luis Obispo,201,Lieutenant Governor,,DEM,Gavin Newsom,294
 San Luis Obispo,201,Lieutenant Governor,,REP,George Yang,27
 San Luis Obispo,201,Lieutenant Governor,,GRN,Jena F. Goodman,5
 San Luis Obispo,201,Lieutenant Governor,,REP,Ron Nehring,104
+San Luis Obispo,201,Proposition 41,,,No,195
+San Luis Obispo,201,Proposition 41,,,Yes,343
+San Luis Obispo,201,Proposition 42,,,No,225
+San Luis Obispo,201,Proposition 42,,,Yes,285
 San Luis Obispo,201,Secretary of State,,DEM,Alex Padilla,141
 San Luis Obispo,201,Secretary of State,,IND,Dan Schnur,19
 San Luis Obispo,201,Secretary of State,,GRN,David Curtis,17
@@ -1822,6 +1930,10 @@ San Luis Obispo,202,Lieutenant Governor,,DEM,Gavin Newsom,256
 San Luis Obispo,202,Lieutenant Governor,,REP,George Yang,30
 San Luis Obispo,202,Lieutenant Governor,,GRN,Jena F. Goodman,10
 San Luis Obispo,202,Lieutenant Governor,,REP,Ron Nehring,107
+San Luis Obispo,202,Proposition 41,,,No,135
+San Luis Obispo,202,Proposition 41,,,Yes,349
+San Luis Obispo,202,Proposition 42,,,No,201
+San Luis Obispo,202,Proposition 42,,,Yes,261
 San Luis Obispo,202,Secretary of State,,DEM,Alex Padilla,125
 San Luis Obispo,202,Secretary of State,,IND,Dan Schnur,19
 San Luis Obispo,202,Secretary of State,,GRN,David Curtis,8
@@ -1888,6 +2000,10 @@ San Luis Obispo,203,Lieutenant Governor,,DEM,Gavin Newsom,255
 San Luis Obispo,203,Lieutenant Governor,,REP,George Yang,16
 San Luis Obispo,203,Lieutenant Governor,,GRN,Jena F. Goodman,10
 San Luis Obispo,203,Lieutenant Governor,,REP,Ron Nehring,68
+San Luis Obispo,203,Proposition 41,,,No,112
+San Luis Obispo,203,Proposition 41,,,Yes,311
+San Luis Obispo,203,Proposition 42,,,No,160
+San Luis Obispo,203,Proposition 42,,,Yes,248
 San Luis Obispo,203,Secretary of State,,DEM,Alex Padilla,137
 San Luis Obispo,203,Secretary of State,,IND,Dan Schnur,14
 San Luis Obispo,203,Secretary of State,,GRN,David Curtis,20
@@ -1954,6 +2070,10 @@ San Luis Obispo,204,Lieutenant Governor,,DEM,Gavin Newsom,437
 San Luis Obispo,204,Lieutenant Governor,,REP,George Yang,39
 San Luis Obispo,204,Lieutenant Governor,,GRN,Jena F. Goodman,6
 San Luis Obispo,204,Lieutenant Governor,,REP,Ron Nehring,129
+San Luis Obispo,204,Proposition 41,,,No,235
+San Luis Obispo,204,Proposition 41,,,Yes,492
+San Luis Obispo,204,Proposition 42,,,No,302
+San Luis Obispo,204,Proposition 42,,,Yes,404
 San Luis Obispo,204,Secretary of State,,DEM,Alex Padilla,210
 San Luis Obispo,204,Secretary of State,,IND,Dan Schnur,32
 San Luis Obispo,204,Secretary of State,,GRN,David Curtis,20
@@ -2020,6 +2140,10 @@ San Luis Obispo,205,Lieutenant Governor,,DEM,Gavin Newsom,79
 San Luis Obispo,205,Lieutenant Governor,,REP,George Yang,10
 San Luis Obispo,205,Lieutenant Governor,,GRN,Jena F. Goodman,2
 San Luis Obispo,205,Lieutenant Governor,,REP,Ron Nehring,28
+San Luis Obispo,205,Proposition 41,,,No,64
+San Luis Obispo,205,Proposition 41,,,Yes,102
+San Luis Obispo,205,Proposition 42,,,No,72
+San Luis Obispo,205,Proposition 42,,,Yes,79
 San Luis Obispo,205,Secretary of State,,DEM,Alex Padilla,43
 San Luis Obispo,205,Secretary of State,,IND,Dan Schnur,6
 San Luis Obispo,205,Secretary of State,,GRN,David Curtis,5
@@ -2086,6 +2210,10 @@ San Luis Obispo,206,Lieutenant Governor,,DEM,Gavin Newsom,201
 San Luis Obispo,206,Lieutenant Governor,,REP,George Yang,29
 San Luis Obispo,206,Lieutenant Governor,,GRN,Jena F. Goodman,12
 San Luis Obispo,206,Lieutenant Governor,,REP,Ron Nehring,95
+San Luis Obispo,206,Proposition 41,,,No,170
+San Luis Obispo,206,Proposition 41,,,Yes,250
+San Luis Obispo,206,Proposition 42,,,No,172
+San Luis Obispo,206,Proposition 42,,,Yes,229
 San Luis Obispo,206,Secretary of State,,DEM,Alex Padilla,107
 San Luis Obispo,206,Secretary of State,,IND,Dan Schnur,13
 San Luis Obispo,206,Secretary of State,,GRN,David Curtis,26
@@ -2152,6 +2280,10 @@ San Luis Obispo,207,Lieutenant Governor,,DEM,Gavin Newsom,277
 San Luis Obispo,207,Lieutenant Governor,,REP,George Yang,48
 San Luis Obispo,207,Lieutenant Governor,,GRN,Jena F. Goodman,10
 San Luis Obispo,207,Lieutenant Governor,,REP,Ron Nehring,100
+San Luis Obispo,207,Proposition 41,,,No,196
+San Luis Obispo,207,Proposition 41,,,Yes,340
+San Luis Obispo,207,Proposition 42,,,No,222
+San Luis Obispo,207,Proposition 42,,,Yes,294
 San Luis Obispo,207,Secretary of State,,DEM,Alex Padilla,122
 San Luis Obispo,207,Secretary of State,,IND,Dan Schnur,21
 San Luis Obispo,207,Secretary of State,,GRN,David Curtis,21
@@ -2218,6 +2350,10 @@ San Luis Obispo,208,Lieutenant Governor,,DEM,Gavin Newsom,272
 San Luis Obispo,208,Lieutenant Governor,,REP,George Yang,31
 San Luis Obispo,208,Lieutenant Governor,,GRN,Jena F. Goodman,8
 San Luis Obispo,208,Lieutenant Governor,,REP,Ron Nehring,118
+San Luis Obispo,208,Proposition 41,,,No,183
+San Luis Obispo,208,Proposition 41,,,Yes,354
+San Luis Obispo,208,Proposition 42,,,No,224
+San Luis Obispo,208,Proposition 42,,,Yes,295
 San Luis Obispo,208,Secretary of State,,DEM,Alex Padilla,131
 San Luis Obispo,208,Secretary of State,,IND,Dan Schnur,13
 San Luis Obispo,208,Secretary of State,,GRN,David Curtis,19
@@ -2284,6 +2420,10 @@ San Luis Obispo,209,Lieutenant Governor,,DEM,Gavin Newsom,227
 San Luis Obispo,209,Lieutenant Governor,,REP,George Yang,33
 San Luis Obispo,209,Lieutenant Governor,,GRN,Jena F. Goodman,13
 San Luis Obispo,209,Lieutenant Governor,,REP,Ron Nehring,82
+San Luis Obispo,209,Proposition 41,,,No,138
+San Luis Obispo,209,Proposition 41,,,Yes,329
+San Luis Obispo,209,Proposition 42,,,No,202
+San Luis Obispo,209,Proposition 42,,,Yes,234
 San Luis Obispo,209,Secretary of State,,DEM,Alex Padilla,124
 San Luis Obispo,209,Secretary of State,,IND,Dan Schnur,13
 San Luis Obispo,209,Secretary of State,,GRN,David Curtis,19
@@ -2350,6 +2490,10 @@ San Luis Obispo,210,Lieutenant Governor,,DEM,Gavin Newsom,249
 San Luis Obispo,210,Lieutenant Governor,,REP,George Yang,34
 San Luis Obispo,210,Lieutenant Governor,,GRN,Jena F. Goodman,12
 San Luis Obispo,210,Lieutenant Governor,,REP,Ron Nehring,82
+San Luis Obispo,210,Proposition 41,,,No,159
+San Luis Obispo,210,Proposition 41,,,Yes,327
+San Luis Obispo,210,Proposition 42,,,No,210
+San Luis Obispo,210,Proposition 42,,,Yes,257
 San Luis Obispo,210,Secretary of State,,DEM,Alex Padilla,122
 San Luis Obispo,210,Secretary of State,,IND,Dan Schnur,18
 San Luis Obispo,210,Secretary of State,,GRN,David Curtis,14
@@ -2416,6 +2560,10 @@ San Luis Obispo,211,Lieutenant Governor,,DEM,Gavin Newsom,179
 San Luis Obispo,211,Lieutenant Governor,,REP,George Yang,30
 San Luis Obispo,211,Lieutenant Governor,,GRN,Jena F. Goodman,5
 San Luis Obispo,211,Lieutenant Governor,,REP,Ron Nehring,102
+San Luis Obispo,211,Proposition 41,,,No,137
+San Luis Obispo,211,Proposition 41,,,Yes,241
+San Luis Obispo,211,Proposition 42,,,No,156
+San Luis Obispo,211,Proposition 42,,,Yes,213
 San Luis Obispo,211,Secretary of State,,DEM,Alex Padilla,93
 San Luis Obispo,211,Secretary of State,,IND,Dan Schnur,11
 San Luis Obispo,211,Secretary of State,,GRN,David Curtis,12
@@ -2482,6 +2630,10 @@ San Luis Obispo,212,Lieutenant Governor,,DEM,Gavin Newsom,331
 San Luis Obispo,212,Lieutenant Governor,,REP,George Yang,43
 San Luis Obispo,212,Lieutenant Governor,,GRN,Jena F. Goodman,20
 San Luis Obispo,212,Lieutenant Governor,,REP,Ron Nehring,135
+San Luis Obispo,212,Proposition 41,,,No,233
+San Luis Obispo,212,Proposition 41,,,Yes,446
+San Luis Obispo,212,Proposition 42,,,No,303
+San Luis Obispo,212,Proposition 42,,,Yes,342
 San Luis Obispo,212,Secretary of State,,DEM,Alex Padilla,192
 San Luis Obispo,212,Secretary of State,,IND,Dan Schnur,26
 San Luis Obispo,212,Secretary of State,,GRN,David Curtis,36
@@ -2548,6 +2700,10 @@ San Luis Obispo,213,Lieutenant Governor,,DEM,Gavin Newsom,220
 San Luis Obispo,213,Lieutenant Governor,,REP,George Yang,23
 San Luis Obispo,213,Lieutenant Governor,,GRN,Jena F. Goodman,14
 San Luis Obispo,213,Lieutenant Governor,,REP,Ron Nehring,61
+San Luis Obispo,213,Proposition 41,,,No,132
+San Luis Obispo,213,Proposition 41,,,Yes,281
+San Luis Obispo,213,Proposition 42,,,No,174
+San Luis Obispo,213,Proposition 42,,,Yes,225
 San Luis Obispo,213,Secretary of State,,DEM,Alex Padilla,93
 San Luis Obispo,213,Secretary of State,,IND,Dan Schnur,23
 San Luis Obispo,213,Secretary of State,,GRN,David Curtis,19
@@ -2614,6 +2770,10 @@ San Luis Obispo,214,Lieutenant Governor,,DEM,Gavin Newsom,412
 San Luis Obispo,214,Lieutenant Governor,,REP,George Yang,60
 San Luis Obispo,214,Lieutenant Governor,,GRN,Jena F. Goodman,17
 San Luis Obispo,214,Lieutenant Governor,,REP,Ron Nehring,121
+San Luis Obispo,214,Proposition 41,,,No,219
+San Luis Obispo,214,Proposition 41,,,Yes,509
+San Luis Obispo,214,Proposition 42,,,No,302
+San Luis Obispo,214,Proposition 42,,,Yes,402
 San Luis Obispo,214,Secretary of State,,DEM,Alex Padilla,202
 San Luis Obispo,214,Secretary of State,,IND,Dan Schnur,24
 San Luis Obispo,214,Secretary of State,,GRN,David Curtis,30
@@ -2680,6 +2840,10 @@ San Luis Obispo,215,Lieutenant Governor,,DEM,Gavin Newsom,217
 San Luis Obispo,215,Lieutenant Governor,,REP,George Yang,13
 San Luis Obispo,215,Lieutenant Governor,,GRN,Jena F. Goodman,10
 San Luis Obispo,215,Lieutenant Governor,,REP,Ron Nehring,45
+San Luis Obispo,215,Proposition 41,,,No,92
+San Luis Obispo,215,Proposition 41,,,Yes,224
+San Luis Obispo,215,Proposition 42,,,No,125
+San Luis Obispo,215,Proposition 42,,,Yes,180
 San Luis Obispo,215,Secretary of State,,DEM,Alex Padilla,124
 San Luis Obispo,215,Secretary of State,,IND,Dan Schnur,10
 San Luis Obispo,215,Secretary of State,,GRN,David Curtis,15
@@ -2746,6 +2910,10 @@ San Luis Obispo,216,Lieutenant Governor,,DEM,Gavin Newsom,261
 San Luis Obispo,216,Lieutenant Governor,,REP,George Yang,19
 San Luis Obispo,216,Lieutenant Governor,,GRN,Jena F. Goodman,9
 San Luis Obispo,216,Lieutenant Governor,,REP,Ron Nehring,48
+San Luis Obispo,216,Proposition 41,,,No,114
+San Luis Obispo,216,Proposition 41,,,Yes,290
+San Luis Obispo,216,Proposition 42,,,No,153
+San Luis Obispo,216,Proposition 42,,,Yes,234
 San Luis Obispo,216,Secretary of State,,DEM,Alex Padilla,164
 San Luis Obispo,216,Secretary of State,,IND,Dan Schnur,14
 San Luis Obispo,216,Secretary of State,,GRN,David Curtis,26
@@ -2812,6 +2980,10 @@ San Luis Obispo,217,Lieutenant Governor,,DEM,Gavin Newsom,293
 San Luis Obispo,217,Lieutenant Governor,,REP,George Yang,40
 San Luis Obispo,217,Lieutenant Governor,,GRN,Jena F. Goodman,19
 San Luis Obispo,217,Lieutenant Governor,,REP,Ron Nehring,94
+San Luis Obispo,217,Proposition 41,,,No,165
+San Luis Obispo,217,Proposition 41,,,Yes,362
+San Luis Obispo,217,Proposition 42,,,No,219
+San Luis Obispo,217,Proposition 42,,,Yes,296
 San Luis Obispo,217,Secretary of State,,DEM,Alex Padilla,170
 San Luis Obispo,217,Secretary of State,,IND,Dan Schnur,18
 San Luis Obispo,217,Secretary of State,,GRN,David Curtis,30
@@ -2878,6 +3050,10 @@ San Luis Obispo,218,Lieutenant Governor,,DEM,Gavin Newsom,278
 San Luis Obispo,218,Lieutenant Governor,,REP,George Yang,29
 San Luis Obispo,218,Lieutenant Governor,,GRN,Jena F. Goodman,16
 San Luis Obispo,218,Lieutenant Governor,,REP,Ron Nehring,71
+San Luis Obispo,218,Proposition 41,,,No,137
+San Luis Obispo,218,Proposition 41,,,Yes,331
+San Luis Obispo,218,Proposition 42,,,No,188
+San Luis Obispo,218,Proposition 42,,,Yes,258
 San Luis Obispo,218,Secretary of State,,DEM,Alex Padilla,153
 San Luis Obispo,218,Secretary of State,,IND,Dan Schnur,18
 San Luis Obispo,218,Secretary of State,,GRN,David Curtis,20
@@ -2944,6 +3120,10 @@ San Luis Obispo,219,Lieutenant Governor,,DEM,Gavin Newsom,426
 San Luis Obispo,219,Lieutenant Governor,,REP,George Yang,33
 San Luis Obispo,219,Lieutenant Governor,,GRN,Jena F. Goodman,14
 San Luis Obispo,219,Lieutenant Governor,,REP,Ron Nehring,85
+San Luis Obispo,219,Proposition 41,,,No,187
+San Luis Obispo,219,Proposition 41,,,Yes,465
+San Luis Obispo,219,Proposition 42,,,No,271
+San Luis Obispo,219,Proposition 42,,,Yes,363
 San Luis Obispo,219,Secretary of State,,DEM,Alex Padilla,231
 San Luis Obispo,219,Secretary of State,,IND,Dan Schnur,22
 San Luis Obispo,219,Secretary of State,,GRN,David Curtis,24
@@ -3010,6 +3190,10 @@ San Luis Obispo,220,Lieutenant Governor,,DEM,Gavin Newsom,196
 San Luis Obispo,220,Lieutenant Governor,,REP,George Yang,19
 San Luis Obispo,220,Lieutenant Governor,,GRN,Jena F. Goodman,6
 San Luis Obispo,220,Lieutenant Governor,,REP,Ron Nehring,55
+San Luis Obispo,220,Proposition 41,,,No,95
+San Luis Obispo,220,Proposition 41,,,Yes,250
+San Luis Obispo,220,Proposition 42,,,No,144
+San Luis Obispo,220,Proposition 42,,,Yes,186
 San Luis Obispo,220,Secretary of State,,DEM,Alex Padilla,104
 San Luis Obispo,220,Secretary of State,,IND,Dan Schnur,16
 San Luis Obispo,220,Secretary of State,,GRN,David Curtis,9
@@ -3076,6 +3260,10 @@ San Luis Obispo,221,Lieutenant Governor,,DEM,Gavin Newsom,229
 San Luis Obispo,221,Lieutenant Governor,,REP,George Yang,29
 San Luis Obispo,221,Lieutenant Governor,,GRN,Jena F. Goodman,6
 San Luis Obispo,221,Lieutenant Governor,,REP,Ron Nehring,46
+San Luis Obispo,221,Proposition 41,,,No,108
+San Luis Obispo,221,Proposition 41,,,Yes,281
+San Luis Obispo,221,Proposition 42,,,No,176
+San Luis Obispo,221,Proposition 42,,,Yes,196
 San Luis Obispo,221,Secretary of State,,DEM,Alex Padilla,126
 San Luis Obispo,221,Secretary of State,,IND,Dan Schnur,13
 San Luis Obispo,221,Secretary of State,,GRN,David Curtis,13
@@ -3142,6 +3330,10 @@ San Luis Obispo,222,Lieutenant Governor,,DEM,Gavin Newsom,209
 San Luis Obispo,222,Lieutenant Governor,,REP,George Yang,22
 San Luis Obispo,222,Lieutenant Governor,,GRN,Jena F. Goodman,13
 San Luis Obispo,222,Lieutenant Governor,,REP,Ron Nehring,37
+San Luis Obispo,222,Proposition 41,,,No,90
+San Luis Obispo,222,Proposition 41,,,Yes,224
+San Luis Obispo,222,Proposition 42,,,No,131
+San Luis Obispo,222,Proposition 42,,,Yes,166
 San Luis Obispo,222,Secretary of State,,DEM,Alex Padilla,114
 San Luis Obispo,222,Secretary of State,,IND,Dan Schnur,11
 San Luis Obispo,222,Secretary of State,,GRN,David Curtis,14
@@ -3208,6 +3400,10 @@ San Luis Obispo,223,Lieutenant Governor,,DEM,Gavin Newsom,398
 San Luis Obispo,223,Lieutenant Governor,,REP,George Yang,40
 San Luis Obispo,223,Lieutenant Governor,,GRN,Jena F. Goodman,18
 San Luis Obispo,223,Lieutenant Governor,,REP,Ron Nehring,111
+San Luis Obispo,223,Proposition 41,,,No,220
+San Luis Obispo,223,Proposition 41,,,Yes,432
+San Luis Obispo,223,Proposition 42,,,No,290
+San Luis Obispo,223,Proposition 42,,,Yes,339
 San Luis Obispo,223,Secretary of State,,DEM,Alex Padilla,224
 San Luis Obispo,223,Secretary of State,,IND,Dan Schnur,30
 San Luis Obispo,223,Secretary of State,,GRN,David Curtis,27
@@ -3274,6 +3470,10 @@ San Luis Obispo,224,Lieutenant Governor,,DEM,Gavin Newsom,252
 San Luis Obispo,224,Lieutenant Governor,,REP,George Yang,38
 San Luis Obispo,224,Lieutenant Governor,,GRN,Jena F. Goodman,2
 San Luis Obispo,224,Lieutenant Governor,,REP,Ron Nehring,88
+San Luis Obispo,224,Proposition 41,,,No,189
+San Luis Obispo,224,Proposition 41,,,Yes,275
+San Luis Obispo,224,Proposition 42,,,No,217
+San Luis Obispo,224,Proposition 42,,,Yes,224
 San Luis Obispo,224,Secretary of State,,DEM,Alex Padilla,138
 San Luis Obispo,224,Secretary of State,,IND,Dan Schnur,18
 San Luis Obispo,224,Secretary of State,,GRN,David Curtis,11
@@ -3340,6 +3540,10 @@ San Luis Obispo,225,Lieutenant Governor,,DEM,Gavin Newsom,238
 San Luis Obispo,225,Lieutenant Governor,,REP,George Yang,16
 San Luis Obispo,225,Lieutenant Governor,,GRN,Jena F. Goodman,9
 San Luis Obispo,225,Lieutenant Governor,,REP,Ron Nehring,44
+San Luis Obispo,225,Proposition 41,,,No,101
+San Luis Obispo,225,Proposition 41,,,Yes,261
+San Luis Obispo,225,Proposition 42,,,No,153
+San Luis Obispo,225,Proposition 42,,,Yes,192
 San Luis Obispo,225,Secretary of State,,DEM,Alex Padilla,138
 San Luis Obispo,225,Secretary of State,,IND,Dan Schnur,13
 San Luis Obispo,225,Secretary of State,,GRN,David Curtis,17
@@ -3406,6 +3610,10 @@ San Luis Obispo,226,Lieutenant Governor,,DEM,Gavin Newsom,318
 San Luis Obispo,226,Lieutenant Governor,,REP,George Yang,29
 San Luis Obispo,226,Lieutenant Governor,,GRN,Jena F. Goodman,15
 San Luis Obispo,226,Lieutenant Governor,,REP,Ron Nehring,85
+San Luis Obispo,226,Proposition 41,,,No,200
+San Luis Obispo,226,Proposition 41,,,Yes,359
+San Luis Obispo,226,Proposition 42,,,No,243
+San Luis Obispo,226,Proposition 42,,,Yes,290
 San Luis Obispo,226,Secretary of State,,DEM,Alex Padilla,197
 San Luis Obispo,226,Secretary of State,,IND,Dan Schnur,16
 San Luis Obispo,226,Secretary of State,,GRN,David Curtis,21
@@ -3472,6 +3680,10 @@ San Luis Obispo,227,Lieutenant Governor,,DEM,Gavin Newsom,245
 San Luis Obispo,227,Lieutenant Governor,,REP,George Yang,29
 San Luis Obispo,227,Lieutenant Governor,,GRN,Jena F. Goodman,8
 San Luis Obispo,227,Lieutenant Governor,,REP,Ron Nehring,52
+San Luis Obispo,227,Proposition 41,,,No,148
+San Luis Obispo,227,Proposition 41,,,Yes,263
+San Luis Obispo,227,Proposition 42,,,No,183
+San Luis Obispo,227,Proposition 42,,,Yes,214
 San Luis Obispo,227,Secretary of State,,DEM,Alex Padilla,157
 San Luis Obispo,227,Secretary of State,,IND,Dan Schnur,16
 San Luis Obispo,227,Secretary of State,,GRN,David Curtis,15
@@ -3538,6 +3750,10 @@ San Luis Obispo,228,Lieutenant Governor,,DEM,Gavin Newsom,26
 San Luis Obispo,228,Lieutenant Governor,,REP,George Yang,2
 San Luis Obispo,228,Lieutenant Governor,,GRN,Jena F. Goodman,1
 San Luis Obispo,228,Lieutenant Governor,,REP,Ron Nehring,8
+San Luis Obispo,228,Proposition 41,,,No,10
+San Luis Obispo,228,Proposition 41,,,Yes,33
+San Luis Obispo,228,Proposition 42,,,No,14
+San Luis Obispo,228,Proposition 42,,,Yes,25
 San Luis Obispo,228,Secretary of State,,DEM,Alex Padilla,15
 San Luis Obispo,228,Secretary of State,,IND,Dan Schnur,2
 San Luis Obispo,228,Secretary of State,,GRN,David Curtis,2
@@ -3604,6 +3820,10 @@ San Luis Obispo,301,Lieutenant Governor,,DEM,Gavin Newsom,210
 San Luis Obispo,301,Lieutenant Governor,,REP,George Yang,19
 San Luis Obispo,301,Lieutenant Governor,,GRN,Jena F. Goodman,9
 San Luis Obispo,301,Lieutenant Governor,,REP,Ron Nehring,54
+San Luis Obispo,301,Proposition 41,,,No,100
+San Luis Obispo,301,Proposition 41,,,Yes,258
+San Luis Obispo,301,Proposition 42,,,No,161
+San Luis Obispo,301,Proposition 42,,,Yes,180
 San Luis Obispo,301,Secretary of State,,DEM,Alex Padilla,104
 San Luis Obispo,301,Secretary of State,,IND,Dan Schnur,22
 San Luis Obispo,301,Secretary of State,,GRN,David Curtis,14
@@ -3670,6 +3890,10 @@ San Luis Obispo,302,Lieutenant Governor,,DEM,Gavin Newsom,68
 San Luis Obispo,302,Lieutenant Governor,,REP,George Yang,13
 San Luis Obispo,302,Lieutenant Governor,,GRN,Jena F. Goodman,6
 San Luis Obispo,302,Lieutenant Governor,,REP,Ron Nehring,40
+San Luis Obispo,302,Proposition 41,,,No,54
+San Luis Obispo,302,Proposition 41,,,Yes,117
+San Luis Obispo,302,Proposition 42,,,No,65
+San Luis Obispo,302,Proposition 42,,,Yes,102
 San Luis Obispo,302,Secretary of State,,DEM,Alex Padilla,42
 San Luis Obispo,302,Secretary of State,,IND,Dan Schnur,5
 San Luis Obispo,302,Secretary of State,,GRN,David Curtis,6
@@ -3736,6 +3960,10 @@ San Luis Obispo,303,Lieutenant Governor,,DEM,Gavin Newsom,193
 San Luis Obispo,303,Lieutenant Governor,,REP,George Yang,22
 San Luis Obispo,303,Lieutenant Governor,,GRN,Jena F. Goodman,17
 San Luis Obispo,303,Lieutenant Governor,,REP,Ron Nehring,55
+San Luis Obispo,303,Proposition 41,,,No,114
+San Luis Obispo,303,Proposition 41,,,Yes,248
+San Luis Obispo,303,Proposition 42,,,No,142
+San Luis Obispo,303,Proposition 42,,,Yes,202
 San Luis Obispo,303,Secretary of State,,DEM,Alex Padilla,94
 San Luis Obispo,303,Secretary of State,,IND,Dan Schnur,18
 San Luis Obispo,303,Secretary of State,,GRN,David Curtis,11
@@ -3802,6 +4030,10 @@ San Luis Obispo,304,Lieutenant Governor,,DEM,Gavin Newsom,224
 San Luis Obispo,304,Lieutenant Governor,,REP,George Yang,25
 San Luis Obispo,304,Lieutenant Governor,,GRN,Jena F. Goodman,12
 San Luis Obispo,304,Lieutenant Governor,,REP,Ron Nehring,79
+San Luis Obispo,304,Proposition 41,,,No,120
+San Luis Obispo,304,Proposition 41,,,Yes,312
+San Luis Obispo,304,Proposition 42,,,No,168
+San Luis Obispo,304,Proposition 42,,,Yes,234
 San Luis Obispo,304,Secretary of State,,DEM,Alex Padilla,121
 San Luis Obispo,304,Secretary of State,,IND,Dan Schnur,18
 San Luis Obispo,304,Secretary of State,,GRN,David Curtis,15
@@ -3868,6 +4100,10 @@ San Luis Obispo,305,Lieutenant Governor,,DEM,Gavin Newsom,335
 San Luis Obispo,305,Lieutenant Governor,,REP,George Yang,30
 San Luis Obispo,305,Lieutenant Governor,,GRN,Jena F. Goodman,10
 San Luis Obispo,305,Lieutenant Governor,,REP,Ron Nehring,72
+San Luis Obispo,305,Proposition 41,,,No,170
+San Luis Obispo,305,Proposition 41,,,Yes,352
+San Luis Obispo,305,Proposition 42,,,No,210
+San Luis Obispo,305,Proposition 42,,,Yes,288
 San Luis Obispo,305,Secretary of State,,DEM,Alex Padilla,176
 San Luis Obispo,305,Secretary of State,,IND,Dan Schnur,18
 San Luis Obispo,305,Secretary of State,,GRN,David Curtis,13
@@ -3934,6 +4170,10 @@ San Luis Obispo,306,Lieutenant Governor,,DEM,Gavin Newsom,203
 San Luis Obispo,306,Lieutenant Governor,,REP,George Yang,10
 San Luis Obispo,306,Lieutenant Governor,,GRN,Jena F. Goodman,7
 San Luis Obispo,306,Lieutenant Governor,,REP,Ron Nehring,31
+San Luis Obispo,306,Proposition 41,,,No,80
+San Luis Obispo,306,Proposition 41,,,Yes,214
+San Luis Obispo,306,Proposition 42,,,No,120
+San Luis Obispo,306,Proposition 42,,,Yes,166
 San Luis Obispo,306,Secretary of State,,DEM,Alex Padilla,102
 San Luis Obispo,306,Secretary of State,,IND,Dan Schnur,10
 San Luis Obispo,306,Secretary of State,,GRN,David Curtis,10
@@ -4000,6 +4240,10 @@ San Luis Obispo,307,Lieutenant Governor,,DEM,Gavin Newsom,225
 San Luis Obispo,307,Lieutenant Governor,,REP,George Yang,23
 San Luis Obispo,307,Lieutenant Governor,,GRN,Jena F. Goodman,11
 San Luis Obispo,307,Lieutenant Governor,,REP,Ron Nehring,66
+San Luis Obispo,307,Proposition 41,,,No,149
+San Luis Obispo,307,Proposition 41,,,Yes,240
+San Luis Obispo,307,Proposition 42,,,No,167
+San Luis Obispo,307,Proposition 42,,,Yes,208
 San Luis Obispo,307,Secretary of State,,DEM,Alex Padilla,93
 San Luis Obispo,307,Secretary of State,,IND,Dan Schnur,13
 San Luis Obispo,307,Secretary of State,,GRN,David Curtis,13
@@ -4066,6 +4310,10 @@ San Luis Obispo,308,Lieutenant Governor,,DEM,Gavin Newsom,122
 San Luis Obispo,308,Lieutenant Governor,,REP,George Yang,21
 San Luis Obispo,308,Lieutenant Governor,,GRN,Jena F. Goodman,6
 San Luis Obispo,308,Lieutenant Governor,,REP,Ron Nehring,30
+San Luis Obispo,308,Proposition 41,,,No,79
+San Luis Obispo,308,Proposition 41,,,Yes,154
+San Luis Obispo,308,Proposition 42,,,No,104
+San Luis Obispo,308,Proposition 42,,,Yes,118
 San Luis Obispo,308,Secretary of State,,DEM,Alex Padilla,73
 San Luis Obispo,308,Secretary of State,,IND,Dan Schnur,8
 San Luis Obispo,308,Secretary of State,,GRN,David Curtis,11
@@ -4132,6 +4380,10 @@ San Luis Obispo,309,Lieutenant Governor,,DEM,Gavin Newsom,258
 San Luis Obispo,309,Lieutenant Governor,,REP,George Yang,26
 San Luis Obispo,309,Lieutenant Governor,,GRN,Jena F. Goodman,8
 San Luis Obispo,309,Lieutenant Governor,,REP,Ron Nehring,60
+San Luis Obispo,309,Proposition 41,,,No,130
+San Luis Obispo,309,Proposition 41,,,Yes,276
+San Luis Obispo,309,Proposition 42,,,No,188
+San Luis Obispo,309,Proposition 42,,,Yes,201
 San Luis Obispo,309,Secretary of State,,DEM,Alex Padilla,117
 San Luis Obispo,309,Secretary of State,,IND,Dan Schnur,16
 San Luis Obispo,309,Secretary of State,,GRN,David Curtis,9
@@ -4198,6 +4450,10 @@ San Luis Obispo,310,Lieutenant Governor,,DEM,Gavin Newsom,227
 San Luis Obispo,310,Lieutenant Governor,,REP,George Yang,25
 San Luis Obispo,310,Lieutenant Governor,,GRN,Jena F. Goodman,6
 San Luis Obispo,310,Lieutenant Governor,,REP,Ron Nehring,51
+San Luis Obispo,310,Proposition 41,,,No,112
+San Luis Obispo,310,Proposition 41,,,Yes,246
+San Luis Obispo,310,Proposition 42,,,No,159
+San Luis Obispo,310,Proposition 42,,,Yes,184
 San Luis Obispo,310,Secretary of State,,DEM,Alex Padilla,106
 San Luis Obispo,310,Secretary of State,,IND,Dan Schnur,9
 San Luis Obispo,310,Secretary of State,,GRN,David Curtis,21
@@ -4264,6 +4520,10 @@ San Luis Obispo,311,Lieutenant Governor,,DEM,Gavin Newsom,239
 San Luis Obispo,311,Lieutenant Governor,,REP,George Yang,19
 San Luis Obispo,311,Lieutenant Governor,,GRN,Jena F. Goodman,4
 San Luis Obispo,311,Lieutenant Governor,,REP,Ron Nehring,56
+San Luis Obispo,311,Proposition 41,,,No,116
+San Luis Obispo,311,Proposition 41,,,Yes,240
+San Luis Obispo,311,Proposition 42,,,No,144
+San Luis Obispo,311,Proposition 42,,,Yes,202
 San Luis Obispo,311,Secretary of State,,DEM,Alex Padilla,112
 San Luis Obispo,311,Secretary of State,,IND,Dan Schnur,15
 San Luis Obispo,311,Secretary of State,,GRN,David Curtis,18
@@ -4330,6 +4590,10 @@ San Luis Obispo,312,Lieutenant Governor,,DEM,Gavin Newsom,132
 San Luis Obispo,312,Lieutenant Governor,,REP,George Yang,6
 San Luis Obispo,312,Lieutenant Governor,,GRN,Jena F. Goodman,10
 San Luis Obispo,312,Lieutenant Governor,,REP,Ron Nehring,20
+San Luis Obispo,312,Proposition 41,,,No,61
+San Luis Obispo,312,Proposition 41,,,Yes,158
+San Luis Obispo,312,Proposition 42,,,No,81
+San Luis Obispo,312,Proposition 42,,,Yes,128
 San Luis Obispo,312,Secretary of State,,DEM,Alex Padilla,57
 San Luis Obispo,312,Secretary of State,,IND,Dan Schnur,6
 San Luis Obispo,312,Secretary of State,,GRN,David Curtis,22
@@ -4396,6 +4660,10 @@ San Luis Obispo,313,Lieutenant Governor,,DEM,Gavin Newsom,194
 San Luis Obispo,313,Lieutenant Governor,,REP,George Yang,6
 San Luis Obispo,313,Lieutenant Governor,,GRN,Jena F. Goodman,7
 San Luis Obispo,313,Lieutenant Governor,,REP,Ron Nehring,25
+San Luis Obispo,313,Proposition 41,,,No,60
+San Luis Obispo,313,Proposition 41,,,Yes,190
+San Luis Obispo,313,Proposition 42,,,No,82
+San Luis Obispo,313,Proposition 42,,,Yes,159
 San Luis Obispo,313,Secretary of State,,DEM,Alex Padilla,92
 San Luis Obispo,313,Secretary of State,,IND,Dan Schnur,12
 San Luis Obispo,313,Secretary of State,,GRN,David Curtis,15
@@ -4462,6 +4730,10 @@ San Luis Obispo,314,Lieutenant Governor,,DEM,Gavin Newsom,221
 San Luis Obispo,314,Lieutenant Governor,,REP,George Yang,18
 San Luis Obispo,314,Lieutenant Governor,,GRN,Jena F. Goodman,9
 San Luis Obispo,314,Lieutenant Governor,,REP,Ron Nehring,23
+San Luis Obispo,314,Proposition 41,,,No,86
+San Luis Obispo,314,Proposition 41,,,Yes,219
+San Luis Obispo,314,Proposition 42,,,No,144
+San Luis Obispo,314,Proposition 42,,,Yes,152
 San Luis Obispo,314,Secretary of State,,DEM,Alex Padilla,100
 San Luis Obispo,314,Secretary of State,,IND,Dan Schnur,14
 San Luis Obispo,314,Secretary of State,,GRN,David Curtis,12
@@ -4528,6 +4800,10 @@ San Luis Obispo,315,Lieutenant Governor,,DEM,Gavin Newsom,402
 San Luis Obispo,315,Lieutenant Governor,,REP,George Yang,31
 San Luis Obispo,315,Lieutenant Governor,,GRN,Jena F. Goodman,9
 San Luis Obispo,315,Lieutenant Governor,,REP,Ron Nehring,73
+San Luis Obispo,315,Proposition 41,,,No,155
+San Luis Obispo,315,Proposition 41,,,Yes,454
+San Luis Obispo,315,Proposition 42,,,No,237
+San Luis Obispo,315,Proposition 42,,,Yes,340
 San Luis Obispo,315,Secretary of State,,DEM,Alex Padilla,208
 San Luis Obispo,315,Secretary of State,,IND,Dan Schnur,23
 San Luis Obispo,315,Secretary of State,,GRN,David Curtis,21
@@ -4594,6 +4870,10 @@ San Luis Obispo,316,Lieutenant Governor,,DEM,Gavin Newsom,242
 San Luis Obispo,316,Lieutenant Governor,,REP,George Yang,59
 San Luis Obispo,316,Lieutenant Governor,,GRN,Jena F. Goodman,9
 San Luis Obispo,316,Lieutenant Governor,,REP,Ron Nehring,149
+San Luis Obispo,316,Proposition 41,,,No,284
+San Luis Obispo,316,Proposition 41,,,Yes,323
+San Luis Obispo,316,Proposition 42,,,No,300
+San Luis Obispo,316,Proposition 42,,,Yes,287
 San Luis Obispo,316,Secretary of State,,DEM,Alex Padilla,119
 San Luis Obispo,316,Secretary of State,,IND,Dan Schnur,30
 San Luis Obispo,316,Secretary of State,,GRN,David Curtis,20
@@ -4660,6 +4940,10 @@ San Luis Obispo,317,Lieutenant Governor,,DEM,Gavin Newsom,385
 San Luis Obispo,317,Lieutenant Governor,,REP,George Yang,57
 San Luis Obispo,317,Lieutenant Governor,,GRN,Jena F. Goodman,9
 San Luis Obispo,317,Lieutenant Governor,,REP,Ron Nehring,131
+San Luis Obispo,317,Proposition 41,,,No,231
+San Luis Obispo,317,Proposition 41,,,Yes,500
+San Luis Obispo,317,Proposition 42,,,No,285
+San Luis Obispo,317,Proposition 42,,,Yes,407
 San Luis Obispo,317,Secretary of State,,DEM,Alex Padilla,188
 San Luis Obispo,317,Secretary of State,,IND,Dan Schnur,31
 San Luis Obispo,317,Secretary of State,,GRN,David Curtis,31
@@ -4726,6 +5010,10 @@ San Luis Obispo,318,Lieutenant Governor,,DEM,Gavin Newsom,309
 San Luis Obispo,318,Lieutenant Governor,,REP,George Yang,44
 San Luis Obispo,318,Lieutenant Governor,,GRN,Jena F. Goodman,6
 San Luis Obispo,318,Lieutenant Governor,,REP,Ron Nehring,113
+San Luis Obispo,318,Proposition 41,,,No,231
+San Luis Obispo,318,Proposition 41,,,Yes,389
+San Luis Obispo,318,Proposition 42,,,No,272
+San Luis Obispo,318,Proposition 42,,,Yes,334
 San Luis Obispo,318,Secretary of State,,DEM,Alex Padilla,152
 San Luis Obispo,318,Secretary of State,,IND,Dan Schnur,34
 San Luis Obispo,318,Secretary of State,,GRN,David Curtis,13
@@ -4792,6 +5080,10 @@ San Luis Obispo,319,Lieutenant Governor,,DEM,Gavin Newsom,135
 San Luis Obispo,319,Lieutenant Governor,,REP,George Yang,22
 San Luis Obispo,319,Lieutenant Governor,,GRN,Jena F. Goodman,6
 San Luis Obispo,319,Lieutenant Governor,,REP,Ron Nehring,80
+San Luis Obispo,319,Proposition 41,,,No,129
+San Luis Obispo,319,Proposition 41,,,Yes,186
+San Luis Obispo,319,Proposition 42,,,No,132
+San Luis Obispo,319,Proposition 42,,,Yes,170
 San Luis Obispo,319,Secretary of State,,DEM,Alex Padilla,72
 San Luis Obispo,319,Secretary of State,,IND,Dan Schnur,15
 San Luis Obispo,319,Secretary of State,,GRN,David Curtis,8
@@ -4858,6 +5150,10 @@ San Luis Obispo,320,Lieutenant Governor,,DEM,Gavin Newsom,192
 San Luis Obispo,320,Lieutenant Governor,,REP,George Yang,39
 San Luis Obispo,320,Lieutenant Governor,,GRN,Jena F. Goodman,4
 San Luis Obispo,320,Lieutenant Governor,,REP,Ron Nehring,85
+San Luis Obispo,320,Proposition 41,,,No,162
+San Luis Obispo,320,Proposition 41,,,Yes,229
+San Luis Obispo,320,Proposition 42,,,No,175
+San Luis Obispo,320,Proposition 42,,,Yes,198
 San Luis Obispo,320,Secretary of State,,DEM,Alex Padilla,88
 San Luis Obispo,320,Secretary of State,,IND,Dan Schnur,19
 San Luis Obispo,320,Secretary of State,,GRN,David Curtis,11
@@ -4924,6 +5220,10 @@ San Luis Obispo,321,Lieutenant Governor,,DEM,Gavin Newsom,160
 San Luis Obispo,321,Lieutenant Governor,,REP,George Yang,53
 San Luis Obispo,321,Lieutenant Governor,,GRN,Jena F. Goodman,4
 San Luis Obispo,321,Lieutenant Governor,,REP,Ron Nehring,112
+San Luis Obispo,321,Proposition 41,,,No,201
+San Luis Obispo,321,Proposition 41,,,Yes,220
+San Luis Obispo,321,Proposition 42,,,No,210
+San Luis Obispo,321,Proposition 42,,,Yes,196
 San Luis Obispo,321,Secretary of State,,DEM,Alex Padilla,81
 San Luis Obispo,321,Secretary of State,,IND,Dan Schnur,14
 San Luis Obispo,321,Secretary of State,,GRN,David Curtis,4
@@ -4990,6 +5290,10 @@ San Luis Obispo,322,Lieutenant Governor,,DEM,Gavin Newsom,230
 San Luis Obispo,322,Lieutenant Governor,,REP,George Yang,35
 San Luis Obispo,322,Lieutenant Governor,,GRN,Jena F. Goodman,6
 San Luis Obispo,322,Lieutenant Governor,,REP,Ron Nehring,133
+San Luis Obispo,322,Proposition 41,,,No,172
+San Luis Obispo,322,Proposition 41,,,Yes,345
+San Luis Obispo,322,Proposition 42,,,No,237
+San Luis Obispo,322,Proposition 42,,,Yes,257
 San Luis Obispo,322,Secretary of State,,DEM,Alex Padilla,101
 San Luis Obispo,322,Secretary of State,,IND,Dan Schnur,25
 San Luis Obispo,322,Secretary of State,,GRN,David Curtis,10
@@ -5056,6 +5360,10 @@ San Luis Obispo,323,Lieutenant Governor,,DEM,Gavin Newsom,120
 San Luis Obispo,323,Lieutenant Governor,,REP,George Yang,12
 San Luis Obispo,323,Lieutenant Governor,,GRN,Jena F. Goodman,5
 San Luis Obispo,323,Lieutenant Governor,,REP,Ron Nehring,46
+San Luis Obispo,323,Proposition 41,,,No,88
+San Luis Obispo,323,Proposition 41,,,Yes,160
+San Luis Obispo,323,Proposition 42,,,No,109
+San Luis Obispo,323,Proposition 42,,,Yes,131
 San Luis Obispo,323,Secretary of State,,DEM,Alex Padilla,60
 San Luis Obispo,323,Secretary of State,,IND,Dan Schnur,9
 San Luis Obispo,323,Secretary of State,,GRN,David Curtis,10
@@ -5122,6 +5430,10 @@ San Luis Obispo,324,Lieutenant Governor,,DEM,Gavin Newsom,174
 San Luis Obispo,324,Lieutenant Governor,,REP,George Yang,19
 San Luis Obispo,324,Lieutenant Governor,,GRN,Jena F. Goodman,6
 San Luis Obispo,324,Lieutenant Governor,,REP,Ron Nehring,59
+San Luis Obispo,324,Proposition 41,,,No,125
+San Luis Obispo,324,Proposition 41,,,Yes,211
+San Luis Obispo,324,Proposition 42,,,No,174
+San Luis Obispo,324,Proposition 42,,,Yes,149
 San Luis Obispo,324,Secretary of State,,DEM,Alex Padilla,74
 San Luis Obispo,324,Secretary of State,,IND,Dan Schnur,8
 San Luis Obispo,324,Secretary of State,,GRN,David Curtis,16
@@ -5188,6 +5500,10 @@ San Luis Obispo,325,Lieutenant Governor,,DEM,Gavin Newsom,99
 San Luis Obispo,325,Lieutenant Governor,,REP,George Yang,19
 San Luis Obispo,325,Lieutenant Governor,,GRN,Jena F. Goodman,5
 San Luis Obispo,325,Lieutenant Governor,,REP,Ron Nehring,29
+San Luis Obispo,325,Proposition 41,,,No,90
+San Luis Obispo,325,Proposition 41,,,Yes,134
+San Luis Obispo,325,Proposition 42,,,No,106
+San Luis Obispo,325,Proposition 42,,,Yes,112
 San Luis Obispo,325,Secretary of State,,DEM,Alex Padilla,56
 San Luis Obispo,325,Secretary of State,,IND,Dan Schnur,14
 San Luis Obispo,325,Secretary of State,,GRN,David Curtis,5
@@ -5254,6 +5570,10 @@ San Luis Obispo,326,Lieutenant Governor,,DEM,Gavin Newsom,127
 San Luis Obispo,326,Lieutenant Governor,,REP,George Yang,33
 San Luis Obispo,326,Lieutenant Governor,,GRN,Jena F. Goodman,4
 San Luis Obispo,326,Lieutenant Governor,,REP,Ron Nehring,66
+San Luis Obispo,326,Proposition 41,,,No,130
+San Luis Obispo,326,Proposition 41,,,Yes,162
+San Luis Obispo,326,Proposition 42,,,No,151
+San Luis Obispo,326,Proposition 42,,,Yes,139
 San Luis Obispo,326,Secretary of State,,DEM,Alex Padilla,70
 San Luis Obispo,326,Secretary of State,,IND,Dan Schnur,17
 San Luis Obispo,326,Secretary of State,,GRN,David Curtis,15
@@ -5320,6 +5640,10 @@ San Luis Obispo,327,Lieutenant Governor,,DEM,Gavin Newsom,163
 San Luis Obispo,327,Lieutenant Governor,,REP,George Yang,36
 San Luis Obispo,327,Lieutenant Governor,,GRN,Jena F. Goodman,12
 San Luis Obispo,327,Lieutenant Governor,,REP,Ron Nehring,77
+San Luis Obispo,327,Proposition 41,,,No,140
+San Luis Obispo,327,Proposition 41,,,Yes,250
+San Luis Obispo,327,Proposition 42,,,No,182
+San Luis Obispo,327,Proposition 42,,,Yes,196
 San Luis Obispo,327,Secretary of State,,DEM,Alex Padilla,96
 San Luis Obispo,327,Secretary of State,,IND,Dan Schnur,17
 San Luis Obispo,327,Secretary of State,,GRN,David Curtis,22
@@ -5386,6 +5710,10 @@ San Luis Obispo,328,Lieutenant Governor,,DEM,Gavin Newsom,91
 San Luis Obispo,328,Lieutenant Governor,,REP,George Yang,17
 San Luis Obispo,328,Lieutenant Governor,,GRN,Jena F. Goodman,3
 San Luis Obispo,328,Lieutenant Governor,,REP,Ron Nehring,38
+San Luis Obispo,328,Proposition 41,,,No,95
+San Luis Obispo,328,Proposition 41,,,Yes,114
+San Luis Obispo,328,Proposition 42,,,No,97
+San Luis Obispo,328,Proposition 42,,,Yes,109
 San Luis Obispo,328,Secretary of State,,DEM,Alex Padilla,51
 San Luis Obispo,328,Secretary of State,,IND,Dan Schnur,6
 San Luis Obispo,328,Secretary of State,,GRN,David Curtis,5
@@ -5452,6 +5780,10 @@ San Luis Obispo,329,Lieutenant Governor,,DEM,Gavin Newsom,161
 San Luis Obispo,329,Lieutenant Governor,,REP,George Yang,33
 San Luis Obispo,329,Lieutenant Governor,,GRN,Jena F. Goodman,8
 San Luis Obispo,329,Lieutenant Governor,,REP,Ron Nehring,71
+San Luis Obispo,329,Proposition 41,,,No,131
+San Luis Obispo,329,Proposition 41,,,Yes,215
+San Luis Obispo,329,Proposition 42,,,No,158
+San Luis Obispo,329,Proposition 42,,,Yes,173
 San Luis Obispo,329,Secretary of State,,DEM,Alex Padilla,93
 San Luis Obispo,329,Secretary of State,,IND,Dan Schnur,25
 San Luis Obispo,329,Secretary of State,,GRN,David Curtis,7
@@ -5518,6 +5850,10 @@ San Luis Obispo,330,Lieutenant Governor,,DEM,Gavin Newsom,103
 San Luis Obispo,330,Lieutenant Governor,,REP,George Yang,18
 San Luis Obispo,330,Lieutenant Governor,,GRN,Jena F. Goodman,7
 San Luis Obispo,330,Lieutenant Governor,,REP,Ron Nehring,68
+San Luis Obispo,330,Proposition 41,,,No,109
+San Luis Obispo,330,Proposition 41,,,Yes,141
+San Luis Obispo,330,Proposition 42,,,No,114
+San Luis Obispo,330,Proposition 42,,,Yes,130
 San Luis Obispo,330,Secretary of State,,DEM,Alex Padilla,52
 San Luis Obispo,330,Secretary of State,,IND,Dan Schnur,8
 San Luis Obispo,330,Secretary of State,,GRN,David Curtis,15
@@ -5584,6 +5920,10 @@ San Luis Obispo,331,Lieutenant Governor,,DEM,Gavin Newsom,196
 San Luis Obispo,331,Lieutenant Governor,,REP,George Yang,25
 San Luis Obispo,331,Lieutenant Governor,,GRN,Jena F. Goodman,4
 San Luis Obispo,331,Lieutenant Governor,,REP,Ron Nehring,104
+San Luis Obispo,331,Proposition 41,,,No,194
+San Luis Obispo,331,Proposition 41,,,Yes,236
+San Luis Obispo,331,Proposition 42,,,No,200
+San Luis Obispo,331,Proposition 42,,,Yes,205
 San Luis Obispo,331,Secretary of State,,DEM,Alex Padilla,89
 San Luis Obispo,331,Secretary of State,,IND,Dan Schnur,26
 San Luis Obispo,331,Secretary of State,,GRN,David Curtis,7
@@ -5650,6 +5990,10 @@ San Luis Obispo,401,Lieutenant Governor,,DEM,Gavin Newsom,220
 San Luis Obispo,401,Lieutenant Governor,,REP,George Yang,31
 San Luis Obispo,401,Lieutenant Governor,,GRN,Jena F. Goodman,3
 San Luis Obispo,401,Lieutenant Governor,,REP,Ron Nehring,162
+San Luis Obispo,401,Proposition 41,,,No,226
+San Luis Obispo,401,Proposition 41,,,Yes,316
+San Luis Obispo,401,Proposition 42,,,No,266
+San Luis Obispo,401,Proposition 42,,,Yes,236
 San Luis Obispo,401,Secretary of State,,DEM,Alex Padilla,111
 San Luis Obispo,401,Secretary of State,,IND,Dan Schnur,87
 San Luis Obispo,401,Secretary of State,,GRN,David Curtis,8
@@ -5716,6 +6060,10 @@ San Luis Obispo,402,Lieutenant Governor,,DEM,Gavin Newsom,231
 San Luis Obispo,402,Lieutenant Governor,,REP,George Yang,55
 San Luis Obispo,402,Lieutenant Governor,,GRN,Jena F. Goodman,3
 San Luis Obispo,402,Lieutenant Governor,,REP,Ron Nehring,128
+San Luis Obispo,402,Proposition 41,,,No,239
+San Luis Obispo,402,Proposition 41,,,Yes,306
+San Luis Obispo,402,Proposition 42,,,No,283
+San Luis Obispo,402,Proposition 42,,,Yes,245
 San Luis Obispo,402,Secretary of State,,DEM,Alex Padilla,130
 San Luis Obispo,402,Secretary of State,,IND,Dan Schnur,77
 San Luis Obispo,402,Secretary of State,,GRN,David Curtis,7
@@ -5782,6 +6130,10 @@ San Luis Obispo,403,Lieutenant Governor,,DEM,Gavin Newsom,145
 San Luis Obispo,403,Lieutenant Governor,,REP,George Yang,45
 San Luis Obispo,403,Lieutenant Governor,,GRN,Jena F. Goodman,8
 San Luis Obispo,403,Lieutenant Governor,,REP,Ron Nehring,93
+San Luis Obispo,403,Proposition 41,,,No,147
+San Luis Obispo,403,Proposition 41,,,Yes,204
+San Luis Obispo,403,Proposition 42,,,No,190
+San Luis Obispo,403,Proposition 42,,,Yes,150
 San Luis Obispo,403,Secretary of State,,DEM,Alex Padilla,82
 San Luis Obispo,403,Secretary of State,,IND,Dan Schnur,38
 San Luis Obispo,403,Secretary of State,,GRN,David Curtis,9
@@ -5848,6 +6200,10 @@ San Luis Obispo,404,Lieutenant Governor,,DEM,Gavin Newsom,231
 San Luis Obispo,404,Lieutenant Governor,,REP,George Yang,55
 San Luis Obispo,404,Lieutenant Governor,,GRN,Jena F. Goodman,13
 San Luis Obispo,404,Lieutenant Governor,,REP,Ron Nehring,164
+San Luis Obispo,404,Proposition 41,,,No,261
+San Luis Obispo,404,Proposition 41,,,Yes,330
+San Luis Obispo,404,Proposition 42,,,No,295
+San Luis Obispo,404,Proposition 42,,,Yes,274
 San Luis Obispo,404,Secretary of State,,DEM,Alex Padilla,127
 San Luis Obispo,404,Secretary of State,,IND,Dan Schnur,76
 San Luis Obispo,404,Secretary of State,,GRN,David Curtis,14
@@ -5914,6 +6270,10 @@ San Luis Obispo,405,Lieutenant Governor,,DEM,Gavin Newsom,173
 San Luis Obispo,405,Lieutenant Governor,,REP,George Yang,29
 San Luis Obispo,405,Lieutenant Governor,,GRN,Jena F. Goodman,2
 San Luis Obispo,405,Lieutenant Governor,,REP,Ron Nehring,87
+San Luis Obispo,405,Proposition 41,,,No,129
+San Luis Obispo,405,Proposition 41,,,Yes,242
+San Luis Obispo,405,Proposition 42,,,No,144
+San Luis Obispo,405,Proposition 42,,,Yes,201
 San Luis Obispo,405,Secretary of State,,DEM,Alex Padilla,97
 San Luis Obispo,405,Secretary of State,,IND,Dan Schnur,45
 San Luis Obispo,405,Secretary of State,,GRN,David Curtis,8
@@ -5980,6 +6340,10 @@ San Luis Obispo,406,Lieutenant Governor,,DEM,Gavin Newsom,139
 San Luis Obispo,406,Lieutenant Governor,,REP,George Yang,37
 San Luis Obispo,406,Lieutenant Governor,,GRN,Jena F. Goodman,8
 San Luis Obispo,406,Lieutenant Governor,,REP,Ron Nehring,112
+San Luis Obispo,406,Proposition 41,,,No,109
+San Luis Obispo,406,Proposition 41,,,Yes,256
+San Luis Obispo,406,Proposition 42,,,No,163
+San Luis Obispo,406,Proposition 42,,,Yes,180
 San Luis Obispo,406,Secretary of State,,DEM,Alex Padilla,88
 San Luis Obispo,406,Secretary of State,,IND,Dan Schnur,64
 San Luis Obispo,406,Secretary of State,,GRN,David Curtis,7
@@ -6046,6 +6410,10 @@ San Luis Obispo,407,Lieutenant Governor,,DEM,Gavin Newsom,218
 San Luis Obispo,407,Lieutenant Governor,,REP,George Yang,46
 San Luis Obispo,407,Lieutenant Governor,,GRN,Jena F. Goodman,8
 San Luis Obispo,407,Lieutenant Governor,,REP,Ron Nehring,145
+San Luis Obispo,407,Proposition 41,,,No,223
+San Luis Obispo,407,Proposition 41,,,Yes,325
+San Luis Obispo,407,Proposition 42,,,No,256
+San Luis Obispo,407,Proposition 42,,,Yes,273
 San Luis Obispo,407,Secretary of State,,DEM,Alex Padilla,126
 San Luis Obispo,407,Secretary of State,,IND,Dan Schnur,58
 San Luis Obispo,407,Secretary of State,,GRN,David Curtis,15
@@ -6112,6 +6480,10 @@ San Luis Obispo,408,Lieutenant Governor,,DEM,Gavin Newsom,194
 San Luis Obispo,408,Lieutenant Governor,,REP,George Yang,19
 San Luis Obispo,408,Lieutenant Governor,,GRN,Jena F. Goodman,7
 San Luis Obispo,408,Lieutenant Governor,,REP,Ron Nehring,76
+San Luis Obispo,408,Proposition 41,,,No,125
+San Luis Obispo,408,Proposition 41,,,Yes,245
+San Luis Obispo,408,Proposition 42,,,No,162
+San Luis Obispo,408,Proposition 42,,,Yes,190
 San Luis Obispo,408,Secretary of State,,DEM,Alex Padilla,108
 San Luis Obispo,408,Secretary of State,,IND,Dan Schnur,49
 San Luis Obispo,408,Secretary of State,,GRN,David Curtis,12
@@ -6178,6 +6550,10 @@ San Luis Obispo,409,Lieutenant Governor,,DEM,Gavin Newsom,136
 San Luis Obispo,409,Lieutenant Governor,,REP,George Yang,25
 San Luis Obispo,409,Lieutenant Governor,,GRN,Jena F. Goodman,7
 San Luis Obispo,409,Lieutenant Governor,,REP,Ron Nehring,68
+San Luis Obispo,409,Proposition 41,,,No,101
+San Luis Obispo,409,Proposition 41,,,Yes,207
+San Luis Obispo,409,Proposition 42,,,No,148
+San Luis Obispo,409,Proposition 42,,,Yes,144
 San Luis Obispo,409,Secretary of State,,DEM,Alex Padilla,83
 San Luis Obispo,409,Secretary of State,,IND,Dan Schnur,34
 San Luis Obispo,409,Secretary of State,,GRN,David Curtis,9
@@ -6244,6 +6620,10 @@ San Luis Obispo,410,Lieutenant Governor,,DEM,Gavin Newsom,121
 San Luis Obispo,410,Lieutenant Governor,,REP,George Yang,27
 San Luis Obispo,410,Lieutenant Governor,,GRN,Jena F. Goodman,5
 San Luis Obispo,410,Lieutenant Governor,,REP,Ron Nehring,67
+San Luis Obispo,410,Proposition 41,,,No,90
+San Luis Obispo,410,Proposition 41,,,Yes,186
+San Luis Obispo,410,Proposition 42,,,No,112
+San Luis Obispo,410,Proposition 42,,,Yes,148
 San Luis Obispo,410,Secretary of State,,DEM,Alex Padilla,62
 San Luis Obispo,410,Secretary of State,,IND,Dan Schnur,32
 San Luis Obispo,410,Secretary of State,,GRN,David Curtis,5
@@ -6310,6 +6690,10 @@ San Luis Obispo,411,Lieutenant Governor,,DEM,Gavin Newsom,184
 San Luis Obispo,411,Lieutenant Governor,,REP,George Yang,25
 San Luis Obispo,411,Lieutenant Governor,,GRN,Jena F. Goodman,6
 San Luis Obispo,411,Lieutenant Governor,,REP,Ron Nehring,76
+San Luis Obispo,411,Proposition 41,,,No,125
+San Luis Obispo,411,Proposition 41,,,Yes,240
+San Luis Obispo,411,Proposition 42,,,No,152
+San Luis Obispo,411,Proposition 42,,,Yes,196
 San Luis Obispo,411,Secretary of State,,DEM,Alex Padilla,103
 San Luis Obispo,411,Secretary of State,,IND,Dan Schnur,40
 San Luis Obispo,411,Secretary of State,,GRN,David Curtis,8
@@ -6376,6 +6760,10 @@ San Luis Obispo,412,Lieutenant Governor,,DEM,Gavin Newsom,120
 San Luis Obispo,412,Lieutenant Governor,,REP,George Yang,18
 San Luis Obispo,412,Lieutenant Governor,,GRN,Jena F. Goodman,3
 San Luis Obispo,412,Lieutenant Governor,,REP,Ron Nehring,62
+San Luis Obispo,412,Proposition 41,,,No,84
+San Luis Obispo,412,Proposition 41,,,Yes,174
+San Luis Obispo,412,Proposition 42,,,No,109
+San Luis Obispo,412,Proposition 42,,,Yes,133
 San Luis Obispo,412,Secretary of State,,DEM,Alex Padilla,67
 San Luis Obispo,412,Secretary of State,,IND,Dan Schnur,19
 San Luis Obispo,412,Secretary of State,,GRN,David Curtis,7
@@ -6442,6 +6830,10 @@ San Luis Obispo,413,Lieutenant Governor,,DEM,Gavin Newsom,162
 San Luis Obispo,413,Lieutenant Governor,,REP,George Yang,32
 San Luis Obispo,413,Lieutenant Governor,,GRN,Jena F. Goodman,8
 San Luis Obispo,413,Lieutenant Governor,,REP,Ron Nehring,97
+San Luis Obispo,413,Proposition 41,,,No,182
+San Luis Obispo,413,Proposition 41,,,Yes,229
+San Luis Obispo,413,Proposition 42,,,No,189
+San Luis Obispo,413,Proposition 42,,,Yes,200
 San Luis Obispo,413,Secretary of State,,DEM,Alex Padilla,91
 San Luis Obispo,413,Secretary of State,,IND,Dan Schnur,49
 San Luis Obispo,413,Secretary of State,,GRN,David Curtis,8
@@ -6508,6 +6900,10 @@ San Luis Obispo,414,Lieutenant Governor,,DEM,Gavin Newsom,155
 San Luis Obispo,414,Lieutenant Governor,,REP,George Yang,43
 San Luis Obispo,414,Lieutenant Governor,,GRN,Jena F. Goodman,5
 San Luis Obispo,414,Lieutenant Governor,,REP,Ron Nehring,142
+San Luis Obispo,414,Proposition 41,,,No,188
+San Luis Obispo,414,Proposition 41,,,Yes,273
+San Luis Obispo,414,Proposition 42,,,No,222
+San Luis Obispo,414,Proposition 42,,,Yes,233
 San Luis Obispo,414,Secretary of State,,DEM,Alex Padilla,79
 San Luis Obispo,414,Secretary of State,,IND,Dan Schnur,85
 San Luis Obispo,414,Secretary of State,,GRN,David Curtis,11
@@ -6574,6 +6970,10 @@ San Luis Obispo,415,Lieutenant Governor,,DEM,Gavin Newsom,196
 San Luis Obispo,415,Lieutenant Governor,,REP,George Yang,42
 San Luis Obispo,415,Lieutenant Governor,,GRN,Jena F. Goodman,10
 San Luis Obispo,415,Lieutenant Governor,,REP,Ron Nehring,115
+San Luis Obispo,415,Proposition 41,,,No,161
+San Luis Obispo,415,Proposition 41,,,Yes,340
+San Luis Obispo,415,Proposition 42,,,No,231
+San Luis Obispo,415,Proposition 42,,,Yes,252
 San Luis Obispo,415,Secretary of State,,DEM,Alex Padilla,92
 San Luis Obispo,415,Secretary of State,,IND,Dan Schnur,66
 San Luis Obispo,415,Secretary of State,,GRN,David Curtis,15
@@ -6640,6 +7040,10 @@ San Luis Obispo,416,Lieutenant Governor,,DEM,Gavin Newsom,151
 San Luis Obispo,416,Lieutenant Governor,,REP,George Yang,44
 San Luis Obispo,416,Lieutenant Governor,,GRN,Jena F. Goodman,2
 San Luis Obispo,416,Lieutenant Governor,,REP,Ron Nehring,115
+San Luis Obispo,416,Proposition 41,,,No,168
+San Luis Obispo,416,Proposition 41,,,Yes,246
+San Luis Obispo,416,Proposition 42,,,No,229
+San Luis Obispo,416,Proposition 42,,,Yes,171
 San Luis Obispo,416,Secretary of State,,DEM,Alex Padilla,69
 San Luis Obispo,416,Secretary of State,,IND,Dan Schnur,60
 San Luis Obispo,416,Secretary of State,,GRN,David Curtis,3
@@ -6706,6 +7110,10 @@ San Luis Obispo,417,Lieutenant Governor,,DEM,Gavin Newsom,159
 San Luis Obispo,417,Lieutenant Governor,,REP,George Yang,31
 San Luis Obispo,417,Lieutenant Governor,,GRN,Jena F. Goodman,11
 San Luis Obispo,417,Lieutenant Governor,,REP,Ron Nehring,113
+San Luis Obispo,417,Proposition 41,,,No,166
+San Luis Obispo,417,Proposition 41,,,Yes,260
+San Luis Obispo,417,Proposition 42,,,No,188
+San Luis Obispo,417,Proposition 42,,,Yes,219
 San Luis Obispo,417,Secretary of State,,DEM,Alex Padilla,75
 San Luis Obispo,417,Secretary of State,,IND,Dan Schnur,73
 San Luis Obispo,417,Secretary of State,,GRN,David Curtis,10
@@ -6772,6 +7180,10 @@ San Luis Obispo,418,Lieutenant Governor,,DEM,Gavin Newsom,97
 San Luis Obispo,418,Lieutenant Governor,,REP,George Yang,25
 San Luis Obispo,418,Lieutenant Governor,,GRN,Jena F. Goodman,4
 San Luis Obispo,418,Lieutenant Governor,,REP,Ron Nehring,61
+San Luis Obispo,418,Proposition 41,,,No,116
+San Luis Obispo,418,Proposition 41,,,Yes,150
+San Luis Obispo,418,Proposition 42,,,No,110
+San Luis Obispo,418,Proposition 42,,,Yes,150
 San Luis Obispo,418,Secretary of State,,DEM,Alex Padilla,73
 San Luis Obispo,418,Secretary of State,,IND,Dan Schnur,19
 San Luis Obispo,418,Secretary of State,,GRN,David Curtis,6
@@ -6838,6 +7250,10 @@ San Luis Obispo,419,Lieutenant Governor,,DEM,Gavin Newsom,131
 San Luis Obispo,419,Lieutenant Governor,,REP,George Yang,25
 San Luis Obispo,419,Lieutenant Governor,,GRN,Jena F. Goodman,8
 San Luis Obispo,419,Lieutenant Governor,,REP,Ron Nehring,82
+San Luis Obispo,419,Proposition 41,,,No,120
+San Luis Obispo,419,Proposition 41,,,Yes,192
+San Luis Obispo,419,Proposition 42,,,No,142
+San Luis Obispo,419,Proposition 42,,,Yes,156
 San Luis Obispo,419,Secretary of State,,DEM,Alex Padilla,87
 San Luis Obispo,419,Secretary of State,,IND,Dan Schnur,25
 San Luis Obispo,419,Secretary of State,,GRN,David Curtis,8
@@ -6904,6 +7320,10 @@ San Luis Obispo,420,Lieutenant Governor,,DEM,Gavin Newsom,265
 San Luis Obispo,420,Lieutenant Governor,,REP,George Yang,57
 San Luis Obispo,420,Lieutenant Governor,,GRN,Jena F. Goodman,15
 San Luis Obispo,420,Lieutenant Governor,,REP,Ron Nehring,226
+San Luis Obispo,420,Proposition 41,,,No,262
+San Luis Obispo,420,Proposition 41,,,Yes,447
+San Luis Obispo,420,Proposition 42,,,No,330
+San Luis Obispo,420,Proposition 42,,,Yes,361
 San Luis Obispo,420,Secretary of State,,DEM,Alex Padilla,121
 San Luis Obispo,420,Secretary of State,,IND,Dan Schnur,112
 San Luis Obispo,420,Secretary of State,,GRN,David Curtis,23
@@ -6970,6 +7390,10 @@ San Luis Obispo,421,Lieutenant Governor,,DEM,Gavin Newsom,142
 San Luis Obispo,421,Lieutenant Governor,,REP,George Yang,25
 San Luis Obispo,421,Lieutenant Governor,,GRN,Jena F. Goodman,3
 San Luis Obispo,421,Lieutenant Governor,,REP,Ron Nehring,87
+San Luis Obispo,421,Proposition 41,,,No,138
+San Luis Obispo,421,Proposition 41,,,Yes,216
+San Luis Obispo,421,Proposition 42,,,No,167
+San Luis Obispo,421,Proposition 42,,,Yes,172
 San Luis Obispo,421,Secretary of State,,DEM,Alex Padilla,74
 San Luis Obispo,421,Secretary of State,,IND,Dan Schnur,29
 San Luis Obispo,421,Secretary of State,,GRN,David Curtis,7
@@ -7036,6 +7460,10 @@ San Luis Obispo,422,Lieutenant Governor,,DEM,Gavin Newsom,105
 San Luis Obispo,422,Lieutenant Governor,,REP,George Yang,28
 San Luis Obispo,422,Lieutenant Governor,,GRN,Jena F. Goodman,10
 San Luis Obispo,422,Lieutenant Governor,,REP,Ron Nehring,80
+San Luis Obispo,422,Proposition 41,,,No,121
+San Luis Obispo,422,Proposition 41,,,Yes,166
+San Luis Obispo,422,Proposition 42,,,No,152
+San Luis Obispo,422,Proposition 42,,,Yes,131
 San Luis Obispo,422,Secretary of State,,DEM,Alex Padilla,68
 San Luis Obispo,422,Secretary of State,,IND,Dan Schnur,27
 San Luis Obispo,422,Secretary of State,,GRN,David Curtis,10
@@ -7102,6 +7530,10 @@ San Luis Obispo,423,Lieutenant Governor,,DEM,Gavin Newsom,79
 San Luis Obispo,423,Lieutenant Governor,,REP,George Yang,22
 San Luis Obispo,423,Lieutenant Governor,,GRN,Jena F. Goodman,3
 San Luis Obispo,423,Lieutenant Governor,,REP,Ron Nehring,49
+San Luis Obispo,423,Proposition 41,,,No,97
+San Luis Obispo,423,Proposition 41,,,Yes,113
+San Luis Obispo,423,Proposition 42,,,No,111
+San Luis Obispo,423,Proposition 42,,,Yes,96
 San Luis Obispo,423,Secretary of State,,DEM,Alex Padilla,56
 San Luis Obispo,423,Secretary of State,,IND,Dan Schnur,21
 San Luis Obispo,423,Secretary of State,,GRN,David Curtis,3
@@ -7168,6 +7600,10 @@ San Luis Obispo,424,Lieutenant Governor,,DEM,Gavin Newsom,154
 San Luis Obispo,424,Lieutenant Governor,,REP,George Yang,57
 San Luis Obispo,424,Lieutenant Governor,,GRN,Jena F. Goodman,12
 San Luis Obispo,424,Lieutenant Governor,,REP,Ron Nehring,134
+San Luis Obispo,424,Proposition 41,,,No,224
+San Luis Obispo,424,Proposition 41,,,Yes,248
+San Luis Obispo,424,Proposition 42,,,No,241
+San Luis Obispo,424,Proposition 42,,,Yes,220
 San Luis Obispo,424,Secretary of State,,DEM,Alex Padilla,89
 San Luis Obispo,424,Secretary of State,,IND,Dan Schnur,55
 San Luis Obispo,424,Secretary of State,,GRN,David Curtis,16
@@ -7234,6 +7670,10 @@ San Luis Obispo,425,Lieutenant Governor,,DEM,Gavin Newsom,159
 San Luis Obispo,425,Lieutenant Governor,,REP,George Yang,55
 San Luis Obispo,425,Lieutenant Governor,,GRN,Jena F. Goodman,11
 San Luis Obispo,425,Lieutenant Governor,,REP,Ron Nehring,147
+San Luis Obispo,425,Proposition 41,,,No,216
+San Luis Obispo,425,Proposition 41,,,Yes,283
+San Luis Obispo,425,Proposition 42,,,No,237
+San Luis Obispo,425,Proposition 42,,,Yes,251
 San Luis Obispo,425,Secretary of State,,DEM,Alex Padilla,89
 San Luis Obispo,425,Secretary of State,,IND,Dan Schnur,63
 San Luis Obispo,425,Secretary of State,,GRN,David Curtis,15
@@ -7300,6 +7740,10 @@ San Luis Obispo,426,Lieutenant Governor,,DEM,Gavin Newsom,146
 San Luis Obispo,426,Lieutenant Governor,,REP,George Yang,45
 San Luis Obispo,426,Lieutenant Governor,,GRN,Jena F. Goodman,5
 San Luis Obispo,426,Lieutenant Governor,,REP,Ron Nehring,195
+San Luis Obispo,426,Proposition 41,,,No,237
+San Luis Obispo,426,Proposition 41,,,Yes,255
+San Luis Obispo,426,Proposition 42,,,No,227
+San Luis Obispo,426,Proposition 42,,,Yes,252
 San Luis Obispo,426,Secretary of State,,DEM,Alex Padilla,70
 San Luis Obispo,426,Secretary of State,,IND,Dan Schnur,74
 San Luis Obispo,426,Secretary of State,,GRN,David Curtis,6
@@ -7366,6 +7810,10 @@ San Luis Obispo,427,Lieutenant Governor,,DEM,Gavin Newsom,314
 San Luis Obispo,427,Lieutenant Governor,,REP,George Yang,61
 San Luis Obispo,427,Lieutenant Governor,,GRN,Jena F. Goodman,7
 San Luis Obispo,427,Lieutenant Governor,,REP,Ron Nehring,171
+San Luis Obispo,427,Proposition 41,,,No,305
+San Luis Obispo,427,Proposition 41,,,Yes,414
+San Luis Obispo,427,Proposition 42,,,No,334
+San Luis Obispo,427,Proposition 42,,,Yes,354
 San Luis Obispo,427,Secretary of State,,DEM,Alex Padilla,177
 San Luis Obispo,427,Secretary of State,,IND,Dan Schnur,68
 San Luis Obispo,427,Secretary of State,,GRN,David Curtis,8
@@ -7432,6 +7880,10 @@ San Luis Obispo,428,Lieutenant Governor,,DEM,Gavin Newsom,138
 San Luis Obispo,428,Lieutenant Governor,,REP,George Yang,17
 San Luis Obispo,428,Lieutenant Governor,,GRN,Jena F. Goodman,8
 San Luis Obispo,428,Lieutenant Governor,,REP,Ron Nehring,63
+San Luis Obispo,428,Proposition 41,,,No,96
+San Luis Obispo,428,Proposition 41,,,Yes,212
+San Luis Obispo,428,Proposition 42,,,No,134
+San Luis Obispo,428,Proposition 42,,,Yes,159
 San Luis Obispo,428,Secretary of State,,DEM,Alex Padilla,75
 San Luis Obispo,428,Secretary of State,,IND,Dan Schnur,19
 San Luis Obispo,428,Secretary of State,,GRN,David Curtis,10
@@ -7498,6 +7950,10 @@ San Luis Obispo,429,Lieutenant Governor,,DEM,Gavin Newsom,139
 San Luis Obispo,429,Lieutenant Governor,,REP,George Yang,32
 San Luis Obispo,429,Lieutenant Governor,,GRN,Jena F. Goodman,10
 San Luis Obispo,429,Lieutenant Governor,,REP,Ron Nehring,66
+San Luis Obispo,429,Proposition 41,,,No,119
+San Luis Obispo,429,Proposition 41,,,Yes,232
+San Luis Obispo,429,Proposition 42,,,No,161
+San Luis Obispo,429,Proposition 42,,,Yes,183
 San Luis Obispo,429,Secretary of State,,DEM,Alex Padilla,109
 San Luis Obispo,429,Secretary of State,,IND,Dan Schnur,30
 San Luis Obispo,429,Secretary of State,,GRN,David Curtis,10
@@ -7564,6 +8020,10 @@ San Luis Obispo,430,Lieutenant Governor,,DEM,Gavin Newsom,163
 San Luis Obispo,430,Lieutenant Governor,,REP,George Yang,28
 San Luis Obispo,430,Lieutenant Governor,,GRN,Jena F. Goodman,13
 San Luis Obispo,430,Lieutenant Governor,,REP,Ron Nehring,61
+San Luis Obispo,430,Proposition 41,,,No,84
+San Luis Obispo,430,Proposition 41,,,Yes,239
+San Luis Obispo,430,Proposition 42,,,No,128
+San Luis Obispo,430,Proposition 42,,,Yes,182
 San Luis Obispo,430,Secretary of State,,DEM,Alex Padilla,94
 San Luis Obispo,430,Secretary of State,,IND,Dan Schnur,22
 San Luis Obispo,430,Secretary of State,,GRN,David Curtis,25
@@ -7630,6 +8090,10 @@ San Luis Obispo,501,Lieutenant Governor,,DEM,Gavin Newsom,258
 San Luis Obispo,501,Lieutenant Governor,,REP,George Yang,63
 San Luis Obispo,501,Lieutenant Governor,,GRN,Jena F. Goodman,8
 San Luis Obispo,501,Lieutenant Governor,,REP,Ron Nehring,186
+San Luis Obispo,501,Proposition 41,,,No,296
+San Luis Obispo,501,Proposition 41,,,Yes,346
+San Luis Obispo,501,Proposition 42,,,No,325
+San Luis Obispo,501,Proposition 42,,,Yes,304
 San Luis Obispo,501,Secretary of State,,DEM,Alex Padilla,100
 San Luis Obispo,501,Secretary of State,,IND,Dan Schnur,37
 San Luis Obispo,501,Secretary of State,,GRN,David Curtis,13
@@ -7696,6 +8160,10 @@ San Luis Obispo,502,Lieutenant Governor,,DEM,Gavin Newsom,201
 San Luis Obispo,502,Lieutenant Governor,,REP,George Yang,65
 San Luis Obispo,502,Lieutenant Governor,,GRN,Jena F. Goodman,10
 San Luis Obispo,502,Lieutenant Governor,,REP,Ron Nehring,151
+San Luis Obispo,502,Proposition 41,,,No,240
+San Luis Obispo,502,Proposition 41,,,Yes,326
+San Luis Obispo,502,Proposition 42,,,No,271
+San Luis Obispo,502,Proposition 42,,,Yes,288
 San Luis Obispo,502,Secretary of State,,DEM,Alex Padilla,109
 San Luis Obispo,502,Secretary of State,,IND,Dan Schnur,34
 San Luis Obispo,502,Secretary of State,,GRN,David Curtis,18
@@ -7762,6 +8230,10 @@ San Luis Obispo,503,Lieutenant Governor,,DEM,Gavin Newsom,285
 San Luis Obispo,503,Lieutenant Governor,,REP,George Yang,66
 San Luis Obispo,503,Lieutenant Governor,,GRN,Jena F. Goodman,6
 San Luis Obispo,503,Lieutenant Governor,,REP,Ron Nehring,140
+San Luis Obispo,503,Proposition 41,,,No,285
+San Luis Obispo,503,Proposition 41,,,Yes,343
+San Luis Obispo,503,Proposition 42,,,No,295
+San Luis Obispo,503,Proposition 42,,,Yes,306
 San Luis Obispo,503,Secretary of State,,DEM,Alex Padilla,122
 San Luis Obispo,503,Secretary of State,,IND,Dan Schnur,29
 San Luis Obispo,503,Secretary of State,,GRN,David Curtis,16
@@ -7828,6 +8300,10 @@ San Luis Obispo,504,Lieutenant Governor,,DEM,Gavin Newsom,111
 San Luis Obispo,504,Lieutenant Governor,,REP,George Yang,21
 San Luis Obispo,504,Lieutenant Governor,,GRN,Jena F. Goodman,4
 San Luis Obispo,504,Lieutenant Governor,,REP,Ron Nehring,97
+San Luis Obispo,504,Proposition 41,,,No,156
+San Luis Obispo,504,Proposition 41,,,Yes,153
+San Luis Obispo,504,Proposition 42,,,No,159
+San Luis Obispo,504,Proposition 42,,,Yes,144
 San Luis Obispo,504,Secretary of State,,DEM,Alex Padilla,58
 San Luis Obispo,504,Secretary of State,,IND,Dan Schnur,8
 San Luis Obispo,504,Secretary of State,,GRN,David Curtis,5
@@ -7894,6 +8370,10 @@ San Luis Obispo,505,Lieutenant Governor,,DEM,Gavin Newsom,247
 San Luis Obispo,505,Lieutenant Governor,,REP,George Yang,50
 San Luis Obispo,505,Lieutenant Governor,,GRN,Jena F. Goodman,10
 San Luis Obispo,505,Lieutenant Governor,,REP,Ron Nehring,167
+San Luis Obispo,505,Proposition 41,,,No,239
+San Luis Obispo,505,Proposition 41,,,Yes,361
+San Luis Obispo,505,Proposition 42,,,No,289
+San Luis Obispo,505,Proposition 42,,,Yes,295
 San Luis Obispo,505,Secretary of State,,DEM,Alex Padilla,115
 San Luis Obispo,505,Secretary of State,,IND,Dan Schnur,17
 San Luis Obispo,505,Secretary of State,,GRN,David Curtis,18
@@ -7960,6 +8440,10 @@ San Luis Obispo,506,Lieutenant Governor,,DEM,Gavin Newsom,122
 San Luis Obispo,506,Lieutenant Governor,,REP,George Yang,31
 San Luis Obispo,506,Lieutenant Governor,,GRN,Jena F. Goodman,5
 San Luis Obispo,506,Lieutenant Governor,,REP,Ron Nehring,68
+San Luis Obispo,506,Proposition 41,,,No,113
+San Luis Obispo,506,Proposition 41,,,Yes,156
+San Luis Obispo,506,Proposition 42,,,No,129
+San Luis Obispo,506,Proposition 42,,,Yes,130
 San Luis Obispo,506,Secretary of State,,DEM,Alex Padilla,52
 San Luis Obispo,506,Secretary of State,,IND,Dan Schnur,8
 San Luis Obispo,506,Secretary of State,,GRN,David Curtis,11
@@ -8026,6 +8510,10 @@ San Luis Obispo,507,Lieutenant Governor,,DEM,Gavin Newsom,117
 San Luis Obispo,507,Lieutenant Governor,,REP,George Yang,27
 San Luis Obispo,507,Lieutenant Governor,,GRN,Jena F. Goodman,4
 San Luis Obispo,507,Lieutenant Governor,,REP,Ron Nehring,68
+San Luis Obispo,507,Proposition 41,,,No,105
+San Luis Obispo,507,Proposition 41,,,Yes,146
+San Luis Obispo,507,Proposition 42,,,No,120
+San Luis Obispo,507,Proposition 42,,,Yes,124
 San Luis Obispo,507,Secretary of State,,DEM,Alex Padilla,66
 San Luis Obispo,507,Secretary of State,,IND,Dan Schnur,5
 San Luis Obispo,507,Secretary of State,,GRN,David Curtis,5
@@ -8092,6 +8580,10 @@ San Luis Obispo,508,Lieutenant Governor,,DEM,Gavin Newsom,127
 San Luis Obispo,508,Lieutenant Governor,,REP,George Yang,32
 San Luis Obispo,508,Lieutenant Governor,,GRN,Jena F. Goodman,5
 San Luis Obispo,508,Lieutenant Governor,,REP,Ron Nehring,102
+San Luis Obispo,508,Proposition 41,,,No,176
+San Luis Obispo,508,Proposition 41,,,Yes,169
+San Luis Obispo,508,Proposition 42,,,No,198
+San Luis Obispo,508,Proposition 42,,,Yes,132
 San Luis Obispo,508,Secretary of State,,DEM,Alex Padilla,67
 San Luis Obispo,508,Secretary of State,,IND,Dan Schnur,13
 San Luis Obispo,508,Secretary of State,,GRN,David Curtis,8
@@ -8158,6 +8650,10 @@ San Luis Obispo,509,Lieutenant Governor,,DEM,Gavin Newsom,112
 San Luis Obispo,509,Lieutenant Governor,,REP,George Yang,39
 San Luis Obispo,509,Lieutenant Governor,,GRN,Jena F. Goodman,13
 San Luis Obispo,509,Lieutenant Governor,,REP,Ron Nehring,99
+San Luis Obispo,509,Proposition 41,,,No,167
+San Luis Obispo,509,Proposition 41,,,Yes,190
+San Luis Obispo,509,Proposition 42,,,No,172
+San Luis Obispo,509,Proposition 42,,,Yes,173
 San Luis Obispo,509,Secretary of State,,DEM,Alex Padilla,66
 San Luis Obispo,509,Secretary of State,,IND,Dan Schnur,15
 San Luis Obispo,509,Secretary of State,,GRN,David Curtis,6
@@ -8224,6 +8720,10 @@ San Luis Obispo,510,Lieutenant Governor,,DEM,Gavin Newsom,117
 San Luis Obispo,510,Lieutenant Governor,,REP,George Yang,25
 San Luis Obispo,510,Lieutenant Governor,,GRN,Jena F. Goodman,7
 San Luis Obispo,510,Lieutenant Governor,,REP,Ron Nehring,62
+San Luis Obispo,510,Proposition 41,,,No,129
+San Luis Obispo,510,Proposition 41,,,Yes,183
+San Luis Obispo,510,Proposition 42,,,No,158
+San Luis Obispo,510,Proposition 42,,,Yes,148
 San Luis Obispo,510,Secretary of State,,DEM,Alex Padilla,59
 San Luis Obispo,510,Secretary of State,,IND,Dan Schnur,11
 San Luis Obispo,510,Secretary of State,,GRN,David Curtis,14
@@ -8290,6 +8790,10 @@ San Luis Obispo,511,Lieutenant Governor,,DEM,Gavin Newsom,162
 San Luis Obispo,511,Lieutenant Governor,,REP,George Yang,26
 San Luis Obispo,511,Lieutenant Governor,,GRN,Jena F. Goodman,9
 San Luis Obispo,511,Lieutenant Governor,,REP,Ron Nehring,76
+San Luis Obispo,511,Proposition 41,,,No,132
+San Luis Obispo,511,Proposition 41,,,Yes,198
+San Luis Obispo,511,Proposition 42,,,No,155
+San Luis Obispo,511,Proposition 42,,,Yes,167
 San Luis Obispo,511,Secretary of State,,DEM,Alex Padilla,83
 San Luis Obispo,511,Secretary of State,,IND,Dan Schnur,12
 San Luis Obispo,511,Secretary of State,,GRN,David Curtis,23
@@ -8356,6 +8860,10 @@ San Luis Obispo,512,Lieutenant Governor,,DEM,Gavin Newsom,110
 San Luis Obispo,512,Lieutenant Governor,,REP,George Yang,23
 San Luis Obispo,512,Lieutenant Governor,,GRN,Jena F. Goodman,4
 San Luis Obispo,512,Lieutenant Governor,,REP,Ron Nehring,71
+San Luis Obispo,512,Proposition 41,,,No,121
+San Luis Obispo,512,Proposition 41,,,Yes,136
+San Luis Obispo,512,Proposition 42,,,No,113
+San Luis Obispo,512,Proposition 42,,,Yes,138
 San Luis Obispo,512,Secretary of State,,DEM,Alex Padilla,62
 San Luis Obispo,512,Secretary of State,,IND,Dan Schnur,11
 San Luis Obispo,512,Secretary of State,,GRN,David Curtis,8
@@ -8422,6 +8930,10 @@ San Luis Obispo,513,Lieutenant Governor,,DEM,Gavin Newsom,112
 San Luis Obispo,513,Lieutenant Governor,,REP,George Yang,25
 San Luis Obispo,513,Lieutenant Governor,,GRN,Jena F. Goodman,7
 San Luis Obispo,513,Lieutenant Governor,,REP,Ron Nehring,62
+San Luis Obispo,513,Proposition 41,,,No,106
+San Luis Obispo,513,Proposition 41,,,Yes,159
+San Luis Obispo,513,Proposition 42,,,No,126
+San Luis Obispo,513,Proposition 42,,,Yes,127
 San Luis Obispo,513,Secretary of State,,DEM,Alex Padilla,52
 San Luis Obispo,513,Secretary of State,,IND,Dan Schnur,13
 San Luis Obispo,513,Secretary of State,,GRN,David Curtis,9
@@ -8488,6 +9000,10 @@ San Luis Obispo,514,Lieutenant Governor,,DEM,Gavin Newsom,108
 San Luis Obispo,514,Lieutenant Governor,,REP,George Yang,24
 San Luis Obispo,514,Lieutenant Governor,,GRN,Jena F. Goodman,10
 San Luis Obispo,514,Lieutenant Governor,,REP,Ron Nehring,108
+San Luis Obispo,514,Proposition 41,,,No,146
+San Luis Obispo,514,Proposition 41,,,Yes,189
+San Luis Obispo,514,Proposition 42,,,No,157
+San Luis Obispo,514,Proposition 42,,,Yes,161
 San Luis Obispo,514,Secretary of State,,DEM,Alex Padilla,51
 San Luis Obispo,514,Secretary of State,,IND,Dan Schnur,10
 San Luis Obispo,514,Secretary of State,,GRN,David Curtis,11
@@ -8554,6 +9070,10 @@ San Luis Obispo,515,Lieutenant Governor,,DEM,Gavin Newsom,136
 San Luis Obispo,515,Lieutenant Governor,,REP,George Yang,27
 San Luis Obispo,515,Lieutenant Governor,,GRN,Jena F. Goodman,9
 San Luis Obispo,515,Lieutenant Governor,,REP,Ron Nehring,75
+San Luis Obispo,515,Proposition 41,,,No,104
+San Luis Obispo,515,Proposition 41,,,Yes,208
+San Luis Obispo,515,Proposition 42,,,No,135
+San Luis Obispo,515,Proposition 42,,,Yes,168
 San Luis Obispo,515,Secretary of State,,DEM,Alex Padilla,85
 San Luis Obispo,515,Secretary of State,,IND,Dan Schnur,13
 San Luis Obispo,515,Secretary of State,,GRN,David Curtis,11
@@ -8620,6 +9140,10 @@ San Luis Obispo,516,Lieutenant Governor,,DEM,Gavin Newsom,127
 San Luis Obispo,516,Lieutenant Governor,,REP,George Yang,22
 San Luis Obispo,516,Lieutenant Governor,,GRN,Jena F. Goodman,8
 San Luis Obispo,516,Lieutenant Governor,,REP,Ron Nehring,62
+San Luis Obispo,516,Proposition 41,,,No,117
+San Luis Obispo,516,Proposition 41,,,Yes,177
+San Luis Obispo,516,Proposition 42,,,No,131
+San Luis Obispo,516,Proposition 42,,,Yes,154
 San Luis Obispo,516,Secretary of State,,DEM,Alex Padilla,72
 San Luis Obispo,516,Secretary of State,,IND,Dan Schnur,11
 San Luis Obispo,516,Secretary of State,,GRN,David Curtis,9
@@ -8686,6 +9210,10 @@ San Luis Obispo,517,Lieutenant Governor,,DEM,Gavin Newsom,214
 San Luis Obispo,517,Lieutenant Governor,,REP,George Yang,63
 San Luis Obispo,517,Lieutenant Governor,,GRN,Jena F. Goodman,14
 San Luis Obispo,517,Lieutenant Governor,,REP,Ron Nehring,154
+San Luis Obispo,517,Proposition 41,,,No,258
+San Luis Obispo,517,Proposition 41,,,Yes,316
+San Luis Obispo,517,Proposition 42,,,No,288
+San Luis Obispo,517,Proposition 42,,,Yes,279
 San Luis Obispo,517,Secretary of State,,DEM,Alex Padilla,112
 San Luis Obispo,517,Secretary of State,,IND,Dan Schnur,29
 San Luis Obispo,517,Secretary of State,,GRN,David Curtis,28
@@ -8752,6 +9280,10 @@ San Luis Obispo,518,Lieutenant Governor,,DEM,Gavin Newsom,93
 San Luis Obispo,518,Lieutenant Governor,,REP,George Yang,32
 San Luis Obispo,518,Lieutenant Governor,,GRN,Jena F. Goodman,5
 San Luis Obispo,518,Lieutenant Governor,,REP,Ron Nehring,98
+San Luis Obispo,518,Proposition 41,,,No,194
+San Luis Obispo,518,Proposition 41,,,Yes,139
+San Luis Obispo,518,Proposition 42,,,No,172
+San Luis Obispo,518,Proposition 42,,,Yes,150
 San Luis Obispo,518,Secretary of State,,DEM,Alex Padilla,36
 San Luis Obispo,518,Secretary of State,,IND,Dan Schnur,18
 San Luis Obispo,518,Secretary of State,,GRN,David Curtis,7
@@ -8818,6 +9350,10 @@ San Luis Obispo,519,Lieutenant Governor,,DEM,Gavin Newsom,129
 San Luis Obispo,519,Lieutenant Governor,,REP,George Yang,46
 San Luis Obispo,519,Lieutenant Governor,,GRN,Jena F. Goodman,9
 San Luis Obispo,519,Lieutenant Governor,,REP,Ron Nehring,126
+San Luis Obispo,519,Proposition 41,,,No,224
+San Luis Obispo,519,Proposition 41,,,Yes,204
+San Luis Obispo,519,Proposition 42,,,No,205
+San Luis Obispo,519,Proposition 42,,,Yes,208
 San Luis Obispo,519,Secretary of State,,DEM,Alex Padilla,74
 San Luis Obispo,519,Secretary of State,,IND,Dan Schnur,19
 San Luis Obispo,519,Secretary of State,,GRN,David Curtis,19
@@ -8884,6 +9420,10 @@ San Luis Obispo,520,Lieutenant Governor,,DEM,Gavin Newsom,89
 San Luis Obispo,520,Lieutenant Governor,,REP,George Yang,34
 San Luis Obispo,520,Lieutenant Governor,,GRN,Jena F. Goodman,3
 San Luis Obispo,520,Lieutenant Governor,,REP,Ron Nehring,117
+San Luis Obispo,520,Proposition 41,,,No,178
+San Luis Obispo,520,Proposition 41,,,Yes,138
+San Luis Obispo,520,Proposition 42,,,No,173
+San Luis Obispo,520,Proposition 42,,,Yes,134
 San Luis Obispo,520,Secretary of State,,DEM,Alex Padilla,49
 San Luis Obispo,520,Secretary of State,,IND,Dan Schnur,10
 San Luis Obispo,520,Secretary of State,,GRN,David Curtis,5
@@ -8950,6 +9490,10 @@ San Luis Obispo,521,Lieutenant Governor,,DEM,Gavin Newsom,107
 San Luis Obispo,521,Lieutenant Governor,,REP,George Yang,43
 San Luis Obispo,521,Lieutenant Governor,,GRN,Jena F. Goodman,8
 San Luis Obispo,521,Lieutenant Governor,,REP,Ron Nehring,121
+San Luis Obispo,521,Proposition 41,,,No,207
+San Luis Obispo,521,Proposition 41,,,Yes,183
+San Luis Obispo,521,Proposition 42,,,No,192
+San Luis Obispo,521,Proposition 42,,,Yes,194
 San Luis Obispo,521,Secretary of State,,DEM,Alex Padilla,59
 San Luis Obispo,521,Secretary of State,,IND,Dan Schnur,16
 San Luis Obispo,521,Secretary of State,,GRN,David Curtis,12
@@ -9016,6 +9560,10 @@ San Luis Obispo,522,Lieutenant Governor,,DEM,Gavin Newsom,176
 San Luis Obispo,522,Lieutenant Governor,,REP,George Yang,23
 San Luis Obispo,522,Lieutenant Governor,,GRN,Jena F. Goodman,8
 San Luis Obispo,522,Lieutenant Governor,,REP,Ron Nehring,126
+San Luis Obispo,522,Proposition 41,,,No,197
+San Luis Obispo,522,Proposition 41,,,Yes,215
+San Luis Obispo,522,Proposition 42,,,No,204
+San Luis Obispo,522,Proposition 42,,,Yes,202
 San Luis Obispo,522,Secretary of State,,DEM,Alex Padilla,98
 San Luis Obispo,522,Secretary of State,,IND,Dan Schnur,28
 San Luis Obispo,522,Secretary of State,,GRN,David Curtis,14
@@ -9082,6 +9630,10 @@ San Luis Obispo,523,Lieutenant Governor,,DEM,Gavin Newsom,138
 San Luis Obispo,523,Lieutenant Governor,,REP,George Yang,21
 San Luis Obispo,523,Lieutenant Governor,,GRN,Jena F. Goodman,14
 San Luis Obispo,523,Lieutenant Governor,,REP,Ron Nehring,46
+San Luis Obispo,523,Proposition 41,,,No,118
+San Luis Obispo,523,Proposition 41,,,Yes,170
+San Luis Obispo,523,Proposition 42,,,No,143
+San Luis Obispo,523,Proposition 42,,,Yes,142
 San Luis Obispo,523,Secretary of State,,DEM,Alex Padilla,83
 San Luis Obispo,523,Secretary of State,,IND,Dan Schnur,10
 San Luis Obispo,523,Secretary of State,,GRN,David Curtis,13
@@ -9148,6 +9700,10 @@ San Luis Obispo,524,Lieutenant Governor,,DEM,Gavin Newsom,143
 San Luis Obispo,524,Lieutenant Governor,,REP,George Yang,10
 San Luis Obispo,524,Lieutenant Governor,,GRN,Jena F. Goodman,5
 San Luis Obispo,524,Lieutenant Governor,,REP,Ron Nehring,29
+San Luis Obispo,524,Proposition 41,,,No,60
+San Luis Obispo,524,Proposition 41,,,Yes,161
+San Luis Obispo,524,Proposition 42,,,No,87
+San Luis Obispo,524,Proposition 42,,,Yes,122
 San Luis Obispo,524,Secretary of State,,DEM,Alex Padilla,64
 San Luis Obispo,524,Secretary of State,,IND,Dan Schnur,9
 San Luis Obispo,524,Secretary of State,,GRN,David Curtis,9
@@ -9214,6 +9770,10 @@ San Luis Obispo,525,Lieutenant Governor,,DEM,Gavin Newsom,211
 San Luis Obispo,525,Lieutenant Governor,,REP,George Yang,7
 San Luis Obispo,525,Lieutenant Governor,,GRN,Jena F. Goodman,12
 San Luis Obispo,525,Lieutenant Governor,,REP,Ron Nehring,36
+San Luis Obispo,525,Proposition 41,,,No,74
+San Luis Obispo,525,Proposition 41,,,Yes,237
+San Luis Obispo,525,Proposition 42,,,No,140
+San Luis Obispo,525,Proposition 42,,,Yes,164
 San Luis Obispo,525,Secretary of State,,DEM,Alex Padilla,103
 San Luis Obispo,525,Secretary of State,,IND,Dan Schnur,14
 San Luis Obispo,525,Secretary of State,,GRN,David Curtis,21
@@ -9280,6 +9840,10 @@ San Luis Obispo,526,Lieutenant Governor,,DEM,Gavin Newsom,177
 San Luis Obispo,526,Lieutenant Governor,,REP,George Yang,16
 San Luis Obispo,526,Lieutenant Governor,,GRN,Jena F. Goodman,10
 San Luis Obispo,526,Lieutenant Governor,,REP,Ron Nehring,31
+San Luis Obispo,526,Proposition 41,,,No,74
+San Luis Obispo,526,Proposition 41,,,Yes,189
+San Luis Obispo,526,Proposition 42,,,No,97
+San Luis Obispo,526,Proposition 42,,,Yes,160
 San Luis Obispo,526,Secretary of State,,DEM,Alex Padilla,83
 San Luis Obispo,526,Secretary of State,,IND,Dan Schnur,10
 San Luis Obispo,526,Secretary of State,,GRN,David Curtis,16
@@ -9346,6 +9910,10 @@ San Luis Obispo,527,Lieutenant Governor,,DEM,Gavin Newsom,169
 San Luis Obispo,527,Lieutenant Governor,,REP,George Yang,25
 San Luis Obispo,527,Lieutenant Governor,,GRN,Jena F. Goodman,5
 San Luis Obispo,527,Lieutenant Governor,,REP,Ron Nehring,50
+San Luis Obispo,527,Proposition 41,,,No,61
+San Luis Obispo,527,Proposition 41,,,Yes,211
+San Luis Obispo,527,Proposition 42,,,No,101
+San Luis Obispo,527,Proposition 42,,,Yes,162
 San Luis Obispo,527,Secretary of State,,DEM,Alex Padilla,88
 San Luis Obispo,527,Secretary of State,,IND,Dan Schnur,17
 San Luis Obispo,527,Secretary of State,,GRN,David Curtis,9
@@ -9412,6 +9980,10 @@ San Luis Obispo,528,Lieutenant Governor,,DEM,Gavin Newsom,9
 San Luis Obispo,528,Lieutenant Governor,,REP,George Yang,2
 San Luis Obispo,528,Lieutenant Governor,,GRN,Jena F. Goodman,2
 San Luis Obispo,528,Lieutenant Governor,,REP,Ron Nehring,2
+San Luis Obispo,528,Proposition 41,,,No,3
+San Luis Obispo,528,Proposition 41,,,Yes,20
+San Luis Obispo,528,Proposition 42,,,No,10
+San Luis Obispo,528,Proposition 42,,,Yes,11
 San Luis Obispo,528,Secretary of State,,DEM,Alex Padilla,10
 San Luis Obispo,528,Secretary of State,,IND,Dan Schnur,1
 San Luis Obispo,528,Secretary of State,,GRN,David Curtis,2
@@ -9478,6 +10050,10 @@ San Luis Obispo,529,Lieutenant Governor,,DEM,Gavin Newsom,21
 San Luis Obispo,529,Lieutenant Governor,,REP,George Yang,4
 San Luis Obispo,529,Lieutenant Governor,,GRN,Jena F. Goodman,1
 San Luis Obispo,529,Lieutenant Governor,,REP,Ron Nehring,9
+San Luis Obispo,529,Proposition 41,,,No,8
+San Luis Obispo,529,Proposition 41,,,Yes,33
+San Luis Obispo,529,Proposition 42,,,No,17
+San Luis Obispo,529,Proposition 42,,,Yes,23
 San Luis Obispo,529,Secretary of State,,DEM,Alex Padilla,12
 San Luis Obispo,529,Secretary of State,,IND,Dan Schnur,1
 San Luis Obispo,529,Secretary of State,,GRN,David Curtis,7
@@ -9544,6 +10120,10 @@ San Luis Obispo,530,Lieutenant Governor,,DEM,Gavin Newsom,131
 San Luis Obispo,530,Lieutenant Governor,,REP,George Yang,13
 San Luis Obispo,530,Lieutenant Governor,,GRN,Jena F. Goodman,4
 San Luis Obispo,530,Lieutenant Governor,,REP,Ron Nehring,33
+San Luis Obispo,530,Proposition 41,,,No,54
+San Luis Obispo,530,Proposition 41,,,Yes,147
+San Luis Obispo,530,Proposition 42,,,No,83
+San Luis Obispo,530,Proposition 42,,,Yes,116
 San Luis Obispo,530,Secretary of State,,DEM,Alex Padilla,59
 San Luis Obispo,530,Secretary of State,,IND,Dan Schnur,2
 San Luis Obispo,530,Secretary of State,,GRN,David Curtis,8
@@ -9610,6 +10190,10 @@ San Luis Obispo,M2,Lieutenant Governor,,DEM,Gavin Newsom,197
 San Luis Obispo,M2,Lieutenant Governor,,REP,George Yang,43
 San Luis Obispo,M2,Lieutenant Governor,,GRN,Jena F. Goodman,9
 San Luis Obispo,M2,Lieutenant Governor,,REP,Ron Nehring,155
+San Luis Obispo,M2,Proposition 41,,,No,265
+San Luis Obispo,M2,Proposition 41,,,Yes,286
+San Luis Obispo,M2,Proposition 42,,,No,255
+San Luis Obispo,M2,Proposition 42,,,Yes,273
 San Luis Obispo,M2,Secretary of State,,DEM,Alex Padilla,89
 San Luis Obispo,M2,Secretary of State,,IND,Dan Schnur,21
 San Luis Obispo,M2,Secretary of State,,GRN,David Curtis,16
@@ -9676,6 +10260,10 @@ San Luis Obispo,M3,Lieutenant Governor,,DEM,Gavin Newsom,238
 San Luis Obispo,M3,Lieutenant Governor,,REP,George Yang,52
 San Luis Obispo,M3,Lieutenant Governor,,GRN,Jena F. Goodman,12
 San Luis Obispo,M3,Lieutenant Governor,,REP,Ron Nehring,149
+San Luis Obispo,M3,Proposition 41,,,No,274
+San Luis Obispo,M3,Proposition 41,,,Yes,300
+San Luis Obispo,M3,Proposition 42,,,No,249
+San Luis Obispo,M3,Proposition 42,,,Yes,293
 San Luis Obispo,M3,Secretary of State,,DEM,Alex Padilla,122
 San Luis Obispo,M3,Secretary of State,,IND,Dan Schnur,16
 San Luis Obispo,M3,Secretary of State,,GRN,David Curtis,22
@@ -9742,6 +10330,10 @@ San Luis Obispo,M4,Lieutenant Governor,,DEM,Gavin Newsom,162
 San Luis Obispo,M4,Lieutenant Governor,,REP,George Yang,47
 San Luis Obispo,M4,Lieutenant Governor,,GRN,Jena F. Goodman,9
 San Luis Obispo,M4,Lieutenant Governor,,REP,Ron Nehring,117
+San Luis Obispo,M4,Proposition 41,,,No,201
+San Luis Obispo,M4,Proposition 41,,,Yes,223
+San Luis Obispo,M4,Proposition 42,,,No,185
+San Luis Obispo,M4,Proposition 42,,,Yes,214
 San Luis Obispo,M4,Secretary of State,,DEM,Alex Padilla,83
 San Luis Obispo,M4,Secretary of State,,IND,Dan Schnur,18
 San Luis Obispo,M4,Secretary of State,,GRN,David Curtis,8
@@ -9808,6 +10400,10 @@ San Luis Obispo,M5,Lieutenant Governor,,DEM,Gavin Newsom,144
 San Luis Obispo,M5,Lieutenant Governor,,REP,George Yang,46
 San Luis Obispo,M5,Lieutenant Governor,,GRN,Jena F. Goodman,10
 San Luis Obispo,M5,Lieutenant Governor,,REP,Ron Nehring,163
+San Luis Obispo,M5,Proposition 41,,,No,278
+San Luis Obispo,M5,Proposition 41,,,Yes,265
+San Luis Obispo,M5,Proposition 42,,,No,270
+San Luis Obispo,M5,Proposition 42,,,Yes,254
 San Luis Obispo,M5,Secretary of State,,DEM,Alex Padilla,72
 San Luis Obispo,M5,Secretary of State,,IND,Dan Schnur,63
 San Luis Obispo,M5,Secretary of State,,GRN,David Curtis,11
@@ -9874,6 +10470,10 @@ San Luis Obispo,M6,Lieutenant Governor,,DEM,Gavin Newsom,86
 San Luis Obispo,M6,Lieutenant Governor,,REP,George Yang,31
 San Luis Obispo,M6,Lieutenant Governor,,GRN,Jena F. Goodman,4
 San Luis Obispo,M6,Lieutenant Governor,,REP,Ron Nehring,72
+San Luis Obispo,M6,Proposition 41,,,No,136
+San Luis Obispo,M6,Proposition 41,,,Yes,140
+San Luis Obispo,M6,Proposition 42,,,No,128
+San Luis Obispo,M6,Proposition 42,,,Yes,135
 San Luis Obispo,M6,Secretary of State,,DEM,Alex Padilla,45
 San Luis Obispo,M6,Secretary of State,,IND,Dan Schnur,7
 San Luis Obispo,M6,Secretary of State,,GRN,David Curtis,13
@@ -9940,6 +10540,10 @@ San Luis Obispo,M7,Lieutenant Governor,,DEM,Gavin Newsom,0
 San Luis Obispo,M7,Lieutenant Governor,,REP,George Yang,0
 San Luis Obispo,M7,Lieutenant Governor,,GRN,Jena F. Goodman,0
 San Luis Obispo,M7,Lieutenant Governor,,REP,Ron Nehring,0
+San Luis Obispo,M7,Proposition 41,,,No,0
+San Luis Obispo,M7,Proposition 41,,,Yes,0
+San Luis Obispo,M7,Proposition 42,,,No,0
+San Luis Obispo,M7,Proposition 42,,,Yes,0
 San Luis Obispo,M7,Secretary of State,,DEM,Alex Padilla,0
 San Luis Obispo,M7,Secretary of State,,IND,Dan Schnur,0
 San Luis Obispo,M7,Secretary of State,,GRN,David Curtis,0
@@ -9948,8 +10552,6 @@ San Luis Obispo,M7,Secretary of State,,DEM,Jeffrey H. Drobman,0
 San Luis Obispo,M7,Secretary of State,,DEM,Leland Yee,0
 San Luis Obispo,M7,Secretary of State,,REP,Pete Peterson,0
 San Luis Obispo,M7,Secretary of State,,REP,Roy Allmond,0
-San Luis Obispo,M7,State Assembly,37,DEM,Das Williams,0
-San Luis Obispo,M7,State Assembly,37,REP,Ron DeBlauw,0
 San Luis Obispo,M7,Superintendent of Public Instruction,,NOP,Lydia A. Gutiérrez,0
 San Luis Obispo,M7,Superintendent of Public Instruction,,NOP,Marshall Tuck,0
 San Luis Obispo,M7,Superintendent of Public Instruction,,NOP,Tom Torlakson,0


### PR DESCRIPTION
Fix 2014 San Luis Obispo tests. Removes 2 records with 0 votes and adds Proposition 41, 42 records for each precinct.