### PR TITLE
Remove duplicate entry from 2017 LA special election candidates

### DIFF
--- a/src/parse_special_primary_2017.py
+++ b/src/parse_special_primary_2017.py
@@ -37,8 +37,7 @@ candidates = {'ADRIENNE N EDWARDS': 'Adrienne Nicole Edwards',
               'MARK VARGAS': 'Mark Vargas',
               'MIKE FONG': 'Mike Fong',
               'PATRICK KOPPULA': 'Patrick Koppula',
-              'RON BIRNBAUM': 'Ron Birnbaum',
-              'WENDY CARRILLO': 'Wendy Carrillo'}
+              'RON BIRNBAUM': 'Ron Birnbaum'}
 
 p = {'Kenneth Mejia': 'GRN',
      'Angela E. McArdle': 'LIB',


### PR DESCRIPTION
The entry for Wendy Carrillo [already exists](https://github.com/openelections/openelections-data-ca/blob/master/src/parse_special_primary_2017.py#L26) in the dictionary.