### PR TITLE
Add additional checks to file format tests

### DIFF
--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -67,6 +67,10 @@ class FileFormatTests(unittest.TestCase):
                     self.assertTrue(required_headers.issubset(headers), f"File {short_path} has header: {headers}, "
                                                         f"which is missing: {required_headers.difference(headers)}.")
 
+                    # An "unknown" header is not useful.
+                    self.assertNotIn("unknown", [x.strip().lower() for x in headers], f"File {short_path} has an "
+                                                                                      f"'unknown' header: {headers}.")
+
                     for row in reader:
                         # Verify that each row has the expected number of entries.
                         self.assertEqual(len(headers), len(row), f"File {short_path} has header {headers}, but row "

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -79,9 +79,9 @@ class FileFormatTests(unittest.TestCase):
                             self.assertEqual(entry.strip(), entry, f"File {short_path} has leading or trailing "
                                                                    f"whitespace in row {reader.line_num}: {row}.")
 
-                            # Verify that there is no redundant whitespace.
-                            self.assertNotRegex(entry, r"\s{2,}", f"File {short_path} contains redundant whitespace "
-                                                                  f"in row {reader.line_num}: {row}.")
+                            # Verify that there is no consecutive whitespace characters.
+                            self.assertNotRegex(entry, r"\s{2,}", f"File {short_path} contains consecutive whitespace "
+                                                                  f"characters in row {reader.line_num}: {row}.")
 
                             # Verify that there are no line breaks in the row (sometimes occurs in between quotes).
                             self.assertNotIn("\n", entry, f"File {short_path} has a newline character in row {reader.line_num}.")

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -71,13 +71,19 @@ class FileFormatTests(unittest.TestCase):
                         # Verify that each row has the expected number of entries.
                         self.assertEqual(len(headers), len(row), f"File {short_path} has header {headers}, but row "
                                                                  f"{reader.line_num} is {row}.")
+                        row_has_content = False
                         for entry in row:
+                            row_has_content |= re.search(r"\S", entry) is not None
+
                             # Verify that there is no redundant whitespace.
                             self.assertIsNone(re.search(r"\s{2,}", entry), f"File {short_path} contains redundant "
                                                                            f"whitespace in row {reader.line_num}: {row}.")
 
                             # Verify that there are no line breaks in the row (sometimes occurs in between quotes).
                             self.assertNotIn("\n", entry, f"File {short_path} has a line break in row {reader.line_num}.")
+
+                        # Verify that the row has actual content.
+                        self.assertTrue(row_has_content, f"File {short_path} row {reader.line_num} is empty.")
 
 
     @staticmethod

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -75,6 +75,10 @@ class FileFormatTests(unittest.TestCase):
                         for entry in row:
                             row_has_content |= re.search(r"\S", entry) is not None
 
+                            # Verify that there is no leading or trailing whitespace.
+                            self.assertEqual(entry.strip(), entry, f"File {short_path} has leading or trailing "
+                                                                   f"whitespace in row {reader.line_num}: {row}.")
+
                             # Verify that there is no redundant whitespace.
                             self.assertIsNone(re.search(r"\s{2,}", entry), f"File {short_path} contains redundant "
                                                                            f"whitespace in row {reader.line_num}: {row}.")

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -84,7 +84,7 @@ class FileFormatTests(unittest.TestCase):
                                                                   f"in row {reader.line_num}: {row}.")
 
                             # Verify that there are no line breaks in the row (sometimes occurs in between quotes).
-                            self.assertNotIn("\n", entry, f"File {short_path} has a line break in row {reader.line_num}.")
+                            self.assertNotIn("\n", entry, f"File {short_path} has a newline character in row {reader.line_num}.")
 
                         # Verify that the row has actual content.
                         self.assertTrue(row_has_content, f"File {short_path} row {reader.line_num} is empty.")

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -73,7 +73,7 @@ class FileFormatTests(unittest.TestCase):
                                                                  f"{reader.line_num} is {row}.")
                         row_has_content = False
                         for entry in row:
