### PR TITLE
Bump versions of actions in unit tests workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,13 +11,13 @@ jobs:
 
     steps:
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.9
 
 
     - name: Check out source
-      uses: actions/checkout@v2.3.4
+      uses: actions/checkout@v3
 
     - name: Configure environment
       run: pip install -r requirements.txt


### PR DESCRIPTION
This bumps the versions of actions used in the unit tests workflow. Several dependencies were deprecated.