### PR TITLE
Add write-in candidates for 2016 Primary Humboldt Precinct data

### DIFF
--- a/2016/counties/20160607__ca__primary__humboldt__precinct.csv
+++ b/2016/counties/20160607__ca__primary__humboldt__precinct.csv
@@ -19,10 +19,12 @@ Humboldt,1CS-1,President,,DEM,Willie Wilson,1
 Humboldt,1CS-1,Proposition 50,,,No,62
 Humboldt,1CS-1,Proposition 50,,,Yes,305
 Humboldt,1CS-1,State Assembly,2,DEM,Jim Wood,291
+Humboldt,1CS-1,State Assembly,2,IND,Ken Anton,0
 Humboldt,1CS-1,U.S. House,2,REP,Dale K. Mensing,85
 Humboldt,1CS-1,U.S. House,2,DEM,Erin A. Schrode,27
 Humboldt,1CS-1,U.S. House,2,DEM,Jared W. Huffman,250
 Humboldt,1CS-1,U.S. House,2,IND,Matthew Robert Wookey,29
+Humboldt,1CS-1,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,1CS-1,U.S. Senate,,IND,Clive Grey,6
 Humboldt,1CS-1,U.S. Senate,,IND,Don J. Grundmann,2
 Humboldt,1CS-1,U.S. Senate,,REP,Don Krampe,4
@@ -66,10 +68,12 @@ Humboldt,1CS-2,President,,REP,Ted Cruz,15
 Humboldt,1CS-2,Proposition 50,,,No,78
 Humboldt,1CS-2,Proposition 50,,,Yes,338
 Humboldt,1CS-2,State Assembly,2,DEM,Jim Wood,317
+Humboldt,1CS-2,State Assembly,2,IND,Ken Anton,0
 Humboldt,1CS-2,U.S. House,2,REP,Dale K. Mensing,109
 Humboldt,1CS-2,U.S. House,2,DEM,Erin A. Schrode,31
 Humboldt,1CS-2,U.S. House,2,DEM,Jared W. Huffman,257
 Humboldt,1CS-2,U.S. House,2,IND,Matthew Robert Wookey,27
+Humboldt,1CS-2,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,1CS-2,U.S. Senate,,IND,Clive Grey,2
 Humboldt,1CS-2,U.S. Senate,,REP,Don Krampe,1
 Humboldt,1CS-2,U.S. Senate,,REP,Duf Sundheim,34
@@ -110,10 +114,12 @@ Humboldt,1CS-3,President,,DEM,Willie Wilson,1
 Humboldt,1CS-3,Proposition 50,,,No,87
 Humboldt,1CS-3,Proposition 50,,,Yes,306
 Humboldt,1CS-3,State Assembly,2,DEM,Jim Wood,302
+Humboldt,1CS-3,State Assembly,2,IND,Ken Anton,0
 Humboldt,1CS-3,U.S. House,2,REP,Dale K. Mensing,115
 Humboldt,1CS-3,U.S. House,2,DEM,Erin A. Schrode,25
 Humboldt,1CS-3,U.S. House,2,DEM,Jared W. Huffman,263
 Humboldt,1CS-3,U.S. House,2,IND,Matthew Robert Wookey,17
+Humboldt,1CS-3,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,1CS-3,U.S. Senate,,IND,Clive Grey,1
 Humboldt,1CS-3,U.S. Senate,,IND,Don J. Grundmann,1
 Humboldt,1CS-3,U.S. Senate,,REP,Don Krampe,7
@@ -158,10 +164,12 @@ Humboldt,1CS-4,President,,AIP,Wiley Drake,1
 Humboldt,1CS-4,Proposition 50,,,No,90
 Humboldt,1CS-4,Proposition 50,,,Yes,317
 Humboldt,1CS-4,State Assembly,2,DEM,Jim Wood,298
+Humboldt,1CS-4,State Assembly,2,IND,Ken Anton,0
 Humboldt,1CS-4,U.S. House,2,REP,Dale K. Mensing,116
 Humboldt,1CS-4,U.S. House,2,DEM,Erin A. Schrode,30
 Humboldt,1CS-4,U.S. House,2,DEM,Jared W. Huffman,239
 Humboldt,1CS-4,U.S. House,2,IND,Matthew Robert Wookey,36
+Humboldt,1CS-4,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,1CS-4,U.S. Senate,,IND,Clive Grey,3
 Humboldt,1CS-4,U.S. Senate,,IND,Don J. Grundmann,2
 Humboldt,1CS-4,U.S. Senate,,REP,Don Krampe,8
@@ -207,10 +215,12 @@ Humboldt,1E-36,President,,DEM,Willie Wilson,1
 Humboldt,1E-36,Proposition 50,,,No,97
 Humboldt,1E-36,Proposition 50,,,Yes,377
 Humboldt,1E-36,State Assembly,2,DEM,Jim Wood,364
+Humboldt,1E-36,State Assembly,2,IND,Ken Anton,0
 Humboldt,1E-36,U.S. House,2,REP,Dale K. Mensing,93
 Humboldt,1E-36,U.S. House,2,DEM,Erin A. Schrode,38
 Humboldt,1E-36,U.S. House,2,DEM,Jared W. Huffman,325
 Humboldt,1E-36,U.S. House,2,IND,Matthew Robert Wookey,44
+Humboldt,1E-36,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,1E-36,U.S. Senate,,IND,Clive Grey,2
 Humboldt,1E-36,U.S. Senate,,IND,Don J. Grundmann,1
 Humboldt,1E-36,U.S. Senate,,REP,Don Krampe,6
@@ -255,10 +265,12 @@ Humboldt,1E-43,President,,REP,Ted Cruz,18
 Humboldt,1E-43,Proposition 50,,,No,98
 Humboldt,1E-43,Proposition 50,,,Yes,332
 Humboldt,1E-43,State Assembly,2,DEM,Jim Wood,342
+Humboldt,1E-43,State Assembly,2,IND,Ken Anton,1
 Humboldt,1E-43,U.S. House,2,REP,Dale K. Mensing,91
 Humboldt,1E-43,U.S. House,2,DEM,Erin A. Schrode,36
 Humboldt,1E-43,U.S. House,2,DEM,Jared W. Huffman,305
 Humboldt,1E-43,U.S. House,2,IND,Matthew Robert Wookey,25
+Humboldt,1E-43,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,1E-43,U.S. Senate,,IND,Clive Grey,2
 Humboldt,1E-43,U.S. Senate,,IND,Don J. Grundmann,1
 Humboldt,1E-43,U.S. Senate,,REP,Don Krampe,4
@@ -302,10 +314,12 @@ Humboldt,1E-45,President,,REP,Ted Cruz,16
 Humboldt,1E-45,Proposition 50,,,No,81
 Humboldt,1E-45,Proposition 50,,,Yes,364
 Humboldt,1E-45,State Assembly,2,DEM,Jim Wood,322
+Humboldt,1E-45,State Assembly,2,IND,Ken Anton,0
 Humboldt,1E-45,U.S. House,2,REP,Dale K. Mensing,134
 Humboldt,1E-45,U.S. House,2,DEM,Erin A. Schrode,30
 Humboldt,1E-45,U.S. House,2,DEM,Jared W. Huffman,274
 Humboldt,1E-45,U.S. House,2,IND,Matthew Robert Wookey,23
+Humboldt,1E-45,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,1E-45,U.S. Senate,,IND,Don J. Grundmann,1
 Humboldt,1E-45,U.S. Senate,,REP,Don Krampe,6
 Humboldt,1E-45,U.S. Senate,,REP,Duf Sundheim,52
@@ -348,10 +362,12 @@ Humboldt,1E-55,President,,REP,Ted Cruz,13
 Humboldt,1E-55,Proposition 50,,,No,52
 Humboldt,1E-55,Proposition 50,,,Yes,250
 Humboldt,1E-55,State Assembly,2,DEM,Jim Wood,240
+Humboldt,1E-55,State Assembly,2,IND,Ken Anton,0
 Humboldt,1E-55,U.S. House,2,REP,Dale K. Mensing,65
 Humboldt,1E-55,U.S. House,2,DEM,Erin A. Schrode,27
 Humboldt,1E-55,U.S. House,2,DEM,Jared W. Huffman,201
 Humboldt,1E-55,U.S. House,2,IND,Matthew Robert Wookey,28
+Humboldt,1E-55,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,1E-55,U.S. Senate,,IND,Clive Grey,1
 Humboldt,1E-55,U.S. Senate,,REP,Don Krampe,3
 Humboldt,1E-55,U.S. Senate,,REP,Duf Sundheim,13
@@ -398,10 +414,12 @@ Humboldt,1ES-1,President,,DEM,Willie Wilson,1
 Humboldt,1ES-1,Proposition 50,,,No,93
 Humboldt,1ES-1,Proposition 50,,,Yes,419
 Humboldt,1ES-1,State Assembly,2,DEM,Jim Wood,421
+Humboldt,1ES-1,State Assembly,2,IND,Ken Anton,0
 Humboldt,1ES-1,U.S. House,2,REP,Dale K. Mensing,95
 Humboldt,1ES-1,U.S. House,2,DEM,Erin A. Schrode,61
 Humboldt,1ES-1,U.S. House,2,DEM,Jared W. Huffman,331
 Humboldt,1ES-1,U.S. House,2,IND,Matthew Robert Wookey,40
+Humboldt,1ES-1,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,1ES-1,U.S. Senate,,IND,Clive Grey,5
 Humboldt,1ES-1,U.S. Senate,,REP,Don Krampe,3
 Humboldt,1ES-1,U.S. Senate,,REP,Duf Sundheim,25
@@ -449,10 +467,12 @@ Humboldt,1F--1,President,,DEM,Willie Wilson,2
 Humboldt,1F--1,Proposition 50,,,No,99
 Humboldt,1F--1,Proposition 50,,,Yes,394
 Humboldt,1F--1,State Assembly,2,DEM,Jim Wood,394
+Humboldt,1F--1,State Assembly,2,IND,Ken Anton,0
 Humboldt,1F--1,U.S. House,2,REP,Dale K. Mensing,127
 Humboldt,1F--1,U.S. House,2,DEM,Erin A. Schrode,36
 Humboldt,1F--1,U.S. House,2,DEM,Jared W. Huffman,339
 Humboldt,1F--1,U.S. House,2,IND,Matthew Robert Wookey,22
+Humboldt,1F--1,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,1F--1,U.S. Senate,,IND,Clive Grey,1
 Humboldt,1F--1,U.S. Senate,,REP,Don Krampe,10
 Humboldt,1F--1,U.S. Senate,,REP,Duf Sundheim,34
@@ -498,10 +518,12 @@ Humboldt,1FS,President,,DEM,Willie Wilson,2
 Humboldt,1FS,Proposition 50,,,No,61
 Humboldt,1FS,Proposition 50,,,Yes,288
 Humboldt,1FS,State Assembly,2,DEM,Jim Wood,267
+Humboldt,1FS,State Assembly,2,IND,Ken Anton,0
 Humboldt,1FS,U.S. House,2,REP,Dale K. Mensing,136
 Humboldt,1FS,U.S. House,2,DEM,Erin A. Schrode,16
 Humboldt,1FS,U.S. House,2,DEM,Jared W. Huffman,210
 Humboldt,1FS,U.S. House,2,IND,Matthew Robert Wookey,18
+Humboldt,1FS,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,1FS,U.S. Senate,,IND,Clive Grey,4
 Humboldt,1FS,U.S. Senate,,IND,Don J. Grundmann,5
 Humboldt,1FS,U.S. Senate,,REP,Don Krampe,4
@@ -541,10 +563,12 @@ Humboldt,1FS-1,President,,AIP,Wiley Drake,1
 Humboldt,1FS-1,Proposition 50,,,No,23
 Humboldt,1FS-1,Proposition 50,,,Yes,64
 Humboldt,1FS-1,State Assembly,2,DEM,Jim Wood,56
+Humboldt,1FS-1,State Assembly,2,IND,Ken Anton,0
 Humboldt,1FS-1,U.S. House,2,REP,Dale K. Mensing,26
 Humboldt,1FS-1,U.S. House,2,DEM,Erin A. Schrode,10
 Humboldt,1FS-1,U.S. House,2,DEM,Jared W. Huffman,38
 Humboldt,1FS-1,U.S. House,2,IND,Matthew Robert Wookey,9
+Humboldt,1FS-1,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,1FS-1,U.S. Senate,,IND,Clive Grey,2
 Humboldt,1FS-1,U.S. Senate,,IND,Don J. Grundmann,1
 Humboldt,1FS-1,U.S. Senate,,REP,Don Krampe,1
@@ -577,10 +601,12 @@ Humboldt,1FS-4,President,,REP,Ted Cruz,9
 Humboldt,1FS-4,Proposition 50,,,No,28
 Humboldt,1FS-4,Proposition 50,,,Yes,71
 Humboldt,1FS-4,State Assembly,2,DEM,Jim Wood,79
+Humboldt,1FS-4,State Assembly,2,IND,Ken Anton,0
 Humboldt,1FS-4,U.S. House,2,REP,Dale K. Mensing,28
 Humboldt,1FS-4,U.S. House,2,DEM,Erin A. Schrode,7
 Humboldt,1FS-4,U.S. House,2,DEM,Jared W. Huffman,70
 Humboldt,1FS-4,U.S. House,2,IND,Matthew Robert Wookey,4
+Humboldt,1FS-4,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,1FS-4,U.S. Senate,,REP,Don Krampe,1
 Humboldt,1FS-4,U.S. Senate,,REP,Duf Sundheim,9
 Humboldt,1FS-4,U.S. Senate,,IND,Eleanor García,1
@@ -611,9 +637,11 @@ Humboldt,1FS-9,President,,DEM,Willie Wilson,1
 Humboldt,1FS-9,Proposition 50,,,No,13
 Humboldt,1FS-9,Proposition 50,,,Yes,53
 Humboldt,1FS-9,State Assembly,2,DEM,Jim Wood,47
+Humboldt,1FS-9,State Assembly,2,IND,Ken Anton,0
 Humboldt,1FS-9,U.S. House,2,REP,Dale K. Mensing,18
 Humboldt,1FS-9,U.S. House,2,DEM,Jared W. Huffman,43
 Humboldt,1FS-9,U.S. House,2,IND,Matthew Robert Wookey,6
+Humboldt,1FS-9,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,1FS-9,U.S. Senate,,REP,Don Krampe,3
 Humboldt,1FS-9,U.S. Senate,,REP,Duf Sundheim,5
 Humboldt,1FS-9,U.S. Senate,,LIB,Gail K. Lightfoot,2
@@ -645,10 +673,12 @@ Humboldt,1LU,President,,DEM,Willie Wilson,2
 Humboldt,1LU,Proposition 50,,,No,79
 Humboldt,1LU,Proposition 50,,,Yes,289
 Humboldt,1LU,State Assembly,2,DEM,Jim Wood,273
