### PR TITLE
Revert removal of non-alphanumeric entries

### DIFF
--- a/2020/20201103__ca__general__san_benito__precinct.csv
+++ b/2020/20201103__ca__general__san_benito__precinct.csv
@@ -107,813 +107,813 @@ San Benito,9235255,Ballots Cast,,,,0,0,0,0
 San Benito,9240001,Ballots Cast,,,,1448,53,121,1274
 San Benito,9240004,Ballots Cast,,,,19,2,2,15
 San Benito,9265000,Ballots Cast,,,,1144,59,105,980
-San Benito,5135101,President,,Joseph R. Biden,DEM,13,,0,11
+San Benito,5135101,President,,Joseph R. Biden,DEM,13,****,0,11
 San Benito,5135103,President,,Joseph R. Biden,DEM,0,0,0,0
 San Benito,5145001,President,,Joseph R. Biden,DEM,235,3,7,225
 San Benito,5145004,President,,Joseph R. Biden,DEM,2,0,0,2
-San Benito,5185003,President,,Joseph R. Biden,DEM,9,0,,8
-San Benito,5235214,President,,Joseph R. Biden,DEM,64,,,63
+San Benito,5185003,President,,Joseph R. Biden,DEM,9,0,****,8
+San Benito,5235214,President,,Joseph R. Biden,DEM,64,****,****,63
 San Benito,5235322,President,,Joseph R. Biden,DEM,109,3,8,98
-San Benito,5280002,President,,Joseph R. Biden,DEM,35,0,,33
-San Benito,5280007,President,,Joseph R. Biden,DEM,71,5,,65
+San Benito,5280002,President,,Joseph R. Biden,DEM,35,0,****,33
+San Benito,5280007,President,,Joseph R. Biden,DEM,71,5,****,65
 San Benito,5335111,President,,Joseph R. Biden,DEM,212,7,8,197
-San Benito,5335159,President,,Joseph R. Biden,DEM,37,,1,36
+San Benito,5335159,President,,Joseph R. Biden,DEM,37,****,1,36
 San Benito,5335213,President,,Joseph R. Biden,DEM,1001,28,44,929
 San Benito,5335262,President,,Joseph R. Biden,DEM,188,3,13,172
 San Benito,5335330,President,,Joseph R. Biden,DEM,554,7,22,525
 San Benito,5335348,President,,Joseph R. Biden,DEM,386,15,20,351
-San Benito,5395002,President,,Joseph R. Biden,DEM,12,0,,11
-San Benito,5530011,President,,Joseph R. Biden,DEM,4,0,,4
+San Benito,5395002,President,,Joseph R. Biden,DEM,12,0,****,11
+San Benito,5530011,President,,Joseph R. Biden,DEM,4,0,****,4
 San Benito,5535105,President,,Joseph R. Biden,DEM,641,21,40,580
 San Benito,5535154,President,,Joseph R. Biden,DEM,191,5,14,172
 San Benito,5535212,President,,Joseph R. Biden,DEM,1089,19,56,1014
 San Benito,5535228,President,,Joseph R. Biden,DEM,438,17,21,400
-San Benito,5585001,President,,Joseph R. Biden,DEM,106,3,,101
+San Benito,5585001,President,,Joseph R. Biden,DEM,106,3,****,101
 San Benito,5585002,President,,Joseph R. Biden,DEM,11,0,0,11
 San Benito,6135425,President,,Joseph R. Biden,DEM,505,9,10,486
-San Benito,6220003,President,,Joseph R. Biden,DEM,9,,0,9
+San Benito,6220003,President,,Joseph R. Biden,DEM,9,****,0,9
 San Benito,6235426,President,,Joseph R. Biden,DEM,670,12,23,635
 San Benito,6235463,President,,Joseph R. Biden,DEM,0,0,0,0
 San Benito,6280001,President,,Joseph R. Biden,DEM,78,0,2,76
-San Benito,6410000,President,,Joseph R. Biden,DEM,8,0,,8
+San Benito,6410000,President,,Joseph R. Biden,DEM,8,0,****,8
 San Benito,6420002,President,,Joseph R. Biden,DEM,553,6,10,537
 San Benito,6435438,President,,Joseph R. Biden,DEM,747,13,29,705
 San Benito,6435458,President,,Joseph R. Biden,DEM,549,9,23,517
 San Benito,6458001,President,,Joseph R. Biden,DEM,766,13,28,725
 San Benito,6475001,President,,Joseph R. Biden,DEM,772,16,15,741
-San Benito,6480005,President,,Joseph R. Biden,DEM,26,0,,25
+San Benito,6480005,President,,Joseph R. Biden,DEM,26,0,****,25
 San Benito,7130001,President,,Joseph R. Biden,DEM,889,9,44,836
 San Benito,7130002,President,,Joseph R. Biden,DEM,670,17,28,625
-San Benito,7130018,President,,Joseph R. Biden,DEM,26,,,24
+San Benito,7130018,President,,Joseph R. Biden,DEM,26,****,****,24
 San Benito,7135106,President,,Joseph R. Biden,DEM,161,3,3,155
 San Benito,7135109,President,,Joseph R. Biden,DEM,797,22,42,733
-San Benito,7135317,President,,Joseph R. Biden,DEM,37,,,33
-San Benito,7135318,President,,Joseph R. Biden,DEM,128,,8,119
+San Benito,7135317,President,,Joseph R. Biden,DEM,37,****,****,33
+San Benito,7135318,President,,Joseph R. Biden,DEM,128,****,8,119
 San Benito,7135423,President,,Joseph R. Biden,DEM,383,8,13,362
 San Benito,7235320,President,,Joseph R. Biden,DEM,211,11,13,187
 San Benito,7235321,President,,Joseph R. Biden,DEM,304,10,8,286
 San Benito,7335315,President,,Joseph R. Biden,DEM,299,6,15,278
 San Benito,7335316,President,,Joseph R. Biden,DEM,652,13,23,616
-San Benito,7335319,President,,Joseph R. Biden,DEM,25,0,,25
+San Benito,7335319,President,,Joseph R. Biden,DEM,25,0,****,25
 San Benito,7535136,President,,Joseph R. Biden,DEM,960,22,58,880
 San Benito,9205001,President,,Joseph R. Biden,DEM,488,3,12,473
 San Benito,9235255,President,,Joseph R. Biden,DEM,0,0,0,0
 San Benito,9240001,President,,Joseph R. Biden,DEM,731,13,39,679
-San Benito,9240004,President,,Joseph R. Biden,DEM,4,,,3
+San Benito,9240004,President,,Joseph R. Biden,DEM,4,****,****,3
 San Benito,9265000,President,,Joseph R. Biden,DEM,772,23,58,691
-San Benito,5135101,President,,Donald J. Trump,REP,6,,0,6
+San Benito,5135101,President,,Donald J. Trump,REP,6,****,0,6
 San Benito,5135103,President,,Donald J. Trump,REP,0,0,0,0
 San Benito,5145001,President,,Donald J. Trump,REP,200,9,9,182
 San Benito,5145004,President,,Donald J. Trump,REP,3,0,0,3
-San Benito,5185003,President,,Donald J. Trump,REP,8,0,,8
-San Benito,5235214,President,,Donald J. Trump,REP,44,,,42
+San Benito,5185003,President,,Donald J. Trump,REP,8,0,****,8
+San Benito,5235214,President,,Donald J. Trump,REP,44,****,****,42
 San Benito,5235322,President,,Donald J. Trump,REP,68,5,11,52
-San Benito,5280002,President,,Donald J. Trump,REP,7,0,,7
-San Benito,5280007,President,,Donald J. Trump,REP,73,0,,70
+San Benito,5280002,President,,Donald J. Trump,REP,7,0,****,7
+San Benito,5280007,President,,Donald J. Trump,REP,73,0,****,70
 San Benito,5335111,President,,Donald J. Trump,REP,106,7,11,88
-San Benito,5335159,President,,Donald J. Trump,REP,17,,4,11
+San Benito,5335159,President,,Donald J. Trump,REP,17,****,4,11
 San Benito,5335213,President,,Donald J. Trump,REP,401,19,46,336
 San Benito,5335262,President,,Donald J. Trump,REP,87,7,8,72
 San Benito,5335330,President,,Donald J. Trump,REP,414,12,33,369
 San Benito,5335348,President,,Donald J. Trump,REP,122,8,12,102
-San Benito,5395002,President,,Donald J. Trump,REP,9,0,,9
-San Benito,5530011,President,,Donald J. Trump,REP,4,0,,1
+San Benito,5395002,President,,Donald J. Trump,REP,9,0,****,9
+San Benito,5530011,President,,Donald J. Trump,REP,4,0,****,1
 San Benito,5535105,President,,Donald J. Trump,REP,228,17,23,188
 San Benito,5535154,President,,Donald J. Trump,REP,53,5,2,46
 San Benito,5535212,President,,Donald J. Trump,REP,232,16,25,191
 San Benito,5535228,President,,Donald J. Trump,REP,106,4,14,88
-San Benito,5585001,President,,Donald J. Trump,REP,43,3,,38
+San Benito,5585001,President,,Donald J. Trump,REP,43,3,****,38
 San Benito,5585002,President,,Donald J. Trump,REP,1,0,0,1
 San Benito,6135425,President,,Donald J. Trump,REP,328,18,24,286
-San Benito,6220003,President,,Donald J. Trump,REP,11,,0,9
+San Benito,6220003,President,,Donald J. Trump,REP,11,****,0,9
 San Benito,6235426,President,,Donald J. Trump,REP,367,27,33,307
 San Benito,6235463,President,,Donald J. Trump,REP,0,0,0,0
 San Benito,6280001,President,,Donald J. Trump,REP,36,0,3,33
-San Benito,6410000,President,,Donald J. Trump,REP,52,0,,51
+San Benito,6410000,President,,Donald J. Trump,REP,52,0,****,51
 San Benito,6420002,President,,Donald J. Trump,REP,545,31,36,478
 San Benito,6435438,President,,Donald J. Trump,REP,435,27,37,371
 San Benito,6435458,President,,Donald J. Trump,REP,304,14,31,259
 San Benito,6458001,President,,Donald J. Trump,REP,731,59,44,628
 San Benito,6475001,President,,Donald J. Trump,REP,959,36,41,882
-San Benito,6480005,President,,Donald J. Trump,REP,14,0,,14
+San Benito,6480005,President,,Donald J. Trump,REP,14,0,****,14
 San Benito,7130001,President,,Donald J. Trump,REP,653,42,43,568
 San Benito,7130002,President,,Donald J. Trump,REP,848,46,49,753
-San Benito,7130018,President,,Donald J. Trump,REP,9,,,7
+San Benito,7130018,President,,Donald J. Trump,REP,9,****,****,7
 San Benito,7135106,President,,Donald J. Trump,REP,86,9,6,71
 San Benito,7135109,President,,Donald J. Trump,REP,368,25,21,322
-San Benito,7135317,President,,Donald J. Trump,REP,16,,,16
-San Benito,7135318,President,,Donald J. Trump,REP,81,,4,76
+San Benito,7135317,President,,Donald J. Trump,REP,16,****,****,16
+San Benito,7135318,President,,Donald J. Trump,REP,81,****,4,76
 San Benito,7135423,President,,Donald J. Trump,REP,238,21,30,187
 San Benito,7235320,President,,Donald J. Trump,REP,113,5,18,90
 San Benito,7235321,President,,Donald J. Trump,REP,232,16,15,201
 San Benito,7335315,President,,Donald J. Trump,REP,90,2,6,82
 San Benito,7335316,President,,Donald J. Trump,REP,384,32,35,317
