### PR TITLE
Fix column mismatch at the bottom of 2018 Santa Clara General CSV

### DIFF
--- a/2018/counties/20181106__ca__general__santa_clara__precinct.csv
+++ b/2018/counties/20181106__ca__general__santa_clara__precinct.csv
@@ -1065,36 +1065,6 @@ Santa Clara,6665,Governor,,Rep,John Cox,1
 Santa Clara,6666,Governor,,Rep,John Cox,35
 Santa Clara,6673,Governor,,Rep,John Cox,1
 Santa Clara,SANTA CLARA CA,Governor,,Rep,John Cox,175791
-Santa Clara,"US Representative, District 17",Governor,,Rep,John Cox,45477
-Santa Clara,"US Representative, District 18",Governor,,Rep,John Cox,62766
-Santa Clara,"US Representative, District 19",Governor,,Rep,John Cox,66483
-Santa Clara,"US Representative, District 20",Governor,,Rep,John Cox,1065
-Santa Clara,"State Senate, District 10",Governor,,Rep,John Cox,26727
-Santa Clara,"State Senate, District 13",Governor,,Rep,John Cox,29854
-Santa Clara,"State Senate, District 15",Governor,,Rep,John Cox,92785
-Santa Clara,"State Senate, District 17",Governor,,Rep,John Cox,26425
-Santa Clara,State Assembly District 24,Governor,,Rep,John Cox,30412
-Santa Clara,State Assembly District 25,Governor,,Rep,John Cox,27033
-Santa Clara,State Assembly District 27,Governor,,Rep,John Cox,31515
-Santa Clara,State Assembly District 28,Governor,,Rep,John Cox,57683
-Santa Clara,State Assembly District 29,Governor,,Rep,John Cox,12976
-Santa Clara,State Assembly District 30,Governor,,Rep,John Cox,16172
-Santa Clara,City of Campbell,Governor,,Rep,John Cox,4733
-Santa Clara,City of Cupertino,Governor,,Rep,John Cox,6086
-Santa Clara,City of Gilroy ,Governor,,Rep,John Cox,6044
-Santa Clara,City of Los Altos,Governor,,Rep,John Cox,4613
-Santa Clara,Town of Los Altos Hills,Governor,,Rep,John Cox,1636
-Santa Clara,Town of Los Gatos,Governor,,Rep,John Cox,5054
-Santa Clara,City of Milpitas,Governor,,Rep,John Cox,5943
-Santa Clara,City of Monte Sereno,Governor,,Rep,John Cox,777
-Santa Clara,City of Morgan Hill,Governor,,Rep,John Cox,6873
-Santa Clara,City of Mountain View,Governor,,Rep,John Cox,5484
-Santa Clara,City of Palo Alto,Governor,,Rep,John Cox,6033
-Santa Clara,City of Santa Clara,Governor,,Rep,John Cox,9590
-Santa Clara,City of Saratoga,Governor,,Rep,John Cox,5437
-Santa Clara,City of Sunnyvale,Governor,,Rep,John Cox,11011
-Santa Clara,City of San Jose,Governor,,Rep,John Cox,86120
-Santa Clara,Unincorporated Area,Governor,,Rep,John Cox,10357
 Santa Clara,1001,Governor,,Dem,Gavin Newsom,679
 Santa Clara,1003,Governor,,Dem,Gavin Newsom,648
 Santa Clara,1006,Governor,,Dem,Gavin Newsom,560
@@ -2161,36 +2131,6 @@ Santa Clara,6665,Governor,,Dem,Gavin Newsom,1
 Santa Clara,6666,Governor,,Dem,Gavin Newsom,80
 Santa Clara,6673,Governor,,Dem,Gavin Newsom,1
 Santa Clara,SANTA CLARA CA,Governor,,Dem,Gavin Newsom,438758
-Santa Clara,"US Representative, District 17",Governor,,Dem,Gavin Newsom,116031
-Santa Clara,"US Representative, District 18",Governor,,Dem,Gavin Newsom,162259
-Santa Clara,"US Representative, District 19",Governor,,Dem,Gavin Newsom,157482
-Santa Clara,"US Representative, District 20",Governor,,Dem,Gavin Newsom,2986
-Santa Clara,"State Senate, District 10",Governor,,Dem,Gavin Newsom,67086
-Santa Clara,"State Senate, District 13",Governor,,Dem,Gavin Newsom,99699
-Santa Clara,"State Senate, District 15",Governor,,Dem,Gavin Newsom,224767
-Santa Clara,"State Senate, District 17",Governor,,Dem,Gavin Newsom,47206
-Santa Clara,State Assembly District 24,Governor,,Dem,Gavin Newsom,101109
-Santa Clara,State Assembly District 25,Governor,,Dem,Gavin Newsom,65752
-Santa Clara,State Assembly District 27,Governor,,Dem,Gavin Newsom,90366
-Santa Clara,State Assembly District 28,Governor,,Dem,Gavin Newsom,132274
-Santa Clara,State Assembly District 29,Governor,,Dem,Gavin Newsom,24577
-Santa Clara,State Assembly District 30,Governor,,Dem,Gavin Newsom,24680
-Santa Clara,City of Campbell,Governor,,Dem,Gavin Newsom,12053
-Santa Clara,City of Cupertino,Governor,,Dem,Gavin Newsom,15424
-Santa Clara,City of Gilroy ,Governor,,Dem,Gavin Newsom,10764
-Santa Clara,City of Los Altos,Governor,,Dem,Gavin Newsom,11880
-Santa Clara,Town of Los Altos Hills,Governor,,Dem,Gavin Newsom,3095
-Santa Clara,Town of Los Gatos,Governor,,Dem,Gavin Newsom,10379
-Santa Clara,City of Milpitas,Governor,,Dem,Gavin Newsom,13523
-Santa Clara,City of Monte Sereno,Governor,,Dem,Gavin Newsom,1215
-Santa Clara,City of Morgan Hill,Governor,,Dem,Gavin Newsom,10268
-Santa Clara,City of Mountain View,Governor,,Dem,Gavin Newsom,22549
-Santa Clara,City of Palo Alto,Governor,,Dem,Gavin Newsom,25172
-Santa Clara,City of Santa Clara,Governor,,Dem,Gavin Newsom,25574
-Santa Clara,City of Saratoga,Governor,,Dem,Gavin Newsom,10134
-Santa Clara,City of Sunnyvale,Governor,,Dem,Gavin Newsom,32567
-Santa Clara,City of San Jose,Governor,,Dem,Gavin Newsom,214071
-Santa Clara,Unincorporated Area,Governor,,Dem,Gavin Newsom,20090
 Santa Clara,1001,Lieutenant Governor,,Dem,Ed Hernandez,287
 Santa Clara,1003,Lieutenant Governor,,Dem,Ed Hernandez,255
 Santa Clara,1006,Lieutenant Governor,,Dem,Ed Hernandez,281
@@ -3257,36 +3197,6 @@ Santa Clara,6665,Lieutenant Governor,,Dem,Ed Hernandez,0
 Santa Clara,6666,Lieutenant Governor,,Dem,Ed Hernandez,34
 Santa Clara,6673,Lieutenant Governor,,Dem,Ed Hernandez,1
 Santa Clara,SANTA CLARA CA,Lieutenant Governor,,Dem,Ed Hernandez,203178
-Santa Clara,"US Representative, District 17",Lieutenant Governor,,Dem,Ed Hernandez,53065
-Santa Clara,"US Representative, District 18",Lieutenant Governor,,Dem,Ed Hernandez,62824
-Santa Clara,"US Representative, District 19",Lieutenant Governor,,Dem,Ed Hernandez,85473
-Santa Clara,"US Representative, District 20",Lieutenant Governor,,Dem,Ed Hernandez,1816
-Santa Clara,"State Senate, District 10",Lieutenant Governor,,Dem,Ed Hernandez,33653
-Santa Clara,"State Senate, District 13",Lieutenant Governor,,Dem,Ed Hernandez,35338
-Santa Clara,"State Senate, District 15",Lieutenant Governor,,Dem,Ed Hernandez,106884
-Santa Clara,"State Senate, District 17",Lieutenant Governor,,Dem,Ed Hernandez,27303
-Santa Clara,State Assembly District 24,Lieutenant Governor,,Dem,Ed Hernandez,35867
-Santa Clara,State Assembly District 25,Lieutenant Governor,,Dem,Ed Hernandez,34038
-Santa Clara,State Assembly District 27,Lieutenant Governor,,Dem,Ed Hernandez,51874
-Santa Clara,State Assembly District 28,Lieutenant Governor,,Dem,Ed Hernandez,54144
-Santa Clara,State Assembly District 29,Lieutenant Governor,,Dem,Ed Hernandez,13070
-Santa Clara,State Assembly District 30,Lieutenant Governor,,Dem,Ed Hernandez,14185
-Santa Clara,City of Campbell,Lieutenant Governor,,Dem,Ed Hernandez,4889
-Santa Clara,City of Cupertino,Lieutenant Governor,,Dem,Ed Hernandez,5764
-Santa Clara,City of Gilroy ,Lieutenant Governor,,Dem,Ed Hernandez,6156
-Santa Clara,City of Los Altos,Lieutenant Governor,,Dem,Ed Hernandez,4052
-Santa Clara,Town of Los Altos Hills,Lieutenant Governor,,Dem,Ed Hernandez,1193
-Santa Clara,Town of Los Gatos,Lieutenant Governor,,Dem,Ed Hernandez,3942
-Santa Clara,City of Milpitas,Lieutenant Governor,,Dem,Ed Hernandez,7372
-Santa Clara,City of Monte Sereno,Lieutenant Governor,,Dem,Ed Hernandez,511
-Santa Clara,City of Morgan Hill,Lieutenant Governor,,Dem,Ed Hernandez,5591
-Santa Clara,City of Mountain View,Lieutenant Governor,,Dem,Ed Hernandez,7737
-Santa Clara,City of Palo Alto,Lieutenant Governor,,Dem,Ed Hernandez,8204
-Santa Clara,City of Santa Clara,Lieutenant Governor,,Dem,Ed Hernandez,12154
-Santa Clara,City of Saratoga,Lieutenant Governor,,Dem,Ed Hernandez,4097
-Santa Clara,City of Sunnyvale,Lieutenant Governor,,Dem,Ed Hernandez,12604
-Santa Clara,City of San Jose,Lieutenant Governor,,Dem,Ed Hernandez,108901
-Santa Clara,Unincorporated Area,Lieutenant Governor,,Dem,Ed Hernandez,10011
 Santa Clara,1001,Lieutenant Governor,,Dem,Eleni Kounalakis,572
 Santa Clara,1003,Lieutenant Governor,,Dem,Eleni Kounalakis,542
 Santa Clara,1006,Lieutenant Governor,,Dem,Eleni Kounalakis,452
@@ -4353,36 +4263,6 @@ Santa Clara,6665,Lieutenant Governor,,Dem,Eleni Kounalakis,1
 Santa Clara,6666,Lieutenant Governor,,Dem,Eleni Kounalakis,67
 Santa Clara,6673,Lieutenant Governor,,Dem,Eleni Kounalakis,0
 Santa Clara,SANTA CLARA CA,Lieutenant Governor,,Dem,Eleni Kounalakis,331520
-Santa Clara,"US Representative, District 17",Lieutenant Governor,,Dem,Eleni Kounalakis,88151
-Santa Clara,"US Representative, District 18",Lieutenant Governor,,Dem,Eleni Kounalakis,131310
-Santa Clara,"US Representative, District 19",Lieutenant Governor,,Dem,Eleni Kounalakis,110236
-Santa Clara,"US Representative, District 20",Lieutenant Governor,,Dem,Eleni Kounalakis,1823
-Santa Clara,"State Senate, District 10",Lieutenant Governor,,Dem,Eleni Kounalakis,48606
-Santa Clara,"State Senate, District 13",Lieutenant Governor,,Dem,Eleni Kounalakis,78177
-Santa Clara,"State Senate, District 15",Lieutenant Governor,,Dem,Eleni Kounalakis,169814
-Santa Clara,"State Senate, District 17",Lieutenant Governor,,Dem,Eleni Kounalakis,34923
-Santa Clara,State Assembly District 24,Lieutenant Governor,,Dem,Eleni Kounalakis,79350
-Santa Clara,State Assembly District 25,Lieutenant Governor,,Dem,Eleni Kounalakis,47173
-Santa Clara,State Assembly District 27,Lieutenant Governor,,Dem,Eleni Kounalakis,57061
-Santa Clara,State Assembly District 28,Lieutenant Governor,,Dem,Eleni Kounalakis,109395
-Santa Clara,State Assembly District 29,Lieutenant Governor,,Dem,Eleni Kounalakis,18924
-Santa Clara,State Assembly District 30,Lieutenant Governor,,Dem,Eleni Kounalakis,19617
-Santa Clara,City of Campbell,Lieutenant Governor,,Dem,Eleni Kounalakis,9728
-Santa Clara,City of Cupertino,Lieutenant Governor,,Dem,Eleni Kounalakis,12673
-Santa Clara,City of Gilroy ,Lieutenant Governor,,Dem,Eleni Kounalakis,8042
-Santa Clara,City of Los Altos,Lieutenant Governor,,Dem,Eleni Kounalakis,9956
-Santa Clara,Town of Los Altos Hills,Lieutenant Governor,,Dem,Eleni Kounalakis,2698
-Santa Clara,Town of Los Gatos,Lieutenant Governor,,Dem,Eleni Kounalakis,9026
-Santa Clara,City of Milpitas,Lieutenant Governor,,Dem,Eleni Kounalakis,9601
-Santa Clara,City of Monte Sereno,Lieutenant Governor,,Dem,Eleni Kounalakis,1112
-Santa Clara,City of Morgan Hill,Lieutenant Governor,,Dem,Eleni Kounalakis,8486
-Santa Clara,City of Mountain View,Lieutenant Governor,,Dem,Eleni Kounalakis,17174
-Santa Clara,City of Palo Alto,Lieutenant Governor,,Dem,Eleni Kounalakis,19275
-Santa Clara,City of Santa Clara,Lieutenant Governor,,Dem,Eleni Kounalakis,18787
-Santa Clara,City of Saratoga,Lieutenant Governor,,Dem,Eleni Kounalakis,8851
-Santa Clara,City of Sunnyvale,Lieutenant Governor,,Dem,Eleni Kounalakis,25768
-Santa Clara,City of San Jose,Lieutenant Governor,,Dem,Eleni Kounalakis,154711
-Santa Clara,Unincorporated Area,Lieutenant Governor,,Dem,Eleni Kounalakis,15632
 Santa Clara,1001,Secretary of State,,Dem,Alex Padilla,683
 Santa Clara,1003,Secretary of State,,Dem,Alex Padilla,639
 Santa Clara,1006,Secretary of State,,Dem,Alex Padilla,545
@@ -5449,36 +5329,6 @@ Santa Clara,6665,Secretary of State,,Dem,Alex Padilla,1
 Santa Clara,6666,Secretary of State,,Dem,Alex Padilla,76
 Santa Clara,6673,Secretary of State,,Dem,Alex Padilla,1
 Santa Clara,SANTA CLARA CA,Secretary of State,,Dem,Alex Padilla,439258
-Santa Clara,"US Representative, District 17",Secretary of State,,Dem,Alex Padilla,115979
-Santa Clara,"US Representative, District 18",Secretary of State,,Dem,Alex Padilla,161042
-Santa Clara,"US Representative, District 19",Secretary of State,,Dem,Alex Padilla,159163
-Santa Clara,"US Representative, District 20",Secretary of State,,Dem,Alex Padilla,3074
-Santa Clara,"State Senate, District 10",Secretary of State,,Dem,Alex Padilla,67668
-Santa Clara,"State Senate, District 13",Secretary of State,,Dem,Alex Padilla,98663
-Santa Clara,"State Senate, District 15",Secretary of State,,Dem,Alex Padilla,224844
-Santa Clara,"State Senate, District 17",Secretary of State,,Dem,Alex Padilla,48083
-Santa Clara,State Assembly District 24,Secretary of State,,Dem,Alex Padilla,100043
-Santa Clara,State Assembly District 25,Secretary of State,,Dem,Alex Padilla,66341
-Santa Clara,State Assembly District 27,Secretary of State,,Dem,Alex Padilla,91252
-Santa Clara,State Assembly District 28,Secretary of State,,Dem,Alex Padilla,131520
-Santa Clara,State Assembly District 29,Secretary of State,,Dem,Alex Padilla,24973
-Santa Clara,State Assembly District 30,Secretary of State,,Dem,Alex Padilla,25129
-Santa Clara,City of Campbell,Secretary of State,,Dem,Alex Padilla,11988
-Santa Clara,City of Cupertino,Secretary of State,,Dem,Alex Padilla,15134
-Santa Clara,City of Gilroy ,Secretary of State,,Dem,Alex Padilla,10950
-Santa Clara,City of Los Altos,Secretary of State,,Dem,Alex Padilla,11718
-Santa Clara,Town of Los Altos Hills,Secretary of State,,Dem,Alex Padilla,3061
-Santa Clara,Town of Los Gatos,Secretary of State,,Dem,Alex Padilla,10260
-Santa Clara,City of Milpitas,Secretary of State,,Dem,Alex Padilla,13602
-Santa Clara,City of Monte Sereno,Secretary of State,,Dem,Alex Padilla,1207
-Santa Clara,City of Morgan Hill,Secretary of State,,Dem,Alex Padilla,10439
-Santa Clara,City of Mountain View,Secretary of State,,Dem,Alex Padilla,22356
-Santa Clara,City of Palo Alto,Secretary of State,,Dem,Alex Padilla,24848
-Santa Clara,City of Santa Clara,Secretary of State,,Dem,Alex Padilla,25863
-Santa Clara,City of Saratoga,Secretary of State,,Dem,Alex Padilla,9983
-Santa Clara,City of Sunnyvale,Secretary of State,,Dem,Alex Padilla,32264
-Santa Clara,City of San Jose,Secretary of State,,Dem,Alex Padilla,215311
-Santa Clara,Unincorporated Area,Secretary of State,,Dem,Alex Padilla,20274
 Santa Clara,1001,Secretary of State,,Rep,Mark Meuser,304
 Santa Clara,1003,Secretary of State,,Rep,Mark Meuser,252
 Santa Clara,1006,Secretary of State,,Rep,Mark Meuser,297
@@ -6545,36 +6395,6 @@ Santa Clara,6665,Secretary of State,,Rep,Mark Meuser,1
 Santa Clara,6666,Secretary of State,,Rep,Mark Meuser,39
 Santa Clara,6673,Secretary of State,,Rep,Mark Meuser,1
 Santa Clara,SANTA CLARA CA,Secretary of State,,Rep,Mark Meuser,162962
-Santa Clara,"US Representative, District 17",Secretary of State,,Rep,Mark Meuser,41968
-Santa Clara,"US Representative, District 18",Secretary of State,,Rep,Mark Meuser,59310
-Santa Clara,"US Representative, District 19",Secretary of State,,Rep,Mark Meuser,60751
-Santa Clara,"US Representative, District 20",Secretary of State,,Rep,Mark Meuser,933
-Santa Clara,"State Senate, District 10",Secretary of State,,Rep,Mark Meuser,24217
-Santa Clara,"State Senate, District 13",Secretary of State,,Rep,Mark Meuser,28200
-Santa Clara,"State Senate, District 15",Secretary of State,,Rep,Mark Meuser,86349
-Santa Clara,"State Senate, District 17",Secretary of State,,Rep,Mark Meuser,24196
-Santa Clara,State Assembly District 24,Secretary of State,,Rep,Mark Meuser,28751
-Santa Clara,State Assembly District 25,Secretary of State,,Rep,Mark Meuser,24492
-Santa Clara,State Assembly District 27,Secretary of State,,Rep,Mark Meuser,28435
-Santa Clara,State Assembly District 28,Secretary of State,,Rep,Mark Meuser,54450
-Santa Clara,State Assembly District 29,Secretary of State,,Rep,Mark Meuser,11838
-Santa Clara,State Assembly District 30,Secretary of State,,Rep,Mark Meuser,14996
-Santa Clara,City of Campbell,Secretary of State,,Rep,Mark Meuser,4461
-Santa Clara,City of Cupertino,Secretary of State,,Rep,Mark Meuser,5764
-Santa Clara,City of Gilroy ,Secretary of State,,Rep,Mark Meuser,5558
-Santa Clara,City of Los Altos,Secretary of State,,Rep,Mark Meuser,4402
-Santa Clara,Town of Los Altos Hills,Secretary of State,,Rep,Mark Meuser,1571
-Santa Clara,Town of Los Gatos,Secretary of State,,Rep,Mark Meuser,4874
-Santa Clara,City of Milpitas,Secretary of State,,Rep,Mark Meuser,5379
-Santa Clara,City of Monte Sereno,Secretary of State,,Rep,Mark Meuser,754
-Santa Clara,City of Morgan Hill,Secretary of State,,Rep,Mark Meuser,6383
-Santa Clara,City of Mountain View,Secretary of State,,Rep,Mark Meuser,5110
-Santa Clara,City of Palo Alto,Secretary of State,,Rep,Mark Meuser,5694
-Santa Clara,City of Santa Clara,Secretary of State,,Rep,Mark Meuser,8630
-Santa Clara,City of Saratoga,Secretary of State,,Rep,Mark Meuser,5216
-Santa Clara,City of Sunnyvale,Secretary of State,,Rep,Mark Meuser,10419
-Santa Clara,City of San Jose,Secretary of State,,Rep,Mark Meuser,79062
-Santa Clara,Unincorporated Area,Secretary of State,,Rep,Mark Meuser,9685
 Santa Clara,1001,Controller,,Rep,Konstantinos Roditis,275
 Santa Clara,1003,Controller,,Rep,Konstantinos Roditis,249
 Santa Clara,1006,Controller,,Rep,Konstantinos Roditis,288
@@ -7641,36 +7461,6 @@ Santa Clara,6665,Controller,,Rep,Konstantinos Roditis,1
 Santa Clara,6666,Controller,,Rep,Konstantinos Roditis,31
 Santa Clara,6673,Controller,,Rep,Konstantinos Roditis,1
 Santa Clara,SANTA CLARA CA,Controller,,Rep,Konstantinos Roditis,156164
-Santa Clara,"US Representative, District 17",Controller,,Rep,Konstantinos Roditis,39234
-Santa Clara,"US Representative, District 18",Controller,,Rep,Konstantinos Roditis,56856
-Santa Clara,"US Representative, District 19",Controller,,Rep,Konstantinos Roditis,59139
-Santa Clara,"US Representative, District 20",Controller,,Rep,Konstantinos Roditis,935
-Santa Clara,"State Senate, District 10",Controller,,Rep,Konstantinos Roditis,22926
-Santa Clara,"State Senate, District 13",Controller,,Rep,Konstantinos Roditis,26650
-Santa Clara,"State Senate, District 15",Controller,,Rep,Konstantinos Roditis,83006
-Santa Clara,"State Senate, District 17",Controller,,Rep,Konstantinos Roditis,23582
-Santa Clara,State Assembly District 24,Controller,,Rep,Konstantinos Roditis,27179
-Santa Clara,State Assembly District 25,Controller,,Rep,Konstantinos Roditis,23143
-Santa Clara,State Assembly District 27,Controller,,Rep,Konstantinos Roditis,27682
-Santa Clara,State Assembly District 28,Controller,,Rep,Konstantinos Roditis,52049
-Santa Clara,State Assembly District 29,Controller,,Rep,Konstantinos Roditis,11506
-Santa Clara,State Assembly District 30,Controller,,Rep,Konstantinos Roditis,14605
-Santa Clara,City of Campbell,Controller,,Rep,Konstantinos Roditis,4280
-Santa Clara,City of Cupertino,Controller,,Rep,Konstantinos Roditis,5284
-Santa Clara,City of Gilroy ,Controller,,Rep,Konstantinos Roditis,5328
-Santa Clara,City of Los Altos,Controller,,Rep,Konstantinos Roditis,4214
-Santa Clara,Town of Los Altos Hills,Controller,,Rep,Konstantinos Roditis,1518
-Santa Clara,Town of Los Gatos,Controller,,Rep,Konstantinos Roditis,4869
-Santa Clara,City of Milpitas,Controller,,Rep,Konstantinos Roditis,4962
-Santa Clara,City of Monte Sereno,Controller,,Rep,Konstantinos Roditis,751
-Santa Clara,City of Morgan Hill,Controller,,Rep,Konstantinos Roditis,6263
-Santa Clara,City of Mountain View,Controller,,Rep,Konstantinos Roditis,4912
-Santa Clara,City of Palo Alto,Controller,,Rep,Konstantinos Roditis,5282
-Santa Clara,City of Santa Clara,Controller,,Rep,Konstantinos Roditis,8375
-Santa Clara,City of Saratoga,Controller,,Rep,Konstantinos Roditis,4814
-Santa Clara,City of Sunnyvale,Controller,,Rep,Konstantinos Roditis,9725
-Santa Clara,City of San Jose,Controller,,Rep,Konstantinos Roditis,76113
-Santa Clara,Unincorporated Area,Controller,,Rep,Konstantinos Roditis,9474
 Santa Clara,1001,Controller,,Dem,Betty Yee,715
 Santa Clara,1003,Controller,,Dem,Betty Yee,640
 Santa Clara,1006,Controller,,Dem,Betty Yee,564
@@ -8737,36 +8527,6 @@ Santa Clara,6665,Controller,,Dem,Betty Yee,1
 Santa Clara,6666,Controller,,Dem,Betty Yee,81
 Santa Clara,6673,Controller,,Dem,Betty Yee,1
 Santa Clara,SANTA CLARA CA,Controller,,Dem,Betty Yee,447306
-Santa Clara,"US Representative, District 17",Controller,,Dem,Betty Yee,119398
-Santa Clara,"US Representative, District 18",Controller,,Dem,Betty Yee,163970
-Santa Clara,"US Representative, District 19",Controller,,Dem,Betty Yee,160893
-Santa Clara,"US Representative, District 20",Controller,,Dem,Betty Yee,3045
-Santa Clara,"State Senate, District 10",Controller,,Dem,Betty Yee,69264
-Santa Clara,"State Senate, District 13",Controller,,Dem,Betty Yee,100368
-Santa Clara,"State Senate, District 15",Controller,,Dem,Betty Yee,229054
-Santa Clara,"State Senate, District 17",Controller,,Dem,Betty Yee,48620
-Santa Clara,State Assembly District 24,Controller,,Dem,Betty Yee,101781
-Santa Clara,State Assembly District 25,Controller,,Dem,Betty Yee,68027
-Santa Clara,State Assembly District 27,Controller,,Dem,Betty Yee,92153
-Santa Clara,State Assembly District 28,Controller,,Dem,Betty Yee,134525
-Santa Clara,State Assembly District 29,Controller,,Dem,Betty Yee,25358
-Santa Clara,State Assembly District 30,Controller,,Dem,Betty Yee,25462
-Santa Clara,City of Campbell,Controller,,Dem,Betty Yee,12203
-Santa Clara,City of Cupertino,Controller,,Dem,Betty Yee,15853
-Santa Clara,City of Gilroy ,Controller,,Dem,Betty Yee,11143
-Santa Clara,City of Los Altos,Controller,,Dem,Betty Yee,11932
-Santa Clara,Town of Los Altos Hills,Controller,,Dem,Betty Yee,3137
-Santa Clara,Town of Los Gatos,Controller,,Dem,Betty Yee,10274
-Santa Clara,City of Milpitas,Controller,,Dem,Betty Yee,14131
-Santa Clara,City of Monte Sereno,Controller,,Dem,Betty Yee,1213
-Santa Clara,City of Morgan Hill,Controller,,Dem,Betty Yee,10544
-Santa Clara,City of Mountain View,Controller,,Dem,Betty Yee,22575
-Santa Clara,City of Palo Alto,Controller,,Dem,Betty Yee,25301
-Santa Clara,City of Santa Clara,Controller,,Dem,Betty Yee,26160
-Santa Clara,City of Saratoga,Controller,,Dem,Betty Yee,10508
-Santa Clara,City of Sunnyvale,Controller,,Dem,Betty Yee,32997
-Santa Clara,City of San Jose,Controller,,Dem,Betty Yee,218865
-Santa Clara,Unincorporated Area,Controller,,Dem,Betty Yee,20470
 Santa Clara,1001,Treasurer,,Rep,Greg Conlon,287
 Santa Clara,1003,Treasurer,,Rep,Greg Conlon,248
 Santa Clara,1006,Treasurer,,Rep,Greg Conlon,300
@@ -9833,36 +9593,6 @@ Santa Clara,6665,Treasurer,,Rep,Greg Conlon,1
 Santa Clara,6666,Treasurer,,Rep,Greg Conlon,36
 Santa Clara,6673,Treasurer,,Rep,Greg Conlon,1
 Santa Clara,SANTA CLARA CA,Treasurer,,Rep,Greg Conlon,162852
-Santa Clara,"US Representative, District 17",Treasurer,,Rep,Greg Conlon,41092
-Santa Clara,"US Representative, District 18",Treasurer,,Rep,Greg Conlon,59395
-Santa Clara,"US Representative, District 19",Treasurer,,Rep,Greg Conlon,61415
-Santa Clara,"US Representative, District 20",Treasurer,,Rep,Greg Conlon,950
-Santa Clara,"State Senate, District 10",Treasurer,,Rep,Greg Conlon,24007
-Santa Clara,"State Senate, District 13",Treasurer,,Rep,Greg Conlon,28229
-Santa Clara,"State Senate, District 15",Treasurer,,Rep,Greg Conlon,86377
-Santa Clara,"State Senate, District 17",Treasurer,,Rep,Greg Conlon,24239
-Santa Clara,State Assembly District 24,Treasurer,,Rep,Greg Conlon,28770
-Santa Clara,State Assembly District 25,Treasurer,,Rep,Greg Conlon,24239
-Santa Clara,State Assembly District 27,Treasurer,,Rep,Greg Conlon,29013
-Santa Clara,State Assembly District 28,Treasurer,,Rep,Greg Conlon,54051
-Santa Clara,State Assembly District 29,Treasurer,,Rep,Greg Conlon,11875
-Santa Clara,State Assembly District 30,Treasurer,,Rep,Greg Conlon,14904
-Santa Clara,City of Campbell,Treasurer,,Rep,Greg Conlon,4444
-Santa Clara,City of Cupertino,Treasurer,,Rep,Greg Conlon,5526
-Santa Clara,City of Gilroy ,Treasurer,,Rep,Greg Conlon,5485
-Santa Clara,City of Los Altos,Treasurer,,Rep,Greg Conlon,4472
-Santa Clara,Town of Los Altos Hills,Treasurer,,Rep,Greg Conlon,1588
-Santa Clara,Town of Los Gatos,Treasurer,,Rep,Greg Conlon,5033
-Santa Clara,City of Milpitas,Treasurer,,Rep,Greg Conlon,5289
-Santa Clara,City of Monte Sereno,Treasurer,,Rep,Greg Conlon,784
-Santa Clara,City of Morgan Hill,Treasurer,,Rep,Greg Conlon,6361
-Santa Clara,City of Mountain View,Treasurer,,Rep,Greg Conlon,5210
-Santa Clara,City of Palo Alto,Treasurer,,Rep,Greg Conlon,5713
-Santa Clara,City of Santa Clara,Treasurer,,Rep,Greg Conlon,8723
-Santa Clara,City of Saratoga,Treasurer,,Rep,Greg Conlon,5078
-Santa Clara,City of Sunnyvale,Treasurer,,Rep,Greg Conlon,10188
-Santa Clara,City of San Jose,Treasurer,,Rep,Greg Conlon,79171
-Santa Clara,Unincorporated Area,Treasurer,,Rep,Greg Conlon,9787
 Santa Clara,1001,Treasurer,,Dem,Fiona Ma,703
 Santa Clara,1003,Treasurer,,Dem,Fiona Ma,643
 Santa Clara,1006,Treasurer,,Dem,Fiona Ma,550
@@ -10929,36 +10659,6 @@ Santa Clara,6665,Treasurer,,Dem,Fiona Ma,1
 Santa Clara,6666,Treasurer,,Dem,Fiona Ma,78
 Santa Clara,6673,Treasurer,,Dem,Fiona Ma,1
 Santa Clara,SANTA CLARA CA,Treasurer,,Dem,Fiona Ma,439879
-Santa Clara,"US Representative, District 17",Treasurer,,Dem,Fiona Ma,117338
-Santa Clara,"US Representative, District 18",Treasurer,,Dem,Fiona Ma,161103
-Santa Clara,"US Representative, District 19",Treasurer,,Dem,Fiona Ma,158383
-Santa Clara,"US Representative, District 20",Treasurer,,Dem,Fiona Ma,3055
-Santa Clara,"State Senate, District 10",Treasurer,,Dem,Fiona Ma,68023
-Santa Clara,"State Senate, District 13",Treasurer,,Dem,Fiona Ma,98695
-Santa Clara,"State Senate, District 15",Treasurer,,Dem,Fiona Ma,225180
-Santa Clara,"State Senate, District 17",Treasurer,,Dem,Fiona Ma,47981
-Santa Clara,State Assembly District 24,Treasurer,,Dem,Fiona Ma,100093
-Santa Clara,State Assembly District 25,Treasurer,,Dem,Fiona Ma,66758
-Santa Clara,State Assembly District 27,Treasurer,,Dem,Fiona Ma,90675
-Santa Clara,State Assembly District 28,Treasurer,,Dem,Fiona Ma,132231
-Santa Clara,State Assembly District 29,Treasurer,,Dem,Fiona Ma,24931
-Santa Clara,State Assembly District 30,Treasurer,,Dem,Fiona Ma,25191
-Santa Clara,City of Campbell,Treasurer,,Dem,Fiona Ma,11971
-Santa Clara,City of Cupertino,Treasurer,,Dem,Fiona Ma,15582
-Santa Clara,City of Gilroy ,Treasurer,,Dem,Fiona Ma,11014
-Santa Clara,City of Los Altos,Treasurer,,Dem,Fiona Ma,11635
-Santa Clara,Town of Los Altos Hills,Treasurer,,Dem,Fiona Ma,3058
-Santa Clara,Town of Los Gatos,Treasurer,,Dem,Fiona Ma,10085
-Santa Clara,City of Milpitas,Treasurer,,Dem,Fiona Ma,13764
-Santa Clara,City of Monte Sereno,Treasurer,,Dem,Fiona Ma,1187
-Santa Clara,City of Morgan Hill,Treasurer,,Dem,Fiona Ma,10432
-Santa Clara,City of Mountain View,Treasurer,,Dem,Fiona Ma,22267
-Santa Clara,City of Palo Alto,Treasurer,,Dem,Fiona Ma,24835
-Santa Clara,City of Santa Clara,Treasurer,,Dem,Fiona Ma,25732
-Santa Clara,City of Saratoga,Treasurer,,Dem,Fiona Ma,10216
-Santa Clara,City of Sunnyvale,Treasurer,,Dem,Fiona Ma,32530
-Santa Clara,City of San Jose,Treasurer,,Dem,Fiona Ma,215394
-Santa Clara,Unincorporated Area,Treasurer,,Dem,Fiona Ma,20177
 Santa Clara,1001,Attorney General,,Rep,Steven Bailey,303
 Santa Clara,1003,Attorney General,,Rep,Steven Bailey,245
 Santa Clara,1006,Attorney General,,Rep,Steven Bailey,299
@@ -12025,36 +11725,6 @@ Santa Clara,6665,Attorney General,,Rep,Steven Bailey,1
 Santa Clara,6666,Attorney General,,Rep,Steven Bailey,33
 Santa Clara,6673,Attorney General,,Rep,Steven Bailey,1
 Santa Clara,SANTA CLARA CA,Attorney General,,Rep,Steven Bailey,167498
-Santa Clara,"US Representative, District 17",Attorney General,,Rep,Steven Bailey,43383
-Santa Clara,"US Representative, District 18",Attorney General,,Rep,Steven Bailey,60306
-Santa Clara,"US Representative, District 19",Attorney General,,Rep,Steven Bailey,62841
-Santa Clara,"US Representative, District 20",Attorney General,,Rep,Steven Bailey,968
-Santa Clara,"State Senate, District 10",Attorney General,,Rep,Steven Bailey,25265
-Santa Clara,"State Senate, District 13",Attorney General,,Rep,Steven Bailey,28572
-Santa Clara,"State Senate, District 15",Attorney General,,Rep,Steven Bailey,88725
-Santa Clara,"State Senate, District 17",Attorney General,,Rep,Steven Bailey,24936
-Santa Clara,State Assembly District 24,Attorney General,,Rep,Steven Bailey,29110
-Santa Clara,State Assembly District 25,Attorney General,,Rep,Steven Bailey,25576
-Santa Clara,State Assembly District 27,Attorney General,,Rep,Steven Bailey,29668
-Santa Clara,State Assembly District 28,Attorney General,,Rep,Steven Bailey,55512
-Santa Clara,State Assembly District 29,Attorney General,,Rep,Steven Bailey,12243
-Santa Clara,State Assembly District 30,Attorney General,,Rep,Steven Bailey,15389
-Santa Clara,City of Campbell,Attorney General,,Rep,Steven Bailey,4502
-Santa Clara,City of Cupertino,Attorney General,,Rep,Steven Bailey,5894
-Santa Clara,City of Gilroy ,Attorney General,,Rep,Steven Bailey,5701
-Santa Clara,City of Los Altos,Attorney General,,Rep,Steven Bailey,4489
-Santa Clara,Town of Los Altos Hills,Attorney General,,Rep,Steven Bailey,1585
-Santa Clara,Town of Los Gatos,Attorney General,,Rep,Steven Bailey,4937
-Santa Clara,City of Milpitas,Attorney General,,Rep,Steven Bailey,5720
-Santa Clara,City of Monte Sereno,Attorney General,,Rep,Steven Bailey,768
-Santa Clara,City of Morgan Hill,Attorney General,,Rep,Steven Bailey,6570
-Santa Clara,City of Mountain View,Attorney General,,Rep,Steven Bailey,5180
-Santa Clara,City of Palo Alto,Attorney General,,Rep,Steven Bailey,5737
-Santa Clara,City of Santa Clara,Attorney General,,Rep,Steven Bailey,8975
-Santa Clara,City of Saratoga,Attorney General,,Rep,Steven Bailey,5305
-Santa Clara,City of Sunnyvale,Attorney General,,Rep,Steven Bailey,10567
-Santa Clara,City of San Jose,Attorney General,,Rep,Steven Bailey,81716
-Santa Clara,Unincorporated Area,Attorney General,,Rep,Steven Bailey,9852
 Santa Clara,1001,Attorney General,,Dem,Xavier Becerra,682
 Santa Clara,1003,Attorney General,,Dem,Xavier Becerra,652
 Santa Clara,1006,Attorney General,,Dem,Xavier Becerra,543
@@ -13121,36 +12791,6 @@ Santa Clara,6665,Attorney General,,Dem,Xavier Becerra,1
 Santa Clara,6666,Attorney General,,Dem,Xavier Becerra,80
 Santa Clara,6673,Attorney General,,Dem,Xavier Becerra,1
 Santa Clara,SANTA CLARA CA,Attorney General,,Dem,Xavier Becerra,435623
-Santa Clara,"US Representative, District 17",Attorney General,,Dem,Xavier Becerra,114692
-Santa Clara,"US Representative, District 18",Attorney General,,Dem,Xavier Becerra,160351
-Santa Clara,"US Representative, District 19",Attorney General,,Dem,Xavier Becerra,157520
-Santa Clara,"US Representative, District 20",Attorney General,,Dem,Xavier Becerra,3060
-Santa Clara,"State Senate, District 10",Attorney General,,Dem,Xavier Becerra,66608
-Santa Clara,"State Senate, District 13",Attorney General,,Dem,Xavier Becerra,98469
-Santa Clara,"State Senate, District 15",Attorney General,,Dem,Xavier Becerra,223036
-Santa Clara,"State Senate, District 17",Attorney General,,Dem,Xavier Becerra,47510
-Santa Clara,State Assembly District 24,Attorney General,,Dem,Xavier Becerra,99862
-Santa Clara,State Assembly District 25,Attorney General,,Dem,Xavier Becerra,65251
-Santa Clara,State Assembly District 27,Attorney General,,Dem,Xavier Becerra,90311
-Santa Clara,State Assembly District 28,Attorney General,,Dem,Xavier Becerra,130718
-Santa Clara,State Assembly District 29,Attorney General,,Dem,Xavier Becerra,24616
-Santa Clara,State Assembly District 30,Attorney General,,Dem,Xavier Becerra,24865
-Santa Clara,City of Campbell,Attorney General,,Dem,Xavier Becerra,11963
-Santa Clara,City of Cupertino,Attorney General,,Dem,Xavier Becerra,15011
-Santa Clara,City of Gilroy ,Attorney General,,Dem,Xavier Becerra,10875
-Santa Clara,City of Los Altos,Attorney General,,Dem,Xavier Becerra,11647
-Santa Clara,Town of Los Altos Hills,Attorney General,,Dem,Xavier Becerra,3063
-Santa Clara,Town of Los Gatos,Attorney General,,Dem,Xavier Becerra,10252
-Santa Clara,City of Milpitas,Attorney General,,Dem,Xavier Becerra,13238
-Santa Clara,City of Monte Sereno,Attorney General,,Dem,Xavier Becerra,1187
-Santa Clara,City of Morgan Hill,Attorney General,,Dem,Xavier Becerra,10288
-Santa Clara,City of Mountain View,Attorney General,,Dem,Xavier Becerra,22304
-Santa Clara,City of Palo Alto,Attorney General,,Dem,Xavier Becerra,24809
-Santa Clara,City of Santa Clara,Attorney General,,Dem,Xavier Becerra,25562
-Santa Clara,City of Saratoga,Attorney General,,Dem,Xavier Becerra,9956
-Santa Clara,City of Sunnyvale,Attorney General,,Dem,Xavier Becerra,32232
-Santa Clara,City of San Jose,Attorney General,,Dem,Xavier Becerra,213117
-Santa Clara,Unincorporated Area,Attorney General,,Dem,Xavier Becerra,20119
 Santa Clara,1001,Insurance Commissioner,,Dem,Ricardo Lara,456
 Santa Clara,1003,Insurance Commissioner,,Dem,Ricardo Lara,442
 Santa Clara,1006,Insurance Commissioner,,Dem,Ricardo Lara,371
@@ -14217,36 +13857,6 @@ Santa Clara,6665,Insurance Commissioner,,Dem,Ricardo Lara,0
 Santa Clara,6666,Insurance Commissioner,,Dem,Ricardo Lara,48
 Santa Clara,6673,Insurance Commissioner,,Dem,Ricardo Lara,0
 Santa Clara,SANTA CLARA CA,Insurance Commissioner,,Dem,Ricardo Lara,315504
-Santa Clara,"US Representative, District 17",Insurance Commissioner,,Dem,Ricardo Lara,83344
-Santa Clara,"US Representative, District 18",Insurance Commissioner,,Dem,Ricardo Lara,105551
-Santa Clara,"US Representative, District 19",Insurance Commissioner,,Dem,Ricardo Lara,123938
-Santa Clara,"US Representative, District 20",Insurance Commissioner,,Dem,Ricardo Lara,2671
-Santa Clara,"State Senate, District 10",Insurance Commissioner,,Dem,Ricardo Lara,50757
-Santa Clara,"State Senate, District 13",Insurance Commissioner,,Dem,Ricardo Lara,64379
-Santa Clara,"State Senate, District 15",Insurance Commissioner,,Dem,Ricardo Lara,163131
-Santa Clara,"State Senate, District 17",Insurance Commissioner,,Dem,Ricardo Lara,37237
-Santa Clara,State Assembly District 24,Insurance Commissioner,,Dem,Ricardo Lara,65197
-Santa Clara,State Assembly District 25,Insurance Commissioner,,Dem,Ricardo Lara,50465
-Santa Clara,State Assembly District 27,Insurance Commissioner,,Dem,Ricardo Lara,74813
-Santa Clara,State Assembly District 28,Insurance Commissioner,,Dem,Ricardo Lara,87753
-Santa Clara,State Assembly District 29,Insurance Commissioner,,Dem,Ricardo Lara,17979
-Santa Clara,State Assembly District 30,Insurance Commissioner,,Dem,Ricardo Lara,19297
-Santa Clara,City of Campbell,Insurance Commissioner,,Dem,Ricardo Lara,8351
-Santa Clara,City of Cupertino,Insurance Commissioner,,Dem,Ricardo Lara,9654
-Santa Clara,City of Gilroy ,Insurance Commissioner,,Dem,Ricardo Lara,8825
-Santa Clara,City of Los Altos,Insurance Commissioner,,Dem,Ricardo Lara,6740
-Santa Clara,Town of Los Altos Hills,Insurance Commissioner,,Dem,Ricardo Lara,1694
-Santa Clara,Town of Los Gatos,Insurance Commissioner,,Dem,Ricardo Lara,6292
-Santa Clara,City of Milpitas,Insurance Commissioner,,Dem,Ricardo Lara,10495
-Santa Clara,City of Monte Sereno,Insurance Commissioner,,Dem,Ricardo Lara,695
-Santa Clara,City of Morgan Hill,Insurance Commissioner,,Dem,Ricardo Lara,7620
-Santa Clara,City of Mountain View,Insurance Commissioner,,Dem,Ricardo Lara,15120
-Santa Clara,City of Palo Alto,Insurance Commissioner,,Dem,Ricardo Lara,15839
-Santa Clara,City of Santa Clara,Insurance Commissioner,,Dem,Ricardo Lara,18946
-Santa Clara,City of Saratoga,Insurance Commissioner,,Dem,Ricardo Lara,5888
-Santa Clara,City of Sunnyvale,Insurance Commissioner,,Dem,Ricardo Lara,22111
-Santa Clara,City of San Jose,Insurance Commissioner,,Dem,Ricardo Lara,162642
-Santa Clara,Unincorporated Area,Insurance Commissioner,,Dem,Ricardo Lara,14592
 Santa Clara,1001,Insurance Commissioner,,NPP,Steve Poizner,495
 Santa Clara,1003,Insurance Commissioner,,NPP,Steve Poizner,431
 Santa Clara,1006,Insurance Commissioner,,NPP,Steve Poizner,451
@@ -15313,36 +14923,6 @@ Santa Clara,6665,Insurance Commissioner,,NPP,Steve Poizner,1
 Santa Clara,6666,Insurance Commissioner,,NPP,Steve Poizner,61
 Santa Clara,6673,Insurance Commissioner,,NPP,Steve Poizner,2
 Santa Clara,SANTA CLARA CA,Insurance Commissioner,,NPP,Steve Poizner,266065
-Santa Clara,"US Representative, District 17",Insurance Commissioner,,NPP,Steve Poizner,68780
-Santa Clara,"US Representative, District 18",Insurance Commissioner,,NPP,Steve Poizner,107246
-Santa Clara,"US Representative, District 19",Insurance Commissioner,,NPP,Steve Poizner,88810
-Santa Clara,"US Representative, District 20",Insurance Commissioner,,NPP,Steve Poizner,1229
-Santa Clara,"State Senate, District 10",Insurance Commissioner,,NPP,Steve Poizner,37709
-Santa Clara,"State Senate, District 13",Insurance Commissioner,,NPP,Steve Poizner,57836
-Santa Clara,"State Senate, District 15",Insurance Commissioner,,NPP,Steve Poizner,138002
-Santa Clara,"State Senate, District 17",Insurance Commissioner,,NPP,Steve Poizner,32518
-Santa Clara,State Assembly District 24,Insurance Commissioner,,NPP,Steve Poizner,58908
-Santa Clara,State Assembly District 25,Insurance Commissioner,,NPP,Steve Poizner,36958
-Santa Clara,State Assembly District 27,Insurance Commissioner,,NPP,Steve Poizner,41140
-Santa Clara,State Assembly District 28,Insurance Commissioner,,NPP,Steve Poizner,92082
-Santa Clara,State Assembly District 29,Insurance Commissioner,,NPP,Steve Poizner,17609
-Santa Clara,State Assembly District 30,Insurance Commissioner,,NPP,Steve Poizner,19368
-Santa Clara,City of Campbell,Insurance Commissioner,,NPP,Steve Poizner,7507
-Santa Clara,City of Cupertino,Insurance Commissioner,,NPP,Steve Poizner,10454
-Santa Clara,City of Gilroy ,Insurance Commissioner,,NPP,Steve Poizner,7154
-Santa Clara,City of Los Altos,Insurance Commissioner,,NPP,Steve Poizner,8801
-Santa Clara,Town of Los Altos Hills,Insurance Commissioner,,NPP,Steve Poizner,2775
-Santa Clara,Town of Los Gatos,Insurance Commissioner,,NPP,Steve Poizner,8323
-Santa Clara,City of Milpitas,Insurance Commissioner,,NPP,Steve Poizner,7732
-Santa Clara,City of Monte Sereno,Insurance Commissioner,,NPP,Steve Poizner,1214
-Santa Clara,City of Morgan Hill,Insurance Commissioner,,NPP,Steve Poizner,8558
-Santa Clara,City of Mountain View,Insurance Commissioner,,NPP,Steve Poizner,11308
-Santa Clara,City of Palo Alto,Insurance Commissioner,,NPP,Steve Poizner,13545
-Santa Clara,City of Santa Clara,Insurance Commissioner,,NPP,Steve Poizner,14323
-Santa Clara,City of Saratoga,Insurance Commissioner,,NPP,Steve Poizner,8844
-Santa Clara,City of Sunnyvale,Insurance Commissioner,,NPP,Steve Poizner,19066
-Santa Clara,City of San Jose,Insurance Commissioner,,NPP,Steve Poizner,122175
-Santa Clara,Unincorporated Area,Insurance Commissioner,,NPP,Steve Poizner,14286
 Santa Clara,1001,U.S. Senate,,Dem,Dianne Feinstein,535
 Santa Clara,1003,U.S. Senate,,Dem,Dianne Feinstein,464
 Santa Clara,1006,U.S. Senate,,Dem,Dianne Feinstein,465
@@ -16409,36 +15989,6 @@ Santa Clara,6665,U.S. Senate,,Dem,Dianne Feinstein,1
 Santa Clara,6666,U.S. Senate,,Dem,Dianne Feinstein,53
 Santa Clara,6673,U.S. Senate,,Dem,Dianne Feinstein,1
 Santa Clara,SANTA CLARA CA,U.S. Senate,,Dem,Dianne Feinstein,339866
-Santa Clara,"US Representative, District 17",U.S. Senate,,Dem,Dianne Feinstein,90467
-Santa Clara,"US Representative, District 18",U.S. Senate,,Dem,Dianne Feinstein,126886
-Santa Clara,"US Representative, District 19",U.S. Senate,,Dem,Dianne Feinstein,120570
-Santa Clara,"US Representative, District 20",U.S. Senate,,Dem,Dianne Feinstein,1943
-Santa Clara,"State Senate, District 10",U.S. Senate,,Dem,Dianne Feinstein,52183
-Santa Clara,"State Senate, District 13",U.S. Senate,,Dem,Dianne Feinstein,76142
-Santa Clara,"State Senate, District 15",U.S. Senate,,Dem,Dianne Feinstein,175174
-Santa Clara,"State Senate, District 17",U.S. Senate,,Dem,Dianne Feinstein,36367
-Santa Clara,State Assembly District 24,U.S. Senate,,Dem,Dianne Feinstein,77329
-Santa Clara,State Assembly District 25,U.S. Senate,,Dem,Dianne Feinstein,51380
-Santa Clara,State Assembly District 27,U.S. Senate,,Dem,Dianne Feinstein,68361
-Santa Clara,State Assembly District 28,U.S. Senate,,Dem,Dianne Feinstein,103976
-Santa Clara,State Assembly District 29,U.S. Senate,,Dem,Dianne Feinstein,19972
-Santa Clara,State Assembly District 30,U.S. Senate,,Dem,Dianne Feinstein,18848
-Santa Clara,City of Campbell,U.S. Senate,,Dem,Dianne Feinstein,8882
-Santa Clara,City of Cupertino,U.S. Senate,,Dem,Dianne Feinstein,12716
-Santa Clara,City of Gilroy ,U.S. Senate,,Dem,Dianne Feinstein,7885
-Santa Clara,City of Los Altos,U.S. Senate,,Dem,Dianne Feinstein,10056
-Santa Clara,Town of Los Altos Hills,U.S. Senate,,Dem,Dianne Feinstein,2651
-Santa Clara,Town of Los Gatos,U.S. Senate,,Dem,Dianne Feinstein,8462
-Santa Clara,City of Milpitas,U.S. Senate,,Dem,Dianne Feinstein,11068
-Santa Clara,City of Monte Sereno,U.S. Senate,,Dem,Dianne Feinstein,1038
-Santa Clara,City of Morgan Hill,U.S. Senate,,Dem,Dianne Feinstein,7987
-Santa Clara,City of Mountain View,U.S. Senate,,Dem,Dianne Feinstein,16269
-Santa Clara,City of Palo Alto,U.S. Senate,,Dem,Dianne Feinstein,20026
-Santa Clara,City of Santa Clara,U.S. Senate,,Dem,Dianne Feinstein,19180
-Santa Clara,City of Saratoga,U.S. Senate,,Dem,Dianne Feinstein,8855
-Santa Clara,City of Sunnyvale,U.S. Senate,,Dem,Dianne Feinstein,23915
-Santa Clara,City of San Jose,U.S. Senate,,Dem,Dianne Feinstein,165441
-Santa Clara,Unincorporated Area,U.S. Senate,,Dem,Dianne Feinstein,15435
 Santa Clara,1001,U.S. Senate,,Dem,Kevin DeLeon,398
 Santa Clara,1003,U.S. Senate,,Dem,Kevin DeLeon,373
 Santa Clara,1006,U.S. Senate,,Dem,Kevin DeLeon,333
@@ -17505,36 +17055,6 @@ Santa Clara,6665,U.S. Senate,,Dem,Kevin DeLeon,0
 Santa Clara,6666,U.S. Senate,,Dem,Kevin DeLeon,52
 Santa Clara,6673,U.S. Senate,,Dem,Kevin DeLeon,1
 Santa Clara,SANTA CLARA CA,U.S. Senate,,Dem,Kevin DeLeon,228642
-Santa Clara,"US Representative, District 17",U.S. Senate,,Dem,Kevin DeLeon,59187
-Santa Clara,"US Representative, District 18",U.S. Senate,,Dem,Kevin DeLeon,81637
-Santa Clara,"US Representative, District 19",U.S. Senate,,Dem,Kevin DeLeon,85984
-Santa Clara,"US Representative, District 20",U.S. Senate,,Dem,Kevin DeLeon,1834
-Santa Clara,"State Senate, District 10",U.S. Senate,,Dem,Kevin DeLeon,34692
-Santa Clara,"State Senate, District 13",U.S. Senate,,Dem,Kevin DeLeon,45579
-Santa Clara,"State Senate, District 15",U.S. Senate,,Dem,Kevin DeLeon,118129
-Santa Clara,"State Senate, District 17",U.S. Senate,,Dem,Kevin DeLeon,30242
-Santa Clara,State Assembly District 24,U.S. Senate,,Dem,Kevin DeLeon,46218
-Santa Clara,State Assembly District 25,U.S. Senate,,Dem,Kevin DeLeon,34317
-Santa Clara,State Assembly District 27,U.S. Senate,,Dem,Kevin DeLeon,45235
-Santa Clara,State Assembly District 28,U.S. Senate,,Dem,Kevin DeLeon,70995
-Santa Clara,State Assembly District 29,U.S. Senate,,Dem,Kevin DeLeon,14174
-Santa Clara,State Assembly District 30,U.S. Senate,,Dem,Kevin DeLeon,17703
-Santa Clara,City of Campbell,U.S. Senate,,Dem,Kevin DeLeon,6581
-Santa Clara,City of Cupertino,U.S. Senate,,Dem,Kevin DeLeon,7289
-Santa Clara,City of Gilroy ,U.S. Senate,,Dem,Kevin DeLeon,7361
-Santa Clara,City of Los Altos,U.S. Senate,,Dem,Kevin DeLeon,5336
-Santa Clara,Town of Los Altos Hills,U.S. Senate,,Dem,Kevin DeLeon,1677
-Santa Clara,Town of Los Gatos,U.S. Senate,,Dem,Kevin DeLeon,5574
-Santa Clara,City of Milpitas,U.S. Senate,,Dem,Kevin DeLeon,6870
-Santa Clara,City of Monte Sereno,U.S. Senate,,Dem,Kevin DeLeon,753
-Santa Clara,City of Morgan Hill,U.S. Senate,,Dem,Kevin DeLeon,7280
-Santa Clara,City of Mountain View,U.S. Senate,,Dem,Kevin DeLeon,10227
-Santa Clara,City of Palo Alto,U.S. Senate,,Dem,Kevin DeLeon,9653
-Santa Clara,City of Santa Clara,U.S. Senate,,Dem,Kevin DeLeon,13595
-Santa Clara,City of Saratoga,U.S. Senate,,Dem,Kevin DeLeon,5315
-Santa Clara,City of Sunnyvale,U.S. Senate,,Dem,Kevin DeLeon,16671
-Santa Clara,City of San Jose,U.S. Senate,,Dem,Kevin DeLeon,112175
-Santa Clara,Unincorporated Area,U.S. Senate,,Dem,Kevin DeLeon,12285
 Santa Clara,1001,Superintendent of Public Instruction,,None,Marshall Tuck,374
 Santa Clara,1003,Superintendent of Public Instruction,,None,Marshall Tuck,330
 Santa Clara,1006,Superintendent of Public Instruction,,None,Marshall Tuck,334
@@ -18601,36 +18121,6 @@ Santa Clara,6665,Superintendent of Public Instruction,,None,Marshall Tuck,1
 Santa Clara,6666,Superintendent of Public Instruction,,None,Marshall Tuck,53
 Santa Clara,6673,Superintendent of Public Instruction,,None,Marshall Tuck,0
 Santa Clara,SANTA CLARA CA,Superintendent of Public Instruction,,None,Marshall Tuck,233752
-Santa Clara,"US Representative, District 17",Superintendent of Public Instruction,,None,Marshall Tuck,61752
-Santa Clara,"US Representative, District 18",Superintendent of Public Instruction,,None,Marshall Tuck,81359
-Santa Clara,"US Representative, District 19",Superintendent of Public Instruction,,None,Marshall Tuck,89043
-Santa Clara,"US Representative, District 20",Superintendent of Public Instruction,,None,Marshall Tuck,1598
-Santa Clara,"State Senate, District 10",Superintendent of Public Instruction,,None,Marshall Tuck,36783
-Santa Clara,"State Senate, District 13",Superintendent of Public Instruction,,None,Marshall Tuck,43926
-Santa Clara,"State Senate, District 15",Superintendent of Public Instruction,,None,Marshall Tuck,123104
-Santa Clara,"State Senate, District 17",Superintendent of Public Instruction,,None,Marshall Tuck,29939
-Santa Clara,State Assembly District 24,Superintendent of Public Instruction,,None,Marshall Tuck,44731
-Santa Clara,State Assembly District 25,Superintendent of Public Instruction,,None,Marshall Tuck,36958
-Santa Clara,State Assembly District 27,Superintendent of Public Instruction,,None,Marshall Tuck,49197
-Santa Clara,State Assembly District 28,Superintendent of Public Instruction,,None,Marshall Tuck,70772
-Santa Clara,State Assembly District 29,Superintendent of Public Instruction,,None,Marshall Tuck,15202
-Santa Clara,State Assembly District 30,Superintendent of Public Instruction,,None,Marshall Tuck,16892
-Santa Clara,City of Campbell,Superintendent of Public Instruction,,None,Marshall Tuck,5834
-Santa Clara,City of Cupertino,Superintendent of Public Instruction,,None,Marshall Tuck,8061
-Santa Clara,City of Gilroy ,Superintendent of Public Instruction,,None,Marshall Tuck,6742
-Santa Clara,City of Los Altos,Superintendent of Public Instruction,,None,Marshall Tuck,6209
-Santa Clara,Town of Los Altos Hills,Superintendent of Public Instruction,,None,Marshall Tuck,2145
-Santa Clara,Town of Los Gatos,Superintendent of Public Instruction,,None,Marshall Tuck,6020
-Santa Clara,City of Milpitas,Superintendent of Public Instruction,,None,Marshall Tuck,8418
-Santa Clara,City of Monte Sereno,Superintendent of Public Instruction,,None,Marshall Tuck,886
-Santa Clara,City of Morgan Hill,Superintendent of Public Instruction,,None,Marshall Tuck,7072
-Santa Clara,City of Mountain View,Superintendent of Public Instruction,,None,Marshall Tuck,8604
-Santa Clara,City of Palo Alto,Superintendent of Public Instruction,,None,Marshall Tuck,10024
-Santa Clara,City of Santa Clara,Superintendent of Public Instruction,,None,Marshall Tuck,13369
-Santa Clara,City of Saratoga,Superintendent of Public Instruction,,None,Marshall Tuck,6399
-Santa Clara,City of Sunnyvale,Superintendent of Public Instruction,,None,Marshall Tuck,15177
-Santa Clara,City of San Jose,Superintendent of Public Instruction,,None,Marshall Tuck,117037
-Santa Clara,Unincorporated Area,Superintendent of Public Instruction,,None,Marshall Tuck,11755
 Santa Clara,1001,Superintendent of Public Instruction,,None,Tony Thurmond,496
 Santa Clara,1003,Superintendent of Public Instruction,,None,Tony Thurmond,450
 Santa Clara,1006,Superintendent of Public Instruction,,None,Tony Thurmond,421
@@ -19697,36 +19187,6 @@ Santa Clara,6665,Superintendent of Public Instruction,,None,Tony Thurmond,1
 Santa Clara,6666,Superintendent of Public Instruction,,None,Tony Thurmond,48
 Santa Clara,6673,Superintendent of Public Instruction,,None,Tony Thurmond,1
 Santa Clara,SANTA CLARA CA,Superintendent of Public Instruction,,None,Tony Thurmond,294172
-Santa Clara,"US Representative, District 17",Superintendent of Public Instruction,,None,Tony Thurmond,75634
-Santa Clara,"US Representative, District 18",Superintendent of Public Instruction,,None,Tony Thurmond,107909
-Santa Clara,"US Representative, District 19",Superintendent of Public Instruction,,None,Tony Thurmond,108538
-Santa Clara,"US Representative, District 20",Superintendent of Public Instruction,,None,Tony Thurmond,2091
-Santa Clara,"State Senate, District 10",Superintendent of Public Instruction,,None,Tony Thurmond,44029
-Santa Clara,"State Senate, District 13",Superintendent of Public Instruction,,None,Tony Thurmond,63723
-Santa Clara,"State Senate, District 15",Superintendent of Public Instruction,,None,Tony Thurmond,151597
-Santa Clara,"State Senate, District 17",Superintendent of Public Instruction,,None,Tony Thurmond,34823
-Santa Clara,State Assembly District 24,Superintendent of Public Instruction,,None,Tony Thurmond,64626
-Santa Clara,State Assembly District 25,Superintendent of Public Instruction,,None,Tony Thurmond,42958
-Santa Clara,State Assembly District 27,Superintendent of Public Instruction,,None,Tony Thurmond,58861
-Santa Clara,State Assembly District 28,Superintendent of Public Instruction,,None,Tony Thurmond,91106
-Santa Clara,State Assembly District 29,Superintendent of Public Instruction,,None,Tony Thurmond,17578
-Santa Clara,State Assembly District 30,Superintendent of Public Instruction,,None,Tony Thurmond,19043
-Santa Clara,City of Campbell,Superintendent of Public Instruction,,None,Tony Thurmond,8445
-Santa Clara,City of Cupertino,Superintendent of Public Instruction,,None,Tony Thurmond,9707
-Santa Clara,City of Gilroy ,Superintendent of Public Instruction,,None,Tony Thurmond,8253
-Santa Clara,City of Los Altos,Superintendent of Public Instruction,,None,Tony Thurmond,7616
-Santa Clara,Town of Los Altos Hills,Superintendent of Public Instruction,,None,Tony Thurmond,1721
-Santa Clara,Town of Los Gatos,Superintendent of Public Instruction,,None,Tony Thurmond,6986
-Santa Clara,City of Milpitas,Superintendent of Public Instruction,,None,Tony Thurmond,8495
-Santa Clara,City of Monte Sereno,Superintendent of Public Instruction,,None,Tony Thurmond,788
-Santa Clara,City of Morgan Hill,Superintendent of Public Instruction,,None,Tony Thurmond,7955
-Santa Clara,City of Mountain View,Superintendent of Public Instruction,,None,Tony Thurmond,14475
-Santa Clara,City of Palo Alto,Superintendent of Public Instruction,,None,Tony Thurmond,15681
-Santa Clara,City of Santa Clara,Superintendent of Public Instruction,,None,Tony Thurmond,16979
-Santa Clara,City of Saratoga,Superintendent of Public Instruction,,None,Tony Thurmond,6405
-Santa Clara,City of Sunnyvale,Superintendent of Public Instruction,,None,Tony Thurmond,21588
-Santa Clara,City of San Jose,Superintendent of Public Instruction,,None,Tony Thurmond,145037
-Santa Clara,Unincorporated Area,Superintendent of Public Instruction,,None,Tony Thurmond,14041
 Santa Clara,1001,U.S. House,18,Dem,Anna Eshoo,685
 Santa Clara,1003,U.S. House,18,Dem,Anna Eshoo,654
 Santa Clara,1006,U.S. House,18,Dem,Anna Eshoo,548
@@ -20793,58 +20253,7 @@ Santa Clara,6665,U.S. House,18,Dem,Anna Eshoo,1
 Santa Clara,6666,U.S. House,18,Dem,Anna Eshoo,82
 Santa Clara,6673,U.S. House,18,Dem,Anna Eshoo,1
 Santa Clara,SANTA CLARA CA,U.S. House,17,Dem,Ro Khanna,120125
-Santa Clara,"US Representative, District 17",U.S. House,17,Dem,Ro Khanna,120125
-Santa Clara,"State Senate, District 10",U.S. House,17,Dem,Ro Khanna,61583
-Santa Clara,"State Senate, District 13",U.S. House,17,Dem,Ro Khanna,33675
-Santa Clara,"State Senate, District 15",U.S. House,17,Dem,Ro Khanna,24867
-Santa Clara,State Assembly District 24,U.S. House,17,Dem,Ro Khanna,35182
-Santa Clara,State Assembly District 25,U.S. House,17,Dem,Ro Khanna,65432
-Santa Clara,State Assembly District 28,U.S. House,17,Dem,Ro Khanna,19511
-Santa Clara,City of Cupertino,U.S. House,17,Dem,Ro Khanna,16178
-Santa Clara,City of Milpitas,U.S. House,17,Dem,Ro Khanna,13970
-Santa Clara,City of Santa Clara,U.S. House,17,Dem,Ro Khanna,26437
-Santa Clara,City of Sunnyvale,U.S. House,17,Dem,Ro Khanna,33695
-Santa Clara,City of San Jose,U.S. House,17,Dem,Ro Khanna,29535
-Santa Clara,Unincorporated Area,U.S. House,17,Dem,Ro Khanna,310
-Santa Clara,SANTA CLARA CA,U.S. House,18,Dem,Anna Eshoo,163535
-Santa Clara,"US Representative, District 18",U.S. House,18,Dem,Anna Eshoo,163535
-Santa Clara,"State Senate, District 10",U.S. House,18,Dem,Anna Eshoo,1658
-Santa Clara,"State Senate, District 13",U.S. House,18,Dem,Anna Eshoo,68390
-Santa Clara,"State Senate, District 15",U.S. House,18,Dem,Anna Eshoo,93480
-Santa Clara,"State Senate, District 17",U.S. House,18,Dem,Anna Eshoo,7
-Santa Clara,State Assembly District 24,U.S. House,18,Dem,Anna Eshoo,68349
-Santa Clara,State Assembly District 28,U.S. House,18,Dem,Anna Eshoo,89501
-Santa Clara,State Assembly District 29,U.S. House,18,Dem,Anna Eshoo,5685
-Santa Clara,City of Campbell,U.S. House,18,Dem,Anna Eshoo,11998
-Santa Clara,City of Los Altos,U.S. House,18,Dem,Anna Eshoo,12164
-Santa Clara,Town of Los Altos Hills,U.S. House,18,Dem,Anna Eshoo,3199
-Santa Clara,Town of Los Gatos,U.S. House,18,Dem,Anna Eshoo,10395
-Santa Clara,City of Monte Sereno,U.S. House,18,Dem,Anna Eshoo,1236
-Santa Clara,City of Mountain View,U.S. House,18,Dem,Anna Eshoo,22864
-Santa Clara,City of Palo Alto,U.S. House,18,Dem,Anna Eshoo,25655
-Santa Clara,City of Saratoga,U.S. House,18,Dem,Anna Eshoo,10264
-Santa Clara,City of San Jose,U.S. House,18,Dem,Anna Eshoo,54843
-Santa Clara,Unincorporated Area,U.S. House,18,Dem,Anna Eshoo,10917
-Santa Clara,SANTA CLARA CA,U.S. House,19,Dem,Zoe Lofgren,162496
-Santa Clara,"US Representative, District 19",U.S. House,19,Dem,Zoe Lofgren,162496
-Santa Clara,"State Senate, District 10",U.S. House,19,Dem,Zoe Lofgren,5755
-Santa Clara,"State Senate, District 15",U.S. House,19,Dem,Zoe Lofgren,110958
-Santa Clara,"State Senate, District 17",U.S. House,19,Dem,Zoe Lofgren,45783
-Santa Clara,State Assembly District 25,U.S. House,19,Dem,Zoe Lofgren,2310
-Santa Clara,State Assembly 27,U.S. House,19,Dem,Zoe Lofgren,93382
-Santa Clara,State Assembly District 28,U.S. House,19,Dem,Zoe Lofgren,24707
-Santa Clara,State Assembly District 29,U.S. House,19,Dem,Zoe Lofgren,19714
-Santa Clara,State Assembly 30,U.S. House,19,Dem,Zoe Lofgren,22383
-Santa Clara,City of Gilroy,U.S. House,19,Dem,Zoe Lofgren,8203
-Santa Clara,City of Morgan Hill,U.S. House,19,Dem,Zoe Lofgren,10606
-Santa Clara,City of San Jose,U.S. House,19,Dem,Zoe Lofgren,134730
-Santa Clara,Unincorporated Area,U.S. House,19,Dem,Zoe Lofgren,8957
 Santa Clara,SANTA CLARA CA,U.S. House,20,Dem,Jimmy Panetta,3059
-Santa Clara,"US Representative, District 20",U.S. House,20,Dem,Jimmy Panetta,3059
-Santa Clara,"State Senate, District 17",U.S. House,20,Dem,Jimmy Panetta,3059
-Santa Clara,State Assembly 30,U.S. House,20,Dem,Jimmy Panetta,3059
-Santa Clara,City of Gilroy,U.S. House,20,Dem,Jimmy Panetta,2835
-Santa Clara,Unincorporated Area,U.S. House,20,Dem,Jimmy Panetta,224
 Santa Clara,1001,U.S. House,18,Rep,Christine Russell,306
 Santa Clara,1003,U.S. House,18,Rep,Christine Russell,242
 Santa Clara,1006,U.S. House,18,Rep,Christine Russell,292
@@ -21911,2651 +21320,2462 @@ Santa Clara,6665,U.S. House,18,Rep,Christine Russell,1
 Santa Clara,6666,U.S. House,18,Rep,Christine Russell,33
 Santa Clara,6673,U.S. House,18,Rep,Christine Russell,1
 Santa Clara,SANTA CLARA CA,U.S. House,17,Rep,Ron Cohen,38614
-Santa Clara,"US Representative, District 17",U.S. House,17,Rep,Ron Cohen,38614
-Santa Clara,"State Senate, District 10",U.S. House,17,Rep,Ron Cohen,20954
-Santa Clara,"State Senate, District 13",U.S. House,17,Rep,Ron Cohen,9288
-Santa Clara,"State Senate, District 15",U.S. House,17,Rep,Ron Cohen,8372
-Santa Clara,State Assembly District 24,U.S. House,17,Rep,Ron Cohen,9796
-Santa Clara,State Assembly District 25,U.S. House,17,Rep,Ron Cohen,22299
-Santa Clara,State Assembly District 28,U.S. House,17,Rep,Ron Cohen,6519
-Santa Clara,City of Cupertino,U.S. House,17,Rep,Ron Cohen,5049
-Santa Clara,City of Milpitas,U.S. House,17,Rep,Ron Cohen,5112
-Santa Clara,City of Santa Clara,U.S. House,17,Rep,Ron Cohen,8087
-Santa Clara,City of Sunnyvale,U.S. House,17,Rep,Ron Cohen,9293
-Santa Clara,City of San Jose,U.S. House,17,Rep,Ron Cohen,10895
-Santa Clara,Unincorporated Area,U.S. House,17,Rep,Ron Cohen,178
 Santa Clara,SANTA CLARA CA,U.S. House,18,Rep,Christine Russell,57596
-Santa Clara,"US Representative, District 18",U.S. House,18,Rep,Christine Russell,57596
-Santa Clara,"State Senate, District 10",U.S. House,18,Rep,Christine Russell,628
-Santa Clara,"State Senate, District 13",U.S. House,18,Rep,Christine Russell,16816
-Santa Clara,"State Senate, District 15",U.S. House,18,Rep,Christine Russell,40150
-Santa Clara,"State Senate, District 17",U.S. House,18,Rep,Christine Russell,2
-Santa Clara,State Assembly District 24,U.S. House,18,Rep,Christine Russell,16782
-Santa Clara,State Assembly District 28,U.S. House,18,Rep,Christine Russell,37835
-Santa Clara,State Assembly District 29,U.S. House,18,Rep,Christine Russell,2979
-Santa Clara,City of Campbell,U.S. House,18,Rep,Christine Russell,4409
-Santa Clara,City of Los Altos,U.S. House,18,Rep,Christine Russell,4183
-Santa Clara,Town of Los Altos Hills,U.S. House,18,Rep,Christine Russell,1495
-Santa Clara,Town of Los Gatos,U.S. House,18,Rep,Christine Russell,4763
-Santa Clara,City of Monte Sereno,U.S. House,18,Rep,Christine Russell,728
-Santa Clara,City of Mountain View,U.S. House,18,Rep,Christine Russell,4882
-Santa Clara,City of Palo Alto,U.S. House,18,Rep,Christine Russell,5281
-Santa Clara,City of Saratoga,U.S. House,18,Rep,Christine Russell,5056
-Santa Clara,City of San Jose,U.S. House,18,Rep,Christine Russell,22981
-Santa Clara,Unincorporated Area,U.S. House,18,Rep,Christine Russell,3818
 Santa Clara,SANTA CLARA CA,U.S. House,19,Rep,Justin Aguilera,57823
-Santa Clara,"US Representative, District 19",U.S. House,19,Rep,Justin Aguilera,57823
-Santa Clara,"State Senate, District 10",U.S. House,19,Rep,Justin Aguilera,1363
-Santa Clara,"State Senate, District 15",U.S. House,19,Rep,Justin Aguilera,33834
-Santa Clara,"State Senate, District 17",U.S. House,19,Rep,Justin Aguilera,22626
-Santa Clara,State Assembly District 25,U.S. House,19,Rep,Justin Aguilera,887
-Santa Clara,State Assembly 27,U.S. House,19,Rep,Justin Aguilera,26504
-Santa Clara,State Assembly District 28,U.S. House,19,Rep,Justin Aguilera,8146
-Santa Clara,State Assembly District 29,U.S. House,19,Rep,Justin Aguilera,8461
-Santa Clara,State Assembly 30,U.S. House,19,Rep,Justin Aguilera,13825
-Santa Clara,City of Gilroy,U.S. House,19,Rep,Justin Aguilera,4694
-Santa Clara,City of Morgan Hill,U.S. House,19,Rep,Justin Aguilera,6248
-Santa Clara,City of San Jose,U.S. House,19,Rep,Justin Aguilera,41431
-Santa Clara,Unincorporated Area,U.S. House,19,Rep,Justin Aguilera,5450
 Santa Clara,SANTA CLARA CA,U.S. House,20,NPP,Ronald Kabat,791
-Santa Clara,"US Representative, District 20",U.S. House,20,NPP,Ronald Kabat,791
-Santa Clara,"State Senate, District 17",U.S. House,20,NPP,Ronald Kabat,791
-Santa Clara,State Assembly 30,U.S. House,20,NPP,Ronald Kabat,791
-Santa Clara,City of Gilroy,U.S. House,20,NPP,Ronald Kabat,688
-Santa Clara,Unincorporated Area,U.S. House,20,NPP,Ronald Kabat,103
-Santa Clara,State Senate,10,1301,Dem,Bob Wieckowski,25
-Santa Clara,State Senate,10,1302,Dem,Bob Wieckowski,270
-Santa Clara,State Senate,10,1303,Dem,Bob Wieckowski,606
-Santa Clara,State Senate,10,1304,Dem,Bob Wieckowski,794
-Santa Clara,State Senate,10,1305,Dem,Bob Wieckowski,588
-Santa Clara,State Senate,10,1312,Dem,Bob Wieckowski,551
-Santa Clara,State Senate,10,1313,Dem,Bob Wieckowski,401
-Santa Clara,State Senate,10,1314,Dem,Bob Wieckowski,464
-Santa Clara,State Senate,10,1370,Dem,Bob Wieckowski,9
-Santa Clara,State Senate,10,1371,Dem,Bob Wieckowski,106
-Santa Clara,State Senate,10,1373,Dem,Bob Wieckowski,4
-Santa Clara,State Senate,10,1385,Dem,Bob Wieckowski,694
-Santa Clara,State Senate,10,1394,Dem,Bob Wieckowski,512
-Santa Clara,State Senate,10,1396,Dem,Bob Wieckowski,541
-Santa Clara,State Senate,10,1397,Dem,Bob Wieckowski,610
-Santa Clara,State Senate,10,1400,Dem,Bob Wieckowski,493
-Santa Clara,State Senate,10,1401,Dem,Bob Wieckowski,465
-Santa Clara,State Senate,10,1403,Dem,Bob Wieckowski,593
-Santa Clara,State Senate,10,1405,Dem,Bob Wieckowski,5
-Santa Clara,State Senate,10,1407,Dem,Bob Wieckowski,502
-Santa Clara,State Senate,10,1408,Dem,Bob Wieckowski,363
-Santa Clara,State Senate,10,1409,Dem,Bob Wieckowski,410
-Santa Clara,State Senate,10,1410,Dem,Bob Wieckowski,511
-Santa Clara,State Senate,10,1411,Dem,Bob Wieckowski,570
-Santa Clara,State Senate,10,1414,Dem,Bob Wieckowski,475
-Santa Clara,State Senate,10,1415,Dem,Bob Wieckowski,641
-Santa Clara,State Senate,10,1417,Dem,Bob Wieckowski,568
-Santa Clara,State Senate,10,1418,Dem,Bob Wieckowski,516
-Santa Clara,State Senate,10,1420,Dem,Bob Wieckowski,593
-Santa Clara,State Senate,10,1421,Dem,Bob Wieckowski,540
-Santa Clara,State Senate,10,1427,Dem,Bob Wieckowski,353
-Santa Clara,State Senate,10,1428,Dem,Bob Wieckowski,516
-Santa Clara,State Senate,10,1429,Dem,Bob Wieckowski,661
-Santa Clara,State Senate,10,1431,Dem,Bob Wieckowski,319
-Santa Clara,State Senate,10,1432,Dem,Bob Wieckowski,594
-Santa Clara,State Senate,10,1433,Dem,Bob Wieckowski,447
-Santa Clara,State Senate,10,1435,Dem,Bob Wieckowski,644
-Santa Clara,State Senate,10,1439,Dem,Bob Wieckowski,677
-Santa Clara,State Senate,10,1444,Dem,Bob Wieckowski,534
-Santa Clara,State Senate,10,1446,Dem,Bob Wieckowski,600
-Santa Clara,State Senate,10,1447,Dem,Bob Wieckowski,359
-Santa Clara,State Senate,10,1448,Dem,Bob Wieckowski,614
-Santa Clara,State Senate,10,1451,Dem,Bob Wieckowski,500
-Santa Clara,State Senate,10,1453,Dem,Bob Wieckowski,410
-Santa Clara,State Senate,10,1455,Dem,Bob Wieckowski,520
-Santa Clara,State Senate,10,1459,Dem,Bob Wieckowski,606
-Santa Clara,State Senate,10,1461,Dem,Bob Wieckowski,542
-Santa Clara,State Senate,10,1465,Dem,Bob Wieckowski,403
-Santa Clara,State Senate,10,1467,Dem,Bob Wieckowski,578
-Santa Clara,State Senate,10,1468,Dem,Bob Wieckowski,515
-Santa Clara,State Senate,10,1478,Dem,Bob Wieckowski,433
-Santa Clara,State Senate,10,1480,Dem,Bob Wieckowski,353
-Santa Clara,State Senate,10,1497,Dem,Bob Wieckowski,454
-Santa Clara,State Senate,10,1570,Dem,Bob Wieckowski,1
-Santa Clara,State Senate,10,1586,Dem,Bob Wieckowski,7
-Santa Clara,State Senate,10,1613,Dem,Bob Wieckowski,417
-Santa Clara,State Senate,10,1615,Dem,Bob Wieckowski,519
-Santa Clara,State Senate,10,1616,Dem,Bob Wieckowski,700
-Santa Clara,State Senate,10,1619,Dem,Bob Wieckowski,35
-Santa Clara,State Senate,10,1620,Dem,Bob Wieckowski,673
-Santa Clara,State Senate,10,1621,Dem,Bob Wieckowski,354
-Santa Clara,State Senate,10,4008,Dem,Bob Wieckowski,20
-Santa Clara,State Senate,10,4201,Dem,Bob Wieckowski,692
-Santa Clara,State Senate,10,4202,Dem,Bob Wieckowski,5
-Santa Clara,State Senate,10,4205,Dem,Bob Wieckowski,69
-Santa Clara,State Senate,10,4207,Dem,Bob Wieckowski,51
-Santa Clara,State Senate,10,4208,Dem,Bob Wieckowski,635
-Santa Clara,State Senate,10,4211,Dem,Bob Wieckowski,610
-Santa Clara,State Senate,10,4212,Dem,Bob Wieckowski,4
-Santa Clara,State Senate,10,4215,Dem,Bob Wieckowski,728
-Santa Clara,State Senate,10,4217,Dem,Bob Wieckowski,518
-Santa Clara,State Senate,10,4218,Dem,Bob Wieckowski,377
-Santa Clara,State Senate,10,4222,Dem,Bob Wieckowski,576
-Santa Clara,State Senate,10,4223,Dem,Bob Wieckowski,714
-Santa Clara,State Senate,10,4224,Dem,Bob Wieckowski,2
-Santa Clara,State Senate,10,4226,Dem,Bob Wieckowski,589
-Santa Clara,State Senate,10,4227,Dem,Bob Wieckowski,545
-Santa Clara,State Senate,10,4231,Dem,Bob Wieckowski,740
-Santa Clara,State Senate,10,4238,Dem,Bob Wieckowski,752
-Santa Clara,State Senate,10,4241,Dem,Bob Wieckowski,683
-Santa Clara,State Senate,10,4242,Dem,Bob Wieckowski,569
-Santa Clara,State Senate,10,4247,Dem,Bob Wieckowski,430
-Santa Clara,State Senate,10,4249,Dem,Bob Wieckowski,713
-Santa Clara,State Senate,10,4250,Dem,Bob Wieckowski,405
-Santa Clara,State Senate,10,4256,Dem,Bob Wieckowski,705
-Santa Clara,State Senate,10,4257,Dem,Bob Wieckowski,352
-Santa Clara,State Senate,10,4258,Dem,Bob Wieckowski,485
-Santa Clara,State Senate,10,4259,Dem,Bob Wieckowski,762
-Santa Clara,State Senate,10,4261,Dem,Bob Wieckowski,496
-Santa Clara,State Senate,10,4265,Dem,Bob Wieckowski,638
-Santa Clara,State Senate,10,4267,Dem,Bob Wieckowski,365
-Santa Clara,State Senate,10,4268,Dem,Bob Wieckowski,396
-Santa Clara,State Senate,10,4269,Dem,Bob Wieckowski,406
-Santa Clara,State Senate,10,4270,Dem,Bob Wieckowski,548
-Santa Clara,State Senate,10,4271,Dem,Bob Wieckowski,689
-Santa Clara,State Senate,10,4272,Dem,Bob Wieckowski,300
-Santa Clara,State Senate,10,4273,Dem,Bob Wieckowski,622
-Santa Clara,State Senate,10,4288,Dem,Bob Wieckowski,436
-Santa Clara,State Senate,10,4289,Dem,Bob Wieckowski,420
-Santa Clara,State Senate,10,4296,Dem,Bob Wieckowski,365
-Santa Clara,State Senate,10,4297,Dem,Bob Wieckowski,712
-Santa Clara,State Senate,10,4298,Dem,Bob Wieckowski,487
-Santa Clara,State Senate,10,4299,Dem,Bob Wieckowski,16
-Santa Clara,State Senate,10,4301,Dem,Bob Wieckowski,611
-Santa Clara,State Senate,10,4305,Dem,Bob Wieckowski,700
-Santa Clara,State Senate,10,4308,Dem,Bob Wieckowski,45
-Santa Clara,State Senate,10,4309,Dem,Bob Wieckowski,25
-Santa Clara,State Senate,10,4312,Dem,Bob Wieckowski,459
-Santa Clara,State Senate,10,4315,Dem,Bob Wieckowski,714
-Santa Clara,State Senate,10,4319,Dem,Bob Wieckowski,376
-Santa Clara,State Senate,10,4321,Dem,Bob Wieckowski,604
-Santa Clara,State Senate,10,4326,Dem,Bob Wieckowski,615
-Santa Clara,State Senate,10,4327,Dem,Bob Wieckowski,688
-Santa Clara,State Senate,10,4332,Dem,Bob Wieckowski,314
-Santa Clara,State Senate,10,4334,Dem,Bob Wieckowski,459
-Santa Clara,State Senate,10,4343,Dem,Bob Wieckowski,387
-Santa Clara,State Senate,10,4401,Dem,Bob Wieckowski,591
-Santa Clara,State Senate,10,4402,Dem,Bob Wieckowski,691
-Santa Clara,State Senate,10,4403,Dem,Bob Wieckowski,55
-Santa Clara,State Senate,10,4404,Dem,Bob Wieckowski,480
-Santa Clara,State Senate,10,4405,Dem,Bob Wieckowski,332
-Santa Clara,State Senate,10,4406,Dem,Bob Wieckowski,350
-Santa Clara,State Senate,10,4407,Dem,Bob Wieckowski,308
-Santa Clara,State Senate,10,4408,Dem,Bob Wieckowski,473
-Santa Clara,State Senate,10,4409,Dem,Bob Wieckowski,583
-Santa Clara,State Senate,10,4411,Dem,Bob Wieckowski,340
-Santa Clara,State Senate,10,4412,Dem,Bob Wieckowski,406
-Santa Clara,State Senate,10,4413,Dem,Bob Wieckowski,424
-Santa Clara,State Senate,10,4414,Dem,Bob Wieckowski,457
-Santa Clara,State Senate,10,4415,Dem,Bob Wieckowski,679
-Santa Clara,State Senate,10,4416,Dem,Bob Wieckowski,373
-Santa Clara,State Senate,10,4417,Dem,Bob Wieckowski,603
-Santa Clara,State Senate,10,4418,Dem,Bob Wieckowski,367
-Santa Clara,State Senate,10,4421,Dem,Bob Wieckowski,361
-Santa Clara,State Senate,10,4422,Dem,Bob Wieckowski,491
-Santa Clara,State Senate,10,4423,Dem,Bob Wieckowski,322
-Santa Clara,State Senate,10,4424,Dem,Bob Wieckowski,344
-Santa Clara,State Senate,10,4425,Dem,Bob Wieckowski,355
-Santa Clara,State Senate,10,4426,Dem,Bob Wieckowski,324
-Santa Clara,State Senate,10,4427,Dem,Bob Wieckowski,402
-Santa Clara,State Senate,10,4428,Dem,Bob Wieckowski,547
-Santa Clara,State Senate,10,4429,Dem,Bob Wieckowski,669
-Santa Clara,State Senate,10,4431,Dem,Bob Wieckowski,1
-Santa Clara,State Senate,10,4432,Dem,Bob Wieckowski,560
-Santa Clara,State Senate,10,4435,Dem,Bob Wieckowski,622
-Santa Clara,State Senate,10,4438,Dem,Bob Wieckowski,387
-Santa Clara,State Senate,10,4440,Dem,Bob Wieckowski,578
-Santa Clara,State Senate,10,4441,Dem,Bob Wieckowski,85
-Santa Clara,State Senate,10,4442,Dem,Bob Wieckowski,1
-Santa Clara,State Senate,10,6401,Dem,Bob Wieckowski,0
-Santa Clara,State Senate,10,6402,Dem,Bob Wieckowski,37
-Santa Clara,State Senate,10,6411,Dem,Bob Wieckowski,62
-Santa Clara,State Senate,10,6419,Dem,Bob Wieckowski,9
-Santa Clara,State Senate,10,6421,Dem,Bob Wieckowski,5
-Santa Clara,State Senate,10,6425,Dem,Bob Wieckowski,11
-Santa Clara,State Senate,10,6515,Dem,Bob Wieckowski,50
-Santa Clara,State Senate,10,City of Milpitas,Dem,Bob Wiechowski,13561
-Santa Clara,State Senate,10,City of San Jose,Dem,Bob Wiechowski,27758
-Santa Clara,State Senate,10,City of Santa Clara,Dem,Bob Wiechowski,25604
-Santa Clara,State Senate,10,City of Sunnyvale,Dem,Bob Wiechowski,20
-Santa Clara,State Senate,10,SANTA CLARA CA,Dem,Bob Wiechowski,67117
-Santa Clara,State Senate,10,State Assembly District 25,Dem,Bob Wiechowski,60810
-Santa Clara,State Senate,10,State Assembly District 27,Dem,Bob Wiechowski,1526
-Santa Clara,State Senate,10,State Assembly District 28,Dem,Bob Wiechowski,4781
-Santa Clara,State Senate,10,"State Senate, District 10",Dem,Bob Wiechowski,67117
-Santa Clara,State Senate,10,Unincorporated Area,Dem,Bob Wiechowski,174
-Santa Clara,State Senate,10,"US Representative, District 17",Dem,Bob Wiechowski,59858
-Santa Clara,State Senate,10,"US Representative, District 18",Dem,Bob Wiechowski,1678
-Santa Clara,State Senate,10,"US Representative, District 19",Dem,Bob Wiechowski,5581
-Santa Clara,State Senate,10,1301,Rep,Victor San Vicente,5
-Santa Clara,State Senate,10,1302,Rep,Victor San Vicente,57
-Santa Clara,State Senate,10,1303,Rep,Victor San Vicente,148
-Santa Clara,State Senate,10,1304,Rep,Victor San Vicente,202
-Santa Clara,State Senate,10,1305,Rep,Victor San Vicente,163
-Santa Clara,State Senate,10,1312,Rep,Victor San Vicente,79
-Santa Clara,State Senate,10,1313,Rep,Victor San Vicente,70
-Santa Clara,State Senate,10,1314,Rep,Victor San Vicente,106
-Santa Clara,State Senate,10,1370,Rep,Victor San Vicente,4
-Santa Clara,State Senate,10,1371,Rep,Victor San Vicente,39
-Santa Clara,State Senate,10,1373,Rep,Victor San Vicente,1
-Santa Clara,State Senate,10,1385,Rep,Victor San Vicente,174
-Santa Clara,State Senate,10,1394,Rep,Victor San Vicente,210
-Santa Clara,State Senate,10,1396,Rep,Victor San Vicente,220
-Santa Clara,State Senate,10,1397,Rep,Victor San Vicente,275
-Santa Clara,State Senate,10,1400,Rep,Victor San Vicente,123
-Santa Clara,State Senate,10,1401,Rep,Victor San Vicente,103
-Santa Clara,State Senate,10,1403,Rep,Victor San Vicente,182
-Santa Clara,State Senate,10,1405,Rep,Victor San Vicente,3
-Santa Clara,State Senate,10,1407,Rep,Victor San Vicente,227
-Santa Clara,State Senate,10,1408,Rep,Victor San Vicente,112
-Santa Clara,State Senate,10,1409,Rep,Victor San Vicente,162
-Santa Clara,State Senate,10,1410,Rep,Victor San Vicente,238
-Santa Clara,State Senate,10,1411,Rep,Victor San Vicente,249
-Santa Clara,State Senate,10,1414,Rep,Victor San Vicente,209
-Santa Clara,State Senate,10,1415,Rep,Victor San Vicente,233
-Santa Clara,State Senate,10,1417,Rep,Victor San Vicente,201
-Santa Clara,State Senate,10,1418,Rep,Victor San Vicente,210
-Santa Clara,State Senate,10,1420,Rep,Victor San Vicente,240
-Santa Clara,State Senate,10,1421,Rep,Victor San Vicente,221
-Santa Clara,State Senate,10,1427,Rep,Victor San Vicente,143
-Santa Clara,State Senate,10,1428,Rep,Victor San Vicente,238
-Santa Clara,State Senate,10,1429,Rep,Victor San Vicente,302
-Santa Clara,State Senate,10,1431,Rep,Victor San Vicente,183
-Santa Clara,State Senate,10,1432,Rep,Victor San Vicente,299
-Santa Clara,State Senate,10,1433,Rep,Victor San Vicente,143
-Santa Clara,State Senate,10,1435,Rep,Victor San Vicente,222
-Santa Clara,State Senate,10,1439,Rep,Victor San Vicente,111
-Santa Clara,State Senate,10,1444,Rep,Victor San Vicente,220
-Santa Clara,State Senate,10,1446,Rep,Victor San Vicente,277
-Santa Clara,State Senate,10,1447,Rep,Victor San Vicente,134
-Santa Clara,State Senate,10,1448,Rep,Victor San Vicente,255
-Santa Clara,State Senate,10,1451,Rep,Victor San Vicente,234
-Santa Clara,State Senate,10,1453,Rep,Victor San Vicente,141
-Santa Clara,State Senate,10,1455,Rep,Victor San Vicente,229
-Santa Clara,State Senate,10,1459,Rep,Victor San Vicente,181
-Santa Clara,State Senate,10,1461,Rep,Victor San Vicente,113
-Santa Clara,State Senate,10,1465,Rep,Victor San Vicente,144
-Santa Clara,State Senate,10,1467,Rep,Victor San Vicente,147
-Santa Clara,State Senate,10,1468,Rep,Victor San Vicente,259
-Santa Clara,State Senate,10,1478,Rep,Victor San Vicente,143
-Santa Clara,State Senate,10,1480,Rep,Victor San Vicente,115
-Santa Clara,State Senate,10,1497,Rep,Victor San Vicente,71
-Santa Clara,State Senate,10,1570,Rep,Victor San Vicente,0
-Santa Clara,State Senate,10,1586,Rep,Victor San Vicente,4
-Santa Clara,State Senate,10,1613,Rep,Victor San Vicente,145
-Santa Clara,State Senate,10,1615,Rep,Victor San Vicente,202
-Santa Clara,State Senate,10,1616,Rep,Victor San Vicente,229
-Santa Clara,State Senate,10,1619,Rep,Victor San Vicente,8
-Santa Clara,State Senate,10,1620,Rep,Victor San Vicente,255
-Santa Clara,State Senate,10,1621,Rep,Victor San Vicente,83
-Santa Clara,State Senate,10,4008,Rep,Victor San Vicente,5
-Santa Clara,State Senate,10,4201,Rep,Victor San Vicente,172
-Santa Clara,State Senate,10,4202,Rep,Victor San Vicente,2
-Santa Clara,State Senate,10,4205,Rep,Victor San Vicente,9
-Santa Clara,State Senate,10,4207,Rep,Victor San Vicente,10
-Santa Clara,State Senate,10,4208,Rep,Victor San Vicente,234
-Santa Clara,State Senate,10,4211,Rep,Victor San Vicente,198
-Santa Clara,State Senate,10,4212,Rep,Victor San Vicente,1
-Santa Clara,State Senate,10,4215,Rep,Victor San Vicente,258
-Santa Clara,State Senate,10,4217,Rep,Victor San Vicente,153
-Santa Clara,State Senate,10,4218,Rep,Victor San Vicente,103
-Santa Clara,State Senate,10,4222,Rep,Victor San Vicente,194
-Santa Clara,State Senate,10,4223,Rep,Victor San Vicente,178
-Santa Clara,State Senate,10,4224,Rep,Victor San Vicente,1
-Santa Clara,State Senate,10,4226,Rep,Victor San Vicente,231
-Santa Clara,State Senate,10,4227,Rep,Victor San Vicente,167
-Santa Clara,State Senate,10,4231,Rep,Victor San Vicente,229
-Santa Clara,State Senate,10,4238,Rep,Victor San Vicente,241
-Santa Clara,State Senate,10,4241,Rep,Victor San Vicente,266
-Santa Clara,State Senate,10,4242,Rep,Victor San Vicente,205
-Santa Clara,State Senate,10,4247,Rep,Victor San Vicente,179
-Santa Clara,State Senate,10,4249,Rep,Victor San Vicente,207
-Santa Clara,State Senate,10,4250,Rep,Victor San Vicente,185
-Santa Clara,State Senate,10,4256,Rep,Victor San Vicente,174
-Santa Clara,State Senate,10,4257,Rep,Victor San Vicente,110
-Santa Clara,State Senate,10,4258,Rep,Victor San Vicente,170
-Santa Clara,State Senate,10,4259,Rep,Victor San Vicente,230
-Santa Clara,State Senate,10,4261,Rep,Victor San Vicente,119
-Santa Clara,State Senate,10,4265,Rep,Victor San Vicente,255
-Santa Clara,State Senate,10,4267,Rep,Victor San Vicente,195
-Santa Clara,State Senate,10,4268,Rep,Victor San Vicente,115
-Santa Clara,State Senate,10,4269,Rep,Victor San Vicente,129
-Santa Clara,State Senate,10,4270,Rep,Victor San Vicente,194
-Santa Clara,State Senate,10,4271,Rep,Victor San Vicente,201
-Santa Clara,State Senate,10,4272,Rep,Victor San Vicente,97
-Santa Clara,State Senate,10,4273,Rep,Victor San Vicente,189
-Santa Clara,State Senate,10,4288,Rep,Victor San Vicente,162
-Santa Clara,State Senate,10,4289,Rep,Victor San Vicente,119
-Santa Clara,State Senate,10,4296,Rep,Victor San Vicente,84
-Santa Clara,State Senate,10,4297,Rep,Victor San Vicente,246
-Santa Clara,State Senate,10,4298,Rep,Victor San Vicente,149
-Santa Clara,State Senate,10,4299,Rep,Victor San Vicente,8
-Santa Clara,State Senate,10,4301,Rep,Victor San Vicente,224
-Santa Clara,State Senate,10,4305,Rep,Victor San Vicente,269
-Santa Clara,State Senate,10,4308,Rep,Victor San Vicente,15
-Santa Clara,State Senate,10,4309,Rep,Victor San Vicente,13
-Santa Clara,State Senate,10,4312,Rep,Victor San Vicente,134
-Santa Clara,State Senate,10,4315,Rep,Victor San Vicente,260
-Santa Clara,State Senate,10,4319,Rep,Victor San Vicente,139
-Santa Clara,State Senate,10,4321,Rep,Victor San Vicente,145
-Santa Clara,State Senate,10,4326,Rep,Victor San Vicente,214
-Santa Clara,State Senate,10,4327,Rep,Victor San Vicente,198
-Santa Clara,State Senate,10,4332,Rep,Victor San Vicente,178
-Santa Clara,State Senate,10,4334,Rep,Victor San Vicente,158
-Santa Clara,State Senate,10,4343,Rep,Victor San Vicente,115
-Santa Clara,State Senate,10,4401,Rep,Victor San Vicente,251
-Santa Clara,State Senate,10,4402,Rep,Victor San Vicente,211
-Santa Clara,State Senate,10,4403,Rep,Victor San Vicente,14
-Santa Clara,State Senate,10,4404,Rep,Victor San Vicente,155
-Santa Clara,State Senate,10,4405,Rep,Victor San Vicente,123
-Santa Clara,State Senate,10,4406,Rep,Victor San Vicente,133
-Santa Clara,State Senate,10,4407,Rep,Victor San Vicente,173
-Santa Clara,State Senate,10,4408,Rep,Victor San Vicente,144
-Santa Clara,State Senate,10,4409,Rep,Victor San Vicente,192
-Santa Clara,State Senate,10,4411,Rep,Victor San Vicente,179
-Santa Clara,State Senate,10,4412,Rep,Victor San Vicente,134
-Santa Clara,State Senate,10,4413,Rep,Victor San Vicente,143
-Santa Clara,State Senate,10,4414,Rep,Victor San Vicente,138
-Santa Clara,State Senate,10,4415,Rep,Victor San Vicente,263
-Santa Clara,State Senate,10,4416,Rep,Victor San Vicente,126
-Santa Clara,State Senate,10,4417,Rep,Victor San Vicente,297
-Santa Clara,State Senate,10,4418,Rep,Victor San Vicente,143
-Santa Clara,State Senate,10,4421,Rep,Victor San Vicente,154
-Santa Clara,State Senate,10,4422,Rep,Victor San Vicente,233
-Santa Clara,State Senate,10,4423,Rep,Victor San Vicente,130
-Santa Clara,State Senate,10,4424,Rep,Victor San Vicente,123
-Santa Clara,State Senate,10,4425,Rep,Victor San Vicente,139
-Santa Clara,State Senate,10,4426,Rep,Victor San Vicente,168
-Santa Clara,State Senate,10,4427,Rep,Victor San Vicente,144
-Santa Clara,State Senate,10,4428,Rep,Victor San Vicente,187
-Santa Clara,State Senate,10,4429,Rep,Victor San Vicente,265
-Santa Clara,State Senate,10,4431,Rep,Victor San Vicente,0
-Santa Clara,State Senate,10,4432,Rep,Victor San Vicente,266
-Santa Clara,State Senate,10,4435,Rep,Victor San Vicente,229
-Santa Clara,State Senate,10,4438,Rep,Victor San Vicente,110
-Santa Clara,State Senate,10,4440,Rep,Victor San Vicente,222
-Santa Clara,State Senate,10,4441,Rep,Victor San Vicente,59
-Santa Clara,State Senate,10,4442,Rep,Victor San Vicente,3
-Santa Clara,State Senate,10,6401,Rep,Victor San Vicente,1
-Santa Clara,State Senate,10,6402,Rep,Victor San Vicente,26
-Santa Clara,State Senate,10,6411,Rep,Victor San Vicente,38
-Santa Clara,State Senate,10,6419,Rep,Victor San Vicente,13
-Santa Clara,State Senate,10,6421,Rep,Victor San Vicente,3
-Santa Clara,State Senate,10,6425,Rep,Victor San Vicente,19
-Santa Clara,State Senate,10,6515,Rep,Victor San Vicente,23
-Santa Clara,State Senate,10,City of Milpitas,Rep,Victor San Vicente,5251
-Santa Clara,State Senate,10,City of San Jose,Rep,Victor San Vicente,9696
-Santa Clara,State Senate,10,City of Santa Clara,Rep,Victor San Vicente,8431
-Santa Clara,State Senate,10,City of Sunnyvale,Rep,Victor San Vicente,5
-Santa Clara,State Senate,10,SANTA CLARA CA,Rep,Victor San Vicente,23506
-Santa Clara,State Senate,10,State Assembly District 25,Rep,Victor San Vicente,21746
-Santa Clara,State Senate,10,State Assembly District 27,Rep,Victor San Vicente,295
-Santa Clara,State Senate,10,State Assembly District 28,Rep,Victor San Vicente,1465
-Santa Clara,State Senate,10,"State Senate, District 10",Rep,Victor San Vicente,23506
-Santa Clara,State Senate,10,Unincorporated Area,Rep,Victor San Vicente,123
-Santa Clara,State Senate,10,"US Representative, District 17",Rep,Victor San Vicente,21513
-Santa Clara,State Senate,10,"US Representative, District 18",Rep,Victor San Vicente,588
-Santa Clara,State Senate,10,"US Representative, District 19",Rep,Victor San Vicente,1405
-Santa Clara,State Assembly,28,1001,Dem,Evan Low,700
-Santa Clara,State Assembly,28,1003,Dem,Evan Low,635
-Santa Clara,State Assembly,28,1006,Dem,Evan Low,540
-Santa Clara,State Assembly,28,1008,Dem,Evan Low,378
-Santa Clara,State Assembly,29,1009,Dem,Mark Stone,498
-Santa Clara,State Assembly,28,1010,Dem,Evan Low,356
-Santa Clara,State Assembly,28,1011,Dem,Evan Low,575
-Santa Clara,State Assembly,28,1013,Dem,Evan Low,542
-Santa Clara,State Assembly,28,1015,Dem,Evan Low,366
-Santa Clara,State Assembly,28,1016,Dem,Evan Low,459
-Santa Clara,State Assembly,28,1019,Dem,Evan Low,582
-Santa Clara,State Assembly,28,1020,Dem,Evan Low,497
-Santa Clara,State Assembly,28,1021,Dem,Evan Low,588
-Santa Clara,State Assembly,28,1024,Dem,Evan Low,562
-Santa Clara,State Assembly,28,1026,Dem,Evan Low,599
-Santa Clara,State Assembly,28,1029,Dem,Evan Low,620
-Santa Clara,State Assembly,28,1032,Dem,Evan Low,583
-Santa Clara,State Assembly,28,1034,Dem,Evan Low,362
-Santa Clara,State Assembly,28,1036,Dem,Evan Low,578
-Santa Clara,State Assembly,28,1037,Dem,Evan Low,544
-Santa Clara,State Assembly,29,1040,Dem,Mark Stone,323
-Santa Clara,State Assembly,29,1041,Dem,Mark Stone,5
-Santa Clara,State Assembly,29,1042,Dem,Mark Stone,2
-Santa Clara,State Assembly,29,1043,Dem,Mark Stone,495
-Santa Clara,State Assembly,29,1046,Dem,Mark Stone,656
-Santa Clara,State Assembly,29,1047,Dem,Mark Stone,392
-Santa Clara,State Assembly,29,1048,Dem,Mark Stone,434
-Santa Clara,State Assembly,29,1050,Dem,Mark Stone,490
-Santa Clara,State Assembly,29,1053,Dem,Mark Stone,589
-Santa Clara,State Assembly,29,1055,Dem,Mark Stone,495
-Santa Clara,State Assembly,28,1056,Dem,Evan Low,673
-Santa Clara,State Assembly,28,1057,Dem,Evan Low,324
-Santa Clara,State Assembly,29,1060,Dem,Mark Stone,580
-Santa Clara,State Assembly,29,1062,Dem,Mark Stone,554
-Santa Clara,State Assembly,29,1063,Dem,Mark Stone,548
-Santa Clara,State Assembly,29,1066,Dem,Mark Stone,651
-Santa Clara,State Assembly,29,1069,Dem,Mark Stone,498
-Santa Clara,State Assembly,29,1070,Dem,Mark Stone,499
-Santa Clara,State Assembly,29,1071,Dem,Mark Stone,0
-Santa Clara,State Assembly,29,1072,Dem,Mark Stone,336
-Santa Clara,State Assembly,28,1077,Dem,Evan Low,147
-Santa Clara,State Assembly,27,1078,Dem,Ash Kaira,146
-Santa Clara,State Assembly,29,1080,Dem,Mark Stone,365
-Santa Clara,State Assembly,29,1081,Dem,Mark Stone,569
-Santa Clara,State Assembly,27,1082,Dem,Ash Kaira,111
-Santa Clara,State Assembly,28,1085,Dem,Evan Low,72
-Santa Clara,State Assembly,29,1087,Dem,Mark Stone,0
-Santa Clara,State Assembly,29,1092,Dem,Mark Stone,327
-Santa Clara,State Assembly,27,1094,Dem,Ash Kaira,131
-Santa Clara,State Assembly,27,1099,Dem,Ash Kaira,0
-Santa Clara,State Assembly,28,1101,Dem,Evan Low,476
-Santa Clara,State Assembly,28,1104,Dem,Evan Low,502
-Santa Clara,State Assembly,28,1106,Dem,Evan Low,493
-Santa Clara,State Assembly,28,1107,Dem,Evan Low,593
-Santa Clara,State Assembly,28,1108,Dem,Evan Low,498
-Santa Clara,State Assembly,28,1111,Dem,Evan Low,113
-Santa Clara,State Assembly,28,1113,Dem,Evan Low,373
-Santa Clara,State Assembly,28,1114,Dem,Evan Low,654
-Santa Clara,State Assembly,28,1115,Dem,Evan Low,548
-Santa Clara,State Assembly,28,1117,Dem,Evan Low,327
-Santa Clara,State Assembly,28,1118,Dem,Evan Low,146
-Santa Clara,State Assembly,28,1121,Dem,Evan Low,223
-Santa Clara,State Assembly,28,1123,Dem,Evan Low,518
-Santa Clara,State Assembly,28,1125,Dem,Evan Low,587
-Santa Clara,State Assembly,28,1127,Dem,Evan Low,565
-Santa Clara,State Assembly,28,1129,Dem,Evan Low,487
-Santa Clara,State Assembly,28,1131,Dem,Evan Low,509
-Santa Clara,State Assembly,28,1134,Dem,Evan Low,358
-Santa Clara,State Assembly,28,1135,Dem,Evan Low,368
-Santa Clara,State Assembly,28,1136,Dem,Evan Low,394
-Santa Clara,State Assembly,28,1138,Dem,Evan Low,493
-Santa Clara,State Assembly,28,1141,Dem,Evan Low,605
-Santa Clara,State Assembly,28,1142,Dem,Evan Low,496
-Santa Clara,State Assembly,28,1144,Dem,Evan Low,535
-Santa Clara,State Assembly,28,1145,Dem,Evan Low,580
-Santa Clara,State Assembly,28,1146,Dem,Evan Low,506
-Santa Clara,State Assembly,28,1149,Dem,Evan Low,490
-Santa Clara,State Assembly,28,1152,Dem,Evan Low,621
-Santa Clara,State Assembly,28,1153,Dem,Evan Low,447
-Santa Clara,State Assembly,28,1154,Dem,Evan Low,532
-Santa Clara,State Assembly,28,1156,Dem,Evan Low,690
-Santa Clara,State Assembly,28,1158,Dem,Evan Low,658
-Santa Clara,State Assembly,28,1160,Dem,Evan Low,619
-Santa Clara,State Assembly,28,1161,Dem,Evan Low,342
-Santa Clara,State Assembly,28,1162,Dem,Evan Low,599
-Santa Clara,State Assembly,28,1169,Dem,Evan Low,41
-Santa Clara,State Assembly,28,1198,Dem,Evan Low,431
-Santa Clara,State Assembly,28,1199,Dem,Evan Low,184
-Santa Clara,State Assembly,29,1200,Dem,Mark Stone,437
-Santa Clara,State Assembly,28,1201,Dem,Evan Low,428
-Santa Clara,State Assembly,28,1204,Dem,Evan Low,343
-Santa Clara,State Assembly,27,1205,Dem,Ash Kaira,163
-Santa Clara,State Assembly,27,1206,Dem,Ash Kaira,112
-Santa Clara,State Assembly,27,1207,Dem,Ash Kaira,149
-Santa Clara,State Assembly,27,1208,Dem,Ash Kaira,149
-Santa Clara,State Assembly,27,1209,Dem,Ash Kaira,131
-Santa Clara,State Assembly,29,1210,Dem,Mark Stone,215
-Santa Clara,State Assembly,27,1211,Dem,Ash Kaira,95
-Santa Clara,State Assembly,29,1213,Dem,Mark Stone,427
-Santa Clara,State Assembly,29,1214,Dem,Mark Stone,542
-Santa Clara,State Assembly,29,1215,Dem,Mark Stone,414
-Santa Clara,State Assembly,29,1218,Dem,Mark Stone,635
-Santa Clara,State Assembly,27,1220,Dem,Ash Kaira,137
-Santa Clara,State Assembly,29,1221,Dem,Mark Stone,376
-Santa Clara,State Assembly,29,1222,Dem,Mark Stone,314
-Santa Clara,State Assembly,29,1223,Dem,Mark Stone,563
-Santa Clara,State Assembly,29,1224,Dem,Mark Stone,569
-Santa Clara,State Assembly,29,1226,Dem,Mark Stone,614
-Santa Clara,State Assembly,29,1228,Dem,Mark Stone,330
-Santa Clara,State Assembly,29,1229,Dem,Mark Stone,672
-Santa Clara,State Assembly,27,1230,Dem,Ash Kaira,120
-Santa Clara,State Assembly,29,1231,Dem,Mark Stone,604
-Santa Clara,State Assembly,29,1232,Dem,Mark Stone,483
-Santa Clara,State Assembly,29,1234,Dem,Mark Stone,193
-Santa Clara,State Assembly,29,1236,Dem,Mark Stone,549
-Santa Clara,State Assembly,29,1238,Dem,Mark Stone,660
-Santa Clara,State Assembly,29,1239,Dem,Mark Stone,560
-Santa Clara,State Assembly,29,1240,Dem,Mark Stone,394
-Santa Clara,State Assembly,29,1242,Dem,Mark Stone,304
-Santa Clara,State Assembly,29,1243,Dem,Mark Stone,499
-Santa Clara,State Assembly,29,1244,Dem,Mark Stone,592
-Santa Clara,State Assembly,29,1246,Dem,Mark Stone,547
-Santa Clara,State Assembly,29,1247,Dem,Mark Stone,550
-Santa Clara,State Assembly,29,1250,Dem,Mark Stone,526
-Santa Clara,State Assembly,29,1252,Dem,Mark Stone,0
-Santa Clara,State Assembly,28,1254,Dem,Evan Low,262
-Santa Clara,State Assembly,29,1263,Dem,Mark Stone,85
-Santa Clara,State Assembly,29,1268,Dem,Mark Stone,10
-Santa Clara,State Assembly,29,1271,Dem,Mark Stone,186
-Santa Clara,State Assembly,29,1274,Dem,Mark Stone,396
-Santa Clara,State Assembly,27,1276,Dem,Ash Kaira,131
-Santa Clara,State Assembly,29,1290,Dem,Mark Stone,9
-Santa Clara,State Assembly,27,1295,Dem,Ash Kaira,120
-Santa Clara,State Assembly,27,1299,Dem,Ash Kaira,0
-Santa Clara,State Assembly,25,1301,Dem,Kansen Chu,25
-Santa Clara,State Assembly,25,1302,Dem,Kansen Chu,272
-Santa Clara,State Assembly,25,1303,Dem,Kansen Chu,610
-Santa Clara,State Assembly,28,1304,Dem,Evan Low,787
-Santa Clara,State Assembly,28,1305,Dem,Evan Low,588
-Santa Clara,State Assembly,28,1307,Dem,Evan Low,343
-Santa Clara,State Assembly,27,1308,Dem,Ash Kaira,0
-Santa Clara,State Assembly,27,1310,Dem,Ash Kaira,181
-Santa Clara,State Assembly,27,1311,Dem,Ash Kaira,206
-Santa Clara,State Assembly,27,1312,Dem,Ash Kaira,136
-Santa Clara,State Assembly,27,1313,Dem,Ash Kaira,111
-Santa Clara,State Assembly,27,1314,Dem,Ash Kaira,120
-Santa Clara,State Assembly,27,1315,Dem,Ash Kaira,95
-Santa Clara,State Assembly,27,1316,Dem,Ash Kaira,122
-Santa Clara,State Assembly,27,1317,Dem,Ash Kaira,164
-Santa Clara,State Assembly,27,1318,Dem,Ash Kaira,63
-Santa Clara,State Assembly,27,1319,Dem,Ash Kaira,129
-Santa Clara,State Assembly,27,1320,Dem,Ash Kaira,95
-Santa Clara,State Assembly,27,1321,Dem,Ash Kaira,175
-Santa Clara,State Assembly,27,1323,Dem,Ash Kaira,173
-Santa Clara,State Assembly,27,1324,Dem,Ash Kaira,95
-Santa Clara,State Assembly,27,1325,Dem,Ash Kaira,171
-Santa Clara,State Assembly,27,1327,Dem,Ash Kaira,93
-Santa Clara,State Assembly,27,1329,Dem,Ash Kaira,233
-Santa Clara,State Assembly,27,1330,Dem,Ash Kaira,218
-Santa Clara,State Assembly,27,1333,Dem,Ash Kaira,190
-Santa Clara,State Assembly,27,1334,Dem,Ash Kaira,229
-Santa Clara,State Assembly,27,1336,Dem,Ash Kaira,110
-Santa Clara,State Assembly,27,1338,Dem,Ash Kaira,130
-Santa Clara,State Assembly,27,1339,Dem,Ash Kaira,101
-Santa Clara,State Assembly,27,1340,Dem,Ash Kaira,93
-Santa Clara,State Assembly,27,1342,Dem,Ash Kaira,46
-Santa Clara,State Assembly,27,1343,Dem,Ash Kaira,207
-Santa Clara,State Assembly,27,1344,Dem,Ash Kaira,172
-Santa Clara,State Assembly,27,1346,Dem,Ash Kaira,79
-Santa Clara,State Assembly,28,1347,Dem,Evan Low,351
-Santa Clara,State Assembly,28,1348,Dem,Evan Low,430
-Santa Clara,State Assembly,27,1353,Dem,Ash Kaira,59
-Santa Clara,State Assembly,27,1356,Dem,Ash Kaira,247
-Santa Clara,State Assembly,27,1357,Dem,Ash Kaira,0
-Santa Clara,State Assembly,28,1358,Dem,Evan Low,169
-Santa Clara,State Assembly,28,1359,Dem,Evan Low,554
-Santa Clara,State Assembly,27,1361,Dem,Ash Kaira,120
-Santa Clara,State Assembly,27,1362,Dem,Ash Kaira,77
-Santa Clara,State Assembly,25,1370,Dem,Kansen Chu,9
-Santa Clara,State Assembly,27,1371,Dem,Ash Kaira,29
-Santa Clara,State Assembly,27,1373,Dem,Ash Kaira,0
-Santa Clara,State Assembly,27,1374,Dem,Ash Kaira,113
-Santa Clara,State Assembly,28,1380,Dem,Evan Low,20
-Santa Clara,State Assembly,27,1384,Dem,Ash Kaira,124
-Santa Clara,State Assembly,28,1385,Dem,Evan Low,694
-Santa Clara,State Assembly,27,1387,Dem,Ash Kaira,166
-Santa Clara,State Assembly,27,1388,Dem,Ash Kaira,119
-Santa Clara,State Assembly,27,1389,Dem,Ash Kaira,86
-Santa Clara,State Assembly,27,1390,Dem,Ash Kaira,50
-Santa Clara,State Assembly,25,1391,Dem,Kansen Chu,422
-Santa Clara,State Assembly,27,1392,Dem,Ash Kaira,70
-Santa Clara,State Assembly,27,1393,Dem,Ash Kaira,124
-Santa Clara,State Assembly,25,1394,Dem,Kansen Chu,519
-Santa Clara,State Assembly,27,1395,Dem,Ash Kaira,134
-Santa Clara,State Assembly,25,1396,Dem,Kansen Chu,556
-Santa Clara,State Assembly,25,1397,Dem,Kansen Chu,623
-Santa Clara,State Assembly,27,1398,Dem,Ash Kaira,54
-Santa Clara,State Assembly,27,1399,Dem,Ash Kaira,148
-Santa Clara,State Assembly,25,1400,Dem,Kansen Chu,499
-Santa Clara,State Assembly,25,1401,Dem,Kansen Chu,461
-Santa Clara,State Assembly,25,1403,Dem,Kansen Chu,590
-Santa Clara,State Assembly,25,1405,Dem,Kansen Chu,5
-Santa Clara,State Assembly,25,1407,Dem,Kansen Chu,512
-Santa Clara,State Assembly,25,1408,Dem,Kansen Chu,377
-Santa Clara,State Assembly,25,1409,Dem,Kansen Chu,410
-Santa Clara,State Assembly,25,1410,Dem,Kansen Chu,546
-Santa Clara,State Assembly,25,1411,Dem,Kansen Chu,601
-Santa Clara,State Assembly,25,1414,Dem,Kansen Chu,506
-Santa Clara,State Assembly,25,1415,Dem,Kansen Chu,655
-Santa Clara,State Assembly,25,1417,Dem,Kansen Chu,596
-Santa Clara,State Assembly,25,1418,Dem,Kansen Chu,539
-Santa Clara,State Assembly,25,1420,Dem,Kansen Chu,632
-Santa Clara,State Assembly,25,1421,Dem,Kansen Chu,573
-Santa Clara,State Assembly,25,1423,Dem,Kansen Chu,450
-Santa Clara,State Assembly,27,1424,Dem,Ash Kaira,125
-Santa Clara,State Assembly,25,1426,Dem,Kansen Chu,190
-Santa Clara,State Assembly,25,1427,Dem,Kansen Chu,370
-Santa Clara,State Assembly,25,1428,Dem,Kansen Chu,547
-Santa Clara,State Assembly,25,1429,Dem,Kansen Chu,687
-Santa Clara,State Assembly,25,1431,Dem,Kansen Chu,335
-Santa Clara,State Assembly,25,1432,Dem,Kansen Chu,610
-Santa Clara,State Assembly,25,1433,Dem,Kansen Chu,464
-Santa Clara,State Assembly,25,1435,Dem,Kansen Chu,669
-Santa Clara,State Assembly,25,1439,Dem,Kansen Chu,666
-Santa Clara,State Assembly,25,1440,Dem,Kansen Chu,85
-Santa Clara,State Assembly,25,1443,Dem,Kansen Chu,75
-Santa Clara,State Assembly,25,1444,Dem,Kansen Chu,571
-Santa Clara,State Assembly,25,1446,Dem,Kansen Chu,640
-Santa Clara,State Assembly,25,1447,Dem,Kansen Chu,373
-Santa Clara,State Assembly,25,1448,Dem,Kansen Chu,669
-Santa Clara,State Assembly,25,1451,Dem,Kansen Chu,533
-Santa Clara,State Assembly,25,1453,Dem,Kansen Chu,410
-Santa Clara,State Assembly,25,1455,Dem,Kansen Chu,543
-Santa Clara,State Assembly,25,1459,Dem,Kansen Chu,601
-Santa Clara,State Assembly,25,1461,Dem,Kansen Chu,541
-Santa Clara,State Assembly,25,1465,Dem,Kansen Chu,422
-Santa Clara,State Assembly,25,1467,Dem,Kansen Chu,584
-Santa Clara,State Assembly,25,1468,Dem,Kansen Chu,570
-Santa Clara,State Assembly,25,1470,Dem,Kansen Chu,342
-Santa Clara,State Assembly,25,1478,Dem,Kansen Chu,426
-Santa Clara,State Assembly,25,1480,Dem,Kansen Chu,355
-Santa Clara,State Assembly,25,1497,Dem,Kansen Chu,445
-Santa Clara,State Assembly,25,1501,Dem,Kansen Chu,148
-Santa Clara,State Assembly,25,1502,Dem,Kansen Chu,16
-Santa Clara,State Assembly,27,1504,Dem,Ash Kaira,143
-Santa Clara,State Assembly,27,1506,Dem,Ash Kaira,171
-Santa Clara,State Assembly,27,1508,Dem,Ash Kaira,84
-Santa Clara,State Assembly,27,1510,Dem,Ash Kaira,108
-Santa Clara,State Assembly,27,1512,Dem,Ash Kaira,155
-Santa Clara,State Assembly,25,1515,Dem,Kansen Chu,338
-Santa Clara,State Assembly,27,1516,Dem,Ash Kaira,157
-Santa Clara,State Assembly,27,1518,Dem,Ash Kaira,162
-Santa Clara,State Assembly,27,1519,Dem,Ash Kaira,93
-Santa Clara,State Assembly,27,1521,Dem,Ash Kaira,142
-Santa Clara,State Assembly,27,1522,Dem,Ash Kaira,62
-Santa Clara,State Assembly,27,1523,Dem,Ash Kaira,49
-Santa Clara,State Assembly,27,1525,Dem,Ash Kaira,121
-Santa Clara,State Assembly,27,1526,Dem,Ash Kaira,85
-Santa Clara,State Assembly,27,1527,Dem,Ash Kaira,119
-Santa Clara,State Assembly,27,1529,Dem,Ash Kaira,165
-Santa Clara,State Assembly,27,1530,Dem,Ash Kaira,108
-Santa Clara,State Assembly,27,1531,Dem,Ash Kaira,99
-Santa Clara,State Assembly,25,1533,Dem,Kansen Chu,372
-Santa Clara,State Assembly,27,1534,Dem,Ash Kaira,159
-Santa Clara,State Assembly,27,1535,Dem,Ash Kaira,70
-Santa Clara,State Assembly,27,1536,Dem,Ash Kaira,179
-Santa Clara,State Assembly,27,1537,Dem,Ash Kaira,171
-Santa Clara,State Assembly,27,1539,Dem,Ash Kaira,82
-Santa Clara,State Assembly,27,1542,Dem,Ash Kaira,117
-Santa Clara,State Assembly,27,1544,Dem,Ash Kaira,148
-Santa Clara,State Assembly,25,1546,Dem,Kansen Chu,314
-Santa Clara,State Assembly,25,1548,Dem,Kansen Chu,116
-Santa Clara,State Assembly,27,1550,Dem,Ash Kaira,0
-Santa Clara,State Assembly,27,1551,Dem,Ash Kaira,165
-Santa Clara,State Assembly,27,1553,Dem,Ash Kaira,80
-Santa Clara,State Assembly,27,1556,Dem,Ash Kaira,50
-Santa Clara,State Assembly,25,1557,Dem,Kansen Chu,552
-Santa Clara,State Assembly,25,1558,Dem,Kansen Chu,511
-Santa Clara,State Assembly,27,1567,Dem,Ash Kaira,0
-Santa Clara,State Assembly,27,1569,Dem,Ash Kaira,0
-Santa Clara,State Assembly,25,1570,Dem,Kansen Chu,1
-Santa Clara,State Assembly,28,1571,Dem,Evan Low,37
-Santa Clara,State Assembly,28,1572,Dem,Evan Low,85
-Santa Clara,State Assembly,28,1574,Dem,Evan Low,3
-Santa Clara,State Assembly,27,1577,Dem,Ash Kaira,44
-Santa Clara,State Assembly,27,1578,Dem,Ash Kaira,0
-Santa Clara,State Assembly,27,1583,Dem,Ash Kaira,73
-Santa Clara,State Assembly,27,1584,Dem,Ash Kaira,55
-Santa Clara,State Assembly,28,1586,Dem,Evan Low,7
-Santa Clara,State Assembly,28,1587,Dem,Evan Low,7
-Santa Clara,State Assembly,28,1588,Dem,Evan Low,550
-Santa Clara,State Assembly,27,1589,Dem,Ash Kaira,42
-Santa Clara,State Assembly,27,1590,Dem,Ash Kaira,115
-Santa Clara,State Assembly,27,1591,Dem,Ash Kaira,0
-Santa Clara,State Assembly,28,1592,Dem,Evan Low,351
-Santa Clara,State Assembly,25,1593,Dem,Kansen Chu,124
-Santa Clara,State Assembly,27,1595,Dem,Ash Kaira,0
-Santa Clara,State Assembly,27,1597,Dem,Ash Kaira,132
-Santa Clara,State Assembly,27,1599,Dem,Ash Kaira,77
-Santa Clara,State Assembly,28,1600,Dem,Evan Low,606
-Santa Clara,State Assembly,28,1601,Dem,Evan Low,687
-Santa Clara,State Assembly,28,1602,Dem,Evan Low,609
-Santa Clara,State Assembly,28,1603,Dem,Evan Low,646
-Santa Clara,State Assembly,28,1606,Dem,Evan Low,436
-Santa Clara,State Assembly,28,1607,Dem,Evan Low,659
-Santa Clara,State Assembly,28,1609,Dem,Evan Low,483
-Santa Clara,State Assembly,28,1612,Dem,Evan Low,441
-Santa Clara,State Assembly,28,1613,Dem,Evan Low,403
-Santa Clara,State Assembly,28,1615,Dem,Evan Low,521
-Santa Clara,State Assembly,28,1616,Dem,Evan Low,692
-Santa Clara,State Assembly,28,1619,Dem,Evan Low,33
-Santa Clara,State Assembly,28,1620,Dem,Evan Low,667
-Santa Clara,State Assembly,28,1621,Dem,Evan Low,352
-Santa Clara,State Assembly,28,1623,Dem,Evan Low,870
-Santa Clara,State Assembly,27,1625,Dem,Ash Kaira,150
-Santa Clara,State Assembly,28,1626,Dem,Evan Low,112
-Santa Clara,State Assembly,28,1629,Dem,Evan Low,531
-Santa Clara,State Assembly,28,1630,Dem,Evan Low,458
-Santa Clara,State Assembly,28,1631,Dem,Evan Low,651
-Santa Clara,State Assembly,28,1632,Dem,Evan Low,228
-Santa Clara,State Assembly,28,1634,Dem,Evan Low,596
-Santa Clara,State Assembly,28,1635,Dem,Evan Low,624
-Santa Clara,State Assembly,28,1636,Dem,Evan Low,520
-Santa Clara,State Assembly,28,1640,Dem,Evan Low,586
-Santa Clara,State Assembly,28,1641,Dem,Evan Low,410
-Santa Clara,State Assembly,28,1643,Dem,Evan Low,457
-Santa Clara,State Assembly,28,1644,Dem,Evan Low,576
-Santa Clara,State Assembly,28,1646,Dem,Evan Low,384
-Santa Clara,State Assembly,28,1648,Dem,Evan Low,710
-Santa Clara,State Assembly,28,1649,Dem,Evan Low,631
-Santa Clara,State Assembly,28,1654,Dem,Evan Low,550
-Santa Clara,State Assembly,28,1656,Dem,Evan Low,615
-Santa Clara,State Assembly,28,1658,Dem,Evan Low,692
-Santa Clara,State Assembly,27,1661,Dem,Ash Kaira,116
-Santa Clara,State Assembly,28,1662,Dem,Evan Low,485
-Santa Clara,State Assembly,28,1663,Dem,Evan Low,448
-Santa Clara,State Assembly,28,1664,Dem,Evan Low,572
-Santa Clara,State Assembly,28,1666,Dem,Evan Low,688
-Santa Clara,State Assembly,28,1671,Dem,Evan Low,642
-Santa Clara,State Assembly,28,1672,Dem,Evan Low,582
-Santa Clara,State Assembly,28,1674,Dem,Evan Low,718
-Santa Clara,State Assembly,28,1677,Dem,Evan Low,457
-Santa Clara,State Assembly,27,1678,Dem,Ash Kaira,107
-Santa Clara,State Assembly,28,1679,Dem,Evan Low,20
-Santa Clara,State Assembly,28,1683,Dem,Evan Low,409
-Santa Clara,State Assembly,27,1685,Dem,Ash Kaira,53
-Santa Clara,State Assembly,28,1687,Dem,Evan Low,727
-Santa Clara,State Assembly,27,1696,Dem,Ash Kaira,117
-Santa Clara,State Assembly,27,1699,Dem,Ash Kaira,76
-Santa Clara,State Assembly,27,1700,Dem,Ash Kaira,158
-Santa Clara,State Assembly,27,1701,Dem,Ash Kaira,164
-Santa Clara,State Assembly,27,1702,Dem,Ash Kaira,161
-Santa Clara,State Assembly,27,1703,Dem,Ash Kaira,126
-Santa Clara,State Assembly,27,1704,Dem,Ash Kaira,97
-Santa Clara,State Assembly,27,1706,Dem,Ash Kaira,96
-Santa Clara,State Assembly,27,1707,Dem,Ash Kaira,32
-Santa Clara,State Assembly,27,1708,Dem,Ash Kaira,115
-Santa Clara,State Assembly,27,1709,Dem,Ash Kaira,82
-Santa Clara,State Assembly,27,1710,Dem,Ash Kaira,123
-Santa Clara,State Assembly,27,1711,Dem,Ash Kaira,129
-Santa Clara,State Assembly,27,1712,Dem,Ash Kaira,108
-Santa Clara,State Assembly,27,1715,Dem,Ash Kaira,77
-Santa Clara,State Assembly,27,1716,Dem,Ash Kaira,89
-Santa Clara,State Assembly,27,1717,Dem,Ash Kaira,57
-Santa Clara,State Assembly,27,1718,Dem,Ash Kaira,84
-Santa Clara,State Assembly,27,1719,Dem,Ash Kaira,112
-Santa Clara,State Assembly,27,1722,Dem,Ash Kaira,36
-Santa Clara,State Assembly,27,1723,Dem,Ash Kaira,87
-Santa Clara,State Assembly,27,1724,Dem,Ash Kaira,89
-Santa Clara,State Assembly,27,1726,Dem,Ash Kaira,72
-Santa Clara,State Assembly,27,1728,Dem,Ash Kaira,78
-Santa Clara,State Assembly,27,1729,Dem,Ash Kaira,95
-Santa Clara,State Assembly,27,1730,Dem,Ash Kaira,53
-Santa Clara,State Assembly,27,1732,Dem,Ash Kaira,77
-Santa Clara,State Assembly,27,1734,Dem,Ash Kaira,215
-Santa Clara,State Assembly,27,1735,Dem,Ash Kaira,88
-Santa Clara,State Assembly,27,1736,Dem,Ash Kaira,91
-Santa Clara,State Assembly,27,1737,Dem,Ash Kaira,156
-Santa Clara,State Assembly,27,1743,Dem,Ash Kaira,113
-Santa Clara,State Assembly,27,1744,Dem,Ash Kaira,121
-Santa Clara,State Assembly,27,1751,Dem,Ash Kaira,148
-Santa Clara,State Assembly,28,1753,Dem,Evan Low,455
-Santa Clara,State Assembly,28,1755,Dem,Evan Low,575
-Santa Clara,State Assembly,27,1757,Dem,Ash Kaira,25
-Santa Clara,State Assembly,27,1767,Dem,Ash Kaira,48
-Santa Clara,State Assembly,27,1775,Dem,Ash Kaira,38
-Santa Clara,State Assembly,27,1778,Dem,Ash Kaira,115
-Santa Clara,State Assembly,27,1780,Dem,Ash Kaira,121
-Santa Clara,State Assembly,27,1781,Dem,Ash Kaira,145
-Santa Clara,State Assembly,27,1782,Dem,Ash Kaira,0
-Santa Clara,State Assembly,27,1783,Dem,Ash Kaira,162
-Santa Clara,State Assembly,27,1784,Dem,Ash Kaira,124
-Santa Clara,State Assembly,27,1785,Dem,Ash Kaira,100
-Santa Clara,State Assembly,27,1786,Dem,Ash Kaira,85
-Santa Clara,State Assembly,27,1787,Dem,Ash Kaira,223
-Santa Clara,State Assembly,27,1788,Dem,Ash Kaira,175
-Santa Clara,State Assembly,27,1789,Dem,Ash Kaira,85
-Santa Clara,State Assembly,27,1790,Dem,Ash Kaira,119
-Santa Clara,State Assembly,27,1792,Dem,Ash Kaira,76
-Santa Clara,State Assembly,27,1793,Dem,Ash Kaira,137
-Santa Clara,State Assembly,27,1795,Dem,Ash Kaira,113
-Santa Clara,State Assembly,27,1796,Dem,Ash Kaira,86
-Santa Clara,State Assembly,27,1797,Dem,Ash Kaira,105
-Santa Clara,State Assembly,27,1798,Dem,Ash Kaira,34
-Santa Clara,State Assembly,27,1799,Dem,Ash Kaira,118
-Santa Clara,State Assembly,27,1800,Dem,Ash Kaira,163
-Santa Clara,State Assembly,25,1801,Dem,Kansen Chu,48
-Santa Clara,State Assembly,27,1805,Dem,Ash Kaira,179
-Santa Clara,State Assembly,27,1811,Dem,Ash Kaira,69
-Santa Clara,State Assembly,27,1813,Dem,Ash Kaira,39
-Santa Clara,State Assembly,27,1817,Dem,Ash Kaira,131
-Santa Clara,State Assembly,27,1818,Dem,Ash Kaira,83
-Santa Clara,State Assembly,27,1820,Dem,Ash Kaira,112
-Santa Clara,State Assembly,27,1821,Dem,Ash Kaira,84
-Santa Clara,State Assembly,27,1822,Dem,Ash Kaira,115
-Santa Clara,State Assembly,27,1824,Dem,Ash Kaira,156
-Santa Clara,State Assembly,27,1826,Dem,Ash Kaira,143
-Santa Clara,State Assembly,27,1829,Dem,Ash Kaira,163
-Santa Clara,State Assembly,27,1830,Dem,Ash Kaira,124
-Santa Clara,State Assembly,27,1831,Dem,Ash Kaira,174
-Santa Clara,State Assembly,27,1832,Dem,Ash Kaira,143
-Santa Clara,State Assembly,27,1838,Dem,Ash Kaira,33
-Santa Clara,State Assembly,27,1839,Dem,Ash Kaira,82
-Santa Clara,State Assembly,27,1841,Dem,Ash Kaira,133
-Santa Clara,State Assembly,27,1842,Dem,Ash Kaira,142
-Santa Clara,State Assembly,27,1843,Dem,Ash Kaira,102
-Santa Clara,State Assembly,27,1844,Dem,Ash Kaira,136
-Santa Clara,State Assembly,27,1846,Dem,Ash Kaira,58
-Santa Clara,State Assembly,27,1848,Dem,Ash Kaira,95
-Santa Clara,State Assembly,27,1850,Dem,Ash Kaira,165
-Santa Clara,State Assembly,27,1852,Dem,Ash Kaira,55
-Santa Clara,State Assembly,27,1853,Dem,Ash Kaira,0
-Santa Clara,State Assembly,27,1856,Dem,Ash Kaira,106
-Santa Clara,State Assembly,27,1859,Dem,Ash Kaira,163
-Santa Clara,State Assembly,27,1860,Dem,Ash Kaira,103
-Santa Clara,State Assembly,27,1861,Dem,Ash Kaira,106
-Santa Clara,State Assembly,27,1863,Dem,Ash Kaira,77
-Santa Clara,State Assembly,27,1865,Dem,Ash Kaira,123
-Santa Clara,State Assembly,27,1866,Dem,Ash Kaira,118
-Santa Clara,State Assembly,27,1871,Dem,Ash Kaira,142
-Santa Clara,State Assembly,27,1882,Dem,Ash Kaira,70
-Santa Clara,State Assembly,27,1886,Dem,Ash Kaira,73
-Santa Clara,State Assembly,27,1888,Dem,Ash Kaira,90
-Santa Clara,State Assembly,27,1897,Dem,Ash Kaira,71
-Santa Clara,State Assembly,27,1898,Dem,Ash Kaira,66
-Santa Clara,State Assembly,28,1901,Dem,Evan Low,329
-Santa Clara,State Assembly,28,1902,Dem,Evan Low,505
-Santa Clara,State Assembly,28,1903,Dem,Evan Low,565
-Santa Clara,State Assembly,28,1904,Dem,Evan Low,553
-Santa Clara,State Assembly,28,1907,Dem,Evan Low,540
-Santa Clara,State Assembly,28,1909,Dem,Evan Low,699
-Santa Clara,State Assembly,28,1911,Dem,Evan Low,584
-Santa Clara,State Assembly,28,1913,Dem,Evan Low,505
-Santa Clara,State Assembly,28,1914,Dem,Evan Low,426
-Santa Clara,State Assembly,28,1916,Dem,Evan Low,755
-Santa Clara,State Assembly,28,1918,Dem,Evan Low,499
-Santa Clara,State Assembly,28,1919,Dem,Evan Low,286
-Santa Clara,State Assembly,28,1920,Dem,Evan Low,545
-Santa Clara,State Assembly,28,1922,Dem,Evan Low,662
-Santa Clara,State Assembly,28,1925,Dem,Evan Low,485
-Santa Clara,State Assembly,28,1928,Dem,Evan Low,479
-Santa Clara,State Assembly,28,1929,Dem,Evan Low,486
-Santa Clara,State Assembly,28,1930,Dem,Evan Low,490
-Santa Clara,State Assembly,28,1932,Dem,Evan Low,412
-Santa Clara,State Assembly,28,1934,Dem,Evan Low,673
-Santa Clara,State Assembly,28,1936,Dem,Evan Low,600
-Santa Clara,State Assembly,28,1937,Dem,Evan Low,588
-Santa Clara,State Assembly,28,1939,Dem,Evan Low,497
-Santa Clara,State Assembly,28,1944,Dem,Evan Low,497
-Santa Clara,State Assembly,28,1945,Dem,Evan Low,505
-Santa Clara,State Assembly,28,1947,Dem,Evan Low,446
-Santa Clara,State Assembly,28,1949,Dem,Evan Low,651
-Santa Clara,State Assembly,28,1952,Dem,Evan Low,513
-Santa Clara,State Assembly,28,1953,Dem,Evan Low,422
-Santa Clara,State Assembly,28,1954,Dem,Evan Low,667
-Santa Clara,State Assembly,28,1958,Dem,Evan Low,342
-Santa Clara,State Assembly,28,1959,Dem,Evan Low,160
-Santa Clara,State Assembly,28,1960,Dem,Evan Low,613
-Santa Clara,State Assembly,28,1961,Dem,Evan Low,147
-Santa Clara,State Assembly,28,1962,Dem,Evan Low,302
-Santa Clara,State Assembly,28,1964,Dem,Evan Low,313
-Santa Clara,State Assembly,28,1966,Dem,Evan Low,376
-Santa Clara,State Assembly,28,1968,Dem,Evan Low,35
-Santa Clara,State Assembly,27,1977,Dem,Ash Kaira,62
-Santa Clara,State Assembly,27,1982,Dem,Ash Kaira,66
-Santa Clara,State Assembly,28,1990,Dem,Evan Low,37
-Santa Clara,State Assembly,27,1991,Dem,Ash Kaira,36
-Santa Clara,State Assembly,28,1994,Dem,Evan Low,168
-Santa Clara,State Assembly,28,1996,Dem,Evan Low,82
-Santa Clara,State Assembly,24,2001,Dem,Marc Berman,2
-Santa Clara,State Assembly,24,2002,Dem,Marc Berman,883
-Santa Clara,State Assembly,24,2003,Dem,Marc Berman,737
-Santa Clara,State Assembly,24,2004,Dem,Marc Berman,839
-Santa Clara,State Assembly,24,2005,Dem,Marc Berman,875
-Santa Clara,State Assembly,24,2006,Dem,Marc Berman,48
-Santa Clara,State Assembly,24,2009,Dem,Marc Berman,860
-Santa Clara,State Assembly,24,2013,Dem,Marc Berman,826
-Santa Clara,State Assembly,24,2014,Dem,Marc Berman,854
-Santa Clara,State Assembly,24,2015,Dem,Marc Berman,742
-Santa Clara,State Assembly,24,2018,Dem,Marc Berman,50
-Santa Clara,State Assembly,24,2019,Dem,Marc Berman,530
-Santa Clara,State Assembly,24,2025,Dem,Marc Berman,842
-Santa Clara,State Assembly,24,2028,Dem,Marc Berman,630
-Santa Clara,State Assembly,24,2034,Dem,Marc Berman,873
-Santa Clara,State Assembly,24,2043,Dem,Marc Berman,688
-Santa Clara,State Assembly,24,2046,Dem,Marc Berman,798
-Santa Clara,State Assembly,24,2049,Dem,Marc Berman,497
-Santa Clara,State Assembly,24,2056,Dem,Marc Berman,841
-Santa Clara,State Assembly,24,2061,Dem,Marc Berman,862
-Santa Clara,State Assembly,24,2065,Dem,Marc Berman,978
-Santa Clara,State Assembly,24,2068,Dem,Marc Berman,773
-Santa Clara,State Assembly,24,2069,Dem,Marc Berman,767
-Santa Clara,State Assembly,24,2081,Dem,Marc Berman,888
-Santa Clara,State Assembly,24,2090,Dem,Marc Berman,500
-Santa Clara,State Assembly,24,2096,Dem,Marc Berman,510
-Santa Clara,State Assembly,24,2098,Dem,Marc Berman,490
-Santa Clara,State Assembly,24,2101,Dem,Marc Berman,416
-Santa Clara,State Assembly,24,2102,Dem,Marc Berman,417
-Santa Clara,State Assembly,24,2107,Dem,Marc Berman,474
-Santa Clara,State Assembly,24,2108,Dem,Marc Berman,831
-Santa Clara,State Assembly,24,2110,Dem,Marc Berman,559
-Santa Clara,State Assembly,24,2112,Dem,Marc Berman,703
-Santa Clara,State Assembly,24,2114,Dem,Marc Berman,416
-Santa Clara,State Assembly,24,2115,Dem,Marc Berman,694
-Santa Clara,State Assembly,24,2117,Dem,Marc Berman,547
-Santa Clara,State Assembly,24,2120,Dem,Marc Berman,520
-Santa Clara,State Assembly,24,2124,Dem,Marc Berman,99
-Santa Clara,State Assembly,24,2125,Dem,Marc Berman,142
-Santa Clara,State Assembly,24,2126,Dem,Marc Berman,39
-Santa Clara,State Assembly,24,2129,Dem,Marc Berman,456
-Santa Clara,State Assembly,24,2301,Dem,Marc Berman,721
-Santa Clara,State Assembly,24,2305,Dem,Marc Berman,399
-Santa Clara,State Assembly,24,2306,Dem,Marc Berman,425
-Santa Clara,State Assembly,24,2307,Dem,Marc Berman,415
-Santa Clara,State Assembly,24,2309,Dem,Marc Berman,653
-Santa Clara,State Assembly,24,2310,Dem,Marc Berman,411
-Santa Clara,State Assembly,24,2311,Dem,Marc Berman,697
-Santa Clara,State Assembly,24,2314,Dem,Marc Berman,386
-Santa Clara,State Assembly,24,2316,Dem,Marc Berman,613
-Santa Clara,State Assembly,24,2317,Dem,Marc Berman,568
-Santa Clara,State Assembly,24,2321,Dem,Marc Berman,793
-Santa Clara,State Assembly,24,2323,Dem,Marc Berman,464
-Santa Clara,State Assembly,24,2326,Dem,Marc Berman,472
-Santa Clara,State Assembly,24,2330,Dem,Marc Berman,418
-Santa Clara,State Assembly,24,2333,Dem,Marc Berman,534
-Santa Clara,State Assembly,24,2338,Dem,Marc Berman,74
-Santa Clara,State Assembly,24,2339,Dem,Marc Berman,783
-Santa Clara,State Assembly,24,2343,Dem,Marc Berman,423
-Santa Clara,State Assembly,24,2345,Dem,Marc Berman,479
-Santa Clara,State Assembly,24,2351,Dem,Marc Berman,662
-Santa Clara,State Assembly,24,2352,Dem,Marc Berman,525
-Santa Clara,State Assembly,24,2357,Dem,Marc Berman,372
-Santa Clara,State Assembly,24,2374,Dem,Marc Berman,102
-Santa Clara,State Assembly,24,2375,Dem,Marc Berman,528
-Santa Clara,State Assembly,24,2378,Dem,Marc Berman,494
-Santa Clara,State Assembly,24,2381,Dem,Marc Berman,1
-Santa Clara,State Assembly,24,2382,Dem,Marc Berman,679
-Santa Clara,State Assembly,24,2385,Dem,Marc Berman,553
-Santa Clara,State Assembly,24,2389,Dem,Marc Berman,549
-Santa Clara,State Assembly,24,2402,Dem,Marc Berman,458
-Santa Clara,State Assembly,24,2403,Dem,Marc Berman,879
-Santa Clara,State Assembly,24,2406,Dem,Marc Berman,832
-Santa Clara,State Assembly,24,2407,Dem,Marc Berman,624
-Santa Clara,State Assembly,24,2408,Dem,Marc Berman,894
-Santa Clara,State Assembly,24,2409,Dem,Marc Berman,713
-Santa Clara,State Assembly,24,2410,Dem,Marc Berman,802
-Santa Clara,State Assembly,24,2412,Dem,Marc Berman,770
-Santa Clara,State Assembly,24,2413,Dem,Marc Berman,494
-Santa Clara,State Assembly,24,2414,Dem,Marc Berman,715
-Santa Clara,State Assembly,24,2417,Dem,Marc Berman,871
-Santa Clara,State Assembly,24,2418,Dem,Marc Berman,715
-Santa Clara,State Assembly,24,2419,Dem,Marc Berman,689
-Santa Clara,State Assembly,24,2427,Dem,Marc Berman,560
-Santa Clara,State Assembly,24,2428,Dem,Marc Berman,649
-Santa Clara,State Assembly,24,2431,Dem,Marc Berman,347
-Santa Clara,State Assembly,24,2434,Dem,Marc Berman,524
-Santa Clara,State Assembly,24,2436,Dem,Marc Berman,583
-Santa Clara,State Assembly,24,2438,Dem,Marc Berman,610
-Santa Clara,State Assembly,24,2439,Dem,Marc Berman,481
-Santa Clara,State Assembly,24,2440,Dem,Marc Berman,403
-Santa Clara,State Assembly,24,2442,Dem,Marc Berman,516
-Santa Clara,State Assembly,24,2445,Dem,Marc Berman,835
-Santa Clara,State Assembly,24,2452,Dem,Marc Berman,464
-Santa Clara,State Assembly,24,2457,Dem,Marc Berman,821
-Santa Clara,State Assembly,24,2459,Dem,Marc Berman,438
-Santa Clara,State Assembly,24,2460,Dem,Marc Berman,738
-Santa Clara,State Assembly,24,2464,Dem,Marc Berman,237
-Santa Clara,State Assembly,24,2465,Dem,Marc Berman,582
-Santa Clara,State Assembly,24,2467,Dem,Marc Berman,424
-Santa Clara,State Assembly,24,2475,Dem,Marc Berman,574
-Santa Clara,State Assembly,24,2479,Dem,Marc Berman,740
-Santa Clara,State Assembly,24,2489,Dem,Marc Berman,693
-Santa Clara,State Assembly,24,2492,Dem,Marc Berman,777
-Santa Clara,State Assembly,24,2494,Dem,Marc Berman,386
-Santa Clara,State Assembly,24,2539,Dem,Marc Berman,40
-Santa Clara,State Assembly,24,2540,Dem,Marc Berman,68
-Santa Clara,State Assembly,24,2542,Dem,Marc Berman,757
-Santa Clara,State Assembly,24,2544,Dem,Marc Berman,869
-Santa Clara,State Assembly,24,2545,Dem,Marc Berman,522
-Santa Clara,State Assembly,24,2546,Dem,Marc Berman,467
-Santa Clara,State Assembly,24,2802,Dem,Marc Berman,605
-Santa Clara,State Assembly,28,2808,Dem,Evan Low,13
-Santa Clara,State Assembly,28,2811,Dem,Evan Low,20
-Santa Clara,State Assembly,24,2812,Dem,Marc Berman,137
-Santa Clara,State Assembly,28,2813,Dem,Evan Low,102
-Santa Clara,State Assembly,28,2816,Dem,Evan Low,13
-Santa Clara,State Assembly,24,2825,Dem,Marc Berman,7
-Santa Clara,State Assembly,24,2833,Dem,Marc Berman,598
-Santa Clara,State Assembly,24,2870,Dem,Marc Berman,59
-Santa Clara,State Assembly,24,2871,Dem,Marc Berman,7
-Santa Clara,State Assembly,24,2873,Dem,Marc Berman,3
-Santa Clara,State Assembly,24,2951,Dem,Marc Berman,51
-Santa Clara,State Assembly,24,2953,Dem,Marc Berman,64
-Santa Clara,State Assembly,24,3601,Dem,Marc Berman,258
-Santa Clara,State Assembly,28,3602,Dem,Evan Low,652
-Santa Clara,State Assembly,24,3603,Dem,Marc Berman,215
-Santa Clara,State Assembly,28,3604,Dem,Evan Low,500
-Santa Clara,State Assembly,28,3605,Dem,Evan Low,442
-Santa Clara,State Assembly,28,3606,Dem,Evan Low,655
-Santa Clara,State Assembly,24,3607,Dem,Marc Berman,420
-Santa Clara,State Assembly,28,3608,Dem,Evan Low,558
-Santa Clara,State Assembly,28,3609,Dem,Evan Low,713
-Santa Clara,State Assembly,28,3610,Dem,Evan Low,653
-Santa Clara,State Assembly,28,3612,Dem,Evan Low,670
-Santa Clara,State Assembly,28,3614,Dem,Evan Low,541
-Santa Clara,State Assembly,28,3615,Dem,Evan Low,580
-Santa Clara,State Assembly,28,3616,Dem,Evan Low,653
-Santa Clara,State Assembly,28,3620,Dem,Evan Low,594
-Santa Clara,State Assembly,28,3621,Dem,Evan Low,650
-Santa Clara,State Assembly,28,3624,Dem,Evan Low,430
-Santa Clara,State Assembly,28,3627,Dem,Evan Low,392
-Santa Clara,State Assembly,28,3628,Dem,Evan Low,740
-Santa Clara,State Assembly,28,3629,Dem,Evan Low,597
-Santa Clara,State Assembly,28,3633,Dem,Evan Low,610
-Santa Clara,State Assembly,28,3635,Dem,Evan Low,60
-Santa Clara,State Assembly,28,3636,Dem,Evan Low,673
-Santa Clara,State Assembly,28,3640,Dem,Evan Low,654
-Santa Clara,State Assembly,28,3642,Dem,Evan Low,658
-Santa Clara,State Assembly,28,3645,Dem,Evan Low,347
-Santa Clara,State Assembly,24,3650,Dem,Marc Berman,459
-Santa Clara,State Assembly,28,3652,Dem,Evan Low,620
-Santa Clara,State Assembly,24,3658,Dem,Marc Berman,19
-Santa Clara,State Assembly,28,3663,Dem,Evan Low,80
-Santa Clara,State Assembly,28,3720,Dem,Evan Low,481
-Santa Clara,State Assembly,28,3721,Dem,Evan Low,629
-Santa Clara,State Assembly,28,3723,Dem,Evan Low,30
-Santa Clara,State Assembly,28,3724,Dem,Evan Low,705
-Santa Clara,State Assembly,28,3725,Dem,Evan Low,328
-Santa Clara,State Assembly,28,3726,Dem,Evan Low,583
-Santa Clara,State Assembly,28,3727,Dem,Evan Low,48
-Santa Clara,State Assembly,28,3728,Dem,Evan Low,2
-Santa Clara,State Assembly,28,3729,Dem,Evan Low,562
-Santa Clara,State Assembly,28,3731,Dem,Evan Low,392
-Santa Clara,State Assembly,28,3733,Dem,Evan Low,360
-Santa Clara,State Assembly,28,3734,Dem,Evan Low,401
-Santa Clara,State Assembly,28,3737,Dem,Evan Low,627
-Santa Clara,State Assembly,28,3740,Dem,Evan Low,548
-Santa Clara,State Assembly,28,3741,Dem,Evan Low,349
-Santa Clara,State Assembly,28,3745,Dem,Evan Low,586
-Santa Clara,State Assembly,28,3749,Dem,Evan Low,264
-Santa Clara,State Assembly,28,3751,Dem,Evan Low,10
-Santa Clara,State Assembly,28,3753,Dem,Evan Low,528
-Santa Clara,State Assembly,28,3754,Dem,Evan Low,373
-Santa Clara,State Assembly,28,3757,Dem,Evan Low,417
-Santa Clara,State Assembly,28,3761,Dem,Evan Low,2
-Santa Clara,State Assembly,28,3767,Dem,Evan Low,396
-Santa Clara,State Assembly,28,3771,Dem,Evan Low,390
-Santa Clara,State Assembly,28,3772,Dem,Evan Low,380
-Santa Clara,State Assembly,28,3774,Dem,Evan Low,754
-Santa Clara,State Assembly,28,3781,Dem,Evan Low,517
-Santa Clara,State Assembly,28,3782,Dem,Evan Low,153
-Santa Clara,State Assembly,28,3784,Dem,Evan Low,49
-Santa Clara,State Assembly,28,3785,Dem,Evan Low,472
-Santa Clara,State Assembly,28,3787,Dem,Evan Low,13
-Santa Clara,State Assembly,28,3801,Dem,Evan Low,507
-Santa Clara,State Assembly,28,3802,Dem,Evan Low,614
-Santa Clara,State Assembly,28,3803,Dem,Evan Low,604
-Santa Clara,State Assembly,28,3804,Dem,Evan Low,498
-Santa Clara,State Assembly,28,3805,Dem,Evan Low,624
-Santa Clara,State Assembly,28,3806,Dem,Evan Low,321
-Santa Clara,State Assembly,28,3809,Dem,Evan Low,578
-Santa Clara,State Assembly,28,3810,Dem,Evan Low,569
-Santa Clara,State Assembly,28,3812,Dem,Evan Low,434
-Santa Clara,State Assembly,28,3814,Dem,Evan Low,557
-Santa Clara,State Assembly,28,3818,Dem,Evan Low,623
-Santa Clara,State Assembly,28,3819,Dem,Evan Low,618
-Santa Clara,State Assembly,28,3820,Dem,Evan Low,696
-Santa Clara,State Assembly,28,3821,Dem,Evan Low,494
-Santa Clara,State Assembly,28,3823,Dem,Evan Low,426
-Santa Clara,State Assembly,28,3825,Dem,Evan Low,460
-Santa Clara,State Assembly,28,3826,Dem,Evan Low,366
-Santa Clara,State Assembly,28,3828,Dem,Evan Low,693
-Santa Clara,State Assembly,28,3834,Dem,Evan Low,560
-Santa Clara,State Assembly,28,3835,Dem,Evan Low,522
-Santa Clara,State Assembly,28,3840,Dem,Evan Low,644
-Santa Clara,State Assembly,28,3843,Dem,Evan Low,713
-Santa Clara,State Assembly,28,3846,Dem,Evan Low,65
-Santa Clara,State Assembly,30,3900,Dem,Robert Rivas,407
-Santa Clara,State Assembly,30,3901,Dem,Robert Rivas,588
-Santa Clara,State Assembly,30,3902,Dem,Robert Rivas,618
-Santa Clara,State Assembly,30,3903,Dem,Robert Rivas,347
-Santa Clara,State Assembly,30,3906,Dem,Robert Rivas,443
-Santa Clara,State Assembly,30,3907,Dem,Robert Rivas,288
-Santa Clara,State Assembly,30,3908,Dem,Robert Rivas,39
-Santa Clara,State Assembly,30,3909,Dem,Robert Rivas,555
-Santa Clara,State Assembly,30,3910,Dem,Robert Rivas,137
-Santa Clara,State Assembly,30,3911,Dem,Robert Rivas,113
-Santa Clara,State Assembly,30,3912,Dem,Robert Rivas,301
-Santa Clara,State Assembly,30,3914,Dem,Robert Rivas,463
-Santa Clara,State Assembly,30,3916,Dem,Robert Rivas,285
-Santa Clara,State Assembly,30,3918,Dem,Robert Rivas,561
-Santa Clara,State Assembly,30,3921,Dem,Robert Rivas,514
-Santa Clara,State Assembly,30,3922,Dem,Robert Rivas,315
-Santa Clara,State Assembly,30,3923,Dem,Robert Rivas,343
-Santa Clara,State Assembly,30,3924,Dem,Robert Rivas,494
-Santa Clara,State Assembly,30,3928,Dem,Robert Rivas,601
-Santa Clara,State Assembly,30,3929,Dem,Robert Rivas,404
-Santa Clara,State Assembly,30,3932,Dem,Robert Rivas,490
-Santa Clara,State Assembly,30,3937,Dem,Robert Rivas,588
-Santa Clara,State Assembly,30,3938,Dem,Robert Rivas,348
-Santa Clara,State Assembly,30,3939,Dem,Robert Rivas,360
-Santa Clara,State Assembly,30,3940,Dem,Robert Rivas,307
-Santa Clara,State Assembly,30,3942,Dem,Robert Rivas,328
-Santa Clara,State Assembly,30,3948,Dem,Robert Rivas,117
-Santa Clara,State Assembly,30,3951,Dem,Robert Rivas,545
-Santa Clara,State Assembly,30,3952,Dem,Robert Rivas,327
-Santa Clara,State Assembly,30,3953,Dem,Robert Rivas,605
-Santa Clara,State Assembly,30,3954,Dem,Robert Rivas,490
-Santa Clara,State Assembly,30,3955,Dem,Robert Rivas,599
-Santa Clara,State Assembly,30,3956,Dem,Robert Rivas,440
-Santa Clara,State Assembly,30,3957,Dem,Robert Rivas,614
-Santa Clara,State Assembly,30,3958,Dem,Robert Rivas,412
-Santa Clara,State Assembly,30,3959,Dem,Robert Rivas,545
-Santa Clara,State Assembly,30,3960,Dem,Robert Rivas,340
-Santa Clara,State Assembly,30,3962,Dem,Robert Rivas,490
-Santa Clara,State Assembly,30,3964,Dem,Robert Rivas,628
-Santa Clara,State Assembly,30,3965,Dem,Robert Rivas,359
-Santa Clara,State Assembly,30,3968,Dem,Robert Rivas,286
-Santa Clara,State Assembly,30,3972,Dem,Robert Rivas,377
-Santa Clara,State Assembly,30,3973,Dem,Robert Rivas,529
-Santa Clara,State Assembly,30,3974,Dem,Robert Rivas,415
-Santa Clara,State Assembly,30,3976,Dem,Robert Rivas,566
-Santa Clara,State Assembly,30,3982,Dem,Robert Rivas,607
-Santa Clara,State Assembly,30,3984,Dem,Robert Rivas,339
-Santa Clara,State Assembly,30,3985,Dem,Robert Rivas,555
-Santa Clara,State Assembly,30,3986,Dem,Robert Rivas,560
-Santa Clara,State Assembly,30,3989,Dem,Robert Rivas,428
-Santa Clara,State Assembly,30,3992,Dem,Robert Rivas,2
-Santa Clara,State Assembly,24,4001,Dem,Marc Berman,432
-Santa Clara,State Assembly,24,4002,Dem,Marc Berman,480
-Santa Clara,State Assembly,24,4004,Dem,Marc Berman,340
-Santa Clara,State Assembly,24,4005,Dem,Marc Berman,32
-Santa Clara,State Assembly,24,4006,Dem,Marc Berman,588
-Santa Clara,State Assembly,24,4007,Dem,Marc Berman,729
-Santa Clara,State Assembly,25,4008,Dem,Kansen Chu,19
-Santa Clara,State Assembly,24,4010,Dem,Marc Berman,742
-Santa Clara,State Assembly,24,4011,Dem,Marc Berman,591
-Santa Clara,State Assembly,24,4012,Dem,Marc Berman,60
-Santa Clara,State Assembly,24,4013,Dem,Marc Berman,553
-Santa Clara,State Assembly,24,4015,Dem,Marc Berman,259
-Santa Clara,State Assembly,24,4016,Dem,Marc Berman,709
-Santa Clara,State Assembly,24,4017,Dem,Marc Berman,501
-Santa Clara,State Assembly,24,4019,Dem,Marc Berman,740
-Santa Clara,State Assembly,24,4022,Dem,Marc Berman,786
-Santa Clara,State Assembly,24,4023,Dem,Marc Berman,654
-Santa Clara,State Assembly,24,4026,Dem,Marc Berman,623
-Santa Clara,State Assembly,24,4030,Dem,Marc Berman,490
-Santa Clara,State Assembly,24,4034,Dem,Marc Berman,643
-Santa Clara,State Assembly,24,4035,Dem,Marc Berman,614
-Santa Clara,State Assembly,24,4036,Dem,Marc Berman,461
-Santa Clara,State Assembly,24,4038,Dem,Marc Berman,614
-Santa Clara,State Assembly,24,4039,Dem,Marc Berman,552
-Santa Clara,State Assembly,24,4041,Dem,Marc Berman,383
-Santa Clara,State Assembly,24,4042,Dem,Marc Berman,514
-Santa Clara,State Assembly,24,4043,,Marc Berman,456
-Santa Clara,State Assembly,24,4045,,Marc Berman,687
-Santa Clara,State Assembly,24,4047,,Marc Berman,601
-Santa Clara,State Assembly,24,4048,,Marc Berman,425
-Santa Clara,State Assembly,24,4050,,Marc Berman,557
-Santa Clara,State Assembly,24,4051,,Marc Berman,619
-Santa Clara,State Assembly,24,4052,,Marc Berman,477
-Santa Clara,State Assembly,24,4053,,Marc Berman,727
-Santa Clara,State Assembly,24,4055,,Marc Berman,529
-Santa Clara,State Assembly,24,4058,,Marc Berman,579
-Santa Clara,State Assembly,24,4060,,Marc Berman,281
-Santa Clara,State Assembly,24,4061,,Marc Berman,58
-Santa Clara,State Assembly,24,4064,,Marc Berman,441
-Santa Clara,State Assembly,24,4067,,Marc Berman,407
-Santa Clara,State Assembly,24,4068,,Marc Berman,83
-Santa Clara,State Assembly,24,4070,,Marc Berman,434
-Santa Clara,State Assembly,24,4071,,Marc Berman,659
-Santa Clara,State Assembly,24,4074,,Marc Berman,265
-Santa Clara,State Assembly,24,4076,,Marc Berman,711
-Santa Clara,State Assembly,24,4079,,Marc Berman,277
-Santa Clara,State Assembly,24,4080,,Marc Berman,578
-Santa Clara,State Assembly,24,4084,,Marc Berman,304
-Santa Clara,State Assembly,24,4086,,Marc Berman,663
-Santa Clara,State Assembly,24,4087,,Marc Berman,406
-Santa Clara,State Assembly,24,4089,,Marc Berman,58
-Santa Clara,State Assembly,24,4098,,Marc Berman,125
-Santa Clara,State Assembly,24,4099,,Marc Berman,320
-Santa Clara,State Assembly,24,4103,,Marc Berman,635
-Santa Clara,State Assembly,24,4116,,Marc Berman,97
-Santa Clara,State Assembly,24,4117,,Marc Berman,449
-Santa Clara,State Assembly,24,4118,,Marc Berman,562
-Santa Clara,State Assembly,24,4119,,Marc Berman,691
-Santa Clara,State Assembly,24,4122,,Marc Berman,596
-Santa Clara,State Assembly,24,4126,,Marc Berman,687
-Santa Clara,State Assembly,24,4128,,Marc Berman,512
-Santa Clara,State Assembly,24,4129,,Marc Berman,638
-Santa Clara,State Assembly,24,4130,,Marc Berman,539
-Santa Clara,State Assembly,24,4131,,Marc Berman,717
-Santa Clara,State Assembly,24,4154,,Marc Berman,634
-Santa Clara,State Assembly,25,4201,Dem,Kansen Chu,682
-Santa Clara,State Assembly,25,4202,Dem,Kansen Chu,6
-Santa Clara,State Assembly,25,4205,Dem,Kansen Chu,66
-Santa Clara,State Assembly,25,4207,Dem,Kansen Chu,50
-Santa Clara,State Assembly,25,4208,Dem,Kansen Chu,631
-Santa Clara,State Assembly,25,4211,Dem,Kansen Chu,618
-Santa Clara,State Assembly,25,4212,Dem,Kansen Chu,4
-Santa Clara,State Assembly,25,4215,Dem,Kansen Chu,727
-Santa Clara,State Assembly,25,4217,Dem,Kansen Chu,502
-Santa Clara,State Assembly,25,4218,Dem,Kansen Chu,363
-Santa Clara,State Assembly,25,4222,Dem,Kansen Chu,566
-Santa Clara,State Assembly,25,4223,Dem,Kansen Chu,698
-Santa Clara,State Assembly,25,4224,Dem,Kansen Chu,2
-Santa Clara,State Assembly,25,4226,Dem,Kansen Chu,578
-Santa Clara,State Assembly,25,4227,Dem,Kansen Chu,530
-Santa Clara,State Assembly,25,4231,Dem,Kansen Chu,732
-Santa Clara,State Assembly,25,4238,Dem,Kansen Chu,741
-Santa Clara,State Assembly,25,4241,Dem,Kansen Chu,684
-Santa Clara,State Assembly,25,4242,Dem,Kansen Chu,560
-Santa Clara,State Assembly,25,4247,Dem,Kansen Chu,429
-Santa Clara,State Assembly,25,4249,Dem,Kansen Chu,701
-Santa Clara,State Assembly,25,4250,Dem,Kansen Chu,400
-Santa Clara,State Assembly,25,4256,Dem,Kansen Chu,698
-Santa Clara,State Assembly,25,4257,Dem,Kansen Chu,354
-Santa Clara,State Assembly,25,4258,Dem,Kansen Chu,482
-Santa Clara,State Assembly,25,4259,Dem,Kansen Chu,759
-Santa Clara,State Assembly,25,4261,Dem,Kansen Chu,488
-Santa Clara,State Assembly,25,4265,Dem,Kansen Chu,642
-Santa Clara,State Assembly,25,4267,Dem,Kansen Chu,367
-Santa Clara,State Assembly,25,4268,Dem,Kansen Chu,386
-Santa Clara,State Assembly,25,4269,Dem,Kansen Chu,421
-Santa Clara,State Assembly,25,4270,Dem,Kansen Chu,541
-Santa Clara,State Assembly,25,4271,Dem,Kansen Chu,672
-Santa Clara,State Assembly,25,4272,Dem,Kansen Chu,299
-Santa Clara,State Assembly,25,4273,Dem,Kansen Chu,622
-Santa Clara,State Assembly,25,4288,Dem,Kansen Chu,428
-Santa Clara,State Assembly,25,4289,Dem,Kansen Chu,408
-Santa Clara,State Assembly,25,4296,Dem,Kansen Chu,358
-Santa Clara,State Assembly,25,4297,Dem,Kansen Chu,686
-Santa Clara,State Assembly,25,4298,Dem,Kansen Chu,484
-Santa Clara,State Assembly,25,4299,Dem,Kansen Chu,17
-Santa Clara,State Assembly,25,4301,Dem,Kansen Chu,611
-Santa Clara,State Assembly,25,4305,Dem,Kansen Chu,704
-Santa Clara,State Assembly,25,4308,Dem,Kansen Chu,44
-Santa Clara,State Assembly,25,4309,Dem,Kansen Chu,24
-Santa Clara,State Assembly,25,4312,Dem,Kansen Chu,459
-Santa Clara,State Assembly,25,4315,Dem,Kansen Chu,689
-Santa Clara,State Assembly,25,4319,Dem,Kansen Chu,375
-Santa Clara,State Assembly,25,4321,Dem,Kansen Chu,593
-Santa Clara,State Assembly,25,4326,Dem,Kansen Chu,607
-Santa Clara,State Assembly,25,4327,Dem,Kansen Chu,679
-Santa Clara,State Assembly,25,4332,Dem,Kansen Chu,309
-Santa Clara,State Assembly,25,4334,Dem,Kansen Chu,450
-Santa Clara,State Assembly,25,4343,Dem,Kansen Chu,385
-Santa Clara,State Assembly,25,4401,Dem,Kansen Chu,585
-Santa Clara,State Assembly,25,4402,Dem,Kansen Chu,692
-Santa Clara,State Assembly,25,4403,Dem,Kansen Chu,55
-Santa Clara,State Assembly,25,4404,Dem,Kansen Chu,497
-Santa Clara,State Assembly,25,4405,Dem,Kansen Chu,327
-Santa Clara,State Assembly,25,4406,Dem,Kansen Chu,361
-Santa Clara,State Assembly,25,4407,Dem,Kansen Chu,314
-Santa Clara,State Assembly,25,4408,Dem,Kansen Chu,466
-Santa Clara,State Assembly,25,4409,Dem,Kansen Chu,591
-Santa Clara,State Assembly,25,4411,Dem,Kansen Chu,332
-Santa Clara,State Assembly,25,4412,Dem,Kansen Chu,398
-Santa Clara,State Assembly,25,4413,Dem,Kansen Chu,427
-Santa Clara,State Assembly,25,4414,Dem,Kansen Chu,479
-Santa Clara,State Assembly,25,4415,Dem,Kansen Chu,691
-Santa Clara,State Assembly,25,4416,Dem,Kansen Chu,368
-Santa Clara,State Assembly,25,4417,Dem,Kansen Chu,614
-Santa Clara,State Assembly,25,4418,Dem,Kansen Chu,367
-Santa Clara,State Assembly,25,4421,Dem,Kansen Chu,386
-Santa Clara,State Assembly,25,4422,Dem,Kansen Chu,520
-Santa Clara,State Assembly,25,4423,Dem,Kansen Chu,332
-Santa Clara,State Assembly,25,4424,Dem,Kansen Chu,380
-Santa Clara,State Assembly,25,4425,Dem,Kansen Chu,380
-Santa Clara,State Assembly,25,4426,Dem,Kansen Chu,342
-Santa Clara,State Assembly,25,4427,Dem,Kansen Chu,393
-Santa Clara,State Assembly,25,4428,Dem,Kansen Chu,554
-Santa Clara,State Assembly,25,4429,Dem,Kansen Chu,686
-Santa Clara,State Assembly,25,4431,Dem,Kansen Chu,1
-Santa Clara,State Assembly,25,4432,Dem,Kansen Chu,587
-Santa Clara,State Assembly,25,4435,Dem,Kansen Chu,642
-Santa Clara,State Assembly,25,4438,Dem,Kansen Chu,393
-Santa Clara,State Assembly,25,4440,Dem,Kansen Chu,594
-Santa Clara,State Assembly,25,4441,Dem,Kansen Chu,85
-Santa Clara,State Assembly,25,4442,Dem,Kansen Chu,1
-Santa Clara,State Assembly,28,4666,Dem,Evan Low,598
-Santa Clara,State Assembly,28,4667,Dem,Evan Low,6
-Santa Clara,State Assembly,28,4668,Dem,Evan Low,494
-Santa Clara,State Assembly,28,4669,Dem,Evan Low,3
-Santa Clara,State Assembly,28,4670,Dem,Evan Low,611
-Santa Clara,State Assembly,28,4672,Dem,Evan Low,31
-Santa Clara,State Assembly,28,4674,Dem,Evan Low,553
-Santa Clara,State Assembly,28,4676,Dem,Evan Low,630
-Santa Clara,State Assembly,28,4677,Dem,Evan Low,478
-Santa Clara,State Assembly,28,4678,Dem,Evan Low,529
-Santa Clara,State Assembly,28,4681,Dem,Evan Low,496
-Santa Clara,State Assembly,28,4685,Dem,Evan Low,569
-Santa Clara,State Assembly,28,4687,Dem,Evan Low,453
-Santa Clara,State Assembly,28,4688,Dem,Evan Low,669
-Santa Clara,State Assembly,28,4690,Dem,Evan Low,615
-Santa Clara,State Assembly,28,4692,Dem,Evan Low,448
-Santa Clara,State Assembly,28,4696,Dem,Evan Low,599
-Santa Clara,State Assembly,28,4699,Dem,Evan Low,699
-Santa Clara,State Assembly,28,4702,Dem,Evan Low,440
-Santa Clara,State Assembly,28,4703,Dem,Evan Low,644
-Santa Clara,State Assembly,28,4704,Dem,Evan Low,133
-Santa Clara,State Assembly,28,4707,Dem,Evan Low,75
-Santa Clara,State Assembly,28,4723,Dem,Evan Low,358
-Santa Clara,State Assembly,28,4733,Dem,Evan Low,15
-Santa Clara,State Assembly,28,4737,Dem,Evan Low,1
-Santa Clara,State Assembly,28,4740,Dem,Evan Low,26
-Santa Clara,State Assembly,25,5449,Dem,Kansen Chu,21
-Santa Clara,State Assembly,25,5452,Dem,Kansen Chu,23
-Santa Clara,State Assembly,27,5453,Dem,Ash Kaira,0
-Santa Clara,State Assembly,25,5456,Dem,Kansen Chu,4
-Santa Clara,State Assembly,25,5502,Dem,Kansen Chu,172
-Santa Clara,State Assembly,27,5503,Dem,Ash Kaira,40
-Santa Clara,State Assembly,25,5505,Dem,Kansen Chu,74
-Santa Clara,State Assembly,28,5556,Dem,Evan Low,747
-Santa Clara,State Assembly,28,5557,Dem,Evan Low,519
-Santa Clara,State Assembly,28,5567,Dem,Evan Low,281
-Santa Clara,State Assembly,28,5743,Dem,Evan Low,306
-Santa Clara,State Assembly,28,5744,Dem,Evan Low,4
-Santa Clara,State Assembly,28,5745,Dem,Evan Low,653
-Santa Clara,State Assembly,28,5746,Dem,Evan Low,239
-Santa Clara,State Assembly,28,5747,Dem,Evan Low,465
-Santa Clara,State Assembly,28,5750,Dem,Evan Low,7
-Santa Clara,State Assembly,28,5752,Dem,Evan Low,563
-Santa Clara,State Assembly,29,5756,Dem,Mark Stone,33
-Santa Clara,State Assembly,28,5758,Dem,Evan Low,61
-Santa Clara,State Assembly,28,5759,Dem,Evan Low,206
-Santa Clara,State Assembly,28,5760,Dem,Evan Low,4
-Santa Clara,State Assembly,28,5762,Dem,Evan Low,42
-Santa Clara,State Assembly,28,5763,Dem,Evan Low,35
-Santa Clara,State Assembly,28,5765,Dem,Evan Low,35
-Santa Clara,State Assembly,28,5770,Dem,Evan Low,71
-Santa Clara,State Assembly,28,5772,Dem,Evan Low,2
-Santa Clara,State Assembly,28,5774,Dem,Evan Low,16
-Santa Clara,State Assembly,28,5775,Dem,Evan Low,171
-Santa Clara,State Assembly,28,5782,Dem,Evan Low,73
-Santa Clara,State Assembly,29,5784,Dem,Mark Stone,1
-Santa Clara,State Assembly,28,5788,Dem,Evan Low,13
-Santa Clara,State Assembly,28,5789,Dem,Evan Low,6
-Santa Clara,State Assembly,29,5792,Dem,Mark Stone,2
-Santa Clara,State Assembly,29,5794,Dem,Mark Stone,22
-Santa Clara,State Assembly,28,5804,Dem,Evan Low,671
-Santa Clara,State Assembly,28,5810,Dem,Evan Low,289
-Santa Clara,State Assembly,28,5813,Dem,Evan Low,29
-Santa Clara,State Assembly,28,5858,Dem,Evan Low,67
-Santa Clara,State Assembly,27,5881,Dem,Ash Kaira,0
-Santa Clara,State Assembly,27,5884,Dem,Ash Kaira,0
-Santa Clara,State Assembly,27,5886,Dem,Ash Kaira,0
-Santa Clara,State Assembly,29,5894,Dem,Mark Stone,3
-Santa Clara,State Assembly,29,5895,Dem,Mark Stone,2
-Santa Clara,State Assembly,29,5902,Dem,Mark Stone,195
-Santa Clara,State Assembly,29,5903,Dem,Mark Stone,248
-Santa Clara,State Assembly,29,5904,Dem,Mark Stone,103
-Santa Clara,State Assembly,30,5906,Dem,Robert Rivas,109
-Santa Clara,State Assembly,30,5911,Dem,Robert Rivas,106
-Santa Clara,State Assembly,29,5912,Dem,Mark Stone,36
-Santa Clara,State Assembly,29,5914,Dem,Mark Stone,363
-Santa Clara,State Assembly,30,5915,Dem,Robert Rivas,309
-Santa Clara,State Assembly,29,5916,Dem,Mark Stone,23
-Santa Clara,State Assembly,30,5917,Dem,Robert Rivas,18
-Santa Clara,State Assembly,30,5920,Dem,Robert Rivas,2
-Santa Clara,State Assembly,25,5925,Dem,Kansen Chu,13
-Santa Clara,State Assembly,29,5926,Dem,Mark Stone,187
-Santa Clara,State Assembly,30,5929,Dem,Robert Rivas,28
-Santa Clara,State Assembly,29,5931,Dem,Mark Stone,25
-Santa Clara,State Assembly,30,5932,Dem,Robert Rivas,52
-Santa Clara,State Assembly,29,5933,Dem,Mark Stone,89
-Santa Clara,State Assembly,30,5936,Dem,Robert Rivas,387
-Santa Clara,State Assembly,30,5937,Dem,Robert Rivas,58
-Santa Clara,State Assembly,25,5938,Dem,Kansen Chu,10
-Santa Clara,State Assembly,29,5940,Dem,Mark Stone,7
-Santa Clara,State Assembly,30,5943,Dem,Robert Rivas,51
-Santa Clara,State Assembly,29,5945,Dem,Mark Stone,116
-Santa Clara,State Assembly,30,5947,Dem,Robert Rivas,250
-Santa Clara,State Assembly,30,5949,Dem,Robert Rivas,66
-Santa Clara,State Assembly,30,5950,Dem,Robert Rivas,136
-Santa Clara,State Assembly,30,5951,Dem,Robert Rivas,28
-Santa Clara,State Assembly,30,5952,Dem,Robert Rivas,6
-Santa Clara,State Assembly,30,5953,Dem,Robert Rivas,57
-Santa Clara,State Assembly,30,5955,Dem,Robert Rivas,425
-Santa Clara,State Assembly,30,5956,Dem,Robert Rivas,442
-Santa Clara,State Assembly,30,5957,Dem,Robert Rivas,30
-Santa Clara,State Assembly,30,5959,Dem,Robert Rivas,20
-Santa Clara,State Assembly,30,5962,Dem,Robert Rivas,417
-Santa Clara,State Assembly,30,5965,Dem,Robert Rivas,415
-Santa Clara,State Assembly,30,5966,Dem,Robert Rivas,49
-Santa Clara,State Assembly,30,5971,Dem,Robert Rivas,54
-Santa Clara,State Assembly,30,5973,Dem,Robert Rivas,28
-Santa Clara,State Assembly,29,5988,Dem,Mark Stone,2
-Santa Clara,State Assembly,30,5989,Dem,Robert Rivas,39
-Santa Clara,State Assembly,29,5991,Dem,Mark Stone,5
-Santa Clara,State Assembly,29,5995,Dem,Mark Stone,3
-Santa Clara,State Assembly,29,5996,Dem,Mark Stone,23
-Santa Clara,State Assembly,29,6002,Dem,Mark Stone,10
-Santa Clara,State Assembly,30,6006,Dem,Robert Rivas,21
-Santa Clara,State Assembly,30,6007,Dem,Robert Rivas,16
-Santa Clara,State Assembly,29,6021,Dem,Mark Stone,10
-Santa Clara,State Assembly,29,6023,Dem,Mark Stone,7
-Santa Clara,State Assembly,25,6028,Dem,Kansen Chu,0
-Santa Clara,State Assembly,30,6031,Dem,Robert Rivas,16
-Santa Clara,State Assembly,30,6032,Dem,Robert Rivas,21
-Santa Clara,State Assembly,29,6034,Dem,Mark Stone,4
-Santa Clara,State Assembly,30,6039,Dem,Robert Rivas,3
-Santa Clara,State Assembly,30,6040,Dem,Robert Rivas,23
-Santa Clara,State Assembly,29,6045,Dem,Mark Stone,2
-Santa Clara,State Assembly,29,6047,Dem,Mark Stone,2
-Santa Clara,State Assembly,25,6401,Dem,Kansen Chu,0
-Santa Clara,State Assembly,25,6402,Dem,Kansen Chu,40
-Santa Clara,State Assembly,27,6404,Dem,Ash Kaira,110
-Santa Clara,State Assembly,25,6405,Dem,Kansen Chu,3
-Santa Clara,State Assembly,25,6410,Dem,Kansen Chu,25
-Santa Clara,State Assembly,25,6411,Dem,Kansen Chu,64
-Santa Clara,State Assembly,25,6413,Dem,Kansen Chu,14
-Santa Clara,State Assembly,27,6417,Dem,Ash Kaira,105
-Santa Clara,State Assembly,25,6418,Dem,Kansen Chu,383
-Santa Clara,State Assembly,25,6419,Dem,Kansen Chu,8
-Santa Clara,State Assembly,25,6421,Dem,Kansen Chu,5
-Santa Clara,State Assembly,25,6422,Dem,Kansen Chu,7
-Santa Clara,State Assembly,25,6423,Dem,Kansen Chu,23
-Santa Clara,State Assembly,25,6425,Dem,Kansen Chu,7
-Santa Clara,State Assembly,25,6427,Dem,Kansen Chu,0
-Santa Clara,State Assembly,27,6452,Dem,Ash Kaira,104
-Santa Clara,State Assembly,27,6454,Dem,Ash Kaira,0
-Santa Clara,State Assembly,27,6455,Dem,Ash Kaira,113
-Santa Clara,State Assembly,27,6457,Dem,Ash Kaira,115
-Santa Clara,State Assembly,27,6458,Dem,Ash Kaira,89
-Santa Clara,State Assembly,27,6462,Dem,Ash Kaira,0
-Santa Clara,State Assembly,27,6463,Dem,Ash Kaira,0
-Santa Clara,State Assembly,25,6464,Dem,Kansen Chu,1
-Santa Clara,State Assembly,27,6465,Dem,Ash Kaira,0
-Santa Clara,State Assembly,25,6466,Dem,Kansen Chu,69
-Santa Clara,State Assembly,27,6470,Dem,Ash Kaira,58
-Santa Clara,State Assembly,25,6490,Dem,Kansen Chu,4
-Santa Clara,State Assembly,25,6491,Dem,Kansen Chu,7
-Santa Clara,State Assembly,25,6492,Dem,Kansen Chu,18
-Santa Clara,State Assembly,25,6493,Dem,Kansen Chu,4
-Santa Clara,State Assembly,25,6502,Dem,Kansen Chu,156
-Santa Clara,State Assembly,25,6509,Dem,Kansen Chu,5
-Santa Clara,State Assembly,25,6510,Dem,Kansen Chu,21
-Santa Clara,State Assembly,25,6515,Dem,Kansen Chu,50
-Santa Clara,State Assembly,28,6624,Dem,Evan Low,8
-Santa Clara,State Assembly,28,6663,Dem,Evan Low,5
-Santa Clara,State Assembly,28,6664,Dem,Evan Low,22
-Santa Clara,State Assembly,28,6665,Dem,Evan Low,1
-Santa Clara,State Assembly,28,6666,Dem,Evan Low,80
-Santa Clara,State Assembly,28,6673,Dem,Evan Low,1
-Santa Clara,State Assembly,24,STATEWIDE,Dem,Marc Berman,97726
-Santa Clara,State Assembly,24,"US Representative, District 17",Dem,Marc Berman,32952
-Santa Clara,State Assembly,24,"US Representative, District 18",Dem,Marc Berman,64774
-Santa Clara,State Assembly,24,"State Senate, District 13",Dem,Marc Berman,96211
-Santa Clara,State Assembly,24,"State Senate, District 15",Dem,Marc Berman,1515
-Santa Clara,State Assembly,24,State Assembly District 24,Dem,Marc Berman,97726
-Santa Clara,State Assembly,24,City of Cupertino,Dem,Marc Berman,1371
-Santa Clara,State Assembly,24,City of Los Altos,Dem,Marc Berman,11287
-Santa Clara,State Assembly,24,Town of Los Altos Hills,Dem,Marc Berman,2906
-Santa Clara,State Assembly,24,City of Mountain View,Dem,Marc Berman,21838
-Santa Clara,State Assembly,24,City of Palo Alto,Dem,Marc Berman,24496
-Santa Clara,State Assembly,24,City of Sunnyvale,Dem,Marc Berman,31574
-Santa Clara,State Assembly,24,Unincorporated Area,Dem,Marc Berman,4254
-Santa Clara,State Assembly,25,STATEWIDE,Dem,Kansen Chu,66652
-Santa Clara,State Assembly,25,"US Representative, District 17",Dem,Kansen Chu,64424
-Santa Clara,State Assembly,25,"US Representative, District 19",Dem,Kansen Chu,2228
-Santa Clara,State Assembly,25,"State Senate, District 10",Dem,Kansen Chu,61492
-Santa Clara,State Assembly,25,"State Senate, District 15",Dem,Kansen Chu,5137
-Santa Clara,State Assembly,25,"State Senate, District 17",Dem,Kansen Chu,23
-Santa Clara,State Assembly,25,State Assembly District 25,Dem,Kansen Chu,66652
-Santa Clara,State Assembly,25,City of Milpitas,Dem,Kansen Chu,13840
-Santa Clara,State Assembly,25,City of Santa Clara,Dem,Kansen Chu,25311
-Santa Clara,State Assembly,25,City of Sunnyvale,Dem,Kansen Chu,19
-Santa Clara,State Assembly,25,City of San Jose,Dem,Kansen Chu,26251
-Santa Clara,State Assembly,25,Unincorporated Area,Dem,Kansen Chu,1231
-Santa Clara,State Assembly,27,SANTA CLARA CA,Dem,Ash Kaira,90068
-Santa Clara,State Assembly,27,"US Representative, District 19",Dem,Ash Kaira,90068
-Santa Clara,State Assembly,27,"State Senate, District 10",Dem,Ash Kaira,1548
-Santa Clara,State Assembly,27,"State Senate, District 15",Dem,Ash Kaira,79763
-Santa Clara,State Assembly,27,"State Senate, District 17",Dem,Ash Kaira,8757
-Santa Clara,State Assembly,27,State Assembly District 27,Dem,Ash Kaira,90068
-Santa Clara,State Assembly,27,City of San Jose,Dem,Ash Kaira,86784
-Santa Clara,State Assembly,27,Unincorporated Area,Dem,Ash Kaira,3284
-Santa Clara,State Assembly,28,SANTA CLARA CA,Dem,Evan Low,130815
-Santa Clara,State Assembly,28,"US Representative, District 17",Dem,Evan Low,18299
-Santa Clara,State Assembly,28,"US Representative, District 18",Dem,Evan Low,88725
-Santa Clara,State Assembly,28,"US Representative, District 19",Dem,Evan Low,23791
-Santa Clara,State Assembly,28,"State Senate, District 10",Dem,Evan Low,4744
-Santa Clara,State Assembly,28,"State Senate, District 13",Dem,Evan Low,173
-Santa Clara,State Assembly,28,"State Senate, District 15",Dem,Evan Low,125898
-Santa Clara,State Assembly,28,State Assembly District 28,Dem,Evan Low,130815
-Santa Clara,State Assembly,28,City of Campbell,Dem,Evan Low,12186
-Santa Clara,State Assembly,28,City of Cupertino,Dem,Evan Low,13722
-Santa Clara,State Assembly,28,Town of Los Gatos,Dem,Evan Low,10145
-Santa Clara,State Assembly,28,City of Monte Sereno,Dem,Evan Low,1204
-Santa Clara,State Assembly,28,City of Saratoga,Dem,Evan Low,10173
-Santa Clara,State Assembly,28,City of San Jose,Dem,Evan Low,77545
-Santa Clara,State Assembly,28,Unincorporated Area,Dem,Evan Low,5840
-Santa Clara,State Assembly,29,SANTA CLARA CA,Dem,Mark Stone,24084
-Santa Clara,State Assembly,29,"US Representative, District 18",Dem,Mark Stone,5410
-Santa Clara,State Assembly,29,"US Representative, District 19",Dem,Mark Stone,18674
-Santa Clara,State Assembly,29,"State Senate, District 15",Dem,Mark Stone,10553
-Santa Clara,State Assembly,29,"State Senate, District 17",Dem,Mark Stone,13531
-Santa Clara,State Assembly,29,State Assembly District 29,Dem,Mark Stone,24084
-Santa Clara,State Assembly,29,City of San Jose,Dem,Mark Stone,22561
-Santa Clara,State Assembly,29,Unincorporated Area,Dem,Mark Stone,1523
-Santa Clara,State Assembly,30,STATEWIDE,Dem,Robert Rivas,25094
-Santa Clara,State Assembly,30,"US Representative, District 19",Dem,Robert Rivas,22032
-Santa Clara,State Assembly,30,"US Representative, District 20",Dem,Robert Rivas,3062
-Santa Clara,State Assembly,30,"State Senate, District 17",Dem,Robert Rivas,25094
-Santa Clara,State Assembly,30,State Assembly District 30,Dem,Robert Rivas,25094
-Santa Clara,State Assembly,30,City of Gilroy ,Dem,Robert Rivas,11058
-Santa Clara,State Assembly,30,City of Morgan Hill,Dem,Robert Rivas,10354
-Santa Clara,State Assembly,30,Unincorporated Area,Dem,Robert Rivas,3682
-Santa Clara,State Assembly,28,1001,Rep,Michael Snyder,284
-Santa Clara,State Assembly,28,1003,Rep,Michael Snyder,245
-Santa Clara,State Assembly,28,1006,Rep,Michael Snyder,286
-Santa Clara,State Assembly,28,1008,Rep,Michael Snyder,147
-Santa Clara,State Assembly,29,1009,Rep,Vicki Nohrden,219
-Santa Clara,State Assembly,28,1010,Rep,Michael Snyder,153
-Santa Clara,State Assembly,28,1011,Rep,Michael Snyder,274
-Santa Clara,State Assembly,28,1013,Rep,Michael Snyder,266
-Santa Clara,State Assembly,28,1015,Rep,Michael Snyder,188
-Santa Clara,State Assembly,28,1016,Rep,Michael Snyder,182
-Santa Clara,State Assembly,28,1019,Rep,Michael Snyder,376
-Santa Clara,State Assembly,28,1020,Rep,Michael Snyder,291
-Santa Clara,State Assembly,28,1021,Rep,Michael Snyder,298
-Santa Clara,State Assembly,28,1024,Rep,Michael Snyder,347
-Santa Clara,State Assembly,28,1026,Rep,Michael Snyder,307
-Santa Clara,State Assembly,28,1029,Rep,Michael Snyder,352
-Santa Clara,State Assembly,28,1032,Rep,Michael Snyder,306
-Santa Clara,State Assembly,28,1034,Rep,Michael Snyder,280
-Santa Clara,State Assembly,28,1036,Rep,Michael Snyder,416
-Santa Clara,State Assembly,28,1037,Rep,Michael Snyder,316
-Santa Clara,State Assembly,29,1040,Rep,Vicki Nohrden,156
-Santa Clara,State Assembly,29,1041,Rep,Vicki Nohrden,4
-Santa Clara,State Assembly,29,1042,Rep,Vicki Nohrden,9
-Santa Clara,State Assembly,29,1043,Rep,Vicki Nohrden,240
-Santa Clara,State Assembly,29,1046,Rep,Vicki Nohrden,361
-Santa Clara,State Assembly,29,1047,Rep,Vicki Nohrden,226
-Santa Clara,State Assembly,29,1048,Rep,Vicki Nohrden,220
-Santa Clara,State Assembly,29,1050,Rep,Vicki Nohrden,334
-Santa Clara,State Assembly,29,1053,Rep,Vicki Nohrden,380
-Santa Clara,State Assembly,29,1055,Rep,Vicki Nohrden,221
-Santa Clara,State Assembly,28,1056,Rep,Michael Snyder,298
-Santa Clara,State Assembly,28,1057,Rep,Michael Snyder,116
-Santa Clara,State Assembly,29,1060,Rep,Vicki Nohrden,199
-Santa Clara,State Assembly,29,1062,Rep,Vicki Nohrden,349
-Santa Clara,State Assembly,29,1063,Rep,Vicki Nohrden,272
-Santa Clara,State Assembly,29,1066,Rep,Vicki Nohrden,305
-Santa Clara,State Assembly,29,1069,Rep,Vicki Nohrden,242
-Santa Clara,State Assembly,29,1070,Rep,Vicki Nohrden,255
-Santa Clara,State Assembly,29,1071,Rep,Vicki Nohrden,1
-Santa Clara,State Assembly,29,1072,Rep,Vicki Nohrden,198
-Santa Clara,State Assembly,28,1077,Rep,Michael Snyder,64
-Santa Clara,State Assembly,27,1078,Rep,Burt Lancaster,32
-Santa Clara,State Assembly,29,1080,Rep,Vicki Nohrden,192
-Santa Clara,State Assembly,29,1081,Rep,Vicki Nohrden,277
-Santa Clara,State Assembly,27,1082,Rep,Burt Lancaster,72
-Santa Clara,State Assembly,28,1085,Rep,Michael Snyder,58
-Santa Clara,State Assembly,29,1087,Rep,Vicki Nohrden,0
-Santa Clara,State Assembly,29,1092,Rep,Vicki Nohrden,229
-Santa Clara,State Assembly,27,1094,Rep,Burt Lancaster,65
-Santa Clara,State Assembly,27,1099,Rep,Burt Lancaster,0
-Santa Clara,State Assembly,28,1101,Rep,Michael Snyder,268
-Santa Clara,State Assembly,28,1104,Rep,Michael Snyder,229
-Santa Clara,State Assembly,28,1106,Rep,Michael Snyder,247
-Santa Clara,State Assembly,28,1107,Rep,Michael Snyder,258
-Santa Clara,State Assembly,28,1108,Rep,Michael Snyder,183
-Santa Clara,State Assembly,28,1111,Rep,Michael Snyder,27
-Santa Clara,State Assembly,28,1113,Rep,Michael Snyder,207
-Santa Clara,State Assembly,28,1114,Rep,Michael Snyder,316
-Santa Clara,State Assembly,28,1115,Rep,Michael Snyder,245
-Santa Clara,State Assembly,28,1117,Rep,Michael Snyder,158
-Santa Clara,State Assembly,28,1118,Rep,Michael Snyder,64
-Santa Clara,State Assembly,28,1121,Rep,Michael Snyder,78
-Santa Clara,State Assembly,28,1123,Rep,Michael Snyder,215
-Santa Clara,State Assembly,28,1125,Rep,Michael Snyder,203
-Santa Clara,State Assembly,28,1127,Rep,Michael Snyder,183
-Santa Clara,State Assembly,28,1129,Rep,Michael Snyder,195
-Santa Clara,State Assembly,28,1131,Rep,Michael Snyder,209
-Santa Clara,State Assembly,28,1134,Rep,Michael Snyder,138
-Santa Clara,State Assembly,28,1135,Rep,Michael Snyder,111
-Santa Clara,State Assembly,28,1136,Rep,Michael Snyder,107
-Santa Clara,State Assembly,28,1138,Rep,Michael Snyder,113
-Santa Clara,State Assembly,28,1141,Rep,Michael Snyder,252
-Santa Clara,State Assembly,28,1142,Rep,Michael Snyder,242
-Santa Clara,State Assembly,28,1144,Rep,Michael Snyder,157
-Santa Clara,State Assembly,28,1145,Rep,Michael Snyder,167
-Santa Clara,State Assembly,28,1146,Rep,Michael Snyder,168
-Santa Clara,State Assembly,28,1149,Rep,Michael Snyder,253
-Santa Clara,State Assembly,28,1152,Rep,Michael Snyder,245
-Santa Clara,State Assembly,28,1153,Rep,Michael Snyder,180
-Santa Clara,State Assembly,28,1154,Rep,Michael Snyder,169
-Santa Clara,State Assembly,28,1156,Rep,Michael Snyder,269
-Santa Clara,State Assembly,28,1158,Rep,Michael Snyder,284
-Santa Clara,State Assembly,28,1160,Rep,Michael Snyder,259
-Santa Clara,State Assembly,28,1161,Rep,Michael Snyder,130
-Santa Clara,State Assembly,28,1162,Rep,Michael Snyder,264
-Santa Clara,State Assembly,28,1169,Rep,Michael Snyder,15
-Santa Clara,State Assembly,28,1198,Rep,Michael Snyder,198
-Santa Clara,State Assembly,28,1199,Rep,Michael Snyder,47
-Santa Clara,State Assembly,29,1200,Rep,Vicki Nohrden,185
-Santa Clara,State Assembly,28,1201,Rep,Michael Snyder,169
-Santa Clara,State Assembly,28,1204,Rep,Michael Snyder,141
-Santa Clara,State Assembly,27,1205,Rep,Burt Lancaster,79
-Santa Clara,State Assembly,27,1206,Rep,Burt Lancaster,39
-Santa Clara,State Assembly,27,1207,Rep,Burt Lancaster,47
-Santa Clara,State Assembly,27,1208,Rep,Burt Lancaster,46
-Santa Clara,State Assembly,27,1209,Rep,Burt Lancaster,56
-Santa Clara,State Assembly,29,1210,Rep,Vicki Nohrden,77
-Santa Clara,State Assembly,27,1211,Rep,Burt Lancaster,33
-Santa Clara,State Assembly,29,1213,Rep,Vicki Nohrden,113
-Santa Clara,State Assembly,29,1214,Rep,Vicki Nohrden,212
-Santa Clara,State Assembly,29,1215,Rep,Vicki Nohrden,104
-Santa Clara,State Assembly,29,1218,Rep,Vicki Nohrden,297
-Santa Clara,State Assembly,27,1220,Rep,Burt Lancaster,31
-Santa Clara,State Assembly,29,1221,Rep,Vicki Nohrden,148
-Santa Clara,State Assembly,29,1222,Rep,Vicki Nohrden,139
-Santa Clara,State Assembly,29,1223,Rep,Vicki Nohrden,242
-Santa Clara,State Assembly,29,1224,Rep,Vicki Nohrden,227
-Santa Clara,State Assembly,29,1226,Rep,Vicki Nohrden,289
-Santa Clara,State Assembly,29,1228,Rep,Vicki Nohrden,173
-Santa Clara,State Assembly,29,1229,Rep,Vicki Nohrden,294
-Santa Clara,State Assembly,27,1230,Rep,Burt Lancaster,30
-Santa Clara,State Assembly,29,1231,Rep,Vicki Nohrden,295
-Santa Clara,State Assembly,29,1232,Rep,Vicki Nohrden,270
-Santa Clara,State Assembly,29,1234,Rep,Vicki Nohrden,99
-Santa Clara,State Assembly,29,1236,Rep,Vicki Nohrden,301
-Santa Clara,State Assembly,29,1238,Rep,Vicki Nohrden,231
-Santa Clara,State Assembly,29,1239,Rep,Vicki Nohrden,328
-Santa Clara,State Assembly,29,1240,Rep,Vicki Nohrden,201
-Santa Clara,State Assembly,29,1242,Rep,Vicki Nohrden,158
-Santa Clara,State Assembly,29,1243,Rep,Vicki Nohrden,242
-Santa Clara,State Assembly,29,1244,Rep,Vicki Nohrden,205
-Santa Clara,State Assembly,29,1246,Rep,Vicki Nohrden,259
-Santa Clara,State Assembly,29,1247,Rep,Vicki Nohrden,297
-Santa Clara,State Assembly,29,1250,Rep,Vicki Nohrden,277
-Santa Clara,State Assembly,29,1252,Rep,Vicki Nohrden,4
-Santa Clara,State Assembly,28,1254,Rep,Michael Snyder,107
-Santa Clara,State Assembly,29,1263,Rep,Vicki Nohrden,63
-Santa Clara,State Assembly,29,1268,Rep,Vicki Nohrden,4
-Santa Clara,State Assembly,29,1271,Rep,Vicki Nohrden,93
-Santa Clara,State Assembly,29,1274,Rep,Vicki Nohrden,185
-Santa Clara,State Assembly,27,1276,Rep,Burt Lancaster,43
-Santa Clara,State Assembly,29,1290,Rep,Vicki Nohrden,2
-Santa Clara,State Assembly,27,1295,Rep,Burt Lancaster,35
-Santa Clara,State Assembly,27,1299,Rep,Burt Lancaster,0
-Santa Clara,State Assembly,25,1301,Rep,Bob Brunton,5
-Santa Clara,State Assembly,25,1302,Rep,Bob Brunton,55
-Santa Clara,State Assembly,25,1303,Rep,Bob Brunton,146
-Santa Clara,State Assembly,28,1304,Rep,Michael Snyder,209
-Santa Clara,State Assembly,28,1305,Rep,Michael Snyder,158
-Santa Clara,State Assembly,28,1307,Rep,Michael Snyder,87
-Santa Clara,State Assembly,27,1308,Rep,Burt Lancaster,0
-Santa Clara,State Assembly,27,1310,Rep,Burt Lancaster,16
-Santa Clara,State Assembly,27,1311,Rep,Burt Lancaster,33
-Santa Clara,State Assembly,27,1312,Rep,Burt Lancaster,19
-Santa Clara,State Assembly,27,1313,Rep,Burt Lancaster,14
-Santa Clara,State Assembly,27,1314,Rep,Burt Lancaster,21
-Santa Clara,State Assembly,27,1315,Rep,Burt Lancaster,22
-Santa Clara,State Assembly,27,1316,Rep,Burt Lancaster,23
-Santa Clara,State Assembly,27,1317,Rep,Burt Lancaster,21
-Santa Clara,State Assembly,27,1318,Rep,Burt Lancaster,16
-Santa Clara,State Assembly,27,1319,Rep,Burt Lancaster,27
-Santa Clara,State Assembly,27,1320,Rep,Burt Lancaster,11
-Santa Clara,State Assembly,27,1321,Rep,Burt Lancaster,28
-Santa Clara,State Assembly,27,1323,Rep,Burt Lancaster,23
-Santa Clara,State Assembly,27,1324,Rep,Burt Lancaster,20
-Santa Clara,State Assembly,27,1325,Rep,Burt Lancaster,38
-Santa Clara,State Assembly,27,1327,Rep,Burt Lancaster,24
-Santa Clara,State Assembly,27,1329,Rep,Burt Lancaster,22
-Santa Clara,State Assembly,27,1330,Rep,Burt Lancaster,43
-Santa Clara,State Assembly,27,1333,Rep,Burt Lancaster,40
-Santa Clara,State Assembly,27,1334,Rep,Burt Lancaster,34
-Santa Clara,State Assembly,27,1336,Rep,Burt Lancaster,11
-Santa Clara,State Assembly,27,1338,Rep,Burt Lancaster,24
-Santa Clara,State Assembly,27,1339,Rep,Burt Lancaster,19
-Santa Clara,State Assembly,27,1340,Rep,Burt Lancaster,17
-Santa Clara,State Assembly,27,1342,Rep,Burt Lancaster,8
-Santa Clara,State Assembly,27,1343,Rep,Burt Lancaster,25
-Santa Clara,State Assembly,27,1344,Rep,Burt Lancaster,22
-Santa Clara,State Assembly,27,1346,Rep,Burt Lancaster,17
-Santa Clara,State Assembly,28,1347,Rep,Michael Snyder,76
-Santa Clara,State Assembly,28,1348,Rep,Michael Snyder,107
-Santa Clara,State Assembly,27,1353,Rep,Burt Lancaster,10
-Santa Clara,State Assembly,27,1356,Rep,Burt Lancaster,28
-Santa Clara,State Assembly,27,1357,Rep,Burt Lancaster,0
-Santa Clara,State Assembly,28,1358,Rep,Michael Snyder,31
-Santa Clara,State Assembly,28,1359,Rep,Michael Snyder,94
-Santa Clara,State Assembly,27,1361,Rep,Burt Lancaster,16
-Santa Clara,State Assembly,27,1362,Rep,Burt Lancaster,7
-Santa Clara,State Assembly,25,1370,Rep,Bob Brunton,4
-Santa Clara,State Assembly,27,1371,Rep,Burt Lancaster,4
-Santa Clara,State Assembly,27,1373,Rep,Burt Lancaster,0
-Santa Clara,State Assembly,27,1374,Rep,Burt Lancaster,20
-Santa Clara,State Assembly,28,1380,Rep,Michael Snyder,12
-Santa Clara,State Assembly,27,1384,Rep,Burt Lancaster,27
-Santa Clara,State Assembly,28,1385,Rep,Michael Snyder,179
-Santa Clara,State Assembly,27,1387,Rep,Burt Lancaster,35
-Santa Clara,State Assembly,27,1388,Rep,Burt Lancaster,22
-Santa Clara,State Assembly,27,1389,Rep,Burt Lancaster,31
-Santa Clara,State Assembly,27,1390,Rep,Burt Lancaster,30
-Santa Clara,State Assembly,25,1391,Rep,Bob Brunton,140
-Santa Clara,State Assembly,27,1392,Rep,Burt Lancaster,35
-Santa Clara,State Assembly,27,1393,Rep,Burt Lancaster,31
-Santa Clara,State Assembly,25,1394,Rep,Bob Brunton,201
-Santa Clara,State Assembly,27,1395,Rep,Burt Lancaster,30
-Santa Clara,State Assembly,25,1396,Rep,Bob Brunton,208
-Santa Clara,State Assembly,25,1397,Rep,Bob Brunton,270
-Santa Clara,State Assembly,27,1398,Rep,Burt Lancaster,7
-Santa Clara,State Assembly,27,1399,Rep,Burt Lancaster,20
-Santa Clara,State Assembly,25,1400,Rep,Bob Brunton,119
-Santa Clara,State Assembly,25,1401,Rep,Bob Brunton,106
-Santa Clara,State Assembly,25,1403,Rep,Bob Brunton,184
-Santa Clara,State Assembly,25,1405,Rep,Bob Brunton,2
-Santa Clara,State Assembly,25,1407,Rep,Bob Brunton,224
-Santa Clara,State Assembly,25,1408,Rep,Bob Brunton,108
-Santa Clara,State Assembly,25,1409,Rep,Bob Brunton,162
-Santa Clara,State Assembly,25,1410,Rep,Bob Brunton,210
-Santa Clara,State Assembly,25,1411,Rep,Bob Brunton,227
-Santa Clara,State Assembly,25,1414,Rep,Bob Brunton,182
-Santa Clara,State Assembly,25,1415,Rep,Bob Brunton,223
-Santa Clara,State Assembly,25,1417,Rep,Bob Brunton,185
-Santa Clara,State Assembly,25,1418,Rep,Bob Brunton,192
-Santa Clara,State Assembly,25,1420,Rep,Bob Brunton,212
-Santa Clara,State Assembly,25,1421,Rep,Bob Brunton,213
-Santa Clara,State Assembly,25,1423,Rep,Bob Brunton,176
-Santa Clara,State Assembly,27,1424,Rep,Burt Lancaster,48
-Santa Clara,State Assembly,25,1426,Rep,Bob Brunton,44
-Santa Clara,State Assembly,25,1427,Rep,Bob Brunton,138
-Santa Clara,State Assembly,25,1428,Rep,Bob Brunton,217
-Santa Clara,State Assembly,25,1429,Rep,Bob Brunton,299
-Santa Clara,State Assembly,25,1431,Rep,Bob Brunton,174
-Santa Clara,State Assembly,25,1432,Rep,Bob Brunton,291
-Santa Clara,State Assembly,25,1433,Rep,Bob Brunton,133
-Santa Clara,State Assembly,25,1435,Rep,Bob Brunton,200
-Santa Clara,State Assembly,25,1439,Rep,Bob Brunton,124
-Santa Clara,State Assembly,25,1440,Rep,Bob Brunton,21
-Santa Clara,State Assembly,25,1443,Rep,Bob Brunton,25
-Santa Clara,State Assembly,25,1444,Rep,Bob Brunton,194
-Santa Clara,State Assembly,25,1446,Rep,Bob Brunton,263
-Santa Clara,State Assembly,25,1447,Rep,Bob Brunton,129
-Santa Clara,State Assembly,25,1448,Rep,Bob Brunton,227
-Santa Clara,State Assembly,25,1451,Rep,Bob Brunton,214
-Santa Clara,State Assembly,25,1453,Rep,Bob Brunton,140
-Santa Clara,State Assembly,25,1455,Rep,Bob Brunton,214
-Santa Clara,State Assembly,25,1459,Rep,Bob Brunton,193
-Santa Clara,State Assembly,25,1461,Rep,Bob Brunton,119
-Santa Clara,State Assembly,25,1465,Rep,Bob Brunton,130
-Santa Clara,State Assembly,25,1467,Rep,Bob Brunton,153
-Santa Clara,State Assembly,25,1468,Rep,Bob Brunton,214
-Santa Clara,State Assembly,25,1470,Rep,Bob Brunton,114
-Santa Clara,State Assembly,25,1478,Rep,Bob Brunton,151
-Santa Clara,State Assembly,25,1480,Rep,Bob Brunton,104
-Santa Clara,State Assembly,25,1497,Rep,Bob Brunton,76
-Santa Clara,State Assembly,25,1501,Rep,Bob Brunton,28
-Santa Clara,State Assembly,25,1502,Rep,Bob Brunton,3
-Santa Clara,State Assembly,27,1504,Rep,Burt Lancaster,32
-Santa Clara,State Assembly,27,1506,Rep,Burt Lancaster,18
-Santa Clara,State Assembly,27,1508,Rep,Burt Lancaster,24
-Santa Clara,State Assembly,27,1510,Rep,Burt Lancaster,43
-Santa Clara,State Assembly,27,1512,Rep,Burt Lancaster,23
-Santa Clara,State Assembly,25,1515,Rep,Bob Brunton,108
-Santa Clara,State Assembly,27,1516,Rep,Burt Lancaster,22
-Santa Clara,State Assembly,27,1518,Rep,Burt Lancaster,16
-Santa Clara,State Assembly,27,1519,Rep,Burt Lancaster,14
-Santa Clara,State Assembly,27,1521,Rep,Burt Lancaster,24
-Santa Clara,State Assembly,27,1522,Rep,Burt Lancaster,20
-Santa Clara,State Assembly,27,1523,Rep,Burt Lancaster,8
-Santa Clara,State Assembly,27,1525,Rep,Burt Lancaster,10
-Santa Clara,State Assembly,27,1526,Rep,Burt Lancaster,15
-Santa Clara,State Assembly,27,1527,Rep,Burt Lancaster,24
-Santa Clara,State Assembly,27,1529,Rep,Burt Lancaster,31
-Santa Clara,State Assembly,27,1530,Rep,Burt Lancaster,10
-Santa Clara,State Assembly,27,1531,Rep,Burt Lancaster,11
-Santa Clara,State Assembly,25,1533,Rep,Bob Brunton,106
-Santa Clara,State Assembly,27,1534,Rep,Burt Lancaster,12
-Santa Clara,State Assembly,27,1535,Rep,Burt Lancaster,23
-Santa Clara,State Assembly,27,1536,Rep,Burt Lancaster,24
-Santa Clara,State Assembly,27,1537,Rep,Burt Lancaster,28
-Santa Clara,State Assembly,27,1539,Rep,Burt Lancaster,16
-Santa Clara,State Assembly,27,1542,Rep,Burt Lancaster,17
-Santa Clara,State Assembly,27,1544,Rep,Burt Lancaster,28
-Santa Clara,State Assembly,25,1546,Rep,Bob Brunton,88
-Santa Clara,State Assembly,25,1548,Rep,Bob Brunton,28
-Santa Clara,State Assembly,27,1550,Rep,Burt Lancaster,0
-Santa Clara,State Assembly,27,1551,Rep,Burt Lancaster,36
-Santa Clara,State Assembly,27,1553,Rep,Burt Lancaster,8
-Santa Clara,State Assembly,27,1556,Rep,Burt Lancaster,12
-Santa Clara,State Assembly,25,1557,Rep,Bob Brunton,175
-Santa Clara,State Assembly,25,1558,Rep,Bob Brunton,227
-Santa Clara,State Assembly,27,1567,Rep,Burt Lancaster,0
-Santa Clara,State Assembly,27,1569,Rep,Burt Lancaster,0
-Santa Clara,State Assembly,25,1570,Rep,Bob Brunton,0
-Santa Clara,State Assembly,28,1571,Rep,Michael Snyder,4
-Santa Clara,State Assembly,28,1572,Rep,Michael Snyder,9
-Santa Clara,State Assembly,28,1574,Rep,Michael Snyder,0
-Santa Clara,State Assembly,27,1577,Rep,Burt Lancaster,14
-Santa Clara,State Assembly,27,1578,Rep,Burt Lancaster,0
-Santa Clara,State Assembly,27,1583,Rep,Burt Lancaster,9
-Santa Clara,State Assembly,27,1584,Rep,Burt Lancaster,16
-Santa Clara,State Assembly,28,1586,Rep,Michael Snyder,4
-Santa Clara,State Assembly,28,1587,Rep,Michael Snyder,2
-Santa Clara,State Assembly,28,1588,Rep,Michael Snyder,239
-Santa Clara,State Assembly,27,1589,Rep,Burt Lancaster,10
-Santa Clara,State Assembly,27,1590,Rep,Burt Lancaster,20
-Santa Clara,State Assembly,27,1591,Rep,Burt Lancaster,0
-Santa Clara,State Assembly,28,1592,Rep,Michael Snyder,57
-Santa Clara,State Assembly,25,1593,Rep,Bob Brunton,45
-Santa Clara,State Assembly,27,1595,Rep,Burt Lancaster,0
-Santa Clara,State Assembly,27,1597,Rep,Burt Lancaster,20
-Santa Clara,State Assembly,27,1599,Rep,Burt Lancaster,20
-Santa Clara,State Assembly,28,1600,Rep,Michael Snyder,128
-Santa Clara,State Assembly,28,1601,Rep,Michael Snyder,192
-Santa Clara,State Assembly,28,1602,Rep,Michael Snyder,171
-Santa Clara,State Assembly,28,1603,Rep,Michael Snyder,244
-Santa Clara,State Assembly,28,1606,Rep,Michael Snyder,161
-Santa Clara,State Assembly,28,1607,Rep,Michael Snyder,191
-Santa Clara,State Assembly,28,1609,Rep,Michael Snyder,183
-Santa Clara,State Assembly,28,1612,Rep,Michael Snyder,165
-Santa Clara,State Assembly,28,1613,Rep,Michael Snyder,155
-Santa Clara,State Assembly,28,1615,Rep,Michael Snyder,200
-Santa Clara,State Assembly,28,1616,Rep,Michael Snyder,233
-Santa Clara,State Assembly,28,1619,Rep,Michael Snyder,10
-Santa Clara,State Assembly,28,1620,Rep,Michael Snyder,263
-Santa Clara,State Assembly,28,1621,Rep,Michael Snyder,87
-Santa Clara,State Assembly,28,1623,Rep,Michael Snyder,205
-Santa Clara,State Assembly,27,1625,Rep,Burt Lancaster,23
-Santa Clara,State Assembly,28,1626,Rep,Michael Snyder,43
-Santa Clara,State Assembly,28,1629,Rep,Michael Snyder,111
-Santa Clara,State Assembly,28,1630,Rep,Michael Snyder,142
-Santa Clara,State Assembly,28,1631,Rep,Michael Snyder,265
-Santa Clara,State Assembly,28,1632,Rep,Michael Snyder,134
-Santa Clara,State Assembly,28,1634,Rep,Michael Snyder,161
-Santa Clara,State Assembly,28,1635,Rep,Michael Snyder,153
-Santa Clara,State Assembly,28,1636,Rep,Michael Snyder,179
-Santa Clara,State Assembly,28,1640,Rep,Michael Snyder,233
-Santa Clara,State Assembly,28,1641,Rep,Michael Snyder,134
-Santa Clara,State Assembly,28,1643,Rep,Michael Snyder,133
-Santa Clara,State Assembly,28,1644,Rep,Michael Snyder,227
-Santa Clara,State Assembly,28,1646,Rep,Michael Snyder,205
-Santa Clara,State Assembly,28,1648,Rep,Michael Snyder,376
-Santa Clara,State Assembly,28,1649,Rep,Michael Snyder,310
-Santa Clara,State Assembly,28,1654,Rep,Michael Snyder,206
-Santa Clara,State Assembly,28,1656,Rep,Michael Snyder,292
-Santa Clara,State Assembly,28,1658,Rep,Michael Snyder,249
-Santa Clara,State Assembly,27,1661,Rep,Burt Lancaster,32
-Santa Clara,State Assembly,28,1662,Rep,Michael Snyder,82
-Santa Clara,State Assembly,28,1663,Rep,Michael Snyder,116
-Santa Clara,State Assembly,28,1664,Rep,Michael Snyder,201
-Santa Clara,State Assembly,28,1666,Rep,Michael Snyder,230
-Santa Clara,State Assembly,28,1671,Rep,Michael Snyder,231
-Santa Clara,State Assembly,28,1672,Rep,Michael Snyder,225
-Santa Clara,State Assembly,28,1674,Rep,Michael Snyder,310
-Santa Clara,State Assembly,28,1677,Rep,Michael Snyder,134
-Santa Clara,State Assembly,27,1678,Rep,Burt Lancaster,27
-Santa Clara,State Assembly,28,1679,Rep,Michael Snyder,7
-Santa Clara,State Assembly,28,1683,Rep,Michael Snyder,117
-Santa Clara,State Assembly,27,1685,Rep,Burt Lancaster,6
-Santa Clara,State Assembly,28,1687,Rep,Michael Snyder,118
-Santa Clara,State Assembly,27,1696,Rep,Burt Lancaster,27
-Santa Clara,State Assembly,27,1699,Rep,Burt Lancaster,21
-Santa Clara,State Assembly,27,1700,Rep,Burt Lancaster,47
-Santa Clara,State Assembly,27,1701,Rep,Burt Lancaster,19
-Santa Clara,State Assembly,27,1702,Rep,Burt Lancaster,40
-Santa Clara,State Assembly,27,1703,Rep,Burt Lancaster,40
-Santa Clara,State Assembly,27,1704,Rep,Burt Lancaster,39
-Santa Clara,State Assembly,27,1706,Rep,Burt Lancaster,34
-Santa Clara,State Assembly,27,1707,Rep,Burt Lancaster,12
-Santa Clara,State Assembly,27,1708,Rep,Burt Lancaster,40
-Santa Clara,State Assembly,27,1709,Rep,Burt Lancaster,14
-Santa Clara,State Assembly,27,1710,Rep,Burt Lancaster,17
-Santa Clara,State Assembly,27,1711,Rep,Burt Lancaster,35
-Santa Clara,State Assembly,27,1712,Rep,Burt Lancaster,32
-Santa Clara,State Assembly,27,1715,Rep,Burt Lancaster,28
-Santa Clara,State Assembly,27,1716,Rep,Burt Lancaster,25
-Santa Clara,State Assembly,27,1717,Rep,Burt Lancaster,29
-Santa Clara,State Assembly,27,1718,Rep,Burt Lancaster,23
-Santa Clara,State Assembly,27,1719,Rep,Burt Lancaster,34
-Santa Clara,State Assembly,27,1722,Rep,Burt Lancaster,10
-Santa Clara,State Assembly,27,1723,Rep,Burt Lancaster,25
-Santa Clara,State Assembly,27,1724,Rep,Burt Lancaster,31
-Santa Clara,State Assembly,27,1726,Rep,Burt Lancaster,21
-Santa Clara,State Assembly,27,1728,Rep,Burt Lancaster,17
-Santa Clara,State Assembly,27,1729,Rep,Burt Lancaster,36
-Santa Clara,State Assembly,27,1730,Rep,Burt Lancaster,10
-Santa Clara,State Assembly,27,1732,Rep,Burt Lancaster,15
-Santa Clara,State Assembly,27,1734,Rep,Burt Lancaster,38
-Santa Clara,State Assembly,27,1735,Rep,Burt Lancaster,19
-Santa Clara,State Assembly,27,1736,Rep,Burt Lancaster,25
-Santa Clara,State Assembly,27,1737,Rep,Burt Lancaster,20
-Santa Clara,State Assembly,27,1743,Rep,Burt Lancaster,58
-Santa Clara,State Assembly,27,1744,Rep,Burt Lancaster,42
-Santa Clara,State Assembly,27,1751,Rep,Burt Lancaster,58
-Santa Clara,State Assembly,28,1753,Rep,Michael Snyder,278
-Santa Clara,State Assembly,28,1755,Rep,Michael Snyder,246
-Santa Clara,State Assembly,27,1757,Rep,Burt Lancaster,12
-Santa Clara,State Assembly,27,1767,Rep,Burt Lancaster,12
-Santa Clara,State Assembly,27,1775,Rep,Burt Lancaster,8
-Santa Clara,State Assembly,27,1778,Rep,Burt Lancaster,61
-Santa Clara,State Assembly,27,1780,Rep,Burt Lancaster,46
-Santa Clara,State Assembly,27,1781,Rep,Burt Lancaster,56
-Santa Clara,State Assembly,27,1782,Rep,Burt Lancaster,0
-Santa Clara,State Assembly,27,1783,Rep,Burt Lancaster,45
-Santa Clara,State Assembly,27,1784,Rep,Burt Lancaster,43
-Santa Clara,State Assembly,27,1785,Rep,Burt Lancaster,31
-Santa Clara,State Assembly,27,1786,Rep,Burt Lancaster,57
-Santa Clara,State Assembly,27,1787,Rep,Burt Lancaster,54
-Santa Clara,State Assembly,27,1788,Rep,Burt Lancaster,41
-Santa Clara,State Assembly,27,1789,Rep,Burt Lancaster,27
-Santa Clara,State Assembly,27,1790,Rep,Burt Lancaster,53
-Santa Clara,State Assembly,27,1792,Rep,Burt Lancaster,28
-Santa Clara,State Assembly,27,1793,Rep,Burt Lancaster,60
-Santa Clara,State Assembly,27,1795,Rep,Burt Lancaster,48
-Santa Clara,State Assembly,27,1796,Rep,Burt Lancaster,40
-Santa Clara,State Assembly,27,1797,Rep,Burt Lancaster,23
-Santa Clara,State Assembly,27,1798,Rep,Burt Lancaster,16
-Santa Clara,State Assembly,27,1799,Rep,Burt Lancaster,40
-Santa Clara,State Assembly,27,1800,Rep,Burt Lancaster,41
-Santa Clara,State Assembly,25,1801,Rep,Bob Brunton,9
-Santa Clara,State Assembly,27,1805,Rep,Burt Lancaster,22
-Santa Clara,State Assembly,27,1811,Rep,Burt Lancaster,24
-Santa Clara,State Assembly,27,1813,Rep,Burt Lancaster,10
-Santa Clara,State Assembly,27,1817,Rep,Burt Lancaster,43
-Santa Clara,State Assembly,27,1818,Rep,Burt Lancaster,41
-Santa Clara,State Assembly,27,1820,Rep,Burt Lancaster,35
-Santa Clara,State Assembly,27,1821,Rep,Burt Lancaster,30
-Santa Clara,State Assembly,27,1822,Rep,Burt Lancaster,61
-Santa Clara,State Assembly,27,1824,Rep,Burt Lancaster,30
-Santa Clara,State Assembly,27,1826,Rep,Burt Lancaster,40
-Santa Clara,State Assembly,27,1829,Rep,Burt Lancaster,36
-Santa Clara,State Assembly,27,1830,Rep,Burt Lancaster,46
-Santa Clara,State Assembly,27,1831,Rep,Burt Lancaster,22
-Santa Clara,State Assembly,27,1832,Rep,Burt Lancaster,45
-Santa Clara,State Assembly,27,1838,Rep,Burt Lancaster,19
-Santa Clara,State Assembly,27,1839,Rep,Burt Lancaster,59
-Santa Clara,State Assembly,27,1841,Rep,Burt Lancaster,34
-Santa Clara,State Assembly,27,1842,Rep,Burt Lancaster,39
-Santa Clara,State Assembly,27,1843,Rep,Burt Lancaster,21
-Santa Clara,State Assembly,27,1844,Rep,Burt Lancaster,40
-Santa Clara,State Assembly,27,1846,Rep,Burt Lancaster,13
-Santa Clara,State Assembly,27,1848,Rep,Burt Lancaster,20
-Santa Clara,State Assembly,27,1850,Rep,Burt Lancaster,39
-Santa Clara,State Assembly,27,1852,Rep,Burt Lancaster,21
-Santa Clara,State Assembly,27,1853,Rep,Burt Lancaster,0
-Santa Clara,State Assembly,27,1856,Rep,Burt Lancaster,33
-Santa Clara,State Assembly,27,1859,Rep,Burt Lancaster,30
-Santa Clara,State Assembly,27,1860,Rep,Burt Lancaster,14
-Santa Clara,State Assembly,27,1861,Rep,Burt Lancaster,5
-Santa Clara,State Assembly,27,1863,Rep,Burt Lancaster,30
-Santa Clara,State Assembly,27,1865,Rep,Burt Lancaster,42
-Santa Clara,State Assembly,27,1866,Rep,Burt Lancaster,33
-Santa Clara,State Assembly,27,1871,Rep,Burt Lancaster,34
-Santa Clara,State Assembly,27,1882,Rep,Burt Lancaster,44
-Santa Clara,State Assembly,27,1886,Rep,Burt Lancaster,26
-Santa Clara,State Assembly,27,1888,Rep,Burt Lancaster,22
-Santa Clara,State Assembly,27,1897,Rep,Burt Lancaster,17
-Santa Clara,State Assembly,27,1898,Rep,Burt Lancaster,18
-Santa Clara,State Assembly,28,1901,Rep,Michael Snyder,112
-Santa Clara,State Assembly,28,1902,Rep,Michael Snyder,248
-Santa Clara,State Assembly,28,1903,Rep,Michael Snyder,194
-Santa Clara,State Assembly,28,1904,Rep,Michael Snyder,256
-Santa Clara,State Assembly,28,1907,Rep,Michael Snyder,183
-Santa Clara,State Assembly,28,1909,Rep,Michael Snyder,254
-Santa Clara,State Assembly,28,1911,Rep,Michael Snyder,201
-Santa Clara,State Assembly,28,1913,Rep,Michael Snyder,187
-Santa Clara,State Assembly,28,1914,Rep,Michael Snyder,148
-Santa Clara,State Assembly,28,1916,Rep,Michael Snyder,328
-Santa Clara,State Assembly,28,1918,Rep,Michael Snyder,247
-Santa Clara,State Assembly,28,1919,Rep,Michael Snyder,119
-Santa Clara,State Assembly,28,1920,Rep,Michael Snyder,266
-Santa Clara,State Assembly,28,1922,Rep,Michael Snyder,338
-Santa Clara,State Assembly,28,1925,Rep,Michael Snyder,167
-Santa Clara,State Assembly,28,1928,Rep,Michael Snyder,225
-Santa Clara,State Assembly,28,1929,Rep,Michael Snyder,247
-Santa Clara,State Assembly,28,1930,Rep,Michael Snyder,163
-Santa Clara,State Assembly,28,1932,Rep,Michael Snyder,240
-Santa Clara,State Assembly,28,1934,Rep,Michael Snyder,277
-Santa Clara,State Assembly,28,1936,Rep,Michael Snyder,286
-Santa Clara,State Assembly,28,1937,Rep,Michael Snyder,256
-Santa Clara,State Assembly,28,1939,Rep,Michael Snyder,225
-Santa Clara,State Assembly,28,1944,Rep,Michael Snyder,237
-Santa Clara,State Assembly,28,1945,Rep,Michael Snyder,201
-Santa Clara,State Assembly,28,1947,Rep,Michael Snyder,224
-Santa Clara,State Assembly,28,1949,Rep,Michael Snyder,295
-Santa Clara,State Assembly,28,1952,Rep,Michael Snyder,209
-Santa Clara,State Assembly,28,1953,Rep,Michael Snyder,198
-Santa Clara,State Assembly,28,1954,Rep,Michael Snyder,276
-Santa Clara,State Assembly,28,1958,Rep,Michael Snyder,140
-Santa Clara,State Assembly,28,1959,Rep,Michael Snyder,83
-Santa Clara,State Assembly,28,1960,Rep,Michael Snyder,267
-Santa Clara,State Assembly,28,1961,Rep,Michael Snyder,43
-Santa Clara,State Assembly,28,1962,Rep,Michael Snyder,116
-Santa Clara,State Assembly,28,1964,Rep,Michael Snyder,136
-Santa Clara,State Assembly,28,1966,Rep,Michael Snyder,182
-Santa Clara,State Assembly,28,1968,Rep,Michael Snyder,8
-Santa Clara,State Assembly,27,1977,Rep,Burt Lancaster,11
-Santa Clara,State Assembly,27,1982,Rep,Burt Lancaster,17
-Santa Clara,State Assembly,28,1990,Rep,Michael Snyder,22
-Santa Clara,State Assembly,27,1991,Rep,Burt Lancaster,11
-Santa Clara,State Assembly,28,1994,Rep,Michael Snyder,72
-Santa Clara,State Assembly,28,1996,Rep,Michael Snyder,20
-Santa Clara,State Assembly,24,2001,Rep,Alex Glew,3
-Santa Clara,State Assembly,24,2002,Rep,Alex Glew,173
-Santa Clara,State Assembly,24,2003,Rep,Alex Glew,125
-Santa Clara,State Assembly,24,2004,Rep,Alex Glew,196
-Santa Clara,State Assembly,24,2005,Rep,Alex Glew,142
-Santa Clara,State Assembly,24,2006,Rep,Alex Glew,18
-Santa Clara,State Assembly,24,2009,Rep,Alex Glew,137
-Santa Clara,State Assembly,24,2013,Rep,Alex Glew,197
-Santa Clara,State Assembly,24,2014,Rep,Alex Glew,192
-Santa Clara,State Assembly,24,2015,Rep,Alex Glew,238
-Santa Clara,State Assembly,24,2018,Rep,Alex Glew,33
-Santa Clara,State Assembly,24,2019,Rep,Alex Glew,141
-Santa Clara,State Assembly,24,2025,Rep,Alex Glew,231
-Santa Clara,State Assembly,24,2028,Rep,Alex Glew,147
-Santa Clara,State Assembly,24,2034,Rep,Alex Glew,189
-Santa Clara,State Assembly,24,2043,Rep,Alex Glew,224
-Santa Clara,State Assembly,24,2046,Rep,Alex Glew,196
-Santa Clara,State Assembly,24,2049,Rep,Alex Glew,62
-Santa Clara,State Assembly,24,2056,Rep,Alex Glew,167
-Santa Clara,State Assembly,24,2061,Rep,Alex Glew,137
-Santa Clara,State Assembly,24,2065,Rep,Alex Glew,131
-Santa Clara,State Assembly,24,2068,Rep,Alex Glew,234
-Santa Clara,State Assembly,24,2069,Rep,Alex Glew,157
-Santa Clara,State Assembly,24,2081,Rep,Alex Glew,221
-Santa Clara,State Assembly,24,2090,Rep,Alex Glew,137
-Santa Clara,State Assembly,24,2096,Rep,Alex Glew,127
-Santa Clara,State Assembly,24,2098,Rep,Alex Glew,102
-Santa Clara,State Assembly,24,2101,Rep,Alex Glew,123
-Santa Clara,State Assembly,24,2102,Rep,Alex Glew,98
-Santa Clara,State Assembly,24,2107,Rep,Alex Glew,155
-Santa Clara,State Assembly,24,2108,Rep,Alex Glew,167
-Santa Clara,State Assembly,24,2110,Rep,Alex Glew,123
-Santa Clara,State Assembly,24,2112,Rep,Alex Glew,194
-Santa Clara,State Assembly,24,2114,Rep,Alex Glew,112
-Santa Clara,State Assembly,24,2115,Rep,Alex Glew,213
-Santa Clara,State Assembly,24,2117,Rep,Alex Glew,103
-Santa Clara,State Assembly,24,2120,Rep,Alex Glew,183
-Santa Clara,State Assembly,24,2124,Rep,Alex Glew,64
-Santa Clara,State Assembly,24,2125,Rep,Alex Glew,53
-Santa Clara,State Assembly,24,2126,Rep,Alex Glew,7
-Santa Clara,State Assembly,24,2129,Rep,Alex Glew,76
-Santa Clara,State Assembly,24,2301,Rep,Alex Glew,258
-Santa Clara,State Assembly,24,2305,Rep,Alex Glew,162
-Santa Clara,State Assembly,24,2306,Rep,Alex Glew,179
-Santa Clara,State Assembly,24,2307,Rep,Alex Glew,148
-Santa Clara,State Assembly,24,2309,Rep,Alex Glew,305
-Santa Clara,State Assembly,24,2310,Rep,Alex Glew,193
-Santa Clara,State Assembly,24,2311,Rep,Alex Glew,297
-Santa Clara,State Assembly,24,2314,Rep,Alex Glew,179
-Santa Clara,State Assembly,24,2316,Rep,Alex Glew,219
-Santa Clara,State Assembly,24,2317,Rep,Alex Glew,304
-Santa Clara,State Assembly,24,2321,Rep,Alex Glew,297
-Santa Clara,State Assembly,24,2323,Rep,Alex Glew,161
-Santa Clara,State Assembly,24,2326,Rep,Alex Glew,179
-Santa Clara,State Assembly,24,2330,Rep,Alex Glew,165
-Santa Clara,State Assembly,24,2333,Rep,Alex Glew,181
-Santa Clara,State Assembly,24,2338,Rep,Alex Glew,30
-Santa Clara,State Assembly,24,2339,Rep,Alex Glew,299
-Santa Clara,State Assembly,24,2343,Rep,Alex Glew,191
-Santa Clara,State Assembly,24,2345,Rep,Alex Glew,177
-Santa Clara,State Assembly,24,2351,Rep,Alex Glew,294
-Santa Clara,State Assembly,24,2352,Rep,Alex Glew,252
-Santa Clara,State Assembly,24,2357,Rep,Alex Glew,180
-Santa Clara,State Assembly,24,2374,Rep,Alex Glew,58
-Santa Clara,State Assembly,24,2375,Rep,Alex Glew,335
-Santa Clara,State Assembly,24,2378,Rep,Alex Glew,261
-Santa Clara,State Assembly,24,2381,Rep,Alex Glew,2
-Santa Clara,State Assembly,24,2382,Rep,Alex Glew,329
-Santa Clara,State Assembly,24,2385,Rep,Alex Glew,358
-Santa Clara,State Assembly,24,2389,Rep,Alex Glew,314
-Santa Clara,State Assembly,24,2402,Rep,Alex Glew,113
-Santa Clara,State Assembly,24,2403,Rep,Alex Glew,154
-Santa Clara,State Assembly,24,2406,Rep,Alex Glew,168
-Santa Clara,State Assembly,24,2407,Rep,Alex Glew,113
-Santa Clara,State Assembly,24,2408,Rep,Alex Glew,168
-Santa Clara,State Assembly,24,2409,Rep,Alex Glew,243
-Santa Clara,State Assembly,24,2410,Rep,Alex Glew,210
-Santa Clara,State Assembly,24,2412,Rep,Alex Glew,176
-Santa Clara,State Assembly,24,2413,Rep,Alex Glew,116
-Santa Clara,State Assembly,24,2414,Rep,Alex Glew,145
-Santa Clara,State Assembly,24,2417,Rep,Alex Glew,214
-Santa Clara,State Assembly,24,2418,Rep,Alex Glew,176
-Santa Clara,State Assembly,24,2419,Rep,Alex Glew,111
-Santa Clara,State Assembly,24,2427,Rep,Alex Glew,120
-Santa Clara,State Assembly,24,2428,Rep,Alex Glew,158
-Santa Clara,State Assembly,24,2431,Rep,Alex Glew,60
-Santa Clara,State Assembly,24,2434,Rep,Alex Glew,164
-Santa Clara,State Assembly,24,2436,Rep,Alex Glew,203
-Santa Clara,State Assembly,24,2438,Rep,Alex Glew,175
-Santa Clara,State Assembly,24,2439,Rep,Alex Glew,159
-Santa Clara,State Assembly,24,2440,Rep,Alex Glew,170
-Santa Clara,State Assembly,24,2442,Rep,Alex Glew,118
-Santa Clara,State Assembly,24,2445,Rep,Alex Glew,169
-Santa Clara,State Assembly,24,2452,Rep,Alex Glew,84
-Santa Clara,State Assembly,24,2457,Rep,Alex Glew,142
-Santa Clara,State Assembly,24,2459,Rep,Alex Glew,97
-Santa Clara,State Assembly,24,2460,Rep,Alex Glew,198
-Santa Clara,State Assembly,24,2464,Rep,Alex Glew,83
-Santa Clara,State Assembly,24,2465,Rep,Alex Glew,142
-Santa Clara,State Assembly,24,2467,Rep,Alex Glew,173
-Santa Clara,State Assembly,24,2475,Rep,Alex Glew,156
-Santa Clara,State Assembly,24,2479,Rep,Alex Glew,163
-Santa Clara,State Assembly,24,2489,Rep,Alex Glew,175
-Santa Clara,State Assembly,24,2492,Rep,Alex Glew,181
-Santa Clara,State Assembly,24,2494,Rep,Alex Glew,115
-Santa Clara,State Assembly,24,2539,Rep,Alex Glew,10
-Santa Clara,State Assembly,24,2540,Rep,Alex Glew,9
-Santa Clara,State Assembly,24,2542,Rep,Alex Glew,76
-Santa Clara,State Assembly,24,2544,Rep,Alex Glew,101
-Santa Clara,State Assembly,24,2545,Rep,Alex Glew,56
-Santa Clara,State Assembly,24,2546,Rep,Alex Glew,46
-Santa Clara,State Assembly,24,2802,Rep,Alex Glew,313
-Santa Clara,State Assembly,28,2808,Rep,Michael Snyder,1
-Santa Clara,State Assembly,28,2811,Rep,Michael Snyder,8
-Santa Clara,State Assembly,24,2812,Rep,Alex Glew,67
-Santa Clara,State Assembly,28,2813,Rep,Michael Snyder,69
-Santa Clara,State Assembly,28,2816,Rep,Michael Snyder,2
-Santa Clara,State Assembly,24,2825,Rep,Alex Glew,3
-Santa Clara,State Assembly,24,2833,Rep,Alex Glew,310
-Santa Clara,State Assembly,24,2870,Rep,Alex Glew,21
-Santa Clara,State Assembly,24,2871,Rep,Alex Glew,2
-Santa Clara,State Assembly,24,2873,Rep,Alex Glew,0
-Santa Clara,State Assembly,24,2951,Rep,Alex Glew,28
-Santa Clara,State Assembly,24,2953,Rep,Alex Glew,16
-Santa Clara,State Assembly,24,3601,Rep,Alex Glew,93
-Santa Clara,State Assembly,28,3602,Rep,Michael Snyder,258
-Santa Clara,State Assembly,24,3603,Rep,Alex Glew,77
-Santa Clara,State Assembly,28,3604,Rep,Michael Snyder,164
-Santa Clara,State Assembly,28,3605,Rep,Michael Snyder,131
-Santa Clara,State Assembly,28,3606,Rep,Michael Snyder,275
-Santa Clara,State Assembly,24,3607,Rep,Alex Glew,193
-Santa Clara,State Assembly,28,3608,Rep,Michael Snyder,242
-Santa Clara,State Assembly,28,3609,Rep,Michael Snyder,272
-Santa Clara,State Assembly,28,3610,Rep,Michael Snyder,218
-Santa Clara,State Assembly,28,3612,Rep,Michael Snyder,289
-Santa Clara,State Assembly,28,3614,Rep,Michael Snyder,197
-Santa Clara,State Assembly,28,3615,Rep,Michael Snyder,195
-Santa Clara,State Assembly,28,3616,Rep,Michael Snyder,229
-Santa Clara,State Assembly,28,3620,Rep,Michael Snyder,295
-Santa Clara,State Assembly,28,3621,Rep,Michael Snyder,176
-Santa Clara,State Assembly,28,3624,Rep,Michael Snyder,161
-Santa Clara,State Assembly,28,3627,Rep,Michael Snyder,92
-Santa Clara,State Assembly,28,3628,Rep,Michael Snyder,245
-Santa Clara,State Assembly,28,3629,Rep,Michael Snyder,236
-Santa Clara,State Assembly,28,3633,Rep,Michael Snyder,244
-Santa Clara,State Assembly,28,3635,Rep,Michael Snyder,15
-Santa Clara,State Assembly,28,3636,Rep,Michael Snyder,256
-Santa Clara,State Assembly,28,3640,Rep,Michael Snyder,209
-Santa Clara,State Assembly,28,3642,Rep,Michael Snyder,239
-Santa Clara,State Assembly,28,3645,Rep,Michael Snyder,167
-Santa Clara,State Assembly,24,3650,Rep,Alex Glew,216
-Santa Clara,State Assembly,28,3652,Rep,Michael Snyder,226
-Santa Clara,State Assembly,24,3658,Rep,Alex Glew,4
-Santa Clara,State Assembly,28,3663,Rep,Michael Snyder,27
-Santa Clara,State Assembly,28,3720,Rep,Michael Snyder,222
-Santa Clara,State Assembly,28,3721,Rep,Michael Snyder,367
-Santa Clara,State Assembly,28,3723,Rep,Michael Snyder,20
-Santa Clara,State Assembly,28,3724,Rep,Michael Snyder,337
-Santa Clara,State Assembly,28,3725,Rep,Michael Snyder,170
-Santa Clara,State Assembly,28,3726,Rep,Michael Snyder,199
-Santa Clara,State Assembly,28,3727,Rep,Michael Snyder,30
-Santa Clara,State Assembly,28,3728,Rep,Michael Snyder,0
-Santa Clara,State Assembly,28,3729,Rep,Michael Snyder,218
-Santa Clara,State Assembly,28,3731,Rep,Michael Snyder,193
-Santa Clara,State Assembly,28,3733,Rep,Michael Snyder,194
-Santa Clara,State Assembly,28,3734,Rep,Michael Snyder,191
-Santa Clara,State Assembly,28,3737,Rep,Michael Snyder,321
-Santa Clara,State Assembly,28,3740,Rep,Michael Snyder,267
-Santa Clara,State Assembly,28,3741,Rep,Michael Snyder,167
-Santa Clara,State Assembly,28,3745,Rep,Michael Snyder,319
-Santa Clara,State Assembly,28,3749,Rep,Michael Snyder,156
-Santa Clara,State Assembly,28,3751,Rep,Michael Snyder,5
-Santa Clara,State Assembly,28,3753,Rep,Michael Snyder,255
-Santa Clara,State Assembly,28,3754,Rep,Michael Snyder,197
-Santa Clara,State Assembly,28,3757,Rep,Michael Snyder,195
-Santa Clara,State Assembly,28,3761,Rep,Michael Snyder,1
-Santa Clara,State Assembly,28,3767,Rep,Michael Snyder,166
-Santa Clara,State Assembly,28,3771,Rep,Michael Snyder,162
-Santa Clara,State Assembly,28,3772,Rep,Michael Snyder,140
-Santa Clara,State Assembly,28,3774,Rep,Michael Snyder,296
-Santa Clara,State Assembly,28,3781,Rep,Michael Snyder,307
-Santa Clara,State Assembly,28,3782,Rep,Michael Snyder,127
-Santa Clara,State Assembly,28,3784,Rep,Michael Snyder,43
-Santa Clara,State Assembly,28,3785,Rep,Michael Snyder,251
-Santa Clara,State Assembly,28,3787,Rep,Michael Snyder,10
-Santa Clara,State Assembly,28,3801,Rep,Michael Snyder,200
-Santa Clara,State Assembly,28,3802,Rep,Michael Snyder,194
-Santa Clara,State Assembly,28,3803,Rep,Michael Snyder,166
-Santa Clara,State Assembly,28,3804,Rep,Michael Snyder,166
-Santa Clara,State Assembly,28,3805,Rep,Michael Snyder,184
-Santa Clara,State Assembly,28,3806,Rep,Michael Snyder,177
-Santa Clara,State Assembly,28,3809,Rep,Michael Snyder,164
-Santa Clara,State Assembly,28,3810,Rep,Michael Snyder,197
-Santa Clara,State Assembly,28,3812,Rep,Michael Snyder,161
-Santa Clara,State Assembly,28,3814,Rep,Michael Snyder,229
-Santa Clara,State Assembly,28,3818,Rep,Michael Snyder,177
-Santa Clara,State Assembly,28,3819,Rep,Michael Snyder,226
-Santa Clara,State Assembly,28,3820,Rep,Michael Snyder,205
-Santa Clara,State Assembly,28,3821,Rep,Michael Snyder,112
-Santa Clara,State Assembly,28,3823,Rep,Michael Snyder,167
-Santa Clara,State Assembly,28,3825,Rep,Michael Snyder,136
-Santa Clara,State Assembly,28,3826,Rep,Michael Snyder,143
-Santa Clara,State Assembly,28,3828,Rep,Michael Snyder,249
-Santa Clara,State Assembly,28,3834,Rep,Michael Snyder,228
-Santa Clara,State Assembly,28,3835,Rep,Michael Snyder,244
-Santa Clara,State Assembly,28,3840,Rep,Michael Snyder,236
-Santa Clara,State Assembly,28,3843,Rep,Michael Snyder,261
-Santa Clara,State Assembly,28,3846,Rep,Michael Snyder,24
-Santa Clara,State Assembly,30,3900,Rep,Neil Kitchens,263
-Santa Clara,State Assembly,30,3901,Rep,Neil Kitchens,417
-Santa Clara,State Assembly,30,3902,Rep,Neil Kitchens,270
-Santa Clara,State Assembly,30,3903,Rep,Neil Kitchens,278
-Santa Clara,State Assembly,30,3906,Rep,Neil Kitchens,255
-Santa Clara,State Assembly,30,3907,Rep,Neil Kitchens,175
-Santa Clara,State Assembly,30,3908,Rep,Neil Kitchens,22
-Santa Clara,State Assembly,30,3909,Rep,Neil Kitchens,355
-Santa Clara,State Assembly,30,3910,Rep,Neil Kitchens,98
-Santa Clara,State Assembly,30,3911,Rep,Neil Kitchens,98
-Santa Clara,State Assembly,30,3912,Rep,Neil Kitchens,191
-Santa Clara,State Assembly,30,3914,Rep,Neil Kitchens,198
-Santa Clara,State Assembly,30,3916,Rep,Neil Kitchens,230
-Santa Clara,State Assembly,30,3918,Rep,Neil Kitchens,241
-Santa Clara,State Assembly,30,3921,Rep,Neil Kitchens,305
-Santa Clara,State Assembly,30,3922,Rep,Neil Kitchens,214
-Santa Clara,State Assembly,30,3923,Rep,Neil Kitchens,214
-Santa Clara,State Assembly,30,3924,Rep,Neil Kitchens,344
-Santa Clara,State Assembly,30,3928,Rep,Neil Kitchens,271
-Santa Clara,State Assembly,30,3929,Rep,Neil Kitchens,207
-Santa Clara,State Assembly,30,3932,Rep,Neil Kitchens,303
-Santa Clara,State Assembly,30,3937,Rep,Neil Kitchens,313
-Santa Clara,State Assembly,30,3938,Rep,Neil Kitchens,278
-Santa Clara,State Assembly,30,3939,Rep,Neil Kitchens,218
-Santa Clara,State Assembly,30,3940,Rep,Neil Kitchens,240
-Santa Clara,State Assembly,30,3942,Rep,Neil Kitchens,142
-Santa Clara,State Assembly,30,3948,Rep,Neil Kitchens,61
-Santa Clara,State Assembly,30,3951,Rep,Neil Kitchens,153
-Santa Clara,State Assembly,30,3952,Rep,Neil Kitchens,199
-Santa Clara,State Assembly,30,3953,Rep,Neil Kitchens,283
-Santa Clara,State Assembly,30,3954,Rep,Neil Kitchens,128
-Santa Clara,State Assembly,30,3955,Rep,Neil Kitchens,220
-Santa Clara,State Assembly,30,3956,Rep,Neil Kitchens,122
-Santa Clara,State Assembly,30,3957,Rep,Neil Kitchens,202
-Santa Clara,State Assembly,30,3958,Rep,Neil Kitchens,77
-Santa Clara,State Assembly,30,3959,Rep,Neil Kitchens,329
-Santa Clara,State Assembly,30,3960,Rep,Neil Kitchens,149
-Santa Clara,State Assembly,30,3962,Rep,Neil Kitchens,116
-Santa Clara,State Assembly,30,3964,Rep,Neil Kitchens,365
-Santa Clara,State Assembly,30,3965,Rep,Neil Kitchens,251
-Santa Clara,State Assembly,30,3968,Rep,Neil Kitchens,206
-Santa Clara,State Assembly,30,3972,Rep,Neil Kitchens,183
-Santa Clara,State Assembly,30,3973,Rep,Neil Kitchens,471
-Santa Clara,State Assembly,30,3974,Rep,Neil Kitchens,123
-Santa Clara,State Assembly,30,3976,Rep,Neil Kitchens,324
-Santa Clara,State Assembly,30,3982,Rep,Neil Kitchens,346
-Santa Clara,State Assembly,30,3984,Rep,Neil Kitchens,266
-Santa Clara,State Assembly,30,3985,Rep,Neil Kitchens,165
-Santa Clara,State Assembly,30,3986,Rep,Neil Kitchens,320
-Santa Clara,State Assembly,30,3989,Rep,Neil Kitchens,345
-Santa Clara,State Assembly,30,3992,Rep,Neil Kitchens,0
-Santa Clara,State Assembly,24,4001,Rep,Alex Glew,196
-Santa Clara,State Assembly,24,4002,Rep,Alex Glew,157
-Santa Clara,State Assembly,24,4004,Rep,Alex Glew,145
-Santa Clara,State Assembly,24,4005,Rep,Alex Glew,2
-Santa Clara,State Assembly,24,4006,Rep,Alex Glew,212
-Santa Clara,State Assembly,24,4007,Rep,Alex Glew,190
-Santa Clara,State Assembly,25,4008,Rep,Bob Brunton,6
-Santa Clara,State Assembly,24,4010,Rep,Alex Glew,259
-Santa Clara,State Assembly,24,4011,Rep,Alex Glew,179
-Santa Clara,State Assembly,24,4012,Rep,Alex Glew,12
-Santa Clara,State Assembly,24,4013,Rep,Alex Glew,146
-Santa Clara,State Assembly,24,4015,Rep,Alex Glew,56
-Santa Clara,State Assembly,24,4016,Rep,Alex Glew,179
-Santa Clara,State Assembly,24,4017,Rep,Alex Glew,128
-Santa Clara,State Assembly,24,4019,Rep,Alex Glew,214
-Santa Clara,State Assembly,24,4022,Rep,Alex Glew,185
-Santa Clara,State Assembly,24,4023,Rep,Alex Glew,243
-Santa Clara,State Assembly,24,4026,Rep,Alex Glew,188
-Santa Clara,State Assembly,24,4030,Rep,Alex Glew,150
-Santa Clara,State Assembly,24,4034,Rep,Alex Glew,235
-Santa Clara,State Assembly,24,4035,Rep,Alex Glew,209
-Santa Clara,State Assembly,24,4036,Rep,Alex Glew,206
-Santa Clara,State Assembly,24,4038,Rep,Alex Glew,255
-Santa Clara,State Assembly,24,4039,Rep,Alex Glew,184
-Santa Clara,State Assembly,24,4041,Rep,Alex Glew,142
-Santa Clara,State Assembly,24,4042,Rep,Alex Glew,177
-Santa Clara,State Assembly,24,4043,,Alex Glew,163
-Santa Clara,State Assembly,24,4045,,Alex Glew,224
-Santa Clara,State Assembly,24,4047,,Alex Glew,257
-Santa Clara,State Assembly,24,4048,,Alex Glew,107
-Santa Clara,State Assembly,24,4050,,Alex Glew,174
-Santa Clara,State Assembly,24,4051,,Alex Glew,228
-Santa Clara,State Assembly,24,4052,,Alex Glew,192
-Santa Clara,State Assembly,24,4053,,Alex Glew,300
-Santa Clara,State Assembly,24,4055,,Alex Glew,188
-Santa Clara,State Assembly,24,4058,,Alex Glew,164
-Santa Clara,State Assembly,24,4060,,Alex Glew,110
-Santa Clara,State Assembly,24,4061,,Alex Glew,13
-Santa Clara,State Assembly,24,4064,,Alex Glew,96
-Santa Clara,State Assembly,24,4067,,Alex Glew,137
-Santa Clara,State Assembly,24,4068,,Alex Glew,9
-Santa Clara,State Assembly,24,4070,,Alex Glew,162
-Santa Clara,State Assembly,24,4071,,Alex Glew,283
-Santa Clara,State Assembly,24,4074,,Alex Glew,108
-Santa Clara,State Assembly,24,4076,,Alex Glew,255
-Santa Clara,State Assembly,24,4079,,Alex Glew,111
-Santa Clara,State Assembly,24,4080,,Alex Glew,186
-Santa Clara,State Assembly,24,4084,,Alex Glew,91
-Santa Clara,State Assembly,24,4086,,Alex Glew,252
-Santa Clara,State Assembly,24,4087,,Alex Glew,144
-Santa Clara,State Assembly,24,4089,,Alex Glew,22
-Santa Clara,State Assembly,24,4098,,Alex Glew,59
-Santa Clara,State Assembly,24,4099,,Alex Glew,85
-Santa Clara,State Assembly,24,4103,,Alex Glew,207
-Santa Clara,State Assembly,24,4116,,Alex Glew,30
-Santa Clara,State Assembly,24,4117,,Alex Glew,125
-Santa Clara,State Assembly,24,4118,,Alex Glew,218
-Santa Clara,State Assembly,24,4119,,Alex Glew,226
-Santa Clara,State Assembly,24,4122,,Alex Glew,201
-Santa Clara,State Assembly,24,4126,,Alex Glew,201
-Santa Clara,State Assembly,24,4128,,Alex Glew,182
-Santa Clara,State Assembly,24,4129,,Alex Glew,232
-Santa Clara,State Assembly,24,4130,,Alex Glew,182
-Santa Clara,State Assembly,24,4131,,Alex Glew,158
-Santa Clara,State Assembly,24,4154,,Alex Glew,200
-Santa Clara,State Assembly,25,4201,Rep,Bob Brunton,171
-Santa Clara,State Assembly,25,4202,Rep,Bob Brunton,1
-Santa Clara,State Assembly,25,4205,Rep,Bob Brunton,10
-Santa Clara,State Assembly,25,4207,Rep,Bob Brunton,9
-Santa Clara,State Assembly,25,4208,Rep,Bob Brunton,230
-Santa Clara,State Assembly,25,4211,Rep,Bob Brunton,186
-Santa Clara,State Assembly,25,4212,Rep,Bob Brunton,0
-Santa Clara,State Assembly,25,4215,Rep,Bob Brunton,258
-Santa Clara,State Assembly,25,4217,Rep,Bob Brunton,164
-Santa Clara,State Assembly,25,4218,Rep,Bob Brunton,106
-Santa Clara,State Assembly,25,4222,Rep,Bob Brunton,201
-Santa Clara,State Assembly,25,4223,Rep,Bob Brunton,183
-Santa Clara,State Assembly,25,4224,Rep,Bob Brunton,1
-Santa Clara,State Assembly,25,4226,Rep,Bob Brunton,232
-Santa Clara,State Assembly,25,4227,Rep,Bob Brunton,175
-Santa Clara,State Assembly,25,4231,Rep,Bob Brunton,229
-Santa Clara,State Assembly,25,4238,Rep,Bob Brunton,252
-Santa Clara,State Assembly,25,4241,Rep,Bob Brunton,252
-Santa Clara,State Assembly,25,4242,Rep,Bob Brunton,225
-Santa Clara,State Assembly,25,4247,Rep,Bob Brunton,169
-Santa Clara,State Assembly,25,4249,Rep,Bob Brunton,219
-Santa Clara,State Assembly,25,4250,Rep,Bob Brunton,177
-Santa Clara,State Assembly,25,4256,Rep,Bob Brunton,173
-Santa Clara,State Assembly,25,4257,Rep,Bob Brunton,104
-Santa Clara,State Assembly,25,4258,Rep,Bob Brunton,177
-Santa Clara,State Assembly,25,4259,Rep,Bob Brunton,237
-Santa Clara,State Assembly,25,4261,Rep,Bob Brunton,121
-Santa Clara,State Assembly,25,4265,Rep,Bob Brunton,249
-Santa Clara,State Assembly,25,4267,Rep,Bob Brunton,193
-Santa Clara,State Assembly,25,4268,Rep,Bob Brunton,118
-Santa Clara,State Assembly,25,4269,Rep,Bob Brunton,110
-Santa Clara,State Assembly,25,4270,Rep,Bob Brunton,195
-Santa Clara,State Assembly,25,4271,Rep,Bob Brunton,224
-Santa Clara,State Assembly,25,4272,Rep,Bob Brunton,94
-Santa Clara,State Assembly,25,4273,Rep,Bob Brunton,182
-Santa Clara,State Assembly,25,4288,Rep,Bob Brunton,167
-Santa Clara,State Assembly,25,4289,Rep,Bob Brunton,129
-Santa Clara,State Assembly,25,4296,Rep,Bob Brunton,87
-Santa Clara,State Assembly,25,4297,Rep,Bob Brunton,272
-Santa Clara,State Assembly,25,4298,Rep,Bob Brunton,145
-Santa Clara,State Assembly,25,4299,Rep,Bob Brunton,8
-Santa Clara,State Assembly,25,4301,Rep,Bob Brunton,221
-Santa Clara,State Assembly,25,4305,Rep,Bob Brunton,261
-Santa Clara,State Assembly,25,4308,Rep,Bob Brunton,17
-Santa Clara,State Assembly,25,4309,Rep,Bob Brunton,13
-Santa Clara,State Assembly,25,4312,Rep,Bob Brunton,133
-Santa Clara,State Assembly,25,4315,Rep,Bob Brunton,271
-Santa Clara,State Assembly,25,4319,Rep,Bob Brunton,136
-Santa Clara,State Assembly,25,4321,Rep,Bob Brunton,150
-Santa Clara,State Assembly,25,4326,Rep,Bob Brunton,220
-Santa Clara,State Assembly,25,4327,Rep,Bob Brunton,199
-Santa Clara,State Assembly,25,4332,Rep,Bob Brunton,182
-Santa Clara,State Assembly,25,4334,Rep,Bob Brunton,158
-Santa Clara,State Assembly,25,4343,Rep,Bob Brunton,115
-Santa Clara,State Assembly,25,4401,Rep,Bob Brunton,250
-Santa Clara,State Assembly,25,4402,Rep,Bob Brunton,214
-Santa Clara,State Assembly,25,4403,Rep,Bob Brunton,14
-Santa Clara,State Assembly,25,4404,Rep,Bob Brunton,143
-Santa Clara,State Assembly,25,4405,Rep,Bob Brunton,127
-Santa Clara,State Assembly,25,4406,Rep,Bob Brunton,122
-Santa Clara,State Assembly,25,4407,Rep,Bob Brunton,169
-Santa Clara,State Assembly,25,4408,Rep,Bob Brunton,148
-Santa Clara,State Assembly,25,4409,Rep,Bob Brunton,190
-Santa Clara,State Assembly,25,4411,Rep,Bob Brunton,191
-Santa Clara,State Assembly,25,4412,Rep,Bob Brunton,140
-Santa Clara,State Assembly,25,4413,Rep,Bob Brunton,140
-Santa Clara,State Assembly,25,4414,Rep,Bob Brunton,135
-Santa Clara,State Assembly,25,4415,Rep,Bob Brunton,246
-Santa Clara,State Assembly,25,4416,Rep,Bob Brunton,126
-Santa Clara,State Assembly,25,4417,Rep,Bob Brunton,284
-Santa Clara,State Assembly,25,4418,Rep,Bob Brunton,145
-Santa Clara,State Assembly,25,4421,Rep,Bob Brunton,137
-Santa Clara,State Assembly,25,4422,Rep,Bob Brunton,212
-Santa Clara,State Assembly,25,4423,Rep,Bob Brunton,128
-Santa Clara,State Assembly,25,4424,Rep,Bob Brunton,111
-Santa Clara,State Assembly,25,4425,Rep,Bob Brunton,124
-Santa Clara,State Assembly,25,4426,Rep,Bob Brunton,154
-Santa Clara,State Assembly,25,4427,Rep,Bob Brunton,151
-Santa Clara,State Assembly,25,4428,Rep,Bob Brunton,187
-Santa Clara,State Assembly,25,4429,Rep,Bob Brunton,253
-Santa Clara,State Assembly,25,4431,Rep,Bob Brunton,0
-Santa Clara,State Assembly,25,4432,Rep,Bob Brunton,239
-Santa Clara,State Assembly,25,4435,Rep,Bob Brunton,210
-Santa Clara,State Assembly,25,4438,Rep,Bob Brunton,113
-Santa Clara,State Assembly,25,4440,Rep,Bob Brunton,205
-Santa Clara,State Assembly,25,4441,Rep,Bob Brunton,60
-Santa Clara,State Assembly,25,4442,Rep,Bob Brunton,3
-Santa Clara,State Assembly,28,4666,Rep,Michael Snyder,244
-Santa Clara,State Assembly,28,4667,Rep,Michael Snyder,1
-Santa Clara,State Assembly,28,4668,Rep,Michael Snyder,224
-Santa Clara,State Assembly,28,4669,Rep,Michael Snyder,3
-Santa Clara,State Assembly,28,4670,Rep,Michael Snyder,304
-Santa Clara,State Assembly,28,4672,Rep,Michael Snyder,14
-Santa Clara,State Assembly,28,4674,Rep,Michael Snyder,253
-Santa Clara,State Assembly,28,4676,Rep,Michael Snyder,399
-Santa Clara,State Assembly,28,4677,Rep,Michael Snyder,195
-Santa Clara,State Assembly,28,4678,Rep,Michael Snyder,218
-Santa Clara,State Assembly,28,4681,Rep,Michael Snyder,351
-Santa Clara,State Assembly,28,4685,Rep,Michael Snyder,376
-Santa Clara,State Assembly,28,4687,Rep,Michael Snyder,249
-Santa Clara,State Assembly,28,4688,Rep,Michael Snyder,299
-Santa Clara,State Assembly,28,4690,Rep,Michael Snyder,301
-Santa Clara,State Assembly,28,4692,Rep,Michael Snyder,209
-Santa Clara,State Assembly,28,4696,Rep,Michael Snyder,224
-Santa Clara,State Assembly,28,4699,Rep,Michael Snyder,291
-Santa Clara,State Assembly,28,4702,Rep,Michael Snyder,171
-Santa Clara,State Assembly,28,4703,Rep,Michael Snyder,334
-Santa Clara,State Assembly,28,4704,Rep,Michael Snyder,46
-Santa Clara,State Assembly,28,4707,Rep,Michael Snyder,27
-Santa Clara,State Assembly,28,4723,Rep,Michael Snyder,193
-Santa Clara,State Assembly,28,4733,Rep,Michael Snyder,10
-Santa Clara,State Assembly,28,4737,Rep,Michael Snyder,1
-Santa Clara,State Assembly,28,4740,Rep,Michael Snyder,8
-Santa Clara,State Assembly,25,5449,Rep,Bob Brunton,12
-Santa Clara,State Assembly,25,5452,Rep,Bob Brunton,25
-Santa Clara,State Assembly,27,5453,Rep,Burt Lancaster,0
-Santa Clara,State Assembly,25,5456,Rep,Bob Brunton,0
-Santa Clara,State Assembly,25,5502,Rep,Bob Brunton,127
-Santa Clara,State Assembly,27,5503,Rep,Burt Lancaster,6
-Santa Clara,State Assembly,25,5505,Rep,Bob Brunton,47
-Santa Clara,State Assembly,28,5556,Rep,Michael Snyder,164
-Santa Clara,State Assembly,28,5557,Rep,Michael Snyder,154
-Santa Clara,State Assembly,28,5567,Rep,Michael Snyder,104
-Santa Clara,State Assembly,28,5743,Rep,Michael Snyder,117
-Santa Clara,State Assembly,28,5744,Rep,Michael Snyder,5
-Santa Clara,State Assembly,28,5745,Rep,Michael Snyder,313
-Santa Clara,State Assembly,28,5746,Rep,Michael Snyder,107
-Santa Clara,State Assembly,28,5747,Rep,Michael Snyder,202
-Santa Clara,State Assembly,28,5750,Rep,Michael Snyder,3
-Santa Clara,State Assembly,28,5752,Rep,Michael Snyder,228
-Santa Clara,State Assembly,29,5756,Rep,Vicki Nohrden,17
-Santa Clara,State Assembly,28,5758,Rep,Michael Snyder,58
-Santa Clara,State Assembly,28,5759,Rep,Michael Snyder,134
-Santa Clara,State Assembly,28,5760,Rep,Michael Snyder,1
-Santa Clara,State Assembly,28,5762,Rep,Michael Snyder,11
-Santa Clara,State Assembly,28,5763,Rep,Michael Snyder,19
-Santa Clara,State Assembly,28,5765,Rep,Michael Snyder,14
-Santa Clara,State Assembly,28,5770,Rep,Michael Snyder,51
-Santa Clara,State Assembly,28,5772,Rep,Michael Snyder,0
-Santa Clara,State Assembly,28,5774,Rep,Michael Snyder,9
-Santa Clara,State Assembly,28,5775,Rep,Michael Snyder,74
-Santa Clara,State Assembly,28,5782,Rep,Michael Snyder,45
-Santa Clara,State Assembly,29,5784,Rep,Vicki Nohrden,7
-Santa Clara,State Assembly,28,5788,Rep,Michael Snyder,2
-Santa Clara,State Assembly,28,5789,Rep,Michael Snyder,0
-Santa Clara,State Assembly,29,5792,Rep,Vicki Nohrden,0
-Santa Clara,State Assembly,29,5794,Rep,Vicki Nohrden,11
-Santa Clara,State Assembly,28,5804,Rep,Michael Snyder,340
-Santa Clara,State Assembly,28,5810,Rep,Michael Snyder,156
-Santa Clara,State Assembly,28,5813,Rep,Michael Snyder,11
-Santa Clara,State Assembly,28,5858,Rep,Michael Snyder,48
-Santa Clara,State Assembly,27,5881,Rep,Burt Lancaster,0
-Santa Clara,State Assembly,27,5884,Rep,Burt Lancaster,0
-Santa Clara,State Assembly,27,5886,Rep,Burt Lancaster,0
-Santa Clara,State Assembly,29,5894,Rep,Vicki Nohrden,1
-Santa Clara,State Assembly,29,5895,Rep,Vicki Nohrden,5
-Santa Clara,State Assembly,29,5902,Rep,Vicki Nohrden,154
-Santa Clara,State Assembly,29,5903,Rep,Vicki Nohrden,186
-Santa Clara,State Assembly,29,5904,Rep,Vicki Nohrden,46
-Santa Clara,State Assembly,30,5906,Rep,Neil Kitchens,65
-Santa Clara,State Assembly,30,5911,Rep,Neil Kitchens,54
-Santa Clara,State Assembly,29,5912,Rep,Vicki Nohrden,18
-Santa Clara,State Assembly,29,5914,Rep,Vicki Nohrden,371
-Santa Clara,State Assembly,30,5915,Rep,Neil Kitchens,287
-Santa Clara,State Assembly,29,5916,Rep,Vicki Nohrden,27
-Santa Clara,State Assembly,30,5917,Rep,Neil Kitchens,18
-Santa Clara,State Assembly,30,5920,Rep,Neil Kitchens,4
-Santa Clara,State Assembly,25,5925,Rep,Bob Brunton,14
-Santa Clara,State Assembly,29,5926,Rep,Vicki Nohrden,172
-Santa Clara,State Assembly,30,5929,Rep,Neil Kitchens,23
-Santa Clara,State Assembly,29,5931,Rep,Vicki Nohrden,16
-Santa Clara,State Assembly,30,5932,Rep,Neil Kitchens,41
-Santa Clara,State Assembly,29,5933,Rep,Vicki Nohrden,74
-Santa Clara,State Assembly,30,5936,Rep,Neil Kitchens,261
-Santa Clara,State Assembly,30,5937,Rep,Neil Kitchens,52
-Santa Clara,State Assembly,25,5938,Rep,Bob Brunton,22
-Santa Clara,State Assembly,29,5940,Rep,Vicki Nohrden,12
-Santa Clara,State Assembly,30,5943,Rep,Neil Kitchens,35
-Santa Clara,State Assembly,29,5945,Rep,Vicki Nohrden,93
-Santa Clara,State Assembly,30,5947,Rep,Neil Kitchens,270
-Santa Clara,State Assembly,30,5949,Rep,Neil Kitchens,30
-Santa Clara,State Assembly,30,5950,Rep,Neil Kitchens,100
-Santa Clara,State Assembly,30,5951,Rep,Neil Kitchens,5
-Santa Clara,State Assembly,30,5952,Rep,Neil Kitchens,6
-Santa Clara,State Assembly,30,5953,Rep,Neil Kitchens,53
-Santa Clara,State Assembly,30,5955,Rep,Neil Kitchens,414
-Santa Clara,State Assembly,30,5956,Rep,Neil Kitchens,412
-Santa Clara,State Assembly,30,5957,Rep,Neil Kitchens,49
-Santa Clara,State Assembly,30,5959,Rep,Neil Kitchens,40
-Santa Clara,State Assembly,30,5962,Rep,Neil Kitchens,307
-Santa Clara,State Assembly,30,5965,Rep,Neil Kitchens,305
-Santa Clara,State Assembly,30,5966,Rep,Neil Kitchens,18
-Santa Clara,State Assembly,30,5971,Rep,Neil Kitchens,54
-Santa Clara,State Assembly,30,5973,Rep,Neil Kitchens,22
-Santa Clara,State Assembly,29,5988,Rep,Vicki Nohrden,0
-Santa Clara,State Assembly,30,5989,Rep,Neil Kitchens,38
-Santa Clara,State Assembly,29,5991,Rep,Vicki Nohrden,3
-Santa Clara,State Assembly,29,5995,Rep,Vicki Nohrden,4
-Santa Clara,State Assembly,29,5996,Rep,Vicki Nohrden,12
-Santa Clara,State Assembly,29,6002,Rep,Vicki Nohrden,13
-Santa Clara,State Assembly,30,6006,Rep,Neil Kitchens,13
-Santa Clara,State Assembly,30,6007,Rep,Neil Kitchens,12
-Santa Clara,State Assembly,29,6021,Rep,Vicki Nohrden,17
-Santa Clara,State Assembly,29,6023,Rep,Vicki Nohrden,2
-Santa Clara,State Assembly,25,6028,Rep,Bob Brunton,1
-Santa Clara,State Assembly,30,6031,Rep,Neil Kitchens,9
-Santa Clara,State Assembly,30,6032,Rep,Neil Kitchens,18
-Santa Clara,State Assembly,29,6034,Rep,Vicki Nohrden,5
-Santa Clara,State Assembly,30,6039,Rep,Neil Kitchens,0
-Santa Clara,State Assembly,30,6040,Rep,Neil Kitchens,16
-Santa Clara,State Assembly,29,6045,Rep,Vicki Nohrden,5
-Santa Clara,State Assembly,29,6047,Rep,Vicki Nohrden,10
-Santa Clara,State Assembly,25,6401,Rep,Bob Brunton,1
-Santa Clara,State Assembly,25,6402,Rep,Bob Brunton,24
-Santa Clara,State Assembly,27,6404,Rep,Burt Lancaster,41
-Santa Clara,State Assembly,25,6405,Rep,Bob Brunton,3
-Santa Clara,State Assembly,25,6410,Rep,Bob Brunton,14
-Santa Clara,State Assembly,25,6411,Rep,Bob Brunton,36
-Santa Clara,State Assembly,25,6413,Rep,Bob Brunton,8
-Santa Clara,State Assembly,27,6417,Rep,Burt Lancaster,41
-Santa Clara,State Assembly,25,6418,Rep,Bob Brunton,210
-Santa Clara,State Assembly,25,6419,Rep,Bob Brunton,14
-Santa Clara,State Assembly,25,6421,Rep,Bob Brunton,3
-Santa Clara,State Assembly,25,6422,Rep,Bob Brunton,6
-Santa Clara,State Assembly,25,6423,Rep,Bob Brunton,23
-Santa Clara,State Assembly,25,6425,Rep,Bob Brunton,22
-Santa Clara,State Assembly,25,6427,Rep,Bob Brunton,0
-Santa Clara,State Assembly,27,6452,Rep,Burt Lancaster,14
-Santa Clara,State Assembly,27,6454,Rep,Burt Lancaster,0
-Santa Clara,State Assembly,27,6455,Rep,Burt Lancaster,33
-Santa Clara,State Assembly,27,6457,Rep,Burt Lancaster,32
-Santa Clara,State Assembly,27,6458,Rep,Burt Lancaster,14
-Santa Clara,State Assembly,27,6462,Rep,Burt Lancaster,0
-Santa Clara,State Assembly,27,6463,Rep,Burt Lancaster,0
-Santa Clara,State Assembly,25,6464,Rep,Bob Brunton,0
-Santa Clara,State Assembly,27,6465,Rep,Burt Lancaster,0
-Santa Clara,State Assembly,25,6466,Rep,Bob Brunton,41
-Santa Clara,State Assembly,27,6470,Rep,Burt Lancaster,38
-Santa Clara,State Assembly,25,6490,Rep,Bob Brunton,5
-Santa Clara,State Assembly,25,6491,Rep,Bob Brunton,1
-Santa Clara,State Assembly,25,6492,Rep,Bob Brunton,30
-Santa Clara,State Assembly,25,6493,Rep,Bob Brunton,0
-Santa Clara,State Assembly,25,6502,Rep,Bob Brunton,42
-Santa Clara,State Assembly,25,6509,Rep,Bob Brunton,9
-Santa Clara,State Assembly,25,6510,Rep,Bob Brunton,8
-Santa Clara,State Assembly,25,6515,Rep,Bob Brunton,23
-Santa Clara,State Assembly,28,6624,Rep,Michael Snyder,0
-Santa Clara,State Assembly,28,6663,Rep,Michael Snyder,0
-Santa Clara,State Assembly,28,6664,Rep,Michael Snyder,13
-Santa Clara,State Assembly,28,6665,Rep,Michael Snyder,1
-Santa Clara,State Assembly,28,6666,Rep,Michael Snyder,35
-Santa Clara,State Assembly,28,6673,Rep,Michael Snyder,1
-Santa Clara,State Assembly,24,STATEWIDE,Rep,Alex Glew,29519
-Santa Clara,State Assembly,24,"US Representative, District 17",Rep,Alex Glew,11117
-Santa Clara,State Assembly,24,"US Representative, District 18",Rep,Alex Glew,18402
-Santa Clara,State Assembly,24,"State Senate, District 13",Rep,Alex Glew,28866
-Santa Clara,State Assembly,24,"State Senate, District 15",Rep,Alex Glew,653
-Santa Clara,State Assembly,24,State Assembly District 24,Rep,Alex Glew,29519
-Santa Clara,State Assembly,24,City of Cupertino,Rep,Alex Glew,583
-Santa Clara,State Assembly,24,City of Los Altos,Rep,Alex Glew,4650
-Santa Clara,State Assembly,24,Town of Los Altos Hills,Rep,Alex Glew,1657
-Santa Clara,State Assembly,24,City of Mountain View,Rep,Alex Glew,5312
-Santa Clara,State Assembly,24,City of Palo Alto,Rep,Alex Glew,5728
-Santa Clara,State Assembly,24,City of Sunnyvale,Rep,Alex Glew,10531
-Santa Clara,State Assembly,24,Unincorporated Area,Rep,Alex Glew,1058
-Santa Clara,State Assembly,25,STATEWIDE,Rep,Bob Brunton,23231
-Santa Clara,State Assembly,25,"US Representative, District 17",Rep,Bob Brunton,22315
-Santa Clara,State Assembly,25,"US Representative, District 19",Rep,Bob Brunton,916
-Santa Clara,State Assembly,25,"State Senate, District 10",Rep,Bob Brunton,21246
-Santa Clara,State Assembly,25,"State Senate, District 15",Rep,Bob Brunton,1949
-Santa Clara,State Assembly,25,"State Senate, District 17",Rep,Bob Brunton,36
-Santa Clara,State Assembly,25,State Assembly District 25,Rep,Bob Brunton,23231
-Santa Clara,State Assembly,25,City of Milpitas,Rep,Bob Brunton,5071
-Santa Clara,State Assembly,25,City of Santa Clara,Rep,Bob Brunton,8511
-Santa Clara,State Assembly,25,City of Sunnyvale,Rep,Bob Brunton,6
-Santa Clara,State Assembly,25,City of San Jose,Rep,Bob Brunton,8872
-Santa Clara,State Assembly,25,Unincorporated Area,Rep,Bob Brunton,771
-Santa Clara,State Assembly,27,SANTA CLARA CA,Rep,Burt Lancaster,27990
-Santa Clara,State Assembly,27,"US Representative, District 19",Rep,Burt Lancaster,27990
-Santa Clara,State Assembly,27,"State Senate, District 10",Rep,Burt Lancaster,279
-Santa Clara,State Assembly,27,"State Senate, District 15",Rep,Burt Lancaster,24924
-Santa Clara,State Assembly,27,"State Senate, District 17",Rep,Burt Lancaster,2787
-Santa Clara,State Assembly,27,State Assembly District 27,Rep,Burt Lancaster,27990
-Santa Clara,State Assembly,27,City of San Jose,Rep,Burt Lancaster,26874
-Santa Clara,State Assembly,27,Unincorporated Area,Rep,Burt Lancaster,1116
-Santa Clara,State Assembly,28,SANTA CLARA CA,Rep,Michael Snyder,53195
-Santa Clara,State Assembly,28,"US Representative, District 17",Rep,Michael Snyder,7196
-Santa Clara,State Assembly,28,"US Representative, District 18",Rep,Michael Snyder,37497
-Santa Clara,State Assembly,28,"US Representative, District 19",Rep,Michael Snyder,8502
-Santa Clara,State Assembly,28,"State Senate, District 10",Rep,Michael Snyder,1498
-Santa Clara,State Assembly,28,"State Senate, District 13",Rep,Michael Snyder,103
-Santa Clara,State Assembly,28,"State Senate, District 15",Rep,Michael Snyder,51594
-Santa Clara,State Assembly,28,State Assembly District 28,Rep,Michael Snyder,53195
-Santa Clara,State Assembly,28,City of Campbell,Rep,Michael Snyder,4246
-Santa Clara,State Assembly,28,City of Cupertino,Rep,Michael Snyder,5058
-Santa Clara,State Assembly,28,Town of Los Gatos,Rep,Michael Snyder,4788
-Santa Clara,State Assembly,28,City of Monte Sereno,Rep,Michael Snyder,738
-Santa Clara,State Assembly,28,City of Saratoga,Rep,Michael Snyder,4945
-Santa Clara,State Assembly,28,City of San Jose,Rep,Michael Snyder,30920
-Santa Clara,State Assembly,28,Unincorporated Area,Rep,Michael Snyder,2500
-Santa Clara,State Assembly,29,SANTA CLARA CA,Rep,Vicki Nohrden,12184
-Santa Clara,State Assembly,29,"US Representative, District 18",Rep,Vicki Nohrden,3134
-Santa Clara,State Assembly,29,"US Representative, District 19",Rep,Vicki Nohrden,9050
-Santa Clara,State Assembly,29,"State Senate, District 15",Rep,Vicki Nohrden,5616
-Santa Clara,State Assembly,29,"State Senate, District 17",Rep,Vicki Nohrden,6568
-Santa Clara,State Assembly,29,State Assembly District 29,Rep,Vicki Nohrden,12184
-Santa Clara,State Assembly,29,City of San Jose,Rep,Vicki Nohrden,10903
-Santa Clara,State Assembly,29,Unincorporated Area,Rep,Vicki Nohrden,1281
-Santa Clara,State Assembly,30,STATEWIDE,Rep,Neil Kitchens,14575
-Santa Clara,State Assembly,30,"US Representative, District 19",Rep,Neil Kitchens,13677
-Santa Clara,State Assembly,30,"US Representative, District 20",Rep,Neil Kitchens,898
-Santa Clara,State Assembly,30,"State Senate, District 17",Rep,Neil Kitchens,14575
-Santa Clara,State Assembly,30,State Assembly District 30,Rep,Neil Kitchens,14575
-Santa Clara,State Assembly,30,City of Gilroy ,Rep,Neil Kitchens,5343
-Santa Clara,State Assembly,30,City of Morgan Hill,Rep,Neil Kitchens,6201
-Santa Clara,State Assembly,30,Unincorporated Area,Rep,Neil Kitchens,3031
+Santa Clara,1301,State Senate,10,Dem,Bob Wieckowski,25
+Santa Clara,1302,State Senate,10,Dem,Bob Wieckowski,270
+Santa Clara,1303,State Senate,10,Dem,Bob Wieckowski,606
+Santa Clara,1304,State Senate,10,Dem,Bob Wieckowski,794
+Santa Clara,1305,State Senate,10,Dem,Bob Wieckowski,588
+Santa Clara,1312,State Senate,10,Dem,Bob Wieckowski,551
+Santa Clara,1313,State Senate,10,Dem,Bob Wieckowski,401
+Santa Clara,1314,State Senate,10,Dem,Bob Wieckowski,464
+Santa Clara,1370,State Senate,10,Dem,Bob Wieckowski,9
+Santa Clara,1371,State Senate,10,Dem,Bob Wieckowski,106
+Santa Clara,1373,State Senate,10,Dem,Bob Wieckowski,4
+Santa Clara,1385,State Senate,10,Dem,Bob Wieckowski,694
+Santa Clara,1394,State Senate,10,Dem,Bob Wieckowski,512
+Santa Clara,1396,State Senate,10,Dem,Bob Wieckowski,541
+Santa Clara,1397,State Senate,10,Dem,Bob Wieckowski,610
+Santa Clara,1400,State Senate,10,Dem,Bob Wieckowski,493
+Santa Clara,1401,State Senate,10,Dem,Bob Wieckowski,465
+Santa Clara,1403,State Senate,10,Dem,Bob Wieckowski,593
+Santa Clara,1405,State Senate,10,Dem,Bob Wieckowski,5
+Santa Clara,1407,State Senate,10,Dem,Bob Wieckowski,502
+Santa Clara,1408,State Senate,10,Dem,Bob Wieckowski,363
+Santa Clara,1409,State Senate,10,Dem,Bob Wieckowski,410
+Santa Clara,1410,State Senate,10,Dem,Bob Wieckowski,511
+Santa Clara,1411,State Senate,10,Dem,Bob Wieckowski,570
+Santa Clara,1414,State Senate,10,Dem,Bob Wieckowski,475
+Santa Clara,1415,State Senate,10,Dem,Bob Wieckowski,641
+Santa Clara,1417,State Senate,10,Dem,Bob Wieckowski,568
+Santa Clara,1418,State Senate,10,Dem,Bob Wieckowski,516
+Santa Clara,1420,State Senate,10,Dem,Bob Wieckowski,593
+Santa Clara,1421,State Senate,10,Dem,Bob Wieckowski,540
+Santa Clara,1427,State Senate,10,Dem,Bob Wieckowski,353
+Santa Clara,1428,State Senate,10,Dem,Bob Wieckowski,516
+Santa Clara,1429,State Senate,10,Dem,Bob Wieckowski,661
+Santa Clara,1431,State Senate,10,Dem,Bob Wieckowski,319
+Santa Clara,1432,State Senate,10,Dem,Bob Wieckowski,594
+Santa Clara,1433,State Senate,10,Dem,Bob Wieckowski,447
+Santa Clara,1435,State Senate,10,Dem,Bob Wieckowski,644
+Santa Clara,1439,State Senate,10,Dem,Bob Wieckowski,677
+Santa Clara,1444,State Senate,10,Dem,Bob Wieckowski,534
+Santa Clara,1446,State Senate,10,Dem,Bob Wieckowski,600
+Santa Clara,1447,State Senate,10,Dem,Bob Wieckowski,359
+Santa Clara,1448,State Senate,10,Dem,Bob Wieckowski,614
+Santa Clara,1451,State Senate,10,Dem,Bob Wieckowski,500
+Santa Clara,1453,State Senate,10,Dem,Bob Wieckowski,410
+Santa Clara,1455,State Senate,10,Dem,Bob Wieckowski,520
+Santa Clara,1459,State Senate,10,Dem,Bob Wieckowski,606
+Santa Clara,1461,State Senate,10,Dem,Bob Wieckowski,542
+Santa Clara,1465,State Senate,10,Dem,Bob Wieckowski,403
+Santa Clara,1467,State Senate,10,Dem,Bob Wieckowski,578
+Santa Clara,1468,State Senate,10,Dem,Bob Wieckowski,515
+Santa Clara,1478,State Senate,10,Dem,Bob Wieckowski,433
+Santa Clara,1480,State Senate,10,Dem,Bob Wieckowski,353
+Santa Clara,1497,State Senate,10,Dem,Bob Wieckowski,454
+Santa Clara,1570,State Senate,10,Dem,Bob Wieckowski,1
+Santa Clara,1586,State Senate,10,Dem,Bob Wieckowski,7
+Santa Clara,1613,State Senate,10,Dem,Bob Wieckowski,417
+Santa Clara,1615,State Senate,10,Dem,Bob Wieckowski,519
+Santa Clara,1616,State Senate,10,Dem,Bob Wieckowski,700
+Santa Clara,1619,State Senate,10,Dem,Bob Wieckowski,35
+Santa Clara,1620,State Senate,10,Dem,Bob Wieckowski,673
+Santa Clara,1621,State Senate,10,Dem,Bob Wieckowski,354
+Santa Clara,4008,State Senate,10,Dem,Bob Wieckowski,20
+Santa Clara,4201,State Senate,10,Dem,Bob Wieckowski,692
+Santa Clara,4202,State Senate,10,Dem,Bob Wieckowski,5
+Santa Clara,4205,State Senate,10,Dem,Bob Wieckowski,69
+Santa Clara,4207,State Senate,10,Dem,Bob Wieckowski,51
+Santa Clara,4208,State Senate,10,Dem,Bob Wieckowski,635
+Santa Clara,4211,State Senate,10,Dem,Bob Wieckowski,610
+Santa Clara,4212,State Senate,10,Dem,Bob Wieckowski,4
+Santa Clara,4215,State Senate,10,Dem,Bob Wieckowski,728
+Santa Clara,4217,State Senate,10,Dem,Bob Wieckowski,518
+Santa Clara,4218,State Senate,10,Dem,Bob Wieckowski,377
+Santa Clara,4222,State Senate,10,Dem,Bob Wieckowski,576
+Santa Clara,4223,State Senate,10,Dem,Bob Wieckowski,714
+Santa Clara,4224,State Senate,10,Dem,Bob Wieckowski,2
+Santa Clara,4226,State Senate,10,Dem,Bob Wieckowski,589
+Santa Clara,4227,State Senate,10,Dem,Bob Wieckowski,545
+Santa Clara,4231,State Senate,10,Dem,Bob Wieckowski,740
+Santa Clara,4238,State Senate,10,Dem,Bob Wieckowski,752
+Santa Clara,4241,State Senate,10,Dem,Bob Wieckowski,683
+Santa Clara,4242,State Senate,10,Dem,Bob Wieckowski,569
+Santa Clara,4247,State Senate,10,Dem,Bob Wieckowski,430
+Santa Clara,4249,State Senate,10,Dem,Bob Wieckowski,713
+Santa Clara,4250,State Senate,10,Dem,Bob Wieckowski,405
+Santa Clara,4256,State Senate,10,Dem,Bob Wieckowski,705
+Santa Clara,4257,State Senate,10,Dem,Bob Wieckowski,352
+Santa Clara,4258,State Senate,10,Dem,Bob Wieckowski,485
+Santa Clara,4259,State Senate,10,Dem,Bob Wieckowski,762
+Santa Clara,4261,State Senate,10,Dem,Bob Wieckowski,496
+Santa Clara,4265,State Senate,10,Dem,Bob Wieckowski,638
+Santa Clara,4267,State Senate,10,Dem,Bob Wieckowski,365
+Santa Clara,4268,State Senate,10,Dem,Bob Wieckowski,396
+Santa Clara,4269,State Senate,10,Dem,Bob Wieckowski,406
+Santa Clara,4270,State Senate,10,Dem,Bob Wieckowski,548
+Santa Clara,4271,State Senate,10,Dem,Bob Wieckowski,689
+Santa Clara,4272,State Senate,10,Dem,Bob Wieckowski,300
+Santa Clara,4273,State Senate,10,Dem,Bob Wieckowski,622
+Santa Clara,4288,State Senate,10,Dem,Bob Wieckowski,436
+Santa Clara,4289,State Senate,10,Dem,Bob Wieckowski,420
+Santa Clara,4296,State Senate,10,Dem,Bob Wieckowski,365
+Santa Clara,4297,State Senate,10,Dem,Bob Wieckowski,712
+Santa Clara,4298,State Senate,10,Dem,Bob Wieckowski,487
+Santa Clara,4299,State Senate,10,Dem,Bob Wieckowski,16
+Santa Clara,4301,State Senate,10,Dem,Bob Wieckowski,611
+Santa Clara,4305,State Senate,10,Dem,Bob Wieckowski,700
+Santa Clara,4308,State Senate,10,Dem,Bob Wieckowski,45
+Santa Clara,4309,State Senate,10,Dem,Bob Wieckowski,25
+Santa Clara,4312,State Senate,10,Dem,Bob Wieckowski,459
+Santa Clara,4315,State Senate,10,Dem,Bob Wieckowski,714
+Santa Clara,4319,State Senate,10,Dem,Bob Wieckowski,376
+Santa Clara,4321,State Senate,10,Dem,Bob Wieckowski,604
+Santa Clara,4326,State Senate,10,Dem,Bob Wieckowski,615
+Santa Clara,4327,State Senate,10,Dem,Bob Wieckowski,688
+Santa Clara,4332,State Senate,10,Dem,Bob Wieckowski,314
+Santa Clara,4334,State Senate,10,Dem,Bob Wieckowski,459
+Santa Clara,4343,State Senate,10,Dem,Bob Wieckowski,387
+Santa Clara,4401,State Senate,10,Dem,Bob Wieckowski,591
+Santa Clara,4402,State Senate,10,Dem,Bob Wieckowski,691
+Santa Clara,4403,State Senate,10,Dem,Bob Wieckowski,55
+Santa Clara,4404,State Senate,10,Dem,Bob Wieckowski,480
+Santa Clara,4405,State Senate,10,Dem,Bob Wieckowski,332
+Santa Clara,4406,State Senate,10,Dem,Bob Wieckowski,350
+Santa Clara,4407,State Senate,10,Dem,Bob Wieckowski,308
+Santa Clara,4408,State Senate,10,Dem,Bob Wieckowski,473
+Santa Clara,4409,State Senate,10,Dem,Bob Wieckowski,583
+Santa Clara,4411,State Senate,10,Dem,Bob Wieckowski,340
+Santa Clara,4412,State Senate,10,Dem,Bob Wieckowski,406
+Santa Clara,4413,State Senate,10,Dem,Bob Wieckowski,424
+Santa Clara,4414,State Senate,10,Dem,Bob Wieckowski,457
+Santa Clara,4415,State Senate,10,Dem,Bob Wieckowski,679
+Santa Clara,4416,State Senate,10,Dem,Bob Wieckowski,373
+Santa Clara,4417,State Senate,10,Dem,Bob Wieckowski,603
+Santa Clara,4418,State Senate,10,Dem,Bob Wieckowski,367
+Santa Clara,4421,State Senate,10,Dem,Bob Wieckowski,361
+Santa Clara,4422,State Senate,10,Dem,Bob Wieckowski,491
+Santa Clara,4423,State Senate,10,Dem,Bob Wieckowski,322
+Santa Clara,4424,State Senate,10,Dem,Bob Wieckowski,344
+Santa Clara,4425,State Senate,10,Dem,Bob Wieckowski,355
+Santa Clara,4426,State Senate,10,Dem,Bob Wieckowski,324
+Santa Clara,4427,State Senate,10,Dem,Bob Wieckowski,402
+Santa Clara,4428,State Senate,10,Dem,Bob Wieckowski,547
+Santa Clara,4429,State Senate,10,Dem,Bob Wieckowski,669
+Santa Clara,4431,State Senate,10,Dem,Bob Wieckowski,1
+Santa Clara,4432,State Senate,10,Dem,Bob Wieckowski,560
+Santa Clara,4435,State Senate,10,Dem,Bob Wieckowski,622
+Santa Clara,4438,State Senate,10,Dem,Bob Wieckowski,387
+Santa Clara,4440,State Senate,10,Dem,Bob Wieckowski,578
+Santa Clara,4441,State Senate,10,Dem,Bob Wieckowski,85
+Santa Clara,4442,State Senate,10,Dem,Bob Wieckowski,1
+Santa Clara,6401,State Senate,10,Dem,Bob Wieckowski,0
+Santa Clara,6402,State Senate,10,Dem,Bob Wieckowski,37
+Santa Clara,6411,State Senate,10,Dem,Bob Wieckowski,62
+Santa Clara,6419,State Senate,10,Dem,Bob Wieckowski,9
+Santa Clara,6421,State Senate,10,Dem,Bob Wieckowski,5
+Santa Clara,6425,State Senate,10,Dem,Bob Wieckowski,11
+Santa Clara,6515,State Senate,10,Dem,Bob Wieckowski,50
+Santa Clara,SANTA CLARA CA,State Senate,10,Dem,Bob Wiechowski,67117
+Santa Clara,1301,State Senate,10,Rep,Victor San Vicente,5
+Santa Clara,1302,State Senate,10,Rep,Victor San Vicente,57
+Santa Clara,1303,State Senate,10,Rep,Victor San Vicente,148
+Santa Clara,1304,State Senate,10,Rep,Victor San Vicente,202
+Santa Clara,1305,State Senate,10,Rep,Victor San Vicente,163
+Santa Clara,1312,State Senate,10,Rep,Victor San Vicente,79
+Santa Clara,1313,State Senate,10,Rep,Victor San Vicente,70
+Santa Clara,1314,State Senate,10,Rep,Victor San Vicente,106
+Santa Clara,1370,State Senate,10,Rep,Victor San Vicente,4
+Santa Clara,1371,State Senate,10,Rep,Victor San Vicente,39
+Santa Clara,1373,State Senate,10,Rep,Victor San Vicente,1
+Santa Clara,1385,State Senate,10,Rep,Victor San Vicente,174
+Santa Clara,1394,State Senate,10,Rep,Victor San Vicente,210
+Santa Clara,1396,State Senate,10,Rep,Victor San Vicente,220
+Santa Clara,1397,State Senate,10,Rep,Victor San Vicente,275
+Santa Clara,1400,State Senate,10,Rep,Victor San Vicente,123
+Santa Clara,1401,State Senate,10,Rep,Victor San Vicente,103
+Santa Clara,1403,State Senate,10,Rep,Victor San Vicente,182
+Santa Clara,1405,State Senate,10,Rep,Victor San Vicente,3
+Santa Clara,1407,State Senate,10,Rep,Victor San Vicente,227
+Santa Clara,1408,State Senate,10,Rep,Victor San Vicente,112
+Santa Clara,1409,State Senate,10,Rep,Victor San Vicente,162
+Santa Clara,1410,State Senate,10,Rep,Victor San Vicente,238
+Santa Clara,1411,State Senate,10,Rep,Victor San Vicente,249
+Santa Clara,1414,State Senate,10,Rep,Victor San Vicente,209
+Santa Clara,1415,State Senate,10,Rep,Victor San Vicente,233
+Santa Clara,1417,State Senate,10,Rep,Victor San Vicente,201
+Santa Clara,1418,State Senate,10,Rep,Victor San Vicente,210
+Santa Clara,1420,State Senate,10,Rep,Victor San Vicente,240
+Santa Clara,1421,State Senate,10,Rep,Victor San Vicente,221
+Santa Clara,1427,State Senate,10,Rep,Victor San Vicente,143
+Santa Clara,1428,State Senate,10,Rep,Victor San Vicente,238
+Santa Clara,1429,State Senate,10,Rep,Victor San Vicente,302
+Santa Clara,1431,State Senate,10,Rep,Victor San Vicente,183
+Santa Clara,1432,State Senate,10,Rep,Victor San Vicente,299
+Santa Clara,1433,State Senate,10,Rep,Victor San Vicente,143
+Santa Clara,1435,State Senate,10,Rep,Victor San Vicente,222
+Santa Clara,1439,State Senate,10,Rep,Victor San Vicente,111
+Santa Clara,1444,State Senate,10,Rep,Victor San Vicente,220
+Santa Clara,1446,State Senate,10,Rep,Victor San Vicente,277
+Santa Clara,1447,State Senate,10,Rep,Victor San Vicente,134
+Santa Clara,1448,State Senate,10,Rep,Victor San Vicente,255
+Santa Clara,1451,State Senate,10,Rep,Victor San Vicente,234
+Santa Clara,1453,State Senate,10,Rep,Victor San Vicente,141
+Santa Clara,1455,State Senate,10,Rep,Victor San Vicente,229
+Santa Clara,1459,State Senate,10,Rep,Victor San Vicente,181
+Santa Clara,1461,State Senate,10,Rep,Victor San Vicente,113
+Santa Clara,1465,State Senate,10,Rep,Victor San Vicente,144
+Santa Clara,1467,State Senate,10,Rep,Victor San Vicente,147
+Santa Clara,1468,State Senate,10,Rep,Victor San Vicente,259
+Santa Clara,1478,State Senate,10,Rep,Victor San Vicente,143
+Santa Clara,1480,State Senate,10,Rep,Victor San Vicente,115
+Santa Clara,1497,State Senate,10,Rep,Victor San Vicente,71
+Santa Clara,1570,State Senate,10,Rep,Victor San Vicente,0
+Santa Clara,1586,State Senate,10,Rep,Victor San Vicente,4
+Santa Clara,1613,State Senate,10,Rep,Victor San Vicente,145
+Santa Clara,1615,State Senate,10,Rep,Victor San Vicente,202
+Santa Clara,1616,State Senate,10,Rep,Victor San Vicente,229
+Santa Clara,1619,State Senate,10,Rep,Victor San Vicente,8
+Santa Clara,1620,State Senate,10,Rep,Victor San Vicente,255
+Santa Clara,1621,State Senate,10,Rep,Victor San Vicente,83
+Santa Clara,4008,State Senate,10,Rep,Victor San Vicente,5
+Santa Clara,4201,State Senate,10,Rep,Victor San Vicente,172
+Santa Clara,4202,State Senate,10,Rep,Victor San Vicente,2
+Santa Clara,4205,State Senate,10,Rep,Victor San Vicente,9
+Santa Clara,4207,State Senate,10,Rep,Victor San Vicente,10
+Santa Clara,4208,State Senate,10,Rep,Victor San Vicente,234
+Santa Clara,4211,State Senate,10,Rep,Victor San Vicente,198
+Santa Clara,4212,State Senate,10,Rep,Victor San Vicente,1
+Santa Clara,4215,State Senate,10,Rep,Victor San Vicente,258
+Santa Clara,4217,State Senate,10,Rep,Victor San Vicente,153
+Santa Clara,4218,State Senate,10,Rep,Victor San Vicente,103
+Santa Clara,4222,State Senate,10,Rep,Victor San Vicente,194
+Santa Clara,4223,State Senate,10,Rep,Victor San Vicente,178
+Santa Clara,4224,State Senate,10,Rep,Victor San Vicente,1
+Santa Clara,4226,State Senate,10,Rep,Victor San Vicente,231
+Santa Clara,4227,State Senate,10,Rep,Victor San Vicente,167
+Santa Clara,4231,State Senate,10,Rep,Victor San Vicente,229
+Santa Clara,4238,State Senate,10,Rep,Victor San Vicente,241
+Santa Clara,4241,State Senate,10,Rep,Victor San Vicente,266
+Santa Clara,4242,State Senate,10,Rep,Victor San Vicente,205
+Santa Clara,4247,State Senate,10,Rep,Victor San Vicente,179
+Santa Clara,4249,State Senate,10,Rep,Victor San Vicente,207
+Santa Clara,4250,State Senate,10,Rep,Victor San Vicente,185
+Santa Clara,4256,State Senate,10,Rep,Victor San Vicente,174
+Santa Clara,4257,State Senate,10,Rep,Victor San Vicente,110
+Santa Clara,4258,State Senate,10,Rep,Victor San Vicente,170
+Santa Clara,4259,State Senate,10,Rep,Victor San Vicente,230
+Santa Clara,4261,State Senate,10,Rep,Victor San Vicente,119
+Santa Clara,4265,State Senate,10,Rep,Victor San Vicente,255
+Santa Clara,4267,State Senate,10,Rep,Victor San Vicente,195
+Santa Clara,4268,State Senate,10,Rep,Victor San Vicente,115
+Santa Clara,4269,State Senate,10,Rep,Victor San Vicente,129
+Santa Clara,4270,State Senate,10,Rep,Victor San Vicente,194
+Santa Clara,4271,State Senate,10,Rep,Victor San Vicente,201
+Santa Clara,4272,State Senate,10,Rep,Victor San Vicente,97
+Santa Clara,4273,State Senate,10,Rep,Victor San Vicente,189
+Santa Clara,4288,State Senate,10,Rep,Victor San Vicente,162
+Santa Clara,4289,State Senate,10,Rep,Victor San Vicente,119
+Santa Clara,4296,State Senate,10,Rep,Victor San Vicente,84
+Santa Clara,4297,State Senate,10,Rep,Victor San Vicente,246
+Santa Clara,4298,State Senate,10,Rep,Victor San Vicente,149
+Santa Clara,4299,State Senate,10,Rep,Victor San Vicente,8
+Santa Clara,4301,State Senate,10,Rep,Victor San Vicente,224
+Santa Clara,4305,State Senate,10,Rep,Victor San Vicente,269
+Santa Clara,4308,State Senate,10,Rep,Victor San Vicente,15
+Santa Clara,4309,State Senate,10,Rep,Victor San Vicente,13
+Santa Clara,4312,State Senate,10,Rep,Victor San Vicente,134
+Santa Clara,4315,State Senate,10,Rep,Victor San Vicente,260
+Santa Clara,4319,State Senate,10,Rep,Victor San Vicente,139
+Santa Clara,4321,State Senate,10,Rep,Victor San Vicente,145
+Santa Clara,4326,State Senate,10,Rep,Victor San Vicente,214
+Santa Clara,4327,State Senate,10,Rep,Victor San Vicente,198
+Santa Clara,4332,State Senate,10,Rep,Victor San Vicente,178
+Santa Clara,4334,State Senate,10,Rep,Victor San Vicente,158
+Santa Clara,4343,State Senate,10,Rep,Victor San Vicente,115
+Santa Clara,4401,State Senate,10,Rep,Victor San Vicente,251
+Santa Clara,4402,State Senate,10,Rep,Victor San Vicente,211
+Santa Clara,4403,State Senate,10,Rep,Victor San Vicente,14
+Santa Clara,4404,State Senate,10,Rep,Victor San Vicente,155
+Santa Clara,4405,State Senate,10,Rep,Victor San Vicente,123
+Santa Clara,4406,State Senate,10,Rep,Victor San Vicente,133
+Santa Clara,4407,State Senate,10,Rep,Victor San Vicente,173
+Santa Clara,4408,State Senate,10,Rep,Victor San Vicente,144
+Santa Clara,4409,State Senate,10,Rep,Victor San Vicente,192
+Santa Clara,4411,State Senate,10,Rep,Victor San Vicente,179
+Santa Clara,4412,State Senate,10,Rep,Victor San Vicente,134
+Santa Clara,4413,State Senate,10,Rep,Victor San Vicente,143
+Santa Clara,4414,State Senate,10,Rep,Victor San Vicente,138
+Santa Clara,4415,State Senate,10,Rep,Victor San Vicente,263
+Santa Clara,4416,State Senate,10,Rep,Victor San Vicente,126
+Santa Clara,4417,State Senate,10,Rep,Victor San Vicente,297
+Santa Clara,4418,State Senate,10,Rep,Victor San Vicente,143
+Santa Clara,4421,State Senate,10,Rep,Victor San Vicente,154
+Santa Clara,4422,State Senate,10,Rep,Victor San Vicente,233
+Santa Clara,4423,State Senate,10,Rep,Victor San Vicente,130
+Santa Clara,4424,State Senate,10,Rep,Victor San Vicente,123
+Santa Clara,4425,State Senate,10,Rep,Victor San Vicente,139
+Santa Clara,4426,State Senate,10,Rep,Victor San Vicente,168
+Santa Clara,4427,State Senate,10,Rep,Victor San Vicente,144
+Santa Clara,4428,State Senate,10,Rep,Victor San Vicente,187
+Santa Clara,4429,State Senate,10,Rep,Victor San Vicente,265
+Santa Clara,4431,State Senate,10,Rep,Victor San Vicente,0
+Santa Clara,4432,State Senate,10,Rep,Victor San Vicente,266
+Santa Clara,4435,State Senate,10,Rep,Victor San Vicente,229
+Santa Clara,4438,State Senate,10,Rep,Victor San Vicente,110
+Santa Clara,4440,State Senate,10,Rep,Victor San Vicente,222
+Santa Clara,4441,State Senate,10,Rep,Victor San Vicente,59
+Santa Clara,4442,State Senate,10,Rep,Victor San Vicente,3
+Santa Clara,6401,State Senate,10,Rep,Victor San Vicente,1
+Santa Clara,6402,State Senate,10,Rep,Victor San Vicente,26
+Santa Clara,6411,State Senate,10,Rep,Victor San Vicente,38
+Santa Clara,6419,State Senate,10,Rep,Victor San Vicente,13
+Santa Clara,6421,State Senate,10,Rep,Victor San Vicente,3
+Santa Clara,6425,State Senate,10,Rep,Victor San Vicente,19
+Santa Clara,6515,State Senate,10,Rep,Victor San Vicente,23
+Santa Clara,SANTA CLARA CA,State Senate,10,Rep,Victor San Vicente,23506
+Santa Clara,1001,State Assembly,28,Dem,Evan Low,700
+Santa Clara,1003,State Assembly,28,Dem,Evan Low,635
+Santa Clara,1006,State Assembly,28,Dem,Evan Low,540
+Santa Clara,1008,State Assembly,28,Dem,Evan Low,378
+Santa Clara,1009,State Assembly,29,Dem,Mark Stone,498
+Santa Clara,1010,State Assembly,28,Dem,Evan Low,356
+Santa Clara,1011,State Assembly,28,Dem,Evan Low,575
+Santa Clara,1013,State Assembly,28,Dem,Evan Low,542
+Santa Clara,1015,State Assembly,28,Dem,Evan Low,366
+Santa Clara,1016,State Assembly,28,Dem,Evan Low,459
+Santa Clara,1019,State Assembly,28,Dem,Evan Low,582
+Santa Clara,1020,State Assembly,28,Dem,Evan Low,497
+Santa Clara,1021,State Assembly,28,Dem,Evan Low,588
+Santa Clara,1024,State Assembly,28,Dem,Evan Low,562
+Santa Clara,1026,State Assembly,28,Dem,Evan Low,599
+Santa Clara,1029,State Assembly,28,Dem,Evan Low,620
+Santa Clara,1032,State Assembly,28,Dem,Evan Low,583
+Santa Clara,1034,State Assembly,28,Dem,Evan Low,362
+Santa Clara,1036,State Assembly,28,Dem,Evan Low,578
+Santa Clara,1037,State Assembly,28,Dem,Evan Low,544
+Santa Clara,1040,State Assembly,29,Dem,Mark Stone,323
+Santa Clara,1041,State Assembly,29,Dem,Mark Stone,5
+Santa Clara,1042,State Assembly,29,Dem,Mark Stone,2
+Santa Clara,1043,State Assembly,29,Dem,Mark Stone,495
+Santa Clara,1046,State Assembly,29,Dem,Mark Stone,656
+Santa Clara,1047,State Assembly,29,Dem,Mark Stone,392
+Santa Clara,1048,State Assembly,29,Dem,Mark Stone,434
+Santa Clara,1050,State Assembly,29,Dem,Mark Stone,490
+Santa Clara,1053,State Assembly,29,Dem,Mark Stone,589
+Santa Clara,1055,State Assembly,29,Dem,Mark Stone,495
+Santa Clara,1056,State Assembly,28,Dem,Evan Low,673
+Santa Clara,1057,State Assembly,28,Dem,Evan Low,324
+Santa Clara,1060,State Assembly,29,Dem,Mark Stone,580
+Santa Clara,1062,State Assembly,29,Dem,Mark Stone,554
+Santa Clara,1063,State Assembly,29,Dem,Mark Stone,548
+Santa Clara,1066,State Assembly,29,Dem,Mark Stone,651
+Santa Clara,1069,State Assembly,29,Dem,Mark Stone,498
+Santa Clara,1070,State Assembly,29,Dem,Mark Stone,499
+Santa Clara,1071,State Assembly,29,Dem,Mark Stone,0
+Santa Clara,1072,State Assembly,29,Dem,Mark Stone,336
+Santa Clara,1077,State Assembly,28,Dem,Evan Low,147
+Santa Clara,1078,State Assembly,27,Dem,Ash Kaira,146
+Santa Clara,1080,State Assembly,29,Dem,Mark Stone,365
+Santa Clara,1081,State Assembly,29,Dem,Mark Stone,569
+Santa Clara,1082,State Assembly,27,Dem,Ash Kaira,111
+Santa Clara,1085,State Assembly,28,Dem,Evan Low,72
+Santa Clara,1087,State Assembly,29,Dem,Mark Stone,0
+Santa Clara,1092,State Assembly,29,Dem,Mark Stone,327
+Santa Clara,1094,State Assembly,27,Dem,Ash Kaira,131
+Santa Clara,1099,State Assembly,27,Dem,Ash Kaira,0
+Santa Clara,1101,State Assembly,28,Dem,Evan Low,476
+Santa Clara,1104,State Assembly,28,Dem,Evan Low,502
+Santa Clara,1106,State Assembly,28,Dem,Evan Low,493
+Santa Clara,1107,State Assembly,28,Dem,Evan Low,593
+Santa Clara,1108,State Assembly,28,Dem,Evan Low,498
+Santa Clara,1111,State Assembly,28,Dem,Evan Low,113
+Santa Clara,1113,State Assembly,28,Dem,Evan Low,373
+Santa Clara,1114,State Assembly,28,Dem,Evan Low,654
+Santa Clara,1115,State Assembly,28,Dem,Evan Low,548
+Santa Clara,1117,State Assembly,28,Dem,Evan Low,327
+Santa Clara,1118,State Assembly,28,Dem,Evan Low,146
+Santa Clara,1121,State Assembly,28,Dem,Evan Low,223
+Santa Clara,1123,State Assembly,28,Dem,Evan Low,518
+Santa Clara,1125,State Assembly,28,Dem,Evan Low,587
+Santa Clara,1127,State Assembly,28,Dem,Evan Low,565
+Santa Clara,1129,State Assembly,28,Dem,Evan Low,487
+Santa Clara,1131,State Assembly,28,Dem,Evan Low,509
+Santa Clara,1134,State Assembly,28,Dem,Evan Low,358
+Santa Clara,1135,State Assembly,28,Dem,Evan Low,368
+Santa Clara,1136,State Assembly,28,Dem,Evan Low,394
+Santa Clara,1138,State Assembly,28,Dem,Evan Low,493
+Santa Clara,1141,State Assembly,28,Dem,Evan Low,605
+Santa Clara,1142,State Assembly,28,Dem,Evan Low,496
+Santa Clara,1144,State Assembly,28,Dem,Evan Low,535
+Santa Clara,1145,State Assembly,28,Dem,Evan Low,580
+Santa Clara,1146,State Assembly,28,Dem,Evan Low,506
+Santa Clara,1149,State Assembly,28,Dem,Evan Low,490
+Santa Clara,1152,State Assembly,28,Dem,Evan Low,621
+Santa Clara,1153,State Assembly,28,Dem,Evan Low,447
+Santa Clara,1154,State Assembly,28,Dem,Evan Low,532
+Santa Clara,1156,State Assembly,28,Dem,Evan Low,690
+Santa Clara,1158,State Assembly,28,Dem,Evan Low,658
+Santa Clara,1160,State Assembly,28,Dem,Evan Low,619
+Santa Clara,1161,State Assembly,28,Dem,Evan Low,342
+Santa Clara,1162,State Assembly,28,Dem,Evan Low,599
+Santa Clara,1169,State Assembly,28,Dem,Evan Low,41
+Santa Clara,1198,State Assembly,28,Dem,Evan Low,431
+Santa Clara,1199,State Assembly,28,Dem,Evan Low,184
+Santa Clara,1200,State Assembly,29,Dem,Mark Stone,437
+Santa Clara,1201,State Assembly,28,Dem,Evan Low,428
+Santa Clara,1204,State Assembly,28,Dem,Evan Low,343
+Santa Clara,1205,State Assembly,27,Dem,Ash Kaira,163
+Santa Clara,1206,State Assembly,27,Dem,Ash Kaira,112
+Santa Clara,1207,State Assembly,27,Dem,Ash Kaira,149
+Santa Clara,1208,State Assembly,27,Dem,Ash Kaira,149
+Santa Clara,1209,State Assembly,27,Dem,Ash Kaira,131
+Santa Clara,1210,State Assembly,29,Dem,Mark Stone,215
+Santa Clara,1211,State Assembly,27,Dem,Ash Kaira,95
+Santa Clara,1213,State Assembly,29,Dem,Mark Stone,427
+Santa Clara,1214,State Assembly,29,Dem,Mark Stone,542
+Santa Clara,1215,State Assembly,29,Dem,Mark Stone,414
+Santa Clara,1218,State Assembly,29,Dem,Mark Stone,635
+Santa Clara,1220,State Assembly,27,Dem,Ash Kaira,137
+Santa Clara,1221,State Assembly,29,Dem,Mark Stone,376
+Santa Clara,1222,State Assembly,29,Dem,Mark Stone,314
+Santa Clara,1223,State Assembly,29,Dem,Mark Stone,563
+Santa Clara,1224,State Assembly,29,Dem,Mark Stone,569
+Santa Clara,1226,State Assembly,29,Dem,Mark Stone,614
+Santa Clara,1228,State Assembly,29,Dem,Mark Stone,330
+Santa Clara,1229,State Assembly,29,Dem,Mark Stone,672
+Santa Clara,1230,State Assembly,27,Dem,Ash Kaira,120
+Santa Clara,1231,State Assembly,29,Dem,Mark Stone,604
+Santa Clara,1232,State Assembly,29,Dem,Mark Stone,483
+Santa Clara,1234,State Assembly,29,Dem,Mark Stone,193
+Santa Clara,1236,State Assembly,29,Dem,Mark Stone,549
+Santa Clara,1238,State Assembly,29,Dem,Mark Stone,660
+Santa Clara,1239,State Assembly,29,Dem,Mark Stone,560
+Santa Clara,1240,State Assembly,29,Dem,Mark Stone,394
+Santa Clara,1242,State Assembly,29,Dem,Mark Stone,304
+Santa Clara,1243,State Assembly,29,Dem,Mark Stone,499
+Santa Clara,1244,State Assembly,29,Dem,Mark Stone,592
+Santa Clara,1246,State Assembly,29,Dem,Mark Stone,547
+Santa Clara,1247,State Assembly,29,Dem,Mark Stone,550
+Santa Clara,1250,State Assembly,29,Dem,Mark Stone,526
+Santa Clara,1252,State Assembly,29,Dem,Mark Stone,0
+Santa Clara,1254,State Assembly,28,Dem,Evan Low,262
+Santa Clara,1263,State Assembly,29,Dem,Mark Stone,85
+Santa Clara,1268,State Assembly,29,Dem,Mark Stone,10
+Santa Clara,1271,State Assembly,29,Dem,Mark Stone,186
+Santa Clara,1274,State Assembly,29,Dem,Mark Stone,396
+Santa Clara,1276,State Assembly,27,Dem,Ash Kaira,131
+Santa Clara,1290,State Assembly,29,Dem,Mark Stone,9
+Santa Clara,1295,State Assembly,27,Dem,Ash Kaira,120
+Santa Clara,1299,State Assembly,27,Dem,Ash Kaira,0
+Santa Clara,1301,State Assembly,25,Dem,Kansen Chu,25
+Santa Clara,1302,State Assembly,25,Dem,Kansen Chu,272
+Santa Clara,1303,State Assembly,25,Dem,Kansen Chu,610
+Santa Clara,1304,State Assembly,28,Dem,Evan Low,787
+Santa Clara,1305,State Assembly,28,Dem,Evan Low,588
+Santa Clara,1307,State Assembly,28,Dem,Evan Low,343
+Santa Clara,1308,State Assembly,27,Dem,Ash Kaira,0
+Santa Clara,1310,State Assembly,27,Dem,Ash Kaira,181
+Santa Clara,1311,State Assembly,27,Dem,Ash Kaira,206
+Santa Clara,1312,State Assembly,27,Dem,Ash Kaira,136
+Santa Clara,1313,State Assembly,27,Dem,Ash Kaira,111
+Santa Clara,1314,State Assembly,27,Dem,Ash Kaira,120
+Santa Clara,1315,State Assembly,27,Dem,Ash Kaira,95
+Santa Clara,1316,State Assembly,27,Dem,Ash Kaira,122
+Santa Clara,1317,State Assembly,27,Dem,Ash Kaira,164
+Santa Clara,1318,State Assembly,27,Dem,Ash Kaira,63
+Santa Clara,1319,State Assembly,27,Dem,Ash Kaira,129
+Santa Clara,1320,State Assembly,27,Dem,Ash Kaira,95
+Santa Clara,1321,State Assembly,27,Dem,Ash Kaira,175
+Santa Clara,1323,State Assembly,27,Dem,Ash Kaira,173
+Santa Clara,1324,State Assembly,27,Dem,Ash Kaira,95
+Santa Clara,1325,State Assembly,27,Dem,Ash Kaira,171
+Santa Clara,1327,State Assembly,27,Dem,Ash Kaira,93
+Santa Clara,1329,State Assembly,27,Dem,Ash Kaira,233
+Santa Clara,1330,State Assembly,27,Dem,Ash Kaira,218
+Santa Clara,1333,State Assembly,27,Dem,Ash Kaira,190
+Santa Clara,1334,State Assembly,27,Dem,Ash Kaira,229
+Santa Clara,1336,State Assembly,27,Dem,Ash Kaira,110
+Santa Clara,1338,State Assembly,27,Dem,Ash Kaira,130
+Santa Clara,1339,State Assembly,27,Dem,Ash Kaira,101
+Santa Clara,1340,State Assembly,27,Dem,Ash Kaira,93
+Santa Clara,1342,State Assembly,27,Dem,Ash Kaira,46
+Santa Clara,1343,State Assembly,27,Dem,Ash Kaira,207
+Santa Clara,1344,State Assembly,27,Dem,Ash Kaira,172
+Santa Clara,1346,State Assembly,27,Dem,Ash Kaira,79
+Santa Clara,1347,State Assembly,28,Dem,Evan Low,351
+Santa Clara,1348,State Assembly,28,Dem,Evan Low,430
+Santa Clara,1353,State Assembly,27,Dem,Ash Kaira,59
+Santa Clara,1356,State Assembly,27,Dem,Ash Kaira,247
+Santa Clara,1357,State Assembly,27,Dem,Ash Kaira,0
+Santa Clara,1358,State Assembly,28,Dem,Evan Low,169
+Santa Clara,1359,State Assembly,28,Dem,Evan Low,554
+Santa Clara,1361,State Assembly,27,Dem,Ash Kaira,120
+Santa Clara,1362,State Assembly,27,Dem,Ash Kaira,77
+Santa Clara,1370,State Assembly,25,Dem,Kansen Chu,9
+Santa Clara,1371,State Assembly,27,Dem,Ash Kaira,29
+Santa Clara,1373,State Assembly,27,Dem,Ash Kaira,0
+Santa Clara,1374,State Assembly,27,Dem,Ash Kaira,113
+Santa Clara,1380,State Assembly,28,Dem,Evan Low,20
+Santa Clara,1384,State Assembly,27,Dem,Ash Kaira,124
+Santa Clara,1385,State Assembly,28,Dem,Evan Low,694
+Santa Clara,1387,State Assembly,27,Dem,Ash Kaira,166
+Santa Clara,1388,State Assembly,27,Dem,Ash Kaira,119
+Santa Clara,1389,State Assembly,27,Dem,Ash Kaira,86
+Santa Clara,1390,State Assembly,27,Dem,Ash Kaira,50
+Santa Clara,1391,State Assembly,25,Dem,Kansen Chu,422
+Santa Clara,1392,State Assembly,27,Dem,Ash Kaira,70
+Santa Clara,1393,State Assembly,27,Dem,Ash Kaira,124
+Santa Clara,1394,State Assembly,25,Dem,Kansen Chu,519
+Santa Clara,1395,State Assembly,27,Dem,Ash Kaira,134
+Santa Clara,1396,State Assembly,25,Dem,Kansen Chu,556
+Santa Clara,1397,State Assembly,25,Dem,Kansen Chu,623
+Santa Clara,1398,State Assembly,27,Dem,Ash Kaira,54
+Santa Clara,1399,State Assembly,27,Dem,Ash Kaira,148
+Santa Clara,1400,State Assembly,25,Dem,Kansen Chu,499
+Santa Clara,1401,State Assembly,25,Dem,Kansen Chu,461
+Santa Clara,1403,State Assembly,25,Dem,Kansen Chu,590
+Santa Clara,1405,State Assembly,25,Dem,Kansen Chu,5
+Santa Clara,1407,State Assembly,25,Dem,Kansen Chu,512
+Santa Clara,1408,State Assembly,25,Dem,Kansen Chu,377
+Santa Clara,1409,State Assembly,25,Dem,Kansen Chu,410
+Santa Clara,1410,State Assembly,25,Dem,Kansen Chu,546
+Santa Clara,1411,State Assembly,25,Dem,Kansen Chu,601
+Santa Clara,1414,State Assembly,25,Dem,Kansen Chu,506
+Santa Clara,1415,State Assembly,25,Dem,Kansen Chu,655
+Santa Clara,1417,State Assembly,25,Dem,Kansen Chu,596
+Santa Clara,1418,State Assembly,25,Dem,Kansen Chu,539
+Santa Clara,1420,State Assembly,25,Dem,Kansen Chu,632
+Santa Clara,1421,State Assembly,25,Dem,Kansen Chu,573
+Santa Clara,1423,State Assembly,25,Dem,Kansen Chu,450
+Santa Clara,1424,State Assembly,27,Dem,Ash Kaira,125
+Santa Clara,1426,State Assembly,25,Dem,Kansen Chu,190
+Santa Clara,1427,State Assembly,25,Dem,Kansen Chu,370
+Santa Clara,1428,State Assembly,25,Dem,Kansen Chu,547
+Santa Clara,1429,State Assembly,25,Dem,Kansen Chu,687
+Santa Clara,1431,State Assembly,25,Dem,Kansen Chu,335
+Santa Clara,1432,State Assembly,25,Dem,Kansen Chu,610
+Santa Clara,1433,State Assembly,25,Dem,Kansen Chu,464
+Santa Clara,1435,State Assembly,25,Dem,Kansen Chu,669
+Santa Clara,1439,State Assembly,25,Dem,Kansen Chu,666
+Santa Clara,1440,State Assembly,25,Dem,Kansen Chu,85
+Santa Clara,1443,State Assembly,25,Dem,Kansen Chu,75
+Santa Clara,1444,State Assembly,25,Dem,Kansen Chu,571
+Santa Clara,1446,State Assembly,25,Dem,Kansen Chu,640
+Santa Clara,1447,State Assembly,25,Dem,Kansen Chu,373
+Santa Clara,1448,State Assembly,25,Dem,Kansen Chu,669
+Santa Clara,1451,State Assembly,25,Dem,Kansen Chu,533
+Santa Clara,1453,State Assembly,25,Dem,Kansen Chu,410
+Santa Clara,1455,State Assembly,25,Dem,Kansen Chu,543
+Santa Clara,1459,State Assembly,25,Dem,Kansen Chu,601
+Santa Clara,1461,State Assembly,25,Dem,Kansen Chu,541
+Santa Clara,1465,State Assembly,25,Dem,Kansen Chu,422
+Santa Clara,1467,State Assembly,25,Dem,Kansen Chu,584
+Santa Clara,1468,State Assembly,25,Dem,Kansen Chu,570
+Santa Clara,1470,State Assembly,25,Dem,Kansen Chu,342
+Santa Clara,1478,State Assembly,25,Dem,Kansen Chu,426
+Santa Clara,1480,State Assembly,25,Dem,Kansen Chu,355
+Santa Clara,1497,State Assembly,25,Dem,Kansen Chu,445
+Santa Clara,1501,State Assembly,25,Dem,Kansen Chu,148
+Santa Clara,1502,State Assembly,25,Dem,Kansen Chu,16
+Santa Clara,1504,State Assembly,27,Dem,Ash Kaira,143
+Santa Clara,1506,State Assembly,27,Dem,Ash Kaira,171
+Santa Clara,1508,State Assembly,27,Dem,Ash Kaira,84
+Santa Clara,1510,State Assembly,27,Dem,Ash Kaira,108
+Santa Clara,1512,State Assembly,27,Dem,Ash Kaira,155
+Santa Clara,1515,State Assembly,25,Dem,Kansen Chu,338
+Santa Clara,1516,State Assembly,27,Dem,Ash Kaira,157
+Santa Clara,1518,State Assembly,27,Dem,Ash Kaira,162
+Santa Clara,1519,State Assembly,27,Dem,Ash Kaira,93
+Santa Clara,1521,State Assembly,27,Dem,Ash Kaira,142
+Santa Clara,1522,State Assembly,27,Dem,Ash Kaira,62
+Santa Clara,1523,State Assembly,27,Dem,Ash Kaira,49
+Santa Clara,1525,State Assembly,27,Dem,Ash Kaira,121
+Santa Clara,1526,State Assembly,27,Dem,Ash Kaira,85
+Santa Clara,1527,State Assembly,27,Dem,Ash Kaira,119
+Santa Clara,1529,State Assembly,27,Dem,Ash Kaira,165
+Santa Clara,1530,State Assembly,27,Dem,Ash Kaira,108
+Santa Clara,1531,State Assembly,27,Dem,Ash Kaira,99
+Santa Clara,1533,State Assembly,25,Dem,Kansen Chu,372
+Santa Clara,1534,State Assembly,27,Dem,Ash Kaira,159
+Santa Clara,1535,State Assembly,27,Dem,Ash Kaira,70
+Santa Clara,1536,State Assembly,27,Dem,Ash Kaira,179
+Santa Clara,1537,State Assembly,27,Dem,Ash Kaira,171
+Santa Clara,1539,State Assembly,27,Dem,Ash Kaira,82
+Santa Clara,1542,State Assembly,27,Dem,Ash Kaira,117
+Santa Clara,1544,State Assembly,27,Dem,Ash Kaira,148
+Santa Clara,1546,State Assembly,25,Dem,Kansen Chu,314
+Santa Clara,1548,State Assembly,25,Dem,Kansen Chu,116
+Santa Clara,1550,State Assembly,27,Dem,Ash Kaira,0
+Santa Clara,1551,State Assembly,27,Dem,Ash Kaira,165
+Santa Clara,1553,State Assembly,27,Dem,Ash Kaira,80
+Santa Clara,1556,State Assembly,27,Dem,Ash Kaira,50
+Santa Clara,1557,State Assembly,25,Dem,Kansen Chu,552
+Santa Clara,1558,State Assembly,25,Dem,Kansen Chu,511
+Santa Clara,1567,State Assembly,27,Dem,Ash Kaira,0
+Santa Clara,1569,State Assembly,27,Dem,Ash Kaira,0
+Santa Clara,1570,State Assembly,25,Dem,Kansen Chu,1
+Santa Clara,1571,State Assembly,28,Dem,Evan Low,37
+Santa Clara,1572,State Assembly,28,Dem,Evan Low,85
+Santa Clara,1574,State Assembly,28,Dem,Evan Low,3
+Santa Clara,1577,State Assembly,27,Dem,Ash Kaira,44
+Santa Clara,1578,State Assembly,27,Dem,Ash Kaira,0
+Santa Clara,1583,State Assembly,27,Dem,Ash Kaira,73
+Santa Clara,1584,State Assembly,27,Dem,Ash Kaira,55
+Santa Clara,1586,State Assembly,28,Dem,Evan Low,7
+Santa Clara,1587,State Assembly,28,Dem,Evan Low,7
+Santa Clara,1588,State Assembly,28,Dem,Evan Low,550
+Santa Clara,1589,State Assembly,27,Dem,Ash Kaira,42
+Santa Clara,1590,State Assembly,27,Dem,Ash Kaira,115
+Santa Clara,1591,State Assembly,27,Dem,Ash Kaira,0
+Santa Clara,1592,State Assembly,28,Dem,Evan Low,351
+Santa Clara,1593,State Assembly,25,Dem,Kansen Chu,124
+Santa Clara,1595,State Assembly,27,Dem,Ash Kaira,0
+Santa Clara,1597,State Assembly,27,Dem,Ash Kaira,132
+Santa Clara,1599,State Assembly,27,Dem,Ash Kaira,77
+Santa Clara,1600,State Assembly,28,Dem,Evan Low,606
+Santa Clara,1601,State Assembly,28,Dem,Evan Low,687
+Santa Clara,1602,State Assembly,28,Dem,Evan Low,609
+Santa Clara,1603,State Assembly,28,Dem,Evan Low,646
+Santa Clara,1606,State Assembly,28,Dem,Evan Low,436
+Santa Clara,1607,State Assembly,28,Dem,Evan Low,659
+Santa Clara,1609,State Assembly,28,Dem,Evan Low,483
+Santa Clara,1612,State Assembly,28,Dem,Evan Low,441
+Santa Clara,1613,State Assembly,28,Dem,Evan Low,403
+Santa Clara,1615,State Assembly,28,Dem,Evan Low,521
+Santa Clara,1616,State Assembly,28,Dem,Evan Low,692
+Santa Clara,1619,State Assembly,28,Dem,Evan Low,33
+Santa Clara,1620,State Assembly,28,Dem,Evan Low,667
+Santa Clara,1621,State Assembly,28,Dem,Evan Low,352
+Santa Clara,1623,State Assembly,28,Dem,Evan Low,870
+Santa Clara,1625,State Assembly,27,Dem,Ash Kaira,150
+Santa Clara,1626,State Assembly,28,Dem,Evan Low,112
+Santa Clara,1629,State Assembly,28,Dem,Evan Low,531
+Santa Clara,1630,State Assembly,28,Dem,Evan Low,458
+Santa Clara,1631,State Assembly,28,Dem,Evan Low,651
+Santa Clara,1632,State Assembly,28,Dem,Evan Low,228
+Santa Clara,1634,State Assembly,28,Dem,Evan Low,596
+Santa Clara,1635,State Assembly,28,Dem,Evan Low,624
+Santa Clara,1636,State Assembly,28,Dem,Evan Low,520
+Santa Clara,1640,State Assembly,28,Dem,Evan Low,586
+Santa Clara,1641,State Assembly,28,Dem,Evan Low,410
+Santa Clara,1643,State Assembly,28,Dem,Evan Low,457
+Santa Clara,1644,State Assembly,28,Dem,Evan Low,576
+Santa Clara,1646,State Assembly,28,Dem,Evan Low,384
+Santa Clara,1648,State Assembly,28,Dem,Evan Low,710
+Santa Clara,1649,State Assembly,28,Dem,Evan Low,631
+Santa Clara,1654,State Assembly,28,Dem,Evan Low,550
+Santa Clara,1656,State Assembly,28,Dem,Evan Low,615
+Santa Clara,1658,State Assembly,28,Dem,Evan Low,692
+Santa Clara,1661,State Assembly,27,Dem,Ash Kaira,116
+Santa Clara,1662,State Assembly,28,Dem,Evan Low,485
+Santa Clara,1663,State Assembly,28,Dem,Evan Low,448
+Santa Clara,1664,State Assembly,28,Dem,Evan Low,572
+Santa Clara,1666,State Assembly,28,Dem,Evan Low,688
+Santa Clara,1671,State Assembly,28,Dem,Evan Low,642
+Santa Clara,1672,State Assembly,28,Dem,Evan Low,582
+Santa Clara,1674,State Assembly,28,Dem,Evan Low,718
+Santa Clara,1677,State Assembly,28,Dem,Evan Low,457
+Santa Clara,1678,State Assembly,27,Dem,Ash Kaira,107
+Santa Clara,1679,State Assembly,28,Dem,Evan Low,20
+Santa Clara,1683,State Assembly,28,Dem,Evan Low,409
+Santa Clara,1685,State Assembly,27,Dem,Ash Kaira,53
+Santa Clara,1687,State Assembly,28,Dem,Evan Low,727
+Santa Clara,1696,State Assembly,27,Dem,Ash Kaira,117
+Santa Clara,1699,State Assembly,27,Dem,Ash Kaira,76
+Santa Clara,1700,State Assembly,27,Dem,Ash Kaira,158
+Santa Clara,1701,State Assembly,27,Dem,Ash Kaira,164
+Santa Clara,1702,State Assembly,27,Dem,Ash Kaira,161
+Santa Clara,1703,State Assembly,27,Dem,Ash Kaira,126
+Santa Clara,1704,State Assembly,27,Dem,Ash Kaira,97
+Santa Clara,1706,State Assembly,27,Dem,Ash Kaira,96
+Santa Clara,1707,State Assembly,27,Dem,Ash Kaira,32
+Santa Clara,1708,State Assembly,27,Dem,Ash Kaira,115
+Santa Clara,1709,State Assembly,27,Dem,Ash Kaira,82
+Santa Clara,1710,State Assembly,27,Dem,Ash Kaira,123
+Santa Clara,1711,State Assembly,27,Dem,Ash Kaira,129
+Santa Clara,1712,State Assembly,27,Dem,Ash Kaira,108
+Santa Clara,1715,State Assembly,27,Dem,Ash Kaira,77
+Santa Clara,1716,State Assembly,27,Dem,Ash Kaira,89
+Santa Clara,1717,State Assembly,27,Dem,Ash Kaira,57
+Santa Clara,1718,State Assembly,27,Dem,Ash Kaira,84
+Santa Clara,1719,State Assembly,27,Dem,Ash Kaira,112
+Santa Clara,1722,State Assembly,27,Dem,Ash Kaira,36
+Santa Clara,1723,State Assembly,27,Dem,Ash Kaira,87
+Santa Clara,1724,State Assembly,27,Dem,Ash Kaira,89
+Santa Clara,1726,State Assembly,27,Dem,Ash Kaira,72
+Santa Clara,1728,State Assembly,27,Dem,Ash Kaira,78
+Santa Clara,1729,State Assembly,27,Dem,Ash Kaira,95
+Santa Clara,1730,State Assembly,27,Dem,Ash Kaira,53
+Santa Clara,1732,State Assembly,27,Dem,Ash Kaira,77
+Santa Clara,1734,State Assembly,27,Dem,Ash Kaira,215
+Santa Clara,1735,State Assembly,27,Dem,Ash Kaira,88
+Santa Clara,1736,State Assembly,27,Dem,Ash Kaira,91
+Santa Clara,1737,State Assembly,27,Dem,Ash Kaira,156
+Santa Clara,1743,State Assembly,27,Dem,Ash Kaira,113
+Santa Clara,1744,State Assembly,27,Dem,Ash Kaira,121
+Santa Clara,1751,State Assembly,27,Dem,Ash Kaira,148
+Santa Clara,1753,State Assembly,28,Dem,Evan Low,455
+Santa Clara,1755,State Assembly,28,Dem,Evan Low,575
+Santa Clara,1757,State Assembly,27,Dem,Ash Kaira,25
+Santa Clara,1767,State Assembly,27,Dem,Ash Kaira,48
+Santa Clara,1775,State Assembly,27,Dem,Ash Kaira,38
+Santa Clara,1778,State Assembly,27,Dem,Ash Kaira,115
+Santa Clara,1780,State Assembly,27,Dem,Ash Kaira,121
+Santa Clara,1781,State Assembly,27,Dem,Ash Kaira,145
+Santa Clara,1782,State Assembly,27,Dem,Ash Kaira,0
+Santa Clara,1783,State Assembly,27,Dem,Ash Kaira,162
+Santa Clara,1784,State Assembly,27,Dem,Ash Kaira,124
+Santa Clara,1785,State Assembly,27,Dem,Ash Kaira,100
+Santa Clara,1786,State Assembly,27,Dem,Ash Kaira,85
+Santa Clara,1787,State Assembly,27,Dem,Ash Kaira,223
+Santa Clara,1788,State Assembly,27,Dem,Ash Kaira,175
+Santa Clara,1789,State Assembly,27,Dem,Ash Kaira,85
+Santa Clara,1790,State Assembly,27,Dem,Ash Kaira,119
+Santa Clara,1792,State Assembly,27,Dem,Ash Kaira,76
+Santa Clara,1793,State Assembly,27,Dem,Ash Kaira,137
+Santa Clara,1795,State Assembly,27,Dem,Ash Kaira,113
+Santa Clara,1796,State Assembly,27,Dem,Ash Kaira,86
+Santa Clara,1797,State Assembly,27,Dem,Ash Kaira,105
+Santa Clara,1798,State Assembly,27,Dem,Ash Kaira,34
+Santa Clara,1799,State Assembly,27,Dem,Ash Kaira,118
+Santa Clara,1800,State Assembly,27,Dem,Ash Kaira,163
+Santa Clara,1801,State Assembly,25,Dem,Kansen Chu,48
+Santa Clara,1805,State Assembly,27,Dem,Ash Kaira,179
+Santa Clara,1811,State Assembly,27,Dem,Ash Kaira,69
+Santa Clara,1813,State Assembly,27,Dem,Ash Kaira,39
+Santa Clara,1817,State Assembly,27,Dem,Ash Kaira,131
+Santa Clara,1818,State Assembly,27,Dem,Ash Kaira,83
+Santa Clara,1820,State Assembly,27,Dem,Ash Kaira,112
+Santa Clara,1821,State Assembly,27,Dem,Ash Kaira,84
+Santa Clara,1822,State Assembly,27,Dem,Ash Kaira,115
+Santa Clara,1824,State Assembly,27,Dem,Ash Kaira,156
+Santa Clara,1826,State Assembly,27,Dem,Ash Kaira,143
+Santa Clara,1829,State Assembly,27,Dem,Ash Kaira,163
+Santa Clara,1830,State Assembly,27,Dem,Ash Kaira,124
+Santa Clara,1831,State Assembly,27,Dem,Ash Kaira,174
+Santa Clara,1832,State Assembly,27,Dem,Ash Kaira,143
+Santa Clara,1838,State Assembly,27,Dem,Ash Kaira,33
+Santa Clara,1839,State Assembly,27,Dem,Ash Kaira,82
+Santa Clara,1841,State Assembly,27,Dem,Ash Kaira,133
+Santa Clara,1842,State Assembly,27,Dem,Ash Kaira,142
+Santa Clara,1843,State Assembly,27,Dem,Ash Kaira,102
+Santa Clara,1844,State Assembly,27,Dem,Ash Kaira,136
+Santa Clara,1846,State Assembly,27,Dem,Ash Kaira,58
+Santa Clara,1848,State Assembly,27,Dem,Ash Kaira,95
+Santa Clara,1850,State Assembly,27,Dem,Ash Kaira,165
+Santa Clara,1852,State Assembly,27,Dem,Ash Kaira,55
+Santa Clara,1853,State Assembly,27,Dem,Ash Kaira,0
+Santa Clara,1856,State Assembly,27,Dem,Ash Kaira,106
+Santa Clara,1859,State Assembly,27,Dem,Ash Kaira,163
+Santa Clara,1860,State Assembly,27,Dem,Ash Kaira,103
+Santa Clara,1861,State Assembly,27,Dem,Ash Kaira,106
+Santa Clara,1863,State Assembly,27,Dem,Ash Kaira,77
+Santa Clara,1865,State Assembly,27,Dem,Ash Kaira,123
+Santa Clara,1866,State Assembly,27,Dem,Ash Kaira,118
+Santa Clara,1871,State Assembly,27,Dem,Ash Kaira,142
+Santa Clara,1882,State Assembly,27,Dem,Ash Kaira,70
+Santa Clara,1886,State Assembly,27,Dem,Ash Kaira,73
+Santa Clara,1888,State Assembly,27,Dem,Ash Kaira,90
+Santa Clara,1897,State Assembly,27,Dem,Ash Kaira,71
+Santa Clara,1898,State Assembly,27,Dem,Ash Kaira,66
+Santa Clara,1901,State Assembly,28,Dem,Evan Low,329
+Santa Clara,1902,State Assembly,28,Dem,Evan Low,505
+Santa Clara,1903,State Assembly,28,Dem,Evan Low,565
+Santa Clara,1904,State Assembly,28,Dem,Evan Low,553
+Santa Clara,1907,State Assembly,28,Dem,Evan Low,540
+Santa Clara,1909,State Assembly,28,Dem,Evan Low,699
+Santa Clara,1911,State Assembly,28,Dem,Evan Low,584
+Santa Clara,1913,State Assembly,28,Dem,Evan Low,505
+Santa Clara,1914,State Assembly,28,Dem,Evan Low,426
+Santa Clara,1916,State Assembly,28,Dem,Evan Low,755
+Santa Clara,1918,State Assembly,28,Dem,Evan Low,499
+Santa Clara,1919,State Assembly,28,Dem,Evan Low,286
+Santa Clara,1920,State Assembly,28,Dem,Evan Low,545
+Santa Clara,1922,State Assembly,28,Dem,Evan Low,662
+Santa Clara,1925,State Assembly,28,Dem,Evan Low,485
+Santa Clara,1928,State Assembly,28,Dem,Evan Low,479
+Santa Clara,1929,State Assembly,28,Dem,Evan Low,486
+Santa Clara,1930,State Assembly,28,Dem,Evan Low,490
+Santa Clara,1932,State Assembly,28,Dem,Evan Low,412
+Santa Clara,1934,State Assembly,28,Dem,Evan Low,673
+Santa Clara,1936,State Assembly,28,Dem,Evan Low,600
+Santa Clara,1937,State Assembly,28,Dem,Evan Low,588
+Santa Clara,1939,State Assembly,28,Dem,Evan Low,497
+Santa Clara,1944,State Assembly,28,Dem,Evan Low,497
+Santa Clara,1945,State Assembly,28,Dem,Evan Low,505
+Santa Clara,1947,State Assembly,28,Dem,Evan Low,446
+Santa Clara,1949,State Assembly,28,Dem,Evan Low,651
+Santa Clara,1952,State Assembly,28,Dem,Evan Low,513
+Santa Clara,1953,State Assembly,28,Dem,Evan Low,422
+Santa Clara,1954,State Assembly,28,Dem,Evan Low,667
+Santa Clara,1958,State Assembly,28,Dem,Evan Low,342
+Santa Clara,1959,State Assembly,28,Dem,Evan Low,160
+Santa Clara,1960,State Assembly,28,Dem,Evan Low,613
+Santa Clara,1961,State Assembly,28,Dem,Evan Low,147
+Santa Clara,1962,State Assembly,28,Dem,Evan Low,302
+Santa Clara,1964,State Assembly,28,Dem,Evan Low,313
+Santa Clara,1966,State Assembly,28,Dem,Evan Low,376
+Santa Clara,1968,State Assembly,28,Dem,Evan Low,35
+Santa Clara,1977,State Assembly,27,Dem,Ash Kaira,62
+Santa Clara,1982,State Assembly,27,Dem,Ash Kaira,66
+Santa Clara,1990,State Assembly,28,Dem,Evan Low,37
+Santa Clara,1991,State Assembly,27,Dem,Ash Kaira,36
+Santa Clara,1994,State Assembly,28,Dem,Evan Low,168
+Santa Clara,1996,State Assembly,28,Dem,Evan Low,82
+Santa Clara,2001,State Assembly,24,Dem,Marc Berman,2
+Santa Clara,2002,State Assembly,24,Dem,Marc Berman,883
+Santa Clara,2003,State Assembly,24,Dem,Marc Berman,737
+Santa Clara,2004,State Assembly,24,Dem,Marc Berman,839
+Santa Clara,2005,State Assembly,24,Dem,Marc Berman,875
+Santa Clara,2006,State Assembly,24,Dem,Marc Berman,48
+Santa Clara,2009,State Assembly,24,Dem,Marc Berman,860
+Santa Clara,2013,State Assembly,24,Dem,Marc Berman,826
+Santa Clara,2014,State Assembly,24,Dem,Marc Berman,854
+Santa Clara,2015,State Assembly,24,Dem,Marc Berman,742
+Santa Clara,2018,State Assembly,24,Dem,Marc Berman,50
+Santa Clara,2019,State Assembly,24,Dem,Marc Berman,530
+Santa Clara,2025,State Assembly,24,Dem,Marc Berman,842
+Santa Clara,2028,State Assembly,24,Dem,Marc Berman,630
+Santa Clara,2034,State Assembly,24,Dem,Marc Berman,873
+Santa Clara,2043,State Assembly,24,Dem,Marc Berman,688
+Santa Clara,2046,State Assembly,24,Dem,Marc Berman,798
+Santa Clara,2049,State Assembly,24,Dem,Marc Berman,497
+Santa Clara,2056,State Assembly,24,Dem,Marc Berman,841
+Santa Clara,2061,State Assembly,24,Dem,Marc Berman,862
+Santa Clara,2065,State Assembly,24,Dem,Marc Berman,978
+Santa Clara,2068,State Assembly,24,Dem,Marc Berman,773
+Santa Clara,2069,State Assembly,24,Dem,Marc Berman,767
+Santa Clara,2081,State Assembly,24,Dem,Marc Berman,888
+Santa Clara,2090,State Assembly,24,Dem,Marc Berman,500
+Santa Clara,2096,State Assembly,24,Dem,Marc Berman,510
+Santa Clara,2098,State Assembly,24,Dem,Marc Berman,490
+Santa Clara,2101,State Assembly,24,Dem,Marc Berman,416
+Santa Clara,2102,State Assembly,24,Dem,Marc Berman,417
+Santa Clara,2107,State Assembly,24,Dem,Marc Berman,474
+Santa Clara,2108,State Assembly,24,Dem,Marc Berman,831
+Santa Clara,2110,State Assembly,24,Dem,Marc Berman,559
+Santa Clara,2112,State Assembly,24,Dem,Marc Berman,703
+Santa Clara,2114,State Assembly,24,Dem,Marc Berman,416
+Santa Clara,2115,State Assembly,24,Dem,Marc Berman,694
+Santa Clara,2117,State Assembly,24,Dem,Marc Berman,547
+Santa Clara,2120,State Assembly,24,Dem,Marc Berman,520
+Santa Clara,2124,State Assembly,24,Dem,Marc Berman,99
+Santa Clara,2125,State Assembly,24,Dem,Marc Berman,142
+Santa Clara,2126,State Assembly,24,Dem,Marc Berman,39
+Santa Clara,2129,State Assembly,24,Dem,Marc Berman,456
+Santa Clara,2301,State Assembly,24,Dem,Marc Berman,721
+Santa Clara,2305,State Assembly,24,Dem,Marc Berman,399
+Santa Clara,2306,State Assembly,24,Dem,Marc Berman,425
+Santa Clara,2307,State Assembly,24,Dem,Marc Berman,415
+Santa Clara,2309,State Assembly,24,Dem,Marc Berman,653
+Santa Clara,2310,State Assembly,24,Dem,Marc Berman,411
+Santa Clara,2311,State Assembly,24,Dem,Marc Berman,697
+Santa Clara,2314,State Assembly,24,Dem,Marc Berman,386
+Santa Clara,2316,State Assembly,24,Dem,Marc Berman,613
+Santa Clara,2317,State Assembly,24,Dem,Marc Berman,568
+Santa Clara,2321,State Assembly,24,Dem,Marc Berman,793
+Santa Clara,2323,State Assembly,24,Dem,Marc Berman,464
+Santa Clara,2326,State Assembly,24,Dem,Marc Berman,472
+Santa Clara,2330,State Assembly,24,Dem,Marc Berman,418
+Santa Clara,2333,State Assembly,24,Dem,Marc Berman,534
+Santa Clara,2338,State Assembly,24,Dem,Marc Berman,74
+Santa Clara,2339,State Assembly,24,Dem,Marc Berman,783
+Santa Clara,2343,State Assembly,24,Dem,Marc Berman,423
+Santa Clara,2345,State Assembly,24,Dem,Marc Berman,479
+Santa Clara,2351,State Assembly,24,Dem,Marc Berman,662
+Santa Clara,2352,State Assembly,24,Dem,Marc Berman,525
+Santa Clara,2357,State Assembly,24,Dem,Marc Berman,372
+Santa Clara,2374,State Assembly,24,Dem,Marc Berman,102
+Santa Clara,2375,State Assembly,24,Dem,Marc Berman,528
+Santa Clara,2378,State Assembly,24,Dem,Marc Berman,494
+Santa Clara,2381,State Assembly,24,Dem,Marc Berman,1
+Santa Clara,2382,State Assembly,24,Dem,Marc Berman,679
+Santa Clara,2385,State Assembly,24,Dem,Marc Berman,553
+Santa Clara,2389,State Assembly,24,Dem,Marc Berman,549
+Santa Clara,2402,State Assembly,24,Dem,Marc Berman,458
+Santa Clara,2403,State Assembly,24,Dem,Marc Berman,879
+Santa Clara,2406,State Assembly,24,Dem,Marc Berman,832
+Santa Clara,2407,State Assembly,24,Dem,Marc Berman,624
+Santa Clara,2408,State Assembly,24,Dem,Marc Berman,894
+Santa Clara,2409,State Assembly,24,Dem,Marc Berman,713
+Santa Clara,2410,State Assembly,24,Dem,Marc Berman,802
+Santa Clara,2412,State Assembly,24,Dem,Marc Berman,770
+Santa Clara,2413,State Assembly,24,Dem,Marc Berman,494
+Santa Clara,2414,State Assembly,24,Dem,Marc Berman,715
+Santa Clara,2417,State Assembly,24,Dem,Marc Berman,871
+Santa Clara,2418,State Assembly,24,Dem,Marc Berman,715
+Santa Clara,2419,State Assembly,24,Dem,Marc Berman,689
+Santa Clara,2427,State Assembly,24,Dem,Marc Berman,560
+Santa Clara,2428,State Assembly,24,Dem,Marc Berman,649
+Santa Clara,2431,State Assembly,24,Dem,Marc Berman,347
+Santa Clara,2434,State Assembly,24,Dem,Marc Berman,524
+Santa Clara,2436,State Assembly,24,Dem,Marc Berman,583
+Santa Clara,2438,State Assembly,24,Dem,Marc Berman,610
+Santa Clara,2439,State Assembly,24,Dem,Marc Berman,481
+Santa Clara,2440,State Assembly,24,Dem,Marc Berman,403
+Santa Clara,2442,State Assembly,24,Dem,Marc Berman,516
+Santa Clara,2445,State Assembly,24,Dem,Marc Berman,835
+Santa Clara,2452,State Assembly,24,Dem,Marc Berman,464
+Santa Clara,2457,State Assembly,24,Dem,Marc Berman,821
+Santa Clara,2459,State Assembly,24,Dem,Marc Berman,438
+Santa Clara,2460,State Assembly,24,Dem,Marc Berman,738
+Santa Clara,2464,State Assembly,24,Dem,Marc Berman,237
+Santa Clara,2465,State Assembly,24,Dem,Marc Berman,582
+Santa Clara,2467,State Assembly,24,Dem,Marc Berman,424
+Santa Clara,2475,State Assembly,24,Dem,Marc Berman,574
+Santa Clara,2479,State Assembly,24,Dem,Marc Berman,740
+Santa Clara,2489,State Assembly,24,Dem,Marc Berman,693
+Santa Clara,2492,State Assembly,24,Dem,Marc Berman,777
+Santa Clara,2494,State Assembly,24,Dem,Marc Berman,386
+Santa Clara,2539,State Assembly,24,Dem,Marc Berman,40
+Santa Clara,2540,State Assembly,24,Dem,Marc Berman,68
+Santa Clara,2542,State Assembly,24,Dem,Marc Berman,757
+Santa Clara,2544,State Assembly,24,Dem,Marc Berman,869
+Santa Clara,2545,State Assembly,24,Dem,Marc Berman,522
+Santa Clara,2546,State Assembly,24,Dem,Marc Berman,467
+Santa Clara,2802,State Assembly,24,Dem,Marc Berman,605
+Santa Clara,2808,State Assembly,28,Dem,Evan Low,13
+Santa Clara,2811,State Assembly,28,Dem,Evan Low,20
+Santa Clara,2812,State Assembly,24,Dem,Marc Berman,137
+Santa Clara,2813,State Assembly,28,Dem,Evan Low,102
+Santa Clara,2816,State Assembly,28,Dem,Evan Low,13
+Santa Clara,2825,State Assembly,24,Dem,Marc Berman,7
+Santa Clara,2833,State Assembly,24,Dem,Marc Berman,598
+Santa Clara,2870,State Assembly,24,Dem,Marc Berman,59
+Santa Clara,2871,State Assembly,24,Dem,Marc Berman,7
+Santa Clara,2873,State Assembly,24,Dem,Marc Berman,3
+Santa Clara,2951,State Assembly,24,Dem,Marc Berman,51
+Santa Clara,2953,State Assembly,24,Dem,Marc Berman,64
+Santa Clara,3601,State Assembly,24,Dem,Marc Berman,258
+Santa Clara,3602,State Assembly,28,Dem,Evan Low,652
+Santa Clara,3603,State Assembly,24,Dem,Marc Berman,215
+Santa Clara,3604,State Assembly,28,Dem,Evan Low,500
+Santa Clara,3605,State Assembly,28,Dem,Evan Low,442
+Santa Clara,3606,State Assembly,28,Dem,Evan Low,655
+Santa Clara,3607,State Assembly,24,Dem,Marc Berman,420
+Santa Clara,3608,State Assembly,28,Dem,Evan Low,558
+Santa Clara,3609,State Assembly,28,Dem,Evan Low,713
+Santa Clara,3610,State Assembly,28,Dem,Evan Low,653
+Santa Clara,3612,State Assembly,28,Dem,Evan Low,670
+Santa Clara,3614,State Assembly,28,Dem,Evan Low,541
+Santa Clara,3615,State Assembly,28,Dem,Evan Low,580
+Santa Clara,3616,State Assembly,28,Dem,Evan Low,653
+Santa Clara,3620,State Assembly,28,Dem,Evan Low,594
+Santa Clara,3621,State Assembly,28,Dem,Evan Low,650
+Santa Clara,3624,State Assembly,28,Dem,Evan Low,430
+Santa Clara,3627,State Assembly,28,Dem,Evan Low,392
+Santa Clara,3628,State Assembly,28,Dem,Evan Low,740
+Santa Clara,3629,State Assembly,28,Dem,Evan Low,597
+Santa Clara,3633,State Assembly,28,Dem,Evan Low,610
+Santa Clara,3635,State Assembly,28,Dem,Evan Low,60
+Santa Clara,3636,State Assembly,28,Dem,Evan Low,673
+Santa Clara,3640,State Assembly,28,Dem,Evan Low,654
+Santa Clara,3642,State Assembly,28,Dem,Evan Low,658
+Santa Clara,3645,State Assembly,28,Dem,Evan Low,347
+Santa Clara,3650,State Assembly,24,Dem,Marc Berman,459
+Santa Clara,3652,State Assembly,28,Dem,Evan Low,620
+Santa Clara,3658,State Assembly,24,Dem,Marc Berman,19
+Santa Clara,3663,State Assembly,28,Dem,Evan Low,80
+Santa Clara,3720,State Assembly,28,Dem,Evan Low,481
+Santa Clara,3721,State Assembly,28,Dem,Evan Low,629
+Santa Clara,3723,State Assembly,28,Dem,Evan Low,30
+Santa Clara,3724,State Assembly,28,Dem,Evan Low,705
+Santa Clara,3725,State Assembly,28,Dem,Evan Low,328
+Santa Clara,3726,State Assembly,28,Dem,Evan Low,583
+Santa Clara,3727,State Assembly,28,Dem,Evan Low,48
+Santa Clara,3728,State Assembly,28,Dem,Evan Low,2
+Santa Clara,3729,State Assembly,28,Dem,Evan Low,562
+Santa Clara,3731,State Assembly,28,Dem,Evan Low,392
+Santa Clara,3733,State Assembly,28,Dem,Evan Low,360
+Santa Clara,3734,State Assembly,28,Dem,Evan Low,401
+Santa Clara,3737,State Assembly,28,Dem,Evan Low,627
+Santa Clara,3740,State Assembly,28,Dem,Evan Low,548
+Santa Clara,3741,State Assembly,28,Dem,Evan Low,349
+Santa Clara,3745,State Assembly,28,Dem,Evan Low,586
+Santa Clara,3749,State Assembly,28,Dem,Evan Low,264
+Santa Clara,3751,State Assembly,28,Dem,Evan Low,10
+Santa Clara,3753,State Assembly,28,Dem,Evan Low,528
+Santa Clara,3754,State Assembly,28,Dem,Evan Low,373
+Santa Clara,3757,State Assembly,28,Dem,Evan Low,417
+Santa Clara,3761,State Assembly,28,Dem,Evan Low,2
+Santa Clara,3767,State Assembly,28,Dem,Evan Low,396
+Santa Clara,3771,State Assembly,28,Dem,Evan Low,390
+Santa Clara,3772,State Assembly,28,Dem,Evan Low,380
+Santa Clara,3774,State Assembly,28,Dem,Evan Low,754
+Santa Clara,3781,State Assembly,28,Dem,Evan Low,517
+Santa Clara,3782,State Assembly,28,Dem,Evan Low,153
+Santa Clara,3784,State Assembly,28,Dem,Evan Low,49
+Santa Clara,3785,State Assembly,28,Dem,Evan Low,472
+Santa Clara,3787,State Assembly,28,Dem,Evan Low,13
+Santa Clara,3801,State Assembly,28,Dem,Evan Low,507
+Santa Clara,3802,State Assembly,28,Dem,Evan Low,614
+Santa Clara,3803,State Assembly,28,Dem,Evan Low,604
+Santa Clara,3804,State Assembly,28,Dem,Evan Low,498
+Santa Clara,3805,State Assembly,28,Dem,Evan Low,624
+Santa Clara,3806,State Assembly,28,Dem,Evan Low,321
+Santa Clara,3809,State Assembly,28,Dem,Evan Low,578
+Santa Clara,3810,State Assembly,28,Dem,Evan Low,569
+Santa Clara,3812,State Assembly,28,Dem,Evan Low,434
+Santa Clara,3814,State Assembly,28,Dem,Evan Low,557
+Santa Clara,3818,State Assembly,28,Dem,Evan Low,623
+Santa Clara,3819,State Assembly,28,Dem,Evan Low,618
+Santa Clara,3820,State Assembly,28,Dem,Evan Low,696
+Santa Clara,3821,State Assembly,28,Dem,Evan Low,494
+Santa Clara,3823,State Assembly,28,Dem,Evan Low,426
+Santa Clara,3825,State Assembly,28,Dem,Evan Low,460
+Santa Clara,3826,State Assembly,28,Dem,Evan Low,366
+Santa Clara,3828,State Assembly,28,Dem,Evan Low,693
+Santa Clara,3834,State Assembly,28,Dem,Evan Low,560
+Santa Clara,3835,State Assembly,28,Dem,Evan Low,522
+Santa Clara,3840,State Assembly,28,Dem,Evan Low,644
+Santa Clara,3843,State Assembly,28,Dem,Evan Low,713
+Santa Clara,3846,State Assembly,28,Dem,Evan Low,65
+Santa Clara,3900,State Assembly,30,Dem,Robert Rivas,407
+Santa Clara,3901,State Assembly,30,Dem,Robert Rivas,588
+Santa Clara,3902,State Assembly,30,Dem,Robert Rivas,618
+Santa Clara,3903,State Assembly,30,Dem,Robert Rivas,347
+Santa Clara,3906,State Assembly,30,Dem,Robert Rivas,443
+Santa Clara,3907,State Assembly,30,Dem,Robert Rivas,288
+Santa Clara,3908,State Assembly,30,Dem,Robert Rivas,39
+Santa Clara,3909,State Assembly,30,Dem,Robert Rivas,555
+Santa Clara,3910,State Assembly,30,Dem,Robert Rivas,137
+Santa Clara,3911,State Assembly,30,Dem,Robert Rivas,113
+Santa Clara,3912,State Assembly,30,Dem,Robert Rivas,301
+Santa Clara,3914,State Assembly,30,Dem,Robert Rivas,463
+Santa Clara,3916,State Assembly,30,Dem,Robert Rivas,285
+Santa Clara,3918,State Assembly,30,Dem,Robert Rivas,561
+Santa Clara,3921,State Assembly,30,Dem,Robert Rivas,514
+Santa Clara,3922,State Assembly,30,Dem,Robert Rivas,315
+Santa Clara,3923,State Assembly,30,Dem,Robert Rivas,343
+Santa Clara,3924,State Assembly,30,Dem,Robert Rivas,494
+Santa Clara,3928,State Assembly,30,Dem,Robert Rivas,601
+Santa Clara,3929,State Assembly,30,Dem,Robert Rivas,404
+Santa Clara,3932,State Assembly,30,Dem,Robert Rivas,490
+Santa Clara,3937,State Assembly,30,Dem,Robert Rivas,588
+Santa Clara,3938,State Assembly,30,Dem,Robert Rivas,348
+Santa Clara,3939,State Assembly,30,Dem,Robert Rivas,360
+Santa Clara,3940,State Assembly,30,Dem,Robert Rivas,307
+Santa Clara,3942,State Assembly,30,Dem,Robert Rivas,328
+Santa Clara,3948,State Assembly,30,Dem,Robert Rivas,117
+Santa Clara,3951,State Assembly,30,Dem,Robert Rivas,545
+Santa Clara,3952,State Assembly,30,Dem,Robert Rivas,327
+Santa Clara,3953,State Assembly,30,Dem,Robert Rivas,605
+Santa Clara,3954,State Assembly,30,Dem,Robert Rivas,490
+Santa Clara,3955,State Assembly,30,Dem,Robert Rivas,599
+Santa Clara,3956,State Assembly,30,Dem,Robert Rivas,440
+Santa Clara,3957,State Assembly,30,Dem,Robert Rivas,614
+Santa Clara,3958,State Assembly,30,Dem,Robert Rivas,412
+Santa Clara,3959,State Assembly,30,Dem,Robert Rivas,545
+Santa Clara,3960,State Assembly,30,Dem,Robert Rivas,340
+Santa Clara,3962,State Assembly,30,Dem,Robert Rivas,490
+Santa Clara,3964,State Assembly,30,Dem,Robert Rivas,628
+Santa Clara,3965,State Assembly,30,Dem,Robert Rivas,359
+Santa Clara,3968,State Assembly,30,Dem,Robert Rivas,286
+Santa Clara,3972,State Assembly,30,Dem,Robert Rivas,377
+Santa Clara,3973,State Assembly,30,Dem,Robert Rivas,529
+Santa Clara,3974,State Assembly,30,Dem,Robert Rivas,415
+Santa Clara,3976,State Assembly,30,Dem,Robert Rivas,566
+Santa Clara,3982,State Assembly,30,Dem,Robert Rivas,607
+Santa Clara,3984,State Assembly,30,Dem,Robert Rivas,339
+Santa Clara,3985,State Assembly,30,Dem,Robert Rivas,555
+Santa Clara,3986,State Assembly,30,Dem,Robert Rivas,560
+Santa Clara,3989,State Assembly,30,Dem,Robert Rivas,428
+Santa Clara,3992,State Assembly,30,Dem,Robert Rivas,2
+Santa Clara,4001,State Assembly,24,Dem,Marc Berman,432
+Santa Clara,4002,State Assembly,24,Dem,Marc Berman,480
+Santa Clara,4004,State Assembly,24,Dem,Marc Berman,340
+Santa Clara,4005,State Assembly,24,Dem,Marc Berman,32
+Santa Clara,4006,State Assembly,24,Dem,Marc Berman,588
+Santa Clara,4007,State Assembly,24,Dem,Marc Berman,729
+Santa Clara,4008,State Assembly,25,Dem,Kansen Chu,19
+Santa Clara,4010,State Assembly,24,Dem,Marc Berman,742
+Santa Clara,4011,State Assembly,24,Dem,Marc Berman,591
+Santa Clara,4012,State Assembly,24,Dem,Marc Berman,60
+Santa Clara,4013,State Assembly,24,Dem,Marc Berman,553
+Santa Clara,4015,State Assembly,24,Dem,Marc Berman,259
+Santa Clara,4016,State Assembly,24,Dem,Marc Berman,709
+Santa Clara,4017,State Assembly,24,Dem,Marc Berman,501
+Santa Clara,4019,State Assembly,24,Dem,Marc Berman,740
+Santa Clara,4022,State Assembly,24,Dem,Marc Berman,786
+Santa Clara,4023,State Assembly,24,Dem,Marc Berman,654
+Santa Clara,4026,State Assembly,24,Dem,Marc Berman,623
+Santa Clara,4030,State Assembly,24,Dem,Marc Berman,490
+Santa Clara,4034,State Assembly,24,Dem,Marc Berman,643
+Santa Clara,4035,State Assembly,24,Dem,Marc Berman,614
+Santa Clara,4036,State Assembly,24,Dem,Marc Berman,461
+Santa Clara,4038,State Assembly,24,Dem,Marc Berman,614
+Santa Clara,4039,State Assembly,24,Dem,Marc Berman,552
+Santa Clara,4041,State Assembly,24,Dem,Marc Berman,383
+Santa Clara,4042,State Assembly,24,Dem,Marc Berman,514
+Santa Clara,4043,State Assembly,24,,Marc Berman,456
+Santa Clara,4045,State Assembly,24,,Marc Berman,687
+Santa Clara,4047,State Assembly,24,,Marc Berman,601
+Santa Clara,4048,State Assembly,24,,Marc Berman,425
+Santa Clara,4050,State Assembly,24,,Marc Berman,557
+Santa Clara,4051,State Assembly,24,,Marc Berman,619
+Santa Clara,4052,State Assembly,24,,Marc Berman,477
+Santa Clara,4053,State Assembly,24,,Marc Berman,727
+Santa Clara,4055,State Assembly,24,,Marc Berman,529
+Santa Clara,4058,State Assembly,24,,Marc Berman,579
+Santa Clara,4060,State Assembly,24,,Marc Berman,281
+Santa Clara,4061,State Assembly,24,,Marc Berman,58
+Santa Clara,4064,State Assembly,24,,Marc Berman,441
+Santa Clara,4067,State Assembly,24,,Marc Berman,407
+Santa Clara,4068,State Assembly,24,,Marc Berman,83
+Santa Clara,4070,State Assembly,24,,Marc Berman,434
+Santa Clara,4071,State Assembly,24,,Marc Berman,659
+Santa Clara,4074,State Assembly,24,,Marc Berman,265
+Santa Clara,4076,State Assembly,24,,Marc Berman,711
+Santa Clara,4079,State Assembly,24,,Marc Berman,277
+Santa Clara,4080,State Assembly,24,,Marc Berman,578
+Santa Clara,4084,State Assembly,24,,Marc Berman,304
+Santa Clara,4086,State Assembly,24,,Marc Berman,663
+Santa Clara,4087,State Assembly,24,,Marc Berman,406
+Santa Clara,4089,State Assembly,24,,Marc Berman,58
+Santa Clara,4098,State Assembly,24,,Marc Berman,125
+Santa Clara,4099,State Assembly,24,,Marc Berman,320
+Santa Clara,4103,State Assembly,24,,Marc Berman,635
+Santa Clara,4116,State Assembly,24,,Marc Berman,97
+Santa Clara,4117,State Assembly,24,,Marc Berman,449
+Santa Clara,4118,State Assembly,24,,Marc Berman,562
+Santa Clara,4119,State Assembly,24,,Marc Berman,691
+Santa Clara,4122,State Assembly,24,,Marc Berman,596
+Santa Clara,4126,State Assembly,24,,Marc Berman,687
+Santa Clara,4128,State Assembly,24,,Marc Berman,512
+Santa Clara,4129,State Assembly,24,,Marc Berman,638
+Santa Clara,4130,State Assembly,24,,Marc Berman,539
+Santa Clara,4131,State Assembly,24,,Marc Berman,717
+Santa Clara,4154,State Assembly,24,,Marc Berman,634
+Santa Clara,4201,State Assembly,25,Dem,Kansen Chu,682
+Santa Clara,4202,State Assembly,25,Dem,Kansen Chu,6
+Santa Clara,4205,State Assembly,25,Dem,Kansen Chu,66
+Santa Clara,4207,State Assembly,25,Dem,Kansen Chu,50
+Santa Clara,4208,State Assembly,25,Dem,Kansen Chu,631
+Santa Clara,4211,State Assembly,25,Dem,Kansen Chu,618
+Santa Clara,4212,State Assembly,25,Dem,Kansen Chu,4
+Santa Clara,4215,State Assembly,25,Dem,Kansen Chu,727
+Santa Clara,4217,State Assembly,25,Dem,Kansen Chu,502
+Santa Clara,4218,State Assembly,25,Dem,Kansen Chu,363
+Santa Clara,4222,State Assembly,25,Dem,Kansen Chu,566
+Santa Clara,4223,State Assembly,25,Dem,Kansen Chu,698
+Santa Clara,4224,State Assembly,25,Dem,Kansen Chu,2
+Santa Clara,4226,State Assembly,25,Dem,Kansen Chu,578
+Santa Clara,4227,State Assembly,25,Dem,Kansen Chu,530
+Santa Clara,4231,State Assembly,25,Dem,Kansen Chu,732
+Santa Clara,4238,State Assembly,25,Dem,Kansen Chu,741
+Santa Clara,4241,State Assembly,25,Dem,Kansen Chu,684
+Santa Clara,4242,State Assembly,25,Dem,Kansen Chu,560
+Santa Clara,4247,State Assembly,25,Dem,Kansen Chu,429
+Santa Clara,4249,State Assembly,25,Dem,Kansen Chu,701
+Santa Clara,4250,State Assembly,25,Dem,Kansen Chu,400
+Santa Clara,4256,State Assembly,25,Dem,Kansen Chu,698
+Santa Clara,4257,State Assembly,25,Dem,Kansen Chu,354
+Santa Clara,4258,State Assembly,25,Dem,Kansen Chu,482
+Santa Clara,4259,State Assembly,25,Dem,Kansen Chu,759
+Santa Clara,4261,State Assembly,25,Dem,Kansen Chu,488
+Santa Clara,4265,State Assembly,25,Dem,Kansen Chu,642
+Santa Clara,4267,State Assembly,25,Dem,Kansen Chu,367
+Santa Clara,4268,State Assembly,25,Dem,Kansen Chu,386
+Santa Clara,4269,State Assembly,25,Dem,Kansen Chu,421
+Santa Clara,4270,State Assembly,25,Dem,Kansen Chu,541
+Santa Clara,4271,State Assembly,25,Dem,Kansen Chu,672
+Santa Clara,4272,State Assembly,25,Dem,Kansen Chu,299
+Santa Clara,4273,State Assembly,25,Dem,Kansen Chu,622
+Santa Clara,4288,State Assembly,25,Dem,Kansen Chu,428
+Santa Clara,4289,State Assembly,25,Dem,Kansen Chu,408
+Santa Clara,4296,State Assembly,25,Dem,Kansen Chu,358
+Santa Clara,4297,State Assembly,25,Dem,Kansen Chu,686
+Santa Clara,4298,State Assembly,25,Dem,Kansen Chu,484
+Santa Clara,4299,State Assembly,25,Dem,Kansen Chu,17
+Santa Clara,4301,State Assembly,25,Dem,Kansen Chu,611
+Santa Clara,4305,State Assembly,25,Dem,Kansen Chu,704
+Santa Clara,4308,State Assembly,25,Dem,Kansen Chu,44
+Santa Clara,4309,State Assembly,25,Dem,Kansen Chu,24
+Santa Clara,4312,State Assembly,25,Dem,Kansen Chu,459
+Santa Clara,4315,State Assembly,25,Dem,Kansen Chu,689
+Santa Clara,4319,State Assembly,25,Dem,Kansen Chu,375
+Santa Clara,4321,State Assembly,25,Dem,Kansen Chu,593
+Santa Clara,4326,State Assembly,25,Dem,Kansen Chu,607
+Santa Clara,4327,State Assembly,25,Dem,Kansen Chu,679
+Santa Clara,4332,State Assembly,25,Dem,Kansen Chu,309
+Santa Clara,4334,State Assembly,25,Dem,Kansen Chu,450
+Santa Clara,4343,State Assembly,25,Dem,Kansen Chu,385
+Santa Clara,4401,State Assembly,25,Dem,Kansen Chu,585
+Santa Clara,4402,State Assembly,25,Dem,Kansen Chu,692
+Santa Clara,4403,State Assembly,25,Dem,Kansen Chu,55
+Santa Clara,4404,State Assembly,25,Dem,Kansen Chu,497
+Santa Clara,4405,State Assembly,25,Dem,Kansen Chu,327
+Santa Clara,4406,State Assembly,25,Dem,Kansen Chu,361
+Santa Clara,4407,State Assembly,25,Dem,Kansen Chu,314
+Santa Clara,4408,State Assembly,25,Dem,Kansen Chu,466
+Santa Clara,4409,State Assembly,25,Dem,Kansen Chu,591
+Santa Clara,4411,State Assembly,25,Dem,Kansen Chu,332
+Santa Clara,4412,State Assembly,25,Dem,Kansen Chu,398
+Santa Clara,4413,State Assembly,25,Dem,Kansen Chu,427
+Santa Clara,4414,State Assembly,25,Dem,Kansen Chu,479
+Santa Clara,4415,State Assembly,25,Dem,Kansen Chu,691
+Santa Clara,4416,State Assembly,25,Dem,Kansen Chu,368
+Santa Clara,4417,State Assembly,25,Dem,Kansen Chu,614
+Santa Clara,4418,State Assembly,25,Dem,Kansen Chu,367
+Santa Clara,4421,State Assembly,25,Dem,Kansen Chu,386
+Santa Clara,4422,State Assembly,25,Dem,Kansen Chu,520
+Santa Clara,4423,State Assembly,25,Dem,Kansen Chu,332
+Santa Clara,4424,State Assembly,25,Dem,Kansen Chu,380
+Santa Clara,4425,State Assembly,25,Dem,Kansen Chu,380
+Santa Clara,4426,State Assembly,25,Dem,Kansen Chu,342
+Santa Clara,4427,State Assembly,25,Dem,Kansen Chu,393
+Santa Clara,4428,State Assembly,25,Dem,Kansen Chu,554
+Santa Clara,4429,State Assembly,25,Dem,Kansen Chu,686
+Santa Clara,4431,State Assembly,25,Dem,Kansen Chu,1
+Santa Clara,4432,State Assembly,25,Dem,Kansen Chu,587
+Santa Clara,4435,State Assembly,25,Dem,Kansen Chu,642
+Santa Clara,4438,State Assembly,25,Dem,Kansen Chu,393
+Santa Clara,4440,State Assembly,25,Dem,Kansen Chu,594
+Santa Clara,4441,State Assembly,25,Dem,Kansen Chu,85
+Santa Clara,4442,State Assembly,25,Dem,Kansen Chu,1
+Santa Clara,4666,State Assembly,28,Dem,Evan Low,598
+Santa Clara,4667,State Assembly,28,Dem,Evan Low,6
+Santa Clara,4668,State Assembly,28,Dem,Evan Low,494
+Santa Clara,4669,State Assembly,28,Dem,Evan Low,3
+Santa Clara,4670,State Assembly,28,Dem,Evan Low,611
+Santa Clara,4672,State Assembly,28,Dem,Evan Low,31
+Santa Clara,4674,State Assembly,28,Dem,Evan Low,553
+Santa Clara,4676,State Assembly,28,Dem,Evan Low,630
+Santa Clara,4677,State Assembly,28,Dem,Evan Low,478
+Santa Clara,4678,State Assembly,28,Dem,Evan Low,529
+Santa Clara,4681,State Assembly,28,Dem,Evan Low,496
+Santa Clara,4685,State Assembly,28,Dem,Evan Low,569
+Santa Clara,4687,State Assembly,28,Dem,Evan Low,453
+Santa Clara,4688,State Assembly,28,Dem,Evan Low,669
+Santa Clara,4690,State Assembly,28,Dem,Evan Low,615
+Santa Clara,4692,State Assembly,28,Dem,Evan Low,448
+Santa Clara,4696,State Assembly,28,Dem,Evan Low,599
+Santa Clara,4699,State Assembly,28,Dem,Evan Low,699
+Santa Clara,4702,State Assembly,28,Dem,Evan Low,440
+Santa Clara,4703,State Assembly,28,Dem,Evan Low,644
+Santa Clara,4704,State Assembly,28,Dem,Evan Low,133
+Santa Clara,4707,State Assembly,28,Dem,Evan Low,75
+Santa Clara,4723,State Assembly,28,Dem,Evan Low,358
+Santa Clara,4733,State Assembly,28,Dem,Evan Low,15
+Santa Clara,4737,State Assembly,28,Dem,Evan Low,1
+Santa Clara,4740,State Assembly,28,Dem,Evan Low,26
+Santa Clara,5449,State Assembly,25,Dem,Kansen Chu,21
+Santa Clara,5452,State Assembly,25,Dem,Kansen Chu,23
+Santa Clara,5453,State Assembly,27,Dem,Ash Kaira,0
+Santa Clara,5456,State Assembly,25,Dem,Kansen Chu,4
+Santa Clara,5502,State Assembly,25,Dem,Kansen Chu,172
+Santa Clara,5503,State Assembly,27,Dem,Ash Kaira,40
+Santa Clara,5505,State Assembly,25,Dem,Kansen Chu,74
+Santa Clara,5556,State Assembly,28,Dem,Evan Low,747
+Santa Clara,5557,State Assembly,28,Dem,Evan Low,519
+Santa Clara,5567,State Assembly,28,Dem,Evan Low,281
+Santa Clara,5743,State Assembly,28,Dem,Evan Low,306
+Santa Clara,5744,State Assembly,28,Dem,Evan Low,4
+Santa Clara,5745,State Assembly,28,Dem,Evan Low,653
+Santa Clara,5746,State Assembly,28,Dem,Evan Low,239
+Santa Clara,5747,State Assembly,28,Dem,Evan Low,465
+Santa Clara,5750,State Assembly,28,Dem,Evan Low,7
+Santa Clara,5752,State Assembly,28,Dem,Evan Low,563
+Santa Clara,5756,State Assembly,29,Dem,Mark Stone,33
+Santa Clara,5758,State Assembly,28,Dem,Evan Low,61
+Santa Clara,5759,State Assembly,28,Dem,Evan Low,206
+Santa Clara,5760,State Assembly,28,Dem,Evan Low,4
+Santa Clara,5762,State Assembly,28,Dem,Evan Low,42
+Santa Clara,5763,State Assembly,28,Dem,Evan Low,35
+Santa Clara,5765,State Assembly,28,Dem,Evan Low,35
+Santa Clara,5770,State Assembly,28,Dem,Evan Low,71
+Santa Clara,5772,State Assembly,28,Dem,Evan Low,2
+Santa Clara,5774,State Assembly,28,Dem,Evan Low,16
+Santa Clara,5775,State Assembly,28,Dem,Evan Low,171
+Santa Clara,5782,State Assembly,28,Dem,Evan Low,73
+Santa Clara,5784,State Assembly,29,Dem,Mark Stone,1
+Santa Clara,5788,State Assembly,28,Dem,Evan Low,13
+Santa Clara,5789,State Assembly,28,Dem,Evan Low,6
+Santa Clara,5792,State Assembly,29,Dem,Mark Stone,2
+Santa Clara,5794,State Assembly,29,Dem,Mark Stone,22
+Santa Clara,5804,State Assembly,28,Dem,Evan Low,671
+Santa Clara,5810,State Assembly,28,Dem,Evan Low,289
+Santa Clara,5813,State Assembly,28,Dem,Evan Low,29
+Santa Clara,5858,State Assembly,28,Dem,Evan Low,67
+Santa Clara,5881,State Assembly,27,Dem,Ash Kaira,0
+Santa Clara,5884,State Assembly,27,Dem,Ash Kaira,0
+Santa Clara,5886,State Assembly,27,Dem,Ash Kaira,0
+Santa Clara,5894,State Assembly,29,Dem,Mark Stone,3
+Santa Clara,5895,State Assembly,29,Dem,Mark Stone,2
+Santa Clara,5902,State Assembly,29,Dem,Mark Stone,195
+Santa Clara,5903,State Assembly,29,Dem,Mark Stone,248
+Santa Clara,5904,State Assembly,29,Dem,Mark Stone,103
+Santa Clara,5906,State Assembly,30,Dem,Robert Rivas,109
+Santa Clara,5911,State Assembly,30,Dem,Robert Rivas,106
+Santa Clara,5912,State Assembly,29,Dem,Mark Stone,36
+Santa Clara,5914,State Assembly,29,Dem,Mark Stone,363
+Santa Clara,5915,State Assembly,30,Dem,Robert Rivas,309
+Santa Clara,5916,State Assembly,29,Dem,Mark Stone,23
+Santa Clara,5917,State Assembly,30,Dem,Robert Rivas,18
+Santa Clara,5920,State Assembly,30,Dem,Robert Rivas,2
+Santa Clara,5925,State Assembly,25,Dem,Kansen Chu,13
+Santa Clara,5926,State Assembly,29,Dem,Mark Stone,187
+Santa Clara,5929,State Assembly,30,Dem,Robert Rivas,28
+Santa Clara,5931,State Assembly,29,Dem,Mark Stone,25
+Santa Clara,5932,State Assembly,30,Dem,Robert Rivas,52
+Santa Clara,5933,State Assembly,29,Dem,Mark Stone,89
+Santa Clara,5936,State Assembly,30,Dem,Robert Rivas,387
+Santa Clara,5937,State Assembly,30,Dem,Robert Rivas,58
+Santa Clara,5938,State Assembly,25,Dem,Kansen Chu,10
+Santa Clara,5940,State Assembly,29,Dem,Mark Stone,7
+Santa Clara,5943,State Assembly,30,Dem,Robert Rivas,51
+Santa Clara,5945,State Assembly,29,Dem,Mark Stone,116
+Santa Clara,5947,State Assembly,30,Dem,Robert Rivas,250
+Santa Clara,5949,State Assembly,30,Dem,Robert Rivas,66
+Santa Clara,5950,State Assembly,30,Dem,Robert Rivas,136
+Santa Clara,5951,State Assembly,30,Dem,Robert Rivas,28
+Santa Clara,5952,State Assembly,30,Dem,Robert Rivas,6
+Santa Clara,5953,State Assembly,30,Dem,Robert Rivas,57
+Santa Clara,5955,State Assembly,30,Dem,Robert Rivas,425
+Santa Clara,5956,State Assembly,30,Dem,Robert Rivas,442
+Santa Clara,5957,State Assembly,30,Dem,Robert Rivas,30
+Santa Clara,5959,State Assembly,30,Dem,Robert Rivas,20
+Santa Clara,5962,State Assembly,30,Dem,Robert Rivas,417
+Santa Clara,5965,State Assembly,30,Dem,Robert Rivas,415
+Santa Clara,5966,State Assembly,30,Dem,Robert Rivas,49
+Santa Clara,5971,State Assembly,30,Dem,Robert Rivas,54
+Santa Clara,5973,State Assembly,30,Dem,Robert Rivas,28
+Santa Clara,5988,State Assembly,29,Dem,Mark Stone,2
+Santa Clara,5989,State Assembly,30,Dem,Robert Rivas,39
+Santa Clara,5991,State Assembly,29,Dem,Mark Stone,5
+Santa Clara,5995,State Assembly,29,Dem,Mark Stone,3
+Santa Clara,5996,State Assembly,29,Dem,Mark Stone,23
+Santa Clara,6002,State Assembly,29,Dem,Mark Stone,10
+Santa Clara,6006,State Assembly,30,Dem,Robert Rivas,21
+Santa Clara,6007,State Assembly,30,Dem,Robert Rivas,16
+Santa Clara,6021,State Assembly,29,Dem,Mark Stone,10
+Santa Clara,6023,State Assembly,29,Dem,Mark Stone,7
+Santa Clara,6028,State Assembly,25,Dem,Kansen Chu,0
+Santa Clara,6031,State Assembly,30,Dem,Robert Rivas,16
+Santa Clara,6032,State Assembly,30,Dem,Robert Rivas,21
+Santa Clara,6034,State Assembly,29,Dem,Mark Stone,4
+Santa Clara,6039,State Assembly,30,Dem,Robert Rivas,3
+Santa Clara,6040,State Assembly,30,Dem,Robert Rivas,23
+Santa Clara,6045,State Assembly,29,Dem,Mark Stone,2
+Santa Clara,6047,State Assembly,29,Dem,Mark Stone,2
+Santa Clara,6401,State Assembly,25,Dem,Kansen Chu,0
+Santa Clara,6402,State Assembly,25,Dem,Kansen Chu,40
+Santa Clara,6404,State Assembly,27,Dem,Ash Kaira,110
+Santa Clara,6405,State Assembly,25,Dem,Kansen Chu,3
+Santa Clara,6410,State Assembly,25,Dem,Kansen Chu,25
+Santa Clara,6411,State Assembly,25,Dem,Kansen Chu,64
+Santa Clara,6413,State Assembly,25,Dem,Kansen Chu,14
+Santa Clara,6417,State Assembly,27,Dem,Ash Kaira,105
+Santa Clara,6418,State Assembly,25,Dem,Kansen Chu,383
+Santa Clara,6419,State Assembly,25,Dem,Kansen Chu,8
+Santa Clara,6421,State Assembly,25,Dem,Kansen Chu,5
+Santa Clara,6422,State Assembly,25,Dem,Kansen Chu,7
+Santa Clara,6423,State Assembly,25,Dem,Kansen Chu,23
+Santa Clara,6425,State Assembly,25,Dem,Kansen Chu,7
+Santa Clara,6427,State Assembly,25,Dem,Kansen Chu,0
+Santa Clara,6452,State Assembly,27,Dem,Ash Kaira,104
+Santa Clara,6454,State Assembly,27,Dem,Ash Kaira,0
+Santa Clara,6455,State Assembly,27,Dem,Ash Kaira,113
+Santa Clara,6457,State Assembly,27,Dem,Ash Kaira,115
+Santa Clara,6458,State Assembly,27,Dem,Ash Kaira,89
+Santa Clara,6462,State Assembly,27,Dem,Ash Kaira,0
+Santa Clara,6463,State Assembly,27,Dem,Ash Kaira,0
+Santa Clara,6464,State Assembly,25,Dem,Kansen Chu,1
+Santa Clara,6465,State Assembly,27,Dem,Ash Kaira,0
+Santa Clara,6466,State Assembly,25,Dem,Kansen Chu,69
+Santa Clara,6470,State Assembly,27,Dem,Ash Kaira,58
+Santa Clara,6490,State Assembly,25,Dem,Kansen Chu,4
+Santa Clara,6491,State Assembly,25,Dem,Kansen Chu,7
+Santa Clara,6492,State Assembly,25,Dem,Kansen Chu,18
+Santa Clara,6493,State Assembly,25,Dem,Kansen Chu,4
+Santa Clara,6502,State Assembly,25,Dem,Kansen Chu,156
+Santa Clara,6509,State Assembly,25,Dem,Kansen Chu,5
+Santa Clara,6510,State Assembly,25,Dem,Kansen Chu,21
+Santa Clara,6515,State Assembly,25,Dem,Kansen Chu,50
+Santa Clara,6624,State Assembly,28,Dem,Evan Low,8
+Santa Clara,6663,State Assembly,28,Dem,Evan Low,5
+Santa Clara,6664,State Assembly,28,Dem,Evan Low,22
+Santa Clara,6665,State Assembly,28,Dem,Evan Low,1
+Santa Clara,6666,State Assembly,28,Dem,Evan Low,80
+Santa Clara,6673,State Assembly,28,Dem,Evan Low,1
+Santa Clara,SANTA CLARA CA,State Assembly,24,Dem,Marc Berman,97726
+Santa Clara,SANTA CLARA CA,State Assembly,25,Dem,Kansen Chu,66652
+Santa Clara,SANTA CLARA CA,State Assembly,27,Dem,Ash Kaira,90068
+Santa Clara,SANTA CLARA CA,State Assembly,28,Dem,Evan Low,130815
+Santa Clara,SANTA CLARA CA,State Assembly,29,Dem,Mark Stone,24084
+Santa Clara,SANTA CLARA CA,State Assembly,30,Dem,Robert Rivas,25094
+Santa Clara,1001,State Assembly,28,Rep,Michael Snyder,284
+Santa Clara,1003,State Assembly,28,Rep,Michael Snyder,245
+Santa Clara,1006,State Assembly,28,Rep,Michael Snyder,286
+Santa Clara,1008,State Assembly,28,Rep,Michael Snyder,147
+Santa Clara,1009,State Assembly,29,Rep,Vicki Nohrden,219
+Santa Clara,1010,State Assembly,28,Rep,Michael Snyder,153
+Santa Clara,1011,State Assembly,28,Rep,Michael Snyder,274
+Santa Clara,1013,State Assembly,28,Rep,Michael Snyder,266
+Santa Clara,1015,State Assembly,28,Rep,Michael Snyder,188
+Santa Clara,1016,State Assembly,28,Rep,Michael Snyder,182
+Santa Clara,1019,State Assembly,28,Rep,Michael Snyder,376
+Santa Clara,1020,State Assembly,28,Rep,Michael Snyder,291
+Santa Clara,1021,State Assembly,28,Rep,Michael Snyder,298
+Santa Clara,1024,State Assembly,28,Rep,Michael Snyder,347
+Santa Clara,1026,State Assembly,28,Rep,Michael Snyder,307
+Santa Clara,1029,State Assembly,28,Rep,Michael Snyder,352
+Santa Clara,1032,State Assembly,28,Rep,Michael Snyder,306
+Santa Clara,1034,State Assembly,28,Rep,Michael Snyder,280
+Santa Clara,1036,State Assembly,28,Rep,Michael Snyder,416
+Santa Clara,1037,State Assembly,28,Rep,Michael Snyder,316
+Santa Clara,1040,State Assembly,29,Rep,Vicki Nohrden,156
+Santa Clara,1041,State Assembly,29,Rep,Vicki Nohrden,4
+Santa Clara,1042,State Assembly,29,Rep,Vicki Nohrden,9
+Santa Clara,1043,State Assembly,29,Rep,Vicki Nohrden,240
+Santa Clara,1046,State Assembly,29,Rep,Vicki Nohrden,361
+Santa Clara,1047,State Assembly,29,Rep,Vicki Nohrden,226
+Santa Clara,1048,State Assembly,29,Rep,Vicki Nohrden,220
+Santa Clara,1050,State Assembly,29,Rep,Vicki Nohrden,334
+Santa Clara,1053,State Assembly,29,Rep,Vicki Nohrden,380
+Santa Clara,1055,State Assembly,29,Rep,Vicki Nohrden,221
+Santa Clara,1056,State Assembly,28,Rep,Michael Snyder,298
+Santa Clara,1057,State Assembly,28,Rep,Michael Snyder,116
+Santa Clara,1060,State Assembly,29,Rep,Vicki Nohrden,199
+Santa Clara,1062,State Assembly,29,Rep,Vicki Nohrden,349
+Santa Clara,1063,State Assembly,29,Rep,Vicki Nohrden,272
+Santa Clara,1066,State Assembly,29,Rep,Vicki Nohrden,305
+Santa Clara,1069,State Assembly,29,Rep,Vicki Nohrden,242
+Santa Clara,1070,State Assembly,29,Rep,Vicki Nohrden,255
+Santa Clara,1071,State Assembly,29,Rep,Vicki Nohrden,1
+Santa Clara,1072,State Assembly,29,Rep,Vicki Nohrden,198
+Santa Clara,1077,State Assembly,28,Rep,Michael Snyder,64
+Santa Clara,1078,State Assembly,27,Rep,Burt Lancaster,32
+Santa Clara,1080,State Assembly,29,Rep,Vicki Nohrden,192
+Santa Clara,1081,State Assembly,29,Rep,Vicki Nohrden,277
+Santa Clara,1082,State Assembly,27,Rep,Burt Lancaster,72
+Santa Clara,1085,State Assembly,28,Rep,Michael Snyder,58
+Santa Clara,1087,State Assembly,29,Rep,Vicki Nohrden,0
+Santa Clara,1092,State Assembly,29,Rep,Vicki Nohrden,229
+Santa Clara,1094,State Assembly,27,Rep,Burt Lancaster,65
+Santa Clara,1099,State Assembly,27,Rep,Burt Lancaster,0
+Santa Clara,1101,State Assembly,28,Rep,Michael Snyder,268
+Santa Clara,1104,State Assembly,28,Rep,Michael Snyder,229
+Santa Clara,1106,State Assembly,28,Rep,Michael Snyder,247
+Santa Clara,1107,State Assembly,28,Rep,Michael Snyder,258
+Santa Clara,1108,State Assembly,28,Rep,Michael Snyder,183
+Santa Clara,1111,State Assembly,28,Rep,Michael Snyder,27
+Santa Clara,1113,State Assembly,28,Rep,Michael Snyder,207
+Santa Clara,1114,State Assembly,28,Rep,Michael Snyder,316
+Santa Clara,1115,State Assembly,28,Rep,Michael Snyder,245
+Santa Clara,1117,State Assembly,28,Rep,Michael Snyder,158
+Santa Clara,1118,State Assembly,28,Rep,Michael Snyder,64
+Santa Clara,1121,State Assembly,28,Rep,Michael Snyder,78
+Santa Clara,1123,State Assembly,28,Rep,Michael Snyder,215
+Santa Clara,1125,State Assembly,28,Rep,Michael Snyder,203
+Santa Clara,1127,State Assembly,28,Rep,Michael Snyder,183
+Santa Clara,1129,State Assembly,28,Rep,Michael Snyder,195
+Santa Clara,1131,State Assembly,28,Rep,Michael Snyder,209
+Santa Clara,1134,State Assembly,28,Rep,Michael Snyder,138
+Santa Clara,1135,State Assembly,28,Rep,Michael Snyder,111
+Santa Clara,1136,State Assembly,28,Rep,Michael Snyder,107
+Santa Clara,1138,State Assembly,28,Rep,Michael Snyder,113
+Santa Clara,1141,State Assembly,28,Rep,Michael Snyder,252
+Santa Clara,1142,State Assembly,28,Rep,Michael Snyder,242
+Santa Clara,1144,State Assembly,28,Rep,Michael Snyder,157
+Santa Clara,1145,State Assembly,28,Rep,Michael Snyder,167
+Santa Clara,1146,State Assembly,28,Rep,Michael Snyder,168
+Santa Clara,1149,State Assembly,28,Rep,Michael Snyder,253
+Santa Clara,1152,State Assembly,28,Rep,Michael Snyder,245
+Santa Clara,1153,State Assembly,28,Rep,Michael Snyder,180
+Santa Clara,1154,State Assembly,28,Rep,Michael Snyder,169
+Santa Clara,1156,State Assembly,28,Rep,Michael Snyder,269
+Santa Clara,1158,State Assembly,28,Rep,Michael Snyder,284
+Santa Clara,1160,State Assembly,28,Rep,Michael Snyder,259
+Santa Clara,1161,State Assembly,28,Rep,Michael Snyder,130
+Santa Clara,1162,State Assembly,28,Rep,Michael Snyder,264
+Santa Clara,1169,State Assembly,28,Rep,Michael Snyder,15
+Santa Clara,1198,State Assembly,28,Rep,Michael Snyder,198
+Santa Clara,1199,State Assembly,28,Rep,Michael Snyder,47
+Santa Clara,1200,State Assembly,29,Rep,Vicki Nohrden,185
+Santa Clara,1201,State Assembly,28,Rep,Michael Snyder,169
+Santa Clara,1204,State Assembly,28,Rep,Michael Snyder,141
+Santa Clara,1205,State Assembly,27,Rep,Burt Lancaster,79
+Santa Clara,1206,State Assembly,27,Rep,Burt Lancaster,39
+Santa Clara,1207,State Assembly,27,Rep,Burt Lancaster,47
+Santa Clara,1208,State Assembly,27,Rep,Burt Lancaster,46
+Santa Clara,1209,State Assembly,27,Rep,Burt Lancaster,56
+Santa Clara,1210,State Assembly,29,Rep,Vicki Nohrden,77
+Santa Clara,1211,State Assembly,27,Rep,Burt Lancaster,33
+Santa Clara,1213,State Assembly,29,Rep,Vicki Nohrden,113
+Santa Clara,1214,State Assembly,29,Rep,Vicki Nohrden,212
+Santa Clara,1215,State Assembly,29,Rep,Vicki Nohrden,104
+Santa Clara,1218,State Assembly,29,Rep,Vicki Nohrden,297
+Santa Clara,1220,State Assembly,27,Rep,Burt Lancaster,31
+Santa Clara,1221,State Assembly,29,Rep,Vicki Nohrden,148
+Santa Clara,1222,State Assembly,29,Rep,Vicki Nohrden,139
+Santa Clara,1223,State Assembly,29,Rep,Vicki Nohrden,242
+Santa Clara,1224,State Assembly,29,Rep,Vicki Nohrden,227
+Santa Clara,1226,State Assembly,29,Rep,Vicki Nohrden,289
+Santa Clara,1228,State Assembly,29,Rep,Vicki Nohrden,173
+Santa Clara,1229,State Assembly,29,Rep,Vicki Nohrden,294
+Santa Clara,1230,State Assembly,27,Rep,Burt Lancaster,30
+Santa Clara,1231,State Assembly,29,Rep,Vicki Nohrden,295
+Santa Clara,1232,State Assembly,29,Rep,Vicki Nohrden,270
+Santa Clara,1234,State Assembly,29,Rep,Vicki Nohrden,99
+Santa Clara,1236,State Assembly,29,Rep,Vicki Nohrden,301
+Santa Clara,1238,State Assembly,29,Rep,Vicki Nohrden,231
+Santa Clara,1239,State Assembly,29,Rep,Vicki Nohrden,328
+Santa Clara,1240,State Assembly,29,Rep,Vicki Nohrden,201
+Santa Clara,1242,State Assembly,29,Rep,Vicki Nohrden,158
+Santa Clara,1243,State Assembly,29,Rep,Vicki Nohrden,242
+Santa Clara,1244,State Assembly,29,Rep,Vicki Nohrden,205
+Santa Clara,1246,State Assembly,29,Rep,Vicki Nohrden,259
+Santa Clara,1247,State Assembly,29,Rep,Vicki Nohrden,297
+Santa Clara,1250,State Assembly,29,Rep,Vicki Nohrden,277
+Santa Clara,1252,State Assembly,29,Rep,Vicki Nohrden,4
+Santa Clara,1254,State Assembly,28,Rep,Michael Snyder,107
+Santa Clara,1263,State Assembly,29,Rep,Vicki Nohrden,63
+Santa Clara,1268,State Assembly,29,Rep,Vicki Nohrden,4
+Santa Clara,1271,State Assembly,29,Rep,Vicki Nohrden,93
+Santa Clara,1274,State Assembly,29,Rep,Vicki Nohrden,185
+Santa Clara,1276,State Assembly,27,Rep,Burt Lancaster,43
+Santa Clara,1290,State Assembly,29,Rep,Vicki Nohrden,2
+Santa Clara,1295,State Assembly,27,Rep,Burt Lancaster,35
+Santa Clara,1299,State Assembly,27,Rep,Burt Lancaster,0
+Santa Clara,1301,State Assembly,25,Rep,Bob Brunton,5
+Santa Clara,1302,State Assembly,25,Rep,Bob Brunton,55
+Santa Clara,1303,State Assembly,25,Rep,Bob Brunton,146
+Santa Clara,1304,State Assembly,28,Rep,Michael Snyder,209
+Santa Clara,1305,State Assembly,28,Rep,Michael Snyder,158
+Santa Clara,1307,State Assembly,28,Rep,Michael Snyder,87
+Santa Clara,1308,State Assembly,27,Rep,Burt Lancaster,0
+Santa Clara,1310,State Assembly,27,Rep,Burt Lancaster,16
+Santa Clara,1311,State Assembly,27,Rep,Burt Lancaster,33
+Santa Clara,1312,State Assembly,27,Rep,Burt Lancaster,19
+Santa Clara,1313,State Assembly,27,Rep,Burt Lancaster,14
+Santa Clara,1314,State Assembly,27,Rep,Burt Lancaster,21
+Santa Clara,1315,State Assembly,27,Rep,Burt Lancaster,22
+Santa Clara,1316,State Assembly,27,Rep,Burt Lancaster,23
+Santa Clara,1317,State Assembly,27,Rep,Burt Lancaster,21
+Santa Clara,1318,State Assembly,27,Rep,Burt Lancaster,16
+Santa Clara,1319,State Assembly,27,Rep,Burt Lancaster,27
+Santa Clara,1320,State Assembly,27,Rep,Burt Lancaster,11
+Santa Clara,1321,State Assembly,27,Rep,Burt Lancaster,28
+Santa Clara,1323,State Assembly,27,Rep,Burt Lancaster,23
+Santa Clara,1324,State Assembly,27,Rep,Burt Lancaster,20
+Santa Clara,1325,State Assembly,27,Rep,Burt Lancaster,38
+Santa Clara,1327,State Assembly,27,Rep,Burt Lancaster,24
+Santa Clara,1329,State Assembly,27,Rep,Burt Lancaster,22
+Santa Clara,1330,State Assembly,27,Rep,Burt Lancaster,43
+Santa Clara,1333,State Assembly,27,Rep,Burt Lancaster,40
+Santa Clara,1334,State Assembly,27,Rep,Burt Lancaster,34
+Santa Clara,1336,State Assembly,27,Rep,Burt Lancaster,11
+Santa Clara,1338,State Assembly,27,Rep,Burt Lancaster,24
+Santa Clara,1339,State Assembly,27,Rep,Burt Lancaster,19
+Santa Clara,1340,State Assembly,27,Rep,Burt Lancaster,17
+Santa Clara,1342,State Assembly,27,Rep,Burt Lancaster,8
+Santa Clara,1343,State Assembly,27,Rep,Burt Lancaster,25
+Santa Clara,1344,State Assembly,27,Rep,Burt Lancaster,22
+Santa Clara,1346,State Assembly,27,Rep,Burt Lancaster,17
+Santa Clara,1347,State Assembly,28,Rep,Michael Snyder,76
+Santa Clara,1348,State Assembly,28,Rep,Michael Snyder,107
+Santa Clara,1353,State Assembly,27,Rep,Burt Lancaster,10
+Santa Clara,1356,State Assembly,27,Rep,Burt Lancaster,28
+Santa Clara,1357,State Assembly,27,Rep,Burt Lancaster,0
+Santa Clara,1358,State Assembly,28,Rep,Michael Snyder,31
+Santa Clara,1359,State Assembly,28,Rep,Michael Snyder,94
+Santa Clara,1361,State Assembly,27,Rep,Burt Lancaster,16
+Santa Clara,1362,State Assembly,27,Rep,Burt Lancaster,7
+Santa Clara,1370,State Assembly,25,Rep,Bob Brunton,4
+Santa Clara,1371,State Assembly,27,Rep,Burt Lancaster,4
+Santa Clara,1373,State Assembly,27,Rep,Burt Lancaster,0
+Santa Clara,1374,State Assembly,27,Rep,Burt Lancaster,20
+Santa Clara,1380,State Assembly,28,Rep,Michael Snyder,12
+Santa Clara,1384,State Assembly,27,Rep,Burt Lancaster,27
+Santa Clara,1385,State Assembly,28,Rep,Michael Snyder,179
+Santa Clara,1387,State Assembly,27,Rep,Burt Lancaster,35
+Santa Clara,1388,State Assembly,27,Rep,Burt Lancaster,22
+Santa Clara,1389,State Assembly,27,Rep,Burt Lancaster,31
+Santa Clara,1390,State Assembly,27,Rep,Burt Lancaster,30
+Santa Clara,1391,State Assembly,25,Rep,Bob Brunton,140
+Santa Clara,1392,State Assembly,27,Rep,Burt Lancaster,35
+Santa Clara,1393,State Assembly,27,Rep,Burt Lancaster,31
+Santa Clara,1394,State Assembly,25,Rep,Bob Brunton,201
+Santa Clara,1395,State Assembly,27,Rep,Burt Lancaster,30
+Santa Clara,1396,State Assembly,25,Rep,Bob Brunton,208
+Santa Clara,1397,State Assembly,25,Rep,Bob Brunton,270
+Santa Clara,1398,State Assembly,27,Rep,Burt Lancaster,7
+Santa Clara,1399,State Assembly,27,Rep,Burt Lancaster,20
+Santa Clara,1400,State Assembly,25,Rep,Bob Brunton,119
+Santa Clara,1401,State Assembly,25,Rep,Bob Brunton,106
+Santa Clara,1403,State Assembly,25,Rep,Bob Brunton,184
+Santa Clara,1405,State Assembly,25,Rep,Bob Brunton,2
+Santa Clara,1407,State Assembly,25,Rep,Bob Brunton,224
+Santa Clara,1408,State Assembly,25,Rep,Bob Brunton,108
+Santa Clara,1409,State Assembly,25,Rep,Bob Brunton,162
+Santa Clara,1410,State Assembly,25,Rep,Bob Brunton,210
+Santa Clara,1411,State Assembly,25,Rep,Bob Brunton,227
+Santa Clara,1414,State Assembly,25,Rep,Bob Brunton,182
+Santa Clara,1415,State Assembly,25,Rep,Bob Brunton,223
+Santa Clara,1417,State Assembly,25,Rep,Bob Brunton,185
+Santa Clara,1418,State Assembly,25,Rep,Bob Brunton,192
+Santa Clara,1420,State Assembly,25,Rep,Bob Brunton,212
+Santa Clara,1421,State Assembly,25,Rep,Bob Brunton,213
+Santa Clara,1423,State Assembly,25,Rep,Bob Brunton,176
+Santa Clara,1424,State Assembly,27,Rep,Burt Lancaster,48
+Santa Clara,1426,State Assembly,25,Rep,Bob Brunton,44
+Santa Clara,1427,State Assembly,25,Rep,Bob Brunton,138
+Santa Clara,1428,State Assembly,25,Rep,Bob Brunton,217
+Santa Clara,1429,State Assembly,25,Rep,Bob Brunton,299
+Santa Clara,1431,State Assembly,25,Rep,Bob Brunton,174
+Santa Clara,1432,State Assembly,25,Rep,Bob Brunton,291
+Santa Clara,1433,State Assembly,25,Rep,Bob Brunton,133
+Santa Clara,1435,State Assembly,25,Rep,Bob Brunton,200
+Santa Clara,1439,State Assembly,25,Rep,Bob Brunton,124
+Santa Clara,1440,State Assembly,25,Rep,Bob Brunton,21
+Santa Clara,1443,State Assembly,25,Rep,Bob Brunton,25
+Santa Clara,1444,State Assembly,25,Rep,Bob Brunton,194
+Santa Clara,1446,State Assembly,25,Rep,Bob Brunton,263
+Santa Clara,1447,State Assembly,25,Rep,Bob Brunton,129
+Santa Clara,1448,State Assembly,25,Rep,Bob Brunton,227
+Santa Clara,1451,State Assembly,25,Rep,Bob Brunton,214
+Santa Clara,1453,State Assembly,25,Rep,Bob Brunton,140
+Santa Clara,1455,State Assembly,25,Rep,Bob Brunton,214
+Santa Clara,1459,State Assembly,25,Rep,Bob Brunton,193
+Santa Clara,1461,State Assembly,25,Rep,Bob Brunton,119
+Santa Clara,1465,State Assembly,25,Rep,Bob Brunton,130
+Santa Clara,1467,State Assembly,25,Rep,Bob Brunton,153
+Santa Clara,1468,State Assembly,25,Rep,Bob Brunton,214
+Santa Clara,1470,State Assembly,25,Rep,Bob Brunton,114
+Santa Clara,1478,State Assembly,25,Rep,Bob Brunton,151
+Santa Clara,1480,State Assembly,25,Rep,Bob Brunton,104
+Santa Clara,1497,State Assembly,25,Rep,Bob Brunton,76
+Santa Clara,1501,State Assembly,25,Rep,Bob Brunton,28
+Santa Clara,1502,State Assembly,25,Rep,Bob Brunton,3
+Santa Clara,1504,State Assembly,27,Rep,Burt Lancaster,32
+Santa Clara,1506,State Assembly,27,Rep,Burt Lancaster,18
+Santa Clara,1508,State Assembly,27,Rep,Burt Lancaster,24
+Santa Clara,1510,State Assembly,27,Rep,Burt Lancaster,43
+Santa Clara,1512,State Assembly,27,Rep,Burt Lancaster,23
+Santa Clara,1515,State Assembly,25,Rep,Bob Brunton,108
+Santa Clara,1516,State Assembly,27,Rep,Burt Lancaster,22
+Santa Clara,1518,State Assembly,27,Rep,Burt Lancaster,16
+Santa Clara,1519,State Assembly,27,Rep,Burt Lancaster,14
+Santa Clara,1521,State Assembly,27,Rep,Burt Lancaster,24
+Santa Clara,1522,State Assembly,27,Rep,Burt Lancaster,20
+Santa Clara,1523,State Assembly,27,Rep,Burt Lancaster,8
+Santa Clara,1525,State Assembly,27,Rep,Burt Lancaster,10
+Santa Clara,1526,State Assembly,27,Rep,Burt Lancaster,15
+Santa Clara,1527,State Assembly,27,Rep,Burt Lancaster,24
+Santa Clara,1529,State Assembly,27,Rep,Burt Lancaster,31
+Santa Clara,1530,State Assembly,27,Rep,Burt Lancaster,10
+Santa Clara,1531,State Assembly,27,Rep,Burt Lancaster,11
+Santa Clara,1533,State Assembly,25,Rep,Bob Brunton,106
+Santa Clara,1534,State Assembly,27,Rep,Burt Lancaster,12
+Santa Clara,1535,State Assembly,27,Rep,Burt Lancaster,23
+Santa Clara,1536,State Assembly,27,Rep,Burt Lancaster,24
+Santa Clara,1537,State Assembly,27,Rep,Burt Lancaster,28
+Santa Clara,1539,State Assembly,27,Rep,Burt Lancaster,16
+Santa Clara,1542,State Assembly,27,Rep,Burt Lancaster,17
+Santa Clara,1544,State Assembly,27,Rep,Burt Lancaster,28
+Santa Clara,1546,State Assembly,25,Rep,Bob Brunton,88
+Santa Clara,1548,State Assembly,25,Rep,Bob Brunton,28
+Santa Clara,1550,State Assembly,27,Rep,Burt Lancaster,0
+Santa Clara,1551,State Assembly,27,Rep,Burt Lancaster,36
+Santa Clara,1553,State Assembly,27,Rep,Burt Lancaster,8
+Santa Clara,1556,State Assembly,27,Rep,Burt Lancaster,12
+Santa Clara,1557,State Assembly,25,Rep,Bob Brunton,175
+Santa Clara,1558,State Assembly,25,Rep,Bob Brunton,227
+Santa Clara,1567,State Assembly,27,Rep,Burt Lancaster,0
+Santa Clara,1569,State Assembly,27,Rep,Burt Lancaster,0
+Santa Clara,1570,State Assembly,25,Rep,Bob Brunton,0
+Santa Clara,1571,State Assembly,28,Rep,Michael Snyder,4
+Santa Clara,1572,State Assembly,28,Rep,Michael Snyder,9
+Santa Clara,1574,State Assembly,28,Rep,Michael Snyder,0
+Santa Clara,1577,State Assembly,27,Rep,Burt Lancaster,14
+Santa Clara,1578,State Assembly,27,Rep,Burt Lancaster,0
+Santa Clara,1583,State Assembly,27,Rep,Burt Lancaster,9
+Santa Clara,1584,State Assembly,27,Rep,Burt Lancaster,16
+Santa Clara,1586,State Assembly,28,Rep,Michael Snyder,4
+Santa Clara,1587,State Assembly,28,Rep,Michael Snyder,2
+Santa Clara,1588,State Assembly,28,Rep,Michael Snyder,239
+Santa Clara,1589,State Assembly,27,Rep,Burt Lancaster,10
+Santa Clara,1590,State Assembly,27,Rep,Burt Lancaster,20
+Santa Clara,1591,State Assembly,27,Rep,Burt Lancaster,0
+Santa Clara,1592,State Assembly,28,Rep,Michael Snyder,57
+Santa Clara,1593,State Assembly,25,Rep,Bob Brunton,45
+Santa Clara,1595,State Assembly,27,Rep,Burt Lancaster,0
+Santa Clara,1597,State Assembly,27,Rep,Burt Lancaster,20
+Santa Clara,1599,State Assembly,27,Rep,Burt Lancaster,20
+Santa Clara,1600,State Assembly,28,Rep,Michael Snyder,128
+Santa Clara,1601,State Assembly,28,Rep,Michael Snyder,192
+Santa Clara,1602,State Assembly,28,Rep,Michael Snyder,171
+Santa Clara,1603,State Assembly,28,Rep,Michael Snyder,244
+Santa Clara,1606,State Assembly,28,Rep,Michael Snyder,161
+Santa Clara,1607,State Assembly,28,Rep,Michael Snyder,191
+Santa Clara,1609,State Assembly,28,Rep,Michael Snyder,183
+Santa Clara,1612,State Assembly,28,Rep,Michael Snyder,165
+Santa Clara,1613,State Assembly,28,Rep,Michael Snyder,155
+Santa Clara,1615,State Assembly,28,Rep,Michael Snyder,200
+Santa Clara,1616,State Assembly,28,Rep,Michael Snyder,233
+Santa Clara,1619,State Assembly,28,Rep,Michael Snyder,10
+Santa Clara,1620,State Assembly,28,Rep,Michael Snyder,263
+Santa Clara,1621,State Assembly,28,Rep,Michael Snyder,87
+Santa Clara,1623,State Assembly,28,Rep,Michael Snyder,205
+Santa Clara,1625,State Assembly,27,Rep,Burt Lancaster,23
+Santa Clara,1626,State Assembly,28,Rep,Michael Snyder,43
+Santa Clara,1629,State Assembly,28,Rep,Michael Snyder,111
+Santa Clara,1630,State Assembly,28,Rep,Michael Snyder,142
+Santa Clara,1631,State Assembly,28,Rep,Michael Snyder,265
+Santa Clara,1632,State Assembly,28,Rep,Michael Snyder,134
+Santa Clara,1634,State Assembly,28,Rep,Michael Snyder,161
+Santa Clara,1635,State Assembly,28,Rep,Michael Snyder,153
+Santa Clara,1636,State Assembly,28,Rep,Michael Snyder,179
+Santa Clara,1640,State Assembly,28,Rep,Michael Snyder,233
+Santa Clara,1641,State Assembly,28,Rep,Michael Snyder,134
+Santa Clara,1643,State Assembly,28,Rep,Michael Snyder,133
+Santa Clara,1644,State Assembly,28,Rep,Michael Snyder,227
+Santa Clara,1646,State Assembly,28,Rep,Michael Snyder,205
+Santa Clara,1648,State Assembly,28,Rep,Michael Snyder,376
+Santa Clara,1649,State Assembly,28,Rep,Michael Snyder,310
+Santa Clara,1654,State Assembly,28,Rep,Michael Snyder,206
+Santa Clara,1656,State Assembly,28,Rep,Michael Snyder,292
+Santa Clara,1658,State Assembly,28,Rep,Michael Snyder,249
+Santa Clara,1661,State Assembly,27,Rep,Burt Lancaster,32
+Santa Clara,1662,State Assembly,28,Rep,Michael Snyder,82
+Santa Clara,1663,State Assembly,28,Rep,Michael Snyder,116
+Santa Clara,1664,State Assembly,28,Rep,Michael Snyder,201
+Santa Clara,1666,State Assembly,28,Rep,Michael Snyder,230
+Santa Clara,1671,State Assembly,28,Rep,Michael Snyder,231
+Santa Clara,1672,State Assembly,28,Rep,Michael Snyder,225
+Santa Clara,1674,State Assembly,28,Rep,Michael Snyder,310
+Santa Clara,1677,State Assembly,28,Rep,Michael Snyder,134
+Santa Clara,1678,State Assembly,27,Rep,Burt Lancaster,27
+Santa Clara,1679,State Assembly,28,Rep,Michael Snyder,7
+Santa Clara,1683,State Assembly,28,Rep,Michael Snyder,117
+Santa Clara,1685,State Assembly,27,Rep,Burt Lancaster,6
+Santa Clara,1687,State Assembly,28,Rep,Michael Snyder,118
+Santa Clara,1696,State Assembly,27,Rep,Burt Lancaster,27
+Santa Clara,1699,State Assembly,27,Rep,Burt Lancaster,21
+Santa Clara,1700,State Assembly,27,Rep,Burt Lancaster,47
+Santa Clara,1701,State Assembly,27,Rep,Burt Lancaster,19
+Santa Clara,1702,State Assembly,27,Rep,Burt Lancaster,40
+Santa Clara,1703,State Assembly,27,Rep,Burt Lancaster,40
+Santa Clara,1704,State Assembly,27,Rep,Burt Lancaster,39
+Santa Clara,1706,State Assembly,27,Rep,Burt Lancaster,34
+Santa Clara,1707,State Assembly,27,Rep,Burt Lancaster,12
+Santa Clara,1708,State Assembly,27,Rep,Burt Lancaster,40
+Santa Clara,1709,State Assembly,27,Rep,Burt Lancaster,14
+Santa Clara,1710,State Assembly,27,Rep,Burt Lancaster,17
+Santa Clara,1711,State Assembly,27,Rep,Burt Lancaster,35
+Santa Clara,1712,State Assembly,27,Rep,Burt Lancaster,32
+Santa Clara,1715,State Assembly,27,Rep,Burt Lancaster,28
+Santa Clara,1716,State Assembly,27,Rep,Burt Lancaster,25
+Santa Clara,1717,State Assembly,27,Rep,Burt Lancaster,29
+Santa Clara,1718,State Assembly,27,Rep,Burt Lancaster,23
+Santa Clara,1719,State Assembly,27,Rep,Burt Lancaster,34
+Santa Clara,1722,State Assembly,27,Rep,Burt Lancaster,10
+Santa Clara,1723,State Assembly,27,Rep,Burt Lancaster,25
+Santa Clara,1724,State Assembly,27,Rep,Burt Lancaster,31
+Santa Clara,1726,State Assembly,27,Rep,Burt Lancaster,21
+Santa Clara,1728,State Assembly,27,Rep,Burt Lancaster,17
+Santa Clara,1729,State Assembly,27,Rep,Burt Lancaster,36
+Santa Clara,1730,State Assembly,27,Rep,Burt Lancaster,10
+Santa Clara,1732,State Assembly,27,Rep,Burt Lancaster,15
+Santa Clara,1734,State Assembly,27,Rep,Burt Lancaster,38
+Santa Clara,1735,State Assembly,27,Rep,Burt Lancaster,19
+Santa Clara,1736,State Assembly,27,Rep,Burt Lancaster,25
+Santa Clara,1737,State Assembly,27,Rep,Burt Lancaster,20
+Santa Clara,1743,State Assembly,27,Rep,Burt Lancaster,58
+Santa Clara,1744,State Assembly,27,Rep,Burt Lancaster,42
+Santa Clara,1751,State Assembly,27,Rep,Burt Lancaster,58
+Santa Clara,1753,State Assembly,28,Rep,Michael Snyder,278
+Santa Clara,1755,State Assembly,28,Rep,Michael Snyder,246
+Santa Clara,1757,State Assembly,27,Rep,Burt Lancaster,12
+Santa Clara,1767,State Assembly,27,Rep,Burt Lancaster,12
+Santa Clara,1775,State Assembly,27,Rep,Burt Lancaster,8
+Santa Clara,1778,State Assembly,27,Rep,Burt Lancaster,61
+Santa Clara,1780,State Assembly,27,Rep,Burt Lancaster,46
+Santa Clara,1781,State Assembly,27,Rep,Burt Lancaster,56
+Santa Clara,1782,State Assembly,27,Rep,Burt Lancaster,0
+Santa Clara,1783,State Assembly,27,Rep,Burt Lancaster,45
+Santa Clara,1784,State Assembly,27,Rep,Burt Lancaster,43
+Santa Clara,1785,State Assembly,27,Rep,Burt Lancaster,31
+Santa Clara,1786,State Assembly,27,Rep,Burt Lancaster,57
+Santa Clara,1787,State Assembly,27,Rep,Burt Lancaster,54
+Santa Clara,1788,State Assembly,27,Rep,Burt Lancaster,41
+Santa Clara,1789,State Assembly,27,Rep,Burt Lancaster,27
+Santa Clara,1790,State Assembly,27,Rep,Burt Lancaster,53
+Santa Clara,1792,State Assembly,27,Rep,Burt Lancaster,28
+Santa Clara,1793,State Assembly,27,Rep,Burt Lancaster,60
+Santa Clara,1795,State Assembly,27,Rep,Burt Lancaster,48
+Santa Clara,1796,State Assembly,27,Rep,Burt Lancaster,40
+Santa Clara,1797,State Assembly,27,Rep,Burt Lancaster,23
+Santa Clara,1798,State Assembly,27,Rep,Burt Lancaster,16
+Santa Clara,1799,State Assembly,27,Rep,Burt Lancaster,40
+Santa Clara,1800,State Assembly,27,Rep,Burt Lancaster,41
+Santa Clara,1801,State Assembly,25,Rep,Bob Brunton,9
+Santa Clara,1805,State Assembly,27,Rep,Burt Lancaster,22
+Santa Clara,1811,State Assembly,27,Rep,Burt Lancaster,24
+Santa Clara,1813,State Assembly,27,Rep,Burt Lancaster,10
+Santa Clara,1817,State Assembly,27,Rep,Burt Lancaster,43
+Santa Clara,1818,State Assembly,27,Rep,Burt Lancaster,41
+Santa Clara,1820,State Assembly,27,Rep,Burt Lancaster,35
+Santa Clara,1821,State Assembly,27,Rep,Burt Lancaster,30
+Santa Clara,1822,State Assembly,27,Rep,Burt Lancaster,61
+Santa Clara,1824,State Assembly,27,Rep,Burt Lancaster,30
+Santa Clara,1826,State Assembly,27,Rep,Burt Lancaster,40
+Santa Clara,1829,State Assembly,27,Rep,Burt Lancaster,36
+Santa Clara,1830,State Assembly,27,Rep,Burt Lancaster,46
+Santa Clara,1831,State Assembly,27,Rep,Burt Lancaster,22
+Santa Clara,1832,State Assembly,27,Rep,Burt Lancaster,45
+Santa Clara,1838,State Assembly,27,Rep,Burt Lancaster,19
+Santa Clara,1839,State Assembly,27,Rep,Burt Lancaster,59
+Santa Clara,1841,State Assembly,27,Rep,Burt Lancaster,34
+Santa Clara,1842,State Assembly,27,Rep,Burt Lancaster,39
+Santa Clara,1843,State Assembly,27,Rep,Burt Lancaster,21
+Santa Clara,1844,State Assembly,27,Rep,Burt Lancaster,40
+Santa Clara,1846,State Assembly,27,Rep,Burt Lancaster,13
+Santa Clara,1848,State Assembly,27,Rep,Burt Lancaster,20
+Santa Clara,1850,State Assembly,27,Rep,Burt Lancaster,39
+Santa Clara,1852,State Assembly,27,Rep,Burt Lancaster,21
+Santa Clara,1853,State Assembly,27,Rep,Burt Lancaster,0
+Santa Clara,1856,State Assembly,27,Rep,Burt Lancaster,33
+Santa Clara,1859,State Assembly,27,Rep,Burt Lancaster,30
+Santa Clara,1860,State Assembly,27,Rep,Burt Lancaster,14
+Santa Clara,1861,State Assembly,27,Rep,Burt Lancaster,5
+Santa Clara,1863,State Assembly,27,Rep,Burt Lancaster,30
+Santa Clara,1865,State Assembly,27,Rep,Burt Lancaster,42
+Santa Clara,1866,State Assembly,27,Rep,Burt Lancaster,33
+Santa Clara,1871,State Assembly,27,Rep,Burt Lancaster,34
+Santa Clara,1882,State Assembly,27,Rep,Burt Lancaster,44
+Santa Clara,1886,State Assembly,27,Rep,Burt Lancaster,26
+Santa Clara,1888,State Assembly,27,Rep,Burt Lancaster,22
+Santa Clara,1897,State Assembly,27,Rep,Burt Lancaster,17
+Santa Clara,1898,State Assembly,27,Rep,Burt Lancaster,18
+Santa Clara,1901,State Assembly,28,Rep,Michael Snyder,112
+Santa Clara,1902,State Assembly,28,Rep,Michael Snyder,248
+Santa Clara,1903,State Assembly,28,Rep,Michael Snyder,194
+Santa Clara,1904,State Assembly,28,Rep,Michael Snyder,256
+Santa Clara,1907,State Assembly,28,Rep,Michael Snyder,183
+Santa Clara,1909,State Assembly,28,Rep,Michael Snyder,254
+Santa Clara,1911,State Assembly,28,Rep,Michael Snyder,201
+Santa Clara,1913,State Assembly,28,Rep,Michael Snyder,187
+Santa Clara,1914,State Assembly,28,Rep,Michael Snyder,148
+Santa Clara,1916,State Assembly,28,Rep,Michael Snyder,328
+Santa Clara,1918,State Assembly,28,Rep,Michael Snyder,247
+Santa Clara,1919,State Assembly,28,Rep,Michael Snyder,119
+Santa Clara,1920,State Assembly,28,Rep,Michael Snyder,266
+Santa Clara,1922,State Assembly,28,Rep,Michael Snyder,338
+Santa Clara,1925,State Assembly,28,Rep,Michael Snyder,167
+Santa Clara,1928,State Assembly,28,Rep,Michael Snyder,225
+Santa Clara,1929,State Assembly,28,Rep,Michael Snyder,247
+Santa Clara,1930,State Assembly,28,Rep,Michael Snyder,163
+Santa Clara,1932,State Assembly,28,Rep,Michael Snyder,240
+Santa Clara,1934,State Assembly,28,Rep,Michael Snyder,277
+Santa Clara,1936,State Assembly,28,Rep,Michael Snyder,286
+Santa Clara,1937,State Assembly,28,Rep,Michael Snyder,256
+Santa Clara,1939,State Assembly,28,Rep,Michael Snyder,225
+Santa Clara,1944,State Assembly,28,Rep,Michael Snyder,237
+Santa Clara,1945,State Assembly,28,Rep,Michael Snyder,201
+Santa Clara,1947,State Assembly,28,Rep,Michael Snyder,224
+Santa Clara,1949,State Assembly,28,Rep,Michael Snyder,295
+Santa Clara,1952,State Assembly,28,Rep,Michael Snyder,209
+Santa Clara,1953,State Assembly,28,Rep,Michael Snyder,198
+Santa Clara,1954,State Assembly,28,Rep,Michael Snyder,276
+Santa Clara,1958,State Assembly,28,Rep,Michael Snyder,140
+Santa Clara,1959,State Assembly,28,Rep,Michael Snyder,83
+Santa Clara,1960,State Assembly,28,Rep,Michael Snyder,267
+Santa Clara,1961,State Assembly,28,Rep,Michael Snyder,43
+Santa Clara,1962,State Assembly,28,Rep,Michael Snyder,116
+Santa Clara,1964,State Assembly,28,Rep,Michael Snyder,136
+Santa Clara,1966,State Assembly,28,Rep,Michael Snyder,182
+Santa Clara,1968,State Assembly,28,Rep,Michael Snyder,8
+Santa Clara,1977,State Assembly,27,Rep,Burt Lancaster,11
+Santa Clara,1982,State Assembly,27,Rep,Burt Lancaster,17
+Santa Clara,1990,State Assembly,28,Rep,Michael Snyder,22
+Santa Clara,1991,State Assembly,27,Rep,Burt Lancaster,11
+Santa Clara,1994,State Assembly,28,Rep,Michael Snyder,72
+Santa Clara,1996,State Assembly,28,Rep,Michael Snyder,20
+Santa Clara,2001,State Assembly,24,Rep,Alex Glew,3
+Santa Clara,2002,State Assembly,24,Rep,Alex Glew,173
+Santa Clara,2003,State Assembly,24,Rep,Alex Glew,125
+Santa Clara,2004,State Assembly,24,Rep,Alex Glew,196
+Santa Clara,2005,State Assembly,24,Rep,Alex Glew,142
+Santa Clara,2006,State Assembly,24,Rep,Alex Glew,18
+Santa Clara,2009,State Assembly,24,Rep,Alex Glew,137
+Santa Clara,2013,State Assembly,24,Rep,Alex Glew,197
+Santa Clara,2014,State Assembly,24,Rep,Alex Glew,192
+Santa Clara,2015,State Assembly,24,Rep,Alex Glew,238
+Santa Clara,2018,State Assembly,24,Rep,Alex Glew,33
+Santa Clara,2019,State Assembly,24,Rep,Alex Glew,141
+Santa Clara,2025,State Assembly,24,Rep,Alex Glew,231
+Santa Clara,2028,State Assembly,24,Rep,Alex Glew,147
+Santa Clara,2034,State Assembly,24,Rep,Alex Glew,189
+Santa Clara,2043,State Assembly,24,Rep,Alex Glew,224
+Santa Clara,2046,State Assembly,24,Rep,Alex Glew,196
+Santa Clara,2049,State Assembly,24,Rep,Alex Glew,62
+Santa Clara,2056,State Assembly,24,Rep,Alex Glew,167
+Santa Clara,2061,State Assembly,24,Rep,Alex Glew,137
+Santa Clara,2065,State Assembly,24,Rep,Alex Glew,131
+Santa Clara,2068,State Assembly,24,Rep,Alex Glew,234
+Santa Clara,2069,State Assembly,24,Rep,Alex Glew,157
+Santa Clara,2081,State Assembly,24,Rep,Alex Glew,221
+Santa Clara,2090,State Assembly,24,Rep,Alex Glew,137
+Santa Clara,2096,State Assembly,24,Rep,Alex Glew,127
+Santa Clara,2098,State Assembly,24,Rep,Alex Glew,102
+Santa Clara,2101,State Assembly,24,Rep,Alex Glew,123
+Santa Clara,2102,State Assembly,24,Rep,Alex Glew,98
+Santa Clara,2107,State Assembly,24,Rep,Alex Glew,155
+Santa Clara,2108,State Assembly,24,Rep,Alex Glew,167
+Santa Clara,2110,State Assembly,24,Rep,Alex Glew,123
+Santa Clara,2112,State Assembly,24,Rep,Alex Glew,194
+Santa Clara,2114,State Assembly,24,Rep,Alex Glew,112
+Santa Clara,2115,State Assembly,24,Rep,Alex Glew,213
+Santa Clara,2117,State Assembly,24,Rep,Alex Glew,103
+Santa Clara,2120,State Assembly,24,Rep,Alex Glew,183
+Santa Clara,2124,State Assembly,24,Rep,Alex Glew,64
+Santa Clara,2125,State Assembly,24,Rep,Alex Glew,53
+Santa Clara,2126,State Assembly,24,Rep,Alex Glew,7
+Santa Clara,2129,State Assembly,24,Rep,Alex Glew,76
+Santa Clara,2301,State Assembly,24,Rep,Alex Glew,258
+Santa Clara,2305,State Assembly,24,Rep,Alex Glew,162
+Santa Clara,2306,State Assembly,24,Rep,Alex Glew,179
+Santa Clara,2307,State Assembly,24,Rep,Alex Glew,148
+Santa Clara,2309,State Assembly,24,Rep,Alex Glew,305
+Santa Clara,2310,State Assembly,24,Rep,Alex Glew,193
+Santa Clara,2311,State Assembly,24,Rep,Alex Glew,297
+Santa Clara,2314,State Assembly,24,Rep,Alex Glew,179
+Santa Clara,2316,State Assembly,24,Rep,Alex Glew,219
+Santa Clara,2317,State Assembly,24,Rep,Alex Glew,304
+Santa Clara,2321,State Assembly,24,Rep,Alex Glew,297
+Santa Clara,2323,State Assembly,24,Rep,Alex Glew,161
+Santa Clara,2326,State Assembly,24,Rep,Alex Glew,179
+Santa Clara,2330,State Assembly,24,Rep,Alex Glew,165
+Santa Clara,2333,State Assembly,24,Rep,Alex Glew,181
+Santa Clara,2338,State Assembly,24,Rep,Alex Glew,30
+Santa Clara,2339,State Assembly,24,Rep,Alex Glew,299
+Santa Clara,2343,State Assembly,24,Rep,Alex Glew,191
+Santa Clara,2345,State Assembly,24,Rep,Alex Glew,177
+Santa Clara,2351,State Assembly,24,Rep,Alex Glew,294
+Santa Clara,2352,State Assembly,24,Rep,Alex Glew,252
+Santa Clara,2357,State Assembly,24,Rep,Alex Glew,180
+Santa Clara,2374,State Assembly,24,Rep,Alex Glew,58
+Santa Clara,2375,State Assembly,24,Rep,Alex Glew,335
+Santa Clara,2378,State Assembly,24,Rep,Alex Glew,261
+Santa Clara,2381,State Assembly,24,Rep,Alex Glew,2
+Santa Clara,2382,State Assembly,24,Rep,Alex Glew,329
+Santa Clara,2385,State Assembly,24,Rep,Alex Glew,358
+Santa Clara,2389,State Assembly,24,Rep,Alex Glew,314
+Santa Clara,2402,State Assembly,24,Rep,Alex Glew,113
+Santa Clara,2403,State Assembly,24,Rep,Alex Glew,154
+Santa Clara,2406,State Assembly,24,Rep,Alex Glew,168
+Santa Clara,2407,State Assembly,24,Rep,Alex Glew,113
+Santa Clara,2408,State Assembly,24,Rep,Alex Glew,168
+Santa Clara,2409,State Assembly,24,Rep,Alex Glew,243
+Santa Clara,2410,State Assembly,24,Rep,Alex Glew,210
+Santa Clara,2412,State Assembly,24,Rep,Alex Glew,176
+Santa Clara,2413,State Assembly,24,Rep,Alex Glew,116
+Santa Clara,2414,State Assembly,24,Rep,Alex Glew,145
+Santa Clara,2417,State Assembly,24,Rep,Alex Glew,214
+Santa Clara,2418,State Assembly,24,Rep,Alex Glew,176
+Santa Clara,2419,State Assembly,24,Rep,Alex Glew,111
+Santa Clara,2427,State Assembly,24,Rep,Alex Glew,120
+Santa Clara,2428,State Assembly,24,Rep,Alex Glew,158
+Santa Clara,2431,State Assembly,24,Rep,Alex Glew,60
+Santa Clara,2434,State Assembly,24,Rep,Alex Glew,164
+Santa Clara,2436,State Assembly,24,Rep,Alex Glew,203
+Santa Clara,2438,State Assembly,24,Rep,Alex Glew,175
+Santa Clara,2439,State Assembly,24,Rep,Alex Glew,159
+Santa Clara,2440,State Assembly,24,Rep,Alex Glew,170
+Santa Clara,2442,State Assembly,24,Rep,Alex Glew,118
+Santa Clara,2445,State Assembly,24,Rep,Alex Glew,169
+Santa Clara,2452,State Assembly,24,Rep,Alex Glew,84
+Santa Clara,2457,State Assembly,24,Rep,Alex Glew,142
+Santa Clara,2459,State Assembly,24,Rep,Alex Glew,97
+Santa Clara,2460,State Assembly,24,Rep,Alex Glew,198
+Santa Clara,2464,State Assembly,24,Rep,Alex Glew,83
+Santa Clara,2465,State Assembly,24,Rep,Alex Glew,142
+Santa Clara,2467,State Assembly,24,Rep,Alex Glew,173
+Santa Clara,2475,State Assembly,24,Rep,Alex Glew,156
+Santa Clara,2479,State Assembly,24,Rep,Alex Glew,163
+Santa Clara,2489,State Assembly,24,Rep,Alex Glew,175
+Santa Clara,2492,State Assembly,24,Rep,Alex Glew,181
+Santa Clara,2494,State Assembly,24,Rep,Alex Glew,115
+Santa Clara,2539,State Assembly,24,Rep,Alex Glew,10
+Santa Clara,2540,State Assembly,24,Rep,Alex Glew,9
+Santa Clara,2542,State Assembly,24,Rep,Alex Glew,76
+Santa Clara,2544,State Assembly,24,Rep,Alex Glew,101
+Santa Clara,2545,State Assembly,24,Rep,Alex Glew,56
+Santa Clara,2546,State Assembly,24,Rep,Alex Glew,46
+Santa Clara,2802,State Assembly,24,Rep,Alex Glew,313
+Santa Clara,2808,State Assembly,28,Rep,Michael Snyder,1
+Santa Clara,2811,State Assembly,28,Rep,Michael Snyder,8
+Santa Clara,2812,State Assembly,24,Rep,Alex Glew,67
+Santa Clara,2813,State Assembly,28,Rep,Michael Snyder,69
+Santa Clara,2816,State Assembly,28,Rep,Michael Snyder,2
+Santa Clara,2825,State Assembly,24,Rep,Alex Glew,3
+Santa Clara,2833,State Assembly,24,Rep,Alex Glew,310
+Santa Clara,2870,State Assembly,24,Rep,Alex Glew,21
+Santa Clara,2871,State Assembly,24,Rep,Alex Glew,2
+Santa Clara,2873,State Assembly,24,Rep,Alex Glew,0
+Santa Clara,2951,State Assembly,24,Rep,Alex Glew,28
+Santa Clara,2953,State Assembly,24,Rep,Alex Glew,16
+Santa Clara,3601,State Assembly,24,Rep,Alex Glew,93
+Santa Clara,3602,State Assembly,28,Rep,Michael Snyder,258
+Santa Clara,3603,State Assembly,24,Rep,Alex Glew,77
+Santa Clara,3604,State Assembly,28,Rep,Michael Snyder,164
+Santa Clara,3605,State Assembly,28,Rep,Michael Snyder,131
+Santa Clara,3606,State Assembly,28,Rep,Michael Snyder,275
+Santa Clara,3607,State Assembly,24,Rep,Alex Glew,193
+Santa Clara,3608,State Assembly,28,Rep,Michael Snyder,242
+Santa Clara,3609,State Assembly,28,Rep,Michael Snyder,272
+Santa Clara,3610,State Assembly,28,Rep,Michael Snyder,218
+Santa Clara,3612,State Assembly,28,Rep,Michael Snyder,289
+Santa Clara,3614,State Assembly,28,Rep,Michael Snyder,197
+Santa Clara,3615,State Assembly,28,Rep,Michael Snyder,195
+Santa Clara,3616,State Assembly,28,Rep,Michael Snyder,229
+Santa Clara,3620,State Assembly,28,Rep,Michael Snyder,295
+Santa Clara,3621,State Assembly,28,Rep,Michael Snyder,176
+Santa Clara,3624,State Assembly,28,Rep,Michael Snyder,161
+Santa Clara,3627,State Assembly,28,Rep,Michael Snyder,92
+Santa Clara,3628,State Assembly,28,Rep,Michael Snyder,245
+Santa Clara,3629,State Assembly,28,Rep,Michael Snyder,236
+Santa Clara,3633,State Assembly,28,Rep,Michael Snyder,244
+Santa Clara,3635,State Assembly,28,Rep,Michael Snyder,15
+Santa Clara,3636,State Assembly,28,Rep,Michael Snyder,256
+Santa Clara,3640,State Assembly,28,Rep,Michael Snyder,209
+Santa Clara,3642,State Assembly,28,Rep,Michael Snyder,239
+Santa Clara,3645,State Assembly,28,Rep,Michael Snyder,167
+Santa Clara,3650,State Assembly,24,Rep,Alex Glew,216
+Santa Clara,3652,State Assembly,28,Rep,Michael Snyder,226
+Santa Clara,3658,State Assembly,24,Rep,Alex Glew,4
+Santa Clara,3663,State Assembly,28,Rep,Michael Snyder,27
+Santa Clara,3720,State Assembly,28,Rep,Michael Snyder,222
+Santa Clara,3721,State Assembly,28,Rep,Michael Snyder,367
+Santa Clara,3723,State Assembly,28,Rep,Michael Snyder,20
+Santa Clara,3724,State Assembly,28,Rep,Michael Snyder,337
+Santa Clara,3725,State Assembly,28,Rep,Michael Snyder,170
+Santa Clara,3726,State Assembly,28,Rep,Michael Snyder,199
+Santa Clara,3727,State Assembly,28,Rep,Michael Snyder,30
+Santa Clara,3728,State Assembly,28,Rep,Michael Snyder,0
+Santa Clara,3729,State Assembly,28,Rep,Michael Snyder,218
+Santa Clara,3731,State Assembly,28,Rep,Michael Snyder,193
+Santa Clara,3733,State Assembly,28,Rep,Michael Snyder,194
+Santa Clara,3734,State Assembly,28,Rep,Michael Snyder,191
+Santa Clara,3737,State Assembly,28,Rep,Michael Snyder,321
+Santa Clara,3740,State Assembly,28,Rep,Michael Snyder,267
+Santa Clara,3741,State Assembly,28,Rep,Michael Snyder,167
+Santa Clara,3745,State Assembly,28,Rep,Michael Snyder,319
+Santa Clara,3749,State Assembly,28,Rep,Michael Snyder,156
+Santa Clara,3751,State Assembly,28,Rep,Michael Snyder,5
+Santa Clara,3753,State Assembly,28,Rep,Michael Snyder,255
+Santa Clara,3754,State Assembly,28,Rep,Michael Snyder,197
+Santa Clara,3757,State Assembly,28,Rep,Michael Snyder,195
+Santa Clara,3761,State Assembly,28,Rep,Michael Snyder,1
+Santa Clara,3767,State Assembly,28,Rep,Michael Snyder,166
+Santa Clara,3771,State Assembly,28,Rep,Michael Snyder,162
+Santa Clara,3772,State Assembly,28,Rep,Michael Snyder,140
+Santa Clara,3774,State Assembly,28,Rep,Michael Snyder,296
+Santa Clara,3781,State Assembly,28,Rep,Michael Snyder,307
+Santa Clara,3782,State Assembly,28,Rep,Michael Snyder,127
+Santa Clara,3784,State Assembly,28,Rep,Michael Snyder,43
+Santa Clara,3785,State Assembly,28,Rep,Michael Snyder,251
+Santa Clara,3787,State Assembly,28,Rep,Michael Snyder,10
+Santa Clara,3801,State Assembly,28,Rep,Michael Snyder,200
+Santa Clara,3802,State Assembly,28,Rep,Michael Snyder,194
+Santa Clara,3803,State Assembly,28,Rep,Michael Snyder,166
+Santa Clara,3804,State Assembly,28,Rep,Michael Snyder,166
+Santa Clara,3805,State Assembly,28,Rep,Michael Snyder,184
+Santa Clara,3806,State Assembly,28,Rep,Michael Snyder,177
+Santa Clara,3809,State Assembly,28,Rep,Michael Snyder,164
+Santa Clara,3810,State Assembly,28,Rep,Michael Snyder,197
+Santa Clara,3812,State Assembly,28,Rep,Michael Snyder,161
+Santa Clara,3814,State Assembly,28,Rep,Michael Snyder,229
+Santa Clara,3818,State Assembly,28,Rep,Michael Snyder,177
+Santa Clara,3819,State Assembly,28,Rep,Michael Snyder,226
+Santa Clara,3820,State Assembly,28,Rep,Michael Snyder,205
+Santa Clara,3821,State Assembly,28,Rep,Michael Snyder,112
+Santa Clara,3823,State Assembly,28,Rep,Michael Snyder,167
+Santa Clara,3825,State Assembly,28,Rep,Michael Snyder,136
+Santa Clara,3826,State Assembly,28,Rep,Michael Snyder,143
+Santa Clara,3828,State Assembly,28,Rep,Michael Snyder,249
+Santa Clara,3834,State Assembly,28,Rep,Michael Snyder,228
+Santa Clara,3835,State Assembly,28,Rep,Michael Snyder,244
+Santa Clara,3840,State Assembly,28,Rep,Michael Snyder,236
+Santa Clara,3843,State Assembly,28,Rep,Michael Snyder,261
+Santa Clara,3846,State Assembly,28,Rep,Michael Snyder,24
+Santa Clara,3900,State Assembly,30,Rep,Neil Kitchens,263
+Santa Clara,3901,State Assembly,30,Rep,Neil Kitchens,417
+Santa Clara,3902,State Assembly,30,Rep,Neil Kitchens,270
+Santa Clara,3903,State Assembly,30,Rep,Neil Kitchens,278
+Santa Clara,3906,State Assembly,30,Rep,Neil Kitchens,255
+Santa Clara,3907,State Assembly,30,Rep,Neil Kitchens,175
+Santa Clara,3908,State Assembly,30,Rep,Neil Kitchens,22
+Santa Clara,3909,State Assembly,30,Rep,Neil Kitchens,355
+Santa Clara,3910,State Assembly,30,Rep,Neil Kitchens,98
+Santa Clara,3911,State Assembly,30,Rep,Neil Kitchens,98
+Santa Clara,3912,State Assembly,30,Rep,Neil Kitchens,191
+Santa Clara,3914,State Assembly,30,Rep,Neil Kitchens,198
+Santa Clara,3916,State Assembly,30,Rep,Neil Kitchens,230
+Santa Clara,3918,State Assembly,30,Rep,Neil Kitchens,241
+Santa Clara,3921,State Assembly,30,Rep,Neil Kitchens,305
+Santa Clara,3922,State Assembly,30,Rep,Neil Kitchens,214
+Santa Clara,3923,State Assembly,30,Rep,Neil Kitchens,214
+Santa Clara,3924,State Assembly,30,Rep,Neil Kitchens,344
+Santa Clara,3928,State Assembly,30,Rep,Neil Kitchens,271
+Santa Clara,3929,State Assembly,30,Rep,Neil Kitchens,207
+Santa Clara,3932,State Assembly,30,Rep,Neil Kitchens,303
+Santa Clara,3937,State Assembly,30,Rep,Neil Kitchens,313
+Santa Clara,3938,State Assembly,30,Rep,Neil Kitchens,278
+Santa Clara,3939,State Assembly,30,Rep,Neil Kitchens,218
+Santa Clara,3940,State Assembly,30,Rep,Neil Kitchens,240
+Santa Clara,3942,State Assembly,30,Rep,Neil Kitchens,142
+Santa Clara,3948,State Assembly,30,Rep,Neil Kitchens,61
+Santa Clara,3951,State Assembly,30,Rep,Neil Kitchens,153
+Santa Clara,3952,State Assembly,30,Rep,Neil Kitchens,199
+Santa Clara,3953,State Assembly,30,Rep,Neil Kitchens,283
+Santa Clara,3954,State Assembly,30,Rep,Neil Kitchens,128
+Santa Clara,3955,State Assembly,30,Rep,Neil Kitchens,220
+Santa Clara,3956,State Assembly,30,Rep,Neil Kitchens,122
+Santa Clara,3957,State Assembly,30,Rep,Neil Kitchens,202
+Santa Clara,3958,State Assembly,30,Rep,Neil Kitchens,77
+Santa Clara,3959,State Assembly,30,Rep,Neil Kitchens,329
+Santa Clara,3960,State Assembly,30,Rep,Neil Kitchens,149
+Santa Clara,3962,State Assembly,30,Rep,Neil Kitchens,116
+Santa Clara,3964,State Assembly,30,Rep,Neil Kitchens,365
+Santa Clara,3965,State Assembly,30,Rep,Neil Kitchens,251
+Santa Clara,3968,State Assembly,30,Rep,Neil Kitchens,206
+Santa Clara,3972,State Assembly,30,Rep,Neil Kitchens,183
+Santa Clara,3973,State Assembly,30,Rep,Neil Kitchens,471
+Santa Clara,3974,State Assembly,30,Rep,Neil Kitchens,123
+Santa Clara,3976,State Assembly,30,Rep,Neil Kitchens,324
+Santa Clara,3982,State Assembly,30,Rep,Neil Kitchens,346
+Santa Clara,3984,State Assembly,30,Rep,Neil Kitchens,266
+Santa Clara,3985,State Assembly,30,Rep,Neil Kitchens,165
+Santa Clara,3986,State Assembly,30,Rep,Neil Kitchens,320
+Santa Clara,3989,State Assembly,30,Rep,Neil Kitchens,345
+Santa Clara,3992,State Assembly,30,Rep,Neil Kitchens,0
+Santa Clara,4001,State Assembly,24,Rep,Alex Glew,196
+Santa Clara,4002,State Assembly,24,Rep,Alex Glew,157
+Santa Clara,4004,State Assembly,24,Rep,Alex Glew,145
+Santa Clara,4005,State Assembly,24,Rep,Alex Glew,2
+Santa Clara,4006,State Assembly,24,Rep,Alex Glew,212
+Santa Clara,4007,State Assembly,24,Rep,Alex Glew,190
+Santa Clara,4008,State Assembly,25,Rep,Bob Brunton,6
+Santa Clara,4010,State Assembly,24,Rep,Alex Glew,259
+Santa Clara,4011,State Assembly,24,Rep,Alex Glew,179
+Santa Clara,4012,State Assembly,24,Rep,Alex Glew,12
+Santa Clara,4013,State Assembly,24,Rep,Alex Glew,146
+Santa Clara,4015,State Assembly,24,Rep,Alex Glew,56
+Santa Clara,4016,State Assembly,24,Rep,Alex Glew,179
+Santa Clara,4017,State Assembly,24,Rep,Alex Glew,128
+Santa Clara,4019,State Assembly,24,Rep,Alex Glew,214
+Santa Clara,4022,State Assembly,24,Rep,Alex Glew,185
+Santa Clara,4023,State Assembly,24,Rep,Alex Glew,243
+Santa Clara,4026,State Assembly,24,Rep,Alex Glew,188
+Santa Clara,4030,State Assembly,24,Rep,Alex Glew,150
+Santa Clara,4034,State Assembly,24,Rep,Alex Glew,235
+Santa Clara,4035,State Assembly,24,Rep,Alex Glew,209
+Santa Clara,4036,State Assembly,24,Rep,Alex Glew,206
+Santa Clara,4038,State Assembly,24,Rep,Alex Glew,255
+Santa Clara,4039,State Assembly,24,Rep,Alex Glew,184
+Santa Clara,4041,State Assembly,24,Rep,Alex Glew,142
+Santa Clara,4042,State Assembly,24,Rep,Alex Glew,177
+Santa Clara,4043,State Assembly,24,,Alex Glew,163
+Santa Clara,4045,State Assembly,24,,Alex Glew,224
+Santa Clara,4047,State Assembly,24,,Alex Glew,257
+Santa Clara,4048,State Assembly,24,,Alex Glew,107
+Santa Clara,4050,State Assembly,24,,Alex Glew,174
+Santa Clara,4051,State Assembly,24,,Alex Glew,228
+Santa Clara,4052,State Assembly,24,,Alex Glew,192
+Santa Clara,4053,State Assembly,24,,Alex Glew,300
+Santa Clara,4055,State Assembly,24,,Alex Glew,188
+Santa Clara,4058,State Assembly,24,,Alex Glew,164
+Santa Clara,4060,State Assembly,24,,Alex Glew,110
+Santa Clara,4061,State Assembly,24,,Alex Glew,13
+Santa Clara,4064,State Assembly,24,,Alex Glew,96
+Santa Clara,4067,State Assembly,24,,Alex Glew,137
+Santa Clara,4068,State Assembly,24,,Alex Glew,9
+Santa Clara,4070,State Assembly,24,,Alex Glew,162
+Santa Clara,4071,State Assembly,24,,Alex Glew,283
+Santa Clara,4074,State Assembly,24,,Alex Glew,108
+Santa Clara,4076,State Assembly,24,,Alex Glew,255
+Santa Clara,4079,State Assembly,24,,Alex Glew,111
+Santa Clara,4080,State Assembly,24,,Alex Glew,186
+Santa Clara,4084,State Assembly,24,,Alex Glew,91
+Santa Clara,4086,State Assembly,24,,Alex Glew,252
+Santa Clara,4087,State Assembly,24,,Alex Glew,144
+Santa Clara,4089,State Assembly,24,,Alex Glew,22
+Santa Clara,4098,State Assembly,24,,Alex Glew,59
+Santa Clara,4099,State Assembly,24,,Alex Glew,85
+Santa Clara,4103,State Assembly,24,,Alex Glew,207
+Santa Clara,4116,State Assembly,24,,Alex Glew,30
+Santa Clara,4117,State Assembly,24,,Alex Glew,125
+Santa Clara,4118,State Assembly,24,,Alex Glew,218
+Santa Clara,4119,State Assembly,24,,Alex Glew,226
+Santa Clara,4122,State Assembly,24,,Alex Glew,201
+Santa Clara,4126,State Assembly,24,,Alex Glew,201
+Santa Clara,4128,State Assembly,24,,Alex Glew,182
+Santa Clara,4129,State Assembly,24,,Alex Glew,232
+Santa Clara,4130,State Assembly,24,,Alex Glew,182
+Santa Clara,4131,State Assembly,24,,Alex Glew,158
+Santa Clara,4154,State Assembly,24,,Alex Glew,200
+Santa Clara,4201,State Assembly,25,Rep,Bob Brunton,171
+Santa Clara,4202,State Assembly,25,Rep,Bob Brunton,1
+Santa Clara,4205,State Assembly,25,Rep,Bob Brunton,10
+Santa Clara,4207,State Assembly,25,Rep,Bob Brunton,9
+Santa Clara,4208,State Assembly,25,Rep,Bob Brunton,230
+Santa Clara,4211,State Assembly,25,Rep,Bob Brunton,186
+Santa Clara,4212,State Assembly,25,Rep,Bob Brunton,0
+Santa Clara,4215,State Assembly,25,Rep,Bob Brunton,258
+Santa Clara,4217,State Assembly,25,Rep,Bob Brunton,164
+Santa Clara,4218,State Assembly,25,Rep,Bob Brunton,106
+Santa Clara,4222,State Assembly,25,Rep,Bob Brunton,201
+Santa Clara,4223,State Assembly,25,Rep,Bob Brunton,183
+Santa Clara,4224,State Assembly,25,Rep,Bob Brunton,1
+Santa Clara,4226,State Assembly,25,Rep,Bob Brunton,232
+Santa Clara,4227,State Assembly,25,Rep,Bob Brunton,175
+Santa Clara,4231,State Assembly,25,Rep,Bob Brunton,229
+Santa Clara,4238,State Assembly,25,Rep,Bob Brunton,252
+Santa Clara,4241,State Assembly,25,Rep,Bob Brunton,252
+Santa Clara,4242,State Assembly,25,Rep,Bob Brunton,225
+Santa Clara,4247,State Assembly,25,Rep,Bob Brunton,169
+Santa Clara,4249,State Assembly,25,Rep,Bob Brunton,219
+Santa Clara,4250,State Assembly,25,Rep,Bob Brunton,177
+Santa Clara,4256,State Assembly,25,Rep,Bob Brunton,173
+Santa Clara,4257,State Assembly,25,Rep,Bob Brunton,104
+Santa Clara,4258,State Assembly,25,Rep,Bob Brunton,177
+Santa Clara,4259,State Assembly,25,Rep,Bob Brunton,237
+Santa Clara,4261,State Assembly,25,Rep,Bob Brunton,121
+Santa Clara,4265,State Assembly,25,Rep,Bob Brunton,249
+Santa Clara,4267,State Assembly,25,Rep,Bob Brunton,193
+Santa Clara,4268,State Assembly,25,Rep,Bob Brunton,118
+Santa Clara,4269,State Assembly,25,Rep,Bob Brunton,110
+Santa Clara,4270,State Assembly,25,Rep,Bob Brunton,195
+Santa Clara,4271,State Assembly,25,Rep,Bob Brunton,224
+Santa Clara,4272,State Assembly,25,Rep,Bob Brunton,94
+Santa Clara,4273,State Assembly,25,Rep,Bob Brunton,182
+Santa Clara,4288,State Assembly,25,Rep,Bob Brunton,167
+Santa Clara,4289,State Assembly,25,Rep,Bob Brunton,129
+Santa Clara,4296,State Assembly,25,Rep,Bob Brunton,87
+Santa Clara,4297,State Assembly,25,Rep,Bob Brunton,272
+Santa Clara,4298,State Assembly,25,Rep,Bob Brunton,145
+Santa Clara,4299,State Assembly,25,Rep,Bob Brunton,8
+Santa Clara,4301,State Assembly,25,Rep,Bob Brunton,221
+Santa Clara,4305,State Assembly,25,Rep,Bob Brunton,261
+Santa Clara,4308,State Assembly,25,Rep,Bob Brunton,17
+Santa Clara,4309,State Assembly,25,Rep,Bob Brunton,13
+Santa Clara,4312,State Assembly,25,Rep,Bob Brunton,133
+Santa Clara,4315,State Assembly,25,Rep,Bob Brunton,271
+Santa Clara,4319,State Assembly,25,Rep,Bob Brunton,136
+Santa Clara,4321,State Assembly,25,Rep,Bob Brunton,150
+Santa Clara,4326,State Assembly,25,Rep,Bob Brunton,220
+Santa Clara,4327,State Assembly,25,Rep,Bob Brunton,199
+Santa Clara,4332,State Assembly,25,Rep,Bob Brunton,182
+Santa Clara,4334,State Assembly,25,Rep,Bob Brunton,158
+Santa Clara,4343,State Assembly,25,Rep,Bob Brunton,115
+Santa Clara,4401,State Assembly,25,Rep,Bob Brunton,250
+Santa Clara,4402,State Assembly,25,Rep,Bob Brunton,214
+Santa Clara,4403,State Assembly,25,Rep,Bob Brunton,14
+Santa Clara,4404,State Assembly,25,Rep,Bob Brunton,143
+Santa Clara,4405,State Assembly,25,Rep,Bob Brunton,127
+Santa Clara,4406,State Assembly,25,Rep,Bob Brunton,122
+Santa Clara,4407,State Assembly,25,Rep,Bob Brunton,169
+Santa Clara,4408,State Assembly,25,Rep,Bob Brunton,148
+Santa Clara,4409,State Assembly,25,Rep,Bob Brunton,190
+Santa Clara,4411,State Assembly,25,Rep,Bob Brunton,191
+Santa Clara,4412,State Assembly,25,Rep,Bob Brunton,140
+Santa Clara,4413,State Assembly,25,Rep,Bob Brunton,140
+Santa Clara,4414,State Assembly,25,Rep,Bob Brunton,135
+Santa Clara,4415,State Assembly,25,Rep,Bob Brunton,246
+Santa Clara,4416,State Assembly,25,Rep,Bob Brunton,126
+Santa Clara,4417,State Assembly,25,Rep,Bob Brunton,284
+Santa Clara,4418,State Assembly,25,Rep,Bob Brunton,145
+Santa Clara,4421,State Assembly,25,Rep,Bob Brunton,137
+Santa Clara,4422,State Assembly,25,Rep,Bob Brunton,212
+Santa Clara,4423,State Assembly,25,Rep,Bob Brunton,128
+Santa Clara,4424,State Assembly,25,Rep,Bob Brunton,111
+Santa Clara,4425,State Assembly,25,Rep,Bob Brunton,124
+Santa Clara,4426,State Assembly,25,Rep,Bob Brunton,154
+Santa Clara,4427,State Assembly,25,Rep,Bob Brunton,151
+Santa Clara,4428,State Assembly,25,Rep,Bob Brunton,187
+Santa Clara,4429,State Assembly,25,Rep,Bob Brunton,253
+Santa Clara,4431,State Assembly,25,Rep,Bob Brunton,0
+Santa Clara,4432,State Assembly,25,Rep,Bob Brunton,239
+Santa Clara,4435,State Assembly,25,Rep,Bob Brunton,210
+Santa Clara,4438,State Assembly,25,Rep,Bob Brunton,113
+Santa Clara,4440,State Assembly,25,Rep,Bob Brunton,205
+Santa Clara,4441,State Assembly,25,Rep,Bob Brunton,60
+Santa Clara,4442,State Assembly,25,Rep,Bob Brunton,3
+Santa Clara,4666,State Assembly,28,Rep,Michael Snyder,244
+Santa Clara,4667,State Assembly,28,Rep,Michael Snyder,1
+Santa Clara,4668,State Assembly,28,Rep,Michael Snyder,224
+Santa Clara,4669,State Assembly,28,Rep,Michael Snyder,3
+Santa Clara,4670,State Assembly,28,Rep,Michael Snyder,304
+Santa Clara,4672,State Assembly,28,Rep,Michael Snyder,14
+Santa Clara,4674,State Assembly,28,Rep,Michael Snyder,253
+Santa Clara,4676,State Assembly,28,Rep,Michael Snyder,399
+Santa Clara,4677,State Assembly,28,Rep,Michael Snyder,195
+Santa Clara,4678,State Assembly,28,Rep,Michael Snyder,218
+Santa Clara,4681,State Assembly,28,Rep,Michael Snyder,351
+Santa Clara,4685,State Assembly,28,Rep,Michael Snyder,376
+Santa Clara,4687,State Assembly,28,Rep,Michael Snyder,249
+Santa Clara,4688,State Assembly,28,Rep,Michael Snyder,299
+Santa Clara,4690,State Assembly,28,Rep,Michael Snyder,301
+Santa Clara,4692,State Assembly,28,Rep,Michael Snyder,209
+Santa Clara,4696,State Assembly,28,Rep,Michael Snyder,224
+Santa Clara,4699,State Assembly,28,Rep,Michael Snyder,291
+Santa Clara,4702,State Assembly,28,Rep,Michael Snyder,171
+Santa Clara,4703,State Assembly,28,Rep,Michael Snyder,334
+Santa Clara,4704,State Assembly,28,Rep,Michael Snyder,46
+Santa Clara,4707,State Assembly,28,Rep,Michael Snyder,27
+Santa Clara,4723,State Assembly,28,Rep,Michael Snyder,193
+Santa Clara,4733,State Assembly,28,Rep,Michael Snyder,10
+Santa Clara,4737,State Assembly,28,Rep,Michael Snyder,1
+Santa Clara,4740,State Assembly,28,Rep,Michael Snyder,8
+Santa Clara,5449,State Assembly,25,Rep,Bob Brunton,12
+Santa Clara,5452,State Assembly,25,Rep,Bob Brunton,25
+Santa Clara,5453,State Assembly,27,Rep,Burt Lancaster,0
+Santa Clara,5456,State Assembly,25,Rep,Bob Brunton,0
+Santa Clara,5502,State Assembly,25,Rep,Bob Brunton,127
+Santa Clara,5503,State Assembly,27,Rep,Burt Lancaster,6
+Santa Clara,5505,State Assembly,25,Rep,Bob Brunton,47
+Santa Clara,5556,State Assembly,28,Rep,Michael Snyder,164
+Santa Clara,5557,State Assembly,28,Rep,Michael Snyder,154
+Santa Clara,5567,State Assembly,28,Rep,Michael Snyder,104
+Santa Clara,5743,State Assembly,28,Rep,Michael Snyder,117
+Santa Clara,5744,State Assembly,28,Rep,Michael Snyder,5
+Santa Clara,5745,State Assembly,28,Rep,Michael Snyder,313
+Santa Clara,5746,State Assembly,28,Rep,Michael Snyder,107
+Santa Clara,5747,State Assembly,28,Rep,Michael Snyder,202
+Santa Clara,5750,State Assembly,28,Rep,Michael Snyder,3
+Santa Clara,5752,State Assembly,28,Rep,Michael Snyder,228
+Santa Clara,5756,State Assembly,29,Rep,Vicki Nohrden,17
+Santa Clara,5758,State Assembly,28,Rep,Michael Snyder,58
+Santa Clara,5759,State Assembly,28,Rep,Michael Snyder,134
+Santa Clara,5760,State Assembly,28,Rep,Michael Snyder,1
+Santa Clara,5762,State Assembly,28,Rep,Michael Snyder,11
+Santa Clara,5763,State Assembly,28,Rep,Michael Snyder,19
+Santa Clara,5765,State Assembly,28,Rep,Michael Snyder,14
+Santa Clara,5770,State Assembly,28,Rep,Michael Snyder,51
+Santa Clara,5772,State Assembly,28,Rep,Michael Snyder,0
+Santa Clara,5774,State Assembly,28,Rep,Michael Snyder,9
+Santa Clara,5775,State Assembly,28,Rep,Michael Snyder,74
+Santa Clara,5782,State Assembly,28,Rep,Michael Snyder,45
+Santa Clara,5784,State Assembly,29,Rep,Vicki Nohrden,7
+Santa Clara,5788,State Assembly,28,Rep,Michael Snyder,2
+Santa Clara,5789,State Assembly,28,Rep,Michael Snyder,0
+Santa Clara,5792,State Assembly,29,Rep,Vicki Nohrden,0
+Santa Clara,5794,State Assembly,29,Rep,Vicki Nohrden,11
+Santa Clara,5804,State Assembly,28,Rep,Michael Snyder,340
+Santa Clara,5810,State Assembly,28,Rep,Michael Snyder,156
+Santa Clara,5813,State Assembly,28,Rep,Michael Snyder,11
+Santa Clara,5858,State Assembly,28,Rep,Michael Snyder,48
+Santa Clara,5881,State Assembly,27,Rep,Burt Lancaster,0
+Santa Clara,5884,State Assembly,27,Rep,Burt Lancaster,0
+Santa Clara,5886,State Assembly,27,Rep,Burt Lancaster,0
+Santa Clara,5894,State Assembly,29,Rep,Vicki Nohrden,1
+Santa Clara,5895,State Assembly,29,Rep,Vicki Nohrden,5
+Santa Clara,5902,State Assembly,29,Rep,Vicki Nohrden,154
+Santa Clara,5903,State Assembly,29,Rep,Vicki Nohrden,186
+Santa Clara,5904,State Assembly,29,Rep,Vicki Nohrden,46
+Santa Clara,5906,State Assembly,30,Rep,Neil Kitchens,65
+Santa Clara,5911,State Assembly,30,Rep,Neil Kitchens,54
+Santa Clara,5912,State Assembly,29,Rep,Vicki Nohrden,18
+Santa Clara,5914,State Assembly,29,Rep,Vicki Nohrden,371
+Santa Clara,5915,State Assembly,30,Rep,Neil Kitchens,287
+Santa Clara,5916,State Assembly,29,Rep,Vicki Nohrden,27
+Santa Clara,5917,State Assembly,30,Rep,Neil Kitchens,18
+Santa Clara,5920,State Assembly,30,Rep,Neil Kitchens,4
+Santa Clara,5925,State Assembly,25,Rep,Bob Brunton,14
+Santa Clara,5926,State Assembly,29,Rep,Vicki Nohrden,172
+Santa Clara,5929,State Assembly,30,Rep,Neil Kitchens,23
+Santa Clara,5931,State Assembly,29,Rep,Vicki Nohrden,16
+Santa Clara,5932,State Assembly,30,Rep,Neil Kitchens,41
+Santa Clara,5933,State Assembly,29,Rep,Vicki Nohrden,74
+Santa Clara,5936,State Assembly,30,Rep,Neil Kitchens,261
+Santa Clara,5937,State Assembly,30,Rep,Neil Kitchens,52
+Santa Clara,5938,State Assembly,25,Rep,Bob Brunton,22
+Santa Clara,5940,State Assembly,29,Rep,Vicki Nohrden,12
+Santa Clara,5943,State Assembly,30,Rep,Neil Kitchens,35
+Santa Clara,5945,State Assembly,29,Rep,Vicki Nohrden,93
+Santa Clara,5947,State Assembly,30,Rep,Neil Kitchens,270
+Santa Clara,5949,State Assembly,30,Rep,Neil Kitchens,30
+Santa Clara,5950,State Assembly,30,Rep,Neil Kitchens,100
+Santa Clara,5951,State Assembly,30,Rep,Neil Kitchens,5
+Santa Clara,5952,State Assembly,30,Rep,Neil Kitchens,6
+Santa Clara,5953,State Assembly,30,Rep,Neil Kitchens,53
+Santa Clara,5955,State Assembly,30,Rep,Neil Kitchens,414
+Santa Clara,5956,State Assembly,30,Rep,Neil Kitchens,412
+Santa Clara,5957,State Assembly,30,Rep,Neil Kitchens,49
+Santa Clara,5959,State Assembly,30,Rep,Neil Kitchens,40
+Santa Clara,5962,State Assembly,30,Rep,Neil Kitchens,307
+Santa Clara,5965,State Assembly,30,Rep,Neil Kitchens,305
+Santa Clara,5966,State Assembly,30,Rep,Neil Kitchens,18
+Santa Clara,5971,State Assembly,30,Rep,Neil Kitchens,54
+Santa Clara,5973,State Assembly,30,Rep,Neil Kitchens,22
+Santa Clara,5988,State Assembly,29,Rep,Vicki Nohrden,0
+Santa Clara,5989,State Assembly,30,Rep,Neil Kitchens,38
+Santa Clara,5991,State Assembly,29,Rep,Vicki Nohrden,3
+Santa Clara,5995,State Assembly,29,Rep,Vicki Nohrden,4
+Santa Clara,5996,State Assembly,29,Rep,Vicki Nohrden,12
+Santa Clara,6002,State Assembly,29,Rep,Vicki Nohrden,13
+Santa Clara,6006,State Assembly,30,Rep,Neil Kitchens,13
+Santa Clara,6007,State Assembly,30,Rep,Neil Kitchens,12
+Santa Clara,6021,State Assembly,29,Rep,Vicki Nohrden,17
+Santa Clara,6023,State Assembly,29,Rep,Vicki Nohrden,2
+Santa Clara,6028,State Assembly,25,Rep,Bob Brunton,1
+Santa Clara,6031,State Assembly,30,Rep,Neil Kitchens,9
+Santa Clara,6032,State Assembly,30,Rep,Neil Kitchens,18
+Santa Clara,6034,State Assembly,29,Rep,Vicki Nohrden,5
+Santa Clara,6039,State Assembly,30,Rep,Neil Kitchens,0
+Santa Clara,6040,State Assembly,30,Rep,Neil Kitchens,16
+Santa Clara,6045,State Assembly,29,Rep,Vicki Nohrden,5
+Santa Clara,6047,State Assembly,29,Rep,Vicki Nohrden,10
+Santa Clara,6401,State Assembly,25,Rep,Bob Brunton,1
+Santa Clara,6402,State Assembly,25,Rep,Bob Brunton,24
+Santa Clara,6404,State Assembly,27,Rep,Burt Lancaster,41
+Santa Clara,6405,State Assembly,25,Rep,Bob Brunton,3
+Santa Clara,6410,State Assembly,25,Rep,Bob Brunton,14
+Santa Clara,6411,State Assembly,25,Rep,Bob Brunton,36
+Santa Clara,6413,State Assembly,25,Rep,Bob Brunton,8
+Santa Clara,6417,State Assembly,27,Rep,Burt Lancaster,41
+Santa Clara,6418,State Assembly,25,Rep,Bob Brunton,210
+Santa Clara,6419,State Assembly,25,Rep,Bob Brunton,14
+Santa Clara,6421,State Assembly,25,Rep,Bob Brunton,3
+Santa Clara,6422,State Assembly,25,Rep,Bob Brunton,6
+Santa Clara,6423,State Assembly,25,Rep,Bob Brunton,23
+Santa Clara,6425,State Assembly,25,Rep,Bob Brunton,22
+Santa Clara,6427,State Assembly,25,Rep,Bob Brunton,0
+Santa Clara,6452,State Assembly,27,Rep,Burt Lancaster,14
+Santa Clara,6454,State Assembly,27,Rep,Burt Lancaster,0
+Santa Clara,6455,State Assembly,27,Rep,Burt Lancaster,33
+Santa Clara,6457,State Assembly,27,Rep,Burt Lancaster,32
+Santa Clara,6458,State Assembly,27,Rep,Burt Lancaster,14
+Santa Clara,6462,State Assembly,27,Rep,Burt Lancaster,0
+Santa Clara,6463,State Assembly,27,Rep,Burt Lancaster,0
+Santa Clara,6464,State Assembly,25,Rep,Bob Brunton,0
+Santa Clara,6465,State Assembly,27,Rep,Burt Lancaster,0
+Santa Clara,6466,State Assembly,25,Rep,Bob Brunton,41
+Santa Clara,6470,State Assembly,27,Rep,Burt Lancaster,38
+Santa Clara,6490,State Assembly,25,Rep,Bob Brunton,5
+Santa Clara,6491,State Assembly,25,Rep,Bob Brunton,1
+Santa Clara,6492,State Assembly,25,Rep,Bob Brunton,30
+Santa Clara,6493,State Assembly,25,Rep,Bob Brunton,0
+Santa Clara,6502,State Assembly,25,Rep,Bob Brunton,42
+Santa Clara,6509,State Assembly,25,Rep,Bob Brunton,9
+Santa Clara,6510,State Assembly,25,Rep,Bob Brunton,8
+Santa Clara,6515,State Assembly,25,Rep,Bob Brunton,23
+Santa Clara,6624,State Assembly,28,Rep,Michael Snyder,0
+Santa Clara,6663,State Assembly,28,Rep,Michael Snyder,0
+Santa Clara,6664,State Assembly,28,Rep,Michael Snyder,13
+Santa Clara,6665,State Assembly,28,Rep,Michael Snyder,1
+Santa Clara,6666,State Assembly,28,Rep,Michael Snyder,35
+Santa Clara,6673,State Assembly,28,Rep,Michael Snyder,1
+Santa Clara,SANTA CLARA CA,State Assembly,24,Rep,Alex Glew,29519
+Santa Clara,SANTA CLARA CA,State Assembly,25,Rep,Bob Brunton,23231
+Santa Clara,SANTA CLARA CA,State Assembly,27,Rep,Burt Lancaster,27990
+Santa Clara,SANTA CLARA CA,State Assembly,28,Rep,Michael Snyder,53195
+Santa Clara,SANTA CLARA CA,State Assembly,29,Rep,Vicki Nohrden,12184
+Santa Clara,SANTA CLARA CA,State Assembly,30,Rep,Neil Kitchens,14575


### PR DESCRIPTION
and remove unnecessary records.

The CSV column order inexplicably changes a few hundred lines from the end of the file, causing data corruption. I fixed the column data by hand and removed the records which had cities or offices for the precinct names.