+Humboldt,1LU,State Assembly,2,IND,Ken Anton,0
 Humboldt,1LU,U.S. House,2,REP,Dale K. Mensing,95
 Humboldt,1LU,U.S. House,2,DEM,Erin A. Schrode,28
 Humboldt,1LU,U.S. House,2,DEM,Jared W. Huffman,223
 Humboldt,1LU,U.S. House,2,IND,Matthew Robert Wookey,26
+Humboldt,1LU,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,1LU,U.S. Senate,,IND,Clive Grey,1
 Humboldt,1LU,U.S. Senate,,IND,Don J. Grundmann,2
 Humboldt,1LU,U.S. Senate,,REP,Don Krampe,2
@@ -688,10 +718,12 @@ Humboldt,1MU,President,,REP,John R. Kasich,2
 Humboldt,1MU,Proposition 50,,,No,25
 Humboldt,1MU,Proposition 50,,,Yes,82
 Humboldt,1MU,State Assembly,2,DEM,Jim Wood,80
+Humboldt,1MU,State Assembly,2,IND,Ken Anton,0
 Humboldt,1MU,U.S. House,2,REP,Dale K. Mensing,21
 Humboldt,1MU,U.S. House,2,DEM,Erin A. Schrode,12
 Humboldt,1MU,U.S. House,2,DEM,Jared W. Huffman,71
 Humboldt,1MU,U.S. House,2,IND,Matthew Robert Wookey,8
+Humboldt,1MU,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,1MU,U.S. Senate,,IND,Clive Grey,1
 Humboldt,1MU,U.S. Senate,,IND,Don J. Grundmann,1
 Humboldt,1MU,U.S. Senate,,REP,Duf Sundheim,4
@@ -720,10 +752,12 @@ Humboldt,1MUF,President,,DEM,Hillary Clinton,7
 Humboldt,1MUF,Proposition 50,,,No,21
 Humboldt,1MUF,Proposition 50,,,Yes,67
 Humboldt,1MUF,State Assembly,2,DEM,Jim Wood,87
+Humboldt,1MUF,State Assembly,2,IND,Ken Anton,0
 Humboldt,1MUF,U.S. House,2,REP,Dale K. Mensing,5
 Humboldt,1MUF,U.S. House,2,DEM,Erin A. Schrode,8
 Humboldt,1MUF,U.S. House,2,DEM,Jared W. Huffman,85
 Humboldt,1MUF,U.S. House,2,IND,Matthew Robert Wookey,3
+Humboldt,1MUF,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,1MUF,U.S. Senate,,DEM,Emory Rodgers,1
 Humboldt,1MUF,U.S. Senate,,LIB,Gail K. Lightfoot,2
 Humboldt,1MUF,U.S. Senate,,IND,Jason Hanania,3
@@ -747,10 +781,12 @@ Humboldt,1RV-2,President,,REP,Ted Cruz,4
 Humboldt,1RV-2,Proposition 50,,,No,9
 Humboldt,1RV-2,Proposition 50,,,Yes,52
 Humboldt,1RV-2,State Assembly,2,DEM,Jim Wood,41
+Humboldt,1RV-2,State Assembly,2,IND,Ken Anton,0
 Humboldt,1RV-2,U.S. House,2,REP,Dale K. Mensing,20
 Humboldt,1RV-2,U.S. House,2,DEM,Erin A. Schrode,1
 Humboldt,1RV-2,U.S. House,2,DEM,Jared W. Huffman,38
 Humboldt,1RV-2,U.S. House,2,IND,Matthew Robert Wookey,5
+Humboldt,1RV-2,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,1RV-2,U.S. Senate,,IND,Clive Grey,1
 Humboldt,1RV-2,U.S. Senate,,REP,Don Krampe,1
 Humboldt,1RV-2,U.S. Senate,,REP,Duf Sundheim,4
@@ -783,10 +819,12 @@ Humboldt,1SB-1,President,,AIP,Wiley Drake,1
 Humboldt,1SB-1,Proposition 50,,,No,108
 Humboldt,1SB-1,Proposition 50,,,Yes,527
 Humboldt,1SB-1,State Assembly,2,DEM,Jim Wood,469
+Humboldt,1SB-1,State Assembly,2,IND,Ken Anton,0
 Humboldt,1SB-1,U.S. House,2,REP,Dale K. Mensing,180
 Humboldt,1SB-1,U.S. House,2,DEM,Erin A. Schrode,41
 Humboldt,1SB-1,U.S. House,2,DEM,Jared W. Huffman,389
 Humboldt,1SB-1,U.S. House,2,IND,Matthew Robert Wookey,43
+Humboldt,1SB-1,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,1SB-1,U.S. Senate,,IND,Clive Grey,3
 Humboldt,1SB-1,U.S. Senate,,REP,Don Krampe,6
 Humboldt,1SB-1,U.S. Senate,,REP,Duf Sundheim,37
@@ -838,10 +876,12 @@ Humboldt,1SB-4,President,,DEM,Willie Wilson,1
 Humboldt,1SB-4,Proposition 50,,,No,115
 Humboldt,1SB-4,Proposition 50,,,Yes,436
 Humboldt,1SB-4,State Assembly,2,DEM,Jim Wood,414
+Humboldt,1SB-4,State Assembly,2,IND,Ken Anton,0
 Humboldt,1SB-4,U.S. House,2,REP,Dale K. Mensing,137
 Humboldt,1SB-4,U.S. House,2,DEM,Erin A. Schrode,39
 Humboldt,1SB-4,U.S. House,2,DEM,Jared W. Huffman,335
 Humboldt,1SB-4,U.S. House,2,IND,Matthew Robert Wookey,52
+Humboldt,1SB-4,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,1SB-4,U.S. Senate,,IND,Clive Grey,2
 Humboldt,1SB-4,U.S. Senate,,IND,Don J. Grundmann,1
 Humboldt,1SB-4,U.S. Senate,,REP,Don Krampe,6
@@ -886,10 +926,12 @@ Humboldt,1SB10,President,,REP,Ted Cruz,29
 Humboldt,1SB10,Proposition 50,,,No,97
 Humboldt,1SB10,Proposition 50,,,Yes,418
 Humboldt,1SB10,State Assembly,2,DEM,Jim Wood,371
+Humboldt,1SB10,State Assembly,2,IND,Ken Anton,0
 Humboldt,1SB10,U.S. House,2,REP,Dale K. Mensing,124
 Humboldt,1SB10,U.S. House,2,DEM,Erin A. Schrode,29
 Humboldt,1SB10,U.S. House,2,DEM,Jared W. Huffman,345
 Humboldt,1SB10,U.S. House,2,IND,Matthew Robert Wookey,32
+Humboldt,1SB10,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,1SB10,U.S. Senate,,IND,Clive Grey,5
 Humboldt,1SB10,U.S. Senate,,IND,Don J. Grundmann,3
 Humboldt,1SB10,U.S. Senate,,REP,Don Krampe,3
@@ -928,10 +970,12 @@ Humboldt,1SB12,President,,REP,Ted Cruz,4
 Humboldt,1SB12,Proposition 50,,,No,9
 Humboldt,1SB12,Proposition 50,,,Yes,43
 Humboldt,1SB12,State Assembly,2,DEM,Jim Wood,32
+Humboldt,1SB12,State Assembly,2,IND,Ken Anton,0
 Humboldt,1SB12,U.S. House,2,REP,Dale K. Mensing,14
 Humboldt,1SB12,U.S. House,2,DEM,Erin A. Schrode,4
 Humboldt,1SB12,U.S. House,2,DEM,Jared W. Huffman,28
 Humboldt,1SB12,U.S. House,2,IND,Matthew Robert Wookey,2
+Humboldt,1SB12,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,1SB12,U.S. Senate,,IND,Don J. Grundmann,1
 Humboldt,1SB12,U.S. Senate,,REP,Duf Sundheim,5
 Humboldt,1SB12,U.S. Senate,,REP,Greg Conlon,4
@@ -959,10 +1003,12 @@ Humboldt,1SU,President,,DEM,Willie Wilson,1
 Humboldt,1SU,Proposition 50,,,No,34
 Humboldt,1SU,Proposition 50,,,Yes,172
 Humboldt,1SU,State Assembly,2,DEM,Jim Wood,151
+Humboldt,1SU,State Assembly,2,IND,Ken Anton,0
 Humboldt,1SU,U.S. House,2,REP,Dale K. Mensing,70
 Humboldt,1SU,U.S. House,2,DEM,Erin A. Schrode,17
 Humboldt,1SU,U.S. House,2,DEM,Jared W. Huffman,102
 Humboldt,1SU,U.S. House,2,IND,Matthew Robert Wookey,27
+Humboldt,1SU,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,1SU,U.S. Senate,,IND,Clive Grey,1
 Humboldt,1SU,U.S. Senate,,IND,Don J. Grundmann,2
 Humboldt,1SU,U.S. Senate,,REP,Don Krampe,5
@@ -1002,10 +1048,12 @@ Humboldt,2BV-1,President,,REP,Ted Cruz,7
 Humboldt,2BV-1,Proposition 50,,,No,27
 Humboldt,2BV-1,Proposition 50,,,Yes,131
 Humboldt,2BV-1,State Assembly,2,DEM,Jim Wood,121
+Humboldt,2BV-1,State Assembly,2,IND,Ken Anton,0
 Humboldt,2BV-1,U.S. House,2,REP,Dale K. Mensing,34
 Humboldt,2BV-1,U.S. House,2,DEM,Erin A. Schrode,13
 Humboldt,2BV-1,U.S. House,2,DEM,Jared W. Huffman,100
 Humboldt,2BV-1,U.S. House,2,IND,Matthew Robert Wookey,18
+Humboldt,2BV-1,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,2BV-1,U.S. Senate,,IND,Clive Grey,1
 Humboldt,2BV-1,U.S. Senate,,IND,Don J. Grundmann,1
 Humboldt,2BV-1,U.S. Senate,,REP,Don Krampe,3
@@ -1042,10 +1090,12 @@ Humboldt,2CU,President,,REP,Ted Cruz,12
 Humboldt,2CU,Proposition 50,,,No,64
 Humboldt,2CU,Proposition 50,,,Yes,143
 Humboldt,2CU,State Assembly,2,DEM,Jim Wood,147
+Humboldt,2CU,State Assembly,2,IND,Ken Anton,0
 Humboldt,2CU,U.S. House,2,REP,Dale K. Mensing,64
 Humboldt,2CU,U.S. House,2,DEM,Erin A. Schrode,13
 Humboldt,2CU,U.S. House,2,DEM,Jared W. Huffman,127
 Humboldt,2CU,U.S. House,2,IND,Matthew Robert Wookey,15
+Humboldt,2CU,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,2CU,U.S. Senate,,IND,Clive Grey,2
 Humboldt,2CU,U.S. Senate,,IND,Don J. Grundmann,2
 Humboldt,2CU,U.S. Senate,,REP,Don Krampe,8
@@ -1093,10 +1143,12 @@ Humboldt,2F--2,President,,DEM,Willie Wilson,1
 Humboldt,2F--2,Proposition 50,,,No,94
 Humboldt,2F--2,Proposition 50,,,Yes,359
 Humboldt,2F--2,State Assembly,2,DEM,Jim Wood,336
+Humboldt,2F--2,State Assembly,2,IND,Ken Anton,0
 Humboldt,2F--2,U.S. House,2,REP,Dale K. Mensing,133
 Humboldt,2F--2,U.S. House,2,DEM,Erin A. Schrode,35
 Humboldt,2F--2,U.S. House,2,DEM,Jared W. Huffman,280
 Humboldt,2F--2,U.S. House,2,IND,Matthew Robert Wookey,32
+Humboldt,2F--2,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,2F--2,U.S. Senate,,IND,Clive Grey,2
 Humboldt,2F--2,U.S. Senate,,IND,Don J. Grundmann,2
 Humboldt,2F--2,U.S. Senate,,REP,Don Krampe,9
@@ -1144,10 +1196,12 @@ Humboldt,2F--3,President,,DEM,Willie Wilson,1
 Humboldt,2F--3,Proposition 50,,,No,51
 Humboldt,2F--3,Proposition 50,,,Yes,277
 Humboldt,2F--3,State Assembly,2,DEM,Jim Wood,249
+Humboldt,2F--3,State Assembly,2,IND,Ken Anton,0
 Humboldt,2F--3,U.S. House,2,REP,Dale K. Mensing,78
 Humboldt,2F--3,U.S. House,2,DEM,Erin A. Schrode,25
 Humboldt,2F--3,U.S. House,2,DEM,Jared W. Huffman,213
 Humboldt,2F--3,U.S. House,2,IND,Matthew Robert Wookey,26
+Humboldt,2F--3,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,2F--3,U.S. Senate,,IND,Clive Grey,2
 Humboldt,2F--3,U.S. Senate,,IND,Don J. Grundmann,2
 Humboldt,2F--3,U.S. Senate,,REP,Don Krampe,5
@@ -1188,10 +1242,12 @@ Humboldt,2F--4,President,,DEM,Willie Wilson,4
 Humboldt,2F--4,Proposition 50,,,No,85
 Humboldt,2F--4,Proposition 50,,,Yes,347
 Humboldt,2F--4,State Assembly,2,DEM,Jim Wood,333
+Humboldt,2F--4,State Assembly,2,IND,Ken Anton,0
 Humboldt,2F--4,U.S. House,2,REP,Dale K. Mensing,101
 Humboldt,2F--4,U.S. House,2,DEM,Erin A. Schrode,31
 Humboldt,2F--4,U.S. House,2,DEM,Jared W. Huffman,251
 Humboldt,2F--4,U.S. House,2,IND,Matthew Robert Wookey,48
+Humboldt,2F--4,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,2F--4,U.S. Senate,,IND,Clive Grey,1
 Humboldt,2F--4,U.S. Senate,,IND,Don J. Grundmann,4
 Humboldt,2F--4,U.S. Senate,,REP,Don Krampe,8
@@ -1242,10 +1298,12 @@ Humboldt,2F-R1,President,,REP,Ted Cruz,26
 Humboldt,2F-R1,Proposition 50,,,No,131
 Humboldt,2F-R1,Proposition 50,,,Yes,412
 Humboldt,2F-R1,State Assembly,2,DEM,Jim Wood,386
+Humboldt,2F-R1,State Assembly,2,IND,Ken Anton,1
 Humboldt,2F-R1,U.S. House,2,REP,Dale K. Mensing,173
 Humboldt,2F-R1,U.S. House,2,DEM,Erin A. Schrode,32
 Humboldt,2F-R1,U.S. House,2,DEM,Jared W. Huffman,304
 Humboldt,2F-R1,U.S. House,2,IND,Matthew Robert Wookey,43
+Humboldt,2F-R1,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,2F-R1,U.S. Senate,,IND,Clive Grey,3
 Humboldt,2F-R1,U.S. Senate,,IND,Don J. Grundmann,5
 Humboldt,2F-R1,U.S. Senate,,REP,Don Krampe,10