-San Benito,7335319,President,,Donald J. Trump,REP,7,0,,6
+San Benito,7335319,President,,Donald J. Trump,REP,7,0,****,6
 San Benito,7535136,President,,Donald J. Trump,REP,255,19,21,215
 San Benito,9205001,President,,Donald J. Trump,REP,181,8,12,161
 San Benito,9235255,President,,Donald J. Trump,REP,0,0,0,0
 San Benito,9240001,President,,Donald J. Trump,REP,671,38,78,555
-San Benito,9240004,President,,Donald J. Trump,REP,15,,,12
+San Benito,9240004,President,,Donald J. Trump,REP,15,****,****,12
 San Benito,9265000,President,,Donald J. Trump,REP,329,35,38,256
-San Benito,5135101,President,,Gloria LaRiva,PF,0,,0,0
+San Benito,5135101,President,,Gloria LaRiva,PF,0,****,0,0
 San Benito,5135103,President,,Gloria LaRiva,PF,0,0,0,0
 San Benito,5145001,President,,Gloria LaRiva,PF,1,0,0,1
 San Benito,5145004,President,,Gloria LaRiva,PF,0,0,0,0
-San Benito,5185003,President,,Gloria LaRiva,PF,0,0,,0
-San Benito,5235214,President,,Gloria LaRiva,PF,0,,,0
+San Benito,5185003,President,,Gloria LaRiva,PF,0,0,****,0
+San Benito,5235214,President,,Gloria LaRiva,PF,0,****,****,0
 San Benito,5235322,President,,Gloria LaRiva,PF,0,0,0,0
-San Benito,5280002,President,,Gloria LaRiva,PF,0,0,,0
-San Benito,5280007,President,,Gloria LaRiva,PF,0,0,,0
+San Benito,5280002,President,,Gloria LaRiva,PF,0,0,****,0
+San Benito,5280007,President,,Gloria LaRiva,PF,0,0,****,0
 San Benito,5335111,President,,Gloria LaRiva,PF,3,1,0,2
-San Benito,5335159,President,,Gloria LaRiva,PF,0,,0,0
+San Benito,5335159,President,,Gloria LaRiva,PF,0,****,0,0
 San Benito,5335213,President,,Gloria LaRiva,PF,11,1,1,9
 San Benito,5335262,President,,Gloria LaRiva,PF,1,0,0,1
 San Benito,5335330,President,,Gloria LaRiva,PF,1,0,0,1
 San Benito,5335348,President,,Gloria LaRiva,PF,2,0,0,2
-San Benito,5395002,President,,Gloria LaRiva,PF,0,0,,0
-San Benito,5530011,President,,Gloria LaRiva,PF,0,0,,0
+San Benito,5395002,President,,Gloria LaRiva,PF,0,0,****,0
+San Benito,5530011,President,,Gloria LaRiva,PF,0,0,****,0
 San Benito,5535105,President,,Gloria LaRiva,PF,2,0,0,2
 San Benito,5535154,President,,Gloria LaRiva,PF,2,0,0,2
 San Benito,5535212,President,,Gloria LaRiva,PF,3,0,0,3
 San Benito,5535228,President,,Gloria LaRiva,PF,5,0,0,5
-San Benito,5585001,President,,Gloria LaRiva,PF,2,0,,2
+San Benito,5585001,President,,Gloria LaRiva,PF,2,0,****,2
 San Benito,5585002,President,,Gloria LaRiva,PF,0,0,0,0
 San Benito,6135425,President,,Gloria LaRiva,PF,1,0,0,1
-San Benito,6220003,President,,Gloria LaRiva,PF,0,,0,0
+San Benito,6220003,President,,Gloria LaRiva,PF,0,****,0,0
 San Benito,6235426,President,,Gloria LaRiva,PF,1,0,0,1
 San Benito,6235463,President,,Gloria LaRiva,PF,0,0,0,0
 San Benito,6280001,President,,Gloria LaRiva,PF,2,0,0,2
-San Benito,6410000,President,,Gloria LaRiva,PF,0,0,,0
+San Benito,6410000,President,,Gloria LaRiva,PF,0,0,****,0
 San Benito,6420002,President,,Gloria LaRiva,PF,2,1,0,1
 San Benito,6435438,President,,Gloria LaRiva,PF,4,0,0,4
 San Benito,6435458,President,,Gloria LaRiva,PF,1,0,0,1
 San Benito,6458001,President,,Gloria LaRiva,PF,2,0,0,2
 San Benito,6475001,President,,Gloria LaRiva,PF,6,0,2,4
-San Benito,6480005,President,,Gloria LaRiva,PF,0,0,,0
+San Benito,6480005,President,,Gloria LaRiva,PF,0,0,****,0
 San Benito,7130001,President,,Gloria LaRiva,PF,3,0,0,3
 San Benito,7130002,President,,Gloria LaRiva,PF,3,0,0,3
-San Benito,7130018,President,,Gloria LaRiva,PF,0,,,0
+San Benito,7130018,President,,Gloria LaRiva,PF,0,****,****,0
 San Benito,7135106,President,,Gloria LaRiva,PF,0,0,0,0
 San Benito,7135109,President,,Gloria LaRiva,PF,3,0,0,3
-San Benito,7135317,President,,Gloria LaRiva,PF,0,,,0
-San Benito,7135318,President,,Gloria LaRiva,PF,1,,0,1
+San Benito,7135317,President,,Gloria LaRiva,PF,0,****,****,0
+San Benito,7135318,President,,Gloria LaRiva,PF,1,****,0,1
 San Benito,7135423,President,,Gloria LaRiva,PF,2,0,1,1
 San Benito,7235320,President,,Gloria LaRiva,PF,1,0,1,0
 San Benito,7235321,President,,Gloria LaRiva,PF,1,0,0,1
 San Benito,7335315,President,,Gloria LaRiva,PF,3,0,0,3
 San Benito,7335316,President,,Gloria LaRiva,PF,3,0,1,2
-San Benito,7335319,President,,Gloria LaRiva,PF,0,0,,0
+San Benito,7335319,President,,Gloria LaRiva,PF,0,0,****,0
 San Benito,7535136,President,,Gloria LaRiva,PF,5,0,0,5
 San Benito,9205001,President,,Gloria LaRiva,PF,2,0,0,2
 San Benito,9235255,President,,Gloria LaRiva,PF,0,0,0,0
 San Benito,9240001,President,,Gloria LaRiva,PF,2,0,1,1
-San Benito,9240004,President,,Gloria LaRiva,PF,0,,,0
+San Benito,9240004,President,,Gloria LaRiva,PF,0,****,****,0
 San Benito,9265000,President,,Gloria LaRiva,PF,2,0,0,2
-San Benito,5135101,President,,"Roque ""Rocky"" De La Fuente",AIP,0,,0,0
+San Benito,5135101,President,,"Roque ""Rocky"" De La Fuente",AIP,0,****,0,0
 San Benito,5135103,President,,"Roque ""Rocky"" De La Fuente",AIP,0,0,0,0
 San Benito,5145001,President,,"Roque ""Rocky"" De La Fuente",AIP,1,0,0,1
 San Benito,5145004,President,,"Roque ""Rocky"" De La Fuente",AIP,0,0,0,0
-San Benito,5185003,President,,"Roque ""Rocky"" De La Fuente",AIP,0,0,,0
-San Benito,5235214,President,,"Roque ""Rocky"" De La Fuente",AIP,0,,,0
+San Benito,5185003,President,,"Roque ""Rocky"" De La Fuente",AIP,0,0,****,0
+San Benito,5235214,President,,"Roque ""Rocky"" De La Fuente",AIP,0,****,****,0
 San Benito,5235322,President,,"Roque ""Rocky"" De La Fuente",AIP,3,0,0,3
-San Benito,5280002,President,,"Roque ""Rocky"" De La Fuente",AIP,0,0,,0
-San Benito,5280007,President,,"Roque ""Rocky"" De La Fuente",AIP,0,0,,0
+San Benito,5280002,President,,"Roque ""Rocky"" De La Fuente",AIP,0,0,****,0
+San Benito,5280007,President,,"Roque ""Rocky"" De La Fuente",AIP,0,0,****,0
 San Benito,5335111,President,,"Roque ""Rocky"" De La Fuente",AIP,0,0,0,0
-San Benito,5335159,President,,"Roque ""Rocky"" De La Fuente",AIP,0,,0,0
+San Benito,5335159,President,,"Roque ""Rocky"" De La Fuente",AIP,0,****,0,0
 San Benito,5335213,President,,"Roque ""Rocky"" De La Fuente",AIP,5,0,0,5
 San Benito,5335262,President,,"Roque ""Rocky"" De La Fuente",AIP,0,0,0,0
 San Benito,5335330,President,,"Roque ""Rocky"" De La Fuente",AIP,2,0,0,2
 San Benito,5335348,President,,"Roque ""Rocky"" De La Fuente",AIP,6,0,0,6
-San Benito,5395002,President,,"Roque ""Rocky"" De La Fuente",AIP,0,0,,0
-San Benito,5530011,President,,"Roque ""Rocky"" De La Fuente",AIP,0,0,,0
+San Benito,5395002,President,,"Roque ""Rocky"" De La Fuente",AIP,0,0,****,0
+San Benito,5530011,President,,"Roque ""Rocky"" De La Fuente",AIP,0,0,****,0
 San Benito,5535105,President,,"Roque ""Rocky"" De La Fuente",AIP,5,0,0,5
 San Benito,5535154,President,,"Roque ""Rocky"" De La Fuente",AIP,1,0,0,1
 San Benito,5535212,President,,"Roque ""Rocky"" De La Fuente",AIP,9,0,2,7
 San Benito,5535228,President,,"Roque ""Rocky"" De La Fuente",AIP,1,0,0,1
-San Benito,5585001,President,,"Roque ""Rocky"" De La Fuente",AIP,0,0,,0
+San Benito,5585001,President,,"Roque ""Rocky"" De La Fuente",AIP,0,0,****,0
 San Benito,5585002,President,,"Roque ""Rocky"" De La Fuente",AIP,0,0,0,0
 San Benito,6135425,President,,"Roque ""Rocky"" De La Fuente",AIP,0,0,0,0
-San Benito,6220003,President,,"Roque ""Rocky"" De La Fuente",AIP,0,,0,0
+San Benito,6220003,President,,"Roque ""Rocky"" De La Fuente",AIP,0,****,0,0
 San Benito,6235426,President,,"Roque ""Rocky"" De La Fuente",AIP,2,0,0,2
 San Benito,6235463,President,,"Roque ""Rocky"" De La Fuente",AIP,0,0,0,0
 San Benito,6280001,President,,"Roque ""Rocky"" De La Fuente",AIP,0,0,0,0
-San Benito,6410000,President,,"Roque ""Rocky"" De La Fuente",AIP,0,0,,0
+San Benito,6410000,President,,"Roque ""Rocky"" De La Fuente",AIP,0,0,****,0
 San Benito,6420002,President,,"Roque ""Rocky"" De La Fuente",AIP,1,0,0,1
 San Benito,6435438,President,,"Roque ""Rocky"" De La Fuente",AIP,10,1,1,8
 San Benito,6435458,President,,"Roque ""Rocky"" De La Fuente",AIP,4,0,0,4
 San Benito,6458001,President,,"Roque ""Rocky"" De La Fuente",AIP,1,0,0,1
 San Benito,6475001,President,,"Roque ""Rocky"" De La Fuente",AIP,6,0,0,6
