### PR TITLE
Add missing write-in records to San Diego 2016 Primary precinct file

### DIFF
--- a/2016/counties/20160607__ca__primary__san_diego__precinct.csv
+++ b/2016/counties/20160607__ca__primary__san_diego__precinct.csv
@@ -32384,6 +32384,7 @@ San Diego,403500,President,,REP,Ted Cruz,16
 San Diego,403500,Proposition 50,,,No,105
 San Diego,403500,Proposition 50,,,Yes,288
 San Diego,403500,State Assembly,76,REP,Rocky Chavez,322
+San Diego,403500,State Assembly,76,REP,Thomas E Krouse,2
 San Diego,403500,U.S. House,49,REP,Darrell Issa,187
 San Diego,403500,U.S. House,49,DEM,Doug Applegate,195
 San Diego,403500,U.S. House,49,IND,Ryan Glenn Wingo,25
@@ -32431,6 +32432,7 @@ San Diego,403520,President,,REP,Ted Cruz,26
 San Diego,403520,Proposition 50,,,No,129
 San Diego,403520,Proposition 50,,,Yes,295
 San Diego,403520,State Assembly,76,REP,Rocky Chavez,290
+San Diego,403520,State Assembly,76,REP,Thomas E Krouse,0
 San Diego,403520,U.S. House,49,REP,Darrell Issa,213
 San Diego,403520,U.S. House,49,DEM,Doug Applegate,228
 San Diego,403520,U.S. House,49,IND,Ryan Glenn Wingo,11
@@ -32479,6 +32481,7 @@ San Diego,403600,President,,REP,Ted Cruz,4
 San Diego,403600,Proposition 50,,,No,89
 San Diego,403600,Proposition 50,,,Yes,365
 San Diego,403600,State Assembly,76,REP,Rocky Chavez,344
+San Diego,403600,State Assembly,76,REP,Thomas E Krouse,0
 San Diego,403600,U.S. House,49,REP,Darrell Issa,182
 San Diego,403600,U.S. House,49,DEM,Doug Applegate,264
 San Diego,403600,U.S. House,49,IND,Ryan Glenn Wingo,23
@@ -32522,6 +32525,7 @@ San Diego,403610,President,,AIP,Thomas Hoefling,1
 San Diego,403610,Proposition 50,,,No,46
 San Diego,403610,Proposition 50,,,Yes,154
 San Diego,403610,State Assembly,76,REP,Rocky Chavez,147
+San Diego,403610,State Assembly,76,REP,Thomas E Krouse,0
 San Diego,403610,U.S. House,49,REP,Darrell Issa,87
 San Diego,403610,U.S. House,49,DEM,Doug Applegate,104
 San Diego,403610,U.S. House,49,IND,Ryan Glenn Wingo,11
@@ -32572,6 +32576,7 @@ San Diego,403630,President,,DEM,Willie Wilson,1
 San Diego,403630,Proposition 50,,,No,101
 San Diego,403630,Proposition 50,,,Yes,382
 San Diego,403630,State Assembly,76,REP,Rocky Chavez,351
+San Diego,403630,State Assembly,76,REP,Thomas E Krouse,6
 San Diego,403630,U.S. House,49,REP,Darrell Issa,266
 San Diego,403630,U.S. House,49,DEM,Doug Applegate,221
 San Diego,403630,U.S. House,49,IND,Ryan Glenn Wingo,14
@@ -32618,6 +32623,7 @@ San Diego,403640,President,,REP,Ted Cruz,14
 San Diego,403640,Proposition 50,,,No,95
 San Diego,403640,Proposition 50,,,Yes,288
 San Diego,403640,State Assembly,76,REP,Rocky Chavez,277
+San Diego,403640,State Assembly,76,REP,Thomas E Krouse,1
 San Diego,403640,U.S. House,49,REP,Darrell Issa,215
 San Diego,403640,U.S. House,49,DEM,Doug Applegate,167
 San Diego,403640,U.S. House,49,IND,Ryan Glenn Wingo,21
@@ -32667,6 +32673,7 @@ San Diego,403650,President,,REP,Ted Cruz,16
 San Diego,403650,Proposition 50,,,No,76
 San Diego,403650,Proposition 50,,,Yes,333
 San Diego,403650,State Assembly,76,REP,Rocky Chavez,323
+San Diego,403650,State Assembly,76,REP,Thomas E Krouse,2
 San Diego,403650,U.S. House,49,REP,Darrell Issa,163
 San Diego,403650,U.S. House,49,DEM,Doug Applegate,232
 San Diego,403650,U.S. House,49,IND,Ryan Glenn Wingo,29
@@ -32714,6 +32721,7 @@ San Diego,403670,President,,REP,Ted Cruz,6
 San Diego,403670,Proposition 50,,,No,90
 San Diego,403670,Proposition 50,,,Yes,273
 San Diego,403670,State Assembly,76,REP,Rocky Chavez,290
+San Diego,403670,State Assembly,76,REP,Thomas E Krouse,0
 San Diego,403670,U.S. House,49,REP,Darrell Issa,215
 San Diego,403670,U.S. House,49,DEM,Doug Applegate,142
 San Diego,403670,U.S. House,49,IND,Ryan Glenn Wingo,20
@@ -32757,6 +32765,7 @@ San Diego,403690,President,,REP,Ted Cruz,10
 San Diego,403690,Proposition 50,,,No,87
 San Diego,403690,Proposition 50,,,Yes,276
 San Diego,403690,State Assembly,76,REP,Rocky Chavez,273
+San Diego,403690,State Assembly,76,REP,Thomas E Krouse,0
 San Diego,403690,U.S. House,49,REP,Darrell Issa,207
 San Diego,403690,U.S. House,49,DEM,Doug Applegate,153
 San Diego,403690,U.S. House,49,IND,Ryan Glenn Wingo,10
@@ -32794,6 +32803,7 @@ San Diego,403700,President,,REP,Ted Cruz,9
 San Diego,403700,Proposition 50,,,No,76
 San Diego,403700,Proposition 50,,,Yes,209
 San Diego,403700,State Assembly,76,REP,Rocky Chavez,220
+San Diego,403700,State Assembly,76,REP,Thomas E Krouse,4
 San Diego,403700,U.S. House,49,REP,Darrell Issa,184
 San Diego,403700,U.S. House,49,DEM,Doug Applegate,97
 San Diego,403700,U.S. House,49,IND,Ryan Glenn Wingo,10
@@ -32833,6 +32843,7 @@ San Diego,403720,President,,REP,Ted Cruz,20
 San Diego,403720,Proposition 50,,,No,115
 San Diego,403720,Proposition 50,,,Yes,405
 San Diego,403720,State Assembly,76,REP,Rocky Chavez,388
+San Diego,403720,State Assembly,76,REP,Thomas E Krouse,1
 San Diego,403720,U.S. House,49,REP,Darrell Issa,231
 San Diego,403720,U.S. House,49,DEM,Doug Applegate,257
 San Diego,403720,U.S. House,49,IND,Ryan Glenn Wingo,41
@@ -32882,6 +32893,7 @@ San Diego,403770,President,,REP,Ted Cruz,30
 San Diego,403770,Proposition 50,,,No,152
 San Diego,403770,Proposition 50,,,Yes,408
 San Diego,403770,State Assembly,76,REP,Rocky Chavez,409
+San Diego,403770,State Assembly,76,REP,Thomas E Krouse,0
 San Diego,403770,U.S. House,49,REP,Darrell Issa,328
 San Diego,403770,U.S. House,49,DEM,Doug Applegate,224
 San Diego,403770,U.S. House,49,IND,Ryan Glenn Wingo,18
@@ -32927,6 +32939,7 @@ San Diego,403820,President,,REP,Ted Cruz,17
 San Diego,403820,Proposition 50,,,No,120
 San Diego,403820,Proposition 50,,,Yes,370
 San Diego,403820,State Assembly,76,REP,Rocky Chavez,360
+San Diego,403820,State Assembly,76,REP,Thomas E Krouse,1
 San Diego,403820,U.S. House,49,REP,Darrell Issa,267
 San Diego,403820,U.S. House,49,DEM,Doug Applegate,212
 San Diego,403820,U.S. House,49,IND,Ryan Glenn Wingo,22
@@ -32969,6 +32982,7 @@ San Diego,403840,President,,REP,Ted Cruz,15
 San Diego,403840,Proposition 50,,,No,75
 San Diego,403840,Proposition 50,,,Yes,245
 San Diego,403840,State Assembly,76,REP,Rocky Chavez,247
+San Diego,403840,State Assembly,76,REP,Thomas E Krouse,0
 San Diego,403840,U.S. House,49,REP,Darrell Issa,186
 San Diego,403840,U.S. House,49,DEM,Doug Applegate,132
 San Diego,403840,U.S. House,49,IND,Ryan Glenn Wingo,19
@@ -33012,6 +33026,7 @@ San Diego,403890,President,,DEM,Willie Wilson,3
 San Diego,403890,Proposition 50,,,No,101
 San Diego,403890,Proposition 50,,,Yes,374
 San Diego,403890,State Assembly,76,REP,Rocky Chavez,363
+San Diego,403890,State Assembly,76,REP,Thomas E Krouse,0
 San Diego,403890,U.S. House,49,REP,Darrell Issa,307
 San Diego,403890,U.S. House,49,DEM,Doug Applegate,166
 San Diego,403890,U.S. House,49,IND,Ryan Glenn Wingo,20
@@ -33059,6 +33074,7 @@ San Diego,403900,President,,REP,Ted Cruz,25
 San Diego,403900,Proposition 50,,,No,122
 San Diego,403900,Proposition 50,,,Yes,339
 San Diego,403900,State Assembly,76,REP,Rocky Chavez,366
+San Diego,403900,State Assembly,76,REP,Thomas E Krouse,1
 San Diego,403900,U.S. House,49,REP,Darrell Issa,288
 San Diego,403900,U.S. House,49,DEM,Doug Applegate,178
 San Diego,403900,U.S. House,49,IND,Ryan Glenn Wingo,18
@@ -33104,6 +33120,7 @@ San Diego,403910,President,,AIP,Wiley Drake,1
 San Diego,403910,Proposition 50,,,No,83
 San Diego,403910,Proposition 50,,,Yes,251
 San Diego,403910,State Assembly,76,REP,Rocky Chavez,249
+San Diego,403910,State Assembly,76,REP,Thomas E Krouse,1
 San Diego,403910,U.S. House,49,REP,Darrell Issa,189
 San Diego,403910,U.S. House,49,DEM,Doug Applegate,136
 San Diego,403910,U.S. House,49,IND,Ryan Glenn Wingo,19
@@ -33148,6 +33165,7 @@ San Diego,403930,President,,DEM,Willie Wilson,1
 San Diego,403930,Proposition 50,,,No,154
 San Diego,403930,Proposition 50,,,Yes,456
 San Diego,403930,State Assembly,76,REP,Rocky Chavez,483
+San Diego,403930,State Assembly,76,REP,Thomas E Krouse,0
 San Diego,403930,U.S. House,49,REP,Darrell Issa,378
 San Diego,403930,U.S. House,49,DEM,Doug Applegate,234
 San Diego,403930,U.S. House,49,IND,Ryan Glenn Wingo,25
@@ -33196,6 +33214,7 @@ San Diego,403950,President,,DEM,Willie Wilson,1
 San Diego,403950,Proposition 50,,,No,82
 San Diego,403950,Proposition 50,,,Yes,294
 San Diego,403950,State Assembly,76,REP,Rocky Chavez,292
+San Diego,403950,State Assembly,76,REP,Thomas E Krouse,0
 San Diego,403950,U.S. House,49,REP,Darrell Issa,258
 San Diego,403950,U.S. House,49,DEM,Doug Applegate,139
 San Diego,403950,U.S. House,49,IND,Ryan Glenn Wingo,6
@@ -33241,6 +33260,7 @@ San Diego,404000,President,,DEM,Willie Wilson,2
 San Diego,404000,Proposition 50,,,No,115
 San Diego,404000,Proposition 50,,,Yes,331
 San Diego,404000,State Assembly,76,REP,Rocky Chavez,334
+San Diego,404000,State Assembly,76,REP,Thomas E Krouse,0
 San Diego,404000,U.S. House,49,REP,Darrell Issa,234
 San Diego,404000,U.S. House,49,DEM,Doug Applegate,205
 San Diego,404000,U.S. House,49,IND,Ryan Glenn Wingo,16
@@ -33294,6 +33314,7 @@ San Diego,404010,President,,DEM,Willie Wilson,1
 San Diego,404010,Proposition 50,,,No,142
 San Diego,404010,Proposition 50,,,Yes,565
 San Diego,404010,State Assembly,76,REP,Rocky Chavez,510
+San Diego,404010,State Assembly,76,REP,Thomas E Krouse,4
 San Diego,404010,U.S. House,49,REP,Darrell Issa,372
 San Diego,404010,U.S. House,49,DEM,Doug Applegate,336
 San Diego,404010,U.S. House,49,IND,Ryan Glenn Wingo,36
@@ -33335,6 +33356,7 @@ San Diego,404040,President,,REP,Ted Cruz,12
 San Diego,404040,Proposition 50,,,No,54
 San Diego,404040,Proposition 50,,,Yes,197
 San Diego,404040,State Assembly,76,REP,Rocky Chavez,192
+San Diego,404040,State Assembly,76,REP,Thomas E Krouse,2
 San Diego,404040,U.S. House,49,REP,Darrell Issa,154
 San Diego,404040,U.S. House,49,DEM,Doug Applegate,99
 San Diego,404040,U.S. House,49,IND,Ryan Glenn Wingo,6
@@ -33376,6 +33398,7 @@ San Diego,404050,President,,DEM,Willie Wilson,1
 San Diego,404050,Proposition 50,,,No,82
 San Diego,404050,Proposition 50,,,Yes,335
 San Diego,404050,State Assembly,76,REP,Rocky Chavez,274
+San Diego,404050,State Assembly,76,REP,Thomas E Krouse,0
 San Diego,404050,U.S. House,49,REP,Darrell Issa,197
 San Diego,404050,U.S. House,49,DEM,Doug Applegate,215
 San Diego,404050,U.S. House,49,IND,Ryan Glenn Wingo,15
@@ -33420,6 +33443,7 @@ San Diego,404060,President,,DEM,Willie Wilson,2
 San Diego,404060,Proposition 50,,,No,116
 San Diego,404060,Proposition 50,,,Yes,314
 San Diego,404060,State Assembly,76,REP,Rocky Chavez,324
+San Diego,404060,State Assembly,76,REP,Thomas E Krouse,0
 San Diego,404060,U.S. House,49,REP,Darrell Issa,234
 San Diego,404060,U.S. House,49,DEM,Doug Applegate,193
 San Diego,404060,U.S. House,49,IND,Ryan Glenn Wingo,14
@@ -33463,6 +33487,7 @@ San Diego,404070,President,,REP,Ted Cruz,19
 San Diego,404070,Proposition 50,,,No,94
 San Diego,404070,Proposition 50,,,Yes,301
 San Diego,404070,State Assembly,76,REP,Rocky Chavez,313
+San Diego,404070,State Assembly,76,REP,Thomas E Krouse,0
 San Diego,404070,U.S. House,49,REP,Darrell Issa,247
 San Diego,404070,U.S. House,49,DEM,Doug Applegate,139
 San Diego,404070,U.S. House,49,IND,Ryan Glenn Wingo,16
@@ -33500,6 +33525,7 @@ San Diego,404090,President,,REP,Ted Cruz,16
 San Diego,404090,Proposition 50,,,No,77
 San Diego,404090,Proposition 50,,,Yes,271
 San Diego,404090,State Assembly,76,REP,Rocky Chavez,245
+San Diego,404090,State Assembly,76,REP,Thomas E Krouse,0
 San Diego,404090,U.S. House,49,REP,Darrell Issa,177
 San Diego,404090,U.S. House,49,DEM,Doug Applegate,167
 San Diego,404090,U.S. House,49,IND,Ryan Glenn Wingo,17
@@ -33548,6 +33574,7 @@ San Diego,404100,President,,REP,Ted Cruz,16
 San Diego,404100,Proposition 50,,,No,124
 San Diego,404100,Proposition 50,,,Yes,426
 San Diego,404100,State Assembly,76,REP,Rocky Chavez,414
+San Diego,404100,State Assembly,76,REP,Thomas E Krouse,1
 San Diego,404100,U.S. House,49,REP,Darrell Issa,314
 San Diego,404100,U.S. House,49,DEM,Doug Applegate,224
 San Diego,404100,U.S. House,49,IND,Ryan Glenn Wingo,28
@@ -33596,6 +33623,7 @@ San Diego,404120,President,,REP,Ted Cruz,13
 San Diego,404120,Proposition 50,,,No,81
 San Diego,404120,Proposition 50,,,Yes,238
 San Diego,404120,State Assembly,76,REP,Rocky Chavez,231
+San Diego,404120,State Assembly,76,REP,Thomas E Krouse,0
 San Diego,404120,U.S. House,49,REP,Darrell Issa,146
 San Diego,404120,U.S. House,49,DEM,Doug Applegate,164
 San Diego,404120,U.S. House,49,IND,Ryan Glenn Wingo,15
@@ -33641,6 +33669,7 @@ San Diego,404130,President,,DEM,Willie Wilson,1
 San Diego,404130,Proposition 50,,,No,71
 San Diego,404130,Proposition 50,,,Yes,343
 San Diego,404130,State Assembly,76,REP,Rocky Chavez,281
+San Diego,404130,State Assembly,76,REP,Thomas E Krouse,2
 San Diego,404130,U.S. House,49,REP,Darrell Issa,219
 San Diego,404130,U.S. House,49,DEM,Doug Applegate,196
 San Diego,404130,U.S. House,49,IND,Ryan Glenn Wingo,21
@@ -33684,6 +33713,7 @@ San Diego,404140,President,,REP,Ted Cruz,9
 San Diego,404140,Proposition 50,,,No,61
 San Diego,404140,Proposition 50,,,Yes,157
 San Diego,404140,State Assembly,76,REP,Rocky Chavez,169
+San Diego,404140,State Assembly,76,REP,Thomas E Krouse,1
 San Diego,404140,U.S. House,49,REP,Darrell Issa,117
 San Diego,404140,U.S. House,49,DEM,Doug Applegate,103
 San Diego,404140,U.S. House,49,IND,Ryan Glenn Wingo,5
@@ -33726,6 +33756,7 @@ San Diego,404190,President,,AIP,Wiley Drake,1
 San Diego,404190,Proposition 50,,,No,86
 San Diego,404190,Proposition 50,,,Yes,321
 San Diego,404190,State Assembly,76,REP,Rocky Chavez,278
+San Diego,404190,State Assembly,76,REP,Thomas E Krouse,3
 San Diego,404190,U.S. House,49,REP,Darrell Issa,208
 San Diego,404190,U.S. House,49,DEM,Doug Applegate,203
 San Diego,404190,U.S. House,49,IND,Ryan Glenn Wingo,19
@@ -33771,6 +33802,7 @@ San Diego,404210,President,,REP,Ted Cruz,4
 San Diego,404210,Proposition 50,,,No,78
 San Diego,404210,Proposition 50,,,Yes,279
 San Diego,404210,State Assembly,76,REP,Rocky Chavez,269
+San Diego,404210,State Assembly,76,REP,Thomas E Krouse,1
 San Diego,404210,U.S. House,49,REP,Darrell Issa,190
 San Diego,404210,U.S. House,49,DEM,Doug Applegate,161
 San Diego,404210,U.S. House,49,IND,Ryan Glenn Wingo,20
@@ -33818,6 +33850,7 @@ San Diego,404220,President,,DEM,Willie Wilson,1
 San Diego,404220,Proposition 50,,,No,99
 San Diego,404220,Proposition 50,,,Yes,446
 San Diego,404220,State Assembly,76,REP,Rocky Chavez,376
+San Diego,404220,State Assembly,76,REP,Thomas E Krouse,7
 San Diego,404220,U.S. House,49,REP,Darrell Issa,252
 San Diego,404220,U.S. House,49,DEM,Doug Applegate,277
 San Diego,404220,U.S. House,49,IND,Ryan Glenn Wingo,27
@@ -33864,6 +33897,7 @@ San Diego,404230,President,,DEM,Willie Wilson,1
 San Diego,404230,Proposition 50,,,No,58
 San Diego,404230,Proposition 50,,,Yes,183
 San Diego,404230,State Assembly,76,REP,Rocky Chavez,168
+San Diego,404230,State Assembly,76,REP,Thomas E Krouse,1
 San Diego,404230,U.S. House,49,REP,Darrell Issa,127
 San Diego,404230,U.S. House,49,DEM,Doug Applegate,110
 San Diego,404230,U.S. House,49,IND,Ryan Glenn Wingo,10
@@ -33907,6 +33941,7 @@ San Diego,404270,President,,REP,Ted Cruz,8
 San Diego,404270,Proposition 50,,,No,51
 San Diego,404270,Proposition 50,,,Yes,161
 San Diego,404270,State Assembly,76,REP,Rocky Chavez,153
+San Diego,404270,State Assembly,76,REP,Thomas E Krouse,1
 San Diego,404270,U.S. House,49,REP,Darrell Issa,99
 San Diego,404270,U.S. House,49,DEM,Doug Applegate,104
 San Diego,404270,U.S. House,49,IND,Ryan Glenn Wingo,16
@@ -33957,6 +33992,7 @@ San Diego,404310,President,,DEM,Willie Wilson,2
 San Diego,404310,Proposition 50,,,No,174
 San Diego,404310,Proposition 50,,,Yes,459
 San Diego,404310,State Assembly,76,REP,Rocky Chavez,472
+San Diego,404310,State Assembly,76,REP,Thomas E Krouse,1
 San Diego,404310,U.S. House,49,REP,Darrell Issa,359
 San Diego,404310,U.S. House,49,DEM,Doug Applegate,273
 San Diego,404310,U.S. House,49,IND,Ryan Glenn Wingo,25
@@ -34009,6 +34045,7 @@ San Diego,404380,President,,DEM,Willie Wilson,4
 San Diego,404380,Proposition 50,,,No,125
 San Diego,404380,Proposition 50,,,Yes,417
 San Diego,404380,State Assembly,76,REP,Rocky Chavez,378