@@ -1293,10 +1351,12 @@ Humboldt,2F-R2,President,,DEM,Willie Wilson,3
 Humboldt,2F-R2,Proposition 50,,,No,71
 Humboldt,2F-R2,Proposition 50,,,Yes,261
 Humboldt,2F-R2,State Assembly,2,DEM,Jim Wood,241
+Humboldt,2F-R2,State Assembly,2,IND,Ken Anton,0
 Humboldt,2F-R2,U.S. House,2,REP,Dale K. Mensing,119
 Humboldt,2F-R2,U.S. House,2,DEM,Erin A. Schrode,18
 Humboldt,2F-R2,U.S. House,2,DEM,Jared W. Huffman,182
 Humboldt,2F-R2,U.S. House,2,IND,Matthew Robert Wookey,31
+Humboldt,2F-R2,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,2F-R2,U.S. Senate,,IND,Clive Grey,2
 Humboldt,2F-R2,U.S. Senate,,IND,Don J. Grundmann,2
 Humboldt,2F-R2,U.S. Senate,,REP,Don Krampe,2
@@ -1343,10 +1403,12 @@ Humboldt,2F-R3,President,,DEM,Willie Wilson,2
 Humboldt,2F-R3,Proposition 50,,,No,68
 Humboldt,2F-R3,Proposition 50,,,Yes,278
 Humboldt,2F-R3,State Assembly,2,DEM,Jim Wood,235
+Humboldt,2F-R3,State Assembly,2,IND,Ken Anton,0
 Humboldt,2F-R3,U.S. House,2,REP,Dale K. Mensing,120
 Humboldt,2F-R3,U.S. House,2,DEM,Erin A. Schrode,20
 Humboldt,2F-R3,U.S. House,2,DEM,Jared W. Huffman,184
 Humboldt,2F-R3,U.S. House,2,IND,Matthew Robert Wookey,27
+Humboldt,2F-R3,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,2F-R3,U.S. Senate,,IND,Clive Grey,4
 Humboldt,2F-R3,U.S. Senate,,IND,Don J. Grundmann,3
 Humboldt,2F-R3,U.S. Senate,,REP,Don Krampe,11
@@ -1394,10 +1456,12 @@ Humboldt,2F-R4,President,,DEM,Willie Wilson,1
 Humboldt,2F-R4,Proposition 50,,,No,72
 Humboldt,2F-R4,Proposition 50,,,Yes,302
 Humboldt,2F-R4,State Assembly,2,DEM,Jim Wood,271
+Humboldt,2F-R4,State Assembly,2,IND,Ken Anton,0
 Humboldt,2F-R4,U.S. House,2,REP,Dale K. Mensing,105
 Humboldt,2F-R4,U.S. House,2,DEM,Erin A. Schrode,25
 Humboldt,2F-R4,U.S. House,2,DEM,Jared W. Huffman,198
 Humboldt,2F-R4,U.S. House,2,IND,Matthew Robert Wookey,46
+Humboldt,2F-R4,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,2F-R4,U.S. Senate,,IND,Clive Grey,1
 Humboldt,2F-R4,U.S. Senate,,IND,Don J. Grundmann,3
 Humboldt,2F-R4,U.S. Senate,,REP,Don Krampe,5
@@ -1446,10 +1510,12 @@ Humboldt,2HV-1,President,,DEM,Willie Wilson,1
 Humboldt,2HV-1,Proposition 50,,,No,76
 Humboldt,2HV-1,Proposition 50,,,Yes,306
 Humboldt,2HV-1,State Assembly,2,DEM,Jim Wood,277
+Humboldt,2HV-1,State Assembly,2,IND,Ken Anton,0
 Humboldt,2HV-1,U.S. House,2,REP,Dale K. Mensing,139
 Humboldt,2HV-1,U.S. House,2,DEM,Erin A. Schrode,26
 Humboldt,2HV-1,U.S. House,2,DEM,Jared W. Huffman,217
 Humboldt,2HV-1,U.S. House,2,IND,Matthew Robert Wookey,20
+Humboldt,2HV-1,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,2HV-1,U.S. Senate,,IND,Clive Grey,6
 Humboldt,2HV-1,U.S. Senate,,IND,Don J. Grundmann,1
 Humboldt,2HV-1,U.S. Senate,,REP,Don Krampe,1
@@ -1484,9 +1550,11 @@ Humboldt,2MR,President,,DEM,Hillary Clinton,1
 Humboldt,2MR,Proposition 50,,,No,6
 Humboldt,2MR,Proposition 50,,,Yes,7
 Humboldt,2MR,State Assembly,2,DEM,Jim Wood,10
+Humboldt,2MR,State Assembly,2,IND,Ken Anton,0
 Humboldt,2MR,U.S. House,2,REP,Dale K. Mensing,5
 Humboldt,2MR,U.S. House,2,DEM,Jared W. Huffman,7
 Humboldt,2MR,U.S. House,2,IND,Matthew Robert Wookey,1
+Humboldt,2MR,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,2MR,U.S. Senate,,IND,Don J. Grundmann,1
 Humboldt,2MR,U.S. Senate,,REP,Duf Sundheim,1
 Humboldt,2MR,U.S. Senate,,DEM,Emory Rodgers,3
@@ -1512,10 +1580,12 @@ Humboldt,2R--1,President,,AIP,Thomas Hoefling,1
 Humboldt,2R--1,Proposition 50,,,No,52
 Humboldt,2R--1,Proposition 50,,,Yes,234
 Humboldt,2R--1,State Assembly,2,DEM,Jim Wood,230
+Humboldt,2R--1,State Assembly,2,IND,Ken Anton,0
 Humboldt,2R--1,U.S. House,2,REP,Dale K. Mensing,85
 Humboldt,2R--1,U.S. House,2,DEM,Erin A. Schrode,32
 Humboldt,2R--1,U.S. House,2,DEM,Jared W. Huffman,149
 Humboldt,2R--1,U.S. House,2,IND,Matthew Robert Wookey,36
+Humboldt,2R--1,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,2R--1,U.S. Senate,,IND,Clive Grey,2
 Humboldt,2R--1,U.S. Senate,,IND,Don J. Grundmann,5
 Humboldt,2R--1,U.S. Senate,,REP,Don Krampe,5
@@ -1561,10 +1631,12 @@ Humboldt,2R--2,President,,AIP,Wiley Drake,1
 Humboldt,2R--2,Proposition 50,,,No,60
 Humboldt,2R--2,Proposition 50,,,Yes,269
 Humboldt,2R--2,State Assembly,2,DEM,Jim Wood,234
+Humboldt,2R--2,State Assembly,2,IND,Ken Anton,0
 Humboldt,2R--2,U.S. House,2,REP,Dale K. Mensing,114
 Humboldt,2R--2,U.S. House,2,DEM,Erin A. Schrode,16
 Humboldt,2R--2,U.S. House,2,DEM,Jared W. Huffman,168
 Humboldt,2R--2,U.S. House,2,IND,Matthew Robert Wookey,43
+Humboldt,2R--2,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,2R--2,U.S. Senate,,IND,Clive Grey,1
 Humboldt,2R--2,U.S. Senate,,IND,Don J. Grundmann,3
 Humboldt,2R--2,U.S. Senate,,REP,Don Krampe,3
@@ -1605,10 +1677,12 @@ Humboldt,2RV-1,President,,REP,Ted Cruz,3
 Humboldt,2RV-1,Proposition 50,,,No,23
 Humboldt,2RV-1,Proposition 50,,,Yes,122
 Humboldt,2RV-1,State Assembly,2,DEM,Jim Wood,92
+Humboldt,2RV-1,State Assembly,2,IND,Ken Anton,0
 Humboldt,2RV-1,U.S. House,2,REP,Dale K. Mensing,46
 Humboldt,2RV-1,U.S. House,2,DEM,Erin A. Schrode,7
 Humboldt,2RV-1,U.S. House,2,DEM,Jared W. Huffman,83
 Humboldt,2RV-1,U.S. House,2,IND,Matthew Robert Wookey,13
+Humboldt,2RV-1,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,2RV-1,U.S. Senate,,IND,Don J. Grundmann,2
 Humboldt,2RV-1,U.S. Senate,,REP,Don Krampe,5
 Humboldt,2RV-1,U.S. Senate,,REP,Duf Sundheim,14
@@ -1637,10 +1711,12 @@ Humboldt,2SH-1,President,,REP,Jim Gilmore,1
 Humboldt,2SH-1,Proposition 50,,,No,29
 Humboldt,2SH-1,Proposition 50,,,Yes,73
 Humboldt,2SH-1,State Assembly,2,DEM,Jim Wood,92
+Humboldt,2SH-1,State Assembly,2,IND,Ken Anton,0
 Humboldt,2SH-1,U.S. House,2,REP,Dale K. Mensing,9
 Humboldt,2SH-1,U.S. House,2,DEM,Erin A. Schrode,22
 Humboldt,2SH-1,U.S. House,2,DEM,Jared W. Huffman,81
 Humboldt,2SH-1,U.S. House,2,IND,Matthew Robert Wookey,6
+Humboldt,2SH-1,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,2SH-1,U.S. Senate,,DEM,Emory Rodgers,1
 Humboldt,2SH-1,U.S. Senate,,LIB,Gail K. Lightfoot,8
 Humboldt,2SH-1,U.S. Senate,,IND,Jason Hanania,1
@@ -1663,10 +1739,12 @@ Humboldt,2SH-2,President,,PAF,Monica Moorehead,1
 Humboldt,2SH-2,Proposition 50,,,No,22
 Humboldt,2SH-2,Proposition 50,,,Yes,42
 Humboldt,2SH-2,State Assembly,2,DEM,Jim Wood,47
+Humboldt,2SH-2,State Assembly,2,IND,Ken Anton,0
 Humboldt,2SH-2,U.S. House,2,REP,Dale K. Mensing,18
 Humboldt,2SH-2,U.S. House,2,DEM,Erin A. Schrode,13
 Humboldt,2SH-2,U.S. House,2,DEM,Jared W. Huffman,28
 Humboldt,2SH-2,U.S. House,2,IND,Matthew Robert Wookey,10
+Humboldt,2SH-2,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,2SH-2,U.S. Senate,,IND,Clive Grey,2
 Humboldt,2SH-2,U.S. Senate,,REP,Don Krampe,1
 Humboldt,2SH-2,U.S. Senate,,REP,Duf Sundheim,4
@@ -1690,10 +1768,12 @@ Humboldt,2SH-3,President,,DEM,Hillary Clinton,4
 Humboldt,2SH-3,Proposition 50,,,No,11
 Humboldt,2SH-3,Proposition 50,,,Yes,49
 Humboldt,2SH-3,State Assembly,2,DEM,Jim Wood,53
+Humboldt,2SH-3,State Assembly,2,IND,Ken Anton,0
 Humboldt,2SH-3,U.S. House,2,REP,Dale K. Mensing,15
 Humboldt,2SH-3,U.S. House,2,DEM,Erin A. Schrode,6
 Humboldt,2SH-3,U.S. House,2,DEM,Jared W. Huffman,37
 Humboldt,2SH-3,U.S. House,2,IND,Matthew Robert Wookey,6
+Humboldt,2SH-3,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,2SH-3,U.S. Senate,,IND,Clive Grey,1
 Humboldt,2SH-3,U.S. Senate,,REP,Don Krampe,2
 Humboldt,2SH-3,U.S. Senate,,REP,Duf Sundheim,3
@@ -1722,10 +1802,12 @@ Humboldt,2SH-4,President,,REP,Ted Cruz,2
 Humboldt,2SH-4,Proposition 50,,,No,71
 Humboldt,2SH-4,Proposition 50,,,Yes,292
 Humboldt,2SH-4,State Assembly,2,DEM,Jim Wood,317
+Humboldt,2SH-4,State Assembly,2,IND,Ken Anton,0
 Humboldt,2SH-4,U.S. House,2,REP,Dale K. Mensing,52
 Humboldt,2SH-4,U.S. House,2,DEM,Erin A. Schrode,46
 Humboldt,2SH-4,U.S. House,2,DEM,Jared W. Huffman,280
 Humboldt,2SH-4,U.S. House,2,IND,Matthew Robert Wookey,20
+Humboldt,2SH-4,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,2SH-4,U.S. Senate,,IND,Clive Grey,2
 Humboldt,2SH-4,U.S. Senate,,IND,Don J. Grundmann,1
 Humboldt,2SH-4,U.S. Senate,,REP,Duf Sundheim,10
@@ -1767,10 +1849,12 @@ Humboldt,2SH-5,President,,DEM,Willie Wilson,3
 Humboldt,2SH-5,Proposition 50,,,No,103
 Humboldt,2SH-5,Proposition 50,,,Yes,357
 Humboldt,2SH-5,State Assembly,2,DEM,Jim Wood,388
+Humboldt,2SH-5,State Assembly,2,IND,Ken Anton,0
 Humboldt,2SH-5,U.S. House,2,REP,Dale K. Mensing,92
 Humboldt,2SH-5,U.S. House,2,DEM,Erin A. Schrode,65
 Humboldt,2SH-5,U.S. House,2,DEM,Jared W. Huffman,311
 Humboldt,2SH-5,U.S. House,2,IND,Matthew Robert Wookey,31
+Humboldt,2SH-5,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,2SH-5,U.S. Senate,,IND,Clive Grey,3
 Humboldt,2SH-5,U.S. Senate,,REP,Don Krampe,1
 Humboldt,2SH-5,U.S. Senate,,REP,Duf Sundheim,10
@@ -1805,10 +1889,12 @@ Humboldt,2SH-7,President,,DEM,Hillary Clinton,1
 Humboldt,2SH-7,Proposition 50,,,No,8
 Humboldt,2SH-7,Proposition 50,,,Yes,22
 Humboldt,2SH-7,State Assembly,2,DEM,Jim Wood,26
+Humboldt,2SH-7,State Assembly,2,IND,Ken Anton,0
 Humboldt,2SH-7,U.S. House,2,REP,Dale K. Mensing,6
 Humboldt,2SH-7,U.S. House,2,DEM,Erin A. Schrode,12
 Humboldt,2SH-7,U.S. House,2,DEM,Jared W. Huffman,22
 Humboldt,2SH-7,U.S. House,2,IND,Matthew Robert Wookey,1
+Humboldt,2SH-7,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,2SH-7,U.S. Senate,,IND,Clive Grey,1
 Humboldt,2SH-7,U.S. Senate,,REP,Duf Sundheim,3
 Humboldt,2SH-7,U.S. Senate,,DEM,Kamala D. Harris,18
@@ -1828,10 +1914,12 @@ Humboldt,2SH-8,President,,REP,Ted Cruz,1
 Humboldt,2SH-8,Proposition 50,,,No,9
 Humboldt,2SH-8,Proposition 50,,,Yes,61
 Humboldt,2SH-8,State Assembly,2,DEM,Jim Wood,61
+Humboldt,2SH-8,State Assembly,2,IND,Ken Anton,0
 Humboldt,2SH-8,U.S. House,2,REP,Dale K. Mensing,15
 Humboldt,2SH-8,U.S. House,2,DEM,Erin A. Schrode,9
 Humboldt,2SH-8,U.S. House,2,DEM,Jared W. Huffman,49
 Humboldt,2SH-8,U.S. House,2,IND,Matthew Robert Wookey,4