-San Benito,6480005,President,,"Roque ""Rocky"" De La Fuente",AIP,0,0,,0
+San Benito,6480005,President,,"Roque ""Rocky"" De La Fuente",AIP,0,0,****,0
 San Benito,7130001,President,,"Roque ""Rocky"" De La Fuente",AIP,1,0,0,1
 San Benito,7130002,President,,"Roque ""Rocky"" De La Fuente",AIP,1,0,0,1
-San Benito,7130018,President,,"Roque ""Rocky"" De La Fuente",AIP,0,,,0
+San Benito,7130018,President,,"Roque ""Rocky"" De La Fuente",AIP,0,****,****,0
 San Benito,7135106,President,,"Roque ""Rocky"" De La Fuente",AIP,1,0,0,1
 San Benito,7135109,President,,"Roque ""Rocky"" De La Fuente",AIP,5,0,0,5
-San Benito,7135317,President,,"Roque ""Rocky"" De La Fuente",AIP,2,,,2
-San Benito,7135318,President,,"Roque ""Rocky"" De La Fuente",AIP,1,,0,1
+San Benito,7135317,President,,"Roque ""Rocky"" De La Fuente",AIP,2,****,****,2
+San Benito,7135318,President,,"Roque ""Rocky"" De La Fuente",AIP,1,****,0,1
 San Benito,7135423,President,,"Roque ""Rocky"" De La Fuente",AIP,1,0,1,0
 San Benito,7235320,President,,"Roque ""Rocky"" De La Fuente",AIP,1,0,0,1
 San Benito,7235321,President,,"Roque ""Rocky"" De La Fuente",AIP,0,0,0,0
 San Benito,7335315,President,,"Roque ""Rocky"" De La Fuente",AIP,2,0,0,2
 San Benito,7335316,President,,"Roque ""Rocky"" De La Fuente",AIP,1,0,0,1
-San Benito,7335319,President,,"Roque ""Rocky"" De La Fuente",AIP,0,0,,0
+San Benito,7335319,President,,"Roque ""Rocky"" De La Fuente",AIP,0,0,****,0
 San Benito,7535136,President,,"Roque ""Rocky"" De La Fuente",AIP,3,0,2,1
 San Benito,9205001,President,,"Roque ""Rocky"" De La Fuente",AIP,0,0,0,0
 San Benito,9235255,President,,"Roque ""Rocky"" De La Fuente",AIP,0,0,0,0
 San Benito,9240001,President,,"Roque ""Rocky"" De La Fuente",AIP,2,0,0,2
-San Benito,9240004,President,,"Roque ""Rocky"" De La Fuente",AIP,0,,,0
+San Benito,9240004,President,,"Roque ""Rocky"" De La Fuente",AIP,0,****,****,0
 San Benito,9265000,President,,"Roque ""Rocky"" De La Fuente",AIP,6,0,1,5
-San Benito,5135101,President,,Howie Hawkins,GRN,0,,0,0
+San Benito,5135101,President,,Howie Hawkins,GRN,0,****,0,0
 San Benito,5135103,President,,Howie Hawkins,GRN,0,0,0,0
 San Benito,5145001,President,,Howie Hawkins,GRN,1,0,0,1
 San Benito,5145004,President,,Howie Hawkins,GRN,0,0,0,0
-San Benito,5185003,President,,Howie Hawkins,GRN,0,0,,0
-San Benito,5235214,President,,Howie Hawkins,GRN,0,,,0
+San Benito,5185003,President,,Howie Hawkins,GRN,0,0,****,0
+San Benito,5235214,President,,Howie Hawkins,GRN,0,****,****,0
 San Benito,5235322,President,,Howie Hawkins,GRN,4,1,0,3
-San Benito,5280002,President,,Howie Hawkins,GRN,0,0,,0
-San Benito,5280007,President,,Howie Hawkins,GRN,2,0,,2
+San Benito,5280002,President,,Howie Hawkins,GRN,0,0,****,0
+San Benito,5280007,President,,Howie Hawkins,GRN,2,0,****,2
 San Benito,5335111,President,,Howie Hawkins,GRN,2,0,0,2
-San Benito,5335159,President,,Howie Hawkins,GRN,0,,0,0
+San Benito,5335159,President,,Howie Hawkins,GRN,0,****,0,0
 San Benito,5335213,President,,Howie Hawkins,GRN,7,0,0,7
 San Benito,5335262,President,,Howie Hawkins,GRN,0,0,0,0
 San Benito,5335330,President,,Howie Hawkins,GRN,1,0,0,1
 San Benito,5335348,President,,Howie Hawkins,GRN,3,0,0,3
-San Benito,5395002,President,,Howie Hawkins,GRN,0,0,,0
-San Benito,5530011,President,,Howie Hawkins,GRN,0,0,,0
+San Benito,5395002,President,,Howie Hawkins,GRN,0,0,****,0
+San Benito,5530011,President,,Howie Hawkins,GRN,0,0,****,0
 San Benito,5535105,President,,Howie Hawkins,GRN,1,0,0,1
 San Benito,5535154,President,,Howie Hawkins,GRN,1,0,0,1
 San Benito,5535212,President,,Howie Hawkins,GRN,3,0,0,3
 San Benito,5535228,President,,Howie Hawkins,GRN,2,0,0,2
-San Benito,5585001,President,,Howie Hawkins,GRN,2,1,,1
+San Benito,5585001,President,,Howie Hawkins,GRN,2,1,****,1
 San Benito,5585002,President,,Howie Hawkins,GRN,0,0,0,0
 San Benito,6135425,President,,Howie Hawkins,GRN,2,0,0,2
-San Benito,6220003,President,,Howie Hawkins,GRN,0,,0,0
+San Benito,6220003,President,,Howie Hawkins,GRN,0,****,0,0
 San Benito,6235426,President,,Howie Hawkins,GRN,4,0,0,4
 San Benito,6235463,President,,Howie Hawkins,GRN,0,0,0,0
 San Benito,6280001,President,,Howie Hawkins,GRN,0,0,0,0
-San Benito,6410000,President,,Howie Hawkins,GRN,0,0,,0
+San Benito,6410000,President,,Howie Hawkins,GRN,0,0,****,0
 San Benito,6420002,President,,Howie Hawkins,GRN,4,0,1,3
 San Benito,6435438,President,,Howie Hawkins,GRN,6,0,0,6
 San Benito,6435458,President,,Howie Hawkins,GRN,0,0,0,0
 San Benito,6458001,President,,Howie Hawkins,GRN,4,0,1,3
 San Benito,6475001,President,,Howie Hawkins,GRN,6,0,0,6
-San Benito,6480005,President,,Howie Hawkins,GRN,0,0,,0
+San Benito,6480005,President,,Howie Hawkins,GRN,0,0,****,0
 San Benito,7130001,President,,Howie Hawkins,GRN,5,0,0,5
 San Benito,7130002,President,,Howie Hawkins,GRN,3,0,0,3
-San Benito,7130018,President,,Howie Hawkins,GRN,0,,,0
+San Benito,7130018,President,,Howie Hawkins,GRN,0,****,****,0
 San Benito,7135106,President,,Howie Hawkins,GRN,0,0,0,0
 San Benito,7135109,President,,Howie Hawkins,GRN,5,0,0,5
-San Benito,7135317,President,,Howie Hawkins,GRN,0,,,0
-San Benito,7135318,President,,Howie Hawkins,GRN,0,,0,0
+San Benito,7135317,President,,Howie Hawkins,GRN,0,****,****,0
+San Benito,7135318,President,,Howie Hawkins,GRN,0,****,0,0
 San Benito,7135423,President,,Howie Hawkins,GRN,1,0,0,1
 San Benito,7235320,President,,Howie Hawkins,GRN,4,0,0,4
 San Benito,7235321,President,,Howie Hawkins,GRN,1,0,0,1
 San Benito,7335315,President,,Howie Hawkins,GRN,0,0,0,0
 San Benito,7335316,President,,Howie Hawkins,GRN,0,0,0,0
-San Benito,7335319,President,,Howie Hawkins,GRN,0,0,,0
+San Benito,7335319,President,,Howie Hawkins,GRN,0,0,****,0
 San Benito,7535136,President,,Howie Hawkins,GRN,5,0,0,5
 San Benito,9205001,President,,Howie Hawkins,GRN,2,0,0,2
 San Benito,9235255,President,,Howie Hawkins,GRN,0,0,0,0
 San Benito,9240001,President,,Howie Hawkins,GRN,3,0,0,3
-San Benito,9240004,President,,Howie Hawkins,GRN,0,,,0
+San Benito,9240004,President,,Howie Hawkins,GRN,0,****,****,0
 San Benito,9265000,President,,Howie Hawkins,GRN,7,0,3,4
-San Benito,5135101,President,,Jo Jorgensen,LIB,1,,0,0
+San Benito,5135101,President,,Jo Jorgensen,LIB,1,****,0,0
 San Benito,5135103,President,,Jo Jorgensen,LIB,0,0,0,0
 San Benito,5145001,President,,Jo Jorgensen,LIB,5,0,0,5
 San Benito,5145004,President,,Jo Jorgensen,LIB,0,0,0,0
-San Benito,5185003,President,,Jo Jorgensen,LIB,0,0,,0
-San Benito,5235214,President,,Jo Jorgensen,LIB,7,,,6
+San Benito,5185003,President,,Jo Jorgensen,LIB,0,0,****,0
+San Benito,5235214,President,,Jo Jorgensen,LIB,7,****,****,6
 San Benito,5235322,President,,Jo Jorgensen,LIB,2,0,0,2
-San Benito,5280002,President,,Jo Jorgensen,LIB,0,0,,0
-San Benito,5280007,President,,Jo Jorgensen,LIB,2,0,,2
+San Benito,5280002,President,,Jo Jorgensen,LIB,0,0,****,0
+San Benito,5280007,President,,Jo Jorgensen,LIB,2,0,****,2
 San Benito,5335111,President,,Jo Jorgensen,LIB,3,0,1,2
-San Benito,5335159,President,,Jo Jorgensen,LIB,1,,0,1
+San Benito,5335159,President,,Jo Jorgensen,LIB,1,****,0,1
 San Benito,5335213,President,,Jo Jorgensen,LIB,16,0,0,16
 San Benito,5335262,President,,Jo Jorgensen,LIB,8,1,1,6
 San Benito,5335330,President,,Jo Jorgensen,LIB,20,0,1,19
 San Benito,5335348,President,,Jo Jorgensen,LIB,6,0,0,6
-San Benito,5395002,President,,Jo Jorgensen,LIB,0,0,,0
-San Benito,5530011,President,,Jo Jorgensen,LIB,1,0,,1
+San Benito,5395002,President,,Jo Jorgensen,LIB,0,0,****,0
+San Benito,5530011,President,,Jo Jorgensen,LIB,1,0,****,1
 San Benito,5535105,President,,Jo Jorgensen,LIB,10,0,1,9
 San Benito,5535154,President,,Jo Jorgensen,LIB,1,0,0,1
 San Benito,5535212,President,,Jo Jorgensen,LIB,18,0,4,14
 San Benito,5535228,President,,Jo Jorgensen,LIB,2,0,0,2
-San Benito,5585001,President,,Jo Jorgensen,LIB,1,0,,1
+San Benito,5585001,President,,Jo Jorgensen,LIB,1,0,****,1
 San Benito,5585002,President,,Jo Jorgensen,LIB,0,0,0,0
 San Benito,6135425,President,,Jo Jorgensen,LIB,12,0,1,11
