### PR TITLE
Update format tests

### DIFF
--- a/.github/workflows/format_tests.yml
+++ b/.github/workflows/format_tests.yml
@@ -24,7 +24,7 @@ jobs:
       uses: actions/checkout@v2.3.4
       with:
         repository: openelections/openelections-format-tests
-        ref: v0.1.0
+        ref: v1.0.0
         path: format_tests
 
     - name: Run format tests


### PR DESCRIPTION
This updates the format tests to version [1.0.0](https://github.com/openelections/openelections-format-tests/releases/tag/v1.0.0).  The tests now verify that the "votes" column contains values that represent integers.  This reveals the following error (see issue #221):

* 2020/20201103__ca__general__imperial__precinct.csv
```
  * There are 2 rows with votes that aren't integers:

  	Headers: ['county', 'precinct', 'office', 'district', 'party', 'candidate', 'votes', 'absentee', 'early_voting', 'election_day', 'mail']:
  	Row 1956: ['Imperial', '588270MB', 'President', '', '', 'Total Votes', '64.5', '0', '5', '5', '54.5']
  	Row 1958: ['Imperial', '588270MB', 'President', '', 'AI', 'ROQUE "ROCKY" DE LA FUENTE GUERRA', '0.5', '0', '0', '0', '0.5']
  ```