+Humboldt,2SH-8,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,2SH-8,U.S. Senate,,REP,Don Krampe,3
 Humboldt,2SH-8,U.S. Senate,,REP,Duf Sundheim,3
 Humboldt,2SH-8,U.S. Senate,,LIB,Gail K. Lightfoot,1
@@ -1861,10 +1949,12 @@ Humboldt,2SHF1,President,,DEM,Willie Wilson,1
 Humboldt,2SHF1,Proposition 50,,,No,28
 Humboldt,2SHF1,Proposition 50,,,Yes,67
 Humboldt,2SHF1,State Assembly,2,DEM,Jim Wood,72
+Humboldt,2SHF1,State Assembly,2,IND,Ken Anton,0
 Humboldt,2SHF1,U.S. House,2,REP,Dale K. Mensing,30
 Humboldt,2SHF1,U.S. House,2,DEM,Erin A. Schrode,12
 Humboldt,2SHF1,U.S. House,2,DEM,Jared W. Huffman,64
 Humboldt,2SHF1,U.S. House,2,IND,Matthew Robert Wookey,3
+Humboldt,2SHF1,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,2SHF1,U.S. Senate,,IND,Clive Grey,1
 Humboldt,2SHF1,U.S. Senate,,REP,Don Krampe,1
 Humboldt,2SHF1,U.S. Senate,,IND,Eleanor García,1
@@ -1892,10 +1982,12 @@ Humboldt,2SHR1,President,,AIP,Thomas Hoefling,1
 Humboldt,2SHR1,Proposition 50,,,No,26
 Humboldt,2SHR1,Proposition 50,,,Yes,64
 Humboldt,2SHR1,State Assembly,2,DEM,Jim Wood,73
+Humboldt,2SHR1,State Assembly,2,IND,Ken Anton,0
 Humboldt,2SHR1,U.S. House,2,REP,Dale K. Mensing,7
 Humboldt,2SHR1,U.S. House,2,DEM,Erin A. Schrode,16
 Humboldt,2SHR1,U.S. House,2,DEM,Jared W. Huffman,68
 Humboldt,2SHR1,U.S. House,2,IND,Matthew Robert Wookey,2
+Humboldt,2SHR1,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,2SHR1,U.S. Senate,,REP,Duf Sundheim,4
 Humboldt,2SHR1,U.S. Senate,,LIB,Gail K. Lightfoot,6
 Humboldt,2SHR1,U.S. Senate,,DEM,Kamala D. Harris,47
@@ -1919,10 +2011,12 @@ Humboldt,2SHR2,President,,REP,Ted Cruz,1
 Humboldt,2SHR2,Proposition 50,,,No,30
 Humboldt,2SHR2,Proposition 50,,,Yes,79
 Humboldt,2SHR2,State Assembly,2,DEM,Jim Wood,78
+Humboldt,2SHR2,State Assembly,2,IND,Ken Anton,0
 Humboldt,2SHR2,U.S. House,2,REP,Dale K. Mensing,38
 Humboldt,2SHR2,U.S. House,2,DEM,Erin A. Schrode,9
 Humboldt,2SHR2,U.S. House,2,DEM,Jared W. Huffman,54
 Humboldt,2SHR2,U.S. House,2,IND,Matthew Robert Wookey,12
+Humboldt,2SHR2,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,2SHR2,U.S. Senate,,IND,Clive Grey,1
 Humboldt,2SHR2,U.S. Senate,,REP,Don Krampe,2
 Humboldt,2SHR2,U.S. Senate,,REP,Duf Sundheim,9
@@ -1961,10 +2055,12 @@ Humboldt,2SHS4,President,,REP,Ted Cruz,1
 Humboldt,2SHS4,Proposition 50,,,No,71
 Humboldt,2SHS4,Proposition 50,,,Yes,238
 Humboldt,2SHS4,State Assembly,2,DEM,Jim Wood,251
+Humboldt,2SHS4,State Assembly,2,IND,Ken Anton,1
 Humboldt,2SHS4,U.S. House,2,REP,Dale K. Mensing,61
 Humboldt,2SHS4,U.S. House,2,DEM,Erin A. Schrode,61
 Humboldt,2SHS4,U.S. House,2,DEM,Jared W. Huffman,177
 Humboldt,2SHS4,U.S. House,2,IND,Matthew Robert Wookey,33
+Humboldt,2SHS4,U.S. House,2,IND,Andrew Augustine Caffrey,3
 Humboldt,2SHS4,U.S. Senate,,IND,Clive Grey,2
 Humboldt,2SHS4,U.S. Senate,,REP,Don Krampe,2
 Humboldt,2SHS4,U.S. Senate,,REP,Duf Sundheim,8
@@ -2006,10 +2102,12 @@ Humboldt,2SHS7,President,,DEM,Willie Wilson,1
 Humboldt,2SHS7,Proposition 50,,,No,119
 Humboldt,2SHS7,Proposition 50,,,Yes,403
 Humboldt,2SHS7,State Assembly,2,DEM,Jim Wood,449
+Humboldt,2SHS7,State Assembly,2,IND,Ken Anton,1
 Humboldt,2SHS7,U.S. House,2,REP,Dale K. Mensing,122
 Humboldt,2SHS7,U.S. House,2,DEM,Erin A. Schrode,93
 Humboldt,2SHS7,U.S. House,2,DEM,Jared W. Huffman,350
 Humboldt,2SHS7,U.S. House,2,IND,Matthew Robert Wookey,42
+Humboldt,2SHS7,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,2SHS7,U.S. Senate,,IND,Clive Grey,2
 Humboldt,2SHS7,U.S. Senate,,IND,Don J. Grundmann,1
 Humboldt,2SHS7,U.S. Senate,,REP,Don Krampe,4
@@ -2047,10 +2145,12 @@ Humboldt,2SHVF,President,,DEM,Hillary Clinton,15
 Humboldt,2SHVF,Proposition 50,,,No,11
 Humboldt,2SHVF,Proposition 50,,,Yes,59
 Humboldt,2SHVF,State Assembly,2,DEM,Jim Wood,51
+Humboldt,2SHVF,State Assembly,2,IND,Ken Anton,0
 Humboldt,2SHVF,U.S. House,2,REP,Dale K. Mensing,16
 Humboldt,2SHVF,U.S. House,2,DEM,Erin A. Schrode,13
 Humboldt,2SHVF,U.S. House,2,DEM,Jared W. Huffman,41
 Humboldt,2SHVF,U.S. House,2,IND,Matthew Robert Wookey,3
+Humboldt,2SHVF,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,2SHVF,U.S. Senate,,IND,Clive Grey,1
 Humboldt,2SHVF,U.S. Senate,,REP,Duf Sundheim,1
 Humboldt,2SHVF,U.S. Senate,,IND,Eleanor García,1
@@ -2078,10 +2178,12 @@ Humboldt,3A--1,President,,DEM,Willie Wilson,1
 Humboldt,3A--1,Proposition 50,,,No,109
 Humboldt,3A--1,Proposition 50,,,Yes,410
 Humboldt,3A--1,State Assembly,2,DEM,Jim Wood,478
+Humboldt,3A--1,State Assembly,2,IND,Ken Anton,0
 Humboldt,3A--1,U.S. House,2,REP,Dale K. Mensing,19
 Humboldt,3A--1,U.S. House,2,DEM,Erin A. Schrode,103
 Humboldt,3A--1,U.S. House,2,DEM,Jared W. Huffman,369
 Humboldt,3A--1,U.S. House,2,IND,Matthew Robert Wookey,70
+Humboldt,3A--1,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,3A--1,U.S. Senate,,IND,Clive Grey,1
 Humboldt,3A--1,U.S. Senate,,IND,Don J. Grundmann,2
 Humboldt,3A--1,U.S. Senate,,REP,Don Krampe,1
@@ -2119,10 +2221,12 @@ Humboldt,3A--2,President,,REP,Ted Cruz,4
 Humboldt,3A--2,Proposition 50,,,No,79
 Humboldt,3A--2,Proposition 50,,,Yes,262
 Humboldt,3A--2,State Assembly,2,DEM,Jim Wood,313
+Humboldt,3A--2,State Assembly,2,IND,Ken Anton,0
 Humboldt,3A--2,U.S. House,2,REP,Dale K. Mensing,29
 Humboldt,3A--2,U.S. House,2,DEM,Erin A. Schrode,55
 Humboldt,3A--2,U.S. House,2,DEM,Jared W. Huffman,264
 Humboldt,3A--2,U.S. House,2,IND,Matthew Robert Wookey,39
+Humboldt,3A--2,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,3A--2,U.S. Senate,,IND,Clive Grey,1
 Humboldt,3A--2,U.S. Senate,,IND,Don J. Grundmann,1
 Humboldt,3A--2,U.S. Senate,,REP,Don Krampe,2
@@ -2164,10 +2268,12 @@ Humboldt,3A--3,President,,DEM,Willie Wilson,1
 Humboldt,3A--3,Proposition 50,,,No,70
 Humboldt,3A--3,Proposition 50,,,Yes,254
 Humboldt,3A--3,State Assembly,2,DEM,Jim Wood,296
+Humboldt,3A--3,State Assembly,2,IND,Ken Anton,0
 Humboldt,3A--3,U.S. House,2,REP,Dale K. Mensing,17
 Humboldt,3A--3,U.S. House,2,DEM,Erin A. Schrode,61
 Humboldt,3A--3,U.S. House,2,DEM,Jared W. Huffman,241
 Humboldt,3A--3,U.S. House,2,IND,Matthew Robert Wookey,34
+Humboldt,3A--3,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,3A--3,U.S. Senate,,IND,Clive Grey,2
 Humboldt,3A--3,U.S. Senate,,REP,Don Krampe,2
 Humboldt,3A--3,U.S. Senate,,REP,Duf Sundheim,7
@@ -2203,10 +2309,12 @@ Humboldt,3A--7,President,,REP,Ted Cruz,7
 Humboldt,3A--7,Proposition 50,,,No,64
 Humboldt,3A--7,Proposition 50,,,Yes,263
 Humboldt,3A--7,State Assembly,2,DEM,Jim Wood,289
+Humboldt,3A--7,State Assembly,2,IND,Ken Anton,0
 Humboldt,3A--7,U.S. House,2,REP,Dale K. Mensing,29
 Humboldt,3A--7,U.S. House,2,DEM,Erin A. Schrode,65
 Humboldt,3A--7,U.S. House,2,DEM,Jared W. Huffman,240
 Humboldt,3A--7,U.S. House,2,IND,Matthew Robert Wookey,25
+Humboldt,3A--7,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,3A--7,U.S. Senate,,IND,Clive Grey,3
 Humboldt,3A--7,U.S. Senate,,IND,Don J. Grundmann,1
 Humboldt,3A--7,U.S. Senate,,REP,Don Krampe,2
@@ -2249,10 +2357,12 @@ Humboldt,3A--9,President,,DEM,Willie Wilson,1
 Humboldt,3A--9,Proposition 50,,,No,85
 Humboldt,3A--9,Proposition 50,,,Yes,380
 Humboldt,3A--9,State Assembly,2,DEM,Jim Wood,402
+Humboldt,3A--9,State Assembly,2,IND,Ken Anton,1
 Humboldt,3A--9,U.S. House,2,REP,Dale K. Mensing,25
 Humboldt,3A--9,U.S. House,2,DEM,Erin A. Schrode,79
 Humboldt,3A--9,U.S. House,2,DEM,Jared W. Huffman,336
 Humboldt,3A--9,U.S. House,2,IND,Matthew Robert Wookey,48
+Humboldt,3A--9,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,3A--9,U.S. Senate,,IND,Clive Grey,5
 Humboldt,3A--9,U.S. Senate,,REP,Don Krampe,2
 Humboldt,3A--9,U.S. Senate,,REP,Duf Sundheim,7
@@ -2295,10 +2405,12 @@ Humboldt,3A-10,President,,DEM,Willie Wilson,1
 Humboldt,3A-10,Proposition 50,,,No,105
 Humboldt,3A-10,Proposition 50,,,Yes,394
 Humboldt,3A-10,State Assembly,2,DEM,Jim Wood,470
+Humboldt,3A-10,State Assembly,2,IND,Ken Anton,0
 Humboldt,3A-10,U.S. House,2,REP,Dale K. Mensing,33
 Humboldt,3A-10,U.S. House,2,DEM,Erin A. Schrode,102
 Humboldt,3A-10,U.S. House,2,DEM,Jared W. Huffman,348
 Humboldt,3A-10,U.S. House,2,IND,Matthew Robert Wookey,58
+Humboldt,3A-10,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,3A-10,U.S. Senate,,IND,Clive Grey,1
 Humboldt,3A-10,U.S. Senate,,REP,Don Krampe,1
 Humboldt,3A-10,U.S. Senate,,REP,Duf Sundheim,7
@@ -2343,10 +2455,12 @@ Humboldt,3A-11,President,,AIP,Wiley Drake,2
 Humboldt,3A-11,Proposition 50,,,No,108
 Humboldt,3A-11,Proposition 50,,,Yes,370
 Humboldt,3A-11,State Assembly,2,DEM,Jim Wood,445
+Humboldt,3A-11,State Assembly,2,IND,Ken Anton,0
 Humboldt,3A-11,U.S. House,2,REP,Dale K. Mensing,22
 Humboldt,3A-11,U.S. House,2,DEM,Erin A. Schrode,100
 Humboldt,3A-11,U.S. House,2,DEM,Jared W. Huffman,338
 Humboldt,3A-11,U.S. House,2,IND,Matthew Robert Wookey,59
+Humboldt,3A-11,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,3A-11,U.S. Senate,,IND,Clive Grey,1
 Humboldt,3A-11,U.S. Senate,,REP,Don Krampe,1
 Humboldt,3A-11,U.S. Senate,,REP,Duf Sundheim,2
@@ -2386,10 +2500,12 @@ Humboldt,3A-12,President,,REP,Ted Cruz,2
 Humboldt,3A-12,Proposition 50,,,No,29
 Humboldt,3A-12,Proposition 50,,,Yes,171
 Humboldt,3A-12,State Assembly,2,DEM,Jim Wood,185
+Humboldt,3A-12,State Assembly,2,IND,Ken Anton,0
 Humboldt,3A-12,U.S. House,2,REP,Dale K. Mensing,8
 Humboldt,3A-12,U.S. House,2,DEM,Erin A. Schrode,37
 Humboldt,3A-12,U.S. House,2,DEM,Jared W. Huffman,152
 Humboldt,3A-12,U.S. House,2,IND,Matthew Robert Wookey,16
+Humboldt,3A-12,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,3A-12,U.S. Senate,,IND,Clive Grey,1
 Humboldt,3A-12,U.S. Senate,,REP,Don Krampe,2
 Humboldt,3A-12,U.S. Senate,,REP,Duf Sundheim,2
