### PR TITLE
Update build status badge to reflect GitHub workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# openelections-data-ca [![Build Status](https://travis-ci.org/openelections/openelections-data-ca.svg?branch=master)](https://travis-ci.org/openelections/openelections-data-ca)
+# openelections-data-ca [![Build Status](https://github.com/openelections/openelections-data-ca/actions/workflows/tests.yml/badge.svg?branch=master)](https://github.com/openelections/openelections-data-ca/actions)
 Pre-processed election results for California elections
 
 ## Code License


### PR DESCRIPTION
The tests are now run via a GitHub workflow instead of Travis (see pull request #195).