### PR TITLE
Fix incorrect precinct in 2014 Kern County primary file

### DIFF
--- a/2014/20140603__ca__primary__kern__precinct.csv
+++ b/2014/20140603__ca__primary__kern__precinct.csv
@@ -13221,7 +13221,7 @@ Kern,0040443,Treasurer,,GRN,Ellen H. Brown,6
 Kern,0040443,Treasurer,,REP,Greg Conlon,101
 Kern,0040443,Treasurer,,DEM,John Chiang,44
 Kern,0040443,U.S. House,23,REP,Kevin McCarthy,129
-Kern,0040441,U.S. House,23,DEM,Raul Garcia,1
+Kern,0040443,U.S. House,23,DEM,Raul Garcia,1
 Kern,0040444,Attorney General,,REP,David King,3
 Kern,0040444,Attorney General,,REP,John Haggerty,4
 Kern,0040444,Attorney General,,LIB,Jonathan Jaech,2


### PR DESCRIPTION
This fixes an incorrect precinct in the 2014 Kern County primary file.  According to [this archived source file](https://web.archive.org/web/20160605145259/https://elections.co.kern.ca.us/elections/SOVC/SOVC_June_3_2014_full.pdf), this entry for Raul Garcia should be associated with Precinct 0040443:

![image](https://user-images.githubusercontent.com/17345532/133823102-edcf48c8-a05a-4d3f-97b8-76dae68d3000.png)
![image](https://user-images.githubusercontent.com/17345532/133823064-5cb9a51a-f66d-4ab5-8b2c-758eae387ae7.png)

With these changes, we have
```
$ grep Garcia 2014/20140603__ca__primary__kern__precinct.csv
...
Kern,0040441,U.S. House,23,DEM,Raul Garcia,2
Kern,0040443,U.S. House,23,DEM,Raul Garcia,1
Kern,0040444,U.S. House,23,DEM,Raul Garcia,3
...
```