@@ -2427,10 +2543,12 @@ Humboldt,3A-13,President,,DEM,Willie Wilson,1
 Humboldt,3A-13,Proposition 50,,,No,107
 Humboldt,3A-13,Proposition 50,,,Yes,442
 Humboldt,3A-13,State Assembly,2,DEM,Jim Wood,459
+Humboldt,3A-13,State Assembly,2,IND,Ken Anton,0
 Humboldt,3A-13,U.S. House,2,REP,Dale K. Mensing,44
 Humboldt,3A-13,U.S. House,2,DEM,Erin A. Schrode,123
 Humboldt,3A-13,U.S. House,2,DEM,Jared W. Huffman,345
 Humboldt,3A-13,U.S. House,2,IND,Matthew Robert Wookey,52
+Humboldt,3A-13,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,3A-13,U.S. Senate,,IND,Clive Grey,2
 Humboldt,3A-13,U.S. Senate,,REP,Don Krampe,1
 Humboldt,3A-13,U.S. Senate,,REP,Duf Sundheim,12
@@ -2474,10 +2592,12 @@ Humboldt,3A-J1,President,,REP,Ted Cruz,7
 Humboldt,3A-J1,Proposition 50,,,No,83
 Humboldt,3A-J1,Proposition 50,,,Yes,335
 Humboldt,3A-J1,State Assembly,2,DEM,Jim Wood,381
+Humboldt,3A-J1,State Assembly,2,IND,Ken Anton,0
 Humboldt,3A-J1,U.S. House,2,REP,Dale K. Mensing,30
 Humboldt,3A-J1,U.S. House,2,DEM,Erin A. Schrode,52
 Humboldt,3A-J1,U.S. House,2,DEM,Jared W. Huffman,353
 Humboldt,3A-J1,U.S. House,2,IND,Matthew Robert Wookey,20
+Humboldt,3A-J1,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,3A-J1,U.S. Senate,,IND,Clive Grey,1
 Humboldt,3A-J1,U.S. Senate,,REP,Don Krampe,3
 Humboldt,3A-J1,U.S. Senate,,REP,Duf Sundheim,4
@@ -2518,10 +2638,12 @@ Humboldt,3A-P2,President,,DEM,Willie Wilson,1
 Humboldt,3A-P2,Proposition 50,,,No,88
 Humboldt,3A-P2,Proposition 50,,,Yes,392
 Humboldt,3A-P2,State Assembly,2,DEM,Jim Wood,429
+Humboldt,3A-P2,State Assembly,2,IND,Ken Anton,2
 Humboldt,3A-P2,U.S. House,2,REP,Dale K. Mensing,53
 Humboldt,3A-P2,U.S. House,2,DEM,Erin A. Schrode,87
 Humboldt,3A-P2,U.S. House,2,DEM,Jared W. Huffman,344
 Humboldt,3A-P2,U.S. House,2,IND,Matthew Robert Wookey,43
+Humboldt,3A-P2,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,3A-P2,U.S. Senate,,REP,Don Krampe,4
 Humboldt,3A-P2,U.S. Senate,,REP,Duf Sundheim,12
 Humboldt,3A-P2,U.S. Senate,,IND,Eleanor García,3
@@ -2566,10 +2688,12 @@ Humboldt,3A-P4,President,,DEM,Willie Wilson,1
 Humboldt,3A-P4,Proposition 50,,,No,102
 Humboldt,3A-P4,Proposition 50,,,Yes,374
 Humboldt,3A-P4,State Assembly,2,DEM,Jim Wood,413
+Humboldt,3A-P4,State Assembly,2,IND,Ken Anton,0
 Humboldt,3A-P4,U.S. House,2,REP,Dale K. Mensing,60
 Humboldt,3A-P4,U.S. House,2,DEM,Erin A. Schrode,92
 Humboldt,3A-P4,U.S. House,2,DEM,Jared W. Huffman,309
 Humboldt,3A-P4,U.S. House,2,IND,Matthew Robert Wookey,46
+Humboldt,3A-P4,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,3A-P4,U.S. Senate,,IND,Clive Grey,3
 Humboldt,3A-P4,U.S. Senate,,IND,Don J. Grundmann,1
 Humboldt,3A-P4,U.S. Senate,,REP,Don Krampe,1
@@ -2612,10 +2736,12 @@ Humboldt,3AS-1,President,,REP,John R. Kasich,1
 Humboldt,3AS-1,Proposition 50,,,No,15
 Humboldt,3AS-1,Proposition 50,,,Yes,66
 Humboldt,3AS-1,State Assembly,2,DEM,Jim Wood,55
+Humboldt,3AS-1,State Assembly,2,IND,Ken Anton,0
 Humboldt,3AS-1,U.S. House,2,REP,Dale K. Mensing,14
 Humboldt,3AS-1,U.S. House,2,DEM,Erin A. Schrode,5
 Humboldt,3AS-1,U.S. House,2,DEM,Jared W. Huffman,60
 Humboldt,3AS-1,U.S. House,2,IND,Matthew Robert Wookey,9
+Humboldt,3AS-1,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,3AS-1,U.S. Senate,,REP,Duf Sundheim,6
 Humboldt,3AS-1,U.S. Senate,,LIB,Gail K. Lightfoot,3
 Humboldt,3AS-1,U.S. Senate,,REP,Greg Conlon,2
@@ -2641,10 +2767,12 @@ Humboldt,3AS-9,President,,DEM,Keith Judd,1
 Humboldt,3AS-9,Proposition 50,,,No,5
 Humboldt,3AS-9,Proposition 50,,,Yes,52
 Humboldt,3AS-9,State Assembly,2,DEM,Jim Wood,53
+Humboldt,3AS-9,State Assembly,2,IND,Ken Anton,0
 Humboldt,3AS-9,U.S. House,2,REP,Dale K. Mensing,11
 Humboldt,3AS-9,U.S. House,2,DEM,Erin A. Schrode,5
 Humboldt,3AS-9,U.S. House,2,DEM,Jared W. Huffman,48
 Humboldt,3AS-9,U.S. House,2,IND,Matthew Robert Wookey,2
+Humboldt,3AS-9,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,3AS-9,U.S. Senate,,REP,Don Krampe,1
 Humboldt,3AS-9,U.S. Senate,,REP,Duf Sundheim,5
 Humboldt,3AS-9,U.S. Senate,,REP,Greg Conlon,2
@@ -2675,10 +2803,12 @@ Humboldt,3B--1,President,,DEM,Willie Wilson,1
 Humboldt,3B--1,Proposition 50,,,No,69
 Humboldt,3B--1,Proposition 50,,,Yes,347
 Humboldt,3B--1,State Assembly,2,DEM,Jim Wood,353
+Humboldt,3B--1,State Assembly,2,IND,Ken Anton,0
 Humboldt,3B--1,U.S. House,2,REP,Dale K. Mensing,63
 Humboldt,3B--1,U.S. House,2,DEM,Erin A. Schrode,54
 Humboldt,3B--1,U.S. House,2,DEM,Jared W. Huffman,300
 Humboldt,3B--1,U.S. House,2,IND,Matthew Robert Wookey,34
+Humboldt,3B--1,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,3B--1,U.S. Senate,,IND,Clive Grey,2
 Humboldt,3B--1,U.S. Senate,,REP,Don Krampe,3
 Humboldt,3B--1,U.S. Senate,,REP,Duf Sundheim,18
@@ -2722,10 +2852,12 @@ Humboldt,3ES-6,President,,DEM,Willie Wilson,1
 Humboldt,3ES-6,Proposition 50,,,No,71
 Humboldt,3ES-6,Proposition 50,,,Yes,212
 Humboldt,3ES-6,State Assembly,2,DEM,Jim Wood,218
+Humboldt,3ES-6,State Assembly,2,IND,Ken Anton,0
 Humboldt,3ES-6,U.S. House,2,REP,Dale K. Mensing,74
 Humboldt,3ES-6,U.S. House,2,DEM,Erin A. Schrode,18
 Humboldt,3ES-6,U.S. House,2,DEM,Jared W. Huffman,183
 Humboldt,3ES-6,U.S. House,2,IND,Matthew Robert Wookey,27
+Humboldt,3ES-6,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,3ES-6,U.S. Senate,,IND,Clive Grey,1
 Humboldt,3ES-6,U.S. Senate,,IND,Don J. Grundmann,2
 Humboldt,3ES-6,U.S. Senate,,REP,Duf Sundheim,21
@@ -2768,10 +2900,12 @@ Humboldt,3FW,President,,REP,Ted Cruz,10
 Humboldt,3FW,Proposition 50,,,No,86
 Humboldt,3FW,Proposition 50,,,Yes,428
 Humboldt,3FW,State Assembly,2,DEM,Jim Wood,418
+Humboldt,3FW,State Assembly,2,IND,Ken Anton,0
 Humboldt,3FW,U.S. House,2,REP,Dale K. Mensing,88
 Humboldt,3FW,U.S. House,2,DEM,Erin A. Schrode,50
 Humboldt,3FW,U.S. House,2,DEM,Jared W. Huffman,369
 Humboldt,3FW,U.S. House,2,IND,Matthew Robert Wookey,38
+Humboldt,3FW,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,3FW,U.S. Senate,,IND,Clive Grey,5
 Humboldt,3FW,U.S. Senate,,REP,Don Krampe,1
 Humboldt,3FW,U.S. Senate,,REP,Duf Sundheim,16
@@ -2816,10 +2950,12 @@ Humboldt,3FWS,President,,DEM,Willie Wilson,2
 Humboldt,3FWS,Proposition 50,,,No,85
 Humboldt,3FWS,Proposition 50,,,Yes,391
 Humboldt,3FWS,State Assembly,2,DEM,Jim Wood,382
+Humboldt,3FWS,State Assembly,2,IND,Ken Anton,1
 Humboldt,3FWS,U.S. House,2,REP,Dale K. Mensing,100
 Humboldt,3FWS,U.S. House,2,DEM,Erin A. Schrode,38
 Humboldt,3FWS,U.S. House,2,DEM,Jared W. Huffman,343
 Humboldt,3FWS,U.S. House,2,IND,Matthew Robert Wookey,26
+Humboldt,3FWS,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,3FWS,U.S. Senate,,IND,Clive Grey,2
 Humboldt,3FWS,U.S. Senate,,IND,Don J. Grundmann,1
 Humboldt,3FWS,U.S. Senate,,REP,Don Krampe,9
@@ -2864,10 +3000,12 @@ Humboldt,3JCFR,President,,REP,Ted Cruz,5
 Humboldt,3JCFR,Proposition 50,,,No,69
 Humboldt,3JCFR,Proposition 50,,,Yes,289
 Humboldt,3JCFR,State Assembly,2,DEM,Jim Wood,298
+Humboldt,3JCFR,State Assembly,2,IND,Ken Anton,0
 Humboldt,3JCFR,U.S. House,2,REP,Dale K. Mensing,44
 Humboldt,3JCFR,U.S. House,2,DEM,Erin A. Schrode,32
 Humboldt,3JCFR,U.S. House,2,DEM,Jared W. Huffman,280
 Humboldt,3JCFR,U.S. House,2,IND,Matthew Robert Wookey,22
+Humboldt,3JCFR,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,3JCFR,U.S. Senate,,IND,Clive Grey,5
 Humboldt,3JCFR,U.S. Senate,,IND,Don J. Grundmann,1
 Humboldt,3JCFR,U.S. Senate,,REP,Don Krampe,1
@@ -2910,10 +3048,12 @@ Humboldt,3JCWR,President,,DEM,Willie Wilson,3
 Humboldt,3JCWR,Proposition 50,,,No,83
 Humboldt,3JCWR,Proposition 50,,,Yes,323
 Humboldt,3JCWR,State Assembly,2,DEM,Jim Wood,336
+Humboldt,3JCWR,State Assembly,2,IND,Ken Anton,0
 Humboldt,3JCWR,U.S. House,2,REP,Dale K. Mensing,59
 Humboldt,3JCWR,U.S. House,2,DEM,Erin A. Schrode,52
 Humboldt,3JCWR,U.S. House,2,DEM,Jared W. Huffman,309
 Humboldt,3JCWR,U.S. House,2,IND,Matthew Robert Wookey,25
+Humboldt,3JCWR,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,3JCWR,U.S. Senate,,IND,Clive Grey,1
 Humboldt,3JCWR,U.S. Senate,,REP,Duf Sundheim,18
 Humboldt,3JCWR,U.S. Senate,,LIB,Gail K. Lightfoot,6
@@ -2948,10 +3088,12 @@ Humboldt,3KL,President,,REP,John R. Kasich,1
 Humboldt,3KL,Proposition 50,,,No,3
 Humboldt,3KL,Proposition 50,,,Yes,19
 Humboldt,3KL,State Assembly,2,DEM,Jim Wood,21
+Humboldt,3KL,State Assembly,2,IND,Ken Anton,0
 Humboldt,3KL,U.S. House,2,REP,Dale K. Mensing,3
 Humboldt,3KL,U.S. House,2,DEM,Erin A. Schrode,1
 Humboldt,3KL,U.S. House,2,DEM,Jared W. Huffman,17
 Humboldt,3KL,U.S. House,2,IND,Matthew Robert Wookey,3
+Humboldt,3KL,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,3KL,U.S. Senate,,IND,Clive Grey,1
 Humboldt,3KL,U.S. Senate,,REP,Don Krampe,2
 Humboldt,3KL,U.S. Senate,,IND,Eleanor García,1
@@ -2972,10 +3114,12 @@ Humboldt,3KL-1,President,,REP,Ted Cruz,6
 Humboldt,3KL-1,Proposition 50,,,No,38
 Humboldt,3KL-1,Proposition 50,,,Yes,72
 Humboldt,3KL-1,State Assembly,2,DEM,Jim Wood,81
+Humboldt,3KL-1,State Assembly,2,IND,Ken Anton,0
 Humboldt,3KL-1,U.S. House,2,REP,Dale K. Mensing,33
 Humboldt,3KL-1,U.S. House,2,DEM,Erin A. Schrode,4
 Humboldt,3KL-1,U.S. House,2,DEM,Jared W. Huffman,77
 Humboldt,3KL-1,U.S. House,2,IND,Matthew Robert Wookey,5
+Humboldt,3KL-1,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,3KL-1,U.S. Senate,,REP,Don Krampe,7
 Humboldt,3KL-1,U.S. Senate,,REP,Duf Sundheim,10
 Humboldt,3KL-1,U.S. Senate,,IND,Eleanor García,2
@@ -3007,10 +3151,12 @@ Humboldt,3MA-1,President,,REP,Ted Cruz,4
 Humboldt,3MA-1,Proposition 50,,,No,59
 Humboldt,3MA-1,Proposition 50,,,Yes,198
 Humboldt,3MA-1,State Assembly,2,DEM,Jim Wood,227
+Humboldt,3MA-1,State Assembly,2,IND,Ken Anton,0
 Humboldt,3MA-1,U.S. House,2,REP,Dale K. Mensing,26
 Humboldt,3MA-1,U.S. House,2,DEM,Erin A. Schrode,38
 Humboldt,3MA-1,U.S. House,2,DEM,Jared W. Huffman,189
 Humboldt,3MA-1,U.S. House,2,IND,Matthew Robert Wookey,24
