### PR TITLE
Use python 3.9 to run unit tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,6 +12,9 @@ jobs:
     steps:
     - name: Set up Python
       uses: actions/setup-python@v2
+      with:
+        python-version: 3.9
+
 
     - name: Check out source
       uses: actions/checkout@v2.3.4


### PR DESCRIPTION
There is some issue running the unit tests with python 3.10 that I haven't been able to look into.  Fixing the version of python will allow the tests to run in the meantime.