-                            row_has_content |= re.search(r"\S", entry) is not None
+                            row_has_content |= (re.search(r"\S", entry) is not None)
 
                             # Verify that there is no leading or trailing whitespace.
                             self.assertEqual(entry.strip(), entry, f"File {short_path} has leading or trailing "

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -88,7 +88,8 @@ class FileFormatTests(unittest.TestCase):
                                                                   f"characters in row {reader.line_num}: {row}.")
 
                             # Verify that there are no line breaks in the row (sometimes occurs in between quotes).
-                            self.assertNotIn("\n", entry, f"File {short_path} has a newline character in row {reader.line_num}.")
+                            self.assertNotIn("\n", entry, f"File {short_path} has a newline character in row "
+                                                          f"{reader.line_num}: {row}.")
 
                             # Verify that the entry does not consist only of non-alphanumeric characters.
                             if entry != "":

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -90,6 +90,11 @@ class FileFormatTests(unittest.TestCase):
                             # Verify that there are no line breaks in the row (sometimes occurs in between quotes).
                             self.assertNotIn("\n", entry, f"File {short_path} has a newline character in row {reader.line_num}.")
 
+                            # Verify that the entry does not consist only of non-alphanumeric characters.
+                            if entry != "":
+                                self.assertRegex(entry, r"\w", f"File {short_path} has an entry of only non-alphanumeric "
+                                                               f"characters in row {reader.line_num}: {row}.")
+
                         # Verify that the row has actual content.
                         self.assertTrue(row_has_content, f"File {short_path} row {reader.line_num} is empty.")
 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -76,6 +76,10 @@ class FileFormatTests(unittest.TestCase):
                             self.assertIsNone(re.search(r"\s{2,}", entry), f"File {short_path} contains redundant "
                                                                            f"whitespace in row {reader.line_num}: {row}.")
 
+                            # Verify that there are no line breaks in the row (sometimes occurs in between quotes).
+                            self.assertNotIn("\n", entry, f"File {short_path} has a line break in row {reader.line_num}.")
+
+
     @staticmethod
     def __get_csv_files():
         data_folders = glob.glob(os.path.join(FileFormatTests.root_path, "[0-9]" * 4))

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -5,6 +5,7 @@ import glob
 import os
 import pandas
 import pytest
+import re
 import unittest
 
 
@@ -66,10 +67,14 @@ class FileFormatTests(unittest.TestCase):
                     self.assertTrue(required_headers.issubset(headers), f"File {short_path} has header: {headers}, "
                                                         f"which is missing: {required_headers.difference(headers)}.")
 
-                    # Verify that each row has the expected number of entries.
                     for row in reader:
+                        # Verify that each row has the expected number of entries.
                         self.assertEqual(len(headers), len(row), f"File {short_path} has header {headers}, but row "
                                                                  f"{reader.line_num} is {row}.")
+                        for entry in row:
+                            # Verify that there is no redundant whitespace.
+                            self.assertIsNone(re.search(r"\s{2,}", entry), f"File {short_path} contains redundant "
+                                                                           f"whitespace in row {reader.line_num}: {row}.")
 
     @staticmethod
     def __get_csv_files():

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -51,6 +51,10 @@ class FileFormatTests(unittest.TestCase):
     root_path = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 
     def test_format(self):
+        regex_non_whitespace = re.compile(r"\S")
+        regex_consecutive_space = re.compile(r"\s{2,}")
+        regex_non_alphanumeric = re.compile(r"\w")
+
         for csv_file in FileFormatTests.__get_csv_files():
             short_path = csv_file.strip(FileFormatTests.root_path)
             with self.subTest(msg=f"{short_path}"):
@@ -77,15 +81,16 @@ class FileFormatTests(unittest.TestCase):
                                                                  f"{reader.line_num} is {row}.")
                         row_has_content = False
                         for entry in row:
-                            row_has_content |= (re.search(r"\S", entry) is not None)
+                            row_has_content |= (regex_non_whitespace.search(entry) is not None)
 
                             # Verify that there is no leading or trailing whitespace.
                             self.assertEqual(entry.strip(), entry, f"File {short_path} has leading or trailing "
                                                                    f"whitespace in row {reader.line_num}: {row}.")
 
                             # Verify that there are no consecutive whitespace characters.