+Humboldt,3MA-1,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,3MA-1,U.S. Senate,,IND,Clive Grey,1
 Humboldt,3MA-1,U.S. Senate,,REP,Don Krampe,2
 Humboldt,3MA-1,U.S. Senate,,REP,Duf Sundheim,3
@@ -3048,10 +3194,12 @@ Humboldt,3PA-1,President,,REP,Ted Cruz,8
 Humboldt,3PA-1,Proposition 50,,,No,79
 Humboldt,3PA-1,Proposition 50,,,Yes,319
 Humboldt,3PA-1,State Assembly,2,DEM,Jim Wood,330
+Humboldt,3PA-1,State Assembly,2,IND,Ken Anton,0
 Humboldt,3PA-1,U.S. House,2,REP,Dale K. Mensing,70
 Humboldt,3PA-1,U.S. House,2,DEM,Erin A. Schrode,36
 Humboldt,3PA-1,U.S. House,2,DEM,Jared W. Huffman,283
 Humboldt,3PA-1,U.S. House,2,IND,Matthew Robert Wookey,31
+Humboldt,3PA-1,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,3PA-1,U.S. Senate,,IND,Clive Grey,2
 Humboldt,3PA-1,U.S. Senate,,IND,Don J. Grundmann,2
 Humboldt,3PA-1,U.S. Senate,,REP,Don Krampe,5
@@ -3099,10 +3247,12 @@ Humboldt,4E-11,President,,DEM,Willie Wilson,2
 Humboldt,4E-11,Proposition 50,,,No,70
 Humboldt,4E-11,Proposition 50,,,Yes,239
 Humboldt,4E-11,State Assembly,2,DEM,Jim Wood,260
+Humboldt,4E-11,State Assembly,2,IND,Ken Anton,1
 Humboldt,4E-11,U.S. House,2,REP,Dale K. Mensing,32
 Humboldt,4E-11,U.S. House,2,DEM,Erin A. Schrode,59
 Humboldt,4E-11,U.S. House,2,DEM,Jared W. Huffman,186
 Humboldt,4E-11,U.S. House,2,IND,Matthew Robert Wookey,43
+Humboldt,4E-11,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,4E-11,U.S. Senate,,IND,Clive Grey,2
 Humboldt,4E-11,U.S. Senate,,REP,Don Krampe,1
 Humboldt,4E-11,U.S. Senate,,REP,Duf Sundheim,13
@@ -3144,10 +3294,12 @@ Humboldt,4E-12,President,,DEM,Willie Wilson,1
 Humboldt,4E-12,Proposition 50,,,No,57
 Humboldt,4E-12,Proposition 50,,,Yes,211
 Humboldt,4E-12,State Assembly,2,DEM,Jim Wood,205
+Humboldt,4E-12,State Assembly,2,IND,Ken Anton,0
 Humboldt,4E-12,U.S. House,2,REP,Dale K. Mensing,44
 Humboldt,4E-12,U.S. House,2,DEM,Erin A. Schrode,42
 Humboldt,4E-12,U.S. House,2,DEM,Jared W. Huffman,150
 Humboldt,4E-12,U.S. House,2,IND,Matthew Robert Wookey,33
+Humboldt,4E-12,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,4E-12,U.S. Senate,,REP,Don Krampe,2
 Humboldt,4E-12,U.S. Senate,,REP,Duf Sundheim,8
 Humboldt,4E-12,U.S. Senate,,IND,Eleanor García,1
@@ -3195,10 +3347,12 @@ Humboldt,4E-13,President,,DEM,Willie Wilson,3
 Humboldt,4E-13,Proposition 50,,,No,95
 Humboldt,4E-13,Proposition 50,,,Yes,421
 Humboldt,4E-13,State Assembly,2,DEM,Jim Wood,448
+Humboldt,4E-13,State Assembly,2,IND,Ken Anton,0
 Humboldt,4E-13,U.S. House,2,REP,Dale K. Mensing,48
 Humboldt,4E-13,U.S. House,2,DEM,Erin A. Schrode,80
 Humboldt,4E-13,U.S. House,2,DEM,Jared W. Huffman,352
 Humboldt,4E-13,U.S. House,2,IND,Matthew Robert Wookey,59
+Humboldt,4E-13,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,4E-13,U.S. Senate,,IND,Clive Grey,4
 Humboldt,4E-13,U.S. Senate,,IND,Don J. Grundmann,1
 Humboldt,4E-13,U.S. Senate,,REP,Don Krampe,3
@@ -3246,10 +3400,12 @@ Humboldt,4E-14,President,,AIP,Thomas Hoefling,1
 Humboldt,4E-14,Proposition 50,,,No,85
 Humboldt,4E-14,Proposition 50,,,Yes,338
 Humboldt,4E-14,State Assembly,2,DEM,Jim Wood,343
+Humboldt,4E-14,State Assembly,2,IND,Ken Anton,2
 Humboldt,4E-14,U.S. House,2,REP,Dale K. Mensing,74
 Humboldt,4E-14,U.S. House,2,DEM,Erin A. Schrode,53
 Humboldt,4E-14,U.S. House,2,DEM,Jared W. Huffman,266
 Humboldt,4E-14,U.S. House,2,IND,Matthew Robert Wookey,42
+Humboldt,4E-14,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,4E-14,U.S. Senate,,IND,Clive Grey,1
 Humboldt,4E-14,U.S. Senate,,IND,Don J. Grundmann,1
 Humboldt,4E-14,U.S. Senate,,REP,Don Krampe,3
@@ -3296,10 +3452,12 @@ Humboldt,4E-21,President,,REP,Ted Cruz,2
 Humboldt,4E-21,Proposition 50,,,No,74
 Humboldt,4E-21,Proposition 50,,,Yes,216
 Humboldt,4E-21,State Assembly,2,DEM,Jim Wood,236
+Humboldt,4E-21,State Assembly,2,IND,Ken Anton,0
 Humboldt,4E-21,U.S. House,2,REP,Dale K. Mensing,37
 Humboldt,4E-21,U.S. House,2,DEM,Erin A. Schrode,47
 Humboldt,4E-21,U.S. House,2,DEM,Jared W. Huffman,173
 Humboldt,4E-21,U.S. House,2,IND,Matthew Robert Wookey,34
+Humboldt,4E-21,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,4E-21,U.S. Senate,,IND,Clive Grey,1
 Humboldt,4E-21,U.S. Senate,,REP,Don Krampe,2
 Humboldt,4E-21,U.S. Senate,,REP,Duf Sundheim,6
@@ -3340,10 +3498,12 @@ Humboldt,4E-22,President,,AIP,Thomas Hoefling,1
 Humboldt,4E-22,Proposition 50,,,No,60
 Humboldt,4E-22,Proposition 50,,,Yes,265
 Humboldt,4E-22,State Assembly,2,DEM,Jim Wood,273
+Humboldt,4E-22,State Assembly,2,IND,Ken Anton,1
 Humboldt,4E-22,U.S. House,2,REP,Dale K. Mensing,58
 Humboldt,4E-22,U.S. House,2,DEM,Erin A. Schrode,41
 Humboldt,4E-22,U.S. House,2,DEM,Jared W. Huffman,213
 Humboldt,4E-22,U.S. House,2,IND,Matthew Robert Wookey,34
+Humboldt,4E-22,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,4E-22,U.S. Senate,,IND,Clive Grey,1
 Humboldt,4E-22,U.S. Senate,,REP,Don Krampe,2
 Humboldt,4E-22,U.S. Senate,,REP,Duf Sundheim,18
@@ -3392,10 +3552,12 @@ Humboldt,4E-23,President,,DEM,Willie Wilson,1
 Humboldt,4E-23,Proposition 50,,,No,136
 Humboldt,4E-23,Proposition 50,,,Yes,441
 Humboldt,4E-23,State Assembly,2,DEM,Jim Wood,473
+Humboldt,4E-23,State Assembly,2,IND,Ken Anton,0
 Humboldt,4E-23,U.S. House,2,REP,Dale K. Mensing,106
 Humboldt,4E-23,U.S. House,2,DEM,Erin A. Schrode,58
 Humboldt,4E-23,U.S. House,2,DEM,Jared W. Huffman,403
 Humboldt,4E-23,U.S. House,2,IND,Matthew Robert Wookey,47
+Humboldt,4E-23,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,4E-23,U.S. Senate,,IND,Clive Grey,4
 Humboldt,4E-23,U.S. Senate,,IND,Don J. Grundmann,2
 Humboldt,4E-23,U.S. Senate,,REP,Don Krampe,11
@@ -3443,10 +3605,12 @@ Humboldt,4E-25,President,,AIP,Wiley Drake,1
 Humboldt,4E-25,Proposition 50,,,No,74
 Humboldt,4E-25,Proposition 50,,,Yes,358
 Humboldt,4E-25,State Assembly,2,DEM,Jim Wood,317
+Humboldt,4E-25,State Assembly,2,IND,Ken Anton,0
 Humboldt,4E-25,U.S. House,2,REP,Dale K. Mensing,104
 Humboldt,4E-25,U.S. House,2,DEM,Erin A. Schrode,28
 Humboldt,4E-25,U.S. House,2,DEM,Jared W. Huffman,281
 Humboldt,4E-25,U.S. House,2,IND,Matthew Robert Wookey,34
+Humboldt,4E-25,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,4E-25,U.S. Senate,,IND,Clive Grey,1
 Humboldt,4E-25,U.S. Senate,,REP,Don Krampe,4
 Humboldt,4E-25,U.S. Senate,,REP,Duf Sundheim,25
@@ -3491,10 +3655,12 @@ Humboldt,4E-32,President,,REP,Ted Cruz,5
 Humboldt,4E-32,Proposition 50,,,No,56
 Humboldt,4E-32,Proposition 50,,,Yes,210
 Humboldt,4E-32,State Assembly,2,DEM,Jim Wood,226
+Humboldt,4E-32,State Assembly,2,IND,Ken Anton,1
 Humboldt,4E-32,U.S. House,2,REP,Dale K. Mensing,30
 Humboldt,4E-32,U.S. House,2,DEM,Erin A. Schrode,41
 Humboldt,4E-32,U.S. House,2,DEM,Jared W. Huffman,186
 Humboldt,4E-32,U.S. House,2,IND,Matthew Robert Wookey,19
+Humboldt,4E-32,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,4E-32,U.S. Senate,,IND,Don J. Grundmann,1
 Humboldt,4E-32,U.S. Senate,,REP,Don Krampe,2
 Humboldt,4E-32,U.S. Senate,,REP,Duf Sundheim,6
@@ -3531,10 +3697,12 @@ Humboldt,4E-33,President,,REP,Ted Cruz,7
 Humboldt,4E-33,Proposition 50,,,No,68
 Humboldt,4E-33,Proposition 50,,,Yes,247
 Humboldt,4E-33,State Assembly,2,DEM,Jim Wood,273
+Humboldt,4E-33,State Assembly,2,IND,Ken Anton,0
 Humboldt,4E-33,U.S. House,2,REP,Dale K. Mensing,50
 Humboldt,4E-33,U.S. House,2,DEM,Erin A. Schrode,39
 Humboldt,4E-33,U.S. House,2,DEM,Jared W. Huffman,212
 Humboldt,4E-33,U.S. House,2,IND,Matthew Robert Wookey,35
+Humboldt,4E-33,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,4E-33,U.S. Senate,,IND,Clive Grey,3
 Humboldt,4E-33,U.S. Senate,,IND,Don J. Grundmann,1
 Humboldt,4E-33,U.S. Senate,,REP,Don Krampe,1
@@ -3581,10 +3749,12 @@ Humboldt,4E-34,President,,DEM,Willie Wilson,1
 Humboldt,4E-34,Proposition 50,,,No,73
 Humboldt,4E-34,Proposition 50,,,Yes,314
 Humboldt,4E-34,State Assembly,2,DEM,Jim Wood,312
+Humboldt,4E-34,State Assembly,2,IND,Ken Anton,0
 Humboldt,4E-34,U.S. House,2,REP,Dale K. Mensing,74
 Humboldt,4E-34,U.S. House,2,DEM,Erin A. Schrode,47
 Humboldt,4E-34,U.S. House,2,DEM,Jared W. Huffman,260
 Humboldt,4E-34,U.S. House,2,IND,Matthew Robert Wookey,25
+Humboldt,4E-34,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,4E-34,U.S. Senate,,IND,Clive Grey,2
 Humboldt,4E-34,U.S. Senate,,REP,Don Krampe,2
 Humboldt,4E-34,U.S. Senate,,REP,Duf Sundheim,25
@@ -3626,10 +3796,12 @@ Humboldt,4E-51,President,,REP,Ted Cruz,7
 Humboldt,4E-51,Proposition 50,,,No,60
 Humboldt,4E-51,Proposition 50,,,Yes,232
 Humboldt,4E-51,State Assembly,2,DEM,Jim Wood,241
+Humboldt,4E-51,State Assembly,2,IND,Ken Anton,0
 Humboldt,4E-51,U.S. House,2,REP,Dale K. Mensing,44
 Humboldt,4E-51,U.S. House,2,DEM,Erin A. Schrode,26
 Humboldt,4E-51,U.S. House,2,DEM,Jared W. Huffman,216
 Humboldt,4E-51,U.S. House,2,IND,Matthew Robert Wookey,16
+Humboldt,4E-51,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,4E-51,U.S. Senate,,IND,Clive Grey,2
 Humboldt,4E-51,U.S. Senate,,REP,Don Krampe,1
 Humboldt,4E-51,U.S. Senate,,REP,Duf Sundheim,18
@@ -3669,10 +3841,12 @@ Humboldt,4E-52,President,,DEM,Willie Wilson,5
 Humboldt,4E-52,Proposition 50,,,No,40
 Humboldt,4E-52,Proposition 50,,,Yes,159
 Humboldt,4E-52,State Assembly,2,DEM,Jim Wood,159
+Humboldt,4E-52,State Assembly,2,IND,Ken Anton,0
 Humboldt,4E-52,U.S. House,2,REP,Dale K. Mensing,36
 Humboldt,4E-52,U.S. House,2,DEM,Erin A. Schrode,26
 Humboldt,4E-52,U.S. House,2,DEM,Jared W. Huffman,131
 Humboldt,4E-52,U.S. House,2,IND,Matthew Robert Wookey,8
+Humboldt,4E-52,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,4E-52,U.S. Senate,,IND,Clive Grey,3
 Humboldt,4E-52,U.S. Senate,,IND,Don J. Grundmann,1
 Humboldt,4E-52,U.S. Senate,,REP,Don Krampe,5
@@ -3719,10 +3893,12 @@ Humboldt,4E-54,President,,AIP,Thomas Hoefling,1
 Humboldt,4E-54,Proposition 50,,,No,97
 Humboldt,4E-54,Proposition 50,,,Yes,362
 Humboldt,4E-54,State Assembly,2,DEM,Jim Wood,376