+San Diego,404380,State Assembly,76,REP,Thomas E Krouse,4
 San Diego,404380,U.S. House,49,REP,Darrell Issa,272
 San Diego,404380,U.S. House,49,DEM,Doug Applegate,274
 San Diego,404380,U.S. House,49,IND,Ryan Glenn Wingo,21
@@ -34054,6 +34091,7 @@ San Diego,404400,President,,REP,Ted Cruz,18
 San Diego,404400,Proposition 50,,,No,99
 San Diego,404400,Proposition 50,,,Yes,210
 San Diego,404400,State Assembly,76,REP,Rocky Chavez,237
+San Diego,404400,State Assembly,76,REP,Thomas E Krouse,1
 San Diego,404400,U.S. House,49,REP,Darrell Issa,194
 San Diego,404400,U.S. House,49,DEM,Doug Applegate,113
 San Diego,404400,U.S. House,49,IND,Ryan Glenn Wingo,10
@@ -34095,6 +34133,7 @@ San Diego,404450,President,,REP,Ted Cruz,8
 San Diego,404450,Proposition 50,,,No,75
 San Diego,404450,Proposition 50,,,Yes,222
 San Diego,404450,State Assembly,76,REP,Rocky Chavez,221
+San Diego,404450,State Assembly,76,REP,Thomas E Krouse,0
 San Diego,404450,U.S. House,49,REP,Darrell Issa,182
 San Diego,404450,U.S. House,49,DEM,Doug Applegate,114
 San Diego,404450,U.S. House,49,IND,Ryan Glenn Wingo,7
@@ -34143,6 +34182,7 @@ San Diego,404500,President,,DEM,Willie Wilson,1
 San Diego,404500,Proposition 50,,,No,97
 San Diego,404500,Proposition 50,,,Yes,365
 San Diego,404500,State Assembly,76,REP,Rocky Chavez,322
+San Diego,404500,State Assembly,76,REP,Thomas E Krouse,1
 San Diego,404500,U.S. House,49,REP,Darrell Issa,159
 San Diego,404500,U.S. House,49,DEM,Doug Applegate,295
 San Diego,404500,U.S. House,49,IND,Ryan Glenn Wingo,42
@@ -34189,6 +34229,7 @@ San Diego,404510,President,,REP,Ted Cruz,6
 San Diego,404510,Proposition 50,,,No,61
 San Diego,404510,Proposition 50,,,Yes,199
 San Diego,404510,State Assembly,76,REP,Rocky Chavez,185
+San Diego,404510,State Assembly,76,REP,Thomas E Krouse,0
 San Diego,404510,U.S. House,49,REP,Darrell Issa,108
 San Diego,404510,U.S. House,49,DEM,Doug Applegate,158
 San Diego,404510,U.S. House,49,IND,Ryan Glenn Wingo,12
@@ -34233,6 +34274,7 @@ San Diego,404600,President,,DEM,Willie Wilson,2
 San Diego,404600,Proposition 50,,,No,70
 San Diego,404600,Proposition 50,,,Yes,232
 San Diego,404600,State Assembly,76,REP,Rocky Chavez,211
+San Diego,404600,State Assembly,76,REP,Thomas E Krouse,0
 San Diego,404600,U.S. House,49,REP,Darrell Issa,149
 San Diego,404600,U.S. House,49,DEM,Doug Applegate,136
 San Diego,404600,U.S. House,49,IND,Ryan Glenn Wingo,22
@@ -34278,6 +34320,7 @@ San Diego,404700,President,,REP,Ted Cruz,4
 San Diego,404700,Proposition 50,,,No,158
 San Diego,404700,Proposition 50,,,Yes,478
 San Diego,404700,State Assembly,76,REP,Rocky Chavez,401
+San Diego,404700,State Assembly,76,REP,Thomas E Krouse,7
 San Diego,404700,U.S. House,49,REP,Darrell Issa,299
 San Diego,404700,U.S. House,49,DEM,Doug Applegate,307
 San Diego,404700,U.S. House,49,IND,Ryan Glenn Wingo,38
@@ -34326,6 +34369,7 @@ San Diego,404800,President,,AIP,Thomas Hoefling,1
 San Diego,404800,Proposition 50,,,No,118
 San Diego,404800,Proposition 50,,,Yes,413
 San Diego,404800,State Assembly,76,REP,Rocky Chavez,357
+San Diego,404800,State Assembly,76,REP,Thomas E Krouse,0
 San Diego,404800,U.S. House,49,REP,Darrell Issa,192
 San Diego,404800,U.S. House,49,DEM,Doug Applegate,324
 San Diego,404800,U.S. House,49,IND,Ryan Glenn Wingo,28
@@ -34375,6 +34419,7 @@ San Diego,404900,President,,AIP,Thomas Hoefling,1
 San Diego,404900,Proposition 50,,,No,102
 San Diego,404900,Proposition 50,,,Yes,355
 San Diego,404900,State Assembly,76,REP,Rocky Chavez,288
+San Diego,404900,State Assembly,76,REP,Thomas E Krouse,1
 San Diego,404900,U.S. House,49,REP,Darrell Issa,196
 San Diego,404900,U.S. House,49,DEM,Doug Applegate,255
 San Diego,404900,U.S. House,49,IND,Ryan Glenn Wingo,22
@@ -34425,6 +34470,7 @@ San Diego,405100,President,,AIP,Wiley Drake,2
 San Diego,405100,Proposition 50,,,No,108
 San Diego,405100,Proposition 50,,,Yes,306
 San Diego,405100,State Assembly,76,REP,Rocky Chavez,269
+San Diego,405100,State Assembly,76,REP,Thomas E Krouse,4
 San Diego,405100,U.S. House,49,REP,Darrell Issa,175
 San Diego,405100,U.S. House,49,DEM,Doug Applegate,238
 San Diego,405100,U.S. House,49,IND,Ryan Glenn Wingo,22
@@ -34474,6 +34520,7 @@ San Diego,405160,President,,AIP,Thomas Hoefling,1
 San Diego,405160,Proposition 50,,,No,129
 San Diego,405160,Proposition 50,,,Yes,428
 San Diego,405160,State Assembly,76,REP,Rocky Chavez,421
+San Diego,405160,State Assembly,76,REP,Thomas E Krouse,3
 San Diego,405160,U.S. House,49,REP,Darrell Issa,320
 San Diego,405160,U.S. House,49,DEM,Doug Applegate,247
 San Diego,405160,U.S. House,49,IND,Ryan Glenn Wingo,16
@@ -34521,6 +34568,7 @@ San Diego,405180,President,,DEM,Willie Wilson,2
 San Diego,405180,Proposition 50,,,No,70
 San Diego,405180,Proposition 50,,,Yes,318
 San Diego,405180,State Assembly,76,REP,Rocky Chavez,265
+San Diego,405180,State Assembly,76,REP,Thomas E Krouse,0
 San Diego,405180,U.S. House,49,REP,Darrell Issa,190
 San Diego,405180,U.S. House,49,DEM,Doug Applegate,184
 San Diego,405180,U.S. House,49,IND,Ryan Glenn Wingo,26
@@ -34566,6 +34614,7 @@ San Diego,405300,President,,DEM,Willie Wilson,1
 San Diego,405300,Proposition 50,,,No,100
 San Diego,405300,Proposition 50,,,Yes,270
 San Diego,405300,State Assembly,76,REP,Rocky Chavez,269
+San Diego,405300,State Assembly,76,REP,Thomas E Krouse,2
 San Diego,405300,U.S. House,49,REP,Darrell Issa,173
 San Diego,405300,U.S. House,49,DEM,Doug Applegate,184
 San Diego,405300,U.S. House,49,IND,Ryan Glenn Wingo,23
@@ -34612,6 +34661,7 @@ San Diego,405400,President,,AIP,Thomas Hoefling,1
 San Diego,405400,Proposition 50,,,No,85
 San Diego,405400,Proposition 50,,,Yes,390
 San Diego,405400,State Assembly,76,REP,Rocky Chavez,322
+San Diego,405400,State Assembly,76,REP,Thomas E Krouse,2
 San Diego,405400,U.S. House,49,REP,Darrell Issa,215
 San Diego,405400,U.S. House,49,DEM,Doug Applegate,247
 San Diego,405400,U.S. House,49,IND,Ryan Glenn Wingo,33
@@ -34658,6 +34708,7 @@ San Diego,405430,President,,AIP,Thomas Hoefling,1
 San Diego,405430,Proposition 50,,,No,91
 San Diego,405430,Proposition 50,,,Yes,242
 San Diego,405430,State Assembly,76,REP,Rocky Chavez,235
+San Diego,405430,State Assembly,76,REP,Thomas E Krouse,2
 San Diego,405430,U.S. House,49,REP,Darrell Issa,170
 San Diego,405430,U.S. House,49,DEM,Doug Applegate,156
 San Diego,405430,U.S. House,49,IND,Ryan Glenn Wingo,20
@@ -34700,6 +34751,7 @@ San Diego,405500,President,,REP,Ted Cruz,9
 San Diego,405500,Proposition 50,,,No,69
 San Diego,405500,Proposition 50,,,Yes,146
 San Diego,405500,State Assembly,76,REP,Rocky Chavez,153
+San Diego,405500,State Assembly,76,REP,Thomas E Krouse,0
 San Diego,405500,U.S. House,49,REP,Darrell Issa,100
 San Diego,405500,U.S. House,49,DEM,Doug Applegate,108
 San Diego,405500,U.S. House,49,IND,Ryan Glenn Wingo,13
@@ -34740,6 +34792,7 @@ San Diego,405600,President,,AIP,Wiley Drake,1
 San Diego,405600,Proposition 50,,,No,36
 San Diego,405600,Proposition 50,,,Yes,128
 San Diego,405600,State Assembly,76,REP,Rocky Chavez,110
+San Diego,405600,State Assembly,76,REP,Thomas E Krouse,0
 San Diego,405600,U.S. House,49,REP,Darrell Issa,75
 San Diego,405600,U.S. House,49,DEM,Doug Applegate,90
 San Diego,405600,U.S. House,49,IND,Ryan Glenn Wingo,7
@@ -34778,6 +34831,7 @@ San Diego,405610,President,,AIP,Thomas Hoefling,3
 San Diego,405610,Proposition 50,,,No,112
 San Diego,405610,Proposition 50,,,Yes,375
 San Diego,405610,State Assembly,76,REP,Rocky Chavez,332
+San Diego,405610,State Assembly,76,REP,Thomas E Krouse,3
 San Diego,405610,U.S. House,49,REP,Darrell Issa,210
 San Diego,405610,U.S. House,49,DEM,Doug Applegate,260
 San Diego,405610,U.S. House,49,IND,Ryan Glenn Wingo,29
@@ -34829,6 +34883,7 @@ San Diego,405700,President,,REP,Ted Cruz,11
 San Diego,405700,Proposition 50,,,No,53
 San Diego,405700,Proposition 50,,,Yes,117
 San Diego,405700,State Assembly,76,REP,Rocky Chavez,128
+San Diego,405700,State Assembly,76,REP,Thomas E Krouse,0
 San Diego,405700,U.S. House,49,REP,Darrell Issa,86
 San Diego,405700,U.S. House,49,DEM,Doug Applegate,77
 San Diego,405700,U.S. House,49,IND,Ryan Glenn Wingo,9
@@ -34872,6 +34927,7 @@ San Diego,405800,President,,DEM,Willie Wilson,1
 San Diego,405800,Proposition 50,,,No,172
 San Diego,405800,Proposition 50,,,Yes,681
 San Diego,405800,State Assembly,76,REP,Rocky Chavez,557
+San Diego,405800,State Assembly,76,REP,Thomas E Krouse,1
 San Diego,405800,U.S. House,49,REP,Darrell Issa,403
 San Diego,405800,U.S. House,49,DEM,Doug Applegate,469
 San Diego,405800,U.S. House,49,IND,Ryan Glenn Wingo,19
@@ -34917,6 +34973,7 @@ San Diego,405890,President,,AIP,Wiley Drake,1
 San Diego,405890,Proposition 50,,,No,71
 San Diego,405890,Proposition 50,,,Yes,220
 San Diego,405890,State Assembly,76,REP,Rocky Chavez,215
+San Diego,405890,State Assembly,76,REP,Thomas E Krouse,0
 San Diego,405890,U.S. House,49,REP,Darrell Issa,145
 San Diego,405890,U.S. House,49,DEM,Doug Applegate,152
 San Diego,405890,U.S. House,49,IND,Ryan Glenn Wingo,11
@@ -34965,6 +35022,7 @@ San Diego,405960,President,,DEM,Willie Wilson,2
 San Diego,405960,Proposition 50,,,No,70
 San Diego,405960,Proposition 50,,,Yes,198
 San Diego,405960,State Assembly,76,REP,Rocky Chavez,197
+San Diego,405960,State Assembly,76,REP,Thomas E Krouse,0
 San Diego,405960,U.S. House,49,REP,Darrell Issa,136
 San Diego,405960,U.S. House,49,DEM,Doug Applegate,132
 San Diego,405960,U.S. House,49,IND,Ryan Glenn Wingo,16
@@ -35012,6 +35070,7 @@ San Diego,406000,President,,REP,Ted Cruz,10
 San Diego,406000,Proposition 50,,,No,126
 San Diego,406000,Proposition 50,,,Yes,406
 San Diego,406000,State Assembly,76,REP,Rocky Chavez,405
+San Diego,406000,State Assembly,76,REP,Thomas E Krouse,5
 San Diego,406000,U.S. House,49,REP,Darrell Issa,262
 San Diego,406000,U.S. House,49,DEM,Doug Applegate,270
 San Diego,406000,U.S. House,49,IND,Ryan Glenn Wingo,24
@@ -35060,6 +35119,7 @@ San Diego,406020,President,,DEM,Willie Wilson,2
 San Diego,406020,Proposition 50,,,No,105
 San Diego,406020,Proposition 50,,,Yes,346
 San Diego,406020,State Assembly,76,REP,Rocky Chavez,337
+San Diego,406020,State Assembly,76,REP,Thomas E Krouse,1
 San Diego,406020,U.S. House,49,REP,Darrell Issa,284
 San Diego,406020,U.S. House,49,DEM,Doug Applegate,181
 San Diego,406020,U.S. House,49,IND,Ryan Glenn Wingo,10
@@ -35104,6 +35164,7 @@ San Diego,406030,President,,DEM,Willie Wilson,2
 San Diego,406030,Proposition 50,,,No,96
 San Diego,406030,Proposition 50,,,Yes,355
 San Diego,406030,State Assembly,76,REP,Rocky Chavez,345
+San Diego,406030,State Assembly,76,REP,Thomas E Krouse,5
 San Diego,406030,U.S. House,49,REP,Darrell Issa,243
 San Diego,406030,U.S. House,49,DEM,Doug Applegate,233
 San Diego,406030,U.S. House,49,IND,Ryan Glenn Wingo,19
@@ -35151,6 +35212,7 @@ San Diego,406090,President,,DEM,Willie Wilson,1
 San Diego,406090,Proposition 50,,,No,88
 San Diego,406090,Proposition 50,,,Yes,209
 San Diego,406090,State Assembly,76,REP,Rocky Chavez,222
+San Diego,406090,State Assembly,76,REP,Thomas E Krouse,0
 San Diego,406090,U.S. House,49,REP,Darrell Issa,168
 San Diego,406090,U.S. House,49,DEM,Doug Applegate,136
 San Diego,406090,U.S. House,49,IND,Ryan Glenn Wingo,14
@@ -35199,6 +35261,7 @@ San Diego,406200,President,,DEM,Willie Wilson,2
 San Diego,406200,Proposition 50,,,No,94
 San Diego,406200,Proposition 50,,,Yes,345
 San Diego,406200,State Assembly,76,REP,Rocky Chavez,303
+San Diego,406200,State Assembly,76,REP,Thomas E Krouse,1
 San Diego,406200,U.S. House,49,REP,Darrell Issa,192
 San Diego,406200,U.S. House,49,DEM,Doug Applegate,225
 San Diego,406200,U.S. House,49,IND,Ryan Glenn Wingo,20
@@ -35253,6 +35316,7 @@ San Diego,406210,President,,DEM,Willie Wilson,1
 San Diego,406210,Proposition 50,,,No,120
 San Diego,406210,Proposition 50,,,Yes,345
 San Diego,406210,State Assembly,76,REP,Rocky Chavez,367
+San Diego,406210,State Assembly,76,REP,Thomas E Krouse,0
 San Diego,406210,U.S. House,49,REP,Darrell Issa,212
 San Diego,406210,U.S. House,49,DEM,Doug Applegate,262
 San Diego,406210,U.S. House,49,IND,Ryan Glenn Wingo,26
@@ -35298,6 +35362,7 @@ San Diego,406270,President,,REP,Ted Cruz,3
 San Diego,406270,Proposition 50,,,No,50
 San Diego,406270,Proposition 50,,,Yes,165
 San Diego,406270,State Assembly,76,REP,Rocky Chavez,169
+San Diego,406270,State Assembly,76,REP,Thomas E Krouse,0
 San Diego,406270,U.S. House,49,REP,Darrell Issa,128
 San Diego,406270,U.S. House,49,DEM,Doug Applegate,95
 San Diego,406270,U.S. House,49,IND,Ryan Glenn Wingo,7
@@ -35338,6 +35403,7 @@ San Diego,406280,President,,DEM,Willie Wilson,1
 San Diego,406280,Proposition 50,,,No,181
 San Diego,406280,Proposition 50,,,Yes,697
 San Diego,406280,State Assembly,76,REP,Rocky Chavez,610
+San Diego,406280,State Assembly,76,REP,Thomas E Krouse,5
 San Diego,406280,U.S. House,49,REP,Darrell Issa,490
 San Diego,406280,U.S. House,49,DEM,Doug Applegate,392
 San Diego,406280,U.S. House,49,IND,Ryan Glenn Wingo,19
@@ -35384,6 +35450,7 @@ San Diego,406300,President,,REP,Ted Cruz,11
 San Diego,406300,Proposition 50,,,No,115
 San Diego,406300,Proposition 50,,,Yes,442
 San Diego,406300,State Assembly,76,REP,Rocky Chavez,381
+San Diego,406300,State Assembly,76,REP,Thomas E Krouse,3
 San Diego,406300,U.S. House,49,REP,Darrell Issa,306
 San Diego,406300,U.S. House,49,DEM,Doug Applegate,239
 San Diego,406300,U.S. House,49,IND,Ryan Glenn Wingo,21
@@ -35429,6 +35496,7 @@ San Diego,406310,President,,AIP,Wiley Drake,1
 San Diego,406310,Proposition 50,,,No,98
 San Diego,406310,Proposition 50,,,Yes,213
 San Diego,406310,State Assembly,76,REP,Rocky Chavez,209
+San Diego,406310,State Assembly,76,REP,Thomas E Krouse,1
 San Diego,406310,U.S. House,49,REP,Darrell Issa,172
 San Diego,406310,U.S. House,49,DEM,Doug Applegate,145
 San Diego,406310,U.S. House,49,IND,Ryan Glenn Wingo,12
@@ -35473,6 +35541,7 @@ San Diego,406340,President,,AIP,Wiley Drake,2
 San Diego,406340,Proposition 50,,,No,131
 San Diego,406340,Proposition 50,,,Yes,479
 San Diego,406340,State Assembly,76,REP,Rocky Chavez,421
+San Diego,406340,State Assembly,76,REP,Thomas E Krouse,0
 San Diego,406340,U.S. House,49,REP,Darrell Issa,341
 San Diego,406340,U.S. House,49,DEM,Doug Applegate,289
 San Diego,406340,U.S. House,49,IND,Ryan Glenn Wingo,10
@@ -35513,6 +35582,7 @@ San Diego,406370,President,,AIP,Thomas Hoefling,1
 San Diego,406370,Proposition 50,,,No,134
 San Diego,406370,Proposition 50,,,Yes,385
 San Diego,406370,State Assembly,76,REP,Rocky Chavez,382
+San Diego,406370,State Assembly,76,REP,Thomas E Krouse,0
 San Diego,406370,U.S. House,49,REP,Darrell Issa,336
 San Diego,406370,U.S. House,49,DEM,Doug Applegate,198
 San Diego,406370,U.S. House,49,IND,Ryan Glenn Wingo,13
@@ -35555,6 +35625,7 @@ San Diego,406380,President,,AIP,Thomas Hoefling,1
 San Diego,406380,Proposition 50,,,No,149
 San Diego,406380,Proposition 50,,,Yes,377
 San Diego,406380,State Assembly,76,REP,Rocky Chavez,365
+San Diego,406380,State Assembly,76,REP,Thomas E Krouse,4
 San Diego,406380,U.S. House,49,REP,Darrell Issa,309
 San Diego,406380,U.S. House,49,DEM,Doug Applegate,238
 San Diego,406380,U.S. House,49,IND,Ryan Glenn Wingo,21
@@ -35601,6 +35672,7 @@ San Diego,406390,President,,DEM,Willie Wilson,2
 San Diego,406390,Proposition 50,,,No,73
 San Diego,406390,Proposition 50,,,Yes,284
 San Diego,406390,State Assembly,76,REP,Rocky Chavez,248
+San Diego,406390,State Assembly,76,REP,Thomas E Krouse,2
 San Diego,406390,U.S. House,49,REP,Darrell Issa,188
 San Diego,406390,U.S. House,49,DEM,Doug Applegate,160
 San Diego,406390,U.S. House,49,IND,Ryan Glenn Wingo,14
@@ -35648,6 +35720,7 @@ San Diego,406400,President,,REP,Ted Cruz,24
 San Diego,406400,Proposition 50,,,No,159
 San Diego,406400,Proposition 50,,,Yes,509
 San Diego,406400,State Assembly,76,REP,Rocky Chavez,514
+San Diego,406400,State Assembly,76,REP,Thomas E Krouse,2
 San Diego,406400,U.S. House,49,REP,Darrell Issa,425
 San Diego,406400,U.S. House,49,DEM,Doug Applegate,241
 San Diego,406400,U.S. House,49,IND,Ryan Glenn Wingo,23
