### PR TITLE
Fix incorrect precinct in 2014 Fresno County primary file

### DIFF
--- a/2014/20140603__ca__primary__fresno__precinct.csv
+++ b/2014/20140603__ca__primary__fresno__precinct.csv
@@ -5029,7 +5029,7 @@ Fresno,0000082,Treasurer,,REP,Greg Conlon,265
 Fresno,0000082,Treasurer,,DEM,John Chiang,145
 Fresno,0000082,U.S. House,4,IND,Jeffrey D. Gerlach,62
 Fresno,0000082,U.S. House,4,REP,Tom McClintock,287
-Fresno,0000079,U.S. House,4,,"Arthur ""Art"" Moore",65
+Fresno,0000082,U.S. House,4,,"Arthur ""Art"" Moore",65
 Fresno,0000083,Attorney General,,REP,David King,31
 Fresno,0000083,Attorney General,,REP,John Haggerty,30
 Fresno,0000083,Attorney General,,LIB,Jonathan Jaech,6


### PR DESCRIPTION
This fixes an incorrect precinct in the 2014 Fresno County general file. According to [this source](https://www2.co.fresno.ca.us/2850/Results/SOV_CSV_20140603.txt), this entry belongs to precinct 0000082.