+Humboldt,4E-54,State Assembly,2,IND,Ken Anton,0
 Humboldt,4E-54,U.S. House,2,REP,Dale K. Mensing,97
 Humboldt,4E-54,U.S. House,2,DEM,Erin A. Schrode,51
 Humboldt,4E-54,U.S. House,2,DEM,Jared W. Huffman,289
 Humboldt,4E-54,U.S. House,2,IND,Matthew Robert Wookey,38
+Humboldt,4E-54,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,4E-54,U.S. Senate,,IND,Clive Grey,1
 Humboldt,4E-54,U.S. Senate,,IND,Don J. Grundmann,2
 Humboldt,4E-54,U.S. Senate,,REP,Don Krampe,8
@@ -3766,10 +3942,12 @@ Humboldt,4ES-4,President,,REP,Ted Cruz,7
 Humboldt,4ES-4,Proposition 50,,,No,73
 Humboldt,4ES-4,Proposition 50,,,Yes,284
 Humboldt,4ES-4,State Assembly,2,DEM,Jim Wood,272
+Humboldt,4ES-4,State Assembly,2,IND,Ken Anton,2
 Humboldt,4ES-4,U.S. House,2,REP,Dale K. Mensing,82
 Humboldt,4ES-4,U.S. House,2,DEM,Erin A. Schrode,40
 Humboldt,4ES-4,U.S. House,2,DEM,Jared W. Huffman,223
 Humboldt,4ES-4,U.S. House,2,IND,Matthew Robert Wookey,28
+Humboldt,4ES-4,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,4ES-4,U.S. Senate,,IND,Clive Grey,1
 Humboldt,4ES-4,U.S. Senate,,REP,Don Krampe,1
 Humboldt,4ES-4,U.S. Senate,,REP,Duf Sundheim,26
@@ -3813,10 +3991,12 @@ Humboldt,4ES-5,President,,DEM,Willie Wilson,3
 Humboldt,4ES-5,Proposition 50,,,No,91
 Humboldt,4ES-5,Proposition 50,,,Yes,351
 Humboldt,4ES-5,State Assembly,2,DEM,Jim Wood,376
+Humboldt,4ES-5,State Assembly,2,IND,Ken Anton,3
 Humboldt,4ES-5,U.S. House,2,REP,Dale K. Mensing,85
 Humboldt,4ES-5,U.S. House,2,DEM,Erin A. Schrode,40
 Humboldt,4ES-5,U.S. House,2,DEM,Jared W. Huffman,305
 Humboldt,4ES-5,U.S. House,2,IND,Matthew Robert Wookey,57
+Humboldt,4ES-5,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,4ES-5,U.S. Senate,,IND,Clive Grey,6
 Humboldt,4ES-5,U.S. Senate,,IND,Don J. Grundmann,2
 Humboldt,4ES-5,U.S. Senate,,REP,Don Krampe,2
@@ -3862,10 +4042,12 @@ Humboldt,4ES-6,President,,DEM,Willie Wilson,1
 Humboldt,4ES-6,Proposition 50,,,No,76
 Humboldt,4ES-6,Proposition 50,,,Yes,315
 Humboldt,4ES-6,State Assembly,2,DEM,Jim Wood,300
+Humboldt,4ES-6,State Assembly,2,IND,Ken Anton,1
 Humboldt,4ES-6,U.S. House,2,REP,Dale K. Mensing,72
 Humboldt,4ES-6,U.S. House,2,DEM,Erin A. Schrode,28
 Humboldt,4ES-6,U.S. House,2,DEM,Jared W. Huffman,254
 Humboldt,4ES-6,U.S. House,2,IND,Matthew Robert Wookey,42
+Humboldt,4ES-6,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,4ES-6,U.S. Senate,,IND,Clive Grey,4
 Humboldt,4ES-6,U.S. Senate,,REP,Duf Sundheim,14
 Humboldt,4ES-6,U.S. Senate,,DEM,Emory Rodgers,1
@@ -3904,10 +4086,12 @@ Humboldt,4PEF,President,,DEM,Willie Wilson,1
 Humboldt,4PEF,Proposition 50,,,No,27
 Humboldt,4PEF,Proposition 50,,,Yes,52
 Humboldt,4PEF,State Assembly,2,DEM,Jim Wood,73
+Humboldt,4PEF,State Assembly,2,IND,Ken Anton,0
 Humboldt,4PEF,U.S. House,2,REP,Dale K. Mensing,8
 Humboldt,4PEF,U.S. House,2,DEM,Erin A. Schrode,12
 Humboldt,4PEF,U.S. House,2,DEM,Jared W. Huffman,52
 Humboldt,4PEF,U.S. House,2,IND,Matthew Robert Wookey,14
+Humboldt,4PEF,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,4PEF,U.S. Senate,,IND,Clive Grey,3
 Humboldt,4PEF,U.S. Senate,,REP,Duf Sundheim,3
 Humboldt,4PEF,U.S. Senate,,LIB,Gail K. Lightfoot,7
@@ -3932,10 +4116,12 @@ Humboldt,5AS-4,President,,REP,John R. Kasich,7
 Humboldt,5AS-4,Proposition 50,,,No,13
 Humboldt,5AS-4,Proposition 50,,,Yes,64
 Humboldt,5AS-4,State Assembly,2,DEM,Jim Wood,62
+Humboldt,5AS-4,State Assembly,2,IND,Ken Anton,0
 Humboldt,5AS-4,U.S. House,2,REP,Dale K. Mensing,12
 Humboldt,5AS-4,U.S. House,2,DEM,Erin A. Schrode,6
 Humboldt,5AS-4,U.S. House,2,DEM,Jared W. Huffman,58
 Humboldt,5AS-4,U.S. House,2,IND,Matthew Robert Wookey,3
+Humboldt,5AS-4,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,5AS-4,U.S. Senate,,REP,Duf Sundheim,12
 Humboldt,5AS-4,U.S. Senate,,IND,Gar Myers,1
 Humboldt,5AS-4,U.S. Senate,,REP,Greg Conlon,2
@@ -3963,10 +4149,12 @@ Humboldt,5BL,President,,GRN,William Kreml,1
 Humboldt,5BL,Proposition 50,,,No,48
 Humboldt,5BL,Proposition 50,,,Yes,212
 Humboldt,5BL,State Assembly,2,DEM,Jim Wood,209
+Humboldt,5BL,State Assembly,2,IND,Ken Anton,1
 Humboldt,5BL,U.S. House,2,REP,Dale K. Mensing,63
 Humboldt,5BL,U.S. House,2,DEM,Erin A. Schrode,30
 Humboldt,5BL,U.S. House,2,DEM,Jared W. Huffman,171
 Humboldt,5BL,U.S. House,2,IND,Matthew Robert Wookey,20
+Humboldt,5BL,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,5BL,U.S. Senate,,IND,Clive Grey,1
 Humboldt,5BL,U.S. Senate,,REP,Don Krampe,1
 Humboldt,5BL,U.S. Senate,,REP,Duf Sundheim,15
@@ -4005,10 +4193,12 @@ Humboldt,5BM,President,,REP,Ted Cruz,2
 Humboldt,5BM,Proposition 50,,,No,25
 Humboldt,5BM,Proposition 50,,,Yes,86
 Humboldt,5BM,State Assembly,2,DEM,Jim Wood,77
+Humboldt,5BM,State Assembly,2,IND,Ken Anton,0
 Humboldt,5BM,U.S. House,2,REP,Dale K. Mensing,28
 Humboldt,5BM,U.S. House,2,DEM,Erin A. Schrode,4
 Humboldt,5BM,U.S. House,2,DEM,Jared W. Huffman,71
 Humboldt,5BM,U.S. House,2,IND,Matthew Robert Wookey,6
+Humboldt,5BM,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,5BM,U.S. Senate,,IND,Clive Grey,2
 Humboldt,5BM,U.S. Senate,,REP,Don Krampe,2
 Humboldt,5BM,U.S. Senate,,REP,Duf Sundheim,3
@@ -4048,10 +4238,12 @@ Humboldt,5FB,President,,REP,Ted Cruz,10
 Humboldt,5FB,Proposition 50,,,No,71
 Humboldt,5FB,Proposition 50,,,Yes,300
 Humboldt,5FB,State Assembly,2,DEM,Jim Wood,301
+Humboldt,5FB,State Assembly,2,IND,Ken Anton,0
 Humboldt,5FB,U.S. House,2,REP,Dale K. Mensing,73
 Humboldt,5FB,U.S. House,2,DEM,Erin A. Schrode,26
 Humboldt,5FB,U.S. House,2,DEM,Jared W. Huffman,268
 Humboldt,5FB,U.S. House,2,IND,Matthew Robert Wookey,23
+Humboldt,5FB,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,5FB,U.S. Senate,,IND,Clive Grey,1
 Humboldt,5FB,U.S. Senate,,REP,Don Krampe,5
 Humboldt,5FB,U.S. Senate,,REP,Duf Sundheim,12
@@ -4090,10 +4282,12 @@ Humboldt,5GP,President,,REP,Ted Cruz,4
 Humboldt,5GP,Proposition 50,,,No,16
 Humboldt,5GP,Proposition 50,,,Yes,40
 Humboldt,5GP,State Assembly,2,DEM,Jim Wood,41
+Humboldt,5GP,State Assembly,2,IND,Ken Anton,0
 Humboldt,5GP,U.S. House,2,REP,Dale K. Mensing,15
 Humboldt,5GP,U.S. House,2,DEM,Erin A. Schrode,6
 Humboldt,5GP,U.S. House,2,DEM,Jared W. Huffman,37
 Humboldt,5GP,U.S. House,2,IND,Matthew Robert Wookey,2
+Humboldt,5GP,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,5GP,U.S. Senate,,REP,Don Krampe,3
 Humboldt,5GP,U.S. Senate,,REP,Duf Sundheim,5
 Humboldt,5GP,U.S. Senate,,LIB,Gail K. Lightfoot,1
@@ -4115,10 +4309,12 @@ Humboldt,5KT-1,President,,REP,John R. Kasich,2
 Humboldt,5KT-1,Proposition 50,,,No,13
 Humboldt,5KT-1,Proposition 50,,,Yes,27
 Humboldt,5KT-1,State Assembly,2,DEM,Jim Wood,38
+Humboldt,5KT-1,State Assembly,2,IND,Ken Anton,0
 Humboldt,5KT-1,U.S. House,2,REP,Dale K. Mensing,5
 Humboldt,5KT-1,U.S. House,2,DEM,Erin A. Schrode,6
 Humboldt,5KT-1,U.S. House,2,DEM,Jared W. Huffman,28
 Humboldt,5KT-1,U.S. House,2,IND,Matthew Robert Wookey,4
+Humboldt,5KT-1,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,5KT-1,U.S. Senate,,IND,Clive Grey,2
 Humboldt,5KT-1,U.S. Senate,,REP,Don Krampe,1
 Humboldt,5KT-1,U.S. Senate,,LIB,Gail K. Lightfoot,1
@@ -4142,10 +4338,12 @@ Humboldt,5KT-3,President,,REP,Ted Cruz,2
 Humboldt,5KT-3,Proposition 50,,,No,26
 Humboldt,5KT-3,Proposition 50,,,Yes,73
 Humboldt,5KT-3,State Assembly,2,DEM,Jim Wood,66
+Humboldt,5KT-3,State Assembly,2,IND,Ken Anton,0
 Humboldt,5KT-3,U.S. House,2,REP,Dale K. Mensing,11
 Humboldt,5KT-3,U.S. House,2,DEM,Erin A. Schrode,16
 Humboldt,5KT-3,U.S. House,2,DEM,Jared W. Huffman,57
 Humboldt,5KT-3,U.S. House,2,IND,Matthew Robert Wookey,13
+Humboldt,5KT-3,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,5KT-3,U.S. Senate,,IND,Clive Grey,2
 Humboldt,5KT-3,U.S. Senate,,IND,Don J. Grundmann,1
 Humboldt,5KT-3,U.S. Senate,,REP,Duf Sundheim,4
@@ -4178,10 +4376,12 @@ Humboldt,5KT-4,President,,DEM,Willie Wilson,1
 Humboldt,5KT-4,Proposition 50,,,No,47
 Humboldt,5KT-4,Proposition 50,,,Yes,180
 Humboldt,5KT-4,State Assembly,2,DEM,Jim Wood,189
+Humboldt,5KT-4,State Assembly,2,IND,Ken Anton,0
 Humboldt,5KT-4,U.S. House,2,REP,Dale K. Mensing,30
 Humboldt,5KT-4,U.S. House,2,DEM,Erin A. Schrode,27
 Humboldt,5KT-4,U.S. House,2,DEM,Jared W. Huffman,158
 Humboldt,5KT-4,U.S. House,2,IND,Matthew Robert Wookey,25
+Humboldt,5KT-4,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,5KT-4,U.S. Senate,,IND,Don J. Grundmann,1
 Humboldt,5KT-4,U.S. Senate,,REP,Don Krampe,3
 Humboldt,5KT-4,U.S. Senate,,REP,Duf Sundheim,4
@@ -4227,10 +4427,12 @@ Humboldt,5KT-6,President,,DEM,Willie Wilson,2
 Humboldt,5KT-6,Proposition 50,,,No,115
 Humboldt,5KT-6,Proposition 50,,,Yes,400
 Humboldt,5KT-6,State Assembly,2,DEM,Jim Wood,370
+Humboldt,5KT-6,State Assembly,2,IND,Ken Anton,0
 Humboldt,5KT-6,U.S. House,2,REP,Dale K. Mensing,151
 Humboldt,5KT-6,U.S. House,2,DEM,Erin A. Schrode,46
 Humboldt,5KT-6,U.S. House,2,DEM,Jared W. Huffman,297
 Humboldt,5KT-6,U.S. House,2,IND,Matthew Robert Wookey,31
+Humboldt,5KT-6,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,5KT-6,U.S. Senate,,IND,Clive Grey,8
 Humboldt,5KT-6,U.S. Senate,,IND,Don J. Grundmann,4
 Humboldt,5KT-6,U.S. Senate,,REP,Don Krampe,9
@@ -4276,10 +4478,12 @@ Humboldt,5KTS3,President,,REP,Ted Cruz,2
 Humboldt,5KTS3,Proposition 50,,,No,17
 Humboldt,5KTS3,Proposition 50,,,Yes,56
 Humboldt,5KTS3,State Assembly,2,DEM,Jim Wood,52
+Humboldt,5KTS3,State Assembly,2,IND,Ken Anton,0
 Humboldt,5KTS3,U.S. House,2,REP,Dale K. Mensing,19
 Humboldt,5KTS3,U.S. House,2,DEM,Erin A. Schrode,3
 Humboldt,5KTS3,U.S. House,2,DEM,Jared W. Huffman,48
 Humboldt,5KTS3,U.S. House,2,IND,Matthew Robert Wookey,6