@@ -35700,6 +35773,7 @@ San Diego,406410,President,,DEM,Willie Wilson,1
 San Diego,406410,Proposition 50,,,No,138
 San Diego,406410,Proposition 50,,,Yes,447
 San Diego,406410,State Assembly,76,REP,Rocky Chavez,407
+San Diego,406410,State Assembly,76,REP,Thomas E Krouse,4
 San Diego,406410,U.S. House,49,REP,Darrell Issa,311
 San Diego,406410,U.S. House,49,DEM,Doug Applegate,295
 San Diego,406410,U.S. House,49,IND,Ryan Glenn Wingo,24
@@ -35747,6 +35821,7 @@ San Diego,406420,President,,DEM,Willie Wilson,2
 San Diego,406420,Proposition 50,,,No,110
 San Diego,406420,Proposition 50,,,Yes,371
 San Diego,406420,State Assembly,76,REP,Rocky Chavez,345
+San Diego,406420,State Assembly,76,REP,Thomas E Krouse,0
 San Diego,406420,U.S. House,49,REP,Darrell Issa,235
 San Diego,406420,U.S. House,49,DEM,Doug Applegate,249
 San Diego,406420,U.S. House,49,IND,Ryan Glenn Wingo,22
@@ -35794,6 +35869,7 @@ San Diego,406430,President,,AIP,Wiley Drake,1
 San Diego,406430,Proposition 50,,,No,88
 San Diego,406430,Proposition 50,,,Yes,238
 San Diego,406430,State Assembly,76,REP,Rocky Chavez,241
+San Diego,406430,State Assembly,76,REP,Thomas E Krouse,0
 San Diego,406430,U.S. House,49,REP,Darrell Issa,197
 San Diego,406430,U.S. House,49,DEM,Doug Applegate,145
 San Diego,406430,U.S. House,49,IND,Ryan Glenn Wingo,11
@@ -35837,6 +35913,7 @@ San Diego,406470,President,,REP,Ted Cruz,5
 San Diego,406470,Proposition 50,,,No,46
 San Diego,406470,Proposition 50,,,Yes,210
 San Diego,406470,State Assembly,76,REP,Rocky Chavez,181
+San Diego,406470,State Assembly,76,REP,Thomas E Krouse,1
 San Diego,406470,U.S. House,49,REP,Darrell Issa,124
 San Diego,406470,U.S. House,49,DEM,Doug Applegate,123
 San Diego,406470,U.S. House,49,IND,Ryan Glenn Wingo,16
@@ -35883,6 +35960,7 @@ San Diego,406510,President,,DEM,Willie Wilson,1
 San Diego,406510,Proposition 50,,,No,147
 San Diego,406510,Proposition 50,,,Yes,353
 San Diego,406510,State Assembly,76,REP,Rocky Chavez,343
+San Diego,406510,State Assembly,76,REP,Thomas E Krouse,4
 San Diego,406510,U.S. House,49,REP,Darrell Issa,225
 San Diego,406510,U.S. House,49,DEM,Doug Applegate,273
 San Diego,406510,U.S. House,49,IND,Ryan Glenn Wingo,20
@@ -35931,6 +36009,7 @@ San Diego,406600,President,,AIP,Wiley Drake,1
 San Diego,406600,Proposition 50,,,No,138
 San Diego,406600,Proposition 50,,,Yes,441
 San Diego,406600,State Assembly,76,REP,Rocky Chavez,384
+San Diego,406600,State Assembly,76,REP,Thomas E Krouse,4
 San Diego,406600,U.S. House,49,REP,Darrell Issa,312
 San Diego,406600,U.S. House,49,DEM,Doug Applegate,277
 San Diego,406600,U.S. House,49,IND,Ryan Glenn Wingo,27
@@ -35982,6 +36061,7 @@ San Diego,406700,President,,DEM,Willie Wilson,2
 San Diego,406700,Proposition 50,,,No,177
 San Diego,406700,Proposition 50,,,Yes,391
 San Diego,406700,State Assembly,76,REP,Rocky Chavez,385
+San Diego,406700,State Assembly,76,REP,Thomas E Krouse,4
 San Diego,406700,U.S. House,49,REP,Darrell Issa,311
 San Diego,406700,U.S. House,49,DEM,Doug Applegate,265
 San Diego,406700,U.S. House,49,IND,Ryan Glenn Wingo,23
@@ -36028,6 +36108,7 @@ San Diego,406800,President,,DEM,Willie Wilson,3
 San Diego,406800,Proposition 50,,,No,49
 San Diego,406800,Proposition 50,,,Yes,171
 San Diego,406800,State Assembly,76,REP,Rocky Chavez,150
+San Diego,406800,State Assembly,76,REP,Thomas E Krouse,1
 San Diego,406800,U.S. House,49,REP,Darrell Issa,91
 San Diego,406800,U.S. House,49,DEM,Doug Applegate,122
 San Diego,406800,U.S. House,49,IND,Ryan Glenn Wingo,14
@@ -36073,6 +36154,7 @@ San Diego,406820,President,,DEM,Willie Wilson,1
 San Diego,406820,Proposition 50,,,No,102
 San Diego,406820,Proposition 50,,,Yes,326
 San Diego,406820,State Assembly,76,REP,Rocky Chavez,269
+San Diego,406820,State Assembly,76,REP,Thomas E Krouse,2
 San Diego,406820,U.S. House,49,REP,Darrell Issa,179
 San Diego,406820,U.S. House,49,DEM,Doug Applegate,234
 San Diego,406820,U.S. House,49,IND,Ryan Glenn Wingo,30
@@ -36121,6 +36203,7 @@ San Diego,407100,President,,DEM,Willie Wilson,1
 San Diego,407100,Proposition 50,,,No,122
 San Diego,407100,Proposition 50,,,Yes,349
 San Diego,407100,State Assembly,76,REP,Rocky Chavez,309
+San Diego,407100,State Assembly,76,REP,Thomas E Krouse,0
 San Diego,407100,U.S. House,49,REP,Darrell Issa,217
 San Diego,407100,U.S. House,49,DEM,Doug Applegate,254
 San Diego,407100,U.S. House,49,IND,Ryan Glenn Wingo,28
@@ -36164,6 +36247,7 @@ San Diego,408000,President,,REP,Ted Cruz,9
 San Diego,408000,Proposition 50,,,No,78
 San Diego,408000,Proposition 50,,,Yes,214
 San Diego,408000,State Assembly,76,REP,Rocky Chavez,175
+San Diego,408000,State Assembly,76,REP,Thomas E Krouse,2
 San Diego,408000,U.S. House,49,REP,Darrell Issa,137
 San Diego,408000,U.S. House,49,DEM,Doug Applegate,144
 San Diego,408000,U.S. House,49,IND,Ryan Glenn Wingo,13
@@ -36202,6 +36286,7 @@ San Diego,408010,President,,DEM,Willie Wilson,1
 San Diego,408010,Proposition 50,,,No,81
 San Diego,408010,Proposition 50,,,Yes,251
 San Diego,408010,State Assembly,76,REP,Rocky Chavez,230
+San Diego,408010,State Assembly,76,REP,Thomas E Krouse,0
 San Diego,408010,U.S. House,49,REP,Darrell Issa,196
 San Diego,408010,U.S. House,49,DEM,Doug Applegate,150
 San Diego,408010,U.S. House,49,IND,Ryan Glenn Wingo,10
@@ -36246,6 +36331,7 @@ San Diego,408030,President,,REP,Ted Cruz,14
 San Diego,408030,Proposition 50,,,No,72
 San Diego,408030,Proposition 50,,,Yes,325
 San Diego,408030,State Assembly,76,REP,Rocky Chavez,235
+San Diego,408030,State Assembly,76,REP,Thomas E Krouse,2
 San Diego,408030,U.S. House,49,REP,Darrell Issa,169
 San Diego,408030,U.S. House,49,DEM,Doug Applegate,246
 San Diego,408030,U.S. House,49,IND,Ryan Glenn Wingo,10
@@ -36287,6 +36373,7 @@ San Diego,408040,President,,AIP,Wiley Drake,1
 San Diego,408040,Proposition 50,,,No,155
 San Diego,408040,Proposition 50,,,Yes,484
 San Diego,408040,State Assembly,76,REP,Rocky Chavez,418
+San Diego,408040,State Assembly,76,REP,Thomas E Krouse,5
 San Diego,408040,U.S. House,49,REP,Darrell Issa,342
 San Diego,408040,U.S. House,49,DEM,Doug Applegate,296
 San Diego,408040,U.S. House,49,IND,Ryan Glenn Wingo,20
@@ -36332,6 +36419,7 @@ San Diego,408100,President,,REP,Ted Cruz,13
 San Diego,408100,Proposition 50,,,No,139
 San Diego,408100,Proposition 50,,,Yes,412
 San Diego,408100,State Assembly,76,REP,Rocky Chavez,380
+San Diego,408100,State Assembly,76,REP,Thomas E Krouse,5
 San Diego,408100,U.S. House,49,REP,Darrell Issa,301
 San Diego,408100,U.S. House,49,DEM,Doug Applegate,251
 San Diego,408100,U.S. House,49,IND,Ryan Glenn Wingo,10
@@ -36376,6 +36464,7 @@ San Diego,408110,President,,AIP,Wiley Drake,1
 San Diego,408110,Proposition 50,,,No,156
 San Diego,408110,Proposition 50,,,Yes,419
 San Diego,408110,State Assembly,76,REP,Rocky Chavez,404
+San Diego,408110,State Assembly,76,REP,Thomas E Krouse,0
 San Diego,408110,U.S. House,49,REP,Darrell Issa,330
 San Diego,408110,U.S. House,49,DEM,Doug Applegate,260
 San Diego,408110,U.S. House,49,IND,Ryan Glenn Wingo,13
@@ -36419,6 +36508,7 @@ San Diego,408150,President,,REP,Ted Cruz,11
 San Diego,408150,Proposition 50,,,No,91
 San Diego,408150,Proposition 50,,,Yes,336
 San Diego,408150,State Assembly,76,REP,Rocky Chavez,296
+San Diego,408150,State Assembly,76,REP,Thomas E Krouse,1
 San Diego,408150,U.S. House,49,REP,Darrell Issa,222
 San Diego,408150,U.S. House,49,DEM,Doug Applegate,199
 San Diego,408150,U.S. House,49,IND,Ryan Glenn Wingo,23
@@ -36467,6 +36557,7 @@ San Diego,408190,President,,REP,Ted Cruz,14
 San Diego,408190,Proposition 50,,,No,181
 San Diego,408190,Proposition 50,,,Yes,470
 San Diego,408190,State Assembly,76,REP,Rocky Chavez,446
+San Diego,408190,State Assembly,76,REP,Thomas E Krouse,1
 San Diego,408190,U.S. House,49,REP,Darrell Issa,375
 San Diego,408190,U.S. House,49,DEM,Doug Applegate,289
 San Diego,408190,U.S. House,49,IND,Ryan Glenn Wingo,24
@@ -36512,6 +36603,7 @@ San Diego,408200,President,,REP,Ted Cruz,11
 San Diego,408200,Proposition 50,,,No,111
 San Diego,408200,Proposition 50,,,Yes,337
 San Diego,408200,State Assembly,76,REP,Rocky Chavez,276
+San Diego,408200,State Assembly,76,REP,Thomas E Krouse,6
 San Diego,408200,U.S. House,49,REP,Darrell Issa,211
 San Diego,408200,U.S. House,49,DEM,Doug Applegate,252
 San Diego,408200,U.S. House,49,IND,Ryan Glenn Wingo,29
@@ -36560,6 +36652,7 @@ San Diego,408210,President,,DEM,Willie Wilson,1
 San Diego,408210,Proposition 50,,,No,103
 San Diego,408210,Proposition 50,,,Yes,284
 San Diego,408210,State Assembly,76,REP,Rocky Chavez,252
+San Diego,408210,State Assembly,76,REP,Thomas E Krouse,1
 San Diego,408210,U.S. House,49,REP,Darrell Issa,173
 San Diego,408210,U.S. House,49,DEM,Doug Applegate,219
 San Diego,408210,U.S. House,49,IND,Ryan Glenn Wingo,18
@@ -36607,6 +36700,7 @@ San Diego,408230,President,,DEM,Willie Wilson,1
 San Diego,408230,Proposition 50,,,No,118
 San Diego,408230,Proposition 50,,,Yes,346
 San Diego,408230,State Assembly,76,REP,Rocky Chavez,299
+San Diego,408230,State Assembly,76,REP,Thomas E Krouse,6
 San Diego,408230,U.S. House,49,REP,Darrell Issa,249
 San Diego,408230,U.S. House,49,DEM,Doug Applegate,208
 San Diego,408230,U.S. House,49,IND,Ryan Glenn Wingo,15
@@ -36650,6 +36744,7 @@ San Diego,408240,President,,AIP,Wiley Drake,1
 San Diego,408240,Proposition 50,,,No,113
 San Diego,408240,Proposition 50,,,Yes,382
 San Diego,408240,State Assembly,76,REP,Rocky Chavez,313
+San Diego,408240,State Assembly,76,REP,Thomas E Krouse,1
 San Diego,408240,U.S. House,49,REP,Darrell Issa,247
 San Diego,408240,U.S. House,49,DEM,Doug Applegate,264
 San Diego,408240,U.S. House,49,IND,Ryan Glenn Wingo,15
@@ -36694,6 +36789,7 @@ San Diego,408250,President,,REP,Ted Cruz,13
 San Diego,408250,Proposition 50,,,No,115
 San Diego,408250,Proposition 50,,,Yes,385
 San Diego,408250,State Assembly,76,REP,Rocky Chavez,340
+San Diego,408250,State Assembly,76,REP,Thomas E Krouse,0
 San Diego,408250,U.S. House,49,REP,Darrell Issa,293
 San Diego,408250,U.S. House,49,DEM,Doug Applegate,208
 San Diego,408250,U.S. House,49,IND,Ryan Glenn Wingo,18
@@ -36734,6 +36830,7 @@ San Diego,408260,President,,REP,Ted Cruz,10
 San Diego,408260,Proposition 50,,,No,108
 San Diego,408260,Proposition 50,,,Yes,335
 San Diego,408260,State Assembly,76,REP,Rocky Chavez,313
+San Diego,408260,State Assembly,76,REP,Thomas E Krouse,0
 San Diego,408260,U.S. House,49,REP,Darrell Issa,233
 San Diego,408260,U.S. House,49,DEM,Doug Applegate,231
 San Diego,408260,U.S. House,49,IND,Ryan Glenn Wingo,11
@@ -36780,6 +36877,7 @@ San Diego,408270,President,,AIP,Thomas Hoefling,2
 San Diego,408270,Proposition 50,,,No,96
 San Diego,408270,Proposition 50,,,Yes,332
 San Diego,408270,State Assembly,76,REP,Rocky Chavez,269
+San Diego,408270,State Assembly,76,REP,Thomas E Krouse,2
 San Diego,408270,U.S. House,49,REP,Darrell Issa,210
 San Diego,408270,U.S. House,49,DEM,Doug Applegate,223
 San Diego,408270,U.S. House,49,IND,Ryan Glenn Wingo,14
@@ -36823,6 +36921,7 @@ San Diego,408280,President,,REP,Ted Cruz,13
 San Diego,408280,Proposition 50,,,No,98
 San Diego,408280,Proposition 50,,,Yes,393
 San Diego,408280,State Assembly,76,REP,Rocky Chavez,344
+San Diego,408280,State Assembly,76,REP,Thomas E Krouse,0
 San Diego,408280,U.S. House,49,REP,Darrell Issa,273
 San Diego,408280,U.S. House,49,DEM,Doug Applegate,237
 San Diego,408280,U.S. House,49,IND,Ryan Glenn Wingo,12
@@ -36869,6 +36968,7 @@ San Diego,408300,President,,REP,Ted Cruz,9
 San Diego,408300,Proposition 50,,,No,138
 San Diego,408300,Proposition 50,,,Yes,370
 San Diego,408300,State Assembly,76,REP,Rocky Chavez,317
+San Diego,408300,State Assembly,76,REP,Thomas E Krouse,5
 San Diego,408300,U.S. House,49,REP,Darrell Issa,266
 San Diego,408300,U.S. House,49,DEM,Doug Applegate,230
 San Diego,408300,U.S. House,49,IND,Ryan Glenn Wingo,18
@@ -36910,6 +37010,7 @@ San Diego,408360,President,,AIP,Thomas Hoefling,1
 San Diego,408360,Proposition 50,,,No,82
 San Diego,408360,Proposition 50,,,Yes,329
 San Diego,408360,State Assembly,76,REP,Rocky Chavez,287
+San Diego,408360,State Assembly,76,REP,Thomas E Krouse,0
 San Diego,408360,U.S. House,49,REP,Darrell Issa,237
 San Diego,408360,U.S. House,49,DEM,Doug Applegate,182
 San Diego,408360,U.S. House,49,IND,Ryan Glenn Wingo,7
@@ -36950,6 +37051,7 @@ San Diego,408390,President,,REP,Ted Cruz,2
 San Diego,408390,Proposition 50,,,No,46
 San Diego,408390,Proposition 50,,,Yes,160
 San Diego,408390,State Assembly,76,REP,Rocky Chavez,152
+San Diego,408390,State Assembly,76,REP,Thomas E Krouse,0
 San Diego,408390,U.S. House,49,REP,Darrell Issa,128
 San Diego,408390,U.S. House,49,DEM,Doug Applegate,76
 San Diego,408390,U.S. House,49,IND,Ryan Glenn Wingo,8
@@ -36986,6 +37088,7 @@ San Diego,408400,President,,REP,Ted Cruz,12
 San Diego,408400,Proposition 50,,,No,108
 San Diego,408400,Proposition 50,,,Yes,341
 San Diego,408400,State Assembly,76,REP,Rocky Chavez,283
+San Diego,408400,State Assembly,76,REP,Thomas E Krouse,5
 San Diego,408400,U.S. House,49,REP,Darrell Issa,197
 San Diego,408400,U.S. House,49,DEM,Doug Applegate,259
 San Diego,408400,U.S. House,49,IND,Ryan Glenn Wingo,19
@@ -37028,6 +37131,7 @@ San Diego,408440,President,,REP,Ted Cruz,11
 San Diego,408440,Proposition 50,,,No,98
 San Diego,408440,Proposition 50,,,Yes,348
 San Diego,408440,State Assembly,76,REP,Rocky Chavez,290
+San Diego,408440,State Assembly,76,REP,Thomas E Krouse,7
 San Diego,408440,U.S. House,49,REP,Darrell Issa,215
 San Diego,408440,U.S. House,49,DEM,Doug Applegate,244
 San Diego,408440,U.S. House,49,IND,Ryan Glenn Wingo,15
@@ -37070,6 +37174,7 @@ San Diego,408490,President,,DEM,Willie Wilson,1
 San Diego,408490,Proposition 50,,,No,48
 San Diego,408490,Proposition 50,,,Yes,204
 San Diego,408490,State Assembly,76,REP,Rocky Chavez,167
+San Diego,408490,State Assembly,76,REP,Thomas E Krouse,1
 San Diego,408490,U.S. House,49,REP,Darrell Issa,145
 San Diego,408490,U.S. House,49,DEM,Doug Applegate,112
 San Diego,408490,U.S. House,49,IND,Ryan Glenn Wingo,6
@@ -37114,6 +37219,7 @@ San Diego,408500,President,,REP,Ted Cruz,8
 San Diego,408500,Proposition 50,,,No,78
 San Diego,408500,Proposition 50,,,Yes,354
 San Diego,408500,State Assembly,76,REP,Rocky Chavez,268
+San Diego,408500,State Assembly,76,REP,Thomas E Krouse,2
 San Diego,408500,U.S. House,49,REP,Darrell Issa,138
 San Diego,408500,U.S. House,49,DEM,Doug Applegate,273
 San Diego,408500,U.S. House,49,IND,Ryan Glenn Wingo,42
@@ -37164,6 +37270,7 @@ San Diego,408550,President,,DEM,Willie Wilson,1
 San Diego,408550,Proposition 50,,,No,136
 San Diego,408550,Proposition 50,,,Yes,538
 San Diego,408550,State Assembly,76,REP,Rocky Chavez,435
+San Diego,408550,State Assembly,76,REP,Thomas E Krouse,2
 San Diego,408550,U.S. House,49,REP,Darrell Issa,393
 San Diego,408550,U.S. House,49,DEM,Doug Applegate,285
 San Diego,408550,U.S. House,49,IND,Ryan Glenn Wingo,23
@@ -37211,6 +37318,7 @@ San Diego,408560,President,,REP,Ted Cruz,13
 San Diego,408560,Proposition 50,,,No,147
 San Diego,408560,Proposition 50,,,Yes,417
 San Diego,408560,State Assembly,76,REP,Rocky Chavez,381
+San Diego,408560,State Assembly,76,REP,Thomas E Krouse,2
 San Diego,408560,U.S. House,49,REP,Darrell Issa,302
 San Diego,408560,U.S. House,49,DEM,Doug Applegate,279
 San Diego,408560,U.S. House,49,IND,Ryan Glenn Wingo,17
@@ -37266,6 +37374,7 @@ San Diego,408570,President,,AIP,Wiley Drake,1
 San Diego,408570,Proposition 50,,,No,198
 San Diego,408570,Proposition 50,,,Yes,512
 San Diego,408570,State Assembly,76,REP,Rocky Chavez,509
+San Diego,408570,State Assembly,76,REP,Thomas E Krouse,5
 San Diego,408570,U.S. House,49,REP,Darrell Issa,428
 San Diego,408570,U.S. House,49,DEM,Doug Applegate,299
 San Diego,408570,U.S. House,49,IND,Ryan Glenn Wingo,19
@@ -37308,6 +37417,7 @@ San Diego,408600,President,,AIP,Wiley Drake,2
 San Diego,408600,Proposition 50,,,No,88
 San Diego,408600,Proposition 50,,,Yes,264
 San Diego,408600,State Assembly,76,REP,Rocky Chavez,214
+San Diego,408600,State Assembly,76,REP,Thomas E Krouse,2
 San Diego,408600,U.S. House,49,REP,Darrell Issa,158
 San Diego,408600,U.S. House,49,DEM,Doug Applegate,190
 San Diego,408600,U.S. House,49,IND,Ryan Glenn Wingo,11