-San Benito,6220003,President,,Jo Jorgensen,LIB,0,,0,0
+San Benito,6220003,President,,Jo Jorgensen,LIB,0,****,0,0
 San Benito,6235426,President,,Jo Jorgensen,LIB,14,0,0,14
 San Benito,6235463,President,,Jo Jorgensen,LIB,0,0,0,0
 San Benito,6280001,President,,Jo Jorgensen,LIB,3,0,0,3
-San Benito,6410000,President,,Jo Jorgensen,LIB,0,0,,0
+San Benito,6410000,President,,Jo Jorgensen,LIB,0,0,****,0
 San Benito,6420002,President,,Jo Jorgensen,LIB,13,1,1,11
 San Benito,6435438,President,,Jo Jorgensen,LIB,19,0,1,18
 San Benito,6435458,President,,Jo Jorgensen,LIB,11,0,0,11
 San Benito,6458001,President,,Jo Jorgensen,LIB,5,0,0,5
 San Benito,6475001,President,,Jo Jorgensen,LIB,21,0,0,21
-San Benito,6480005,President,,Jo Jorgensen,LIB,0,0,,0
+San Benito,6480005,President,,Jo Jorgensen,LIB,0,0,****,0
 San Benito,7130001,President,,Jo Jorgensen,LIB,18,0,1,17
 San Benito,7130002,President,,Jo Jorgensen,LIB,22,1,0,21
-San Benito,7130018,President,,Jo Jorgensen,LIB,0,,,0
+San Benito,7130018,President,,Jo Jorgensen,LIB,0,****,****,0
 San Benito,7135106,President,,Jo Jorgensen,LIB,5,0,0,5
 San Benito,7135109,President,,Jo Jorgensen,LIB,14,0,2,12
-San Benito,7135317,President,,Jo Jorgensen,LIB,1,,,1
-San Benito,7135318,President,,Jo Jorgensen,LIB,4,,0,4
+San Benito,7135317,President,,Jo Jorgensen,LIB,1,****,****,1
+San Benito,7135318,President,,Jo Jorgensen,LIB,4,****,0,4
 San Benito,7135423,President,,Jo Jorgensen,LIB,5,0,0,5
 San Benito,7235320,President,,Jo Jorgensen,LIB,4,0,1,3
 San Benito,7235321,President,,Jo Jorgensen,LIB,4,0,0,4
 San Benito,7335315,President,,Jo Jorgensen,LIB,2,0,1,1
 San Benito,7335316,President,,Jo Jorgensen,LIB,11,0,0,11
-San Benito,7335319,President,,Jo Jorgensen,LIB,1,0,,1
+San Benito,7335319,President,,Jo Jorgensen,LIB,1,0,****,1
 San Benito,7535136,President,,Jo Jorgensen,LIB,10,0,0,10
 San Benito,9205001,President,,Jo Jorgensen,LIB,9,0,0,9
 San Benito,9235255,President,,Jo Jorgensen,LIB,0,0,0,0
 San Benito,9240001,President,,Jo Jorgensen,LIB,19,0,1,18
-San Benito,9240004,President,,Jo Jorgensen,LIB,0,,,0
+San Benito,9240004,President,,Jo Jorgensen,LIB,0,****,****,0
 San Benito,9265000,President,,Jo Jorgensen,LIB,14,1,2,11
-San Benito,5135101,President,,Brian Carroll,,0,,0,0
+San Benito,5135101,President,,Brian Carroll,,0,****,0,0
 San Benito,5135103,President,,Brian Carroll,,0,0,0,0
 San Benito,5145001,President,,Brian Carroll,,0,0,0,0
 San Benito,5145004,President,,Brian Carroll,,0,0,0,0
-San Benito,5185003,President,,Brian Carroll,,0,0,,0
-San Benito,5235214,President,,Brian Carroll,,0,,,0
+San Benito,5185003,President,,Brian Carroll,,0,0,****,0
+San Benito,5235214,President,,Brian Carroll,,0,****,****,0
 San Benito,5235322,President,,Brian Carroll,,0,0,0,0
-San Benito,5280002,President,,Brian Carroll,,0,0,,0
-San Benito,5280007,President,,Brian Carroll,,2,0,,2
+San Benito,5280002,President,,Brian Carroll,,0,0,****,0
+San Benito,5280007,President,,Brian Carroll,,2,0,****,2
 San Benito,5335111,President,,Brian Carroll,,0,0,0,0
-San Benito,5335159,President,,Brian Carroll,,0,,0,0
+San Benito,5335159,President,,Brian Carroll,,0,****,0,0
 San Benito,5335213,President,,Brian Carroll,,0,0,0,0
 San Benito,5335262,President,,Brian Carroll,,0,0,0,0
 San Benito,5335330,President,,Brian Carroll,,1,0,0,1
 San Benito,5335348,President,,Brian Carroll,,0,0,0,0
-San Benito,5395002,President,,Brian Carroll,,0,0,,0
-San Benito,5530011,President,,Brian Carroll,,0,0,,0
+San Benito,5395002,President,,Brian Carroll,,0,0,****,0
+San Benito,5530011,President,,Brian Carroll,,0,0,****,0
 San Benito,5535105,President,,Brian Carroll,,0,0,0,0
 San Benito,5535154,President,,Brian Carroll,,1,0,0,1
 San Benito,5535212,President,,Brian Carroll,,0,0,0,0
 San Benito,5535228,President,,Brian Carroll,,0,0,0,0
-San Benito,5585001,President,,Brian Carroll,,0,0,,0
+San Benito,5585001,President,,Brian Carroll,,0,0,****,0
 San Benito,5585002,President,,Brian Carroll,,0,0,0,0
 San Benito,6135425,President,,Brian Carroll,,0,0,0,0
-San Benito,6220003,President,,Brian Carroll,,0,,0,0
+San Benito,6220003,President,,Brian Carroll,,0,****,0,0
 San Benito,6235426,President,,Brian Carroll,,0,0,0,0
 San Benito,6235463,President,,Brian Carroll,,0,0,0,0
 San Benito,6280001,President,,Brian Carroll,,0,0,0,0
-San Benito,6410000,President,,Brian Carroll,,0,0,,0
+San Benito,6410000,President,,Brian Carroll,,0,0,****,0
 San Benito,6420002,President,,Brian Carroll,,0,0,0,0
 San Benito,6435438,President,,Brian Carroll,,1,0,1,0
 San Benito,6435458,President,,Brian Carroll,,0,0,0,0
 San Benito,6458001,President,,Brian Carroll,,0,0,0,0
 San Benito,6475001,President,,Brian Carroll,,1,0,0,1
-San Benito,6480005,President,,Brian Carroll,,0,0,,0
+San Benito,6480005,President,,Brian Carroll,,0,0,****,0
 San Benito,7130001,President,,Brian Carroll,,0,0,0,0
 San Benito,7130002,President,,Brian Carroll,,0,0,0,0
-San Benito,7130018,President,,Brian Carroll,,0,,,0
+San Benito,7130018,President,,Brian Carroll,,0,****,****,0
 San Benito,7135106,President,,Brian Carroll,,0,0,0,0
 San Benito,7135109,President,,Brian Carroll,,0,0,0,0
-San Benito,7135317,President,,Brian Carroll,,0,,,0
-San Benito,7135318,President,,Brian Carroll,,0,,0,0
+San Benito,7135317,President,,Brian Carroll,,0,****,****,0
+San Benito,7135318,President,,Brian Carroll,,0,****,0,0
 San Benito,7135423,President,,Brian Carroll,,0,0,0,0
 San Benito,7235320,President,,Brian Carroll,,0,0,0,0
 San Benito,7235321,President,,Brian Carroll,,0,0,0,0
 San Benito,7335315,President,,Brian Carroll,,0,0,0,0
 San Benito,7335316,President,,Brian Carroll,,0,0,0,0
-San Benito,7335319,President,,Brian Carroll,,0,0,,0
+San Benito,7335319,President,,Brian Carroll,,0,0,****,0
 San Benito,7535136,President,,Brian Carroll,,0,0,0,0
 San Benito,9205001,President,,Brian Carroll,,0,0,0,0
 San Benito,9235255,President,,Brian Carroll,,0,0,0,0
 San Benito,9240001,President,,Brian Carroll,,0,0,0,0
-San Benito,9240004,President,,Brian Carroll,,0,,,0
+San Benito,9240004,President,,Brian Carroll,,0,****,****,0
 San Benito,9265000,President,,Brian Carroll,,0,0,0,0
-San Benito,5135101,President,,Mark Charles,,0,,0,0
+San Benito,5135101,President,,Mark Charles,,0,****,0,0
 San Benito,5135103,President,,Mark Charles,,0,0,0,0
 San Benito,5145001,President,,Mark Charles,,0,0,0,0
 San Benito,5145004,President,,Mark Charles,,0,0,0,0
-San Benito,5185003,President,,Mark Charles,,0,0,,0
-San Benito,5235214,President,,Mark Charles,,0,,,0
+San Benito,5185003,President,,Mark Charles,,0,0,****,0
+San Benito,5235214,President,,Mark Charles,,0,****,****,0
 San Benito,5235322,President,,Mark Charles,,0,0,0,0
-San Benito,5280002,President,,Mark Charles,,0,0,,0
-San Benito,5280007,President,,Mark Charles,,0,0,,0
+San Benito,5280002,President,,Mark Charles,,0,0,****,0
+San Benito,5280007,President,,Mark Charles,,0,0,****,0
 San Benito,5335111,President,,Mark Charles,,0,0,0,0
-San Benito,5335159,President,,Mark Charles,,0,,0,0
+San Benito,5335159,President,,Mark Charles,,0,****,0,0
 San Benito,5335213,President,,Mark Charles,,0,0,0,0
 San Benito,5335262,President,,Mark Charles,,1,0,0,1
 San Benito,5335330,President,,Mark Charles,,0,0,0,0
 San Benito,5335348,President,,Mark Charles,,0,0,0,0
-San Benito,5395002,President,,Mark Charles,,0,0,,0
-San Benito,5530011,President,,Mark Charles,,0,0,,0
+San Benito,5395002,President,,Mark Charles,,0,0,****,0
+San Benito,5530011,President,,Mark Charles,,0,0,****,0
 San Benito,5535105,President,,Mark Charles,,0,0,0,0
 San Benito,5535154,President,,Mark Charles,,0,0,0,0
 San Benito,5535212,President,,Mark Charles,,0,0,0,0
 San Benito,5535228,President,,Mark Charles,,0,0,0,0
-San Benito,5585001,President,,Mark Charles,,0,0,,0
+San Benito,5585001,President,,Mark Charles,,0,0,****,0
 San Benito,5585002,President,,Mark Charles,,0,0,0,0
 San Benito,6135425,President,,Mark Charles,,0,0,0,0
-San Benito,6220003,President,,Mark Charles,,0,,0,0
+San Benito,6220003,President,,Mark Charles,,0,****,0,0
 San Benito,6235426,President,,Mark Charles,,0,0,0,0
 San Benito,6235463,President,,Mark Charles,,0,0,0,0
 San Benito,6280001,President,,Mark Charles,,0,0,0,0
-San Benito,6410000,President,,Mark Charles,,0,0,,0
+San Benito,6410000,President,,Mark Charles,,0,0,****,0
 San Benito,6420002,President,,Mark Charles,,0,0,0,0
 San Benito,6435438,President,,Mark Charles,,0,0,0,0
 San Benito,6435458,President,,Mark Charles,,0,0,0,0
 San Benito,6458001,President,,Mark Charles,,0,0,0,0
 San Benito,6475001,President,,Mark Charles,,0,0,0,0