-                            self.assertNotRegex(entry, r"\s{2,}", f"File {short_path} contains consecutive whitespace "
-                                                                  f"characters in row {reader.line_num}: {row}.")
+                            self.assertNotRegex(entry, regex_consecutive_space, f"File {short_path} contains "
+                                                                                f"consecutive whitespace characters "
+                                                                                f"in row {reader.line_num}: {row}.")
 
                             # Verify that there are no line breaks in the row (sometimes occurs in between quotes).
                             self.assertNotIn("\n", entry, f"File {short_path} has a newline character in row "
@@ -93,12 +98,12 @@ class FileFormatTests(unittest.TestCase):
 
                             # Verify that the entry does not consist only of non-alphanumeric characters.
                             if entry != "":
-                                self.assertRegex(entry, r"\w", f"File {short_path} has an entry of only non-alphanumeric "
-                                                               f"characters in row {reader.line_num}: {row}.")
+                                self.assertRegex(entry, regex_non_alphanumeric, f"File {short_path} has an entry of "
+                                                                                f"only non-alphanumeric characters in"
+                                                                                f" row {reader.line_num}: {row}.")
 
                         # Verify that the row has actual content.
                         self.assertTrue(row_has_content, f"File {short_path} row {reader.line_num} is empty.")
-
 
     @staticmethod
     def __get_csv_files():

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -83,7 +83,7 @@ class FileFormatTests(unittest.TestCase):
                             self.assertEqual(entry.strip(), entry, f"File {short_path} has leading or trailing "
                                                                    f"whitespace in row {reader.line_num}: {row}.")
 
-                            # Verify that there is no consecutive whitespace characters.
+                            # Verify that there are no consecutive whitespace characters.
                             self.assertNotRegex(entry, r"\s{2,}", f"File {short_path} contains consecutive whitespace "
                                                                   f"characters in row {reader.line_num}: {row}.")
 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -80,8 +80,8 @@ class FileFormatTests(unittest.TestCase):
                                                                    f"whitespace in row {reader.line_num}: {row}.")
 
                             # Verify that there is no redundant whitespace.
-                            self.assertIsNone(re.search(r"\s{2,}", entry), f"File {short_path} contains redundant "
-                                                                           f"whitespace in row {reader.line_num}: {row}.")
+                            self.assertNotRegex(entry, r"\s{2,}", f"File {short_path} contains redundant whitespace "
+                                                                  f"in row {reader.line_num}: {row}.")
 
                             # Verify that there are no line breaks in the row (sometimes occurs in between quotes).
                             self.assertNotIn("\n", entry, f"File {short_path} has a line break in row {reader.line_num}.")

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -83,8 +83,10 @@ class FileFormatTests(unittest.TestCase):
                         for entry in row:
                             row_has_content |= (regex_non_whitespace.search(entry) is not None)
 
-                            # Verify that there is no leading or trailing whitespace.
-                            self.assertEqual(entry.strip(), entry, f"File {short_path} has leading or trailing "
+                            # Verify that there is no leading or trailing whitespace.  Using assertFalse instead of
+                            # assertEqual provides a slightly better failure message.
+                            has_leading_trailing_space = entry.strip() != entry
+                            self.assertFalse(has_leading_trailing_space, f"File {short_path} has leading or trailing "
                                                                    f"whitespace in row {reader.line_num}: {row}.")
 
                             # Verify that there are no consecutive whitespace characters.


### PR DESCRIPTION
This adds some additional checks to our file format tests that look for:

* Leading or trailing whitespace characters.
* Consecutive whitespace characters.
* Newline characters.  Sometimes a row is broken up into 2 lines due to a newline character appearing in between a quoted string:
  ```
  Tulare,102009,President,,DEM,JOSEPH R. BIDEN,1373,173,1200
  Tulare,102009,President,,"GRN
  WALKER",HOWIE HAWKINS,14,3,11
  Tulare,102009,President,,LIB,JO JOREGENSEN,39,10,29
  ```
* Empty rows (e.g., `,,,,,`).
* Entries that consist of only non-alphanumeric characters (e.g., a hyphen `foo,-,bar` instead of being empty `foo,,bar`).
* An `unknown` column header.  I've seen this in other states.  Such a header does not seem very useful.

The tests take some time to run (~10 mins), but I think they are useful to have.