@@ -37355,6 +37465,7 @@ San Diego,408620,President,,AIP,Wiley Drake,1
 San Diego,408620,Proposition 50,,,No,167
 San Diego,408620,Proposition 50,,,Yes,496
 San Diego,408620,State Assembly,76,REP,Rocky Chavez,452
+San Diego,408620,State Assembly,76,REP,Thomas E Krouse,3
 San Diego,408620,U.S. House,49,REP,Darrell Issa,336
 San Diego,408620,U.S. House,49,DEM,Doug Applegate,331
 San Diego,408620,U.S. House,49,IND,Ryan Glenn Wingo,27
@@ -37404,6 +37515,7 @@ San Diego,408670,President,,REP,Ted Cruz,14
 San Diego,408670,Proposition 50,,,No,117
 San Diego,408670,Proposition 50,,,Yes,423
 San Diego,408670,State Assembly,76,REP,Rocky Chavez,409
+San Diego,408670,State Assembly,76,REP,Thomas E Krouse,3
 San Diego,408670,U.S. House,49,REP,Darrell Issa,409
 San Diego,408670,U.S. House,49,DEM,Doug Applegate,192
 San Diego,408670,U.S. House,49,IND,Ryan Glenn Wingo,5
@@ -37447,6 +37559,7 @@ San Diego,408690,President,,REP,Ted Cruz,4
 San Diego,408690,Proposition 50,,,No,115
 San Diego,408690,Proposition 50,,,Yes,381
 San Diego,408690,State Assembly,76,REP,Rocky Chavez,319
+San Diego,408690,State Assembly,76,REP,Thomas E Krouse,5
 San Diego,408690,U.S. House,49,REP,Darrell Issa,277
 San Diego,408690,U.S. House,49,DEM,Doug Applegate,231
 San Diego,408690,U.S. House,49,IND,Ryan Glenn Wingo,11
@@ -37493,6 +37606,7 @@ San Diego,408700,President,,DEM,Willie Wilson,1
 San Diego,408700,Proposition 50,,,No,124
 San Diego,408700,Proposition 50,,,Yes,362
 San Diego,408700,State Assembly,76,REP,Rocky Chavez,312
+San Diego,408700,State Assembly,76,REP,Thomas E Krouse,3
 San Diego,408700,U.S. House,49,REP,Darrell Issa,194
 San Diego,408700,U.S. House,49,DEM,Doug Applegate,282
 San Diego,408700,U.S. House,49,IND,Ryan Glenn Wingo,24
@@ -37538,6 +37652,7 @@ San Diego,408720,President,,REP,Ted Cruz,11
 San Diego,408720,Proposition 50,,,No,117
 San Diego,408720,Proposition 50,,,Yes,316
 San Diego,408720,State Assembly,76,REP,Rocky Chavez,293
+San Diego,408720,State Assembly,76,REP,Thomas E Krouse,1
 San Diego,408720,U.S. House,49,REP,Darrell Issa,262
 San Diego,408720,U.S. House,49,DEM,Doug Applegate,200
 San Diego,408720,U.S. House,49,IND,Ryan Glenn Wingo,9
@@ -37582,6 +37697,7 @@ San Diego,408750,President,,REP,Ted Cruz,12
 San Diego,408750,Proposition 50,,,No,78
 San Diego,408750,Proposition 50,,,Yes,319
 San Diego,408750,State Assembly,76,REP,Rocky Chavez,286
+San Diego,408750,State Assembly,76,REP,Thomas E Krouse,0
 San Diego,408750,U.S. House,49,REP,Darrell Issa,183
 San Diego,408750,U.S. House,49,DEM,Doug Applegate,217
 San Diego,408750,U.S. House,49,IND,Ryan Glenn Wingo,19
@@ -37625,6 +37741,7 @@ San Diego,408780,President,,DEM,Willie Wilson,1
 San Diego,408780,Proposition 50,,,No,194
 San Diego,408780,Proposition 50,,,Yes,489
 San Diego,408780,State Assembly,76,REP,Rocky Chavez,509
+San Diego,408780,State Assembly,76,REP,Thomas E Krouse,1
 San Diego,408780,U.S. House,49,REP,Darrell Issa,461
 San Diego,408780,U.S. House,49,DEM,Doug Applegate,260
 San Diego,408780,U.S. House,49,IND,Ryan Glenn Wingo,10
@@ -37668,6 +37785,7 @@ San Diego,408810,President,,REP,Ted Cruz,4
 San Diego,408810,Proposition 50,,,No,57
 San Diego,408810,Proposition 50,,,Yes,180
 San Diego,408810,State Assembly,76,REP,Rocky Chavez,179
+San Diego,408810,State Assembly,76,REP,Thomas E Krouse,0
 San Diego,408810,U.S. House,49,REP,Darrell Issa,137
 San Diego,408810,U.S. House,49,DEM,Doug Applegate,103
 San Diego,408810,U.S. House,49,IND,Ryan Glenn Wingo,10
@@ -37709,6 +37827,7 @@ San Diego,408850,President,,DEM,Willie Wilson,1
 San Diego,408850,Proposition 50,,,No,148
 San Diego,408850,Proposition 50,,,Yes,386
 San Diego,408850,State Assembly,76,REP,Rocky Chavez,344
+San Diego,408850,State Assembly,76,REP,Thomas E Krouse,1
 San Diego,408850,U.S. House,49,REP,Darrell Issa,266
 San Diego,408850,U.S. House,49,DEM,Doug Applegate,289
 San Diego,408850,U.S. House,49,IND,Ryan Glenn Wingo,10
@@ -37758,6 +37877,7 @@ San Diego,408900,President,,AIP,Wiley Drake,1
 San Diego,408900,Proposition 50,,,No,142
 San Diego,408900,Proposition 50,,,Yes,481
 San Diego,408900,State Assembly,76,REP,Rocky Chavez,415
+San Diego,408900,State Assembly,76,REP,Thomas E Krouse,6
 San Diego,408900,U.S. House,49,REP,Darrell Issa,304
 San Diego,408900,U.S. House,49,DEM,Doug Applegate,320
 San Diego,408900,U.S. House,49,IND,Ryan Glenn Wingo,27
@@ -37809,6 +37929,7 @@ San Diego,408920,President,,REP,Ted Cruz,17
 San Diego,408920,Proposition 50,,,No,134
 San Diego,408920,Proposition 50,,,Yes,471
 San Diego,408920,State Assembly,76,REP,Rocky Chavez,393
+San Diego,408920,State Assembly,76,REP,Thomas E Krouse,2
 San Diego,408920,U.S. House,49,REP,Darrell Issa,332
 San Diego,408920,U.S. House,49,DEM,Doug Applegate,265
 San Diego,408920,U.S. House,49,IND,Ryan Glenn Wingo,28
@@ -37858,6 +37979,7 @@ San Diego,409080,President,,DEM,Willie Wilson,1
 San Diego,409080,Proposition 50,,,No,213
 San Diego,409080,Proposition 50,,,Yes,472
 San Diego,409080,State Assembly,76,REP,Rocky Chavez,469
+San Diego,409080,State Assembly,76,REP,Thomas E Krouse,2
 San Diego,409080,U.S. House,49,REP,Darrell Issa,415
 San Diego,409080,U.S. House,49,DEM,Doug Applegate,277
 San Diego,409080,U.S. House,49,IND,Ryan Glenn Wingo,30
@@ -37905,6 +38027,7 @@ San Diego,409110,President,,DEM,Willie Wilson,1
 San Diego,409110,Proposition 50,,,No,140
 San Diego,409110,Proposition 50,,,Yes,424
 San Diego,409110,State Assembly,76,REP,Rocky Chavez,365
+San Diego,409110,State Assembly,76,REP,Thomas E Krouse,1
 San Diego,409110,U.S. House,49,REP,Darrell Issa,311
 San Diego,409110,U.S. House,49,DEM,Doug Applegate,277
 San Diego,409110,U.S. House,49,IND,Ryan Glenn Wingo,12
@@ -37951,6 +38074,7 @@ San Diego,409180,President,,DEM,Willie Wilson,3
 San Diego,409180,Proposition 50,,,No,157
 San Diego,409180,Proposition 50,,,Yes,463
 San Diego,409180,State Assembly,76,REP,Rocky Chavez,446
+San Diego,409180,State Assembly,76,REP,Thomas E Krouse,7
 San Diego,409180,U.S. House,49,REP,Darrell Issa,347
 San Diego,409180,U.S. House,49,DEM,Doug Applegate,264
 San Diego,409180,U.S. House,49,IND,Ryan Glenn Wingo,23
@@ -38001,6 +38125,7 @@ San Diego,409190,President,,DEM,Willie Wilson,1
 San Diego,409190,Proposition 50,,,No,133
 San Diego,409190,Proposition 50,,,Yes,399
 San Diego,409190,State Assembly,76,REP,Rocky Chavez,328
+San Diego,409190,State Assembly,76,REP,Thomas E Krouse,2
 San Diego,409190,U.S. House,49,REP,Darrell Issa,273
 San Diego,409190,U.S. House,49,DEM,Doug Applegate,259
 San Diego,409190,U.S. House,49,IND,Ryan Glenn Wingo,27
@@ -38046,6 +38171,7 @@ San Diego,409210,President,,AIP,Wiley Drake,1
 San Diego,409210,Proposition 50,,,No,94
 San Diego,409210,Proposition 50,,,Yes,335
 San Diego,409210,State Assembly,76,REP,Rocky Chavez,282
+San Diego,409210,State Assembly,76,REP,Thomas E Krouse,4
 San Diego,409210,U.S. House,49,REP,Darrell Issa,191
 San Diego,409210,U.S. House,49,DEM,Doug Applegate,232
 San Diego,409210,U.S. House,49,IND,Ryan Glenn Wingo,26
@@ -38092,6 +38218,7 @@ San Diego,409240,President,,REP,Ted Cruz,16
 San Diego,409240,Proposition 50,,,No,126
 San Diego,409240,Proposition 50,,,Yes,356
 San Diego,409240,State Assembly,76,REP,Rocky Chavez,335
+San Diego,409240,State Assembly,76,REP,Thomas E Krouse,0
 San Diego,409240,U.S. House,49,REP,Darrell Issa,277
 San Diego,409240,U.S. House,49,DEM,Doug Applegate,203
 San Diego,409240,U.S. House,49,IND,Ryan Glenn Wingo,22
@@ -38140,6 +38267,7 @@ San Diego,409300,President,,DEM,Willie Wilson,1
 San Diego,409300,Proposition 50,,,No,95
 San Diego,409300,Proposition 50,,,Yes,279
 San Diego,409300,State Assembly,76,REP,Rocky Chavez,223
+San Diego,409300,State Assembly,76,REP,Thomas E Krouse,1
 San Diego,409300,U.S. House,49,REP,Darrell Issa,162
 San Diego,409300,U.S. House,49,DEM,Doug Applegate,189
 San Diego,409300,U.S. House,49,IND,Ryan Glenn Wingo,24
@@ -38190,6 +38318,7 @@ San Diego,409310,President,,DEM,Willie Wilson,1
 San Diego,409310,Proposition 50,,,No,130
 San Diego,409310,Proposition 50,,,Yes,365
 San Diego,409310,State Assembly,76,REP,Rocky Chavez,340
+San Diego,409310,State Assembly,76,REP,Thomas E Krouse,1
 San Diego,409310,U.S. House,49,REP,Darrell Issa,295
 San Diego,409310,U.S. House,49,DEM,Doug Applegate,215
 San Diego,409310,U.S. House,49,IND,Ryan Glenn Wingo,5
@@ -38239,6 +38368,7 @@ San Diego,409402,President,,GRN,William Kreml,1
 San Diego,409402,Proposition 50,,,No,182
 San Diego,409402,Proposition 50,,,Yes,395
 San Diego,409402,State Assembly,76,REP,Rocky Chavez,376
+San Diego,409402,State Assembly,76,REP,Thomas E Krouse,12
 San Diego,409402,U.S. House,49,REP,Darrell Issa,297
 San Diego,409402,U.S. House,49,DEM,Doug Applegate,287
 San Diego,409402,U.S. House,49,IND,Ryan Glenn Wingo,21
@@ -38287,6 +38417,7 @@ San Diego,409440,President,,AIP,Wiley Drake,1
 San Diego,409440,Proposition 50,,,No,116
 San Diego,409440,Proposition 50,,,Yes,438
 San Diego,409440,State Assembly,76,REP,Rocky Chavez,398
+San Diego,409440,State Assembly,76,REP,Thomas E Krouse,3
 San Diego,409440,U.S. House,49,REP,Darrell Issa,296
 San Diego,409440,U.S. House,49,DEM,Doug Applegate,275
 San Diego,409440,U.S. House,49,IND,Ryan Glenn Wingo,26
@@ -38337,6 +38468,7 @@ San Diego,409460,President,,DEM,Willie Wilson,1
 San Diego,409460,Proposition 50,,,No,176
 San Diego,409460,Proposition 50,,,Yes,657
 San Diego,409460,State Assembly,76,REP,Rocky Chavez,600
+San Diego,409460,State Assembly,76,REP,Thomas E Krouse,0
 San Diego,409460,U.S. House,49,REP,Darrell Issa,460
 San Diego,409460,U.S. House,49,DEM,Doug Applegate,380
 San Diego,409460,U.S. House,49,IND,Ryan Glenn Wingo,18
@@ -38385,6 +38517,7 @@ San Diego,409490,President,,DEM,Willie Wilson,1
 San Diego,409490,Proposition 50,,,No,96
 San Diego,409490,Proposition 50,,,Yes,311
 San Diego,409490,State Assembly,76,REP,Rocky Chavez,268
+San Diego,409490,State Assembly,76,REP,Thomas E Krouse,2
 San Diego,409490,U.S. House,49,REP,Darrell Issa,207
 San Diego,409490,U.S. House,49,DEM,Doug Applegate,205
 San Diego,409490,U.S. House,49,IND,Ryan Glenn Wingo,29
@@ -38425,6 +38558,7 @@ San Diego,409520,President,,REP,Ted Cruz,10
 San Diego,409520,Proposition 50,,,No,79
 San Diego,409520,Proposition 50,,,Yes,263
 San Diego,409520,State Assembly,76,REP,Rocky Chavez,246
+San Diego,409520,State Assembly,76,REP,Thomas E Krouse,2
 San Diego,409520,U.S. House,49,REP,Darrell Issa,215
 San Diego,409520,U.S. House,49,DEM,Doug Applegate,152
 San Diego,409520,U.S. House,49,IND,Ryan Glenn Wingo,4
@@ -38466,6 +38600,7 @@ San Diego,409590,President,,REP,Ted Cruz,14
 San Diego,409590,Proposition 50,,,No,111
 San Diego,409590,Proposition 50,,,Yes,389
 San Diego,409590,State Assembly,76,REP,Rocky Chavez,328
+San Diego,409590,State Assembly,76,REP,Thomas E Krouse,1
 San Diego,409590,U.S. House,49,REP,Darrell Issa,280
 San Diego,409590,U.S. House,49,DEM,Doug Applegate,226
 San Diego,409590,U.S. House,49,IND,Ryan Glenn Wingo,14
@@ -38509,6 +38644,7 @@ San Diego,409600,President,,DEM,Willie Wilson,1
 San Diego,409600,Proposition 50,,,No,118
 San Diego,409600,Proposition 50,,,Yes,381
 San Diego,409600,State Assembly,76,REP,Rocky Chavez,327
+San Diego,409600,State Assembly,76,REP,Thomas E Krouse,3
 San Diego,409600,U.S. House,49,REP,Darrell Issa,302
 San Diego,409600,U.S. House,49,DEM,Doug Applegate,199
 San Diego,409600,U.S. House,49,IND,Ryan Glenn Wingo,17
@@ -38552,6 +38688,7 @@ San Diego,409660,President,,DEM,Willie Wilson,1
 San Diego,409660,Proposition 50,,,No,119
 San Diego,409660,Proposition 50,,,Yes,415
 San Diego,409660,State Assembly,76,REP,Rocky Chavez,324
+San Diego,409660,State Assembly,76,REP,Thomas E Krouse,0
 San Diego,409660,U.S. House,49,REP,Darrell Issa,247
 San Diego,409660,U.S. House,49,DEM,Doug Applegate,307
 San Diego,409660,U.S. House,49,IND,Ryan Glenn Wingo,18
@@ -38595,6 +38732,7 @@ San Diego,409670,President,,REP,Ted Cruz,4
 San Diego,409670,Proposition 50,,,No,69
 San Diego,409670,Proposition 50,,,Yes,220
 San Diego,409670,State Assembly,76,REP,Rocky Chavez,204
+San Diego,409670,State Assembly,76,REP,Thomas E Krouse,0
 San Diego,409670,U.S. House,49,REP,Darrell Issa,157
 San Diego,409670,U.S. House,49,DEM,Doug Applegate,144
 San Diego,409670,U.S. House,49,IND,Ryan Glenn Wingo,7
@@ -38631,6 +38769,7 @@ San Diego,409690,President,,AIP,Wiley Drake,1
 San Diego,409690,Proposition 50,,,No,73
 San Diego,409690,Proposition 50,,,Yes,316
 San Diego,409690,State Assembly,76,REP,Rocky Chavez,228
+San Diego,409690,State Assembly,76,REP,Thomas E Krouse,0
 San Diego,409690,U.S. House,49,REP,Darrell Issa,149
 San Diego,409690,U.S. House,49,DEM,Doug Applegate,235
 San Diego,409690,U.S. House,49,IND,Ryan Glenn Wingo,8
@@ -38667,6 +38806,7 @@ San Diego,409780,President,,DEM,Willie Wilson,1
 San Diego,409780,Proposition 50,,,No,106
 San Diego,409780,Proposition 50,,,Yes,311
 San Diego,409780,State Assembly,76,REP,Rocky Chavez,273
+San Diego,409780,State Assembly,76,REP,Thomas E Krouse,0
 San Diego,409780,U.S. House,49,REP,Darrell Issa,229
 San Diego,409780,U.S. House,49,DEM,Doug Applegate,198
 San Diego,409780,U.S. House,49,IND,Ryan Glenn Wingo,8
@@ -38712,6 +38852,7 @@ San Diego,409800,President,,REP,Ted Cruz,14
 San Diego,409800,Proposition 50,,,No,139
 San Diego,409800,Proposition 50,,,Yes,396
 San Diego,409800,State Assembly,76,REP,Rocky Chavez,339
+San Diego,409800,State Assembly,76,REP,Thomas E Krouse,1
 San Diego,409800,U.S. House,49,REP,Darrell Issa,251
 San Diego,409800,U.S. House,49,DEM,Doug Applegate,275
 San Diego,409800,U.S. House,49,IND,Ryan Glenn Wingo,19
@@ -38757,6 +38898,7 @@ San Diego,409810,President,,REP,Ted Cruz,13
 San Diego,409810,Proposition 50,,,No,96
 San Diego,409810,Proposition 50,,,Yes,314
 San Diego,409810,State Assembly,76,REP,Rocky Chavez,277
+San Diego,409810,State Assembly,76,REP,Thomas E Krouse,1
 San Diego,409810,U.S. House,49,REP,Darrell Issa,222
 San Diego,409810,U.S. House,49,DEM,Doug Applegate,190
 San Diego,409810,U.S. House,49,IND,Ryan Glenn Wingo,10
@@ -38801,6 +38943,7 @@ San Diego,409830,President,,DEM,Willie Wilson,1
 San Diego,409830,Proposition 50,,,No,139
 San Diego,409830,Proposition 50,,,Yes,466
 San Diego,409830,State Assembly,76,REP,Rocky Chavez,396
+San Diego,409830,State Assembly,76,REP,Thomas E Krouse,4
 San Diego,409830,U.S. House,49,REP,Darrell Issa,339
 San Diego,409830,U.S. House,49,DEM,Doug Applegate,304
 San Diego,409830,U.S. House,49,IND,Ryan Glenn Wingo,18
@@ -38847,6 +38990,7 @@ San Diego,409860,President,,REP,Ted Cruz,8
 San Diego,409860,Proposition 50,,,No,92
 San Diego,409860,Proposition 50,,,Yes,281
 San Diego,409860,State Assembly,76,REP,Rocky Chavez,248
+San Diego,409860,State Assembly,76,REP,Thomas E Krouse,2
 San Diego,409860,U.S. House,49,REP,Darrell Issa,200
 San Diego,409860,U.S. House,49,DEM,Doug Applegate,178
 San Diego,409860,U.S. House,49,IND,Ryan Glenn Wingo,16
@@ -38889,6 +39033,7 @@ San Diego,409880,President,,REP,Ted Cruz,15
 San Diego,409880,Proposition 50,,,No,113
 San Diego,409880,Proposition 50,,,Yes,390
 San Diego,409880,State Assembly,76,REP,Rocky Chavez,317
+San Diego,409880,State Assembly,76,REP,Thomas E Krouse,0
 San Diego,409880,U.S. House,49,REP,Darrell Issa,266
 San Diego,409880,U.S. House,49,DEM,Doug Applegate,252
 San Diego,409880,U.S. House,49,IND,Ryan Glenn Wingo,13
@@ -38929,6 +39074,7 @@ San Diego,409970,President,,REP,Ted Cruz,2
 San Diego,409970,Proposition 50,,,No,38
 San Diego,409970,Proposition 50,,,Yes,139
 San Diego,409970,State Assembly,76,REP,Rocky Chavez,115
+San Diego,409970,State Assembly,76,REP,Thomas E Krouse,1
 San Diego,409970,U.S. House,49,REP,Darrell Issa,94
 San Diego,409970,U.S. House,49,DEM,Doug Applegate,91
 San Diego,409970,U.S. House,49,IND,Ryan Glenn Wingo,4
@@ -38966,6 +39112,7 @@ San Diego,412000,President,,DEM,Willie Wilson,1
 San Diego,412000,Proposition 50,,,No,63
 San Diego,412000,Proposition 50,,,Yes,243
 San Diego,412000,State Assembly,76,REP,Rocky Chavez,164
+San Diego,412000,State Assembly,76,REP,Thomas E Krouse,0
 San Diego,412000,U.S. House,49,REP,Darrell Issa,127
 San Diego,412000,U.S. House,49,DEM,Doug Applegate,179
 San Diego,412000,U.S. House,49,IND,Ryan Glenn Wingo,22