-San Benito,6480005,President,,Mark Charles,,0,0,,0
+San Benito,6480005,President,,Mark Charles,,0,0,****,0
 San Benito,7130001,President,,Mark Charles,,0,0,0,0
 San Benito,7130002,President,,Mark Charles,,0,0,0,0
-San Benito,7130018,President,,Mark Charles,,0,,,0
+San Benito,7130018,President,,Mark Charles,,0,****,****,0
 San Benito,7135106,President,,Mark Charles,,0,0,0,0
 San Benito,7135109,President,,Mark Charles,,0,0,0,0
-San Benito,7135317,President,,Mark Charles,,0,,,0
-San Benito,7135318,President,,Mark Charles,,0,,0,0
+San Benito,7135317,President,,Mark Charles,,0,****,****,0
+San Benito,7135318,President,,Mark Charles,,0,****,0,0
 San Benito,7135423,President,,Mark Charles,,0,0,0,0
 San Benito,7235320,President,,Mark Charles,,0,0,0,0
 San Benito,7235321,President,,Mark Charles,,0,0,0,0
 San Benito,7335315,President,,Mark Charles,,0,0,0,0
 San Benito,7335316,President,,Mark Charles,,0,0,0,0
-San Benito,7335319,President,,Mark Charles,,0,0,,0
+San Benito,7335319,President,,Mark Charles,,0,0,****,0
 San Benito,7535136,President,,Mark Charles,,0,0,0,0
 San Benito,9205001,President,,Mark Charles,,0,0,0,0
 San Benito,9235255,President,,Mark Charles,,0,0,0,0
 San Benito,9240001,President,,Mark Charles,,0,0,0,0
-San Benito,9240004,President,,Mark Charles,,0,,,0
+San Benito,9240004,President,,Mark Charles,,0,****,****,0
 San Benito,9265000,President,,Mark Charles,,1,0,0,1
-San Benito,5135101,President,,Joseph Kishore,,0,,0,0
+San Benito,5135101,President,,Joseph Kishore,,0,****,0,0
 San Benito,5135103,President,,Joseph Kishore,,0,0,0,0
 San Benito,5145001,President,,Joseph Kishore,,0,0,0,0
 San Benito,5145004,President,,Joseph Kishore,,0,0,0,0
-San Benito,5185003,President,,Joseph Kishore,,0,0,,0
-San Benito,5235214,President,,Joseph Kishore,,0,,,0
+San Benito,5185003,President,,Joseph Kishore,,0,0,****,0
+San Benito,5235214,President,,Joseph Kishore,,0,****,****,0
 San Benito,5235322,President,,Joseph Kishore,,0,0,0,0
-San Benito,5280002,President,,Joseph Kishore,,0,0,,0
-San Benito,5280007,President,,Joseph Kishore,,0,0,,0
+San Benito,5280002,President,,Joseph Kishore,,0,0,****,0
+San Benito,5280007,President,,Joseph Kishore,,0,0,****,0
 San Benito,5335111,President,,Joseph Kishore,,0,0,0,0
-San Benito,5335159,President,,Joseph Kishore,,0,,0,0
+San Benito,5335159,President,,Joseph Kishore,,0,****,0,0
 San Benito,5335213,President,,Joseph Kishore,,0,0,0,0
 San Benito,5335262,President,,Joseph Kishore,,0,0,0,0
 San Benito,5335330,President,,Joseph Kishore,,0,0,0,0
 San Benito,5335348,President,,Joseph Kishore,,0,0,0,0
-San Benito,5395002,President,,Joseph Kishore,,0,0,,0
-San Benito,5530011,President,,Joseph Kishore,,0,0,,0
+San Benito,5395002,President,,Joseph Kishore,,0,0,****,0
+San Benito,5530011,President,,Joseph Kishore,,0,0,****,0
 San Benito,5535105,President,,Joseph Kishore,,0,0,0,0
 San Benito,5535154,President,,Joseph Kishore,,0,0,0,0
 San Benito,5535212,President,,Joseph Kishore,,0,0,0,0
 San Benito,5535228,President,,Joseph Kishore,,0,0,0,0
-San Benito,5585001,President,,Joseph Kishore,,0,0,,0
+San Benito,5585001,President,,Joseph Kishore,,0,0,****,0
 San Benito,5585002,President,,Joseph Kishore,,0,0,0,0
 San Benito,6135425,President,,Joseph Kishore,,0,0,0,0
-San Benito,6220003,President,,Joseph Kishore,,0,,0,0
+San Benito,6220003,President,,Joseph Kishore,,0,****,0,0
 San Benito,6235426,President,,Joseph Kishore,,0,0,0,0
 San Benito,6235463,President,,Joseph Kishore,,0,0,0,0
 San Benito,6280001,President,,Joseph Kishore,,0,0,0,0
-San Benito,6410000,President,,Joseph Kishore,,0,0,,0
+San Benito,6410000,President,,Joseph Kishore,,0,0,****,0
 San Benito,6420002,President,,Joseph Kishore,,0,0,0,0
 San Benito,6435438,President,,Joseph Kishore,,0,0,0,0
 San Benito,6435458,President,,Joseph Kishore,,0,0,0,0
 San Benito,6458001,President,,Joseph Kishore,,0,0,0,0
 San Benito,6475001,President,,Joseph Kishore,,0,0,0,0
-San Benito,6480005,President,,Joseph Kishore,,0,0,,0
+San Benito,6480005,President,,Joseph Kishore,,0,0,****,0
 San Benito,7130001,President,,Joseph Kishore,,0,0,0,0
 San Benito,7130002,President,,Joseph Kishore,,0,0,0,0
-San Benito,7130018,President,,Joseph Kishore,,0,,,0
+San Benito,7130018,President,,Joseph Kishore,,0,****,****,0
 San Benito,7135106,President,,Joseph Kishore,,0,0,0,0
 San Benito,7135109,President,,Joseph Kishore,,0,0,0,0
-San Benito,7135317,President,,Joseph Kishore,,0,,,0
-San Benito,7135318,President,,Joseph Kishore,,0,,0,0
+San Benito,7135317,President,,Joseph Kishore,,0,****,****,0
+San Benito,7135318,President,,Joseph Kishore,,0,****,0,0
 San Benito,7135423,President,,Joseph Kishore,,0,0,0,0
 San Benito,7235320,President,,Joseph Kishore,,0,0,0,0
 San Benito,7235321,President,,Joseph Kishore,,0,0,0,0
 San Benito,7335315,President,,Joseph Kishore,,0,0,0,0
 San Benito,7335316,President,,Joseph Kishore,,0,0,0,0
-San Benito,7335319,President,,Joseph Kishore,,0,0,,0
+San Benito,7335319,President,,Joseph Kishore,,0,0,****,0
 San Benito,7535136,President,,Joseph Kishore,,0,0,0,0
 San Benito,9205001,President,,Joseph Kishore,,0,0,0,0
 San Benito,9235255,President,,Joseph Kishore,,0,0,0,0
 San Benito,9240001,President,,Joseph Kishore,,0,0,0,0
-San Benito,9240004,President,,Joseph Kishore,,0,,,0
+San Benito,9240004,President,,Joseph Kishore,,0,****,****,0
 San Benito,9265000,President,,Joseph Kishore,,0,0,0,0
-San Benito,5135101,President,,Brock Pierce,,0,,0,0
+San Benito,5135101,President,,Brock Pierce,,0,****,0,0
 San Benito,5135103,President,,Brock Pierce,,0,0,0,0
 San Benito,5145001,President,,Brock Pierce,,0,0,0,0
 San Benito,5145004,President,,Brock Pierce,,0,0,0,0
-San Benito,5185003,President,,Brock Pierce,,0,0,,0
-San Benito,5235214,President,,Brock Pierce,,0,,,0
+San Benito,5185003,President,,Brock Pierce,,0,0,****,0
+San Benito,5235214,President,,Brock Pierce,,0,****,****,0
 San Benito,5235322,President,,Brock Pierce,,0,0,0,0
-San Benito,5280002,President,,Brock Pierce,,0,0,,0
-San Benito,5280007,President,,Brock Pierce,,0,0,,0
+San Benito,5280002,President,,Brock Pierce,,0,0,****,0
+San Benito,5280007,President,,Brock Pierce,,0,0,****,0
 San Benito,5335111,President,,Brock Pierce,,0,0,0,0
-San Benito,5335159,President,,Brock Pierce,,0,,0,0
+San Benito,5335159,President,,Brock Pierce,,0,****,0,0
 San Benito,5335213,President,,Brock Pierce,,0,0,0,0
 San Benito,5335262,President,,Brock Pierce,,0,0,0,0
 San Benito,5335330,President,,Brock Pierce,,0,0,0,0
 San Benito,5335348,President,,Brock Pierce,,0,0,0,0
-San Benito,5395002,President,,Brock Pierce,,0,0,,0
-San Benito,5530011,President,,Brock Pierce,,0,0,,0
+San Benito,5395002,President,,Brock Pierce,,0,0,****,0
+San Benito,5530011,President,,Brock Pierce,,0,0,****,0
 San Benito,5535105,President,,Brock Pierce,,0,0,0,0
 San Benito,5535154,President,,Brock Pierce,,0,0,0,0
 San Benito,5535212,President,,Brock Pierce,,0,0,0,0
 San Benito,5535228,President,,Brock Pierce,,0,0,0,0
-San Benito,5585001,President,,Brock Pierce,,0,0,,0
+San Benito,5585001,President,,Brock Pierce,,0,0,****,0
 San Benito,5585002,President,,Brock Pierce,,0,0,0,0
 San Benito,6135425,President,,Brock Pierce,,0,0,0,0
-San Benito,6220003,President,,Brock Pierce,,0,,0,0
+San Benito,6220003,President,,Brock Pierce,,0,****,0,0
 San Benito,6235426,President,,Brock Pierce,,0,0,0,0
 San Benito,6235463,President,,Brock Pierce,,0,0,0,0
 San Benito,6280001,President,,Brock Pierce,,0,0,0,0
-San Benito,6410000,President,,Brock Pierce,,0,0,,0
+San Benito,6410000,President,,Brock Pierce,,0,0,****,0
 San Benito,6420002,President,,Brock Pierce,,0,0,0,0
 San Benito,6435438,President,,Brock Pierce,,0,0,0,0
 San Benito,6435458,President,,Brock Pierce,,0,0,0,0
 San Benito,6458001,President,,Brock Pierce,,0,0,0,0
 San Benito,6475001,President,,Brock Pierce,,0,0,0,0
-San Benito,6480005,President,,Brock Pierce,,0,0,,0
+San Benito,6480005,President,,Brock Pierce,,0,0,****,0
 San Benito,7130001,President,,Brock Pierce,,0,0,0,0
 San Benito,7130002,President,,Brock Pierce,,0,0,0,0
-San Benito,7130018,President,,Brock Pierce,,0,,,0
+San Benito,7130018,President,,Brock Pierce,,0,****,****,0
 San Benito,7135106,President,,Brock Pierce,,0,0,0,0
 San Benito,7135109,President,,Brock Pierce,,0,0,0,0
-San Benito,7135317,President,,Brock Pierce,,0,,,0
-San Benito,7135318,President,,Brock Pierce,,0,,0,0
+San Benito,7135317,President,,Brock Pierce,,0,****,****,0
+San Benito,7135318,President,,Brock Pierce,,0,****,0,0
 San Benito,7135423,President,,Brock Pierce,,0,0,0,0
 San Benito,7235320,President,,Brock Pierce,,0,0,0,0
 San Benito,7235321,President,,Brock Pierce,,0,0,0,0
 San Benito,7335315,President,,Brock Pierce,,0,0,0,0
 San Benito,7335316,President,,Brock Pierce,,0,0,0,0
