### PR TITLE
Fix non-integer votes in 2020 Imperial general file

### DIFF
--- a/2020/20201103__ca__general__imperial__precinct.csv
+++ b/2020/20201103__ca__general__imperial__precinct.csv
@@ -1952,15 +1952,15 @@ Imperial,588264MB,President,,GRN,HOWIE HAWKINS,0,0,0,0,0
 Imperial,588264MB,President,,LIB,JO JORGENSEN,0,0,0,0,0
 Imperial,588264MB,President,,PF,GLORIA LA RIVA,0,0,0,0,0
 Imperial,588264MB,President,,REP,DONALD J. TRUMP,0,0,0,0,0
-Imperial,588270MB,President,,,Times Cast,65,0,5,5,55
-Imperial,588270MB,President,,,Total Votes,64.5,0,5,5,54.5
+Imperial,588270MB,President,,,Times Cast,130,0,10,10,110
+Imperial,588270MB,President,,,Total Votes,129,0,10,10,109
 Imperial,588270MB,President,,,Write-in,0,0,0,0,0
-Imperial,588270MB,President,,AI,"ROQUE ""ROCKY"" DE LA FUENTE GUERRA",0.5,0,0,0,0.5
-Imperial,588270MB,President,,DEM,JOSEPH R. BIDEN,38,0,1.5,3,33.5
+Imperial,588270MB,President,,AI,"ROQUE ""ROCKY"" DE LA FUENTE GUERRA",1,0,0,0,1
+Imperial,588270MB,President,,DEM,JOSEPH R. BIDEN,76,0,3,6,67
 Imperial,588270MB,President,,GRN,HOWIE HAWKINS,0,0,0,0,0
-Imperial,588270MB,President,,LIB,JO JORGENSEN,1,0,0.5,0,0.5
+Imperial,588270MB,President,,LIB,JO JORGENSEN,2,0,1,0,1
 Imperial,588270MB,President,,PF,GLORIA LA RIVA,0,0,0,0,0
-Imperial,588270MB,President,,REP,DONALD J. TRUMP,25,0,3,2,20
+Imperial,588270MB,President,,REP,DONALD J. TRUMP,50,0,6,4,40
 Imperial,121004,U.S. House,51,,Times Cast,681,416,8,257,0
 Imperial,121004,U.S. House,51,,Total Votes,655,409,7,239,0
 Imperial,121004,U.S. House,51,DEM,JUAN C. VARGAS,534,349,6,179,0


### PR DESCRIPTION
Some values for precinct 588270MB were erroneously divided by 2.

This fixes #221, and should fix the test failures introduced in pull request #222.