@@ -39006,6 +39153,7 @@ San Diego,412010,President,,REP,Ted Cruz,6
 San Diego,412010,Proposition 50,,,No,77
 San Diego,412010,Proposition 50,,,Yes,243
 San Diego,412010,State Assembly,76,REP,Rocky Chavez,174
+San Diego,412010,State Assembly,76,REP,Thomas E Krouse,0
 San Diego,412010,U.S. House,49,REP,Darrell Issa,119
 San Diego,412010,U.S. House,49,DEM,Doug Applegate,198
 San Diego,412010,U.S. House,49,IND,Ryan Glenn Wingo,23
@@ -39053,6 +39201,7 @@ San Diego,412040,President,,REP,Ted Cruz,3
 San Diego,412040,Proposition 50,,,No,131
 San Diego,412040,Proposition 50,,,Yes,446
 San Diego,412040,State Assembly,76,REP,Rocky Chavez,325
+San Diego,412040,State Assembly,76,REP,Thomas E Krouse,0
 San Diego,412040,U.S. House,49,REP,Darrell Issa,220
 San Diego,412040,U.S. House,49,DEM,Doug Applegate,352
 San Diego,412040,U.S. House,49,IND,Ryan Glenn Wingo,22
@@ -39101,6 +39250,7 @@ San Diego,412130,President,,REP,Ted Cruz,16
 San Diego,412130,Proposition 50,,,No,204
 San Diego,412130,Proposition 50,,,Yes,519
 San Diego,412130,State Assembly,76,REP,Rocky Chavez,414
+San Diego,412130,State Assembly,76,REP,Thomas E Krouse,0
 San Diego,412130,U.S. House,49,REP,Darrell Issa,312
 San Diego,412130,U.S. House,49,DEM,Doug Applegate,419
 San Diego,412130,U.S. House,49,IND,Ryan Glenn Wingo,31
@@ -39146,6 +39296,7 @@ San Diego,412140,President,,REP,Ted Cruz,2
 San Diego,412140,Proposition 50,,,No,28
 San Diego,412140,Proposition 50,,,Yes,130
 San Diego,412140,State Assembly,76,REP,Rocky Chavez,75
+San Diego,412140,State Assembly,76,REP,Thomas E Krouse,0
 San Diego,412140,U.S. House,49,REP,Darrell Issa,45
 San Diego,412140,U.S. House,49,DEM,Doug Applegate,109
 San Diego,412140,U.S. House,49,IND,Ryan Glenn Wingo,4
@@ -39183,6 +39334,7 @@ San Diego,412200,President,,DEM,Willie Wilson,1
 San Diego,412200,Proposition 50,,,No,82
 San Diego,412200,Proposition 50,,,Yes,359
 San Diego,412200,State Assembly,76,REP,Rocky Chavez,207
+San Diego,412200,State Assembly,76,REP,Thomas E Krouse,0
 San Diego,412200,U.S. House,49,REP,Darrell Issa,136
 San Diego,412200,U.S. House,49,DEM,Doug Applegate,308
 San Diego,412200,U.S. House,49,IND,Ryan Glenn Wingo,13
@@ -39227,6 +39379,7 @@ San Diego,412280,President,,REP,Ted Cruz,8
 San Diego,412280,Proposition 50,,,No,66
 San Diego,412280,Proposition 50,,,Yes,255
 San Diego,412280,State Assembly,76,REP,Rocky Chavez,190
+San Diego,412280,State Assembly,76,REP,Thomas E Krouse,0
 San Diego,412280,U.S. House,49,REP,Darrell Issa,142
 San Diego,412280,U.S. House,49,DEM,Doug Applegate,184
 San Diego,412280,U.S. House,49,IND,Ryan Glenn Wingo,5
@@ -39268,6 +39421,7 @@ San Diego,412300,President,,AIP,Wiley Drake,1
 San Diego,412300,Proposition 50,,,No,186
 San Diego,412300,Proposition 50,,,Yes,511
 San Diego,412300,State Assembly,76,REP,Rocky Chavez,430
+San Diego,412300,State Assembly,76,REP,Thomas E Krouse,0
 San Diego,412300,U.S. House,49,REP,Darrell Issa,323
 San Diego,412300,U.S. House,49,DEM,Doug Applegate,399
 San Diego,412300,U.S. House,49,IND,Ryan Glenn Wingo,21
@@ -39312,6 +39466,7 @@ San Diego,412390,President,,REP,Ted Cruz,7
 San Diego,412390,Proposition 50,,,No,84
 San Diego,412390,Proposition 50,,,Yes,298
 San Diego,412390,State Assembly,76,REP,Rocky Chavez,194
+San Diego,412390,State Assembly,76,REP,Thomas E Krouse,3
 San Diego,412390,U.S. House,49,REP,Darrell Issa,127
 San Diego,412390,U.S. House,49,DEM,Doug Applegate,273
 San Diego,412390,U.S. House,49,IND,Ryan Glenn Wingo,14
@@ -39356,6 +39511,7 @@ San Diego,412400,President,,REP,Ted Cruz,8
 San Diego,412400,Proposition 50,,,No,74
 San Diego,412400,Proposition 50,,,Yes,333
 San Diego,412400,State Assembly,76,REP,Rocky Chavez,225
+San Diego,412400,State Assembly,76,REP,Thomas E Krouse,0
 San Diego,412400,U.S. House,49,REP,Darrell Issa,147
 San Diego,412400,U.S. House,49,DEM,Doug Applegate,275
 San Diego,412400,U.S. House,49,IND,Ryan Glenn Wingo,13
@@ -39404,6 +39560,7 @@ San Diego,412440,President,,DEM,Willie Wilson,1
 San Diego,412440,Proposition 50,,,No,166
 San Diego,412440,Proposition 50,,,Yes,521
 San Diego,412440,State Assembly,76,REP,Rocky Chavez,423
+San Diego,412440,State Assembly,76,REP,Thomas E Krouse,2
 San Diego,412440,U.S. House,49,REP,Darrell Issa,321
 San Diego,412440,U.S. House,49,DEM,Doug Applegate,382
 San Diego,412440,U.S. House,49,IND,Ryan Glenn Wingo,21
@@ -39449,6 +39606,7 @@ San Diego,412530,President,,DEM,Willie Wilson,1
 San Diego,412530,Proposition 50,,,No,57
 San Diego,412530,Proposition 50,,,Yes,249
 San Diego,412530,State Assembly,76,REP,Rocky Chavez,145
+San Diego,412530,State Assembly,76,REP,Thomas E Krouse,5
 San Diego,412530,U.S. House,49,REP,Darrell Issa,88
 San Diego,412530,U.S. House,49,DEM,Doug Applegate,225
 San Diego,412530,U.S. House,49,IND,Ryan Glenn Wingo,4
@@ -39486,6 +39644,7 @@ San Diego,412710,President,,REP,Ted Cruz,7
 San Diego,412710,Proposition 50,,,No,86
 San Diego,412710,Proposition 50,,,Yes,257
 San Diego,412710,State Assembly,76,REP,Rocky Chavez,212
+San Diego,412710,State Assembly,76,REP,Thomas E Krouse,2
 San Diego,412710,U.S. House,49,REP,Darrell Issa,158
 San Diego,412710,U.S. House,49,DEM,Doug Applegate,189
 San Diego,412710,U.S. House,49,IND,Ryan Glenn Wingo,5
@@ -39525,6 +39684,7 @@ San Diego,412720,President,,REP,Ted Cruz,10
 San Diego,412720,Proposition 50,,,No,110
 San Diego,412720,Proposition 50,,,Yes,385
 San Diego,412720,State Assembly,76,REP,Rocky Chavez,272
+San Diego,412720,State Assembly,76,REP,Thomas E Krouse,2
 San Diego,412720,U.S. House,49,REP,Darrell Issa,181
 San Diego,412720,U.S. House,49,DEM,Doug Applegate,316
 San Diego,412720,U.S. House,49,IND,Ryan Glenn Wingo,21
@@ -39569,6 +39729,7 @@ San Diego,412750,President,,DEM,Willie Wilson,1
 San Diego,412750,Proposition 50,,,No,58
 San Diego,412750,Proposition 50,,,Yes,165
 San Diego,412750,State Assembly,76,REP,Rocky Chavez,118
+San Diego,412750,State Assembly,76,REP,Thomas E Krouse,4
 San Diego,412750,U.S. House,49,REP,Darrell Issa,71
 San Diego,412750,U.S. House,49,DEM,Doug Applegate,144
 San Diego,412750,U.S. House,49,IND,Ryan Glenn Wingo,10
@@ -39613,6 +39774,7 @@ San Diego,412760,President,,DEM,Willie Wilson,1
 San Diego,412760,Proposition 50,,,No,180
 San Diego,412760,Proposition 50,,,Yes,488
 San Diego,412760,State Assembly,76,REP,Rocky Chavez,356
+San Diego,412760,State Assembly,76,REP,Thomas E Krouse,1
 San Diego,412760,U.S. House,49,REP,Darrell Issa,238
 San Diego,412760,U.S. House,49,DEM,Doug Applegate,438
 San Diego,412760,U.S. House,49,IND,Ryan Glenn Wingo,20
@@ -39662,6 +39824,7 @@ San Diego,412780,President,,DEM,Willie Wilson,3
 San Diego,412780,Proposition 50,,,No,109
 San Diego,412780,Proposition 50,,,Yes,367
 San Diego,412780,State Assembly,76,REP,Rocky Chavez,300
+San Diego,412780,State Assembly,76,REP,Thomas E Krouse,0
 San Diego,412780,U.S. House,49,REP,Darrell Issa,206
 San Diego,412780,U.S. House,49,DEM,Doug Applegate,287
 San Diego,412780,U.S. House,49,IND,Ryan Glenn Wingo,15
@@ -39709,6 +39872,7 @@ San Diego,412800,President,,DEM,Willie Wilson,2
 San Diego,412800,Proposition 50,,,No,159
 San Diego,412800,Proposition 50,,,Yes,497
 San Diego,412800,State Assembly,76,REP,Rocky Chavez,385
+San Diego,412800,State Assembly,76,REP,Thomas E Krouse,0
 San Diego,412800,U.S. House,49,REP,Darrell Issa,298
 San Diego,412800,U.S. House,49,DEM,Doug Applegate,358
 San Diego,412800,U.S. House,49,IND,Ryan Glenn Wingo,21
@@ -39756,6 +39920,7 @@ San Diego,412810,President,,REP,Ted Cruz,5
 San Diego,412810,Proposition 50,,,No,75
 San Diego,412810,Proposition 50,,,Yes,256
 San Diego,412810,State Assembly,76,REP,Rocky Chavez,192
+San Diego,412810,State Assembly,76,REP,Thomas E Krouse,0
 San Diego,412810,U.S. House,49,REP,Darrell Issa,145
 San Diego,412810,U.S. House,49,DEM,Doug Applegate,196
 San Diego,412810,U.S. House,49,IND,Ryan Glenn Wingo,11
@@ -39794,6 +39959,7 @@ San Diego,412820,President,,DEM,Willie Wilson,1
 San Diego,412820,Proposition 50,,,No,143
 San Diego,412820,Proposition 50,,,Yes,409
 San Diego,412820,State Assembly,76,REP,Rocky Chavez,364
+San Diego,412820,State Assembly,76,REP,Thomas E Krouse,6
 San Diego,412820,U.S. House,49,REP,Darrell Issa,314
 San Diego,412820,U.S. House,49,DEM,Doug Applegate,242
 San Diego,412820,U.S. House,49,IND,Ryan Glenn Wingo,11
@@ -39834,6 +40000,7 @@ San Diego,412830,President,,REP,Ted Cruz,7
 San Diego,412830,Proposition 50,,,No,77
 San Diego,412830,Proposition 50,,,Yes,234
 San Diego,412830,State Assembly,76,REP,Rocky Chavez,188
+San Diego,412830,State Assembly,76,REP,Thomas E Krouse,2
 San Diego,412830,U.S. House,49,REP,Darrell Issa,120
 San Diego,412830,U.S. House,49,DEM,Doug Applegate,183
 San Diego,412830,U.S. House,49,IND,Ryan Glenn Wingo,18
@@ -39873,6 +40040,7 @@ San Diego,412840,President,,DEM,Willie Wilson,1
 San Diego,412840,Proposition 50,,,No,91
 San Diego,412840,Proposition 50,,,Yes,297
 San Diego,412840,State Assembly,76,REP,Rocky Chavez,225
+San Diego,412840,State Assembly,76,REP,Thomas E Krouse,1
 San Diego,412840,U.S. House,49,REP,Darrell Issa,184
 San Diego,412840,U.S. House,49,DEM,Doug Applegate,212
 San Diego,412840,U.S. House,49,IND,Ryan Glenn Wingo,11
@@ -39908,6 +40076,7 @@ San Diego,412900,President,,REP,Ted Cruz,4
 San Diego,412900,Proposition 50,,,No,57
 San Diego,412900,Proposition 50,,,Yes,76
 San Diego,412900,State Assembly,76,REP,Rocky Chavez,96
+San Diego,412900,State Assembly,76,REP,Thomas E Krouse,0
 San Diego,412900,U.S. House,49,REP,Darrell Issa,85
 San Diego,412900,U.S. House,49,DEM,Doug Applegate,61
 San Diego,412900,U.S. House,49,IND,Ryan Glenn Wingo,1
@@ -39938,6 +40107,7 @@ San Diego,412920,President,,REP,Ted Cruz,10
 San Diego,412920,Proposition 50,,,No,102
 San Diego,412920,Proposition 50,,,Yes,202
 San Diego,412920,State Assembly,76,REP,Rocky Chavez,185
+San Diego,412920,State Assembly,76,REP,Thomas E Krouse,1
 San Diego,412920,U.S. House,49,REP,Darrell Issa,187
 San Diego,412920,U.S. House,49,DEM,Doug Applegate,129
 San Diego,412920,U.S. House,49,IND,Ryan Glenn Wingo,3
@@ -39972,6 +40142,7 @@ San Diego,413440,President,,REP,Ted Cruz,18
 San Diego,413440,Proposition 50,,,No,152
 San Diego,413440,Proposition 50,,,Yes,363
 San Diego,413440,State Assembly,76,REP,Rocky Chavez,325
+San Diego,413440,State Assembly,76,REP,Thomas E Krouse,3
 San Diego,413440,U.S. House,49,REP,Darrell Issa,243
 San Diego,413440,U.S. House,49,DEM,Doug Applegate,265
 San Diego,413440,U.S. House,49,IND,Ryan Glenn Wingo,20
@@ -40011,6 +40182,7 @@ San Diego,413480,President,,REP,Ted Cruz,6
 San Diego,413480,Proposition 50,,,No,48
 San Diego,413480,Proposition 50,,,Yes,177
 San Diego,413480,State Assembly,76,REP,Rocky Chavez,117
+San Diego,413480,State Assembly,76,REP,Thomas E Krouse,2
 San Diego,413480,U.S. House,49,REP,Darrell Issa,74
 San Diego,413480,U.S. House,49,DEM,Doug Applegate,151
 San Diego,413480,U.S. House,49,IND,Ryan Glenn Wingo,10
@@ -40045,6 +40217,7 @@ San Diego,413490,President,,REP,Ted Cruz,6
 San Diego,413490,Proposition 50,,,No,87
 San Diego,413490,Proposition 50,,,Yes,318
 San Diego,413490,State Assembly,76,REP,Rocky Chavez,197
+San Diego,413490,State Assembly,76,REP,Thomas E Krouse,0
 San Diego,413490,U.S. House,49,REP,Darrell Issa,113
 San Diego,413490,U.S. House,49,DEM,Doug Applegate,287
 San Diego,413490,U.S. House,49,IND,Ryan Glenn Wingo,14
@@ -40086,6 +40259,7 @@ San Diego,413500,President,,DEM,Willie Wilson,1
 San Diego,413500,Proposition 50,,,No,87
 San Diego,413500,Proposition 50,,,Yes,289
 San Diego,413500,State Assembly,76,REP,Rocky Chavez,211
+San Diego,413500,State Assembly,76,REP,Thomas E Krouse,3
 San Diego,413500,U.S. House,49,REP,Darrell Issa,151
 San Diego,413500,U.S. House,49,DEM,Doug Applegate,230
 San Diego,413500,U.S. House,49,IND,Ryan Glenn Wingo,17
@@ -40123,6 +40297,7 @@ San Diego,413530,President,,REP,Ted Cruz,10
 San Diego,413530,Proposition 50,,,No,80
 San Diego,413530,Proposition 50,,,Yes,195
 San Diego,413530,State Assembly,76,REP,Rocky Chavez,178
+San Diego,413530,State Assembly,76,REP,Thomas E Krouse,0
 San Diego,413530,U.S. House,49,REP,Darrell Issa,156
 San Diego,413530,U.S. House,49,DEM,Doug Applegate,133
 San Diego,413530,U.S. House,49,IND,Ryan Glenn Wingo,4
@@ -40157,6 +40332,7 @@ San Diego,413580,President,,REP,Ted Cruz,2
 San Diego,413580,Proposition 50,,,No,95
 San Diego,413580,Proposition 50,,,Yes,265
 San Diego,413580,State Assembly,76,REP,Rocky Chavez,217
+San Diego,413580,State Assembly,76,REP,Thomas E Krouse,0
 San Diego,413580,U.S. House,49,REP,Darrell Issa,156
 San Diego,413580,U.S. House,49,DEM,Doug Applegate,221
 San Diego,413580,U.S. House,49,IND,Ryan Glenn Wingo,6
@@ -40202,6 +40378,7 @@ San Diego,413590,President,,DEM,Willie Wilson,1
 San Diego,413590,Proposition 50,,,No,61
 San Diego,413590,Proposition 50,,,Yes,223
 San Diego,413590,State Assembly,76,REP,Rocky Chavez,178
+San Diego,413590,State Assembly,76,REP,Thomas E Krouse,0
 San Diego,413590,U.S. House,49,REP,Darrell Issa,82
 San Diego,413590,U.S. House,49,DEM,Doug Applegate,208
 San Diego,413590,U.S. House,49,IND,Ryan Glenn Wingo,16
@@ -40244,6 +40421,7 @@ San Diego,413600,President,,AIP,Wiley Drake,1
 San Diego,413600,Proposition 50,,,No,100
 San Diego,413600,Proposition 50,,,Yes,331
 San Diego,413600,State Assembly,76,REP,Rocky Chavez,235
+San Diego,413600,State Assembly,76,REP,Thomas E Krouse,1
 San Diego,413600,U.S. House,49,REP,Darrell Issa,149
 San Diego,413600,U.S. House,49,DEM,Doug Applegate,264
 San Diego,413600,U.S. House,49,IND,Ryan Glenn Wingo,16
@@ -40288,6 +40466,7 @@ San Diego,413700,President,,REP,Ted Cruz,2
 San Diego,413700,Proposition 50,,,No,90
 San Diego,413700,Proposition 50,,,Yes,262
 San Diego,413700,State Assembly,76,REP,Rocky Chavez,186
+San Diego,413700,State Assembly,76,REP,Thomas E Krouse,2
 San Diego,413700,U.S. House,49,REP,Darrell Issa,123
 San Diego,413700,U.S. House,49,DEM,Doug Applegate,228
 San Diego,413700,U.S. House,49,IND,Ryan Glenn Wingo,15
@@ -40326,6 +40505,7 @@ San Diego,413750,President,,REP,Ted Cruz,8
 San Diego,413750,Proposition 50,,,No,93
 San Diego,413750,Proposition 50,,,Yes,249
 San Diego,413750,State Assembly,76,REP,Rocky Chavez,213
+San Diego,413750,State Assembly,76,REP,Thomas E Krouse,0
 San Diego,413750,U.S. House,49,REP,Darrell Issa,144
 San Diego,413750,U.S. House,49,DEM,Doug Applegate,192
 San Diego,413750,U.S. House,49,IND,Ryan Glenn Wingo,10
@@ -40372,6 +40552,7 @@ San Diego,413780,President,,DEM,Willie Wilson,1
 San Diego,413780,Proposition 50,,,No,152
 San Diego,413780,Proposition 50,,,Yes,471
 San Diego,413780,State Assembly,76,REP,Rocky Chavez,364
+San Diego,413780,State Assembly,76,REP,Thomas E Krouse,2
 San Diego,413780,U.S. House,49,REP,Darrell Issa,256
 San Diego,413780,U.S. House,49,DEM,Doug Applegate,357
 San Diego,413780,U.S. House,49,IND,Ryan Glenn Wingo,19
@@ -40416,6 +40597,7 @@ San Diego,413830,President,,REP,Ted Cruz,4
 San Diego,413830,Proposition 50,,,No,66
 San Diego,413830,Proposition 50,,,Yes,163
 San Diego,413830,State Assembly,76,REP,Rocky Chavez,142
+San Diego,413830,State Assembly,76,REP,Thomas E Krouse,0
 San Diego,413830,U.S. House,49,REP,Darrell Issa,113
 San Diego,413830,U.S. House,49,DEM,Doug Applegate,115
 San Diego,413830,U.S. House,49,IND,Ryan Glenn Wingo,14
@@ -40463,6 +40645,7 @@ San Diego,413900,President,,REP,Ted Cruz,13
 San Diego,413900,Proposition 50,,,No,134
 San Diego,413900,Proposition 50,,,Yes,401
 San Diego,413900,State Assembly,76,REP,Rocky Chavez,325
+San Diego,413900,State Assembly,76,REP,Thomas E Krouse,4
 San Diego,413900,U.S. House,49,REP,Darrell Issa,197
 San Diego,413900,U.S. House,49,DEM,Doug Applegate,337
 San Diego,413900,U.S. House,49,IND,Ryan Glenn Wingo,27
@@ -40509,6 +40692,7 @@ San Diego,413910,President,,DEM,Willie Wilson,1
 San Diego,413910,Proposition 50,,,No,107
 San Diego,413910,Proposition 50,,,Yes,443
 San Diego,413910,State Assembly,76,REP,Rocky Chavez,314
+San Diego,413910,State Assembly,76,REP,Thomas E Krouse,1
 San Diego,413910,U.S. House,49,REP,Darrell Issa,195
 San Diego,413910,U.S. House,49,DEM,Doug Applegate,363
 San Diego,413910,U.S. House,49,IND,Ryan Glenn Wingo,23