-San Benito,7335319,President,,Brock Pierce,,0,0,,0
+San Benito,7335319,President,,Brock Pierce,,0,0,****,0
 San Benito,7535136,President,,Brock Pierce,,0,0,0,0
 San Benito,9205001,President,,Brock Pierce,,0,0,0,0
 San Benito,9235255,President,,Brock Pierce,,0,0,0,0
 San Benito,9240001,President,,Brock Pierce,,0,0,0,0
-San Benito,9240004,President,,Brock Pierce,,0,,,0
+San Benito,9240004,President,,Brock Pierce,,0,****,****,0
 San Benito,9265000,President,,Brock Pierce,,0,0,0,0
-San Benito,5135101,President,,Jesse Ventura,,0,,0,0
+San Benito,5135101,President,,Jesse Ventura,,0,****,0,0
 San Benito,5135103,President,,Jesse Ventura,,0,0,0,0
 San Benito,5145001,President,,Jesse Ventura,,0,0,0,0
 San Benito,5145004,President,,Jesse Ventura,,0,0,0,0
-San Benito,5185003,President,,Jesse Ventura,,0,0,,0
-San Benito,5235214,President,,Jesse Ventura,,0,,,0
+San Benito,5185003,President,,Jesse Ventura,,0,0,****,0
+San Benito,5235214,President,,Jesse Ventura,,0,****,****,0
 San Benito,5235322,President,,Jesse Ventura,,0,0,0,0
-San Benito,5280002,President,,Jesse Ventura,,0,0,,0
-San Benito,5280007,President,,Jesse Ventura,,0,0,,0
+San Benito,5280002,President,,Jesse Ventura,,0,0,****,0
+San Benito,5280007,President,,Jesse Ventura,,0,0,****,0
 San Benito,5335111,President,,Jesse Ventura,,0,0,0,0
-San Benito,5335159,President,,Jesse Ventura,,0,,0,0
+San Benito,5335159,President,,Jesse Ventura,,0,****,0,0
 San Benito,5335213,President,,Jesse Ventura,,0,0,0,0
 San Benito,5335262,President,,Jesse Ventura,,0,0,0,0
 San Benito,5335330,President,,Jesse Ventura,,0,0,0,0
 San Benito,5335348,President,,Jesse Ventura,,0,0,0,0
-San Benito,5395002,President,,Jesse Ventura,,0,0,,0
-San Benito,5530011,President,,Jesse Ventura,,0,0,,0
+San Benito,5395002,President,,Jesse Ventura,,0,0,****,0
+San Benito,5530011,President,,Jesse Ventura,,0,0,****,0
 San Benito,5535105,President,,Jesse Ventura,,0,0,0,0
 San Benito,5535154,President,,Jesse Ventura,,0,0,0,0
 San Benito,5535212,President,,Jesse Ventura,,0,0,0,0
 San Benito,5535228,President,,Jesse Ventura,,0,0,0,0
-San Benito,5585001,President,,Jesse Ventura,,0,0,,0
+San Benito,5585001,President,,Jesse Ventura,,0,0,****,0
 San Benito,5585002,President,,Jesse Ventura,,0,0,0,0
 San Benito,6135425,President,,Jesse Ventura,,0,0,0,0
-San Benito,6220003,President,,Jesse Ventura,,0,,0,0
+San Benito,6220003,President,,Jesse Ventura,,0,****,0,0
 San Benito,6235426,President,,Jesse Ventura,,0,0,0,0
 San Benito,6235463,President,,Jesse Ventura,,0,0,0,0
 San Benito,6280001,President,,Jesse Ventura,,0,0,0,0
-San Benito,6410000,President,,Jesse Ventura,,0,0,,0
+San Benito,6410000,President,,Jesse Ventura,,0,0,****,0
 San Benito,6420002,President,,Jesse Ventura,,0,0,0,0
 San Benito,6435438,President,,Jesse Ventura,,0,0,0,0
 San Benito,6435458,President,,Jesse Ventura,,0,0,0,0
 San Benito,6458001,President,,Jesse Ventura,,0,0,0,0
 San Benito,6475001,President,,Jesse Ventura,,0,0,0,0
-San Benito,6480005,President,,Jesse Ventura,,0,0,,0
+San Benito,6480005,President,,Jesse Ventura,,0,0,****,0
 San Benito,7130001,President,,Jesse Ventura,,0,0,0,0
 San Benito,7130002,President,,Jesse Ventura,,0,0,0,0
-San Benito,7130018,President,,Jesse Ventura,,0,,,0
+San Benito,7130018,President,,Jesse Ventura,,0,****,****,0
 San Benito,7135106,President,,Jesse Ventura,,0,0,0,0
 San Benito,7135109,President,,Jesse Ventura,,0,0,0,0
-San Benito,7135317,President,,Jesse Ventura,,0,,,0
-San Benito,7135318,President,,Jesse Ventura,,0,,0,0
+San Benito,7135317,President,,Jesse Ventura,,0,****,****,0
+San Benito,7135318,President,,Jesse Ventura,,0,****,0,0
 San Benito,7135423,President,,Jesse Ventura,,0,0,0,0
 San Benito,7235320,President,,Jesse Ventura,,0,0,0,0
 San Benito,7235321,President,,Jesse Ventura,,0,0,0,0
 San Benito,7335315,President,,Jesse Ventura,,0,0,0,0
 San Benito,7335316,President,,Jesse Ventura,,1,0,0,1
-San Benito,7335319,President,,Jesse Ventura,,0,0,,0
+San Benito,7335319,President,,Jesse Ventura,,0,0,****,0
 San Benito,7535136,President,,Jesse Ventura,,0,0,0,0
 San Benito,9205001,President,,Jesse Ventura,,0,0,0,0
 San Benito,9235255,President,,Jesse Ventura,,0,0,0,0
 San Benito,9240001,President,,Jesse Ventura,,0,0,0,0
-San Benito,9240004,President,,Jesse Ventura,,0,,,0
+San Benito,9240004,President,,Jesse Ventura,,0,****,****,0
 San Benito,9265000,President,,Jesse Ventura,,0,0,0,0
-San Benito,5135101,U.S. House,20,Jeff Gorman,REP,5,,0,5
+San Benito,5135101,U.S. House,20,Jeff Gorman,REP,5,****,0,5
 San Benito,5135103,U.S. House,20,Jeff Gorman,REP,0,0,0,0
 San Benito,5145001,U.S. House,20,Jeff Gorman,REP,169,7,10,152
 San Benito,5145004,U.S. House,20,Jeff Gorman,REP,3,0,0,3
-San Benito,5185003,U.S. House,20,Jeff Gorman,REP,6,0,,6
-San Benito,5235214,U.S. House,20,Jeff Gorman,REP,41,,,40
+San Benito,5185003,U.S. House,20,Jeff Gorman,REP,6,0,****,6
+San Benito,5235214,U.S. House,20,Jeff Gorman,REP,41,****,****,40
 San Benito,5235322,U.S. House,20,Jeff Gorman,REP,66,5,10,51
-San Benito,5280002,U.S. House,20,Jeff Gorman,REP,9,0,,8
-San Benito,5280007,U.S. House,20,Jeff Gorman,REP,62,0,,58
+San Benito,5280002,U.S. House,20,Jeff Gorman,REP,9,0,****,8
+San Benito,5280007,U.S. House,20,Jeff Gorman,REP,62,0,****,58
 San Benito,5335111,U.S. House,20,Jeff Gorman,REP,92,7,9,76
-San Benito,5335159,U.S. House,20,Jeff Gorman,REP,14,,2,10
+San Benito,5335159,U.S. House,20,Jeff Gorman,REP,14,****,2,10
 San Benito,5335213,U.S. House,20,Jeff Gorman,REP,363,17,43,303
 San Benito,5335262,U.S. House,20,Jeff Gorman,REP,79,6,8,65
 San Benito,5335330,U.S. House,20,Jeff Gorman,REP,360,11,30,319
 San Benito,5335348,U.S. House,20,Jeff Gorman,REP,117,7,14,96
-San Benito,5395002,U.S. House,20,Jeff Gorman,REP,9,0,,9
-San Benito,5530011,U.S. House,20,Jeff Gorman,REP,4,0,,1
+San Benito,5395002,U.S. House,20,Jeff Gorman,REP,9,0,****,9
+San Benito,5530011,U.S. House,20,Jeff Gorman,REP,4,0,****,1
 San Benito,5535105,U.S. House,20,Jeff Gorman,REP,204,16,22,166
 San Benito,5535154,U.S. House,20,Jeff Gorman,REP,56,5,1,50
 San Benito,5535212,U.S. House,20,Jeff Gorman,REP,210,13,29,168
 San Benito,5535228,U.S. House,20,Jeff Gorman,REP,110,5,14,91
-San Benito,5585001,U.S. House,20,Jeff Gorman,REP,36,4,,30
+San Benito,5585001,U.S. House,20,Jeff Gorman,REP,36,4,****,30
 San Benito,5585002,U.S. House,20,Jeff Gorman,REP,1,0,0,1
 San Benito,6135425,U.S. House,20,Jeff Gorman,REP,294,16,20,258
-San Benito,6220003,U.S. House,20,Jeff Gorman,REP,10,,0,8
+San Benito,6220003,U.S. House,20,Jeff Gorman,REP,10,****,0,8
 San Benito,6235426,U.S. House,20,Jeff Gorman,REP,333,24,31,278
 San Benito,6235463,U.S. House,20,Jeff Gorman,REP,0,0,0,0
 San Benito,6280001,U.S. House,20,Jeff Gorman,REP,35,0,3,32
-San Benito,6410000,U.S. House,20,Jeff Gorman,REP,51,0,,50
+San Benito,6410000,U.S. House,20,Jeff Gorman,REP,51,0,****,50
 San Benito,6420002,U.S. House,20,Jeff Gorman,REP,482,29,30,423
 San Benito,6435438,U.S. House,20,Jeff Gorman,REP,420,24,39,357
 San Benito,6435458,U.S. House,20,Jeff Gorman,REP,282,14,29,239
 San Benito,6458001,U.S. House,20,Jeff Gorman,REP,602,51,36,515
 San Benito,6475001,U.S. House,20,Jeff Gorman,REP,818,32,35,751
-San Benito,6480005,U.S. House,20,Jeff Gorman,REP,10,0,,10
+San Benito,6480005,U.S. House,20,Jeff Gorman,REP,10,0,****,10
 San Benito,7130001,U.S. House,20,Jeff Gorman,REP,597,40,38,519
 San Benito,7130002,U.S. House,20,Jeff Gorman,REP,753,42,43,668
-San Benito,7130018,U.S. House,20,Jeff Gorman,REP,5,,,4
+San Benito,7130018,U.S. House,20,Jeff Gorman,REP,5,****,****,4
 San Benito,7135106,U.S. House,20,Jeff Gorman,REP,85,9,5,71
 San Benito,7135109,U.S. House,20,Jeff Gorman,REP,335,23,20,292
