### PR TITLE
Run tests using GitHub workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,4 +24,4 @@ jobs:
       run: pip install -r requirements.txt
 
     - name: Run unit tests
-      run: pytest --tb=line
+      run: pytest --tb=line --color=yes

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,4 +24,4 @@ jobs:
       run: pip install -r requirements.txt
 
     - name: Run unit tests
-      run: pytest
+      run: pytest --tb=line

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,27 @@
+name: Tests
+
+on:
+  push:
+    branches: "*"
+  pull_request:
+    branches: "*"
+
+jobs:
+  unit_tests:
+    name: Unit tests
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+
+    steps:
+    - name: Set up Python
+      uses: actions/setup-python@v2
+
+    - name: Check out source
+      uses: actions/checkout@v2.3.4
+
+    - name: Configure environment
+      run: pip install -r requirements.txt
+
+    - name: Run unit tests
+      run: pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,0 @@
-dist: focal
-language: python
-script: pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-numpy==1.13.1
-pandas==0.20.3
+numpy==1.20.0
+pandas==1.2.3
 py==1.8.2
 pytest==6.2.3
 pytest-subtests==0.4.0
-python-dateutil==2.6.1
-pytz==2017.2
+python-dateutil==2.8.1
+pytz==2021.1
 six==1.10.0


### PR DESCRIPTION
This adds a GitHub workflow to run the unit tests.  In doing so, we also update the `requirements.txt` file to require more updated versions of some packages, and remove the Travis configuration.

Compared to Travis, this should provide us with more flexibility and also does not have limits on storage or the number of builds.  

To see the builds, you can either
1. Click on the icon next to each revision (similar to the Travis builds).
2. Click on the "Actions" tab at the top of the page.