@@ -40556,6 +40740,7 @@ San Diego,414000,President,,AIP,Wiley Drake,2
 San Diego,414000,Proposition 50,,,No,107
 San Diego,414000,Proposition 50,,,Yes,433
 San Diego,414000,State Assembly,76,REP,Rocky Chavez,233
+San Diego,414000,State Assembly,76,REP,Thomas E Krouse,0
 San Diego,414000,U.S. House,49,REP,Darrell Issa,139
 San Diego,414000,U.S. House,49,DEM,Doug Applegate,413
 San Diego,414000,U.S. House,49,IND,Ryan Glenn Wingo,21
@@ -40600,6 +40785,7 @@ San Diego,414030,President,,AIP,Thomas Hoefling,1
 San Diego,414030,Proposition 50,,,No,139
 San Diego,414030,Proposition 50,,,Yes,382
 San Diego,414030,State Assembly,76,REP,Rocky Chavez,277
+San Diego,414030,State Assembly,76,REP,Thomas E Krouse,0
 San Diego,414030,U.S. House,49,REP,Darrell Issa,189
 San Diego,414030,U.S. House,49,DEM,Doug Applegate,338
 San Diego,414030,U.S. House,49,IND,Ryan Glenn Wingo,16
@@ -40643,6 +40829,7 @@ San Diego,414050,President,,REP,Ted Cruz,8
 San Diego,414050,Proposition 50,,,No,82
 San Diego,414050,Proposition 50,,,Yes,256
 San Diego,414050,State Assembly,76,REP,Rocky Chavez,167
+San Diego,414050,State Assembly,76,REP,Thomas E Krouse,1
 San Diego,414050,U.S. House,49,REP,Darrell Issa,124
 San Diego,414050,U.S. House,49,DEM,Doug Applegate,232
 San Diego,414050,U.S. House,49,IND,Ryan Glenn Wingo,14
@@ -40684,6 +40871,7 @@ San Diego,414060,President,,REP,Ted Cruz,3
 San Diego,414060,Proposition 50,,,No,79
 San Diego,414060,Proposition 50,,,Yes,247
 San Diego,414060,State Assembly,76,REP,Rocky Chavez,174
+San Diego,414060,State Assembly,76,REP,Thomas E Krouse,0
 San Diego,414060,U.S. House,49,REP,Darrell Issa,114
 San Diego,414060,U.S. House,49,DEM,Doug Applegate,218
 San Diego,414060,U.S. House,49,IND,Ryan Glenn Wingo,16
@@ -40726,6 +40914,7 @@ San Diego,414080,President,,AIP,Wiley Drake,1
 San Diego,414080,Proposition 50,,,No,112
 San Diego,414080,Proposition 50,,,Yes,321
 San Diego,414080,State Assembly,76,REP,Rocky Chavez,243
+San Diego,414080,State Assembly,76,REP,Thomas E Krouse,0
 San Diego,414080,U.S. House,49,REP,Darrell Issa,168
 San Diego,414080,U.S. House,49,DEM,Doug Applegate,272
 San Diego,414080,U.S. House,49,IND,Ryan Glenn Wingo,19
@@ -42187,6 +42376,7 @@ San Diego,420520,Proposition 50,,,No,141
 San Diego,420520,Proposition 50,,,Yes,378
 San Diego,420520,State Assembly,75,DEM,Andrew Masiel Sr.,137
 San Diego,420520,State Assembly,75,REP,Marie Waldron,375
+San Diego,420520,State Assembly,75,REP,Thomas E Krouse,1
 San Diego,420520,U.S. House,50,DEM,David Secor,46
 San Diego,420520,U.S. House,50,REP,Duncan Hunter,317
 San Diego,420520,U.S. House,50,IND,H. Fuji Shioura,19
@@ -42231,6 +42421,7 @@ San Diego,420600,President,,REP,Ted Cruz,7
 San Diego,420600,Proposition 50,,,No,110
 San Diego,420600,Proposition 50,,,Yes,215
 San Diego,420600,State Assembly,76,REP,Rocky Chavez,237
+San Diego,420600,State Assembly,76,REP,Thomas E Krouse,0
 San Diego,420600,U.S. House,49,REP,Darrell Issa,228
 San Diego,420600,U.S. House,49,DEM,Doug Applegate,94
 San Diego,420600,U.S. House,49,IND,Ryan Glenn Wingo,15
@@ -42447,6 +42638,7 @@ San Diego,422900,President,,AIP,Wiley Drake,1
 San Diego,422900,Proposition 50,,,No,72
 San Diego,422900,Proposition 50,,,Yes,262
 San Diego,422900,State Assembly,76,REP,Rocky Chavez,249
+San Diego,422900,State Assembly,76,REP,Thomas E Krouse,3
 San Diego,422900,U.S. House,49,REP,Darrell Issa,174
 San Diego,422900,U.S. House,49,DEM,Doug Applegate,147
 San Diego,422900,U.S. House,49,IND,Ryan Glenn Wingo,20
@@ -42490,6 +42682,7 @@ San Diego,422920,President,,DEM,Willie Wilson,1
 San Diego,422920,Proposition 50,,,No,112
 San Diego,422920,Proposition 50,,,Yes,333
 San Diego,422920,State Assembly,76,REP,Rocky Chavez,301
+San Diego,422920,State Assembly,76,REP,Thomas E Krouse,0
 San Diego,422920,U.S. House,49,REP,Darrell Issa,210
 San Diego,422920,U.S. House,49,DEM,Doug Applegate,241
 San Diego,422920,U.S. House,49,IND,Ryan Glenn Wingo,13
@@ -42537,6 +42730,7 @@ San Diego,422940,President,,REP,Ted Cruz,22
 San Diego,422940,Proposition 50,,,No,130
 San Diego,422940,Proposition 50,,,Yes,441
 San Diego,422940,State Assembly,76,REP,Rocky Chavez,395
+San Diego,422940,State Assembly,76,REP,Thomas E Krouse,3
 San Diego,422940,U.S. House,49,REP,Darrell Issa,277
 San Diego,422940,U.S. House,49,DEM,Doug Applegate,294
 San Diego,422940,U.S. House,49,IND,Ryan Glenn Wingo,25
@@ -42585,6 +42779,7 @@ San Diego,422960,President,,REP,Ted Cruz,9
 San Diego,422960,Proposition 50,,,No,74
 San Diego,422960,Proposition 50,,,Yes,286
 San Diego,422960,State Assembly,76,REP,Rocky Chavez,266
+San Diego,422960,State Assembly,76,REP,Thomas E Krouse,3
 San Diego,422960,U.S. House,49,REP,Darrell Issa,210
 San Diego,422960,U.S. House,49,DEM,Doug Applegate,174
 San Diego,422960,U.S. House,49,IND,Ryan Glenn Wingo,10
@@ -42627,6 +42822,7 @@ San Diego,422980,President,,AIP,Wiley Drake,1
 San Diego,422980,Proposition 50,,,No,90
 San Diego,422980,Proposition 50,,,Yes,330
 San Diego,422980,State Assembly,76,REP,Rocky Chavez,271
+San Diego,422980,State Assembly,76,REP,Thomas E Krouse,3
 San Diego,422980,U.S. House,49,REP,Darrell Issa,216
 San Diego,422980,U.S. House,49,DEM,Doug Applegate,200
 San Diego,422980,U.S. House,49,IND,Ryan Glenn Wingo,22
@@ -42674,6 +42870,7 @@ San Diego,422990,President,,DEM,Willie Wilson,1
 San Diego,422990,Proposition 50,,,No,106
 San Diego,422990,Proposition 50,,,Yes,324
 San Diego,422990,State Assembly,76,REP,Rocky Chavez,341
+San Diego,422990,State Assembly,76,REP,Thomas E Krouse,3
 San Diego,422990,U.S. House,49,REP,Darrell Issa,283
 San Diego,422990,U.S. House,49,DEM,Doug Applegate,159
 San Diego,422990,U.S. House,49,IND,Ryan Glenn Wingo,18
@@ -42717,6 +42914,7 @@ San Diego,423000,President,,AIP,Wiley Drake,1
 San Diego,423000,Proposition 50,,,No,90
 San Diego,423000,Proposition 50,,,Yes,396
 San Diego,423000,State Assembly,76,REP,Rocky Chavez,354
+San Diego,423000,State Assembly,76,REP,Thomas E Krouse,2
 San Diego,423000,U.S. House,49,REP,Darrell Issa,263
 San Diego,423000,U.S. House,49,DEM,Doug Applegate,229
 San Diego,423000,U.S. House,49,IND,Ryan Glenn Wingo,17
@@ -42763,6 +42961,7 @@ San Diego,423010,President,,DEM,Willie Wilson,1
 San Diego,423010,Proposition 50,,,No,41
 San Diego,423010,Proposition 50,,,Yes,171
 San Diego,423010,State Assembly,76,REP,Rocky Chavez,156
+San Diego,423010,State Assembly,76,REP,Thomas E Krouse,1
 San Diego,423010,U.S. House,49,REP,Darrell Issa,137
 San Diego,423010,U.S. House,49,DEM,Doug Applegate,82
 San Diego,423010,U.S. House,49,IND,Ryan Glenn Wingo,6
@@ -42801,6 +43000,7 @@ San Diego,423030,President,,REP,Ted Cruz,12
 San Diego,423030,Proposition 50,,,No,74
 San Diego,423030,Proposition 50,,,Yes,235
 San Diego,423030,State Assembly,76,REP,Rocky Chavez,217
+San Diego,423030,State Assembly,76,REP,Thomas E Krouse,1
 San Diego,423030,U.S. House,49,REP,Darrell Issa,132
 San Diego,423030,U.S. House,49,DEM,Doug Applegate,167
 San Diego,423030,U.S. House,49,IND,Ryan Glenn Wingo,23
@@ -42843,6 +43043,7 @@ San Diego,423040,President,,DEM,Willie Wilson,1
 San Diego,423040,Proposition 50,,,No,58
 San Diego,423040,Proposition 50,,,Yes,187
 San Diego,423040,State Assembly,76,REP,Rocky Chavez,170
+San Diego,423040,State Assembly,76,REP,Thomas E Krouse,0
 San Diego,423040,U.S. House,49,REP,Darrell Issa,159
 San Diego,423040,U.S. House,49,DEM,Doug Applegate,93
 San Diego,423040,U.S. House,49,IND,Ryan Glenn Wingo,9
@@ -42890,6 +43091,7 @@ San Diego,423280,President,,DEM,Willie Wilson,1
 San Diego,423280,Proposition 50,,,No,104
 San Diego,423280,Proposition 50,,,Yes,379
 San Diego,423280,State Assembly,76,REP,Rocky Chavez,361
+San Diego,423280,State Assembly,76,REP,Thomas E Krouse,0
 San Diego,423280,U.S. House,49,REP,Darrell Issa,281
 San Diego,423280,U.S. House,49,DEM,Doug Applegate,198
 San Diego,423280,U.S. House,49,IND,Ryan Glenn Wingo,11
@@ -42934,6 +43136,7 @@ San Diego,423410,President,,AIP,Wiley Drake,1
 San Diego,423410,Proposition 50,,,No,93
 San Diego,423410,Proposition 50,,,Yes,267
 San Diego,423410,State Assembly,76,REP,Rocky Chavez,255
+San Diego,423410,State Assembly,76,REP,Thomas E Krouse,3
 San Diego,423410,U.S. House,49,REP,Darrell Issa,145
 San Diego,423410,U.S. House,49,DEM,Doug Applegate,191
 San Diego,423410,U.S. House,49,IND,Ryan Glenn Wingo,22
@@ -42986,6 +43189,7 @@ San Diego,423600,President,,AIP,Wiley Drake,1
 San Diego,423600,Proposition 50,,,No,100
 San Diego,423600,Proposition 50,,,Yes,290
 San Diego,423600,State Assembly,76,REP,Rocky Chavez,282
+San Diego,423600,State Assembly,76,REP,Thomas E Krouse,1
 San Diego,423600,U.S. House,49,REP,Darrell Issa,117
 San Diego,423600,U.S. House,49,DEM,Doug Applegate,247
 San Diego,423600,U.S. House,49,IND,Ryan Glenn Wingo,28
@@ -43027,6 +43231,7 @@ San Diego,423700,President,,AIP,Wiley Drake,1
 San Diego,423700,Proposition 50,,,No,97
 San Diego,423700,Proposition 50,,,Yes,368
 San Diego,423700,State Assembly,76,REP,Rocky Chavez,336
+San Diego,423700,State Assembly,76,REP,Thomas E Krouse,2
 San Diego,423700,U.S. House,49,REP,Darrell Issa,210
 San Diego,423700,U.S. House,49,DEM,Doug Applegate,243
 San Diego,423700,U.S. House,49,IND,Ryan Glenn Wingo,29
@@ -43069,6 +43274,7 @@ San Diego,423900,President,,REP,Ted Cruz,1
 San Diego,423900,Proposition 50,,,No,44
 San Diego,423900,Proposition 50,,,Yes,160
 San Diego,423900,State Assembly,76,REP,Rocky Chavez,130
+San Diego,423900,State Assembly,76,REP,Thomas E Krouse,0
 San Diego,423900,U.S. House,49,REP,Darrell Issa,49
 San Diego,423900,U.S. House,49,DEM,Doug Applegate,135
 San Diego,423900,U.S. House,49,IND,Ryan Glenn Wingo,14
@@ -43115,6 +43321,7 @@ San Diego,424100,President,,DEM,Willie Wilson,1
 San Diego,424100,Proposition 50,,,No,101
 San Diego,424100,Proposition 50,,,Yes,355
 San Diego,424100,State Assembly,76,REP,Rocky Chavez,327
+San Diego,424100,State Assembly,76,REP,Thomas E Krouse,5
 San Diego,424100,U.S. House,49,REP,Darrell Issa,247
 San Diego,424100,U.S. House,49,DEM,Doug Applegate,197
 San Diego,424100,U.S. House,49,IND,Ryan Glenn Wingo,28
@@ -43162,6 +43369,7 @@ San Diego,424200,President,,DEM,Willie Wilson,1
 San Diego,424200,Proposition 50,,,No,106
 San Diego,424200,Proposition 50,,,Yes,327
 San Diego,424200,State Assembly,76,REP,Rocky Chavez,280
+San Diego,424200,State Assembly,76,REP,Thomas E Krouse,2
 San Diego,424200,U.S. House,49,REP,Darrell Issa,254
 San Diego,424200,U.S. House,49,DEM,Doug Applegate,188
 San Diego,424200,U.S. House,49,IND,Ryan Glenn Wingo,22
@@ -43204,6 +43412,7 @@ San Diego,424510,President,,REP,Ted Cruz,10
 San Diego,424510,Proposition 50,,,No,44
 San Diego,424510,Proposition 50,,,Yes,160
 San Diego,424510,State Assembly,76,REP,Rocky Chavez,140
+San Diego,424510,State Assembly,76,REP,Thomas E Krouse,0
 San Diego,424510,U.S. House,49,REP,Darrell Issa,82
 San Diego,424510,U.S. House,49,DEM,Doug Applegate,114
 San Diego,424510,U.S. House,49,IND,Ryan Glenn Wingo,7
@@ -43245,6 +43454,7 @@ San Diego,424700,President,,AIP,Wiley Drake,1
 San Diego,424700,Proposition 50,,,No,73
 San Diego,424700,Proposition 50,,,Yes,291
 San Diego,424700,State Assembly,76,REP,Rocky Chavez,256
+San Diego,424700,State Assembly,76,REP,Thomas E Krouse,0
 San Diego,424700,U.S. House,49,REP,Darrell Issa,163
 San Diego,424700,U.S. House,49,DEM,Doug Applegate,190
 San Diego,424700,U.S. House,49,IND,Ryan Glenn Wingo,24
@@ -43291,6 +43501,7 @@ San Diego,424790,President,,AIP,Thomas Hoefling,1
 San Diego,424790,Proposition 50,,,No,100
 San Diego,424790,Proposition 50,,,Yes,389
 San Diego,424790,State Assembly,76,REP,Rocky Chavez,342
+San Diego,424790,State Assembly,76,REP,Thomas E Krouse,1
 San Diego,424790,U.S. House,49,REP,Darrell Issa,222
 San Diego,424790,U.S. House,49,DEM,Doug Applegate,242
 San Diego,424790,U.S. House,49,IND,Ryan Glenn Wingo,43
@@ -43334,6 +43545,7 @@ San Diego,424890,President,,DEM,Willie Wilson,1
 San Diego,424890,Proposition 50,,,No,57
 San Diego,424890,Proposition 50,,,Yes,257
 San Diego,424890,State Assembly,76,REP,Rocky Chavez,222
+San Diego,424890,State Assembly,76,REP,Thomas E Krouse,0
 San Diego,424890,U.S. House,49,REP,Darrell Issa,114
 San Diego,424890,U.S. House,49,DEM,Doug Applegate,183
 San Diego,424890,U.S. House,49,IND,Ryan Glenn Wingo,20
@@ -43379,6 +43591,7 @@ San Diego,424930,President,,DEM,Willie Wilson,1
 San Diego,424930,Proposition 50,,,No,95
 San Diego,424930,Proposition 50,,,Yes,381
 San Diego,424930,State Assembly,76,REP,Rocky Chavez,329
+San Diego,424930,State Assembly,76,REP,Thomas E Krouse,2
 San Diego,424930,U.S. House,49,REP,Darrell Issa,263
 San Diego,424930,U.S. House,49,DEM,Doug Applegate,218
 San Diego,424930,U.S. House,49,IND,Ryan Glenn Wingo,21
@@ -43425,6 +43638,7 @@ San Diego,425000,President,,DEM,Willie Wilson,2
 San Diego,425000,Proposition 50,,,No,82
 San Diego,425000,Proposition 50,,,Yes,219
 San Diego,425000,State Assembly,76,REP,Rocky Chavez,209
+San Diego,425000,State Assembly,76,REP,Thomas E Krouse,0
 San Diego,425000,U.S. House,49,REP,Darrell Issa,156
 San Diego,425000,U.S. House,49,DEM,Doug Applegate,141
 San Diego,425000,U.S. House,49,IND,Ryan Glenn Wingo,24
@@ -43471,6 +43685,7 @@ San Diego,425160,President,,REP,Ted Cruz,12
 San Diego,425160,Proposition 50,,,No,121
 San Diego,425160,Proposition 50,,,Yes,506
 San Diego,425160,State Assembly,76,REP,Rocky Chavez,452
+San Diego,425160,State Assembly,76,REP,Thomas E Krouse,1
 San Diego,425160,U.S. House,49,REP,Darrell Issa,347
 San Diego,425160,U.S. House,49,DEM,Doug Applegate,287
 San Diego,425160,U.S. House,49,IND,Ryan Glenn Wingo,27
@@ -43521,6 +43736,7 @@ San Diego,425220,President,,DEM,Willie Wilson,2
 San Diego,425220,Proposition 50,,,No,105
 San Diego,425220,Proposition 50,,,Yes,431
 San Diego,425220,State Assembly,76,REP,Rocky Chavez,392
+San Diego,425220,State Assembly,76,REP,Thomas E Krouse,1
 San Diego,425220,U.S. House,49,REP,Darrell Issa,344
 San Diego,425220,U.S. House,49,DEM,Doug Applegate,218
 San Diego,425220,U.S. House,49,IND,Ryan Glenn Wingo,18
@@ -43574,6 +43790,7 @@ San Diego,425300,President,,AIP,Thomas Hoefling,1
 San Diego,425300,Proposition 50,,,No,43
 San Diego,425300,Proposition 50,,,Yes,178
 San Diego,425300,State Assembly,76,REP,Rocky Chavez,160
+San Diego,425300,State Assembly,76,REP,Thomas E Krouse,1
 San Diego,425300,U.S. House,49,REP,Darrell Issa,116
 San Diego,425300,U.S. House,49,DEM,Doug Applegate,100
 San Diego,425300,U.S. House,49,IND,Ryan Glenn Wingo,15
@@ -43620,6 +43837,7 @@ San Diego,425320,President,,DEM,Willie Wilson,1
 San Diego,425320,Proposition 50,,,No,106
 San Diego,425320,Proposition 50,,,Yes,357
 San Diego,425320,State Assembly,76,REP,Rocky Chavez,330
+San Diego,425320,State Assembly,76,REP,Thomas E Krouse,1
 San Diego,425320,U.S. House,49,REP,Darrell Issa,245
 San Diego,425320,U.S. House,49,DEM,Doug Applegate,215
 San Diego,425320,U.S. House,49,IND,Ryan Glenn Wingo,30
@@ -43670,6 +43888,7 @@ San Diego,425390,President,,AIP,Thomas Hoefling,1
 San Diego,425390,Proposition 50,,,No,121
 San Diego,425390,Proposition 50,,,Yes,413
 San Diego,425390,State Assembly,76,REP,Rocky Chavez,345
+San Diego,425390,State Assembly,76,REP,Thomas E Krouse,3
 San Diego,425390,U.S. House,49,REP,Darrell Issa,324
 San Diego,425390,U.S. House,49,DEM,Doug Applegate,220
 San Diego,425390,U.S. House,49,IND,Ryan Glenn Wingo,20
@@ -43714,6 +43933,7 @@ San Diego,425450,President,,AIP,Thomas Hoefling,1
 San Diego,425450,Proposition 50,,,No,94
 San Diego,425450,Proposition 50,,,Yes,328
 San Diego,425450,State Assembly,76,REP,Rocky Chavez,279
+San Diego,425450,State Assembly,76,REP,Thomas E Krouse,3
 San Diego,425450,U.S. House,49,REP,Darrell Issa,214
 San Diego,425450,U.S. House,49,DEM,Doug Applegate,218
 San Diego,425450,U.S. House,49,IND,Ryan Glenn Wingo,16
@@ -43761,6 +43981,7 @@ San Diego,425460,President,,AIP,Thomas Hoefling,2
 San Diego,425460,Proposition 50,,,No,116
 San Diego,425460,Proposition 50,,,Yes,346
 San Diego,425460,State Assembly,76,REP,Rocky Chavez,340