-San Benito,7135317,U.S. House,20,Jeff Gorman,REP,16,,,15
-San Benito,7135318,U.S. House,20,Jeff Gorman,REP,62,,5,56
+San Benito,7135317,U.S. House,20,Jeff Gorman,REP,16,****,****,15
+San Benito,7135318,U.S. House,20,Jeff Gorman,REP,62,****,5,56
 San Benito,7135423,U.S. House,20,Jeff Gorman,REP,188,17,21,150
 San Benito,7235320,U.S. House,20,Jeff Gorman,REP,102,6,16,80
 San Benito,7235321,U.S. House,20,Jeff Gorman,REP,194,15,14,165
 San Benito,7335315,U.S. House,20,Jeff Gorman,REP,78,2,4,72
 San Benito,7335316,U.S. House,20,Jeff Gorman,REP,338,26,28,284
-San Benito,7335319,U.S. House,20,Jeff Gorman,REP,3,0,,2
+San Benito,7335319,U.S. House,20,Jeff Gorman,REP,3,0,****,2
 San Benito,7535136,U.S. House,20,Jeff Gorman,REP,230,18,15,197
 San Benito,9205001,U.S. House,20,Jeff Gorman,REP,157,6,12,139
 San Benito,9235255,U.S. House,20,Jeff Gorman,REP,0,0,0,0
 San Benito,9240001,U.S. House,20,Jeff Gorman,REP,626,36,72,518
-San Benito,9240004,U.S. House,20,Jeff Gorman,REP,12,,,11
+San Benito,9240004,U.S. House,20,Jeff Gorman,REP,12,****,****,11
 San Benito,9265000,U.S. House,20,Jeff Gorman,REP,278,30,30,218
-San Benito,5135101,U.S. House,20,Jimmy Panetta,DEM,14,,0,11
+San Benito,5135101,U.S. House,20,Jimmy Panetta,DEM,14,****,0,11
 San Benito,5135103,U.S. House,20,Jimmy Panetta,DEM,0,0,0,0
 San Benito,5145001,U.S. House,20,Jimmy Panetta,DEM,256,4,6,246
 San Benito,5145004,U.S. House,20,Jimmy Panetta,DEM,2,0,0,2
-San Benito,5185003,U.S. House,20,Jimmy Panetta,DEM,11,0,,10
-San Benito,5235214,U.S. House,20,Jimmy Panetta,DEM,69,,,66
+San Benito,5185003,U.S. House,20,Jimmy Panetta,DEM,11,0,****,10
+San Benito,5235214,U.S. House,20,Jimmy Panetta,DEM,69,****,****,66
 San Benito,5235322,U.S. House,20,Jimmy Panetta,DEM,116,3,9,104
-San Benito,5280002,U.S. House,20,Jimmy Panetta,DEM,34,0,,33
-San Benito,5280007,U.S. House,20,Jimmy Panetta,DEM,78,5,,73
+San Benito,5280002,U.S. House,20,Jimmy Panetta,DEM,34,0,****,33
+San Benito,5280007,U.S. House,20,Jimmy Panetta,DEM,78,5,****,73
 San Benito,5335111,U.S. House,20,Jimmy Panetta,DEM,227,8,10,209
-San Benito,5335159,U.S. House,20,Jimmy Panetta,DEM,41,,3,38
+San Benito,5335159,U.S. House,20,Jimmy Panetta,DEM,41,****,3,38
 San Benito,5335213,U.S. House,20,Jimmy Panetta,DEM,1038,28,44,966
 San Benito,5335262,U.S. House,20,Jimmy Panetta,DEM,197,4,12,181
 San Benito,5335330,U.S. House,20,Jimmy Panetta,DEM,619,7,24,588
 San Benito,5335348,U.S. House,20,Jimmy Panetta,DEM,400,15,17,368
-San Benito,5395002,U.S. House,20,Jimmy Panetta,DEM,12,0,,11
-San Benito,5530011,U.S. House,20,Jimmy Panetta,DEM,5,0,,5
+San Benito,5395002,U.S. House,20,Jimmy Panetta,DEM,12,0,****,11
+San Benito,5530011,U.S. House,20,Jimmy Panetta,DEM,5,0,****,5
 San Benito,5535105,U.S. House,20,Jimmy Panetta,DEM,656,20,42,594
 San Benito,5535154,U.S. House,20,Jimmy Panetta,DEM,198,5,15,178
 San Benito,5535212,U.S. House,20,Jimmy Panetta,DEM,1108,21,55,1032
 San Benito,5535228,U.S. House,20,Jimmy Panetta,DEM,438,15,20,403
-San Benito,5585001,U.S. House,20,Jimmy Panetta,DEM,111,2,,107
+San Benito,5585001,U.S. House,20,Jimmy Panetta,DEM,111,2,****,107
 San Benito,5585002,U.S. House,20,Jimmy Panetta,DEM,11,0,0,11
 San Benito,6135425,U.S. House,20,Jimmy Panetta,DEM,527,10,14,503
-San Benito,6220003,U.S. House,20,Jimmy Panetta,DEM,10,,0,10
+San Benito,6220003,U.S. House,20,Jimmy Panetta,DEM,10,****,0,10
 San Benito,6235426,U.S. House,20,Jimmy Panetta,DEM,707,14,24,669
 San Benito,6235463,U.S. House,20,Jimmy Panetta,DEM,0,0,0,0
 San Benito,6280001,U.S. House,20,Jimmy Panetta,DEM,80,0,2,78
-San Benito,6410000,U.S. House,20,Jimmy Panetta,DEM,9,0,,9
+San Benito,6410000,U.S. House,20,Jimmy Panetta,DEM,9,0,****,9
 San Benito,6420002,U.S. House,20,Jimmy Panetta,DEM,631,12,18,601
 San Benito,6435438,U.S. House,20,Jimmy Panetta,DEM,770,14,28,728
 San Benito,6435458,U.S. House,20,Jimmy Panetta,DEM,571,9,23,539
 San Benito,6458001,U.S. House,20,Jimmy Panetta,DEM,861,18,33,810
 San Benito,6475001,U.S. House,20,Jimmy Panetta,DEM,914,19,20,875
-San Benito,6480005,U.S. House,20,Jimmy Panetta,DEM,30,0,,29
+San Benito,6480005,U.S. House,20,Jimmy Panetta,DEM,30,0,****,29
 San Benito,7130001,U.S. House,20,Jimmy Panetta,DEM,926,12,47,867
 San Benito,7130002,U.S. House,20,Jimmy Panetta,DEM,773,21,33,719
-San Benito,7130018,U.S. House,20,Jimmy Panetta,DEM,30,,,27
+San Benito,7130018,U.S. House,20,Jimmy Panetta,DEM,30,****,****,27
 San Benito,7135106,U.S. House,20,Jimmy Panetta,DEM,153,3,3,147
 San Benito,7135109,U.S. House,20,Jimmy Panetta,DEM,835,24,41,770
-San Benito,7135317,U.S. House,20,Jimmy Panetta,DEM,39,,,36
-San Benito,7135318,U.S. House,20,Jimmy Panetta,DEM,146,,6,138
+San Benito,7135317,U.S. House,20,Jimmy Panetta,DEM,39,****,****,36
+San Benito,7135318,U.S. House,20,Jimmy Panetta,DEM,146,****,6,138
 San Benito,7135423,U.S. House,20,Jimmy Panetta,DEM,430,10,23,397
 San Benito,7235320,U.S. House,20,Jimmy Panetta,DEM,226,9,15,202
 San Benito,7235321,U.S. House,20,Jimmy Panetta,DEM,331,10,8,313
 San Benito,7335315,U.S. House,20,Jimmy Panetta,DEM,306,6,14,286
 San Benito,7335316,U.S. House,20,Jimmy Panetta,DEM,706,13,31,662
-San Benito,7335319,U.S. House,20,Jimmy Panetta,DEM,28,0,,28
+San Benito,7335319,U.S. House,20,Jimmy Panetta,DEM,28,0,****,28
 San Benito,7535136,U.S. House,20,Jimmy Panetta,DEM,964,23,62,879
 San Benito,9205001,U.S. House,20,Jimmy Panetta,DEM,512,4,11,497
 San Benito,9235255,U.S. House,20,Jimmy Panetta,DEM,0,0,0,0
 San Benito,9240001,U.S. House,20,Jimmy Panetta,DEM,773,16,41,716
-San Benito,9240004,U.S. House,20,Jimmy Panetta,DEM,6,,,3
+San Benito,9240004,U.S. House,20,Jimmy Panetta,DEM,6,****,****,3
 San Benito,9265000,U.S. House,20,Jimmy Panetta,DEM,800,26,67,707
-San Benito,5135101,State Assembly,30,Gregory Swett,REP,7,,0,7
+San Benito,5135101,State Assembly,30,Gregory Swett,REP,7,****,0,7
 San Benito,5135103,State Assembly,30,Gregory Swett,REP,0,0,0,0
 San Benito,5145001,State Assembly,30,Gregory Swett,REP,176,8,7,161
 San Benito,5145004,State Assembly,30,Gregory Swett,REP,3,0,0,3
-San Benito,5185003,State Assembly,30,Gregory Swett,REP,9,0,,9
-San Benito,5235214,State Assembly,30,Gregory Swett,REP,44,,,43
+San Benito,5185003,State Assembly,30,Gregory Swett,REP,9,0,****,9
+San Benito,5235214,State Assembly,30,Gregory Swett,REP,44,****,****,43
 San Benito,5235322,State Assembly,30,Gregory Swett,REP,69,4,11,54
-San Benito,5280002,State Assembly,30,Gregory Swett,REP,8,0,,8
-San Benito,5280007,State Assembly,30,Gregory Swett,REP,66,0,,63
+San Benito,5280002,State Assembly,30,Gregory Swett,REP,8,0,****,8
+San Benito,5280007,State Assembly,30,Gregory Swett,REP,66,0,****,63
 San Benito,5335111,State Assembly,30,Gregory Swett,REP,99,7,10,82
-San Benito,5335159,State Assembly,30,Gregory Swett,REP,17,,2,13
+San Benito,5335159,State Assembly,30,Gregory Swett,REP,17,****,2,13
 San Benito,5335213,State Assembly,30,Gregory Swett,REP,355,17,40,298
 San Benito,5335262,State Assembly,30,Gregory Swett,REP,90,5,9,76
 San Benito,5335330,State Assembly,30,Gregory Swett,REP,367,10,28,329
 San Benito,5335348,State Assembly,30,Gregory Swett,REP,127,7,13,107
-San Benito,5395002,State Assembly,30,Gregory Swett,REP,10,0,,10
-San Benito,5530011,State Assembly,30,Gregory Swett,REP,4,0,,1
+San Benito,5395002,State Assembly,30,Gregory Swett,REP,10,0,****,10
+San Benito,5530011,State Assembly,30,Gregory Swett,REP,4,0,****,1
 San Benito,5535105,State Assembly,30,Gregory Swett,REP,224,16,26,182
 San Benito,5535154,State Assembly,30,Gregory Swett,REP,54,6,1,47
 San Benito,5535212,State Assembly,30,Gregory Swett,REP,245,15,26,204
 San Benito,5535228,State Assembly,30,Gregory Swett,REP,125,6,16,103
-San Benito,5585001,State Assembly,30,Gregory Swett,REP,41,2,,37
+San Benito,5585001,State Assembly,30,Gregory Swett,REP,41,2,****,37
 San Benito,5585002,State Assembly,30,Gregory Swett,REP,1,0,0,1
 San Benito,6135425,State Assembly,30,Gregory Swett,REP,317,16,21,280
