### PR TITLE
Fix path to 2016 county files in tests

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+filterwarnings = ignore:A private pytest class or function was used.:pytest.PytestDeprecationWarning

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -21,7 +21,7 @@ columns = ['candidate', 'county', 'district', 'office', 'votes']
     ("2017", "0606", "special__general", ""),
     ("2017", "1003", "special__primary", ""),
 ])
-def test_data(year, date, election_type, county_directory):
+def test_data(subtests, year, date, election_type, county_directory):
     state_file = '{0}/{0}{1}__ca__{2}.csv'.format(
         year, date, election_type)
     state_data = pandas.read_csv(state_file, na_values='').fillna('')
@@ -29,17 +29,18 @@ def test_data(year, date, election_type, county_directory):
 
     county_file_pattern = os.path.join(year, county_directory, f"{year}{date}__ca__{election_type}__*__precinct.csv")
     for county_file in sorted(glob.glob(county_file_pattern)):
-        county_data = pandas.read_csv(county_file, na_values='').fillna('')
+        with subtests.test(msg=f"{county_file}"):
+            county_data = pandas.read_csv(county_file, na_values='').fillna('')
 
-        # Each county file should only contain a single county.
-        assert len(county_data.drop_duplicates(
-            ['county']).county.values) == 1
+            # Each county file should only contain a single county.
+            assert len(county_data.drop_duplicates(
+                ['county']).county.values) == 1
 
-        county = county_data.drop_duplicates(['county']).county.values[0]
-        county_data = county_data[columns].groupby(
-            columns[:-1]).sum()
-        state_cmp = state_data[state_data.county == county][
-            columns].groupby(columns[: -1]).sum()
+            county = county_data.drop_duplicates(['county']).county.values[0]
+            county_data = county_data[columns].groupby(
+                columns[:-1]).sum()
+            state_cmp = state_data[state_data.county == county][
+                columns].groupby(columns[: -1]).sum()
 
-        assert state_cmp.to_dict()['votes'] == county_data.to_dict()[
-            'votes'], '%s failed' % county
+            assert state_cmp.to_dict()['votes'] == county_data.to_dict()[
+                'votes'], '%s failed' % county

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import glob
+import os
 import pandas
 import pytest
 
@@ -8,25 +9,26 @@ import pytest
 columns = ['candidate', 'county', 'district', 'office', 'votes']
 
 
-@pytest.mark.parametrize("year,date,election_type", [
-    ("2014", "0603", "primary"),
-    ("2014", "1104", "general"),
-    ("2015", "0317", "special__primary"),
-    ("2015", "0519", "special__general"),
-    ("2016", "0405", "special__primary"),
-    ("2016", "0607", "primary"),
-    ("2016", "1108", "general"),
-    ("2017", "0404", "special__primary"),
-    ("2017", "0606", "special__general"),
-    ("2017", "1003", "special__primary"),
+@pytest.mark.parametrize("year,date,election_type,county_directory", [
+    ("2014", "0603", "primary", ""),
+    ("2014", "1104", "general", ""),
+    ("2015", "0317", "special__primary", ""),
+    ("2015", "0519", "special__general", ""),
+    ("2016", "0405", "special__primary", "counties"),
+    ("2016", "0607", "primary", "counties"),
+    ("2016", "1108", "general", "counties"),
+    ("2017", "0404", "special__primary", ""),
+    ("2017", "0606", "special__general", ""),
+    ("2017", "1003", "special__primary", ""),
 ])
-def test_data(year, date, election_type):
+def test_data(year, date, election_type, county_directory):
     state_file = '{0}/{0}{1}__ca__{2}.csv'.format(
         year, date, election_type)
     state_data = pandas.read_csv(state_file, na_values='').fillna('')
     state_data = state_data[state_data.votes != 0]
 
-    for county_file in sorted(glob.glob('{0}/{0}{1}__ca__{2}__*__precinct.csv'.format(year, date, election_type))):
+    county_file_pattern = os.path.join(year, county_directory, f"{year}{date}__ca__{election_type}__*__precinct.csv")
+    for county_file in sorted(glob.glob(county_file_pattern)):
         county_data = pandas.read_csv(county_file, na_values='').fillna('')
 
         # Each county file should only contain a single county.

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -9,25 +9,25 @@ import pytest
 columns = ['candidate', 'county', 'district', 'office', 'votes']
 
 
-@pytest.mark.parametrize("year,date,election_type,county_directory", [
-    ("2014", "0603", "primary", ""),
-    ("2014", "1104", "general", ""),
-    ("2015", "0317", "special__primary", ""),
-    ("2015", "0519", "special__general", ""),
-    ("2016", "0405", "special__primary", "counties"),
-    ("2016", "0607", "primary", "counties"),
-    ("2016", "1108", "general", "counties"),
-    ("2017", "0404", "special__primary", ""),
-    ("2017", "0606", "special__general", ""),
-    ("2017", "1003", "special__primary", ""),
+@pytest.mark.parametrize("year,date,election_type", [
+    ("2014", "0603", "primary"),
+    ("2014", "1104", "general"),
+    ("2015", "0317", "special__primary"),
+    ("2015", "0519", "special__general"),
+    ("2016", "0405", "special__primary"),
+    ("2016", "0607", "primary"),
+    ("2016", "1108", "general"),
+    ("2017", "0404", "special__primary"),
+    ("2017", "0606", "special__general"),
+    ("2017", "1003", "special__primary"),
 ])
-def test_data(subtests, year, date, election_type, county_directory):
+def test_data(subtests, year, date, election_type):
     state_file = '{0}/{0}{1}__ca__{2}.csv'.format(
         year, date, election_type)
     state_data = pandas.read_csv(state_file, na_values='').fillna('')
     state_data = state_data[state_data.votes != 0]
 
-    county_file_pattern = os.path.join(year, county_directory, f"{year}{date}__ca__{election_type}__*__precinct.csv")
+    county_file_pattern = os.path.join(year, "**", f"{year}{date}__ca__{election_type}__*__precinct.csv")
     for county_file in sorted(glob.glob(county_file_pattern)):
         with subtests.test(msg=f"{county_file}"):
             county_data = pandas.read_csv(county_file, na_values='').fillna('')


### PR DESCRIPTION
This modifies the test that compares state and county files to support county files that reside in a different directory.  The 2016 country files were moved in revision b052d555b0a46f1278c15c14f161a391c30a0727, which prevented the tests from running on these files.

We also make use of subtests so that all county failures are detected.  Previously, the tests would stop running after the first failure.

As such, many failures for the 2016 files are now apparent.  Some of these have old issues (#48, #68, #69, #80, #81, #82, #127) that might be related.