+San Diego,425460,State Assembly,76,REP,Thomas E Krouse,2
 San Diego,425460,U.S. House,49,REP,Darrell Issa,268
 San Diego,425460,U.S. House,49,DEM,Doug Applegate,206
 San Diego,425460,U.S. House,49,IND,Ryan Glenn Wingo,17
@@ -43812,6 +44033,7 @@ San Diego,425470,President,,DEM,Willie Wilson,1
 San Diego,425470,Proposition 50,,,No,107
 San Diego,425470,Proposition 50,,,Yes,468
 San Diego,425470,State Assembly,76,REP,Rocky Chavez,382
+San Diego,425470,State Assembly,76,REP,Thomas E Krouse,2
 San Diego,425470,U.S. House,49,REP,Darrell Issa,361
 San Diego,425470,U.S. House,49,DEM,Doug Applegate,250
 San Diego,425470,U.S. House,49,IND,Ryan Glenn Wingo,10
@@ -43861,6 +44083,7 @@ San Diego,425480,President,,AIP,Thomas Hoefling,1
 San Diego,425480,Proposition 50,,,No,97
 San Diego,425480,Proposition 50,,,Yes,262
 San Diego,425480,State Assembly,76,REP,Rocky Chavez,260
+San Diego,425480,State Assembly,76,REP,Thomas E Krouse,2
 San Diego,425480,U.S. House,49,REP,Darrell Issa,165
 San Diego,425480,U.S. House,49,DEM,Doug Applegate,187
 San Diego,425480,U.S. House,49,IND,Ryan Glenn Wingo,29
@@ -43911,6 +44134,7 @@ San Diego,425490,President,,DEM,Willie Wilson,1
 San Diego,425490,Proposition 50,,,No,139
 San Diego,425490,Proposition 50,,,Yes,490
 San Diego,425490,State Assembly,76,REP,Rocky Chavez,464
+San Diego,425490,State Assembly,76,REP,Thomas E Krouse,0
 San Diego,425490,U.S. House,49,REP,Darrell Issa,426
 San Diego,425490,U.S. House,49,DEM,Doug Applegate,228
 San Diego,425490,U.S. House,49,IND,Ryan Glenn Wingo,17
@@ -43964,6 +44188,7 @@ San Diego,425530,President,,AIP,Wiley Drake,1
 San Diego,425530,Proposition 50,,,No,163
 San Diego,425530,Proposition 50,,,Yes,458
 San Diego,425530,State Assembly,76,REP,Rocky Chavez,441
+San Diego,425530,State Assembly,76,REP,Thomas E Krouse,0
 San Diego,425530,U.S. House,49,REP,Darrell Issa,353
 San Diego,425530,U.S. House,49,DEM,Doug Applegate,288
 San Diego,425530,U.S. House,49,IND,Ryan Glenn Wingo,22
@@ -44013,6 +44238,7 @@ San Diego,425560,President,,REP,Ted Cruz,9
 San Diego,425560,Proposition 50,,,No,87
 San Diego,425560,Proposition 50,,,Yes,259
 San Diego,425560,State Assembly,76,REP,Rocky Chavez,243
+San Diego,425560,State Assembly,76,REP,Thomas E Krouse,0
 San Diego,425560,U.S. House,49,REP,Darrell Issa,181
 San Diego,425560,U.S. House,49,DEM,Doug Applegate,155
 San Diego,425560,U.S. House,49,IND,Ryan Glenn Wingo,14
@@ -44059,6 +44285,7 @@ San Diego,425610,President,,DEM,Willie Wilson,2
 San Diego,425610,Proposition 50,,,No,78
 San Diego,425610,Proposition 50,,,Yes,312
 San Diego,425610,State Assembly,76,REP,Rocky Chavez,288
+San Diego,425610,State Assembly,76,REP,Thomas E Krouse,2
 San Diego,425610,U.S. House,49,REP,Darrell Issa,255
 San Diego,425610,U.S. House,49,DEM,Doug Applegate,147
 San Diego,425610,U.S. House,49,IND,Ryan Glenn Wingo,7
@@ -44103,6 +44330,7 @@ San Diego,425660,President,,DEM,Willie Wilson,1
 San Diego,425660,Proposition 50,,,No,92
 San Diego,425660,Proposition 50,,,Yes,241
 San Diego,425660,State Assembly,76,REP,Rocky Chavez,251
+San Diego,425660,State Assembly,76,REP,Thomas E Krouse,0
 San Diego,425660,U.S. House,49,REP,Darrell Issa,204
 San Diego,425660,U.S. House,49,DEM,Doug Applegate,139
 San Diego,425660,U.S. House,49,IND,Ryan Glenn Wingo,8
@@ -44500,6 +44728,7 @@ San Diego,429900,President,,REP,Ted Cruz,11
 San Diego,429900,Proposition 50,,,No,64
 San Diego,429900,Proposition 50,,,Yes,253
 San Diego,429900,State Assembly,76,REP,Rocky Chavez,219
+San Diego,429900,State Assembly,76,REP,Thomas E Krouse,1
 San Diego,429900,U.S. House,49,REP,Darrell Issa,178
 San Diego,429900,U.S. House,49,DEM,Doug Applegate,133
 San Diego,429900,U.S. House,49,IND,Ryan Glenn Wingo,12
@@ -75659,6 +75888,7 @@ San Diego,999048,President,,DEM,Willie Wilson,1
 San Diego,999048,Proposition 50,,,No,137
 San Diego,999048,Proposition 50,,,Yes,396
 San Diego,999048,State Assembly,76,REP,Rocky Chavez,330
+San Diego,999048,State Assembly,76,REP,Thomas E Krouse,0
 San Diego,999048,U.S. House,49,REP,Darrell Issa,262
 San Diego,999048,U.S. House,49,DEM,Doug Applegate,283
 San Diego,999048,U.S. House,49,IND,Ryan Glenn Wingo,16
@@ -75690,6 +75920,7 @@ San Diego,999048,U.S. Senate,,DEM,Steve Stokes,5
 San Diego,999048,U.S. Senate,,REP,Thomas G. Del Beccaro,48
 San Diego,999048,U.S. Senate,,REP,Tom Palzer,3
 San Diego,999048,U.S. Senate,,REP,Von Hougo,2
+San Diego,999049,State Assembly,76,REP,Thomas E Krouse,6
 San Diego,999050,President,,DEM,Bernie Sanders,26
 San Diego,999050,President,,REP,Donald Trump,29
 San Diego,999050,President,,DEM,Hillary Clinton,16
@@ -75699,6 +75930,7 @@ San Diego,999050,President,,AIP,Wiley Drake,1
 San Diego,999050,Proposition 50,,,No,14
 San Diego,999050,Proposition 50,,,Yes,62
 San Diego,999050,State Assembly,76,REP,Rocky Chavez,65
+San Diego,999050,State Assembly,76,REP,Thomas E Krouse,0
 San Diego,999050,U.S. House,49,REP,Darrell Issa,47
 San Diego,999050,U.S. House,49,DEM,Doug Applegate,35
 San Diego,999050,U.S. Senate,,REP,Don Krampe,3
@@ -75714,6 +75946,7 @@ San Diego,999050,U.S. Senate,,GRN,Pamela Elizondo,1
 San Diego,999050,U.S. Senate,,REP,Phil Wyman,9
 San Diego,999050,U.S. Senate,,REP,Thomas G. Del Beccaro,4
 San Diego,999050,U.S. Senate,,REP,Tom Palzer,5
+San Diego,999051,State Assembly,76,REP,Thomas E Krouse,2
 San Diego,999052,President,,REP,Ben Carson,2
 San Diego,999052,President,,DEM,Bernie Sanders,93
 San Diego,999052,President,,REP,Donald Trump,103
@@ -75725,6 +75958,7 @@ San Diego,999052,President,,REP,Ted Cruz,6
 San Diego,999052,Proposition 50,,,No,83
 San Diego,999052,Proposition 50,,,Yes,222
 San Diego,999052,State Assembly,76,REP,Rocky Chavez,203
+San Diego,999052,State Assembly,76,REP,Thomas E Krouse,0
 San Diego,999052,U.S. House,49,REP,Darrell Issa,154
 San Diego,999052,U.S. House,49,DEM,Doug Applegate,141
 San Diego,999052,U.S. House,49,IND,Ryan Glenn Wingo,13
@@ -75770,6 +76004,7 @@ San Diego,999053,President,,REP,Ted Cruz,4
 San Diego,999053,Proposition 50,,,No,71
 San Diego,999053,Proposition 50,,,Yes,196
 San Diego,999053,State Assembly,76,REP,Rocky Chavez,182
+San Diego,999053,State Assembly,76,REP,Thomas E Krouse,1
 San Diego,999053,U.S. House,49,REP,Darrell Issa,179
 San Diego,999053,U.S. House,49,DEM,Doug Applegate,98
 San Diego,999053,U.S. House,49,IND,Ryan Glenn Wingo,4
@@ -75808,6 +76043,7 @@ San Diego,999054,President,,REP,Ted Cruz,8
 San Diego,999054,Proposition 50,,,No,76
 San Diego,999054,Proposition 50,,,Yes,224
 San Diego,999054,State Assembly,76,REP,Rocky Chavez,186
+San Diego,999054,State Assembly,76,REP,Thomas E Krouse,0
 San Diego,999054,U.S. House,49,REP,Darrell Issa,156
 San Diego,999054,U.S. House,49,DEM,Doug Applegate,145
 San Diego,999054,U.S. House,49,IND,Ryan Glenn Wingo,10
@@ -75856,6 +76092,7 @@ San Diego,999056,President,,DEM,Willie Wilson,1
 San Diego,999056,Proposition 50,,,No,70
 San Diego,999056,Proposition 50,,,Yes,283
 San Diego,999056,State Assembly,76,REP,Rocky Chavez,261
+San Diego,999056,State Assembly,76,REP,Thomas E Krouse,1
 San Diego,999056,U.S. House,49,REP,Darrell Issa,210
 San Diego,999056,U.S. House,49,DEM,Doug Applegate,136
 San Diego,999056,U.S. House,49,IND,Ryan Glenn Wingo,9
@@ -75899,6 +76136,7 @@ San Diego,999058,President,,DEM,Willie Wilson,1
 San Diego,999058,Proposition 50,,,No,168
 San Diego,999058,Proposition 50,,,Yes,529
 San Diego,999058,State Assembly,76,REP,Rocky Chavez,538
+San Diego,999058,State Assembly,76,REP,Thomas E Krouse,0
 San Diego,999058,U.S. House,49,REP,Darrell Issa,404
 San Diego,999058,U.S. House,49,DEM,Doug Applegate,271
 San Diego,999058,U.S. House,49,IND,Ryan Glenn Wingo,41
@@ -75943,6 +76181,7 @@ San Diego,999060,President,,REP,Ted Cruz,1
 San Diego,999060,Proposition 50,,,No,8
 San Diego,999060,Proposition 50,,,Yes,15
 San Diego,999060,State Assembly,76,REP,Rocky Chavez,9
+San Diego,999060,State Assembly,76,REP,Thomas E Krouse,2
 San Diego,999060,State Senate,39,REP,J. Bribiesca,2
 San Diego,999060,State Senate,39,REP,John Renison,3
 San Diego,999060,State Senate,39,REP,Richard M. Fago,4

--- a/2016/counties/20160607__ca__primary__san_diego__precinct.csv
+++ b/2016/counties/20160607__ca__primary__san_diego__precinct.csv
@@ -10578,6 +10578,7 @@ San Diego,152800,U.S. Senate,,REP,Tom Palzer,2
 San Diego,152800,U.S. Senate,,REP,Von Hougo,8
 San Diego,153600,President,,REP,Ben Carson,5
 San Diego,153600,President,,DEM,Bernie Sanders,170
+San Diego,153600,President,,REP,David P. Thomson,1
 San Diego,153600,President,,REP,Donald Trump,118
 San Diego,153600,President,,LIB,Gary Johnson,2
 San Diego,153600,President,,DEM,Henry Hewes,3
@@ -11819,6 +11820,7 @@ San Diego,163100,President,,DEM,Henry Hewes,2
 San Diego,163100,President,,DEM,Hillary Clinton,185
 San Diego,163100,President,,AIP,James Hedges,1
 San Diego,163100,President,,GRN,Jill Stein,1
+San Diego,163100,President,,REP,Joann Brievogel,1
 San Diego,163100,President,,REP,John R. Kasich,17
 San Diego,163100,President,,DEM,Roque De La Fuente,2
 San Diego,163100,President,,REP,Ted Cruz,24
@@ -12965,6 +12967,7 @@ San Diego,175110,U.S. House,53,REP,James Veltmeyer,85
 San Diego,175110,U.S. House,53,REP,Jim Ash,77
 San Diego,175110,U.S. House,53,DEM,"Nicholas ""Nick"" Walpert",5
 San Diego,175110,U.S. House,53,DEM,Susan A. Davis,198
+San Diego,175110,U.S. Senate,,REP,Billy Falling,1
 San Diego,175110,U.S. Senate,,REP,Don Krampe,3
 San Diego,175110,U.S. Senate,,REP,Duf Sundheim,52
 San Diego,175110,U.S. Senate,,IND,Eleanor García,3
@@ -16324,6 +16327,7 @@ San Diego,210190,President,,DEM,Keith Judd,1
 San Diego,210190,President,,AIP,Robert Ornelas,1
 San Diego,210190,President,,GRN,Sedinam Moyowasifsa-Curry,1
 San Diego,210190,President,,REP,Ted Cruz,14
+San Diego,210190,President,,REP,Troy Hugh Southern,1
 San Diego,210190,President,,AIP,Wiley Drake,1
 San Diego,210190,Proposition 50,,,No,117
 San Diego,210190,Proposition 50,,,Yes,490
@@ -26021,6 +26025,7 @@ San Diego,325800,Proposition 50,,,No,83
 San Diego,325800,Proposition 50,,,Yes,359
 San Diego,325800,State Assembly,78,REP,Kevin D. Melton,159
 San Diego,325800,State Assembly,78,DEM,Todd Gloria,304
+San Diego,325800,State Senate,39,REP,Billy Falling,2
 San Diego,325800,State Senate,39,REP,J. Bribiesca,51
 San Diego,325800,State Senate,39,REP,John Renison,94
 San Diego,325800,State Senate,39,REP,Richard M. Fago,25
@@ -30476,6 +30481,7 @@ San Diego,385000,U.S. House,51,REP,Carlos J. Sanchez,39
 San Diego,385000,U.S. House,51,DEM,"Juan ""Charly"" Mercado-Flores",63
 San Diego,385000,U.S. House,51,REP,Juan M. Hidalgo Jr.,80
 San Diego,385000,U.S. House,51,DEM,Juan Vargas,365
+San Diego,385000,U.S. Senate,,REP,Billy Falling,1
 San Diego,385000,U.S. Senate,,IND,Clive Grey,2
 San Diego,385000,U.S. Senate,,REP,Don Krampe,6
 San Diego,385000,U.S. Senate,,REP,Duf Sundheim,8
@@ -30784,6 +30790,7 @@ San Diego,385700,U.S. House,51,REP,Carlos J. Sanchez,51
 San Diego,385700,U.S. House,51,DEM,"Juan ""Charly"" Mercado-Flores",36
 San Diego,385700,U.S. House,51,REP,Juan M. Hidalgo Jr.,149
 San Diego,385700,U.S. House,51,DEM,Juan Vargas,253
+San Diego,385700,U.S. Senate,,REP,Billy Falling,2
 San Diego,385700,U.S. Senate,,IND,Don J. Grundmann,1
 San Diego,385700,U.S. Senate,,REP,Don Krampe,10
 San Diego,385700,U.S. Senate,,REP,Duf Sundheim,26
@@ -30830,6 +30837,7 @@ San Diego,385710,U.S. House,51,REP,Carlos J. Sanchez,40
 San Diego,385710,U.S. House,51,DEM,"Juan ""Charly"" Mercado-Flores",25
 San Diego,385710,U.S. House,51,REP,Juan M. Hidalgo Jr.,74
 San Diego,385710,U.S. House,51,DEM,Juan Vargas,341
+San Diego,385710,U.S. Senate,,REP,Billy Falling,3
 San Diego,385710,U.S. Senate,,IND,Clive Grey,3
 San Diego,385710,U.S. Senate,,IND,Don J. Grundmann,2
 San Diego,385710,U.S. Senate,,REP,Don Krampe,6
@@ -30877,6 +30885,7 @@ San Diego,385740,U.S. House,51,REP,Carlos J. Sanchez,38
 San Diego,385740,U.S. House,51,DEM,"Juan ""Charly"" Mercado-Flores",34
 San Diego,385740,U.S. House,51,REP,Juan M. Hidalgo Jr.,67
 San Diego,385740,U.S. House,51,DEM,Juan Vargas,283
+San Diego,385740,U.S. Senate,,REP,Billy Falling,3
 San Diego,385740,U.S. Senate,,IND,Don J. Grundmann,1
 San Diego,385740,U.S. Senate,,REP,Don Krampe,3
 San Diego,385740,U.S. Senate,,REP,Duf Sundheim,1
@@ -31227,6 +31236,7 @@ San Diego,386100,U.S. House,51,REP,Carlos J. Sanchez,38
 San Diego,386100,U.S. House,51,DEM,"Juan ""Charly"" Mercado-Flores",34
 San Diego,386100,U.S. House,51,REP,Juan M. Hidalgo Jr.,71
 San Diego,386100,U.S. House,51,DEM,Juan Vargas,390
+San Diego,386100,U.S. Senate,,REP,Billy Falling,1
 San Diego,386100,U.S. Senate,,IND,Clive Grey,3
 San Diego,386100,U.S. Senate,,REP,Don Krampe,2
 San Diego,386100,U.S. Senate,,REP,Duf Sundheim,7
@@ -31331,6 +31341,7 @@ San Diego,390210,U.S. House,51,REP,Carlos J. Sanchez,59
 San Diego,390210,U.S. House,51,DEM,"Juan ""Charly"" Mercado-Flores",32
 San Diego,390210,U.S. House,51,REP,Juan M. Hidalgo Jr.,95
 San Diego,390210,U.S. House,51,DEM,Juan Vargas,397
+San Diego,390210,U.S. Senate,,REP,Billy Falling,3
 San Diego,390210,U.S. Senate,,IND,Clive Grey,2
 San Diego,390210,U.S. Senate,,IND,Don J. Grundmann,2
 San Diego,390210,U.S. Senate,,REP,Don Krampe,4
@@ -31428,6 +31439,7 @@ San Diego,390400,U.S. House,51,REP,Carlos J. Sanchez,34
 San Diego,390400,U.S. House,51,DEM,"Juan ""Charly"" Mercado-Flores",33
 San Diego,390400,U.S. House,51,REP,Juan M. Hidalgo Jr.,67
 San Diego,390400,U.S. House,51,DEM,Juan Vargas,311
+San Diego,390400,U.S. Senate,,REP,Billy Falling,2
 San Diego,390400,U.S. Senate,,IND,Clive Grey,3
 San Diego,390400,U.S. Senate,,IND,Don J. Grundmann,1
 San Diego,390400,U.S. Senate,,REP,Don Krampe,5
@@ -31579,6 +31591,7 @@ San Diego,390700,U.S. House,51,REP,Carlos J. Sanchez,20
 San Diego,390700,U.S. House,51,DEM,"Juan ""Charly"" Mercado-Flores",32
 San Diego,390700,U.S. House,51,REP,Juan M. Hidalgo Jr.,59
 San Diego,390700,U.S. House,51,DEM,Juan Vargas,246
+San Diego,390700,U.S. Senate,,REP,Billy Falling,1
 San Diego,390700,U.S. Senate,,IND,Don J. Grundmann,1
 San Diego,390700,U.S. Senate,,REP,Don Krampe,1
 San Diego,390700,U.S. Senate,,REP,Duf Sundheim,5
@@ -31678,6 +31691,7 @@ San Diego,390800,U.S. House,51,REP,Carlos J. Sanchez,33
 San Diego,390800,U.S. House,51,DEM,"Juan ""Charly"" Mercado-Flores",37
 San Diego,390800,U.S. House,51,REP,Juan M. Hidalgo Jr.,48
 San Diego,390800,U.S. House,51,DEM,Juan Vargas,372
+San Diego,390800,U.S. Senate,,REP,Billy Falling,3
 San Diego,390800,U.S. Senate,,IND,Clive Grey,2
 San Diego,390800,U.S. Senate,,IND,Don J. Grundmann,1
 San Diego,390800,U.S. Senate,,REP,Don Krampe,3
@@ -32003,6 +32017,7 @@ San Diego,395090,U.S. House,51,REP,Carlos J. Sanchez,36
 San Diego,395090,U.S. House,51,DEM,"Juan ""Charly"" Mercado-Flores",19
 San Diego,395090,U.S. House,51,REP,Juan M. Hidalgo Jr.,46
 San Diego,395090,U.S. House,51,DEM,Juan Vargas,214
+San Diego,395090,U.S. Senate,,REP,Billy Falling,3
 San Diego,395090,U.S. Senate,,REP,Don Krampe,4
 San Diego,395090,U.S. Senate,,REP,Duf Sundheim,8
 San Diego,395090,U.S. Senate,,IND,Eleanor García,11
@@ -32189,6 +32204,7 @@ San Diego,395190,U.S. House,51,REP,Carlos J. Sanchez,34
 San Diego,395190,U.S. House,51,DEM,"Juan ""Charly"" Mercado-Flores",61
 San Diego,395190,U.S. House,51,REP,Juan M. Hidalgo Jr.,75
 San Diego,395190,U.S. House,51,DEM,Juan Vargas,320
+San Diego,395190,U.S. Senate,,REP,Billy Falling,1
 San Diego,395190,U.S. Senate,,IND,Clive Grey,3
 San Diego,395190,U.S. Senate,,REP,Don Krampe,3
 San Diego,395190,U.S. Senate,,REP,Duf Sundheim,6
@@ -46615,6 +46631,7 @@ San Diego,432870,U.S. Senate,,REP,Tom Palzer,3
 San Diego,432870,U.S. Senate,,REP,Von Hougo,7
 San Diego,432970,President,,REP,Ben Carson,1
 San Diego,432970,President,,DEM,Bernie Sanders,116