-San Benito,6220003,State Assembly,30,Gregory Swett,REP,10,,0,8
+San Benito,6220003,State Assembly,30,Gregory Swett,REP,10,****,0,8
 San Benito,6235426,State Assembly,30,Gregory Swett,REP,350,21,31,298
 San Benito,6235463,State Assembly,30,Gregory Swett,REP,0,0,0,0
 San Benito,6280001,State Assembly,30,Gregory Swett,REP,38,0,3,35
-San Benito,6410000,State Assembly,30,Gregory Swett,REP,53,0,,52
+San Benito,6410000,State Assembly,30,Gregory Swett,REP,53,0,****,52
 San Benito,6420002,State Assembly,30,Gregory Swett,REP,526,33,31,462
 San Benito,6435438,State Assembly,30,Gregory Swett,REP,434,24,36,374
 San Benito,6435458,State Assembly,30,Gregory Swett,REP,286,14,28,244
 San Benito,6458001,State Assembly,30,Gregory Swett,REP,690,55,40,595
 San Benito,6475001,State Assembly,30,Gregory Swett,REP,928,35,35,858
-San Benito,6480005,State Assembly,30,Gregory Swett,REP,14,0,,14
+San Benito,6480005,State Assembly,30,Gregory Swett,REP,14,0,****,14
 San Benito,7130001,State Assembly,30,Gregory Swett,REP,625,38,35,552
 San Benito,7130002,State Assembly,30,Gregory Swett,REP,811,45,44,722
-San Benito,7130018,State Assembly,30,Gregory Swett,REP,7,,,6
+San Benito,7130018,State Assembly,30,Gregory Swett,REP,7,****,****,6
 San Benito,7135106,State Assembly,30,Gregory Swett,REP,86,7,6,73
 San Benito,7135109,State Assembly,30,Gregory Swett,REP,353,23,21,309
-San Benito,7135317,State Assembly,30,Gregory Swett,REP,15,,,15
-San Benito,7135318,State Assembly,30,Gregory Swett,REP,74,,4,68
+San Benito,7135317,State Assembly,30,Gregory Swett,REP,15,****,****,15
+San Benito,7135318,State Assembly,30,Gregory Swett,REP,74,****,4,68
 San Benito,7135423,State Assembly,30,Gregory Swett,REP,213,18,25,170
 San Benito,7235320,State Assembly,30,Gregory Swett,REP,108,4,14,90
 San Benito,7235321,State Assembly,30,Gregory Swett,REP,210,15,11,184
 San Benito,7335315,State Assembly,30,Gregory Swett,REP,92,2,5,85
 San Benito,7335316,State Assembly,30,Gregory Swett,REP,370,28,30,312
-San Benito,7335319,State Assembly,30,Gregory Swett,REP,5,0,,4
+San Benito,7335319,State Assembly,30,Gregory Swett,REP,5,0,****,4
 San Benito,7535136,State Assembly,30,Gregory Swett,REP,258,19,17,222
 San Benito,9205001,State Assembly,30,Gregory Swett,REP,187,7,9,171
 San Benito,9235255,State Assembly,30,Gregory Swett,REP,0,0,0,0
 San Benito,9240001,State Assembly,30,Gregory Swett,REP,688,37,75,576
-San Benito,9240004,State Assembly,30,Gregory Swett,REP,12,,,11
+San Benito,9240004,State Assembly,30,Gregory Swett,REP,12,****,****,11
 San Benito,9265000,State Assembly,30,Gregory Swett,REP,336,30,34,272
-San Benito,5135101,State Assembly,30,Robert Rivas,DEM,14,,0,11
+San Benito,5135101,State Assembly,30,Robert Rivas,DEM,14,****,0,11
 San Benito,5135103,State Assembly,30,Robert Rivas,DEM,0,0,0,0
 San Benito,5145001,State Assembly,30,Robert Rivas,DEM,251,3,9,239
 San Benito,5145004,State Assembly,30,Robert Rivas,DEM,2,0,0,2
-San Benito,5185003,State Assembly,30,Robert Rivas,DEM,8,0,,7
-San Benito,5235214,State Assembly,30,Robert Rivas,DEM,67,,,64
+San Benito,5185003,State Assembly,30,Robert Rivas,DEM,8,0,****,7
+San Benito,5235214,State Assembly,30,Robert Rivas,DEM,67,****,****,64
 San Benito,5235322,State Assembly,30,Robert Rivas,DEM,110,3,7,100
-San Benito,5280002,State Assembly,30,Robert Rivas,DEM,34,0,,32
-San Benito,5280007,State Assembly,30,Robert Rivas,DEM,75,5,,69
+San Benito,5280002,State Assembly,30,Robert Rivas,DEM,34,0,****,32
+San Benito,5280007,State Assembly,30,Robert Rivas,DEM,75,5,****,69
 San Benito,5335111,State Assembly,30,Robert Rivas,DEM,222,8,9,205
-San Benito,5335159,State Assembly,30,Robert Rivas,DEM,37,,3,34
+San Benito,5335159,State Assembly,30,Robert Rivas,DEM,37,****,3,34
 San Benito,5335213,State Assembly,30,Robert Rivas,DEM,1048,30,46,972
 San Benito,5335262,State Assembly,30,Robert Rivas,DEM,185,6,11,168
 San Benito,5335330,State Assembly,30,Robert Rivas,DEM,602,8,25,569
 San Benito,5335348,State Assembly,30,Robert Rivas,DEM,393,14,18,361
-San Benito,5395002,State Assembly,30,Robert Rivas,DEM,11,0,,10
-San Benito,5530011,State Assembly,30,Robert Rivas,DEM,5,0,,5
+San Benito,5395002,State Assembly,30,Robert Rivas,DEM,11,0,****,10
+San Benito,5530011,State Assembly,30,Robert Rivas,DEM,5,0,****,5
 San Benito,5535105,State Assembly,30,Robert Rivas,DEM,649,20,38,591
 San Benito,5535154,State Assembly,30,Robert Rivas,DEM,200,4,15,181
 San Benito,5535212,State Assembly,30,Robert Rivas,DEM,1068,20,55,993
 San Benito,5535228,State Assembly,30,Robert Rivas,DEM,424,12,18,394
-San Benito,5585001,State Assembly,30,Robert Rivas,DEM,106,4,,101
+San Benito,5585001,State Assembly,30,Robert Rivas,DEM,106,4,****,101
 San Benito,5585002,State Assembly,30,Robert Rivas,DEM,11,0,0,11
 San Benito,6135425,State Assembly,30,Robert Rivas,DEM,504,10,14,480
-San Benito,6220003,State Assembly,30,Robert Rivas,DEM,11,,0,11
+San Benito,6220003,State Assembly,30,Robert Rivas,DEM,11,****,0,11
 San Benito,6235426,State Assembly,30,Robert Rivas,DEM,685,16,23,646
 San Benito,6235463,State Assembly,30,Robert Rivas,DEM,0,0,0,0
 San Benito,6280001,State Assembly,30,Robert Rivas,DEM,78,0,2,76
-San Benito,6410000,State Assembly,30,Robert Rivas,DEM,8,0,,8
+San Benito,6410000,State Assembly,30,Robert Rivas,DEM,8,0,****,8
 San Benito,6420002,State Assembly,30,Robert Rivas,DEM,564,7,14,543
 San Benito,6435438,State Assembly,30,Robert Rivas,DEM,757,14,31,712
 San Benito,6435458,State Assembly,30,Robert Rivas,DEM,572,9,24,539
 San Benito,6458001,State Assembly,30,Robert Rivas,DEM,757,13,30,714
 San Benito,6475001,State Assembly,30,Robert Rivas,DEM,789,14,21,754
-San Benito,6480005,State Assembly,30,Robert Rivas,DEM,26,0,,25
+San Benito,6480005,State Assembly,30,Robert Rivas,DEM,26,0,****,25
 San Benito,7130001,State Assembly,30,Robert Rivas,DEM,905,13,49,843
 San Benito,7130002,State Assembly,30,Robert Rivas,DEM,692,17,31,644
-San Benito,7130018,State Assembly,30,Robert Rivas,DEM,28,,,25
+San Benito,7130018,State Assembly,30,Robert Rivas,DEM,28,****,****,25
 San Benito,7135106,State Assembly,30,Robert Rivas,DEM,163,5,3,155
 San Benito,7135109,State Assembly,30,Robert Rivas,DEM,816,23,40,753
-San Benito,7135317,State Assembly,30,Robert Rivas,DEM,41,,,37
-San Benito,7135318,State Assembly,30,Robert Rivas,DEM,130,,8,121
+San Benito,7135317,State Assembly,30,Robert Rivas,DEM,41,****,****,37
+San Benito,7135318,State Assembly,30,Robert Rivas,DEM,130,****,8,121
 San Benito,7135423,State Assembly,30,Robert Rivas,DEM,402,8,19,375
 San Benito,7235320,State Assembly,30,Robert Rivas,DEM,223,12,16,195
 San Benito,7235321,State Assembly,30,Robert Rivas,DEM,319,9,12,298
 San Benito,7335315,State Assembly,30,Robert Rivas,DEM,285,6,14,265
 San Benito,7335316,State Assembly,30,Robert Rivas,DEM,675,13,29,633
-San Benito,7335319,State Assembly,30,Robert Rivas,DEM,25,0,,25
+San Benito,7335319,State Assembly,30,Robert Rivas,DEM,25,0,****,25
 San Benito,7535136,State Assembly,30,Robert Rivas,DEM,939,22,57,860
 San Benito,9205001,State Assembly,30,Robert Rivas,DEM,464,3,10,451
 San Benito,9235255,State Assembly,30,Robert Rivas,DEM,0,0,0,0
 San Benito,9240001,State Assembly,30,Robert Rivas,DEM,700,15,36,649
-San Benito,9240004,State Assembly,30,Robert Rivas,DEM,6,,,4
+San Benito,9240004,State Assembly,30,Robert Rivas,DEM,6,****,****,4
 San Benito,9265000,State Assembly,30,Robert Rivas,DEM,753,26,61,666

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -53,7 +53,6 @@ class FileFormatTests(unittest.TestCase):
     def test_format(self):
         regex_non_whitespace = re.compile(r"\S")
         regex_consecutive_space = re.compile(r"\s{2,}")
-        regex_non_alphanumeric = re.compile(r"\w")
 
         for csv_file in FileFormatTests.__get_csv_files():
             short_path = os.path.relpath(csv_file, start=FileFormatTests.root_path)
@@ -97,12 +96,6 @@ class FileFormatTests(unittest.TestCase):
                             # Verify that there are no line breaks in the row (sometimes occurs in between quotes).
                             self.assertNotIn("\n", entry, f"File {short_path} has a newline character in row "
                                                           f"{reader.line_num}: {row}.")
-
-                            # Verify that the entry does not consist only of non-alphanumeric characters.
-                            if entry != "":
-                                self.assertRegex(entry, regex_non_alphanumeric, f"File {short_path} has an entry of "
-                                                                                f"only non-alphanumeric characters in"
-                                                                                f" row {reader.line_num}: {row}.")
 
                         # Verify that the row has actual content.
                         self.assertTrue(row_has_content, f"File {short_path} row {reader.line_num} is empty.")


### PR DESCRIPTION
This reverts the removal of non-alphanumeric entries made in pull request #207.  According to the [source data](https://github.com/openelections/openelections-sources-ca/blob/928b3925d7498af1ebb2ad60f5e2cbd85bd7202c/2020/general/San%20Benito%20CA%20SoVCountyPrecinctWithCountingGroups.xlsx), the presence of `****` denotes insufficient turnout, and the value is masked to protect voter privacy.  Our preference is to leave such placeholders in the data.

This also removes the test for non-alphanumeric entries to allow for such entries.
