### PR TITLE
Fix bug in constructing relative path

### DIFF
--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -56,7 +56,7 @@ class FileFormatTests(unittest.TestCase):
         regex_non_alphanumeric = re.compile(r"\w")
 
         for csv_file in FileFormatTests.__get_csv_files():
-            short_path = csv_file.strip(FileFormatTests.root_path)
+            short_path = os.path.relpath(csv_file, start=FileFormatTests.root_path)
             with self.subTest(msg=f"{short_path}"):
                 with open(csv_file, "r") as csv_data:
                     reader = csv.reader(csv_data)


### PR DESCRIPTION
This fixes a bug in building a relative path used for display purposes.  The argument to `strip()` is [not a prefix or suffix](https://docs.python.org/3/library/stdtypes.html#str.strip); rather, all combinations of its values are stripped.