### PR TITLE
Fix column headers in 20201103 imperial precinct file

### DIFF
--- a/2020/20201103__ca__general__imperial__precinct.csv
+++ b/2020/20201103__ca__general__imperial__precinct.csv
@@ -1,4 +1,4 @@
-﻿County,Precinct,Office,District,Party,Candidate,votes,Absentee,early_voting,election_day,mail
+County,Precinct,Office,District,Party,Candidate,votes,Absentee,early_voting,election_day,mail
 Imperial,121004,President,,,Times Cast,681,416,8,257,0
 Imperial,121004,President,,,Total Votes,670,410,8,252,0
 Imperial,121004,President,,,Write-in,1,0,0,1,0

--- a/2020/20201103__ca__general__imperial__precinct.csv
+++ b/2020/20201103__ca__general__imperial__precinct.csv
@@ -1,4 +1,4 @@
-County,Precinct,Office,District,Party,Candidate,votes,Absentee,early_voting,election_day,mail
+county,precinct,office,district,party,candidate,votes,absentee,early_voting,election_day,mail
 Imperial,121004,President,,,Times Cast,681,416,8,257,0
 Imperial,121004,President,,,Total Votes,670,410,8,252,0
 Imperial,121004,President,,,Write-in,1,0,0,1,0


### PR DESCRIPTION
This fixes the column headers in `2020/20201103__ca__general__imperial__precinct.csv` by
1. Removing the byte order mark (the file is utf-8 encoded).
2. Making the column headers all lowercase for consistency.