+Humboldt,5KTS3,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,5KTS3,U.S. Senate,,REP,Don Krampe,3
 Humboldt,5KTS3,U.S. Senate,,REP,Duf Sundheim,2
 Humboldt,5KTS3,U.S. Senate,,LIB,Gail K. Lightfoot,5
@@ -4305,9 +4509,11 @@ Humboldt,5MC,President,,REP,Ted Cruz,1
 Humboldt,5MC,Proposition 50,,,No,3
 Humboldt,5MC,Proposition 50,,,Yes,12
 Humboldt,5MC,State Assembly,2,DEM,Jim Wood,15
+Humboldt,5MC,State Assembly,2,IND,Ken Anton,0
 Humboldt,5MC,U.S. House,2,DEM,Erin A. Schrode,1
 Humboldt,5MC,U.S. House,2,DEM,Jared W. Huffman,14
 Humboldt,5MC,U.S. House,2,IND,Matthew Robert Wookey,1
+Humboldt,5MC,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,5MC,U.S. Senate,,IND,Clive Grey,1
 Humboldt,5MC,U.S. Senate,,REP,Duf Sundheim,1
 Humboldt,5MC,U.S. Senate,,REP,Jerry J. Laws,1
@@ -4331,10 +4537,12 @@ Humboldt,5MK-1,President,,REP,Ted Cruz,12
 Humboldt,5MK-1,Proposition 50,,,No,83
 Humboldt,5MK-1,Proposition 50,,,Yes,379
 Humboldt,5MK-1,State Assembly,2,DEM,Jim Wood,382
+Humboldt,5MK-1,State Assembly,2,IND,Ken Anton,0
 Humboldt,5MK-1,U.S. House,2,REP,Dale K. Mensing,89
 Humboldt,5MK-1,U.S. House,2,DEM,Erin A. Schrode,51
 Humboldt,5MK-1,U.S. House,2,DEM,Jared W. Huffman,317
 Humboldt,5MK-1,U.S. House,2,IND,Matthew Robert Wookey,33
+Humboldt,5MK-1,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,5MK-1,U.S. Senate,,IND,Clive Grey,1
 Humboldt,5MK-1,U.S. Senate,,REP,Duf Sundheim,17
 Humboldt,5MK-1,U.S. Senate,,IND,Eleanor García,3
@@ -4377,10 +4585,12 @@ Humboldt,5MK-2,President,,DEM,Willie Wilson,1
 Humboldt,5MK-2,Proposition 50,,,No,90
 Humboldt,5MK-2,Proposition 50,,,Yes,368
 Humboldt,5MK-2,State Assembly,2,DEM,Jim Wood,342
+Humboldt,5MK-2,State Assembly,2,IND,Ken Anton,0
 Humboldt,5MK-2,U.S. House,2,REP,Dale K. Mensing,106
 Humboldt,5MK-2,U.S. House,2,DEM,Erin A. Schrode,34
 Humboldt,5MK-2,U.S. House,2,DEM,Jared W. Huffman,303
 Humboldt,5MK-2,U.S. House,2,IND,Matthew Robert Wookey,29
+Humboldt,5MK-2,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,5MK-2,U.S. Senate,,IND,Don J. Grundmann,1
 Humboldt,5MK-2,U.S. Senate,,REP,Don Krampe,3
 Humboldt,5MK-2,U.S. Senate,,REP,Duf Sundheim,44
@@ -4422,10 +4632,12 @@ Humboldt,5MK-3,President,,REP,Ted Cruz,5
 Humboldt,5MK-3,Proposition 50,,,No,67
 Humboldt,5MK-3,Proposition 50,,,Yes,250
 Humboldt,5MK-3,State Assembly,2,DEM,Jim Wood,264
+Humboldt,5MK-3,State Assembly,2,IND,Ken Anton,0
 Humboldt,5MK-3,U.S. House,2,REP,Dale K. Mensing,55
 Humboldt,5MK-3,U.S. House,2,DEM,Erin A. Schrode,53
 Humboldt,5MK-3,U.S. House,2,DEM,Jared W. Huffman,218
 Humboldt,5MK-3,U.S. House,2,IND,Matthew Robert Wookey,26
+Humboldt,5MK-3,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,5MK-3,U.S. Senate,,IND,Clive Grey,1
 Humboldt,5MK-3,U.S. Senate,,REP,Don Krampe,4
 Humboldt,5MK-3,U.S. Senate,,REP,Duf Sundheim,13
@@ -4469,10 +4681,12 @@ Humboldt,5MK-4,President,,REP,Ted Cruz,28
 Humboldt,5MK-4,Proposition 50,,,No,153
 Humboldt,5MK-4,Proposition 50,,,Yes,633
 Humboldt,5MK-4,State Assembly,2,DEM,Jim Wood,640
+Humboldt,5MK-4,State Assembly,2,IND,Ken Anton,0
 Humboldt,5MK-4,U.S. House,2,REP,Dale K. Mensing,164
 Humboldt,5MK-4,U.S. House,2,DEM,Erin A. Schrode,84
 Humboldt,5MK-4,U.S. House,2,DEM,Jared W. Huffman,531
 Humboldt,5MK-4,U.S. House,2,IND,Matthew Robert Wookey,53
+Humboldt,5MK-4,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,5MK-4,U.S. Senate,,IND,Clive Grey,2
 Humboldt,5MK-4,U.S. Senate,,REP,Don Krampe,12
 Humboldt,5MK-4,U.S. Senate,,REP,Duf Sundheim,53
@@ -4524,10 +4738,12 @@ Humboldt,5MK-5,President,,DEM,Willie Wilson,1
 Humboldt,5MK-5,Proposition 50,,,No,173
 Humboldt,5MK-5,Proposition 50,,,Yes,706
 Humboldt,5MK-5,State Assembly,2,DEM,Jim Wood,685
+Humboldt,5MK-5,State Assembly,2,IND,Ken Anton,0
 Humboldt,5MK-5,U.S. House,2,REP,Dale K. Mensing,174
 Humboldt,5MK-5,U.S. House,2,DEM,Erin A. Schrode,75
 Humboldt,5MK-5,U.S. House,2,DEM,Jared W. Huffman,597
 Humboldt,5MK-5,U.S. House,2,IND,Matthew Robert Wookey,53
+Humboldt,5MK-5,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,5MK-5,U.S. Senate,,IND,Clive Grey,4
 Humboldt,5MK-5,U.S. Senate,,IND,Don J. Grundmann,3
 Humboldt,5MK-5,U.S. Senate,,REP,Don Krampe,7
@@ -4578,10 +4794,12 @@ Humboldt,5MK-6,President,,DEM,Willie Wilson,2
 Humboldt,5MK-6,Proposition 50,,,No,143
 Humboldt,5MK-6,Proposition 50,,,Yes,500
 Humboldt,5MK-6,State Assembly,2,DEM,Jim Wood,514
+Humboldt,5MK-6,State Assembly,2,IND,Ken Anton,0
 Humboldt,5MK-6,U.S. House,2,REP,Dale K. Mensing,119
 Humboldt,5MK-6,U.S. House,2,DEM,Erin A. Schrode,78
 Humboldt,5MK-6,U.S. House,2,DEM,Jared W. Huffman,403
 Humboldt,5MK-6,U.S. House,2,IND,Matthew Robert Wookey,66
+Humboldt,5MK-6,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,5MK-6,U.S. Senate,,IND,Clive Grey,2
 Humboldt,5MK-6,U.S. Senate,,REP,Don Krampe,8
 Humboldt,5MK-6,U.S. Senate,,REP,Duf Sundheim,39
@@ -4628,10 +4846,12 @@ Humboldt,5MK-7,President,,REP,Ted Cruz,13
 Humboldt,5MK-7,Proposition 50,,,No,77
 Humboldt,5MK-7,Proposition 50,,,Yes,285
 Humboldt,5MK-7,State Assembly,2,DEM,Jim Wood,289
+Humboldt,5MK-7,State Assembly,2,IND,Ken Anton,0
 Humboldt,5MK-7,U.S. House,2,REP,Dale K. Mensing,88
 Humboldt,5MK-7,U.S. House,2,DEM,Erin A. Schrode,25
 Humboldt,5MK-7,U.S. House,2,DEM,Jared W. Huffman,251
 Humboldt,5MK-7,U.S. House,2,IND,Matthew Robert Wookey,22
+Humboldt,5MK-7,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,5MK-7,U.S. Senate,,IND,Clive Grey,2
 Humboldt,5MK-7,U.S. Senate,,IND,Don J. Grundmann,1
 Humboldt,5MK-7,U.S. Senate,,REP,Don Krampe,7
@@ -4680,10 +4900,12 @@ Humboldt,5MK-8,President,,AIP,Thomas Hoefling,1
 Humboldt,5MK-8,Proposition 50,,,No,80
 Humboldt,5MK-8,Proposition 50,,,Yes,349
 Humboldt,5MK-8,State Assembly,2,DEM,Jim Wood,362
+Humboldt,5MK-8,State Assembly,2,IND,Ken Anton,0
 Humboldt,5MK-8,U.S. House,2,REP,Dale K. Mensing,70
 Humboldt,5MK-8,U.S. House,2,DEM,Erin A. Schrode,24
 Humboldt,5MK-8,U.S. House,2,DEM,Jared W. Huffman,337
 Humboldt,5MK-8,U.S. House,2,IND,Matthew Robert Wookey,31
+Humboldt,5MK-8,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,5MK-8,U.S. Senate,,IND,Clive Grey,4
 Humboldt,5MK-8,U.S. Senate,,REP,Don Krampe,1
 Humboldt,5MK-8,U.S. Senate,,REP,Duf Sundheim,13
@@ -4727,10 +4949,12 @@ Humboldt,5OR,President,,DEM,Willie Wilson,1
 Humboldt,5OR,Proposition 50,,,No,12
 Humboldt,5OR,Proposition 50,,,Yes,55
 Humboldt,5OR,State Assembly,2,DEM,Jim Wood,53
+Humboldt,5OR,State Assembly,2,IND,Ken Anton,0
 Humboldt,5OR,U.S. House,2,REP,Dale K. Mensing,15
 Humboldt,5OR,U.S. House,2,DEM,Erin A. Schrode,8
 Humboldt,5OR,U.S. House,2,DEM,Jared W. Huffman,37
 Humboldt,5OR,U.S. House,2,IND,Matthew Robert Wookey,10
+Humboldt,5OR,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,5OR,U.S. Senate,,REP,Don Krampe,1
 Humboldt,5OR,U.S. Senate,,REP,Duf Sundheim,2
 Humboldt,5OR,U.S. Senate,,LIB,Gail K. Lightfoot,2
@@ -4757,10 +4981,12 @@ Humboldt,5PA-3,President,,REP,Ted Cruz,2
 Humboldt,5PA-3,Proposition 50,,,No,9
 Humboldt,5PA-3,Proposition 50,,,Yes,47
 Humboldt,5PA-3,State Assembly,2,DEM,Jim Wood,50
+Humboldt,5PA-3,State Assembly,2,IND,Ken Anton,0
 Humboldt,5PA-3,U.S. House,2,REP,Dale K. Mensing,13
 Humboldt,5PA-3,U.S. House,2,DEM,Erin A. Schrode,1
 Humboldt,5PA-3,U.S. House,2,DEM,Jared W. Huffman,42
 Humboldt,5PA-3,U.S. House,2,IND,Matthew Robert Wookey,2
+Humboldt,5PA-3,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,5PA-3,U.S. Senate,,REP,Duf Sundheim,5
 Humboldt,5PA-3,U.S. Senate,,LIB,Gail K. Lightfoot,2
 Humboldt,5PA-3,U.S. Senate,,REP,Greg Conlon,6
@@ -4785,10 +5011,12 @@ Humboldt,5T--1,President,,DEM,Keith Judd,1
 Humboldt,5T--1,Proposition 50,,,No,30
 Humboldt,5T--1,Proposition 50,,,Yes,106
 Humboldt,5T--1,State Assembly,2,DEM,Jim Wood,121
+Humboldt,5T--1,State Assembly,2,IND,Ken Anton,0
 Humboldt,5T--1,U.S. House,2,REP,Dale K. Mensing,14
 Humboldt,5T--1,U.S. House,2,DEM,Erin A. Schrode,17
 Humboldt,5T--1,U.S. House,2,DEM,Jared W. Huffman,102
 Humboldt,5T--1,U.S. House,2,IND,Matthew Robert Wookey,6
+Humboldt,5T--1,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,5T--1,U.S. Senate,,REP,Don Krampe,2
 Humboldt,5T--1,U.S. Senate,,REP,Duf Sundheim,1
 Humboldt,5T--1,U.S. Senate,,IND,Eleanor García,1
@@ -4824,10 +5052,12 @@ Humboldt,5TU-1,President,,REP,Ted Cruz,6
 Humboldt,5TU-1,Proposition 50,,,No,97
 Humboldt,5TU-1,Proposition 50,,,Yes,367
 Humboldt,5TU-1,State Assembly,2,DEM,Jim Wood,391
+Humboldt,5TU-1,State Assembly,2,IND,Ken Anton,0
 Humboldt,5TU-1,U.S. House,2,REP,Dale K. Mensing,54
 Humboldt,5TU-1,U.S. House,2,DEM,Erin A. Schrode,41
 Humboldt,5TU-1,U.S. House,2,DEM,Jared W. Huffman,366
 Humboldt,5TU-1,U.S. House,2,IND,Matthew Robert Wookey,34
+Humboldt,5TU-1,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,5TU-1,U.S. Senate,,IND,Clive Grey,3
 Humboldt,5TU-1,U.S. Senate,,IND,Don J. Grundmann,1
 Humboldt,5TU-1,U.S. Senate,,REP,Don Krampe,3
@@ -4870,10 +5100,12 @@ Humboldt,5TU-4,President,,AIP,Wiley Drake,1
 Humboldt,5TU-4,Proposition 50,,,No,77
 Humboldt,5TU-4,Proposition 50,,,Yes,315
 Humboldt,5TU-4,State Assembly,2,DEM,Jim Wood,339
+Humboldt,5TU-4,State Assembly,2,IND,Ken Anton,0
 Humboldt,5TU-4,U.S. House,2,REP,Dale K. Mensing,43
 Humboldt,5TU-4,U.S. House,2,DEM,Erin A. Schrode,46
 Humboldt,5TU-4,U.S. House,2,DEM,Jared W. Huffman,313
 Humboldt,5TU-4,U.S. House,2,IND,Matthew Robert Wookey,18
+Humboldt,5TU-4,U.S. House,2,IND,Andrew Augustine Caffrey,0
 Humboldt,5TU-4,U.S. Senate,,IND,Clive Grey,1
 Humboldt,5TU-4,U.S. Senate,,REP,Don Krampe,4
 Humboldt,5TU-4,U.S. Senate,,REP,Duf Sundheim,11


### PR DESCRIPTION
Add write-in candidates for 2016 Primary Humboldt Precinct data

Data gathered from [Final Canvass of that election](https://humboldtgov.org/DocumentCenter/View/55591/final-canvass?bidId=)

Should fix #80