+San Diego,432970,President,,REP,David P. Thomson,1
 San Diego,432970,President,,REP,Donald Trump,100
 San Diego,432970,President,,DEM,Hillary Clinton,115
 San Diego,432970,President,,REP,John R. Kasich,16
@@ -47429,6 +47446,7 @@ San Diego,436420,U.S. Senate,,REP,Von Hougo,1
 San Diego,436560,President,,REP,Ben Carson,2
 San Diego,436560,President,,DEM,Bernie Sanders,38
 San Diego,436560,President,,LIB,Cecil Ince,1
+San Diego,436560,President,,REP,David P. Thomson,1
 San Diego,436560,President,,REP,Donald Trump,237
 San Diego,436560,President,,LIB,Gary Johnson,1
 San Diego,436560,President,,DEM,Hillary Clinton,93
@@ -48066,6 +48084,7 @@ San Diego,441600,U.S. House,51,REP,Carlos J. Sanchez,33
 San Diego,441600,U.S. House,51,DEM,"Juan ""Charly"" Mercado-Flores",41
 San Diego,441600,U.S. House,51,REP,Juan M. Hidalgo Jr.,140
 San Diego,441600,U.S. House,51,DEM,Juan Vargas,215
+San Diego,441600,U.S. Senate,,REP,Billy Falling,1
 San Diego,441600,U.S. Senate,,IND,Clive Grey,3
 San Diego,441600,U.S. Senate,,IND,Don J. Grundmann,5
 San Diego,441600,U.S. Senate,,REP,Don Krampe,3
@@ -48118,6 +48137,7 @@ San Diego,441610,U.S. House,51,REP,Carlos J. Sanchez,45
 San Diego,441610,U.S. House,51,DEM,"Juan ""Charly"" Mercado-Flores",55
 San Diego,441610,U.S. House,51,REP,Juan M. Hidalgo Jr.,135
 San Diego,441610,U.S. House,51,DEM,Juan Vargas,180
+San Diego,441610,U.S. Senate,,REP,Billy Falling,2
 San Diego,441610,U.S. Senate,,IND,Clive Grey,3
 San Diego,441610,U.S. Senate,,REP,Don Krampe,12
 San Diego,441610,U.S. Senate,,REP,Duf Sundheim,18
@@ -48166,6 +48186,7 @@ San Diego,441800,U.S. House,51,REP,Carlos J. Sanchez,19
 San Diego,441800,U.S. House,51,DEM,"Juan ""Charly"" Mercado-Flores",42
 San Diego,441800,U.S. House,51,REP,Juan M. Hidalgo Jr.,61
 San Diego,441800,U.S. House,51,DEM,Juan Vargas,124
+San Diego,441800,U.S. Senate,,REP,Billy Falling,2
 San Diego,441800,U.S. Senate,,IND,Clive Grey,2
 San Diego,441800,U.S. Senate,,IND,Don J. Grundmann,1
 San Diego,441800,U.S. Senate,,REP,Duf Sundheim,11
@@ -48368,6 +48389,7 @@ San Diego,442400,U.S. House,51,REP,Carlos J. Sanchez,33
 San Diego,442400,U.S. House,51,DEM,"Juan ""Charly"" Mercado-Flores",42
 San Diego,442400,U.S. House,51,REP,Juan M. Hidalgo Jr.,101
 San Diego,442400,U.S. House,51,DEM,Juan Vargas,192
+San Diego,442400,U.S. Senate,,REP,Billy Falling,2
 San Diego,442400,U.S. Senate,,IND,Clive Grey,2
 San Diego,442400,U.S. Senate,,REP,Don Krampe,4
 San Diego,442400,U.S. Senate,,REP,Duf Sundheim,21
@@ -48415,6 +48437,7 @@ San Diego,442500,U.S. House,51,REP,Carlos J. Sanchez,25
 San Diego,442500,U.S. House,51,DEM,"Juan ""Charly"" Mercado-Flores",24
 San Diego,442500,U.S. House,51,REP,Juan M. Hidalgo Jr.,140
 San Diego,442500,U.S. House,51,DEM,Juan Vargas,169
+San Diego,442500,U.S. Senate,,REP,Billy Falling,2
 San Diego,442500,U.S. Senate,,IND,Clive Grey,1
 San Diego,442500,U.S. Senate,,IND,Don J. Grundmann,1
 San Diego,442500,U.S. Senate,,REP,Don Krampe,3
@@ -49900,6 +49923,7 @@ San Diego,451600,U.S. House,50,REP,Duncan Hunter,340
 San Diego,451600,U.S. House,50,IND,H. Fuji Shioura,13
 San Diego,451600,U.S. House,50,DEM,Patrick Malloy,148
 San Diego,451600,U.S. House,50,REP,Scott C. Meisterlin,47
+San Diego,451600,U.S. Senate,,REP,Billy Falling,2
 San Diego,451600,U.S. Senate,,IND,Clive Grey,5
 San Diego,451600,U.S. Senate,,IND,Don J. Grundmann,1
 San Diego,451600,U.S. Senate,,REP,Don Krampe,4
@@ -50136,6 +50160,7 @@ San Diego,454600,U.S. House,50,REP,Duncan Hunter,117
 San Diego,454600,U.S. House,50,IND,H. Fuji Shioura,10
 San Diego,454600,U.S. House,50,DEM,Patrick Malloy,45
 San Diego,454600,U.S. House,50,REP,Scott C. Meisterlin,13
+San Diego,454600,U.S. Senate,,REP,Billy Falling,1
 San Diego,454600,U.S. Senate,,REP,Don Krampe,3
 San Diego,454600,U.S. Senate,,REP,Duf Sundheim,41
 San Diego,454600,U.S. Senate,,IND,Eleanor García,3
@@ -50778,6 +50803,7 @@ San Diego,455040,U.S. House,50,REP,Duncan Hunter,264
 San Diego,455040,U.S. House,50,IND,H. Fuji Shioura,29
 San Diego,455040,U.S. House,50,DEM,Patrick Malloy,124
 San Diego,455040,U.S. House,50,REP,Scott C. Meisterlin,33
+San Diego,455040,U.S. Senate,,REP,Billy Falling,1
 San Diego,455040,U.S. Senate,,IND,Clive Grey,3
 San Diego,455040,U.S. Senate,,IND,Don J. Grundmann,1
 San Diego,455040,U.S. Senate,,REP,Don Krampe,1
@@ -51915,6 +51941,7 @@ San Diego,457230,U.S. House,50,REP,Duncan Hunter,159
 San Diego,457230,U.S. House,50,IND,H. Fuji Shioura,32
 San Diego,457230,U.S. House,50,DEM,Patrick Malloy,165
 San Diego,457230,U.S. House,50,REP,Scott C. Meisterlin,26
+San Diego,457230,U.S. Senate,,REP,Billy Falling,2
 San Diego,457230,U.S. Senate,,IND,Clive Grey,1
 San Diego,457230,U.S. Senate,,IND,Don J. Grundmann,2
 San Diego,457230,U.S. Senate,,REP,Don Krampe,10
@@ -54569,6 +54596,7 @@ San Diego,466300,President,,REP,Ben Carson,9
 San Diego,466300,President,,DEM,Bernie Sanders,94
 San Diego,466300,President,,REP,Donald Trump,148
 San Diego,466300,President,,DEM,Hillary Clinton,97
+San Diego,466300,President,,REP,John Dowell,1
 San Diego,466300,President,,REP,John R. Kasich,11
 San Diego,466300,President,,DEM,Michael Steinberg,2
 San Diego,466300,President,,AIP,Robert Ornelas,1
@@ -54919,6 +54947,7 @@ San Diego,466440,U.S. Senate,,DEM,Steve Stokes,7
 San Diego,466440,U.S. Senate,,REP,Thomas G. Del Beccaro,28
 San Diego,466440,U.S. Senate,,REP,Tom Palzer,3
 San Diego,466440,U.S. Senate,,REP,Von Hougo,2
+San Diego,466450,President,,DEM,Andrew D. Basiago,1
 San Diego,466450,President,,AIP,Arthur Harris,1
 San Diego,466450,President,,REP,Ben Carson,2
 San Diego,466450,President,,DEM,Bernie Sanders,117
@@ -61503,6 +61532,7 @@ San Diego,500110,U.S. House,53,REP,James Veltmeyer,94
 San Diego,500110,U.S. House,53,REP,Jim Ash,83
 San Diego,500110,U.S. House,53,DEM,"Nicholas ""Nick"" Walpert",8
 San Diego,500110,U.S. House,53,DEM,Susan A. Davis,194
+San Diego,500110,U.S. Senate,,REP,Billy Falling,1
 San Diego,500110,U.S. Senate,,IND,Clive Grey,1
 San Diego,500110,U.S. Senate,,REP,Don Krampe,6
 San Diego,500110,U.S. Senate,,REP,Duf Sundheim,52
@@ -63070,6 +63100,7 @@ San Diego,510620,U.S. House,53,REP,James Veltmeyer,59
 San Diego,510620,U.S. House,53,REP,Jim Ash,35
 San Diego,510620,U.S. House,53,DEM,"Nicholas ""Nick"" Walpert",15
 San Diego,510620,U.S. House,53,DEM,Susan A. Davis,181
+San Diego,510620,U.S. Senate,,REP,Billy Falling,1
 San Diego,510620,U.S. Senate,,IND,Don J. Grundmann,2
 San Diego,510620,U.S. Senate,,REP,Duf Sundheim,25
 San Diego,510620,U.S. Senate,,IND,Eleanor García,4
@@ -64214,6 +64245,7 @@ San Diego,525100,U.S. House,51,REP,Carlos J. Sanchez,60
 San Diego,525100,U.S. House,51,DEM,"Juan ""Charly"" Mercado-Flores",89
 San Diego,525100,U.S. House,51,REP,Juan M. Hidalgo Jr.,59
 San Diego,525100,U.S. House,51,DEM,Juan Vargas,416
+San Diego,525100,U.S. Senate,,REP,Billy Falling,1
 San Diego,525100,U.S. Senate,,IND,Clive Grey,2
 San Diego,525100,U.S. Senate,,REP,Don Krampe,1
 San Diego,525100,U.S. Senate,,REP,Duf Sundheim,8
@@ -64722,6 +64754,7 @@ San Diego,526100,U.S. House,51,REP,Carlos J. Sanchez,40
 San Diego,526100,U.S. House,51,DEM,"Juan ""Charly"" Mercado-Flores",66
 San Diego,526100,U.S. House,51,REP,Juan M. Hidalgo Jr.,91
 San Diego,526100,U.S. House,51,DEM,Juan Vargas,373
+San Diego,526100,U.S. Senate,,REP,Billy Falling,2
 San Diego,526100,U.S. Senate,,IND,Clive Grey,2
 San Diego,526100,U.S. Senate,,IND,Don J. Grundmann,3
 San Diego,526100,U.S. Senate,,REP,Don Krampe,4
@@ -64931,6 +64964,7 @@ San Diego,526810,U.S. House,51,REP,Carlos J. Sanchez,52
 San Diego,526810,U.S. House,51,DEM,"Juan ""Charly"" Mercado-Flores",54
 San Diego,526810,U.S. House,51,REP,Juan M. Hidalgo Jr.,94
 San Diego,526810,U.S. House,51,DEM,Juan Vargas,329
+San Diego,526810,U.S. Senate,,REP,Billy Falling,1
 San Diego,526810,U.S. Senate,,IND,Don J. Grundmann,2
 San Diego,526810,U.S. Senate,,REP,Don Krampe,7
 San Diego,526810,U.S. Senate,,REP,Duf Sundheim,21
@@ -64986,6 +65020,7 @@ San Diego,526900,U.S. House,51,REP,Carlos J. Sanchez,62
 San Diego,526900,U.S. House,51,DEM,"Juan ""Charly"" Mercado-Flores",67
 San Diego,526900,U.S. House,51,REP,Juan M. Hidalgo Jr.,61
 San Diego,526900,U.S. House,51,DEM,Juan Vargas,414
+San Diego,526900,U.S. Senate,,REP,Billy Falling,1
 San Diego,526900,U.S. Senate,,IND,Clive Grey,5
 San Diego,526900,U.S. Senate,,IND,Don J. Grundmann,1
 San Diego,526900,U.S. Senate,,REP,Don Krampe,6
@@ -65142,6 +65177,7 @@ San Diego,527800,U.S. House,51,REP,Carlos J. Sanchez,42
 San Diego,527800,U.S. House,51,DEM,"Juan ""Charly"" Mercado-Flores",28
 San Diego,527800,U.S. House,51,REP,Juan M. Hidalgo Jr.,78
 San Diego,527800,U.S. House,51,DEM,Juan Vargas,233
+San Diego,527800,U.S. Senate,,REP,Billy Falling,1
 San Diego,527800,U.S. Senate,,IND,Clive Grey,1
 San Diego,527800,U.S. Senate,,IND,Don J. Grundmann,2
 San Diego,527800,U.S. Senate,,REP,Don Krampe,6
@@ -65347,6 +65383,7 @@ San Diego,528820,U.S. House,53,REP,James Veltmeyer,137
 San Diego,528820,U.S. House,53,REP,Jim Ash,94
 San Diego,528820,U.S. House,53,DEM,"Nicholas ""Nick"" Walpert",26
 San Diego,528820,U.S. House,53,DEM,Susan A. Davis,400
+San Diego,528820,U.S. Senate,,REP,Billy Falling,1
 San Diego,528820,U.S. Senate,,IND,Clive Grey,2
 San Diego,528820,U.S. Senate,,REP,Don Krampe,5
 San Diego,528820,U.S. Senate,,REP,Duf Sundheim,18
@@ -65579,6 +65616,7 @@ San Diego,528940,U.S. House,53,REP,James Veltmeyer,82
 San Diego,528940,U.S. House,53,REP,Jim Ash,48
 San Diego,528940,U.S. House,53,DEM,"Nicholas ""Nick"" Walpert",18
 San Diego,528940,U.S. House,53,DEM,Susan A. Davis,299
+San Diego,528940,U.S. Senate,,REP,Billy Falling,1
 San Diego,528940,U.S. Senate,,IND,Clive Grey,2
 San Diego,528940,U.S. Senate,,REP,Don Krampe,1
 San Diego,528940,U.S. Senate,,REP,Duf Sundheim,18
@@ -65780,6 +65818,7 @@ San Diego,529300,U.S. House,51,REP,Carlos J. Sanchez,54
 San Diego,529300,U.S. House,51,DEM,"Juan ""Charly"" Mercado-Flores",46
 San Diego,529300,U.S. House,51,REP,Juan M. Hidalgo Jr.,113
 San Diego,529300,U.S. House,51,DEM,Juan Vargas,270
+San Diego,529300,U.S. Senate,,REP,Billy Falling,1
 San Diego,529300,U.S. Senate,,IND,Clive Grey,4
 San Diego,529300,U.S. Senate,,REP,Don Krampe,5
 San Diego,529300,U.S. Senate,,REP,Duf Sundheim,17
@@ -65906,6 +65945,7 @@ San Diego,529520,U.S. House,51,REP,Carlos J. Sanchez,49
 San Diego,529520,U.S. House,51,DEM,"Juan ""Charly"" Mercado-Flores",51
 San Diego,529520,U.S. House,51,REP,Juan M. Hidalgo Jr.,87
 San Diego,529520,U.S. House,51,DEM,Juan Vargas,402
+San Diego,529520,U.S. Senate,,REP,Billy Falling,2
 San Diego,529520,U.S. Senate,,IND,Clive Grey,1
 San Diego,529520,U.S. Senate,,IND,Don J. Grundmann,3
 San Diego,529520,U.S. Senate,,REP,Don Krampe,2
@@ -66507,6 +66547,7 @@ San Diego,531090,U.S. House,51,REP,Carlos J. Sanchez,48
 San Diego,531090,U.S. House,51,DEM,"Juan ""Charly"" Mercado-Flores",45
 San Diego,531090,U.S. House,51,REP,Juan M. Hidalgo Jr.,77
 San Diego,531090,U.S. House,51,DEM,Juan Vargas,376
+San Diego,531090,U.S. Senate,,REP,Billy Falling,1
 San Diego,531090,U.S. Senate,,IND,Clive Grey,2
 San Diego,531090,U.S. Senate,,IND,Don J. Grundmann,1
 San Diego,531090,U.S. Senate,,REP,Don Krampe,7
@@ -66719,6 +66760,7 @@ San Diego,531400,U.S. House,51,REP,Carlos J. Sanchez,52
 San Diego,531400,U.S. House,51,DEM,"Juan ""Charly"" Mercado-Flores",57
 San Diego,531400,U.S. House,51,REP,Juan M. Hidalgo Jr.,62
 San Diego,531400,U.S. House,51,DEM,Juan Vargas,414
+San Diego,531400,U.S. Senate,,REP,Billy Falling,2
 San Diego,531400,U.S. Senate,,IND,Clive Grey,1
 San Diego,531400,U.S. Senate,,IND,Don J. Grundmann,2
 San Diego,531400,U.S. Senate,,REP,Don Krampe,4
@@ -67620,6 +67662,7 @@ San Diego,532220,President,,REP,Ben Carson,3
 San Diego,532220,President,,DEM,Bernie Sanders,77
 San Diego,532220,President,,REP,Donald Trump,59
 San Diego,532220,President,,DEM,Hillary Clinton,132
+San Diego,532220,President,,DEM,Ignació León Nuñez,1
 San Diego,532220,President,,AIP,James Hedges,2
 San Diego,532220,President,,REP,Jim Gilmore,2
 San Diego,532220,President,,REP,John R. Kasich,4
@@ -67685,6 +67728,7 @@ San Diego,532290,U.S. House,53,REP,James Veltmeyer,70
 San Diego,532290,U.S. House,53,REP,Jim Ash,69
 San Diego,532290,U.S. House,53,DEM,"Nicholas ""Nick"" Walpert",28
 San Diego,532290,U.S. House,53,DEM,Susan A. Davis,366
+San Diego,532290,U.S. Senate,,REP,Billy Falling,1
 San Diego,532290,U.S. Senate,,IND,Clive Grey,1
 San Diego,532290,U.S. Senate,,IND,Don J. Grundmann,3
 San Diego,532290,U.S. Senate,,REP,Don Krampe,9
@@ -68278,6 +68322,7 @@ San Diego,532630,U.S. House,53,REP,James Veltmeyer,45
 San Diego,532630,U.S. House,53,REP,Jim Ash,37
 San Diego,532630,U.S. House,53,DEM,"Nicholas ""Nick"" Walpert",23
 San Diego,532630,U.S. House,53,DEM,Susan A. Davis,259
+San Diego,532630,U.S. Senate,,REP,Billy Falling,1
 San Diego,532630,U.S. Senate,,IND,Clive Grey,1
 San Diego,532630,U.S. Senate,,REP,Don Krampe,2
 San Diego,532630,U.S. Senate,,REP,Duf Sundheim,10
@@ -69317,6 +69362,7 @@ San Diego,538300,U.S. House,51,REP,Carlos J. Sanchez,45
 San Diego,538300,U.S. House,51,DEM,"Juan ""Charly"" Mercado-Flores",50
 San Diego,538300,U.S. House,51,REP,Juan M. Hidalgo Jr.,49
 San Diego,538300,U.S. House,51,DEM,Juan Vargas,294
+San Diego,538300,U.S. Senate,,REP,Billy Falling,2
 San Diego,538300,U.S. Senate,,IND,Don J. Grundmann,1
 San Diego,538300,U.S. Senate,,REP,Don Krampe,5
 San Diego,538300,U.S. Senate,,REP,Duf Sundheim,10
@@ -69368,6 +69414,7 @@ San Diego,538500,U.S. House,51,REP,Carlos J. Sanchez,56
 San Diego,538500,U.S. House,51,DEM,"Juan ""Charly"" Mercado-Flores",58
 San Diego,538500,U.S. House,51,REP,Juan M. Hidalgo Jr.,97
 San Diego,538500,U.S. House,51,DEM,Juan Vargas,413
+San Diego,538500,U.S. Senate,,REP,Billy Falling,3
 San Diego,538500,U.S. Senate,,IND,Clive Grey,1
 San Diego,538500,U.S. Senate,,IND,Don J. Grundmann,1
 San Diego,538500,U.S. Senate,,REP,Don Krampe,10
@@ -69470,6 +69517,7 @@ San Diego,539200,U.S. House,51,REP,Carlos J. Sanchez,39
 San Diego,539200,U.S. House,51,DEM,"Juan ""Charly"" Mercado-Flores",34
 San Diego,539200,U.S. House,51,REP,Juan M. Hidalgo Jr.,33
 San Diego,539200,U.S. House,51,DEM,Juan Vargas,243
+San Diego,539200,U.S. Senate,,REP,Billy Falling,1
 San Diego,539200,U.S. Senate,,IND,Clive Grey,2
 San Diego,539200,U.S. Senate,,REP,Don Krampe,3
 San Diego,539200,U.S. Senate,,REP,Duf Sundheim,8
@@ -70476,6 +70524,7 @@ San Diego,547060,President,,REP,Donald Trump,211
 San Diego,547060,President,,DEM,Hillary Clinton,48
 San Diego,547060,President,,GRN,Jill Stein,1
 San Diego,547060,President,,REP,Jim Gilmore,1
+San Diego,547060,President,,REP,John Dowell,1
 San Diego,547060,President,,REP,John R. Kasich,30
 San Diego,547060,President,,REP,Ted Cruz,15
 San Diego,547060,President,,AIP,Wiley Drake,2
@@ -75754,6 +75803,7 @@ San Diego,999044,U.S. House,50,REP,Duncan Hunter,1435
 San Diego,999044,U.S. House,50,IND,H. Fuji Shioura,102
 San Diego,999044,U.S. House,50,DEM,Patrick Malloy,574
 San Diego,999044,U.S. House,50,REP,Scott C. Meisterlin,210
+San Diego,999044,U.S. Senate,,REP,Billy Falling,2
 San Diego,999044,U.S. Senate,,IND,Clive Grey,17
 San Diego,999044,U.S. Senate,,IND,Don J. Grundmann,5
 San Diego,999044,U.S. Senate,,REP,Don Krampe,44


### PR DESCRIPTION
Add Thomas E Krouse write-in records to 2016 Primary San Diego State Assembly 76 office.

Closes #81 